### PR TITLE
Update some OpenLCB Tests

### DIFF
--- a/java/test/jmri/jmrix/openlcb/OlcbSignalMastTest.java
+++ b/java/test/jmri/jmrix/openlcb/OlcbSignalMastTest.java
@@ -74,7 +74,7 @@ public class OlcbSignalMastTest {
         t.setOutputForAppearance("Stop", "1.2.3.4.5.6.7.13");
 
         Assert.assertEquals("Init sent for 8 events", 32, messages.size());
-        messages = new java.util.ArrayList<>(); // reset test message queue
+        resetMessages(); // reset test message queue
 
         // confirm that setting again doesn't resend
         t.setLitEventId("1.2.3.4.5.6.7.1");
@@ -91,12 +91,12 @@ public class OlcbSignalMastTest {
         // but a different event does
         t.setOutputForAppearance("Stop", "11.2.3.4.5.6.7.13");
         Assert.assertEquals("Init for single new event", 4, messages.size());
-        messages = new java.util.ArrayList<>(); // reset test message queue
+        resetMessages(); // reset test message queue
 
         // and zero doesn't
         t.setOutputForAppearance("Stop", "0.0.0.0.0.0.0.0");
         Assert.assertEquals("Init sent nothing", 0, messages.size());
-        messages = new java.util.ArrayList<>(); // reset test message queue
+        resetMessages(); // reset test message queue
 
         Assert.assertTrue("lit defaults true", t.getLit());
 
@@ -126,7 +126,7 @@ public class OlcbSignalMastTest {
         t.setOutputForAppearance("Stop", "1.2.3.4.5.6.7.13");
 
         Assert.assertEquals("Init sent for 8 events", 32, messages.size());
-        messages = new java.util.ArrayList<>(); // reset test message queue
+        resetMessages(); // reset test message queue
 
         Assert.assertTrue("lit defaults true", t.getLit());
 
@@ -153,7 +153,7 @@ public class OlcbSignalMastTest {
         t.setOutputForAppearance("Stop", "1.2.3.4.5.6.7.13");
 
         Assert.assertEquals("Init sent for 8 events", 32, messages.size());
-        messages = new java.util.ArrayList<>(); // reset test message queue
+        resetMessages(); // reset test message queue
 
         Assert.assertTrue("lit defaults true", t.getLit());
 
@@ -199,7 +199,7 @@ public class OlcbSignalMastTest {
         machine.setEventForState(States2.B, "01.00.00.00.00.00.02.00");
 
         Assert.assertEquals("Init sent for 2 events", 8, messages.size());
-        messages = new java.util.ArrayList<>(); // reset test message queue
+        resetMessages(); // reset test message queue
 
         Assert.assertEquals("A event", new EventID(new byte[]{1, 0, 0, 0, 0, 0, 1, 0}), machine.getEventIDForState(States2.A));
         Assert.assertEquals("B event", new EventID(new byte[]{1, 0, 0, 0, 0, 0, 2, 0}), machine.getEventIDForState(States2.B));
@@ -224,7 +224,7 @@ public class OlcbSignalMastTest {
         machine.setEventForState(States2.B, "01.00.00.00.00.00.02.00");
 
         Assert.assertEquals("Init sent for 2 events", 8, messages.size());
-        messages = new java.util.ArrayList<>(); // reset test message queue
+        resetMessages(); // reset test message queue
 
         machine.handleIdentifyEventsAddressed( new IdentifyEventsAddressedMessage(new NodeID(),
                 new NodeID()), null);
@@ -239,7 +239,7 @@ public class OlcbSignalMastTest {
         Assert.assertEquals("msg 1", "01.00.00.00.00.00                     Producer Identified Unknown for EventID:01.00.00.00.00.00.02.00", messages.get(1).toString());
         Assert.assertEquals("msg 2", "01.00.00.00.00.00                     Consumer Identified Unknown for EventID:01.00.00.00.00.00.01.00", messages.get(2).toString());
         Assert.assertEquals("msg 3", "01.00.00.00.00.00                     Producer Identified Unknown for EventID:01.00.00.00.00.00.01.00", messages.get(3).toString());
-        messages = new java.util.ArrayList<>(); // reset test message queue
+        resetMessages(); // reset test message queue
 
         machine.handleIdentifyEventsGlobal( new IdentifyEventsGlobalMessage(new NodeID()),
                 null);
@@ -249,7 +249,7 @@ public class OlcbSignalMastTest {
         Assert.assertEquals("msg 1", "01.00.00.00.00.00                     Producer Identified Unknown for EventID:01.00.00.00.00.00.02.00", messages.get(1).toString());
         Assert.assertEquals("msg 2", "01.00.00.00.00.00                     Consumer Identified Unknown for EventID:01.00.00.00.00.00.01.00", messages.get(2).toString());
         Assert.assertEquals("msg 3", "01.00.00.00.00.00                     Producer Identified Unknown for EventID:01.00.00.00.00.00.01.00", messages.get(3).toString());
-        messages = new java.util.ArrayList<>(); // reset test message queue
+        resetMessages(); // reset test message queue
 
         machine.handleIdentifyProducers( new IdentifyProducersMessage(new NodeID(), new EventID(new byte[]{11, 0, 0, 0, 0, 0, 2, 0})), null);
         Assert.assertEquals("no reply", 0, messages.size());
@@ -259,7 +259,7 @@ public class OlcbSignalMastTest {
         // check by string comparison as a short cut
         Assert.assertEquals("reply", "01.00.00.00.00.00                     Producer Identified Unknown for EventID:01.00.00.00.00.00.02.00", messages.get(0).toString());
 
-        messages = new java.util.ArrayList<>(); // reset test message queue
+        resetMessages(); // reset test message queue
 
         machine.handleIdentifyConsumers( new IdentifyConsumersMessage(new NodeID(), new EventID(new byte[]{11, 0, 0, 0, 0, 0, 2, 0})), null);
         Assert.assertEquals("no reply", 0, messages.size());
@@ -285,7 +285,7 @@ public class OlcbSignalMastTest {
         Assert.assertEquals("B event", new EventID(new byte[]{1, 0, 0, 0, 0, 0, 2, 0}), machine.getEventIDForState("B"));
 
         Assert.assertEquals("Init sent for 2 events", 8, messages.size());
-        messages = new java.util.ArrayList<>(); // reset test message queue
+        resetMessages(); // reset test message queue
 
         machine.setState("A");
         Assert.assertEquals("still starting state", "B", machine.getState());
@@ -307,7 +307,7 @@ public class OlcbSignalMastTest {
         machine.setEventForState("B", "01.00.00.00.00.00.02.00");
 
         Assert.assertEquals("Init sent for 2 events", 8, messages.size());
-        messages = new java.util.ArrayList<>(); // reset test message queue
+        resetMessages(); // reset test message queue
 
         machine.handleIdentifyEventsAddressed( new IdentifyEventsAddressedMessage(new NodeID(),
                 new NodeID()), null);
@@ -322,7 +322,7 @@ public class OlcbSignalMastTest {
         Assert.assertEquals("msg 2", "01.00.00.00.00.00                     Consumer Identified Unknown for EventID:01.00.00.00.00.00.01.00", messages.get(2).toString());
         Assert.assertEquals("msg 3", "01.00.00.00.00.00                     Producer Identified Unknown for EventID:01.00.00.00.00.00.01.00", messages.get(3).toString());
 
-        messages = new java.util.ArrayList<>();
+        resetMessages();
 
         machine.handleIdentifyProducers( new IdentifyProducersMessage(new NodeID(), new EventID(new byte[]{11, 0, 0, 0, 0, 0, 2, 0})), null);
         Assert.assertEquals("no reply", 0, messages.size());
@@ -332,7 +332,7 @@ public class OlcbSignalMastTest {
         // check by string comparison as a short cut
         Assert.assertEquals("reply", "01.00.00.00.00.00                     Producer Identified Unknown for EventID:01.00.00.00.00.00.02.00", messages.get(0).toString());
 
-        messages = new java.util.ArrayList<>();
+        resetMessages();
 
         machine.handleIdentifyConsumers( new IdentifyConsumersMessage(new NodeID(), new EventID(new byte[]{11, 0, 0, 0, 0, 0, 2, 0})), null);
         Assert.assertEquals("no reply", 0, messages.size());
@@ -350,9 +350,13 @@ public class OlcbSignalMastTest {
     static NodeID nodeID = new NodeID(new byte[]{1, 0, 0, 0, 0, 0});
     static java.util.ArrayList<Message> messages;
 
+    private static void resetMessages(){
+        messages = new java.util.ArrayList<>();
+    }
+
     @BeforeEach
     public void setUp() {
-        messages = new java.util.ArrayList<>();
+        resetMessages();
     }
 
     @BeforeAll
@@ -362,7 +366,7 @@ public class OlcbSignalMastTest {
         JUnitUtil.initInternalTurnoutManager();
         nodeID = new NodeID(new byte[]{1, 0, 0, 0, 0, 0});
 
-        messages = new java.util.ArrayList<>();
+        resetMessages();
         connection = new AbstractConnection() {
             @Override
             public void put(Message msg, Connection sender) {
@@ -379,18 +383,18 @@ public class OlcbSignalMastTest {
             }
         });
 
-        jmri.util.JUnitUtil.waitFor(()-> (messages.size()>0),"Initialization Complete message");
+        JUnitUtil.waitFor(()-> (!messages.isEmpty()),"Initialization Complete message");
     }
 
     @AfterEach
     public void tearDown() {
-        messages = null;
     }
 
     @AfterAll
     public static void postClassTearDown() {
         if(memo != null && memo.getInterface() !=null ) {
            memo.getInterface().dispose();
+           memo.dispose();
         }
         memo = null;
         connection = null;

--- a/java/test/jmri/jmrix/openlcb/OlcbTurnoutInheritedTest.java
+++ b/java/test/jmri/jmrix/openlcb/OlcbTurnoutInheritedTest.java
@@ -37,6 +37,7 @@ public class OlcbTurnoutInheritedTest extends AbstractTurnoutTestBase {
     }
 
     @AfterEach
+    @Override
     public void tearDown() {
         if (Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning") == false) {
             tif.dispose();
@@ -70,17 +71,19 @@ public class OlcbTurnoutInheritedTest extends AbstractTurnoutTestBase {
         //t.finishLoad();
 
         t.addPropertyChangeListener(l);
+        l.resetPropertyChanged();
 
         t.setState(Turnout.THROWN);
         tif.flush();
-        JUnitUtil.waitFor( () -> l.getPropertyChanged());
+        JUnitUtil.waitFor( () -> l.getPropertyChanged()," > thrown");
 
         Assert.assertEquals(Turnout.THROWN, t.getCommandedState());
         Assert.assertEquals(Turnout.THROWN, t.getKnownState());
 
+        l.resetPropertyChanged();
         t.setState(Turnout.CLOSED);
         tif.flush();
-        JUnitUtil.waitFor( () -> l.getPropertyChanged());
+        JUnitUtil.waitFor( () -> l.getPropertyChanged(),"thrown > closed");
 
         Assert.assertEquals(Turnout.CLOSED, t.getCommandedState());
         Assert.assertEquals(Turnout.CLOSED, t.getKnownState());

--- a/java/test/jmri/jmrix/openlcb/OlcbTurnoutTest.java
+++ b/java/test/jmri/jmrix/openlcb/OlcbTurnoutTest.java
@@ -50,19 +50,19 @@ public class OlcbTurnoutTest {
         s.addPropertyChangeListener(l);
 
         // check states
-        Assert.assertEquals(s.getCommandedState(), Turnout.UNKNOWN);
+        Assert.assertEquals(Turnout.UNKNOWN, s.getCommandedState());
 
         t.sendMessage(mActive);
 
-        JUnitUtil.waitFor( () -> l.getPropertyChanged());
+        JUnitUtil.waitFor( () -> l.getPropertyChanged(),"no prop change unknown > thrown");
         Assert.assertEquals("called twice",2,l.getCallCount());
-        Assert.assertEquals(s.getCommandedState(), Turnout.THROWN);
+        Assert.assertEquals(Turnout.THROWN, s.getCommandedState());
 
         l.resetPropertyChanged();
         t.sendMessage(mInactive);
-        JUnitUtil.waitFor( () -> l.getPropertyChanged());
+        JUnitUtil.waitFor( () -> l.getPropertyChanged(), "no prop change thrown > closed");
         Assert.assertEquals("called twice",2,l.getCallCount());
-        Assert.assertEquals(s.getCommandedState(), Turnout.CLOSED);
+        Assert.assertEquals(Turnout.CLOSED, s.getCommandedState());
     }
 
     @Test
@@ -77,9 +77,9 @@ public class OlcbTurnoutTest {
         t.tc.rcvMessage = null;
         s.setState(Turnout.THROWN);
         t.flush();
-        JUnitUtil.waitFor( () -> l.getPropertyChanged());
+        JUnitUtil.waitFor( () -> l.getPropertyChanged(),"no prop change > thrown");
         Assert.assertEquals("called twice",2,l.getCallCount());
-        Assert.assertEquals(s.getCommandedState(), Turnout.THROWN);
+        Assert.assertEquals(Turnout.THROWN, s.getCommandedState());
         log.debug("recv msg: {} header {}", t.tc.rcvMessage, Integer.toHexString(t.tc.rcvMessage.getHeader()));
         Assert.assertTrue(new OlcbAddress("1.2.3.4.5.6.7.8").match(t.tc.rcvMessage));
 
@@ -87,18 +87,18 @@ public class OlcbTurnoutTest {
         t.tc.rcvMessage = null;
         s.setState(Turnout.CLOSED);
         t.flush();
-        JUnitUtil.waitFor( () -> l.getPropertyChanged());
+        JUnitUtil.waitFor( () -> l.getPropertyChanged(), "no prop change thrown > closed");
         Assert.assertEquals("called twice",2,l.getCallCount());
-        Assert.assertEquals(s.getCommandedState(), Turnout.CLOSED);
+        Assert.assertEquals(Turnout.CLOSED, s.getCommandedState());
         Assert.assertTrue(new OlcbAddress("1.2.3.4.5.6.7.9").match(t.tc.rcvMessage));
 
         // repeated set of local state
         t.tc.rcvMessage = null;
         s.setState(Turnout.CLOSED);
         t.flush();
-        JUnitUtil.waitFor( () -> l.getPropertyChanged());
+        Assert.assertTrue(l.getPropertyChanged());
         Assert.assertEquals("called twice",2,l.getCallCount());
-        Assert.assertEquals(s.getCommandedState(), Turnout.CLOSED);
+        Assert.assertEquals(Turnout.CLOSED, s.getCommandedState());
         Assert.assertTrue(new OlcbAddress("1.2.3.4.5.6.7.9").match(t.tc.rcvMessage));
     }
 
@@ -150,16 +150,16 @@ public class OlcbTurnoutTest {
 
         s.setState(Turnout.THROWN);
         t.flush();
-        JUnitUtil.waitFor( () -> l.getPropertyChanged());
+        JUnitUtil.waitFor( () -> l.getPropertyChanged(),"prop change > thrown");
         Assert.assertEquals("called twice",2,l.getCallCount());
-        Assert.assertEquals(s.getCommandedState(), Turnout.THROWN);
+        Assert.assertEquals(Turnout.THROWN, s.getCommandedState());
 
         l.resetPropertyChanged();
         s.setState(Turnout.CLOSED);
         t.flush();
-        JUnitUtil.waitFor( () -> l.getPropertyChanged());
+        JUnitUtil.waitFor( () -> l.getPropertyChanged(),"prop change > closed");
         Assert.assertEquals("called twice",2,l.getCallCount());
-        Assert.assertEquals(s.getCommandedState(), Turnout.CLOSED);
+        Assert.assertEquals(Turnout.CLOSED, s.getCommandedState());
     }
 
     @Test
@@ -190,7 +190,7 @@ public class OlcbTurnoutTest {
 
         // Resets the turnout to unknown state
         s.setState(Turnout.UNKNOWN);
-        JUnitUtil.waitFor( () -> l.getPropertyChanged());
+        JUnitUtil.waitFor( () -> l.getPropertyChanged(), "prop changed > unknown");
         Assert.assertEquals("called twice",2,l.getCallCount());
         l.resetPropertyChanged();
         t.assertNoSentMessages();
@@ -200,7 +200,7 @@ public class OlcbTurnoutTest {
                 ":X19547C4CN0102030405060708;");
         // getting a state notify will change state
         t.sendMessage(":X19544123N0102030405060709;");
-        JUnitUtil.waitFor( () -> l.getPropertyChanged());
+        JUnitUtil.waitFor( () -> l.getPropertyChanged(), "prop change > closed");
         Assert.assertEquals("called twice",2,l.getCallCount());
         l.resetPropertyChanged();
         Assert.assertEquals(Turnout.CLOSED, s.getKnownState());
@@ -314,13 +314,13 @@ public class OlcbTurnoutTest {
         mInactive.setExtended(true);
 
         // check states
-        Assert.assertEquals(s.getCommandedState(), Turnout.UNKNOWN);
+        Assert.assertEquals(Turnout.UNKNOWN, s.getCommandedState());
 
         t.sendMessage(mActive);
-        Assert.assertEquals(s.getCommandedState(), Turnout.THROWN);
+        Assert.assertEquals(Turnout.THROWN, s.getCommandedState());
 
         t.sendMessage(mInactive);
-        Assert.assertEquals(s.getCommandedState(), Turnout.CLOSED);
+        Assert.assertEquals(Turnout.CLOSED, s.getCommandedState());
 
     }
 
@@ -345,13 +345,13 @@ public class OlcbTurnoutTest {
         mInactive.setExtended(true);
 
         // check states
-        Assert.assertEquals(s.getCommandedState(), Turnout.UNKNOWN);
+        Assert.assertEquals(Turnout.UNKNOWN, s.getCommandedState());
 
         t.sendMessage(mActive);
-        Assert.assertEquals(s.getCommandedState(), Turnout.THROWN);
+        Assert.assertEquals(Turnout.THROWN, s.getCommandedState());
 
         t.sendMessage(mInactive);
-        Assert.assertEquals(s.getCommandedState(), Turnout.CLOSED);
+        Assert.assertEquals(Turnout.CLOSED, s.getCommandedState());
 
     }
 

--- a/java/test/jmri/jmrix/openlcb/configurexml/LoadAndStoreTest.java
+++ b/java/test/jmri/jmrix/openlcb/configurexml/LoadAndStoreTest.java
@@ -41,6 +41,7 @@ public class LoadAndStoreTest extends LoadAndStoreTestBase {
 
     public LoadAndStoreTest() {
         super(SaveType.Config, false);
+        messages = new ArrayList<>();
     }
 
     // from here down is testing infrastructure
@@ -51,7 +52,9 @@ public class LoadAndStoreTest extends LoadAndStoreTestBase {
 
     @BeforeEach
     @SuppressWarnings("deprecated") // OlcbInterface(NodeID, Connection)
-    public void localSetUp() {
+    @Override
+    public void setUp() {
+        super.setUp();
         nodeID = new NodeID(new byte[]{1, 0, 0, 0, 0, 0});
 
         messages = new ArrayList<>();
@@ -75,13 +78,15 @@ public class LoadAndStoreTest extends LoadAndStoreTestBase {
     }
 
     @AfterEach
-    public void localTearDown() {
+    @Override
+    public void tearDown() {
         if (memo != null && memo.getInterface() != null) {
             memo.getInterface().dispose();
         }
         memo = null;
         connection = null;
         nodeID = null;
+        super.tearDown();
     }
 
 }

--- a/java/test/jmri/jmrix/openlcb/configurexml/OlcbSignalMastXmlTest.java
+++ b/java/test/jmri/jmrix/openlcb/configurexml/OlcbSignalMastXmlTest.java
@@ -14,14 +14,17 @@ import org.jdom2.Element;
 
 import org.junit.Assert;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 /**
  * OlcbSignalMastXmlTest
  *
- * Test for the OlcbSignalMastXml class
+ * Test for the OlcbSignalMastXml class.
+ * Tests are run separately because they leave a lot of threads behind.
  *
  * @author   Bob Jacobsen Copyright (C) 2018
  */
+@DisabledIfSystemProperty(named ="jmri.skipTestsRequiringSeparateRunning", matches ="true")
 public class OlcbSignalMastXmlTest {
 
     private static OlcbSystemConnectionMemo memo;
@@ -52,9 +55,13 @@ public class OlcbSignalMastXmlTest {
         Assert.assertEquals("1.2.3.4.5.6.7.4", e.getChild("held").getChild("notheld").getValue());
     }
 
+    private static void resetMessages(){
+        messages = new java.util.ArrayList<>();
+    }
+
     @BeforeEach
     public void setUp() {
-        messages = new java.util.ArrayList<>();
+        resetMessages();
     }
 
     @BeforeAll
@@ -62,11 +69,10 @@ public class OlcbSignalMastXmlTest {
     static public void preClassInit() {
         JUnitUtil.setUp();
        // this test is run separately because it leaves a lot of threads behind
-        org.junit.Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
         JUnitUtil.initInternalTurnoutManager();
         nodeID = new NodeID(new byte[]{1, 0, 0, 0, 0, 0});
 
-        messages = new java.util.ArrayList<>();
+        resetMessages();
         connection = new AbstractConnection() {
             @Override
             public void put(Message msg, Connection sender) {
@@ -83,24 +89,23 @@ public class OlcbSignalMastXmlTest {
             }
         });
 
-        jmri.util.JUnitUtil.waitFor(()-> (messages.size()>0),"Initialization Complete message");
+        JUnitUtil.waitFor(()-> (!messages.isEmpty()),"Initialization Complete message");
     }
 
     @AfterEach
     public void tearDown() {
-        messages = null;
     }
 
     @AfterAll
     public static void postClassTearDown() {
-        if (Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning") == false) {
-            if(memo != null && memo.getInterface() !=null ) {
-               memo.getInterface().dispose();
-            }
-            memo = null;
-            connection = null;
-            nodeID = null;
+
+        if(memo != null && memo.getInterface() !=null ) {
+           memo.getInterface().dispose();
         }
+        memo = null;
+        connection = null;
+        nodeID = null;
+
         JUnitUtil.tearDown();
     }
 }

--- a/java/test/jmri/jmrix/openlcb/swing/send/OpenLcbCanSendActionTest.java
+++ b/java/test/jmri/jmrix/openlcb/swing/send/OpenLcbCanSendActionTest.java
@@ -1,7 +1,5 @@
 package jmri.jmrix.openlcb.swing.send;
 
-import java.awt.GraphicsEnvironment;
-
 import jmri.InstanceManager;
 import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.jmrix.openlcb.OlcbSystemConnectionMemo;
@@ -9,7 +7,7 @@ import jmri.util.JUnitUtil;
 
 import org.junit.jupiter.api.*;
 
-import jmri.jmrix.can.TestTrafficController;
+// import jmri.jmrix.can.TestTrafficController;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.mockito.Mockito;
 
@@ -22,7 +20,7 @@ import static org.assertj.core.api.Java6Assertions.assertThat;
 public class OpenLcbCanSendActionTest {
 
     jmri.jmrix.can.CanSystemConnectionMemo memo;
-    jmri.jmrix.can.TrafficController tc;
+    // jmri.jmrix.can.TrafficController tc;
 
     @Test
     @DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")


### PR DESCRIPTION
LoadAndStoreTest -
init messages in constructor
init JUnitUtil before local setup
shutdown JUnitUtil after local teardown

OlcbSignalMastXmlTest -
add static resetMessages method
set jmri.skipTestsRequiringSeparateRunning in class annotation

OlcbSensorTest - set jmri.skipTestsRequiringSeparateRunning in class annotation

OlcbSignalMastTest - add static method resetMessages

OlcbTurnoutInheritedTest - add JUnitUtil.waitFor failure strings

OlcbTurnoutTest -
order asserts
reason for JUnitUtil.waitFor failure

OlcbSignalMastAddPaneTest -
add static method resetMessages
JUnitUtil.waitFor failure messages
nonnull checks

OpenLcbCanSendActionTest.java - comment out unused var