### PR TITLE
Add LogixNG action SimulateTurnoutFeedback

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -407,6 +407,9 @@
           <li>The action <i>Simulate turnout feedback</i> has been added.
           It's useful to simulate a layout when a simulator connection is
           used, for example the LocoNet simulator.</li>
+          <li>The action <i>Connection name</i> has been added.
+          It's useful together with <i>Simulate turnout feedback</i> so
+          that simulation only happens for simulated connections.</li>
         </ul>
 
     <h3>Meters and MeterFrames</h3>

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -404,7 +404,9 @@
     <h3>LogixNG</h3>
         <a id="LogixNG" name="LogixNG"></a>
         <ul>
-          <li></li>
+          <li>The action <i>Simulate turnout feedback</i> has been added.
+          It's useful to simulate a layout when a simulator connection is
+          used, for example the LocoNet simulator.</li>
         </ul>
 
     <h3>Meters and MeterFrames</h3>

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -409,7 +409,7 @@
         <ul>
           <li>The action <i>Simulate turnout feedback</i> has been added.
           It's useful to simulate feedback based turnout actions when a
-          simulator connection is used, for example the LocoNet simulator.</li>
+          simulator connection is used, for example the <i>LocoNet simulator</i>.</li>
           <li>The expression <i>Connection name</i> has been added.
           It's useful together with <i>Simulate turnout feedback</i> so
           that simulation only happens for simulated connections.</li>

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -408,9 +408,9 @@
         <a id="LogixNG" name="LogixNG"></a>
         <ul>
           <li>The action <i>Simulate turnout feedback</i> has been added.
-          It's useful to simulate a layout when a simulator connection is
-          used, for example the LocoNet simulator.</li>
-          <li>The action <i>Connection name</i> has been added.
+          It's useful to simulate feedback based turnout actions when a
+          simulator connection is used, for example the LocoNet simulator.</li>
+          <li>The expression <i>Connection name</i> has been added.
           It's useful together with <i>Simulate turnout feedback</i> so
           that simulation only happens for simulated connections.</li>
         </ul>

--- a/java/src/jmri/jmrit/logixng/actions/ActionBundle.properties
+++ b/java/src/jmri/jmrit/logixng/actions/ActionBundle.properties
@@ -374,6 +374,9 @@ SignalMastOperationType_PermissiveSmlDisabled       = permissive sml disabled
 SignalMastOperationType_PermissiveSmlNotDisabled    = permissive sml not disabled
 SignalMast_SignalMastInUseSignalMastActionVeto  = SignalMast is in use by SignalMast action "{0}"
 
+SimulateTurnoutFeedback_Short   = Simulate turnout feedback
+SimulateTurnoutFeedback_Long    = Simulate turnout feedback. Delay: {0} seconds
+
 Sequence_Short          = Sequence
 Sequence_Long           = Sequence
 SequenceSocketStart     = Start

--- a/java/src/jmri/jmrit/logixng/actions/DigitalFactory.java
+++ b/java/src/jmri/jmrit/logixng/actions/DigitalFactory.java
@@ -58,6 +58,7 @@ public class DigitalFactory implements DigitalActionFactory {
                         new AbstractMap.SimpleEntry<>(Category.COMMON, Sequence.class),
                         new AbstractMap.SimpleEntry<>(Category.OTHER, ShowDialog.class),
                         new AbstractMap.SimpleEntry<>(Category.OTHER, ShutdownComputer.class),
+                        new AbstractMap.SimpleEntry<>(Category.OTHER, SimulateTurnoutFeedback.class),
                         new AbstractMap.SimpleEntry<>(Category.COMMON, TableForEach.class),
                         new AbstractMap.SimpleEntry<>(Category.OTHER, Timeout.class),
                         new AbstractMap.SimpleEntry<>(Category.ITEM, TriggerRoute.class),

--- a/java/src/jmri/jmrit/logixng/actions/SimulateTurnoutFeedback.java
+++ b/java/src/jmri/jmrit/logixng/actions/SimulateTurnoutFeedback.java
@@ -138,7 +138,7 @@ public class SimulateTurnoutFeedback extends AbstractDigitalAction
                 _timerTasks.remove(t);
             }
             TurnoutTimerTask task = new TurnoutTimerTask(t, newState);
-            TimerUtil.schedule(task, _delay * 1000);
+            TimerUtil.schedule(task, _delay * 1000L);
         }
 
         @Override

--- a/java/src/jmri/jmrit/logixng/actions/SimulateTurnoutFeedback.java
+++ b/java/src/jmri/jmrit/logixng/actions/SimulateTurnoutFeedback.java
@@ -88,14 +88,12 @@ public class SimulateTurnoutFeedback extends AbstractDigitalAction
         if (!_turnouts.containsKey(turnout.getSystemName())) {
             _turnouts.put(turnout.getSystemName(), turnout);
             turnout.addPropertyChangeListener("CommandedState", _turnoutListener);
-//            System.out.format("Turnout: add prop: %s%n", turnout.getDisplayName());
         }
     }
 
     private void removeTurnoutListener(Turnout turnout) {
         _turnouts.remove(turnout.getSystemName());
         turnout.removePropertyChangeListener("CommandedState", _turnoutListener);
-//        System.out.format("Turnout: remove prop: %s%n", turnout.getDisplayName());
     }
 
     /** {@inheritDoc} */
@@ -118,8 +116,6 @@ public class SimulateTurnoutFeedback extends AbstractDigitalAction
                 }
             }
         }
-
-        System.out.format("Source: %s, name: %s, old: %s, new: %s%n", evt.getSource(), evt.getPropertyName(), evt.getOldValue(), evt.getNewValue());
     }
 
     /** {@inheritDoc} */
