### PR TITLE
Jmrix traffic controller tests

### DIFF
--- a/java/test/jmri/jmrix/nce/NceListenerScaffold.java
+++ b/java/test/jmri/jmrix/nce/NceListenerScaffold.java
@@ -6,7 +6,7 @@
 package jmri.jmrix.nce;
 
 
-class NceListenerScaffold implements jmri.jmrix.nce.NceListener {
+public class NceListenerScaffold implements jmri.jmrix.nce.NceListener {
 
     public NceListenerScaffold() {
         rcvdReply = null;

--- a/java/test/jmri/jmrix/qsi/QsiListenerScaffold.java
+++ b/java/test/jmri/jmrix/qsi/QsiListenerScaffold.java
@@ -6,7 +6,7 @@ package jmri.jmrix.qsi;
  *
  * @author Bob Jacobsen
  */
-class QsiListenerScaffold implements QsiListener {
+public class QsiListenerScaffold implements QsiListener {
 
     public QsiListenerScaffold() {
         rcvdReply = null;

--- a/java/test/jmri/jmrix/secsi/SerialTrafficControllerTest.java
+++ b/java/test/jmri/jmrix/secsi/SerialTrafficControllerTest.java
@@ -6,13 +6,10 @@ import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
 
 import jmri.jmrix.AbstractMRMessage;
-import jmri.SystemConnectionMemo;
 import jmri.util.JUnitUtil;
 
 import org.junit.Assert;
 import org.junit.jupiter.api.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * JUnit tests for the SerialTrafficController class
@@ -71,10 +68,41 @@ public class SerialTrafficControllerTest extends jmri.jmrix.AbstractMRNodeTraffi
         Assert.assertEquals("byte 4 hi nibble", 0x70, m.getElement(8));
     }
 
-    // internal class to simulate a Listener
-    class SerialListenerScaffold implements SerialListener {
+    @Test
+    public void testListenerScaffold() {
+        SerialListenerScaffold l = new SerialListenerScaffold();
+        SerialMessage msg = new SerialMessage(5);
+        msg.setOpCode(0x81);
+        msg.setElement(1, (byte) 0x02);
+        msg.setElement(2, (byte) 0xA2);
+        msg.setElement(3, (byte) 0x00);
+        
+        l.message(msg);
+        Assertions.assertTrue( msg == rcvdMsg );
+        
+        SerialReply reply = new SerialReply("010203");
+        l.reply(reply);
+        Assertions.assertTrue( reply == rcvdReply );
+        
+    }
 
-        public SerialListenerScaffold() {
+    @Test
+    public void testScaffold() throws java.io.IOException {
+        SerialPortControllerScaffold scaff = new SerialPortControllerScaffold(memo);
+        
+        Assertions.assertNotNull(scaff);
+        Assertions.assertNotNull(tostream);
+        Assertions.assertNotNull(ostream);
+        Assertions.assertNotNull(istream);
+        Assertions.assertNotNull(tistream);
+        
+        scaff.dispose();
+    }
+
+    // internal class to simulate a Listener
+    private class SerialListenerScaffold implements SerialListener {
+
+        SerialListenerScaffold() {
             rcvdReply = null;
             rcvdMsg = null;
         }
@@ -93,7 +121,18 @@ public class SerialTrafficControllerTest extends jmri.jmrix.AbstractMRNodeTraffi
     SerialMessage rcvdMsg;
 
     // internal class to simulate a PortController
-    class SerialPortControllerScaffold extends SerialPortController {
+    private class SerialPortControllerScaffold extends SerialPortController {
+
+        SerialPortControllerScaffold(SecsiSystemConnectionMemo memo) throws java.io.IOException {
+            super(memo);
+            PipedInputStream tempPipe;
+            tempPipe = new PipedInputStream();
+            tostream = new DataInputStream(tempPipe);
+            ostream = new DataOutputStream(new PipedOutputStream(tempPipe));
+            tempPipe = new PipedInputStream();
+            istream = new DataInputStream(tempPipe);
+            tistream = new DataOutputStream(new PipedOutputStream(tempPipe));
+        }
 
         @Override
         public java.util.Vector<String> getPortNames() {
@@ -120,17 +159,6 @@ public class SerialTrafficControllerTest extends jmri.jmrix.AbstractMRNodeTraffi
             return new int[] {};
         }
 
-        protected SerialPortControllerScaffold() throws Exception {
-            super(null);
-            PipedInputStream tempPipe;
-            tempPipe = new PipedInputStream();
-            tostream = new DataInputStream(tempPipe);
-            ostream = new DataOutputStream(new PipedOutputStream(tempPipe));
-            tempPipe = new PipedInputStream();
-            istream = new DataInputStream(tempPipe);
-            tistream = new DataOutputStream(new PipedOutputStream(tempPipe));
-        }
-
         // returns the InputStream from the port
         @Override
         public DataInputStream getInputStream() {
@@ -149,28 +177,31 @@ public class SerialTrafficControllerTest extends jmri.jmrix.AbstractMRNodeTraffi
             return true;
         }
 
-        @Override
-        public SystemConnectionMemo getSystemConnectionMemo() {
-            return null; // No SystemConnectionMemo
-        }
     }
-    static DataOutputStream ostream;  // Traffic controller writes to this
-    static DataInputStream tostream; // so we can read it from this
 
-    static DataOutputStream tistream; // tests write to this
-    static DataInputStream istream;  // so the traffic controller can read from this
+    private DataOutputStream ostream;  // Traffic controller writes to this
+    private DataInputStream tostream; // so we can read it from this
 
+    private DataOutputStream tistream; // tests write to this
+    private DataInputStream istream;  // so the traffic controller can read from this
+
+    private SecsiSystemConnectionMemo memo;
+    
     @Override
     @BeforeEach
     public  void setUp() {
         JUnitUtil.setUp();
-        SecsiSystemConnectionMemo memo = new SecsiSystemConnectionMemo();
+        memo = new SecsiSystemConnectionMemo();
         tc = new SerialTrafficController(memo);
     }
 
     @Override
     @AfterEach
     public  void tearDown() {
+        if ( memo != null ) {
+            memo.dispose();
+            memo = null;
+        }
         JUnitUtil.clearShutDownManager(); // put in place because AbstractMRTrafficController implementing subclass was not terminated properly
         JUnitUtil.tearDown();
     }

--- a/java/test/jmri/jmrix/secsi/SerialTrafficControllerTest.java
+++ b/java/test/jmri/jmrix/secsi/SerialTrafficControllerTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.*;
  */
 public class SerialTrafficControllerTest extends jmri.jmrix.AbstractMRNodeTrafficControllerTest {
 
+    @Test
     public void testSerialNodeEnumeration() {
         SerialTrafficController c = (SerialTrafficController)tc;
         SerialNode b = new SerialNode(1, SerialNode.DAUGHTER,c);
@@ -46,6 +47,8 @@ public class SerialTrafficControllerTest extends jmri.jmrix.AbstractMRNodeTraffi
         Assert.assertEquals("no more Nodes after del2", null, c.getNode(2));
     }
 
+    @Test
+    @Disabled("Test requires further setup")
     public void testSerialOutput() {
         SerialTrafficController c = (SerialTrafficController)tc;
         SerialNode a = new SerialNode(c);

--- a/java/test/jmri/jmrix/sprog/SprogTrafficControlScaffold.java
+++ b/java/test/jmri/jmrix/sprog/SprogTrafficControlScaffold.java
@@ -20,7 +20,7 @@ public class SprogTrafficControlScaffold extends SprogTrafficController {
        super(memo);
     }
 
-    public void setTestReplies(boolean state) {
+    public synchronized void setTestReplies(boolean state) {
         useTestReplies = state;
     }
     
@@ -33,7 +33,7 @@ public class SprogTrafficControlScaffold extends SprogTrafficController {
     /**
      * record messages sent, provide access for making sure they are OK
      */
-    public Vector<SprogMessage> outbound = new Vector<SprogMessage>();  // public OK here, so long as this is a test class
+    public Vector<SprogMessage> outbound = new Vector<>();  // public OK here, so long as this is a test class
 
     @Override
     public void sendSprogMessage(SprogMessage m) {
@@ -70,11 +70,8 @@ public class SprogTrafficControlScaffold extends SprogTrafficController {
      */
     protected void sendTestMessage(SprogMessage m, SprogListener l) {
         // forward a test message to NceListeners
-        if (log.isDebugEnabled()) {
-            log.debug("sendTestMessage    [{}]", m);
-        }
+        log.debug("sendTestMessage    [{}]", m);
         notifyMessage(m, l);
-        return;
     }
 
     /**
@@ -82,16 +79,14 @@ public class SprogTrafficControlScaffold extends SprogTrafficController {
      */
     protected void sendTestReply(SprogReply m) {
         // forward a test message to NceListeners
-        if (log.isDebugEnabled()) {
-            log.debug("sendTestReply [{}]", m);
-        }
+        log.debug("sendTestReply [{}]", m);
         notifyReply(m);
         try {
             Thread.sleep(50);
         } catch (InterruptedException e) {
             log.debug("Thread interrupted while sleeping");
         }
-        return;
+
     }
 
     /*

--- a/java/test/jmri/jmrix/sprog/SprogTrafficControllerTest.java
+++ b/java/test/jmri/jmrix/sprog/SprogTrafficControllerTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.*;
 public class SprogTrafficControllerTest {
 
    @Test
-   public void ConstructorTest(){
+   public void testConstructor(){
        SprogSystemConnectionMemo m = new SprogSystemConnectionMemo();
        SprogTrafficController tc = new SprogTrafficController(m);
        Assert.assertNotNull(tc);


### PR DESCRIPTION
Update QsiListenerScaffold.java - make class public
 
Update QsiTrafficControllerTest.java -
Use JUnitUtil.waitFor over wait
use external QsiListenerScaffold, remove duplicated class
DataStreams from static to instance
 
Update secsi SerialTrafficControllerTest.java -
DataStreams to instance from static
Add scaffold tests
SerialPortControllerScaffold constructor to top of class
add Test annotation

Update SprogTrafficControllerTest.java - method name starts lowercase
 
Update tmcc SerialTrafficControllerTest.java -
use JUnitUtil.waitFor
move SerialPortControllerScaffold constructor to top of class
Datastreams to instance from static

Update SprogTrafficControlScaffold.java - useTestReplies synchronized access
 
Update oaktree SerialTrafficControllerTest.java - 
test Listener Scaffold
SerialPortControllerScaffold constructor to top of class
Datastreams to instance from static
 
Update NceTrafficControllerTest.java - 
use JUnitUtil.waitFor
use main NceListenerScaffold
DataStreams to instance from static
 
Update NceListenerScaffold.java  - public class for public constructor