### PR TITLE
More jmrix traffic control test tweaks

### DIFF
--- a/java/src/jmri/jmrix/grapevine/SerialTrafficController.java
+++ b/java/src/jmri/jmrix/grapevine/SerialTrafficController.java
@@ -377,7 +377,7 @@ public class SerialTrafficController extends AbstractMRNodeTrafficController imp
         }
     }
 
-    void loadBuffer(AbstractMRReply msg) {
+    protected void loadBuffer(AbstractMRReply msg) {
         msg.setElement(0, buffer[0]);
         msg.setElement(1, buffer[1]);
         msg.setElement(2, buffer[2]);

--- a/java/test/jmri/jmrix/easydcc/EasyDccListenerScaffold.java
+++ b/java/test/jmri/jmrix/easydcc/EasyDccListenerScaffold.java
@@ -5,7 +5,7 @@ package jmri.jmrix.easydcc;
  *
  * @author Bob Jacobsen
  */
-class EasyDccListenerScaffold implements EasyDccListener {
+public class EasyDccListenerScaffold implements EasyDccListener {
 
     public EasyDccListenerScaffold() {
         rcvdReply = null;
@@ -22,7 +22,7 @@ class EasyDccListenerScaffold implements EasyDccListener {
         rcvdReply = r;
     }
 
-    EasyDccReply rcvdReply;
-    EasyDccMessage rcvdMsg;
+    public EasyDccReply rcvdReply;
+    public EasyDccMessage rcvdMsg;
 
 }

--- a/java/test/jmri/jmrix/easydcc/EasyDccTrafficControllerTest.java
+++ b/java/test/jmri/jmrix/easydcc/EasyDccTrafficControllerTest.java
@@ -33,7 +33,7 @@ public class EasyDccTrafficControllerTest extends jmri.jmrix.AbstractMRTrafficCo
         c.connectPort(p);
 
         // object to receive reply
-        EasyDccListener l = new EasyDccListenerScaffold();
+        EasyDccListenerScaffold l = new EasyDccListenerScaffold();
         c.addEasyDccListener(l);
 
         // send a message
@@ -48,9 +48,9 @@ public class EasyDccTrafficControllerTest extends jmri.jmrix.AbstractMRTrafficCo
         
         // test the result of sending
         Assert.assertEquals("total length ", 4, tostream.available());
-        Assert.assertEquals("Char 0", '0', tostream.readByte());
-        Assert.assertEquals("Char 1", '1', tostream.readByte());
-        Assert.assertEquals("Char 2", '2', tostream.readByte());
+        Assert.assertEquals("Char 0", (byte)'0', tostream.readByte());
+        Assert.assertEquals("Char 1", (byte)'1', tostream.readByte());
+        Assert.assertEquals("Char 2", (byte)'2', tostream.readByte());
         Assert.assertEquals("EOM", 0x0d, tostream.readByte());
 
         // now send reply
@@ -59,36 +59,26 @@ public class EasyDccTrafficControllerTest extends jmri.jmrix.AbstractMRTrafficCo
 
         // threading causes the traffic controller to handle the reply,
         // so wait until that happens.
-        JUnitUtil.waitFor(()->{return rcvdReply != null;}, "reply received");
+        JUnitUtil.waitFor(()->{return l.rcvdReply != null;}, "reply received");
 
-        Assert.assertTrue("reply received ", rcvdReply != null);
-        Assert.assertEquals("first char of reply ", 'P', rcvdReply.getOpCode());
+        Assert.assertTrue("reply received ", l.rcvdReply != null);
+        Assert.assertEquals("first char of reply ", 'P', l.rcvdReply.getOpCode());
         c.terminateThreads(); // stop any threads we might have created.
     }
 
-    // internal class to simulate an EasyDccListener
-    class EasyDccListenerScaffold implements EasyDccListener {
-
-        public EasyDccListenerScaffold() {
-            rcvdReply = null;
-            rcvdMsg = null;
-        }
-
-        @Override
-        public void message(EasyDccMessage m) {
-            rcvdMsg = m;
-        }
-
-        @Override
-        public void reply(EasyDccReply r) {
-            rcvdReply = r;
-        }
-    }
-    EasyDccReply rcvdReply;
-    EasyDccMessage rcvdMsg;
-
     // internal class to simulate an EasyDccPortController
-    class EasyDccPortControllerScaffold extends EasyDccPortController {
+    private class EasyDccPortControllerScaffold extends EasyDccPortController {
+
+        EasyDccPortControllerScaffold() throws Exception {
+            super(new EasyDccSystemConnectionMemo());
+            PipedInputStream tempPipe;
+            tempPipe = new PipedInputStream();
+            tostream = new DataInputStream(tempPipe);
+            ostream = new DataOutputStream(new PipedOutputStream(tempPipe));
+            tempPipe = new PipedInputStream();
+            istream = new DataInputStream(tempPipe);
+            tistream = new DataOutputStream(new PipedOutputStream(tempPipe));
+        }
 
         @Override
         public Vector<String> getPortNames() {
@@ -115,17 +105,6 @@ public class EasyDccTrafficControllerTest extends jmri.jmrix.AbstractMRTrafficCo
             return new int[] {};
         }
 
-        protected EasyDccPortControllerScaffold() throws Exception {
-            super(new EasyDccSystemConnectionMemo());
-            PipedInputStream tempPipe;
-            tempPipe = new PipedInputStream();
-            tostream = new DataInputStream(tempPipe);
-            ostream = new DataOutputStream(new PipedOutputStream(tempPipe));
-            tempPipe = new PipedInputStream();
-            istream = new DataInputStream(tempPipe);
-            tistream = new DataOutputStream(new PipedOutputStream(tempPipe));
-        }
-
         // returns the InputStream from the port
         @Override
         public DataInputStream getInputStream() {
@@ -144,17 +123,21 @@ public class EasyDccTrafficControllerTest extends jmri.jmrix.AbstractMRTrafficCo
             return true;
         }
     }
-    DataOutputStream ostream;  // Traffic controller writes to this
-    DataInputStream tostream;  // so we can read it from this
 
-    DataOutputStream tistream; // tests write to this
-    DataInputStream istream;   // so the traffic controller can read from this
+    private DataOutputStream ostream;  // Traffic controller writes to this
+    private DataInputStream tostream;  // so we can read it from this
+
+    private DataOutputStream tistream; // tests write to this
+    private DataInputStream istream;   // so the traffic controller can read from this
+
+    private EasyDccSystemConnectionMemo memo;
 
     @Override
     @BeforeEach
     public void setUp() {
-        jmri.util.JUnitUtil.setUp();
-        tc = new EasyDccTrafficController(new EasyDccSystemConnectionMemo("E", "EasyDCC Test"));
+        JUnitUtil.setUp();
+        memo = new EasyDccSystemConnectionMemo("E", "EasyDCC Test");
+        tc = new EasyDccTrafficController(memo);
     }
 
     @Override
@@ -163,7 +146,11 @@ public class EasyDccTrafficControllerTest extends jmri.jmrix.AbstractMRTrafficCo
         if (tc!=null) {
             tc.terminateThreads();
         }
-        jmri.util.JUnitUtil.tearDown();
+        if ( memo != null ) {
+            memo.dispose();
+            memo = null;
+        }
+        JUnitUtil.tearDown();
     }
 
 }

--- a/java/test/jmri/jmrix/easydcc/simulator/EasyDccSimulatorTrafficControllerTest.java
+++ b/java/test/jmri/jmrix/easydcc/simulator/EasyDccSimulatorTrafficControllerTest.java
@@ -8,10 +8,10 @@ import java.util.Vector;
 
 import jmri.util.JUnitUtil;
 import jmri.jmrix.easydcc.EasyDccMessage;
-import jmri.jmrix.easydcc.EasyDccListener;
-import jmri.jmrix.easydcc.EasyDccReply;
+import jmri.jmrix.easydcc.EasyDccListenerScaffold;
 import jmri.jmrix.easydcc.EasyDccPortController;
 import jmri.jmrix.easydcc.EasyDccSystemConnectionMemo;
+
 import org.junit.Assert;
 import org.junit.jupiter.api.*;
 
@@ -38,7 +38,7 @@ public class EasyDccSimulatorTrafficControllerTest extends jmri.jmrix.AbstractMR
         c.connectPort(p);
 
         // object to receive reply
-        EasyDccListener l = new EasyDccListenerScaffold();
+        EasyDccListenerScaffold l = new EasyDccListenerScaffold();
         c.addEasyDccListener(l);
 
         // send a message
@@ -53,9 +53,9 @@ public class EasyDccSimulatorTrafficControllerTest extends jmri.jmrix.AbstractMR
         
         // test the result of sending
         Assert.assertEquals("total length ", 4, tostream.available());
-        Assert.assertEquals("Char 0", '0', tostream.readByte());
-        Assert.assertEquals("Char 1", '1', tostream.readByte());
-        Assert.assertEquals("Char 2", '2', tostream.readByte());
+        Assert.assertEquals("Char 0", (byte)'0', tostream.readByte());
+        Assert.assertEquals("Char 1", (byte)'1', tostream.readByte());
+        Assert.assertEquals("Char 2", (byte)'2', tostream.readByte());
         Assert.assertEquals("EOM", 0x0d, tostream.readByte());
 
         // now send reply
@@ -64,36 +64,26 @@ public class EasyDccSimulatorTrafficControllerTest extends jmri.jmrix.AbstractMR
 
         // threading causes the traffic controller to handle the reply,
         // so wait until that happens.
-        JUnitUtil.waitFor(()->{return rcvdReply != null;}, "reply received");
+        JUnitUtil.waitFor(()->{return l.rcvdReply != null;}, "reply received");
 
-        Assert.assertTrue("reply received ", rcvdReply != null);
-        Assert.assertEquals("first char of reply ", 'P', rcvdReply.getOpCode());
+        Assert.assertNotNull("reply received ", l.rcvdReply );
+        Assert.assertEquals("first char of reply ", 'P', l.rcvdReply.getOpCode());
         c.terminateThreads(); // stop any threads we might have created.
     }
 
-    // internal class to simulate an EasyDccListener
-    class EasyDccListenerScaffold implements EasyDccListener {
-
-        public EasyDccListenerScaffold() {
-            rcvdReply = null;
-            rcvdMsg = null;
-        }
-
-        @Override
-        public void message(EasyDccMessage m) {
-            rcvdMsg = m;
-        }
-
-        @Override
-        public void reply(EasyDccReply r) {
-            rcvdReply = r;
-        }
-    }
-    EasyDccReply rcvdReply;
-    EasyDccMessage rcvdMsg;
-
     // internal class to simulate an EasyDccPortController
-    class EasyDccPortControllerScaffold extends EasyDccPortController {
+    private class EasyDccPortControllerScaffold extends EasyDccPortController {
+
+        protected EasyDccPortControllerScaffold() throws Exception {
+            super(new EasyDccSystemConnectionMemo());
+            PipedInputStream tempPipe;
+            tempPipe = new PipedInputStream();
+            tostream = new DataInputStream(tempPipe);
+            ostream = new DataOutputStream(new PipedOutputStream(tempPipe));
+            tempPipe = new PipedInputStream();
+            istream = new DataInputStream(tempPipe);
+            tistream = new DataOutputStream(new PipedOutputStream(tempPipe));
+        }
 
         @Override
         public Vector<String> getPortNames() {
@@ -120,17 +110,6 @@ public class EasyDccSimulatorTrafficControllerTest extends jmri.jmrix.AbstractMR
             return new int[] {};
         }
 
-        protected EasyDccPortControllerScaffold() throws Exception {
-            super(new EasyDccSystemConnectionMemo());
-            PipedInputStream tempPipe;
-            tempPipe = new PipedInputStream();
-            tostream = new DataInputStream(tempPipe);
-            ostream = new DataOutputStream(new PipedOutputStream(tempPipe));
-            tempPipe = new PipedInputStream();
-            istream = new DataInputStream(tempPipe);
-            tistream = new DataOutputStream(new PipedOutputStream(tempPipe));
-        }
-
         // returns the InputStream from the port
         @Override
         public DataInputStream getInputStream() {
@@ -149,17 +128,21 @@ public class EasyDccSimulatorTrafficControllerTest extends jmri.jmrix.AbstractMR
             return true;
         }
     }
-    DataOutputStream ostream;  // Traffic controller writes to this
-    DataInputStream tostream;  // so we can read it from this
 
-    DataOutputStream tistream; // tests write to this
-    DataInputStream istream;   // so the traffic controller can read from this
+    private DataOutputStream ostream;  // Traffic controller writes to this
+    private DataInputStream tostream;  // so we can read it from this
+
+    private DataOutputStream tistream; // tests write to this
+    private DataInputStream istream;   // so the traffic controller can read from this
+
+    private EasyDccSystemConnectionMemo memo;
 
     @Override
     @BeforeEach
     public void setUp() {
-        jmri.util.JUnitUtil.setUp();
-        tc = new EasyDccSimulatorTrafficController(new EasyDccSystemConnectionMemo("E", "EasyDCC Test"));
+        JUnitUtil.setUp();
+        memo = new EasyDccSystemConnectionMemo("E", "EasyDCC Test");
+        tc = new EasyDccSimulatorTrafficController(memo);
     }
 
     @Override
@@ -168,7 +151,11 @@ public class EasyDccSimulatorTrafficControllerTest extends jmri.jmrix.AbstractMR
         if (tc!=null) {
             tc.terminateThreads();
         }
-        jmri.util.JUnitUtil.tearDown();
+        if ( memo != null ) {
+            memo.dispose();
+            memo = null;
+        }
+        JUnitUtil.tearDown();
     }
 
 }

