### PR TITLE
Symbolicprog tests

### DIFF
--- a/java/test/jmri/jmrit/symbolicprog/AbstractVariableValueTestBase.java
+++ b/java/test/jmri/jmrit/symbolicprog/AbstractVariableValueTestBase.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.*;
  */
 public abstract class AbstractVariableValueTestBase {
 
-    ProgDebugger p = new ProgDebugger();
+    ProgDebugger p;
 
     abstract VariableValue makeVar(String label, String comment, String cvName,
             boolean readOnly, boolean infoOnly, boolean writeOnly, boolean opsOnly,
@@ -205,8 +205,6 @@ public abstract class AbstractVariableValueTestBase {
     // check a read operation
     @Test
     public void testVariableValueRead() {
-        log.debug("testVariableValueRead base starts");
-
         HashMap<String, CvValue> v = createCvMap();
         CvValue cv = new CvValue("81", p);
         v.put("81", cv);
@@ -227,8 +225,6 @@ public abstract class AbstractVariableValueTestBase {
     // check a write operation to the variable
     @Test
     public void testVariableValueWrite() {
-        log.debug("testVariableValueWrite base starts");
-
         HashMap<String, CvValue> v = createCvMap();
         CvValue cv = new CvValue("81", p);
         v.put("81", cv);
@@ -251,10 +247,6 @@ public abstract class AbstractVariableValueTestBase {
     // check synch during a write operation to the CV
     @Test
     public void testVariableCvWrite() {
-        if (log.isDebugEnabled()) {
-            log.debug("start testVariableCvWrite test");
-        }
-
         HashMap<String, CvValue> v = createCvMap();
         CvValue cv = new CvValue("81", p);
         cv.setValue(3);
@@ -273,9 +265,6 @@ public abstract class AbstractVariableValueTestBase {
         Assert.assertEquals("cv state ", AbstractValue.STORED, cv.getState());
         Assert.assertEquals("value written ", 5 * 4 + 3, p.lastWrite()); // includes initial value bits
         Assert.assertEquals("status label ", "OK", statusLabel.getText());
-        if (log.isDebugEnabled()) {
-            log.debug("end testVariableCvWrite test");
-        }
     }
 
     // check the state diagram
@@ -413,9 +402,6 @@ public abstract class AbstractVariableValueTestBase {
     // check synchronization of two vars during a write
     @Test
     public void testWriteSynch2() {
-        if (log.isDebugEnabled()) {
-            log.debug("start testWriteSynch2 test");
-        }
 
         HashMap<String, CvValue> v = createCvMap();
         CvValue cv = new CvValue("81", p);
@@ -435,9 +421,7 @@ public abstract class AbstractVariableValueTestBase {
         Assert.assertEquals("1st variable state ", AbstractValue.STORED, var1.getState());
         Assert.assertEquals("2nd variable state ", AbstractValue.STORED, var2.getState());
         Assert.assertEquals("value written to programmer ", 5 * 4 + 3, p.lastWrite()); // includes initial value bits
-        if (log.isDebugEnabled()) {
-            log.debug("end testWriteSynch2 test");
-        }
+
     }
 
     // end of common tests
@@ -446,6 +430,7 @@ public abstract class AbstractVariableValueTestBase {
     @Test
     @Disabled("Disabled in JUnit 3")
     public void testSpaceUsage() {
+        /* // Avoid being picked up by code linting tools
         HashMap<String, CvValue> v = createCvMap();
         CvValue cv = new CvValue("81", p);
         cv.setValue(3);
@@ -479,21 +464,27 @@ public abstract class AbstractVariableValueTestBase {
         System.out.println("free, total memory after gc = " + Runtime.getRuntime().freeMemory()
                 + " " + Runtime.getRuntime().totalMemory());
         System.out.println("used & kept = " + (usedAfterGC - usedStart) + " used before reclaim = " + (usedAfter - usedStart));
+        */
     }
 
     protected HashMap<String, CvValue> createCvMap() {
-        HashMap<String, CvValue> m = new HashMap<String, CvValue>();
+        HashMap<String, CvValue> m = new HashMap<>();
         return m;
     }
 
     public void setUp() {
         JUnitUtil.setUp();
+        p = new ProgDebugger();
     }
 
     public void tearDown() {
+        if ( p != null ) {
+            p.dispose();
+            p = null;
+        }
         JUnitUtil.tearDown();
     }
 
-    private final static  org.slf4j.Logger log =  org.slf4j.LoggerFactory.getLogger(AbstractVariableValueTestBase.class);
+    // private final static  org.slf4j.Logger log =  org.slf4j.LoggerFactory.getLogger(AbstractVariableValueTestBase.class);
 
 }

--- a/java/test/jmri/jmrit/symbolicprog/LongAddrVariableValueTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/LongAddrVariableValueTest.java
@@ -127,7 +127,7 @@ public class LongAddrVariableValueTest extends AbstractVariableValueTestBase {
         v.put("17", cv17);
         v.put("18", cv18);
         // create a variable pointed at CV 17&18, check name
-        LongAddrVariableValue var = new LongAddrVariableValue("label", "comment", "", false, false, false, false, "17", "VVVVVVVV", 0, 255, v, null, null, cv18);
+        LongAddrVariableValue var = new LongAddrVariableValue("label", "comment", "", false, false, false, false, "17", "VVVVVVVV", 0, 255, v, jlabel, "stdname", cv18);
         Assert.assertSame("label", var.label());
         // pretend you've edited the value, check its in same object
         ((JTextField) var.getCommonRep()).setText("4797");
@@ -150,7 +150,7 @@ public class LongAddrVariableValueTest extends AbstractVariableValueTestBase {
         v.put("17", cv17);
         v.put("18", cv18);
         // create a variable pointed at CV 17 & 18
-        LongAddrVariableValue var = new LongAddrVariableValue("name", "comment", "", false, false, false, false, "17", "VVVVVVVV", 0, 255, v, null, null, cv18);
+        LongAddrVariableValue var = new LongAddrVariableValue("name", "comment", "", false, false, false, false, "17", "VVVVVVVV", 0, 255, v, jlabel, "stdname", cv18);
         ((JTextField) var.getCommonRep()).setText("1029");
         var.actionPerformed(new java.awt.event.ActionEvent(var, 0, ""));
 
@@ -176,7 +176,7 @@ public class LongAddrVariableValueTest extends AbstractVariableValueTestBase {
         v.put("17", cv17);
         v.put("18", cv18);
 
-        LongAddrVariableValue var = new LongAddrVariableValue("name", "comment", "", false, false, false, false, "17", "XXVVVVXX", 0, 255, v, null, null, cv18);
+        LongAddrVariableValue var = new LongAddrVariableValue("name", "comment", "", false, false, false, false, "17", "XXVVVVXX", 0, 255, v, jlabel, "stdname", cv18);
         // register a listener for parameter changes
         java.beans.PropertyChangeListener listen = new java.beans.PropertyChangeListener() {
             @Override
@@ -187,7 +187,7 @@ public class LongAddrVariableValueTest extends AbstractVariableValueTestBase {
                 }
             }
         };
-        evtList = new ArrayList<java.beans.PropertyChangeEvent>();
+        evtList = new ArrayList<>();
         var.addPropertyChangeListener(listen);
 
         // set to specific value
@@ -224,7 +224,7 @@ public class LongAddrVariableValueTest extends AbstractVariableValueTestBase {
         v.put("17", cv17);
         v.put("18", cv18);
 
-        LongAddrVariableValue var = new LongAddrVariableValue("name", "comment", "", false, false, false, false, "17", "XXVVVVXX", 0, 255, v, null, null, cv18);
+        LongAddrVariableValue var = new LongAddrVariableValue("name", "comment", "", false, false, false, false, "17", "XXVVVVXX", 0, 255, v, jlabel, "stdname", cv18);
         ((JTextField) var.getCommonRep()).setText("4797");
         var.actionPerformed(new java.awt.event.ActionEvent(var, 0, ""));
 
@@ -240,16 +240,20 @@ public class LongAddrVariableValueTest extends AbstractVariableValueTestBase {
         // how do you check separation of the two writes?  State model?
     }
 
+    private JLabel jlabel; 
+    
     @BeforeEach
     @Override
     public void setUp() {
         super.setUp();
+        jlabel = new JLabel();
     }
     
     @AfterEach
     @Override
     public void tearDown() {
         super.tearDown();
+        jlabel = null;
     }
 
     private final static Logger log = LoggerFactory.getLogger(LongAddrVariableValueTest.class);

--- a/java/test/jmri/jmrit/symbolicprog/SplitDateTimeVariableValueTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/SplitDateTimeVariableValueTest.java
@@ -236,6 +236,11 @@ public class SplitDateTimeVariableValueTest extends AbstractVariableValueTestBas
         CvValue cv25 = v.get("25");
         CvValue cv26 = v.get("26");
 
+        Assert.assertNotNull(cv23);
+        Assert.assertNotNull(cv24);
+        Assert.assertNotNull(cv25);
+        Assert.assertNotNull(cv26);
+
         // change the CVs, expect to see a change in the variable value
         cv23.setValue(83);
         cv24.setValue(252);
@@ -281,6 +286,11 @@ public class SplitDateTimeVariableValueTest extends AbstractVariableValueTestBas
         CvValue cv25 = v.get("25");
         CvValue cv26 = v.get("26");
 
+        Assert.assertNotNull(cv23);
+        Assert.assertNotNull(cv24);
+        Assert.assertNotNull(cv25);
+        Assert.assertNotNull(cv26);
+
         // change the CVs, expect to see a change in the variable value
         cv23.setValue(83);
         cv24.setValue(252);
@@ -325,6 +335,11 @@ public class SplitDateTimeVariableValueTest extends AbstractVariableValueTestBas
         CvValue cv24 = v.get("24");
         CvValue cv25 = v.get("25");
         CvValue cv26 = v.get("26");
+
+        Assert.assertNotNull(cv23);
+        Assert.assertNotNull(cv24);
+        Assert.assertNotNull(cv25);
+        Assert.assertNotNull(cv26);
 
         // change the CVs, expect to see a change in the variable value
         cv23.setValue(83);

--- a/java/test/jmri/jmrit/symbolicprog/SplitHexVariableValueTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/SplitHexVariableValueTest.java
@@ -19,6 +19,8 @@ import org.junit.jupiter.api.*;
  * @author Bob Jacobsen Copyright 2001, 2002, 2015
  * @author Dave Heap Copyright 2019
  */
+@edu.umd.cs.findbugs.annotations.SuppressFBWarnings( value = "NP_LOAD_OF_KNOWN_NULL_VALUE",
+    justification = "passing known null variables for clarity in constructors")
 public class SplitHexVariableValueTest extends AbstractVariableValueTestBase {
 
     // Local tests version of makeVar with extra parameters and cvList support.
@@ -28,9 +30,8 @@ public class SplitHexVariableValueTest extends AbstractVariableValueTestBase {
             HashMap<String, CvValue> v, JLabel status, String item,
             String highCV, int pFactor, int pOffset, String uppermask,
             String extra1, String extra2, String extra3, String extra4) {
-        ProgDebugger p = new ProgDebugger();
 
-        if (!cvNum.equals("")) { // some variables have no CV per se
+        if (!cvNum.isEmpty()) { // some variables have no CV per se
             List<String> cvList = CvUtil.expandCvList(cvNum);
             if (cvList.isEmpty()) {
                 CvValue cvNext = new CvValue(cvNum, p);
@@ -44,7 +45,7 @@ public class SplitHexVariableValueTest extends AbstractVariableValueTestBase {
                 }
             }
         }
-        if (highCV != null && !highCV.equals("")) {
+        if (highCV != null && !highCV.isEmpty()) {
             CvValue cvNext = new CvValue(highCV, p);
             cvNext.setValue(0);
             v.put(highCV, cvNext);

--- a/java/test/jmri/jmrit/symbolicprog/SplitVariableValueTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/SplitVariableValueTest.java
@@ -27,11 +27,12 @@ import jmri.util.JUnitUtil;
  * @author Bob Jacobsen Copyright 2001, 2002, 2015
  * @author Dave Heap Copyright 2019
  */
+@edu.umd.cs.findbugs.annotations.SuppressFBWarnings( value = "NP_LOAD_OF_KNOWN_NULL_VALUE",
+    justification = "passing known null variables for clarity in constructors")
 public class SplitVariableValueTest extends AbstractVariableValueTestBase {
 
     final String lowCV = "12";
     final String highCV = "18";
-    ProgDebugger p = new ProgDebugger();
 
     // Local tests version of makeVar with settable parameters and cvList support.
     SplitVariableValue makeVar(String label, String comment, String cvName,
@@ -42,7 +43,7 @@ public class SplitVariableValueTest extends AbstractVariableValueTestBase {
             String extra1, String extra2, String extra3, String extra4) {
         ProgDebugger pp = new ProgDebugger();
 
-        if (!cvNum.equals("")) { // some variables have no CV per se
+        if (!cvNum.isEmpty()) { // some variables have no CV per se
             List<String> cvList = CvUtil.expandCvList(cvNum);
             if (cvList.isEmpty()) {
                 CvValue cvNext = new CvValue(cvNum, pp);
@@ -56,7 +57,7 @@ public class SplitVariableValueTest extends AbstractVariableValueTestBase {
                 }
             }
         }
-        if (highCV != null && !highCV.equals("")) {
+        if (highCV != null && !highCV.isEmpty()) {
             CvValue cvNext = new CvValue(highCV, pp);
             cvNext.setValue(0);
             v.put(highCV, cvNext);


### PR DESCRIPTION
Remove some individual start / end test logging, this can be accomplished better with JunitUtil start / end test logging.
Comment out Disabled AbstractVariableValueTestBase.testSpaceUsage
Add JLabel to pass to non-null constructor
Non null asserts