@@ -145,8 +141,6 @@ public class SimulateTurnoutFeedback extends AbstractDigitalAction
 
         @Override
         public void propertyChange(PropertyChangeEvent evt) {
-            System.out.format("Turnout: Source: %s, name: %s, old: %s, new: %s%n", evt.getSource(), evt.getPropertyName(), evt.getOldValue(), evt.getNewValue());
-
             if (evt.getPropertyName().equals("CommandedState")) {
                 String sysName = evt.getSource().toString();
                 TurnoutManager tm = InstanceManager.getDefault(TurnoutManager.class);
@@ -193,8 +187,6 @@ public class SimulateTurnoutFeedback extends AbstractDigitalAction
         }
 
         private void startMove() {
-            System.out.format("Start move turnout %s%n", _turnout.getDisplayName());
-
             Sensor sensor1;
             Sensor sensor2;
 
@@ -232,8 +224,6 @@ public class SimulateTurnoutFeedback extends AbstractDigitalAction
         }
 
         private void stopMove() {
-            System.out.format("Stop move turnout %s%n", _turnout.getDisplayName());
-
             Sensor sensor;
 
             switch (_turnout.getFeedbackMode()) {

--- a/java/src/jmri/jmrit/logixng/actions/SimulateTurnoutFeedback.java
+++ b/java/src/jmri/jmrit/logixng/actions/SimulateTurnoutFeedback.java
@@ -130,7 +130,7 @@ public class SimulateTurnoutFeedback extends AbstractDigitalAction
         turnout.removePropertyChangeListener("turnoutFeedbackSecondSensorChange", this);
         if (ti != null && ti._hasListener) {
             turnout.removePropertyChangeListener("CommandedState", _turnoutListener);
-            ti._hasListener = true;
+            ti._hasListener = false;
         }
     }
 

--- a/java/src/jmri/jmrit/logixng/actions/SimulateTurnoutFeedback.java
+++ b/java/src/jmri/jmrit/logixng/actions/SimulateTurnoutFeedback.java
@@ -1,0 +1,294 @@
+package jmri.jmrit.logixng.actions;
+
+import java.beans.*;
+import java.util.*;
+
+import jmri.*;
+import jmri.jmrit.logixng.*;
+import jmri.util.TimerUtil;
+
+/**
+ * Simulates turnout feedback.
+ * @author Daniel Bergqvist (C) 2022
+ */
+public class SimulateTurnoutFeedback extends AbstractDigitalAction
+        implements PropertyChangeListener, VetoableChangeListener {
+
+    private final TurnoutListener _turnoutListener = new TurnoutListener();
+
+    private int _delay = 3;     // Delay in seconds
+    private final Map<String, Turnout> _turnouts = new HashMap<>();
+
+
+    public SimulateTurnoutFeedback(String sys, String user)
+            throws BadUserNameException, BadSystemNameException {
+        super(sys, user, Category.OTHER);
+    }
+
+    @Override
+    public Base getDeepCopy(Map<String, String> systemNames, Map<String, String> userNames) throws JmriException {
+        DigitalActionManager manager = InstanceManager.getDefault(DigitalActionManager.class);
+        String sysName = systemNames.get(getSystemName());
+        String userName = userNames.get(getSystemName());
+        if (sysName == null) sysName = manager.getAutoSystemName();
+        SimulateTurnoutFeedback copy = new SimulateTurnoutFeedback(sysName, userName);
+        copy.setComment(getComment());
+        copy._delay = _delay;
+        return manager.registerAction(copy);
+    }
+
+    @Override
+    public String getShortDescription(Locale locale) {
+        return Bundle.getMessage(locale, "SimulateTurnoutFeedback_Short");
+    }
+
+    @Override
+    public String getLongDescription(Locale locale) {
+        return Bundle.getMessage(locale, "SimulateTurnoutFeedback_Long", _delay);
+    }
+
+    @Override
+    public void setup() {
+        // Do nothing
+    }
+
+    @Override
+    public void execute() throws JmriException {
+        // Do nothing
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public synchronized void registerListenersForThisClass() {
+        if (!_listenersAreRegistered) {
+            _listenersAreRegistered = true;
+            TurnoutManager tm = InstanceManager.getDefault(TurnoutManager.class);
+            for (Turnout t : tm.getNamedBeanSet()) {
+                addTurnoutListener(t);
+            }
+            tm.addPropertyChangeListener("beans", this);
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public synchronized void unregisterListenersForThisClass() {
+        if (_listenersAreRegistered) {
+            TurnoutManager tm = InstanceManager.getDefault(TurnoutManager.class);
+            for (Turnout t : tm.getNamedBeanSet()) {
+                removeTurnoutListener(t);
+            }
+            tm.removePropertyChangeListener("beans", this);
+            _listenersAreRegistered = false;
+        }
+    }
+
+    private void addTurnoutListener(Turnout turnout) {
+        if (!_turnouts.containsKey(turnout.getSystemName())) {
+            _turnouts.put(turnout.getSystemName(), turnout);
+            turnout.addPropertyChangeListener("CommandedState", _turnoutListener);
+//            System.out.format("Turnout: add prop: %s%n", turnout.getDisplayName());
+        }
+    }
+
+    private void removeTurnoutListener(Turnout turnout) {
+        _turnouts.remove(turnout.getSystemName());
+        turnout.removePropertyChangeListener("CommandedState", _turnoutListener);
+//        System.out.format("Turnout: remove prop: %s%n", turnout.getDisplayName());
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public synchronized void propertyChange(PropertyChangeEvent evt) {
+        if (evt.getPropertyName().equals("beans")) {
+            if (!(evt.getSource() instanceof TurnoutManager)) return;
+            TurnoutManager manager = (TurnoutManager)evt.getSource();
+            if (evt.getNewValue() != null) {
+                String sysName = evt.getNewValue().toString();
+                Turnout turnout = manager.getBySystemName(sysName);
+                if (_listenersAreRegistered && (turnout != null)) {
+                    addTurnoutListener(turnout);
+                }
+            } else if (evt.getOldValue() != null) {
+                String sysName = evt.getOldValue().toString();
+                Turnout turnout = _turnouts.get(sysName);
+                if (_listenersAreRegistered && (turnout != null)) {
+                    removeTurnoutListener(turnout);
+                }
+            }
+        }
+
+        System.out.format("Source: %s, name: %s, old: %s, new: %s%n", evt.getSource(), evt.getPropertyName(), evt.getOldValue(), evt.getNewValue());
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void disposeMe() {
+    }
+
+
+    private class TurnoutListener implements PropertyChangeListener {
+
+        private final Map<Turnout, TurnoutTimerTask> _timerTasks = new HashMap<>();
+
+        private void manageTurnout(Turnout t, int newState) {
+            if (_timerTasks.containsKey(t)) {
+                TurnoutTimerTask task = _timerTasks.get(t);
+                task.cancel();
+                _timerTasks.remove(t);
+            }
+            TurnoutTimerTask task = new TurnoutTimerTask(t, newState);
+            TimerUtil.schedule(task, _delay * 1000);
+        }
+
+        @Override
+        public void propertyChange(PropertyChangeEvent evt) {
+            System.out.format("Turnout: Source: %s, name: %s, old: %s, new: %s%n", evt.getSource(), evt.getPropertyName(), evt.getOldValue(), evt.getNewValue());
+
+            if (evt.getPropertyName().equals("CommandedState")) {
+                String sysName = evt.getSource().toString();
+                TurnoutManager tm = InstanceManager.getDefault(TurnoutManager.class);
+                Turnout t = tm.getBySystemName(sysName);
+                if (t == null) {
+                    log.error("Turnout {} does not exists in manager {}", sysName, tm);
+                    return;
+                }
+
+                switch (t.getFeedbackMode()) {
+                    case Turnout.DIRECT:
+                    case Turnout.SIGNAL:
+                    case Turnout.DELAYED:
+                        // Do nothing
+                        break;
+
+                    case Turnout.EXACT:
+                    case Turnout.INDIRECT:
+                    case Turnout.MONITORING:
+                    case Turnout.ONESENSOR:
+                    case Turnout.TWOSENSOR:
+                    case Turnout.LNALTERNATE:
+                        // Hardware feedback
+                        manageTurnout(t, (int) evt.getNewValue());
+                        break;
+
+                    default:
+                        log.debug("Unsupported turnout feedback mode: {}, {}", t.getFeedbackMode(), t.getFeedbackModeName());
+                }
+            }
+        }
+
+    }
+
+    private static class TurnoutTimerTask extends java.util.TimerTask {
+
+        private final Turnout _turnout;
+        private final int _newState;
+
+        private TurnoutTimerTask(Turnout t, int newState) {
+            _turnout = t;
+            _newState = newState;
+            startMove();
+        }
+
+        private void startMove() {
+            System.out.format("Start move turnout %s%n", _turnout.getDisplayName());
+
+            Sensor sensor1;
+            Sensor sensor2;
+
+            switch (_turnout.getFeedbackMode()) {
+                case Turnout.EXACT:
+                    // Hardware feedback
+                    break;
+
+                case Turnout.INDIRECT:
+                    // Hardware feedback
+                    break;
+
+                case Turnout.MONITORING:
+                    // Hardware feedback
+                    break;
+
+                case Turnout.ONESENSOR:
+                    // Do nothing
+                    break;
+
+                case Turnout.TWOSENSOR:
+                    sensor1 = _turnout.getFirstSensor();
+                    if (sensor1 != null) sensor1.setCommandedState(Sensor.INACTIVE);
+                    sensor2 = _turnout.getSecondSensor();
+                    if (sensor2 != null) sensor2.setCommandedState(Sensor.INACTIVE);
+                    break;
+
+                case Turnout.LNALTERNATE:
+                    // Hardware feedback
+                    break;
+
+                default:
+                    log.debug("Unsupported turnout feedback mode: {}, {}", _turnout.getFeedbackMode(), _turnout.getFeedbackModeName());
+            }
+        }
+
+        private void stopMove() {
+            System.out.format("Stop move turnout %s%n", _turnout.getDisplayName());
+
+            Sensor sensor;
+
+            switch (_turnout.getFeedbackMode()) {
+                case Turnout.EXACT:
+                    if (_turnout instanceof jmri.jmrix.loconet.LnTurnout) {
+                        jmri.jmrix.loconet.LnTurnout lnTurnout = (jmri.jmrix.loconet.LnTurnout)_turnout;
+                        lnTurnout.newKnownState(_newState);
+                    } else if (_turnout instanceof jmri.jmrix.lenz.XNetTurnout) {
+                        jmri.jmrix.lenz.XNetTurnout xnetTurnout = (jmri.jmrix.lenz.XNetTurnout)_turnout;
+                        xnetTurnout.newKnownState(_newState);
+                    } else {
+                        log.warn("Unknown type of turnout {}, {}", _turnout.getSystemName(), _turnout.getDisplayName());
+                    }
+                    break;
+
+                case Turnout.INDIRECT:
+                    // Hardware feedback
+                    break;
+
+                case Turnout.MONITORING:
+                    // Hardware feedback
+                    break;
+
+                case Turnout.ONESENSOR:
+                    sensor = _turnout.getFirstSensor();
+                    if (_newState == Turnout.CLOSED) {
+                        if (sensor != null) sensor.setCommandedState(Sensor.INACTIVE);
+                    } else if (_newState == Turnout.THROWN) {
+                        if (sensor != null) sensor.setCommandedState(Sensor.ACTIVE);
+                    }
+                    break;
+
+                case Turnout.TWOSENSOR:
+                    if (_newState == Turnout.CLOSED) {
+                        sensor = _turnout.getSecondSensor();
+                        if (sensor != null) sensor.setCommandedState(Sensor.ACTIVE);
+                    } else if (_newState == Turnout.THROWN) {
+                        sensor = _turnout.getFirstSensor();
+                        if (sensor != null) sensor.setCommandedState(Sensor.ACTIVE);
+                    }
+                    break;
+
+                case Turnout.LNALTERNATE:
+                    // Hardware feedback
+                    break;
+
+                default:
+                    log.debug("Unsupported turnout feedback mode: {}, {}", _turnout.getFeedbackMode(), _turnout.getFeedbackModeName());
+            }
+        }
+
+        @Override
+        public void run() {
+            stopMove();
+        }
+    }
+
+
+    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(SimulateTurnoutFeedback.class);
+}

--- a/java/src/jmri/jmrit/logixng/actions/SimulateTurnoutFeedback.java
+++ b/java/src/jmri/jmrit/logixng/actions/SimulateTurnoutFeedback.java
@@ -208,7 +208,7 @@ public class SimulateTurnoutFeedback extends AbstractDigitalAction
 
         @Override
         public void propertyChange(PropertyChangeEvent evt) {
-            System.out.format("Source: %s, name: %s, old: %s, new: %s%n", evt.getSource(), evt.getPropertyName(), evt.getOldValue(), evt.getNewValue());
+//            System.out.format("Source: %s, name: %s, old: %s, new: %s%n", evt.getSource(), evt.getPropertyName(), evt.getOldValue(), evt.getNewValue());
 
             if (evt.getPropertyName().equals("CommandedState")) {
                 String sysName = evt.getSource().toString();

--- a/java/src/jmri/jmrit/logixng/actions/configurexml/SimulateTurnoutFeedbackXml.java
+++ b/java/src/jmri/jmrit/logixng/actions/configurexml/SimulateTurnoutFeedbackXml.java
@@ -1,0 +1,56 @@
+package jmri.jmrit.logixng.actions.configurexml;
+
+import jmri.InstanceManager;
+import jmri.jmrit.logixng.DigitalActionManager;
+import jmri.jmrit.logixng.actions.SimulateTurnoutFeedback;
+
+import org.jdom2.Element;
+
+/**
+ * Handle XML configuration for SimulateTurnoutFeedback objects.
+ *
+ * @author Bob Jacobsen Copyright: Copyright (c) 2004, 2008, 2010
+ * @author Daniel Bergqvist Copyright (C) 2019
+ */
+public class SimulateTurnoutFeedbackXml extends jmri.managers.configurexml.AbstractNamedBeanManagerConfigXML {
+
+    public SimulateTurnoutFeedbackXml() {
+    }
+
+    /**
+     * Default implementation for storing the contents of a SimulateTurnoutFeedback
+     *
+     * @param o Object to store, of type Many
+     * @return Element containing the complete info
+     */
+    @Override
+    public Element store(Object o) {
+        SimulateTurnoutFeedback p = (SimulateTurnoutFeedback) o;
+
+        Element element = new Element("SimulateTurnoutFeedback");
+        element.setAttribute("class", this.getClass().getName());
+        element.addContent(new Element("systemName").addContent(p.getSystemName()));
+
+        storeCommon(p, element);
+
+        return element;
+    }
+
+    @Override
+    public boolean load(Element shared, Element perNode) {
+
+        // put it together
+        String sys = getSystemName(shared);
+        String uname = getUserName(shared);
+        SimulateTurnoutFeedback h = new SimulateTurnoutFeedback(sys, uname);
+
+        loadCommon(h, shared);
+
+        InstanceManager.getDefault(DigitalActionManager.class).registerAction(h);
+
+        return true;
+    }
+
+//    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ManyXml.class);
+
+}

--- a/java/src/jmri/jmrit/logixng/actions/swing/DigitalActionSwingBundle.properties
+++ b/java/src/jmri/jmrit/logixng/actions/swing/DigitalActionSwingBundle.properties
@@ -169,3 +169,10 @@ ShowDialog_TableAdd                 = Add
 ShowDialog_ColumnType               = Type
 ShowDialog_ColumnData               = Data
 ShowDialog_ErrorNoEnabledButton     = At least one button must be enabled
+
+SimulateTurnoutFeedback_Info    = <html>                                            \
+This action will simulate turnout feedback.<br>                                     \
+It's useful when using a simulated connection, like the LocoNet simulator.<br>      \
+The simulation will start once this action has been executed the first time,<br>    \
+which allows it to be conditionally started.                                        \
+</html>

--- a/java/src/jmri/jmrit/logixng/actions/swing/SimulateTurnoutFeedbackSwing.java
+++ b/java/src/jmri/jmrit/logixng/actions/swing/SimulateTurnoutFeedbackSwing.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+import javax.swing.JLabel;
 import javax.swing.JPanel;
 
 import jmri.InstanceManager;
@@ -22,6 +23,7 @@ public class SimulateTurnoutFeedbackSwing extends AbstractDigitalActionSwing {
     @Override
     protected void createPanel(@CheckForNull Base object, @Nonnull JPanel buttonPanel) {
         panel = new JPanel();
+        panel.add(new JLabel(Bundle.getMessage("SimulateTurnoutFeedback_Info")));
     }
 
     /** {@inheritDoc} */

--- a/java/src/jmri/jmrit/logixng/actions/swing/SimulateTurnoutFeedbackSwing.java
+++ b/java/src/jmri/jmrit/logixng/actions/swing/SimulateTurnoutFeedbackSwing.java
@@ -1,0 +1,56 @@
+package jmri.jmrit.logixng.actions.swing;
+
+import java.util.List;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import javax.swing.JPanel;
+
+import jmri.InstanceManager;
+import jmri.jmrit.logixng.Base;
+import jmri.jmrit.logixng.DigitalActionManager;
+import jmri.jmrit.logixng.MaleSocket;
+import jmri.jmrit.logixng.actions.SimulateTurnoutFeedback;
+
+/**
+ * Configures an SimulateTurnoutFeedback object with a Swing JPanel.
+ *
+ * @author Daniel Bergqvist Copyright 2021
+ */
+public class SimulateTurnoutFeedbackSwing extends AbstractDigitalActionSwing {
+
+    @Override
+    protected void createPanel(@CheckForNull Base object, @Nonnull JPanel buttonPanel) {
+        panel = new JPanel();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean validate(@Nonnull List<String> errorMessages) {
+        return true;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public MaleSocket createNewObject(@Nonnull String systemName, @CheckForNull String userName) {
+        SimulateTurnoutFeedback action = new SimulateTurnoutFeedback(systemName, userName);
+        return InstanceManager.getDefault(DigitalActionManager.class).registerAction(action);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void updateObject(@Nonnull Base object) {
+        // Do nothing
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String toString() {
+        return Bundle.getMessage("SimulateTurnoutFeedback_Short");
+    }
+
+    @Override
+    public void dispose() {
+    }
+
+}

--- a/java/src/jmri/jmrit/logixng/expressions/ConnectionName.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ConnectionName.java
@@ -1,0 +1,119 @@
+package jmri.jmrit.logixng.expressions;
+
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Locale;
+import java.util.Map;
+
+import jmri.InstanceManager;
+import jmri.JmriException;
+import jmri.jmrit.logixng.*;
+import jmri.jmrit.logixng.util.LogixNG_SelectString;
+import jmri.jmrit.logixng.util.parser.ParserException;
+import jmri.jmrix.*;
+
+/**
+ * Returns true if there is a connection of specified type.
+ *
+ * @author Daniel Bergqvist Copyright 2022
+ */
+public class ConnectionName extends AbstractDigitalExpression
+        implements PropertyChangeListener {
+
+    private final LogixNG_SelectString _connectionName =
+            new LogixNG_SelectString(this, this);
+
+
+    public ConnectionName(String sys, String user)
+            throws BadUserNameException, BadSystemNameException {
+        super(sys, user);
+
+        _connectionName.setValue("LocoNet Simulator");
+    }
+
+    @Override
+    public Base getDeepCopy(Map<String, String> systemNames, Map<String, String> userNames) throws ParserException {
+        DigitalExpressionManager manager = InstanceManager.getDefault(DigitalExpressionManager.class);
+        String sysName = systemNames.get(getSystemName());
+        String userName = userNames.get(getSystemName());
+        if (sysName == null) sysName = manager.getAutoSystemName();
+        ConnectionName copy = new ConnectionName(sysName, userName);
+        copy.setComment(getComment());
+        _connectionName.copy(copy._connectionName);
+        return manager.registerExpression(copy);
+    }
+
+    public LogixNG_SelectString getSelectConnectionName() {
+        return _connectionName;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Category getCategory() {
+        return Category.OTHER;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean evaluate() throws JmriException {
+        String connectionName = _connectionName.evaluateValue(getConditionalNG());
+        ConnectionConfigManager manager = InstanceManager.getDefault(ConnectionConfigManager.class);
+        for (ConnectionConfig cc : manager.getConnections()) {
+            if (cc.name().equals(connectionName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public FemaleSocket getChild(int index) throws IllegalArgumentException, UnsupportedOperationException {
+        throw new UnsupportedOperationException("Not supported.");
+    }
+
+    @Override
+    public int getChildCount() {
+        return 0;
+    }
+
+    @Override
+    public String getShortDescription(Locale locale) {
+        return Bundle.getMessage(locale, "ConnectionName_Short");
+    }
+
+    @Override
+    public String getLongDescription(Locale locale) {
+        return Bundle.getMessage(locale, "ConnectionName_Long", _connectionName.getDescription(locale));
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void setup() {
+        // Do nothing
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void registerListenersForThisClass() {
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void unregisterListenersForThisClass() {
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void propertyChange(PropertyChangeEvent evt) {
+        getConditionalNG().execute();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void disposeMe() {
+    }
+
+
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ConnectionName.class);
+}

--- a/java/src/jmri/jmrit/logixng/expressions/ConnectionName.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ConnectionName.java
@@ -2,7 +2,6 @@ package jmri.jmrit.logixng.expressions;
 
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
-import java.lang.reflect.InvocationTargetException;
 import java.util.Locale;
 import java.util.Map;
 

--- a/java/src/jmri/jmrit/logixng/expressions/ConnectionName.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ConnectionName.java
@@ -8,9 +8,9 @@ import java.util.Map;
 import jmri.InstanceManager;
 import jmri.JmriException;
 import jmri.jmrit.logixng.*;
-import jmri.jmrit.logixng.util.LogixNG_SelectString;
 import jmri.jmrit.logixng.util.parser.ParserException;
 import jmri.jmrix.*;
+import static jmri.jmrix.JmrixConfigPane.NONE_SELECTED;
 
 /**
  * Returns true if there is a connection of specified type.
@@ -20,15 +20,13 @@ import jmri.jmrix.*;
 public class ConnectionName extends AbstractDigitalExpression
         implements PropertyChangeListener {
 
-    private final LogixNG_SelectString _connectionName =
-            new LogixNG_SelectString(this, this);
+    private String _manufacturer = NONE_SELECTED;
+    private String _connectionName = NONE_SELECTED;
 
 
     public ConnectionName(String sys, String user)
             throws BadUserNameException, BadSystemNameException {
         super(sys, user);
-
-        _connectionName.setValue("LocoNet Simulator");
     }
 
     @Override
@@ -39,11 +37,24 @@ public class ConnectionName extends AbstractDigitalExpression
         if (sysName == null) sysName = manager.getAutoSystemName();
         ConnectionName copy = new ConnectionName(sysName, userName);
         copy.setComment(getComment());
-        _connectionName.copy(copy._connectionName);
+        copy._manufacturer = _manufacturer;
+        copy._connectionName = _connectionName;
         return manager.registerExpression(copy);
     }
 
-    public LogixNG_SelectString getSelectConnectionName() {
+    public void setManufacturer(String manufacturer) {
+        _manufacturer = manufacturer;
+    }
+
+    public String getManufacturer() {
+        return _manufacturer;
+    }
+
+    public void setConnectionName(String name) {
+        _connectionName = name;
+    }
+
+    public String getConnectionName() {
         return _connectionName;
     }
 
@@ -56,10 +67,9 @@ public class ConnectionName extends AbstractDigitalExpression
     /** {@inheritDoc} */
     @Override
     public boolean evaluate() throws JmriException {
-        String connectionName = _connectionName.evaluateValue(getConditionalNG());
         ConnectionConfigManager manager = InstanceManager.getDefault(ConnectionConfigManager.class);
         for (ConnectionConfig cc : manager.getConnections()) {
-            if (cc.name().equals(connectionName)) {
+            if (cc.getManufacturer().equals(_manufacturer) && cc.name().equals(_connectionName)) {
                 return true;
             }
         }
@@ -83,7 +93,7 @@ public class ConnectionName extends AbstractDigitalExpression
 
     @Override
     public String getLongDescription(Locale locale) {
-        return Bundle.getMessage(locale, "ConnectionName_Long", _connectionName.getDescription(locale));
+        return Bundle.getMessage(locale, "ConnectionName_Long", _manufacturer, _connectionName);
     }
 
     /** {@inheritDoc} */

--- a/java/src/jmri/jmrit/logixng/expressions/ConnectionName.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ConnectionName.java
@@ -114,5 +114,5 @@ public class ConnectionName extends AbstractDigitalExpression
     }
 
 
-    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ConnectionName.class);
+//    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ConnectionName.class);
 }

--- a/java/src/jmri/jmrit/logixng/expressions/DigitalFactory.java
+++ b/java/src/jmri/jmrit/logixng/expressions/DigitalFactory.java
@@ -21,6 +21,7 @@ public class DigitalFactory implements DigitalExpressionFactory {
                         new AbstractMap.SimpleEntry<>(Category.COMMON, And.class),
                         new AbstractMap.SimpleEntry<>(Category.COMMON, Antecedent.class),
                         new AbstractMap.SimpleEntry<>(Category.OTHER, DigitalCallModule.class),
+                        new AbstractMap.SimpleEntry<>(Category.OTHER, ConnectionName.class),
                         new AbstractMap.SimpleEntry<>(Category.ITEM, ExpressionBlock.class),
                         new AbstractMap.SimpleEntry<>(Category.ITEM, ExpressionClock.class),
                         new AbstractMap.SimpleEntry<>(Category.ITEM, ExpressionConditional.class),
@@ -49,7 +50,7 @@ public class DigitalFactory implements DigitalExpressionFactory {
                         new AbstractMap.SimpleEntry<>(Category.OTHER, TriggerOnce.class),
                         new AbstractMap.SimpleEntry<>(Category.OTHER, True.class)
                 );
-        
+
         return expressionClasses;
     }
 

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionBundle.properties
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionBundle.properties
@@ -54,7 +54,7 @@ ConditionalOtherStatus  = Other
 Conditional_ConditionalInUseConditionalExpressionVeto   = Conditional is in use by Conditional expression "{0}"
 
 ConnectionName_Short    = Connection name
-ConnectionName_Long     = Connection "{0}" exists
+ConnectionName_Long     = Connection "{0}: {1}" exists
 
 DigitalCallModule_Short = Call module
 DigitalCallModule_Long  = Call module: {0}

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionBundle.properties
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionBundle.properties
@@ -53,6 +53,9 @@ ConditionalStateTrue    = True
 ConditionalOtherStatus  = Other
 Conditional_ConditionalInUseConditionalExpressionVeto   = Conditional is in use by Conditional expression "{0}"
 
+ConnectionName_Short    = Connection name
+ConnectionName_Long     = Connection "{0}" exists
+
 DigitalCallModule_Short = Call module
 DigitalCallModule_Long  = Call module: {0}
 DigitalCallModule_ModuleInUseVeto  = Module is in use by CallModule action "{0}"

--- a/java/src/jmri/jmrit/logixng/expressions/configurexml/ConnectionNameXml.java
+++ b/java/src/jmri/jmrit/logixng/expressions/configurexml/ConnectionNameXml.java
@@ -1,0 +1,64 @@
+package jmri.jmrit.logixng.expressions.configurexml;
+
+import jmri.InstanceManager;
+import jmri.configurexml.JmriConfigureXmlException;
+import jmri.jmrit.logixng.DigitalExpressionManager;
+import jmri.jmrit.logixng.expressions.ConnectionName;
+
+import org.jdom2.Element;
+
+import jmri.jmrit.logixng.DigitalExpressionBean;
+import jmri.jmrit.logixng.util.configurexml.LogixNG_SelectStringXml;
+
+/**
+ * Handle XML configuration for ConnectionName objects.
+ *
+ * @author Bob Jacobsen Copyright: Copyright (c) 2004, 2008, 2010
+ * @author Daniel Bergqvist Copyright (C) 2022
+ */
+public class ConnectionNameXml extends jmri.managers.configurexml.AbstractNamedBeanManagerConfigXML {
+
+    public ConnectionNameXml() {
+    }
+
+    /**
+     * Default implementation for storing the contents of a SE8cSignalHead
+     *
+     * @param o Object to store, of type ConnectionName
+     * @return Element containing the complete info
+     */
+    @Override
+    public Element store(Object o) {
+        ConnectionName p = (ConnectionName) o;
+
+        var selectConnectionNameXml = new LogixNG_SelectStringXml();
+
+        Element element = new Element("ConnectionName");
+        element.setAttribute("class", this.getClass().getName());
+        element.addContent(new Element("systemName").addContent(p.getSystemName()));
+
+        storeCommon(p, element);
+
+        element.addContent(selectConnectionNameXml.store(p.getSelectConnectionName(), "connectionName"));
+
+        return element;
+    }
+
+    @Override
+    public boolean load(Element shared, Element perNode) throws JmriConfigureXmlException {
+        String sys = getSystemName(shared);
+        String uname = getUserName(shared);
+        ConnectionName h = new ConnectionName(sys, uname);
+
+        loadCommon(h, shared);
+
+        var selectConnectionNameXml = new LogixNG_SelectStringXml();
+
+        selectConnectionNameXml.load(shared.getChild("connectionName"), h.getSelectConnectionName());
+
+        InstanceManager.getDefault(DigitalExpressionManager.class).registerExpression(h);
+        return true;
+    }
+
+//    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ConnectionNameXml.class);
+}

--- a/java/src/jmri/jmrit/logixng/expressions/configurexml/ConnectionNameXml.java
+++ b/java/src/jmri/jmrit/logixng/expressions/configurexml/ConnectionNameXml.java
@@ -31,15 +31,14 @@ public class ConnectionNameXml extends jmri.managers.configurexml.AbstractNamedB
     public Element store(Object o) {
         ConnectionName p = (ConnectionName) o;
 
-        var selectConnectionNameXml = new LogixNG_SelectStringXml();
-
         Element element = new Element("ConnectionName");
         element.setAttribute("class", this.getClass().getName());
         element.addContent(new Element("systemName").addContent(p.getSystemName()));
 
         storeCommon(p, element);
 
-        element.addContent(selectConnectionNameXml.store(p.getSelectConnectionName(), "connectionName"));
+        element.addContent(new Element("manufacturer").addContent(p.getManufacturer()));
+        element.addContent(new Element("connectionName").addContent(p.getConnectionName()));
 
         return element;
     }
@@ -52,9 +51,12 @@ public class ConnectionNameXml extends jmri.managers.configurexml.AbstractNamedB
 
         loadCommon(h, shared);
 
-        var selectConnectionNameXml = new LogixNG_SelectStringXml();
-
-        selectConnectionNameXml.load(shared.getChild("connectionName"), h.getSelectConnectionName());
+        if (shared.getChild("manufacturer") != null) {
+            h.setManufacturer(shared.getChild("manufacturer").getTextTrim());
+        }
+        if (shared.getChild("connectionName") != null) {
+            h.setConnectionName(shared.getChild("connectionName").getTextTrim());
+        }
 
         InstanceManager.getDefault(DigitalExpressionManager.class).registerExpression(h);
         return true;

--- a/java/src/jmri/jmrit/logixng/expressions/swing/ConnectionNameSwing.java
+++ b/java/src/jmri/jmrit/logixng/expressions/swing/ConnectionNameSwing.java
@@ -14,6 +14,7 @@ import jmri.jmrit.logixng.MaleSocket;
 import jmri.jmrit.logixng.expressions.ConnectionName;
 import jmri.jmrix.*;
 import static jmri.jmrix.JmrixConfigPane.NONE_SELECTED;
+import jmri.util.swing.JComboBoxUtil;
 
 /**
  * Configures an ConnectionName object with a Swing JPanel.
@@ -84,6 +85,9 @@ public class ConnectionNameSwing extends AbstractDigitalExpressionSwing {
         });
 
         updateConnectionComboBox(action);
+
+        JComboBoxUtil.setupComboBoxMaxRows(_manufacturerComboBox);
+        JComboBoxUtil.setupComboBoxMaxRows(_connectionComboBox);
 
 
         panel.add(manufacturerPanel);

--- a/java/src/jmri/jmrit/logixng/expressions/swing/ConnectionNameSwing.java
+++ b/java/src/jmri/jmrit/logixng/expressions/swing/ConnectionNameSwing.java
@@ -1,0 +1,176 @@
+package jmri.jmrit.logixng.expressions.swing;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.List;
+import java.awt.Dimension;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import javax.swing.*;
+
+import jmri.InstanceManager;
+import jmri.jmrit.logixng.Base;
+import jmri.jmrit.logixng.DigitalExpressionManager;
+import jmri.jmrit.logixng.MaleSocket;
+import jmri.jmrit.logixng.expressions.ConnectionName;
+import jmri.jmrit.logixng.util.swing.LogixNG_SelectStringSwing;
+import jmri.jmrix.*;
+
+/**
+ * Configures an ConnectionName object with a Swing JPanel.
+ *
+ * @author Daniel Bergqvist Copyright 2022
+ */
+public class ConnectionNameSwing extends AbstractDigitalExpressionSwing {
+
+    private LogixNG_SelectStringSwing _selectConnectionNameSwing;
+
+    public ConnectionNameSwing() {
+    }
+
+    public ConnectionNameSwing(JDialog dialog) {
+        super.setJDialog(dialog);
+    }
+
+    @Override
+    protected void createPanel(@CheckForNull Base object, @Nonnull JPanel buttonPanel) {
+        ConnectionName action = (ConnectionName) object;
+        if (action == null) {
+            // Create a temporary action
+            action = new ConnectionName("IQDE1", null);
+        }
+
+        _selectConnectionNameSwing = new LogixNG_SelectStringSwing(getJDialog(), this);
+
+        panel = new JPanel();
+        panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
+
+        JPanel tabbedPaneTopic = _selectConnectionNameSwing.createPanel(action.getSelectConnectionName());
+        panel.add(tabbedPaneTopic);
+
+
+        ConnectionConfigManager manager = InstanceManager.getDefault(ConnectionConfigManager.class);
+
+        JPanel connections = new JPanel();
+
+        JPanel currentConnections = new JPanel();
+        currentConnections.setLayout(new BoxLayout(currentConnections, BoxLayout.Y_AXIS));
+
+        currentConnections.add(new JLabel("Current connections"));
+        StringBuilder sb = new StringBuilder();
+        JTextArea currentConnectionsTextBox = new JTextArea();
+        currentConnectionsTextBox.setEditable(false);
+        JScrollPane connectionsScrollPane = new JScrollPane(currentConnectionsTextBox);
+        connectionsScrollPane.setPreferredSize(new Dimension(400, 300));
+        currentConnections.add(connectionsScrollPane);
+        for (ConnectionConfig cc : manager.getConnections()) {
+            sb.append(cc.name());
+            sb.append('\n');
+        }
+        currentConnectionsTextBox.setText(sb.toString());
+        currentConnectionsTextBox.setCaretPosition(0);
+        connections.add(currentConnections);
+
+
+        JPanel availableConnections = new JPanel();
+        availableConnections.setLayout(new BoxLayout(availableConnections, BoxLayout.Y_AXIS));
+
+        availableConnections.add(new JLabel("Available connections"));
+        sb = new StringBuilder();
+        JTextArea availableConnectionsTextBox = new JTextArea();
+        availableConnectionsTextBox.setEditable(false);
+        JScrollPane availableConnectionsScrollPane = new JScrollPane(availableConnectionsTextBox);
+        availableConnectionsScrollPane.setPreferredSize(new Dimension(400, 300));
+        availableConnections.add(availableConnectionsScrollPane);
+
+        String[] manufactureNameList = manager.getConnectionManufacturers();
+        for (String manuName : manufactureNameList) {
+            if (sb.length() != 0) {
+                sb.append("\n===============================\n\n");
+            }
+
+            sb.append(manuName);
+            sb.append("\n-------------------------------\n");
+
+            String[] classConnectionNameList;
+            classConnectionNameList = manager.getConnectionTypes(manuName);
+
+            for (String className : classConnectionNameList) {
+                try {
+                    ConnectionConfig config;
+                    Class<?> cl = Class.forName(className);
+                    config = (ConnectionConfig) cl.getDeclaredConstructor().newInstance();
+                    if( !(config instanceof StreamConnectionConfig)) {
+                        // only include if the connection is not a
+                        // StreamConnection.  Those connections require
+                        // additional context.
+                        if (config != null) {
+                            sb.append(config.name());
+                            sb.append('\n');
+                        }
+                    }
+                } catch (NullPointerException e) {
+                    log.error("Attempt to load {} failed.", className, e);
+                } catch (InvocationTargetException | ClassNotFoundException | InstantiationException | IllegalAccessException | NoSuchMethodException e) {
+                    log.error("Attempt to load {} failed", className, e);
+                }
+            }
+        }
+
+        for (ConnectionConfig cc : manager.getConnections()) {
+            sb.append(cc.name());
+            sb.append('\n');
+        }
+        availableConnectionsTextBox.setText(sb.toString());
+        availableConnectionsTextBox.setCaretPosition(0);
+        connections.add(availableConnections);
+
+
+        panel.add(connections);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean validate(@Nonnull List<String> errorMessages) {
+        // Create a temporary action to test formula
+        ConnectionName action = new ConnectionName("IQDE1", null);
+
+        _selectConnectionNameSwing.validate(action.getSelectConnectionName(), errorMessages);
+
+        return errorMessages.isEmpty();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public MaleSocket createNewObject(@Nonnull String systemName, @CheckForNull String userName) {
+        ConnectionName action = new ConnectionName(systemName, userName);
+        updateObject(action);
+        return InstanceManager.getDefault(DigitalExpressionManager.class).registerExpression(action);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void updateObject(@Nonnull Base object) {
+        if (! (object instanceof ConnectionName)) {
+            throw new IllegalArgumentException("object must be an ConnectionName but is a: "+object.getClass().getName());
+        }
+        ConnectionName action = (ConnectionName) object;
+
+        _selectConnectionNameSwing.updateObject(action.getSelectConnectionName());
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String toString() {
+        return Bundle.getMessage("ConnectionName_Short");
+    }
+
+    @Override
+    public void dispose() {
+        _selectConnectionNameSwing.dispose();
+    }
+
+
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ConnectionNameSwing.class);
+
+}

--- a/java/src/jmri/jmrit/logixng/expressions/swing/ConnectionNameSwing.java
+++ b/java/src/jmri/jmrit/logixng/expressions/swing/ConnectionNameSwing.java
@@ -138,10 +138,9 @@ public class ConnectionNameSwing extends AbstractDigitalExpressionSwing {
             }
         }
 
-        // Resize panel if needed
-        panel.doLayout();
-//        JDialog dialog = (JDialog) SwingUtilities.getAncestorOfClass(JDialog.class, _manufacturerComboBox);
-//        if (dialog != null) dialog.doLayout();
+        // Resize dialog if needed
+        JDialog dialog = (JDialog) SwingUtilities.getAncestorOfClass(JDialog.class, _manufacturerComboBox);
+        if (dialog != null) dialog.pack();
     }
 
     /** {@inheritDoc} */

--- a/java/test/jmri/jmrit/logixng/ActionsAndExpressionsTest.java
+++ b/java/test/jmri/jmrit/logixng/ActionsAndExpressionsTest.java
@@ -14,7 +14,6 @@ import javax.swing.JPanel;
 
 import jmri.InstanceManager;
 import jmri.jmrit.logixng.swing.SwingConfiguratorInterface;
-import jmri.util.JUnitAppender;
 import jmri.util.JUnitUtil;
 
 // import org.apache.log4j.Level;
@@ -318,7 +317,6 @@ public class ActionsAndExpressionsTest {
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.deregisterBlockManagerShutdownTask();
-        JUnitAppender.suppressErrorMessage("Expected to run on Raspberry PI, but does not appear to be.");
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/ActionsAndExpressionsTest.java
+++ b/java/test/jmri/jmrit/logixng/ActionsAndExpressionsTest.java
@@ -14,7 +14,7 @@ import javax.swing.JPanel;
 
 import jmri.InstanceManager;
 import jmri.jmrit.logixng.swing.SwingConfiguratorInterface;
-// import jmri.util.JUnitAppender;
+import jmri.util.JUnitAppender;
 import jmri.util.JUnitUtil;
 
 // import org.apache.log4j.Level;
@@ -318,6 +318,7 @@ public class ActionsAndExpressionsTest {
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.deregisterBlockManagerShutdownTask();
+        JUnitAppender.suppressErrorMessage("Expected to run on Raspberry PI, but does not appear to be.");
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/CreateLogixNGTreeScaffold.java
+++ b/java/test/jmri/jmrit/logixng/CreateLogixNGTreeScaffold.java
@@ -2547,6 +2547,19 @@ public class CreateLogixNGTreeScaffold {
         actionManySocket.getChild(indexAction++).connect(maleSocket);
 
 
+        SimulateTurnoutFeedback simulateTurnoutFeedback =
+                new SimulateTurnoutFeedback(digitalActionManager.getAutoSystemName(), null);
+        maleSocket = digitalActionManager.registerAction(simulateTurnoutFeedback);
+        maleSocket.setEnabled(false);
+        actionManySocket.getChild(indexAction++).connect(maleSocket);
+
+        simulateTurnoutFeedback = new SimulateTurnoutFeedback(digitalActionManager.getAutoSystemName(), null);
+        simulateTurnoutFeedback.setComment("A comment");
+        maleSocket = digitalActionManager.registerAction(simulateTurnoutFeedback);
+        actionManySocket.getChild(indexAction++).connect(maleSocket);
+
+
+
         TableForEach tableForEach = new TableForEach(digitalActionManager.getAutoSystemName(), null);
         tableForEach.setRowOrColumn(TableRowOrColumn.Column);
         maleSocket = digitalActionManager.registerAction(tableForEach);

--- a/java/test/jmri/jmrit/logixng/CreateLogixNGTreeScaffold.java
+++ b/java/test/jmri/jmrit/logixng/CreateLogixNGTreeScaffold.java
@@ -2735,6 +2735,17 @@ public class CreateLogixNGTreeScaffold {
         and.getChild(indexExpr++).connect(maleSocket);
 
 
+        ConnectionName connectionType = new ConnectionName(digitalExpressionManager.getAutoSystemName(), null);
+        maleSocket = digitalExpressionManager.registerExpression(connectionType);
+        maleSocket.setEnabled(false);
+        and.getChild(indexExpr++).connect(maleSocket);
+
+        connectionType = new ConnectionName(digitalExpressionManager.getAutoSystemName(), null);
+        connectionType.setComment("A comment");
+        maleSocket = digitalExpressionManager.registerExpression(connectionType);
+        and.getChild(indexExpr++).connect(maleSocket);
+
+
         jmri.jmrit.logixng.expressions.DigitalCallModule expressionCallModule = new jmri.jmrit.logixng.expressions.DigitalCallModule(digitalExpressionManager.getAutoSystemName(), null);
         maleSocket = digitalExpressionManager.registerExpression(expressionCallModule);
         maleSocket.setEnabled(false);

--- a/java/test/jmri/jmrit/logixng/SocketOperationTest.java
+++ b/java/test/jmri/jmrit/logixng/SocketOperationTest.java
@@ -183,7 +183,6 @@ public class SocketOperationTest {
         CreateLogixNGTreeScaffold.tearDown();
     }
 
-
 //    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(DeepCopyTest.class);
 
 }

--- a/java/test/jmri/jmrit/logixng/SocketOperationTest.java
+++ b/java/test/jmri/jmrit/logixng/SocketOperationTest.java
@@ -179,6 +179,7 @@ public class SocketOperationTest {
     @After
     public void tearDown() {
 //        JUnitAppender.clearBacklog();    // REMOVE THIS!!!
+        JUnitAppender.suppressErrorMessage("Expected to run on Raspberry PI, but does not appear to be.");
         CreateLogixNGTreeScaffold.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/SocketOperationTest.java
+++ b/java/test/jmri/jmrit/logixng/SocketOperationTest.java
@@ -179,7 +179,7 @@ public class SocketOperationTest {
     @After
     public void tearDown() {
 //        JUnitAppender.clearBacklog();    // REMOVE THIS!!!
-        JUnitAppender.suppressErrorMessage("Expected to run on Raspberry PI, but does not appear to be.");
+        jmri.util.JUnitAppender.suppressErrorMessage("Expected to run on Raspberry PI, but does not appear to be.");
         CreateLogixNGTreeScaffold.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/SocketOperationTest.java
+++ b/java/test/jmri/jmrit/logixng/SocketOperationTest.java
@@ -7,7 +7,6 @@ import java.util.*;
 import jmri.*;
 import jmri.jmrit.logixng.swing.SwingConfiguratorInterface;
 import jmri.jmrit.logixng.swing.SwingTools;
-import jmri.util.*;
 
 import org.junit.*;
 
@@ -179,7 +178,6 @@ public class SocketOperationTest {
     @After
     public void tearDown() {
 //        JUnitAppender.clearBacklog();    // REMOVE THIS!!!
-        jmri.util.JUnitAppender.suppressErrorMessage("Expected to run on Raspberry PI, but does not appear to be.");
         CreateLogixNGTreeScaffold.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/TestSwingClasses.java
+++ b/java/test/jmri/jmrit/logixng/TestSwingClasses.java
@@ -10,8 +10,7 @@ import javax.swing.JPanel;
 import jmri.*;
 import jmri.jmrit.logixng.swing.SwingConfiguratorInterface;
 import jmri.jmrit.logixng.swing.SwingTools;
-import jmri.util.JUnitUtil;
-import jmri.util.ThreadingUtil;
+import jmri.util.*;
 
 import org.junit.Assert;
 import org.junit.jupiter.api.*;
@@ -130,6 +129,7 @@ public class TestSwingClasses {
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.deregisterBlockManagerShutdownTask();
+        JUnitAppender.suppressErrorMessage("Expected to run on Raspberry PI, but does not appear to be.");
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/TestSwingClasses.java
+++ b/java/test/jmri/jmrit/logixng/TestSwingClasses.java
@@ -129,7 +129,6 @@ public class TestSwingClasses {
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.deregisterBlockManagerShutdownTask();
-        JUnitAppender.suppressErrorMessage("Expected to run on Raspberry PI, but does not appear to be.");
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/implementation/DefaultFemaleDigitalActionSocketTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/DefaultFemaleDigitalActionSocketTest.java
@@ -140,6 +140,7 @@ public class DefaultFemaleDigitalActionSocketTest extends FemaleSocketTestBase {
         classes.add(jmri.jmrit.logixng.actions.Timeout.class);
         classes.add(jmri.jmrit.logixng.actions.ShowDialog.class);
         classes.add(jmri.jmrit.logixng.actions.ShutdownComputer.class);
+        classes.add(jmri.jmrit.logixng.actions.SimulateTurnoutFeedback.class);
         classes.add(jmri.jmrit.logixng.actions.WebBrowser.class);
         map.put(Category.OTHER, classes);
 

--- a/java/test/jmri/jmrit/logixng/implementation/DefaultFemaleDigitalExpressionSocketTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/DefaultFemaleDigitalExpressionSocketTest.java
@@ -119,6 +119,7 @@ public class DefaultFemaleDigitalExpressionSocketTest extends FemaleSocketTestBa
         map.put(Category.COMMON, classes);
 
         classes = new ArrayList<>();
+        classes.add(jmri.jmrit.logixng.expressions.ConnectionName.class);
         classes.add(jmri.jmrit.logixng.expressions.DigitalCallModule.class);
         classes.add(jmri.jmrit.logixng.expressions.False.class);
         classes.add(jmri.jmrit.logixng.expressions.Hold.class);
@@ -169,6 +170,7 @@ public class DefaultFemaleDigitalExpressionSocketTest extends FemaleSocketTestBa
 //        JUnitAppender.clearBacklog();   // REMOVE THIS!!!
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.deregisterBlockManagerShutdownTask();
+        JUnitAppender.suppressErrorMessage("Expected to run on Raspberry PI, but does not appear to be.");
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/implementation/DefaultFemaleDigitalExpressionSocketTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/DefaultFemaleDigitalExpressionSocketTest.java
@@ -9,7 +9,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import jmri.*;
 import jmri.jmrit.logixng.*;
 import jmri.jmrit.logixng.expressions.ExpressionTurnout;
-import jmri.util.JUnitAppender;
 import jmri.util.JUnitUtil;
 
 import org.junit.After;
@@ -170,7 +169,6 @@ public class DefaultFemaleDigitalExpressionSocketTest extends FemaleSocketTestBa
 //        JUnitAppender.clearBacklog();   // REMOVE THIS!!!
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.deregisterBlockManagerShutdownTask();
-        JUnitAppender.suppressErrorMessage("Expected to run on Raspberry PI, but does not appear to be.");
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/implementation/DefaultFemaleGenericExpressionSocket1_Test.java
+++ b/java/test/jmri/jmrit/logixng/implementation/DefaultFemaleGenericExpressionSocket1_Test.java
@@ -14,6 +14,7 @@ import jmri.jmrit.logixng.expressions.ExpressionMemory;
 import jmri.jmrit.logixng.expressions.ExpressionTurnout;
 import jmri.jmrit.logixng.expressions.StringExpressionConstant;
 import jmri.jmrit.logixng.expressions.StringExpressionMemory;
+import jmri.util.JUnitAppender;
 import jmri.util.JUnitUtil;
 
 import org.junit.After;
@@ -430,6 +431,7 @@ public class DefaultFemaleGenericExpressionSocket1_Test extends FemaleSocketTest
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.deregisterBlockManagerShutdownTask();
+        JUnitAppender.suppressErrorMessage("Expected to run on Raspberry PI, but does not appear to be.");
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/implementation/DefaultFemaleGenericExpressionSocket1_Test.java
+++ b/java/test/jmri/jmrit/logixng/implementation/DefaultFemaleGenericExpressionSocket1_Test.java
@@ -14,13 +14,11 @@ import jmri.jmrit.logixng.expressions.ExpressionMemory;
 import jmri.jmrit.logixng.expressions.ExpressionTurnout;
 import jmri.jmrit.logixng.expressions.StringExpressionConstant;
 import jmri.jmrit.logixng.expressions.StringExpressionMemory;
-import jmri.util.JUnitAppender;
 import jmri.util.JUnitUtil;
 
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -431,7 +429,6 @@ public class DefaultFemaleGenericExpressionSocket1_Test extends FemaleSocketTest
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.deregisterBlockManagerShutdownTask();
-        JUnitAppender.suppressErrorMessage("Expected to run on Raspberry PI, but does not appear to be.");
         JUnitUtil.tearDown();
     }
 

--- a/xml/schema/logixng/digital-actions/digital-actions-4.23.1.xsd
+++ b/xml/schema/logixng/digital-actions/digital-actions-4.23.1.xsd
@@ -69,6 +69,7 @@
   <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/digital-actions/sequence-4.23.1.xsd"/>
   <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/digital-actions/show-dialog-4.25.7.xsd"/>
   <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/digital-actions/shutdown-computer-4.23.1.xsd"/>
+  <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/digital-actions/simulate-turnout-feedback-5.1.3.xsd"/>
   <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/digital-actions/table-for-each-4.23.1.xsd"/>
   <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/digital-actions/timeout-4.25.7.xsd"/>
   <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/digital-actions/throttle-4.23.1.xsd"/>
@@ -134,6 +135,7 @@
             <xs:element name="Sequence"          type="LogixNG_DigitalAction_SequenceType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="ShowDialog"        type="LogixNG_DigitalAction_ShowDialogType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="ShutdownComputer"  type="LogixNG_DigitalAction_ShutdownComputerType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="SimulateTurnoutFeedback"  type="LogixNG_DigitalAction_SimulateTurnoutFeedbackType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="TableForEach"      type="LogixNG_DigitalAction_TableForEachType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="Throttle"          type="LogixNG_DigitalAction_ThrottleType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="Timeout"           type="LogixNG_DigitalAction_TimeoutType" minOccurs="0" maxOccurs="unbounded" />

--- a/xml/schema/logixng/digital-actions/simulate-turnout-feedback-5.1.3.xsd
+++ b/xml/schema/logixng/digital-actions/simulate-turnout-feedback-5.1.3.xsd
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="../schema2xhtml.xsl" type="text/xsl"?>
+
+<!-- This schema is part of JMRI. Copyright 2018.                           -->
+<!--                                                                        -->
+<!-- JMRI is free software; you can redistribute it and/or modify it under  -->
+<!-- the terms of version 2 of the GNU General Public License as published  -->
+<!-- by the Free Software Foundation. See the "COPYING" file for a copy     -->
+<!-- of this license.                                                       -->
+<!--                                                                        -->
+<!-- JMRI is distributed in the hope that it will be useful, but WITHOUT    -->
+<!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
+<!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
+<!-- for more details.                                                      -->
+
+<!-- This file contains definitions for LogixNG                             -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:xsi ="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:docbook="http://docbook.org/ns/docbook"
+           xmlns:jmri="http://jmri.org/xml/schema/JMRIschema"
+           xsi:schemaLocation="
+                http://jmri.org/xml/schema/JMRIschema http://jmri.org/xml/schema/JMRIschema.xsd
+                http://docbook.org/ns/docbook http://jmri.org/xml/schema/docbook/docbook.xsd
+            "
+        >
+
+    <xs:complexType name="LogixNG_DigitalAction_SimulateTurnoutFeedbackType">
+      <xs:annotation>
+        <xs:documentation>
+          Define the XML stucture for storing the contents of a SimulateTurnoutFeedback class.
+        </xs:documentation>
+        <xs:appinfo>
+            <jmri:usingclass configurexml="true">jmri.jmrit.logixng.digital.actions.configurexml.ManyXml</jmri:usingclass>
+        </xs:appinfo>
+      </xs:annotation>
+
+            <xs:sequence>
+              <xs:element name="systemName" type="systemNameType" minOccurs="1" maxOccurs="1"/>
+              <xs:element name="userName" type="userNameType" minOccurs="0" maxOccurs="1"/>
+              <xs:element name="comment" type="commentType" minOccurs="0" maxOccurs="unbounded"/>
+
+              <xs:element name="MaleSocket" type="LogixNG_MaleSocket_Type" minOccurs="0" maxOccurs="1"/>
+
+            </xs:sequence>
+            <xs:attribute name="enabled" type="yesNoType" />
+            <xs:attribute name="class" type="classType" use="required"/>
+
+    </xs:complexType>
+
+</xs:schema>

--- a/xml/schema/logixng/digital-expressions/connection-name-5.1.3.xsd
+++ b/xml/schema/logixng/digital-expressions/connection-name-5.1.3.xsd
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="../schema2xhtml.xsl" type="text/xsl"?>
+
+<!-- This schema is part of JMRI. Copyright 2018.                           -->
+<!--                                                                        -->
+<!-- JMRI is free software; you can redistribute it and/or modify it under  -->
+<!-- the terms of version 2 of the GNU General Public License as published  -->
+<!-- by the Free Software Foundation. See the "COPYING" file for a copy     -->
+<!-- of this license.                                                       -->
+<!--                                                                        -->
+<!-- JMRI is distributed in the hope that it will be useful, but WITHOUT    -->
+<!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
+<!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
+<!-- for more details.                                                      -->
+
+<!-- This file contains definitions for LogixNG                             -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:xsi ="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:docbook="http://docbook.org/ns/docbook"
+           xmlns:jmri="http://jmri.org/xml/schema/JMRIschema"
+           xsi:schemaLocation="
+                http://jmri.org/xml/schema/JMRIschema http://jmri.org/xml/schema/JMRIschema.xsd
+                http://docbook.org/ns/docbook http://jmri.org/xml/schema/docbook/docbook.xsd
+            "
+        >
+
+    <xs:complexType name="LogixNG_DigitalExpression_ConnectionNameType">
+      <xs:annotation>
+        <xs:documentation>
+          Define the XML stucture for storing the contents of a ConnectionName class.
+        </xs:documentation>
+        <xs:appinfo>
+            <jmri:usingclass configurexml="true">jmri.jmrit.logixng.digital.expressions.configurexml.ConnectionNameXml</jmri:usingclass>
+        </xs:appinfo>
+      </xs:annotation>
+
+            <xs:sequence>
+              <xs:element name="systemName" type="systemNameType" minOccurs="1" maxOccurs="1"/>
+              <xs:element name="userName" type="userNameType" minOccurs="0" maxOccurs="1"/>
+              <xs:element name="comment" type="commentType" minOccurs="0" maxOccurs="unbounded"/>
+
+              <xs:element name="connectionName" type="LogixNG_SelectStringType" minOccurs="1" maxOccurs="1" />
+
+			  <xs:element name="MaleSocket" type="LogixNG_MaleSocket_Type" minOccurs="0" maxOccurs="1"/>
+
+            </xs:sequence>
+<!--            <xs:attribute name="enabled" type="yesNoType" /> -->
+            <xs:attribute name="class" type="classType" use="required"/>
+
+    </xs:complexType>
+
+</xs:schema>

--- a/xml/schema/logixng/digital-expressions/connection-name-5.1.3.xsd
+++ b/xml/schema/logixng/digital-expressions/connection-name-5.1.3.xsd
@@ -40,7 +40,8 @@
               <xs:element name="userName" type="userNameType" minOccurs="0" maxOccurs="1"/>
               <xs:element name="comment" type="commentType" minOccurs="0" maxOccurs="unbounded"/>
 
-              <xs:element name="connectionName" type="LogixNG_SelectStringType" minOccurs="1" maxOccurs="1" />
+              <xs:element name="manufacturer" type="xs:string" minOccurs="1" maxOccurs="1" />
+              <xs:element name="connectionName" type="xs:string" minOccurs="1" maxOccurs="1" />
 
 			  <xs:element name="MaleSocket" type="LogixNG_MaleSocket_Type" minOccurs="0" maxOccurs="1"/>
 

--- a/xml/schema/logixng/digital-expressions/digital-expressions-4.23.1.xsd
+++ b/xml/schema/logixng/digital-expressions/digital-expressions-4.23.1.xsd
@@ -27,6 +27,7 @@
 
   <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/digital-expressions/and-4.23.1.xsd"/>
   <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/digital-expressions/antecedent-4.23.1.xsd"/>
+  <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/digital-expressions/connection-name-5.1.3.xsd"/>
   <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/digital-expressions/digital-call-module-4.23.4.xsd"/>
   <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/digital-expressions/expression-block-4.23.1.xsd"/>
   <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/digital-expressions/expression-clock-4.23.1.xsd"/>
@@ -76,6 +77,7 @@
             <xs:element name="And"                type="LogixNG_DigitalExpression_AndType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="Antecedent"         type="LogixNG_DigitalExpression_AntecedentType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="CallDigitalExpressionModule"  type="LogixNG_DigitalExpression_CallModuleType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="ConnectionName"     type="LogixNG_DigitalExpression_ConnectionNameType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="ExpressionBlock"    type="LogixNG_DigitalExpression_ExpressionBlock" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="ExpressionClock"    type="LogixNG_DigitalExpression_ExpressionClockType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="ExpressionConditional"  type="LogixNG_DigitalExpression_ExpressionConditionalType" minOccurs="0" maxOccurs="unbounded" />


### PR DESCRIPTION
See jmri developers thread:
https://jmri-developers.groups.io/g/jmri/message/7580

This PR adds a new LogixNG action `Simulate turnout feedback`. It's currently experimental so feel free to come with your opinions.

The new action register itself as a listener to all existing and new turnouts. When a turnout changes its commanded state, the action looks at the turnout's feedback mode.

**One sensor feedback**
It waits some time and then sets the feedback sensor to INACTIVE or ACTIVE.

**Two sensor feedback**
Sets the both feedback sensors to INACTIVE. It then waits some time and then sets the proper feedback sensor to ACTIVE.

**Exact**
For LocoNet and XpressNet turnouts, it waits some time and then sets the Known state to the Commanded state.

Other feedback modes are not yet implemented. Comments on how to do that are welcome.

Currently, the delay is three seconds. It's easy to do that configurable by the user, but I would like feedback from the developers about this new LogixNG action first.