--- a/java/test/jmri/jmrix/grapevine/SerialTrafficControllerTest.java
+++ b/java/test/jmri/jmrix/grapevine/SerialTrafficControllerTest.java
@@ -1,19 +1,14 @@
 package jmri.jmrix.grapevine;
 
-import java.io.ByteArrayInputStream;
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
-import java.io.PipedInputStream;
-import java.io.PipedOutputStream;
+import java.io.*;
 
 import jmri.jmrix.AbstractMRMessage;
 import jmri.jmrix.AbstractMRReply;
+import jmri.util.JUnitAppender;
 import jmri.util.JUnitUtil;
 
 import org.junit.Assert;
 import org.junit.jupiter.api.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * JUnit tests for the SerialTrafficController class
@@ -28,68 +23,58 @@ public class SerialTrafficControllerTest extends jmri.jmrix.AbstractMRNodeTraffi
     @Test
     public void testStateMachine1() throws java.io.IOException {
         SerialTrafficController c = (SerialTrafficController) tc;
-        testBuffer = new byte[4];
-        invoked = false;
 
         DataInputStream i = new DataInputStream(new ByteArrayInputStream(
                 new byte[]{1, 2, 3, 4}));
 
         c.doNextStep(new SerialReply(), i);
 
-        jmri.util.JUnitAppender.assertWarnMessage("1st byte not address: 1");
+        JUnitAppender.assertWarnMessage("1st byte not address: 1");
         Assert.assertEquals("not invoked", false, invoked);
     }
 
     @Test
     public void testStateMachine2() throws java.io.IOException {
         SerialTrafficController c = (SerialTrafficController) tc;
-        testBuffer = new byte[4];
-        invoked = false;
 
         DataInputStream i = new DataInputStream(new ByteArrayInputStream(
                 new byte[]{(byte) 128, (byte) 129, 3, 4}));
 
         c.doNextStep(new SerialReply(), i);
 
-        jmri.util.JUnitAppender.assertWarnMessage("2nd byte HOB set: 129, going to state 1");
+        JUnitAppender.assertWarnMessage("2nd byte HOB set: 129, going to state 1");
         Assert.assertEquals("not invoked", false, invoked);
     }
 
     @Test
     public void testStateMachine3() throws java.io.IOException {
         SerialTrafficController c = (SerialTrafficController) tc;
-        testBuffer = new byte[4];
-        invoked = false;
 
         DataInputStream i = new DataInputStream(new ByteArrayInputStream(
                 new byte[]{(byte) 128, (byte) 12, 1, 4}));
 
         c.doNextStep(new SerialReply(), i);
 
-        jmri.util.JUnitAppender.assertWarnMessage("addresses don't match: 128, 1. going to state 1");
+        JUnitAppender.assertWarnMessage("addresses don't match: 128, 1. going to state 1");
         Assert.assertEquals("not invoked", false, invoked);
     }
 
     @Test
     public void testStateMachine4() throws java.io.IOException {
         SerialTrafficController c = (SerialTrafficController) tc;
-        testBuffer = new byte[4];
-        invoked = false;
 
         DataInputStream i = new DataInputStream(new ByteArrayInputStream(
                 new byte[]{(byte) 128, (byte) 12, (byte) 128, (byte) 129}));
 
         c.doNextStep(new SerialReply(), i);
 
-        jmri.util.JUnitAppender.assertWarnMessage("3rd byte HOB set: 129, going to state 1");
+        JUnitAppender.assertWarnMessage("3rd byte HOB set: 129, going to state 1");
         Assert.assertEquals("not invoked", false, invoked);
     }
 
     @Test
     public void testStateMachine5() throws java.io.IOException {
         SerialTrafficController c = (SerialTrafficController) tc;
-        testBuffer = new byte[4];
-        invoked = false;
 
         DataInputStream i = new DataInputStream(new ByteArrayInputStream(
                 new byte[]{(byte) 129, (byte) 90, (byte) 129, (byte) 32}));
@@ -97,15 +82,13 @@ public class SerialTrafficControllerTest extends jmri.jmrix.AbstractMRNodeTraffi
 
         c.doNextStep(new SerialReply(), i);
 
-        jmri.util.JUnitAppender.assertWarnMessage("parity mismatch: 18, going to state 2 with content 129, 32");
+        JUnitAppender.assertWarnMessage("parity mismatch: 18, going to state 2 with content 129, 32");
         Assert.assertEquals("not invoked", false, invoked);
     }
 
     @Test
     public void testStateMachineOK1() throws java.io.IOException {
         SerialTrafficController c = (SerialTrafficController) tc;
-        testBuffer = new byte[4];
-        invoked = false;
 
         DataInputStream i = new DataInputStream(new ByteArrayInputStream(
                 new byte[]{(byte) 129, (byte) 90, (byte) 129, (byte) 31}));
@@ -122,8 +105,6 @@ public class SerialTrafficControllerTest extends jmri.jmrix.AbstractMRNodeTraffi
     @Test
     public void testStateMachineOK2() throws java.io.IOException {
         SerialTrafficController c = (SerialTrafficController) tc;
-        testBuffer = new byte[4];
-        invoked = false;
 
         DataInputStream i = new DataInputStream(new ByteArrayInputStream(
                 new byte[]{(byte) 0xE2, (byte) 119, (byte) 0xE2, (byte) 119}));
@@ -140,8 +121,6 @@ public class SerialTrafficControllerTest extends jmri.jmrix.AbstractMRNodeTraffi
     @Test
     public void testStateMachineOK3() throws java.io.IOException {
         SerialTrafficController c = (SerialTrafficController) tc;
-        testBuffer = new byte[4];
-        invoked = false;
 
         DataInputStream i = new DataInputStream(new ByteArrayInputStream(
                 new byte[]{(byte) 0xE2, (byte) 13, (byte) 0xE2, (byte) 88}));
@@ -158,8 +137,6 @@ public class SerialTrafficControllerTest extends jmri.jmrix.AbstractMRNodeTraffi
     @Test
     public void testStateMachineOK4() throws java.io.IOException {
         SerialTrafficController c = (SerialTrafficController) tc;
-        testBuffer = new byte[4];
-        invoked = false;
 
         DataInputStream i = new DataInputStream(new ByteArrayInputStream(
                 new byte[]{(byte) 0xE2, (byte) 14, (byte) 0xE2, (byte) 86}));
@@ -176,8 +153,6 @@ public class SerialTrafficControllerTest extends jmri.jmrix.AbstractMRNodeTraffi
     @Test
     public void testStateMachineOK5() throws java.io.IOException {
         SerialTrafficController c = (SerialTrafficController) tc;
-        testBuffer = new byte[4];
-        invoked = false;
 
         DataInputStream i = new DataInputStream(new ByteArrayInputStream(
                 new byte[]{(byte) 0xE2, (byte) 15, (byte) 0xE2, (byte) 84}));
@@ -194,8 +169,6 @@ public class SerialTrafficControllerTest extends jmri.jmrix.AbstractMRNodeTraffi
     @Test
     public void testStateMachineRecover1() throws java.io.IOException {
         SerialTrafficController c = (SerialTrafficController) tc;
-        testBuffer = new byte[4];
-        invoked = false;
 
         DataInputStream i = new DataInputStream(new ByteArrayInputStream(
                 new byte[]{12, (byte) 129, (byte) 90, (byte) 129, (byte) 31}));
@@ -203,7 +176,7 @@ public class SerialTrafficControllerTest extends jmri.jmrix.AbstractMRNodeTraffi
         c.doNextStep(new SerialReply(), i);
         c.doNextStep(new SerialReply(), i);
 
-        jmri.util.JUnitAppender.assertWarnMessage("1st byte not address: 12");
+        JUnitAppender.assertWarnMessage("1st byte not address: 12");
         Assert.assertEquals("invoked", true, invoked);
         Assert.assertEquals("byte 0", (byte) 129, testBuffer[0]);
         Assert.assertEquals("byte 1", (byte) 90, testBuffer[1]);
@@ -214,8 +187,6 @@ public class SerialTrafficControllerTest extends jmri.jmrix.AbstractMRNodeTraffi
     @Test
     public void testStateMachineRecover2() throws java.io.IOException {
         SerialTrafficController c = (SerialTrafficController) tc;
-        testBuffer = new byte[4];
-        invoked = false;
 
         DataInputStream i = new DataInputStream(new ByteArrayInputStream(
                 new byte[]{(byte) 129, (byte) 129, (byte) 90, (byte) 129, (byte) 31}));
@@ -223,7 +194,7 @@ public class SerialTrafficControllerTest extends jmri.jmrix.AbstractMRNodeTraffi
         c.doNextStep(new SerialReply(), i);
         c.doNextStep(new SerialReply(), i);
 
-        jmri.util.JUnitAppender.assertWarnMessage("2nd byte HOB set: 129, going to state 1");
+        JUnitAppender.assertWarnMessage("2nd byte HOB set: 129, going to state 1");
         Assert.assertEquals("invoked", true, invoked);
         Assert.assertEquals("byte 0", (byte) 129, testBuffer[0]);
         Assert.assertEquals("byte 1", (byte) 90, testBuffer[1]);
@@ -234,8 +205,6 @@ public class SerialTrafficControllerTest extends jmri.jmrix.AbstractMRNodeTraffi
     @Test
     public void testStateMachineRecover3() throws java.io.IOException {
         SerialTrafficController c = (SerialTrafficController) tc;
-        testBuffer = new byte[4];
-        invoked = false;
 
         DataInputStream i = new DataInputStream(new ByteArrayInputStream(
                 new byte[]{(byte) 128, (byte) 12, (byte) 129, (byte) 90, (byte) 129, (byte) 31}));
@@ -243,7 +212,7 @@ public class SerialTrafficControllerTest extends jmri.jmrix.AbstractMRNodeTraffi
         c.doNextStep(new SerialReply(), i);
         c.doNextStep(new SerialReply(), i);
 
-        jmri.util.JUnitAppender.assertWarnMessage("addresses don't match: 128, 129. going to state 1");
+        JUnitAppender.assertWarnMessage("addresses don't match: 128, 129. going to state 1");
         Assert.assertEquals("invoked", true, invoked);
         Assert.assertEquals("byte 0", (byte) 129, testBuffer[0]);
         Assert.assertEquals("byte 1", (byte) 90, testBuffer[1]);
@@ -254,8 +223,6 @@ public class SerialTrafficControllerTest extends jmri.jmrix.AbstractMRNodeTraffi
     @Test
     public void testStateMachineRecover4() throws java.io.IOException {
         SerialTrafficController c = (SerialTrafficController) tc;
-        testBuffer = new byte[4];
-        invoked = false;
 
         DataInputStream i = new DataInputStream(new ByteArrayInputStream(
                 new byte[]{(byte) 129, (byte) 12, (byte) 129, (byte) 90, (byte) 129, (byte) 31}));
@@ -263,7 +230,7 @@ public class SerialTrafficControllerTest extends jmri.jmrix.AbstractMRNodeTraffi
         c.doNextStep(new SerialReply(), i);
         c.doNextStep(new SerialReply(), i);
 
-        jmri.util.JUnitAppender.assertWarnMessage("parity mismatch: 25, going to state 2 with content 129, 90");
+        JUnitAppender.assertWarnMessage("parity mismatch: 25, going to state 2 with content 129, 90");
         Assert.assertEquals("invoked", true, invoked);
         Assert.assertEquals("byte 0", (byte) 129, testBuffer[0]);
         Assert.assertEquals("byte 1", (byte) 90, testBuffer[1]);
@@ -294,7 +261,7 @@ public class SerialTrafficControllerTest extends jmri.jmrix.AbstractMRNodeTraffi
         Assert.assertEquals("3rd Node after del", d, c.getNode(2));
         Assert.assertEquals("no more Nodes after del", null, c.getNode(3));
         c.deleteNode(1);
-        jmri.util.JUnitAppender.assertWarnMessage("Deleting the serial node active in the polling loop");
+        JUnitAppender.assertWarnMessage("Deleting the serial node active in the polling loop");
         Assert.assertEquals("1st Node after del2", f, c.getNode(0));
         Assert.assertEquals("2nd Node after del2", d, c.getNode(1));
         Assert.assertEquals("no more Nodes after del2", null, c.getNode(2));
@@ -316,10 +283,38 @@ public class SerialTrafficControllerTest extends jmri.jmrix.AbstractMRNodeTraffi
         Assert.assertEquals("packet type", 17, m.getElement(1));  // 'T'
     }
 
-    // internal class to simulate a Listener
-    class SerialListenerScaffold implements SerialListener {
+    @Test
+    public void testListenerScaffolds() {
 
-        public SerialListenerScaffold() {
+        SerialListenerScaffold s = new SerialListenerScaffold();
+        Assertions.assertNull(rcvdReply);
+        Assertions.assertNull(rcvdMsg);
+
+        SerialMessage msg = new SerialMessage(new byte[]{0,1,2,3});
+        s.message(msg);
+        Assertions.assertEquals(msg, rcvdMsg);
+
+        SerialReply reply = new SerialReply("0123");
+        s.reply(reply);
+        Assertions.assertEquals(reply, rcvdReply);
+
+    }
+
+    @Test
+    public void testPortControllerScaffold() throws IOException {
+
+        SerialPortControllerScaffold spcs = new SerialPortControllerScaffold(memo);
+        Assertions.assertNotNull(spcs,"no exception");
+        Assertions.assertNotNull(tostream);
+        Assertions.assertNotNull(tistream);
+        spcs.dispose();
+        memo.dispose();
+    }
+
+    // internal class to simulate a Listener
+    private class SerialListenerScaffold implements SerialListener {
+
+        SerialListenerScaffold() {
             rcvdReply = null;
             rcvdMsg = null;
         }
@@ -338,7 +333,18 @@ public class SerialTrafficControllerTest extends jmri.jmrix.AbstractMRNodeTraffi
     SerialMessage rcvdMsg;
 
     // internal class to simulate a PortController
-    class SerialPortControllerScaffold extends SerialPortController {
+    private class SerialPortControllerScaffold extends SerialPortController {
+
+        protected SerialPortControllerScaffold(GrapevineSystemConnectionMemo memo) throws IOException {
+            super(memo);
+            PipedInputStream tempPipe;
+            tempPipe = new PipedInputStream();
+            tostream = new DataInputStream(tempPipe);
+            ostream = new DataOutputStream(new PipedOutputStream(tempPipe));
+            tempPipe = new PipedInputStream();
+            istream = new DataInputStream(tempPipe);
+            tistream = new DataOutputStream(new PipedOutputStream(tempPipe));
+        }
 
         @Override
         public java.util.Vector<String> getPortNames() {
@@ -365,17 +371,6 @@ public class SerialTrafficControllerTest extends jmri.jmrix.AbstractMRNodeTraffi
             return new int[] {};
         }
 
-        protected SerialPortControllerScaffold() throws Exception {
-            super(null);
-            PipedInputStream tempPipe;
-            tempPipe = new PipedInputStream();
-            tostream = new DataInputStream(tempPipe);
-            ostream = new DataOutputStream(new PipedOutputStream(tempPipe));
-            tempPipe = new PipedInputStream();
-            istream = new DataInputStream(tempPipe);
-            tistream = new DataOutputStream(new PipedOutputStream(tempPipe));
-        }
-
         // returns the InputStream from the port
         @Override
         public DataInputStream getInputStream() {
@@ -394,31 +389,46 @@ public class SerialTrafficControllerTest extends jmri.jmrix.AbstractMRNodeTraffi
             return true;
         }
     }
-    static DataOutputStream ostream;  // Traffic controller writes to this
-    static DataInputStream tostream; // so we can read it from this
 
-    static DataOutputStream tistream; // tests write to this
-    static DataInputStream istream;  // so the traffic controller can read from this
+    private DataOutputStream ostream;  // Traffic controller writes to this
+    private DataInputStream tostream; // so we can read it from this
+
+    private DataOutputStream tistream; // tests write to this
+    private DataInputStream istream;  // so the traffic controller can read from this
+
+    private GrapevineSystemConnectionMemo memo;
+
+    private class SerialTrafficControllerImpl extends SerialTrafficController {
+
+        SerialTrafficControllerImpl(GrapevineSystemConnectionMemo memo){
+            super(memo);
+        }
+
+        @Override
+        protected void loadBuffer(AbstractMRReply msg) {
+            testBuffer[0] = buffer[0];
+            testBuffer[1] = buffer[1];
+            testBuffer[2] = buffer[2];
+            testBuffer[3] = buffer[3];
+            invoked = true;
+        }
+
+    }
 
     @Override
     @BeforeEach
     public void setUp() {
-        jmri.util.JUnitUtil.setUp();
-        tc = new SerialTrafficController(new GrapevineSystemConnectionMemo()) {
-            @Override
-            void loadBuffer(AbstractMRReply msg) {
-                testBuffer[0] = buffer[0];
-                testBuffer[1] = buffer[1];
-                testBuffer[2] = buffer[2];
-                testBuffer[3] = buffer[3];
-                invoked = true;
-            }
-        };
+        JUnitUtil.setUp();
+        testBuffer = new byte[4];
+        invoked = false;
+        memo = new GrapevineSystemConnectionMemo();
+        tc = new SerialTrafficControllerImpl(memo);
     }
 
     @Override
     @AfterEach
     public void tearDown() {
+        memo.dispose();
         JUnitUtil.clearShutDownManager(); // put in place because AbstractMRTrafficController implementing subclass was not terminated properly
         JUnitUtil.tearDown();
 

--- a/java/test/jmri/jmrix/loconet/LnTrafficControllerTest.java
+++ b/java/test/jmri/jmrix/loconet/LnTrafficControllerTest.java
@@ -28,7 +28,10 @@ public class LnTrafficControllerTest {
 
     @AfterEach
     public void tearDown() {
-        memo.dispose();
+        if ( memo !=null ) {
+            memo.dispose();
+            memo = null;
+        }
         JUnitUtil.tearDown();
     }
 


### PR DESCRIPTION
Update grapevine SerialTrafficController.java - protected loadbuffer

Update grapevine SerialTrafficControllerTest.java -
add SerialTrafficControllerImpl
add scaffold tests
move SerialPortControllerScaffold constructor to top of class
reset testBuffer and invoked in setup
 
Update EasyDccTrafficControllerTest.java & EasyDccSimulatorTrafficControllerTest -
use external EasyDccListenerScaffold
EasyDccPortControllerScaffold constructor to top of class
memo dispose
 
Update maple SerialTrafficControllerTest.java - test scaffolds
 
Update LnTrafficControllerTest.java - dispose memo
 
Update Dcc4PcTrafficControllerTest.java -
add test annotation
test listener scaffold
Dcc4PcPortControllerScaffold constructor to top of class
 
Update cmri SerialTrafficControllerTest.java -
add test annotation
scaffold tests
SerialPortAdapterScaffold constructor to top of class
Datastreams to instance
create memo + dispose

Update AcelaTrafficControllerTest.java -
remove unused method
test scaffolds
move AcelaPortControllerScaffold constructor to top of class

Update EasyDccListenerScaffold.java - public class