### PR TITLE
Update jmrix Roco tests

### DIFF
--- a/java/test/jmri/jmrix/roco/RocoXNetThrottleTest.java
+++ b/java/test/jmri/jmrix/roco/RocoXNetThrottleTest.java
@@ -49,7 +49,7 @@ public class RocoXNetThrottleTest extends jmri.jmrix.lenz.XNetThrottleTest {
         m.setElement(4, 0x00);
         m.setElement(5, 0xE0);
 
-        n = tc.outbound.size();
+        // n = tc.outbound.size();
         t.message(m);
 
         // this should put the throttle into idle state,
@@ -190,7 +190,7 @@ public class RocoXNetThrottleTest extends jmri.jmrix.lenz.XNetThrottleTest {
         m.setElement(1, 0x04);
         m.setElement(2, 0x05);
 
-        n = tc.outbound.size();
+        // n = tc.outbound.size();
         t.message(m);
         // which sets the status back state back to idle..
     }

--- a/java/test/jmri/jmrix/roco/z21/RocoZ21CommandStationTest.java
+++ b/java/test/jmri/jmrix/roco/z21/RocoZ21CommandStationTest.java
@@ -14,12 +14,12 @@ import org.junit.jupiter.api.*;
 public class RocoZ21CommandStationTest {
 
    @Test
-   public void ConstructorTest(){
+   public void testConstructor(){
       Assert.assertNotNull("RocoZ21CommandStation constructor",new RocoZ21CommandStation());
    }
 
    @Test
-   public void SerialNumber(){
+   public void testSerialNumber(){
       RocoZ21CommandStation rcs = new RocoZ21CommandStation();
       Assert.assertEquals("initial serial number",0,rcs.getSerialNumber());
       rcs.setSerialNumber(3456);
@@ -27,7 +27,7 @@ public class RocoZ21CommandStationTest {
    }
 
    @Test
-   public void SoftwareVersion(){
+   public void testSoftwareVersion(){
       RocoZ21CommandStation rcs = new RocoZ21CommandStation();
       Assert.assertEquals("initial software version",0,rcs.getSoftwareVersion(),0.0);
       rcs.setSoftwareVersion(3456);
@@ -35,7 +35,7 @@ public class RocoZ21CommandStationTest {
    }
 
    @Test
-   public void HardwareVersion(){
+   public void testHardwareVersion(){
       RocoZ21CommandStation rcs = new RocoZ21CommandStation();
       Assert.assertEquals("initial hardware version",0,rcs.getHardwareVersion());
       rcs.setHardwareVersion(3456);
@@ -43,7 +43,7 @@ public class RocoZ21CommandStationTest {
    }
 
    @Test
-   public void BroadcastFlags(){
+   public void testBroadcastFlags(){
       RocoZ21CommandStation rcs = new RocoZ21CommandStation();
       Assert.assertEquals("initial Broadcast Flags",0,rcs.getZ21BroadcastFlags());
       rcs.setZ21BroadcastFlags(3456);
@@ -51,7 +51,7 @@ public class RocoZ21CommandStationTest {
    }
 
    @Test
-   public void XPressNetFlag(){
+   public void testXPressNetFlag(){
       RocoZ21CommandStation rcs = new RocoZ21CommandStation();
       Assert.assertFalse("initial XpressNet Flag",rcs.getXPressNetMessagesFlag());
       rcs.setXPressNetMessagesFlag(true);
@@ -61,7 +61,7 @@ public class RocoZ21CommandStationTest {
    }
 
    @Test
-   public void RMBusFlag(){
+   public void testRMBusFlag(){
       RocoZ21CommandStation rcs = new RocoZ21CommandStation();
       Assert.assertFalse("initial RMBus Flag",rcs.getRMBusMessagesFlag());
       rcs.setRMBusMessagesFlag(true);
@@ -71,7 +71,7 @@ public class RocoZ21CommandStationTest {
    }
 
    @Test
-   public void RailComFlag(){
+   public void testRailComFlag(){
       RocoZ21CommandStation rcs = new RocoZ21CommandStation();
       Assert.assertFalse("initial RailCom Flag",rcs.getRailComMessagesFlag());
       rcs.setRailComMessagesFlag(true);
@@ -81,7 +81,7 @@ public class RocoZ21CommandStationTest {
    }
 
    @Test
-   public void SystemStatusFlag(){
+   public void testSystemStatusFlag(){
       RocoZ21CommandStation rcs = new RocoZ21CommandStation();
       Assert.assertFalse("initial System Status Flag",rcs.getSystemStatusMessagesFlag());
       rcs.setSystemStatusMessagesFlag(true);
@@ -91,7 +91,7 @@ public class RocoZ21CommandStationTest {
    }
 
    @Test
-   public void XPressNetLocoMotiveFlag(){
+   public void testXPressNetLocoMotiveFlag(){
       RocoZ21CommandStation rcs = new RocoZ21CommandStation();
       Assert.assertFalse("initial XpressNet Locomotive Flag",rcs.getXPressNetLocomotiveMessagesFlag());
       rcs.setXPressNetLocomotiveMessagesFlag(true);
@@ -101,7 +101,7 @@ public class RocoZ21CommandStationTest {
    }
 
    @Test
-   public void LocoNetFlag(){
+   public void testLocoNetFlag(){
       RocoZ21CommandStation rcs = new RocoZ21CommandStation();
       Assert.assertFalse("initial LocoNet Flag",rcs.getLocoNetMessagesFlag());
       rcs.setLocoNetMessagesFlag(true);
@@ -111,7 +111,7 @@ public class RocoZ21CommandStationTest {
    }
 
    @Test
-   public void LocoNetLocoMotiveFlag(){
+   public void testLocoNetLocoMotiveFlag(){
       RocoZ21CommandStation rcs = new RocoZ21CommandStation();
       Assert.assertFalse("initial LocoNet Locomotive Flag",rcs.getLocoNetLocomotiveMessagesFlag());
       rcs.setLocoNetLocomotiveMessagesFlag(true);
@@ -121,7 +121,7 @@ public class RocoZ21CommandStationTest {
    }
 
    @Test
-   public void LocoNetTurnoutFlag(){
+   public void testLocoNetTurnoutFlag(){
       RocoZ21CommandStation rcs = new RocoZ21CommandStation();
       Assert.assertFalse("initial LocoNet Turnout Flag",rcs.getLocoNetTurnoutMessagesFlag());
       rcs.setLocoNetTurnoutMessagesFlag(true);
@@ -131,7 +131,7 @@ public class RocoZ21CommandStationTest {
    }
 
    @Test
-   public void LocoNetOccupancyFlag(){
+   public void testLocoNetOccupancyFlag(){
       RocoZ21CommandStation rcs = new RocoZ21CommandStation();
       Assert.assertFalse("initial LocoNet Occupancy Flag",rcs.getLocoNetOccupancyMessagesFlag());
       rcs.setLocoNetOccupancyMessagesFlag(true);

--- a/java/test/jmri/jmrix/roco/z21/Z21CanReporterTest.java
+++ b/java/test/jmri/jmrix/roco/z21/Z21CanReporterTest.java
@@ -1,7 +1,5 @@
 package jmri.jmrix.roco.z21;
 
-import java.util.ArrayList;
-
 import jmri.util.JUnitUtil;
 
 import org.junit.Assert;
@@ -65,7 +63,7 @@ public class Z21CanReporterTest extends jmri.implementation.AbstractRailComRepor
         zr.reply(reply);
         // Check that the collection has one element.
         Assert.assertEquals("Collection Size 1 after message", 1, zr.getCollection().size());
-        Assert.assertEquals("Current Report = last entry", zr.getCurrentReport(), ((ArrayList) zr.getCollection()).get(0));
+        Assert.assertEquals("Current Report = last entry", zr.getCurrentReport(), zr.getCollection().toArray()[0]);
 
         byte msg2[] = {(byte) 0x0E, (byte) 0x00, (byte) 0xC4, (byte) 0x00, (byte) 0xcd, (byte) 0xab, (byte) 0x01, (byte) 0x00, (byte) 0x01, (byte) 0x11, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00};
         reply = new Z21Reply(msg2, 14);
@@ -89,7 +87,7 @@ public class Z21CanReporterTest extends jmri.implementation.AbstractRailComRepor
         // Check that the collection has two element.
         Assert.assertEquals("Collection Size 2 after message", 2, zr.getCollection().size());
         Assert.assertNotNull("Current Report NotNull", zr.getCurrentReport());
-        Assert.assertEquals("Current Report = last entry", zr.getCurrentReport(), ((ArrayList) zr.getCollection()).get(1));
+        Assert.assertEquals("Current Report = last entry", zr.getCurrentReport(), zr.getCollection().toArray()[1]);
         Assert.assertEquals("Current State", jmri.IdTag.SEEN, zr.getState());
         // Check that both CurrentReport and LastReport were seen by the listener
         Assert.assertTrue("CurrentReport seen", currentReportSeen);
@@ -125,7 +123,7 @@ public class Z21CanReporterTest extends jmri.implementation.AbstractRailComRepor
         // Check that the collection has two element.
         JUnitUtil.waitFor(() -> {
             return (zr.getCollection().size() > 2);
-        });
+        },"collection size > 2");
         Assert.assertEquals("Collection Size 3 after message", 3, zr.getCollection().size());
 
         byte msg3[] = {(byte) 0x0E, (byte) 0x00, (byte) 0xC4, (byte) 0x00, (byte) 0xcd, (byte) 0xab, (byte) 0x01, (byte) 0x00, (byte) 0x01, (byte) 0x11, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00};

--- a/java/test/jmri/jmrix/roco/z21/Z21MessageTest.java
+++ b/java/test/jmri/jmrix/roco/z21/Z21MessageTest.java
@@ -52,7 +52,7 @@ public class Z21MessageTest extends jmri.jmrix.AbstractMessageTestBase {
 
     //Test some canned messages.
     @Test
-    public void SerialNumberRequest() {
+    public void testSerialNumberRequest() {
         msg = Z21Message.getSerialNumberRequestMessage();
         Assert.assertEquals("length", 4, msg.getNumDataElements());
         Assert.assertEquals("0th byte", 0x04, msg.getElement(0) & 0xFF);
@@ -62,13 +62,13 @@ public class Z21MessageTest extends jmri.jmrix.AbstractMessageTestBase {
     }
 
     @Test
-    public void toMonitorStringSerialNumberRequest() {
+    public void testToMonitorStringSerialNumberRequest() {
         msg = Z21Message.getSerialNumberRequestMessage();
         Assert.assertEquals("Monitor String", "Z21 Serial Number Request", msg.toMonitorString());
     }
 
     @Test
-    public void GetHardwareInfoRequest() {
+    public void testGetHardwareInfoRequest() {
         msg = Z21Message.getLanGetHardwareInfoRequestMessage();
         Assert.assertEquals("length", 4, msg.getNumDataElements());
         Assert.assertEquals("0th byte", 0x04, msg.getElement(0) & 0xFF);
@@ -78,13 +78,13 @@ public class Z21MessageTest extends jmri.jmrix.AbstractMessageTestBase {
     }
 
     @Test
-    public void toMonitorStringGetHardwareInfoRequest() {
+    public void testToMonitorStringGetHardwareInfoRequest() {
         msg = Z21Message.getLanGetHardwareInfoRequestMessage();
         Assert.assertEquals("Monitor String", "Z21 Version Request", msg.toMonitorString());
     }
 
     @Test
-    public void LanLogoffRequest() {
+    public void testLanLogoffRequest() {
         msg = Z21Message.getLanLogoffRequestMessage();
         Assert.assertEquals("length", 4, msg.getNumDataElements());
         Assert.assertEquals("0th byte", 0x04, msg.getElement(0) & 0xFF);
@@ -101,7 +101,7 @@ public class Z21MessageTest extends jmri.jmrix.AbstractMessageTestBase {
     }
 
     @Test
-    public void GetBroadCastFlagsRequest() {
+    public void testGetBroadCastFlagsRequest() {
         msg = Z21Message.getLanGetBroadcastFlagsRequestMessage();
         Assert.assertEquals("length", 4, msg.getNumDataElements());
         Assert.assertEquals("0th byte", 0x04, msg.getElement(0) & 0xFF);
@@ -117,7 +117,7 @@ public class Z21MessageTest extends jmri.jmrix.AbstractMessageTestBase {
     }
 
     @Test
-    public void SetBroadCastFlagsRequest() {
+    public void testSetBroadCastFlagsRequest() {
         msg = Z21Message.getLanSetBroadcastFlagsRequestMessage(0x01020304);
         Assert.assertEquals("length", 8, msg.getNumDataElements());
         Assert.assertEquals("0th byte", 0x08, msg.getElement(0) & 0xFF);
@@ -138,7 +138,7 @@ public class Z21MessageTest extends jmri.jmrix.AbstractMessageTestBase {
     }
 
     @Test
-    public void GetRailComDataRequest() {
+    public void testGetRailComDataRequest() {
         msg = Z21Message.getLanRailComGetDataRequestMessage();
         Assert.assertEquals("length", 4, msg.getNumDataElements());
         Assert.assertEquals("0th byte", 0x04, msg.getElement(0) & 0xFF);
@@ -154,7 +154,7 @@ public class Z21MessageTest extends jmri.jmrix.AbstractMessageTestBase {
     }
 
     @Test
-    public void GetSystemStateDataChangedRequest() {
+    public void testGetSystemStateDataChangedRequest() {
         msg = Z21Message.getLanSystemStateDataChangedRequestMessage();
         Assert.assertEquals("length", 4, msg.getNumDataElements());
         Assert.assertEquals("0th byte", 0x04, msg.getElement(0) & 0xFF);
@@ -164,13 +164,13 @@ public class Z21MessageTest extends jmri.jmrix.AbstractMessageTestBase {
     }
 
     @Test
-    public void toMonitorStringSystemStateDataChangedRequest() {
+    public void testToMonitorStringSystemStateDataChangedRequest() {
         msg = Z21Message.getLanSystemStateDataChangedRequestMessage();
         Assert.assertEquals("Monitor String", "04 00 85 00", msg.toMonitorString());
     }
 
     @Test
-    public void getLocoNetMessage() {
+    public void testGetLocoNetMessage() {
         byte message[] = {
             (byte) 0xEF, (byte) 0x0E, (byte) 0x03, (byte) 0x00, (byte) 0x03,
             (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00,
@@ -187,14 +187,14 @@ public class Z21MessageTest extends jmri.jmrix.AbstractMessageTestBase {
     }
 
     @Test
-    public void getNullLocoNetMessage() {
+    public void testGetNullLocoNetMessage() {
         byte message[] = {(byte) 0x11, (byte) 0x00, (byte) 0x88, (byte) 0x00, (byte) 0x00, (byte) 0x01, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x01, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x05, (byte) 0x06, (byte) 0x07, (byte) 0x08};
-        Z21Message msg = new Z21Message(message, 17);
-        Assert.assertNull("non-LocoNetTunnel LocoNet Message", msg.getLocoNetMessage());
+        Z21Message z21msg = new Z21Message(message, 17);
+        Assert.assertNull("non-LocoNetTunnel LocoNet Message", z21msg.getLocoNetMessage());
     }
 
     @Test
-    public void MonitorStringLocoNetMessage() {
+    public void testMonitorStringLocoNetMessage() {
         byte message[] = {
             (byte) 0xEF, (byte) 0x0E, (byte) 0x03, (byte) 0x00, (byte) 0x03,
             (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00,
@@ -205,7 +205,7 @@ public class Z21MessageTest extends jmri.jmrix.AbstractMessageTestBase {
     }
 
     @Test
-    public void MonitorStringLocoNetMessage2() {
+    public void testMonitorStringLocoNetMessage2() {
         byte message[] = {
             (byte) 0xD0, (byte) 0x20, (byte) 0x04,
             (byte) 0x7D, (byte) 0x0A, (byte) 0x7C};
@@ -215,13 +215,13 @@ public class Z21MessageTest extends jmri.jmrix.AbstractMessageTestBase {
     }
 
     @Test
-    public void toMonitorStringLanRMBusGetDataRequest() {
+    public void testToMonitorStringLanRMBusGetDataRequest() {
         msg = Z21Message.getLanRMBusGetDataRequestMessage(0);
         Assert.assertEquals("Monitor String", "Z21 RM Bus Data Request for group 0", msg.toMonitorString());
     }
 
     @Test
-    public void toMonitorStringLanRMBusProgramModule() {
+    public void testToMonitorStringLanRMBusProgramModule() {
         msg = Z21Message.getLanRMBusProgramModuleMessage(0);
         Assert.assertEquals("Monitor String", "Z21 RM Bus Program Module to Address 0", msg.toMonitorString());
     }
@@ -234,6 +234,7 @@ public class Z21MessageTest extends jmri.jmrix.AbstractMessageTestBase {
     }
 
     @AfterEach
+    @Override
     public void tearDown() {
         m = msg = null;
         JUnitUtil.tearDown();

--- a/java/test/jmri/jmrix/roco/z21/Z21ReplyTest.java
+++ b/java/test/jmri/jmrix/roco/z21/Z21ReplyTest.java
@@ -15,7 +15,7 @@ public class Z21ReplyTest extends jmri.jmrix.AbstractMessageTestBase {
     private Z21Reply message = null;
 
     @Test
-    public void prefixSkip() {
+    public void testPrefixSkip() {
         message = new Z21Reply();
         Assert.assertEquals("prefix skip", 0, message.skipPrefix(5));
     }
@@ -42,7 +42,7 @@ public class Z21ReplyTest extends jmri.jmrix.AbstractMessageTestBase {
     }
 
     @Test
-    public void getBCDElement() {
+    public void testGetBCDElement() {
         byte msg[] = {(byte) 0x0D, (byte) 0x00, (byte) 0x04, (byte) 0x00, (byte) 0x12, (byte) 0x34, (byte) 0xAB, (byte) 0x03, (byte) 0x19, (byte) 0x06, (byte) 0x0B, (byte) 0xB1};
         message = new Z21Reply(msg, 12);
         Assert.assertEquals("4th byte BCD", Integer.valueOf(12), message.getElementBCD(4));
@@ -51,7 +51,7 @@ public class Z21ReplyTest extends jmri.jmrix.AbstractMessageTestBase {
 
     // Test XpressNet Tunnel related methods.
     @Test
-    public void tunnelXPressNet() {
+    public void testTunnelXPressNet() {
         byte msg[] = {(byte) 0x07, (byte) 0x00, (byte) 0x40, (byte) 0x00, (byte) 0x61, (byte) 0x82, (byte) 0xE3};
         message = new Z21Reply(msg, 7);
         Assert.assertTrue("XpressNet Tunnel Message", message.isXPressNetTunnelMessage());
@@ -61,7 +61,7 @@ public class Z21ReplyTest extends jmri.jmrix.AbstractMessageTestBase {
     }
 
     @Test
-    public void getXPressNetReply() {
+    public void testGetXPressNetReply() {
         byte msg[] = {(byte) 0x07, (byte) 0x00, (byte) 0x40, (byte) 0x00, (byte) 0x61, (byte) 0x82, (byte) 0xE3};
         message = new Z21Reply(msg, 7);
         jmri.jmrix.lenz.XNetReply x = message.getXNetReply();
@@ -71,21 +71,21 @@ public class Z21ReplyTest extends jmri.jmrix.AbstractMessageTestBase {
     }
 
     @Test
-    public void getNullXPressNetReply() {
+    public void testGetNullXPressNetReply() {
         byte msg[] = {(byte) 0x11, (byte) 0x00, (byte) 0x88, (byte) 0x00, (byte) 0x00, (byte) 0x01, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x01, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x05, (byte) 0x06, (byte) 0x07, (byte) 0x08};
         message = new Z21Reply(msg, 17);
         Assert.assertNull("non-XNetTunnel XpressNet Reply", message.getXNetReply());
     }
 
     @Test
-    public void MonitorStringXPressNetReply() {
+    public void testMonitorStringXPressNetReply() {
         byte msg[] = {(byte) 0x07, (byte) 0x00, (byte) 0x40, (byte) 0x00, (byte) 0x61, (byte) 0x82, (byte) 0xE3};
         message = new Z21Reply(msg, 7);
         Assert.assertEquals("Monitor String", "XpressNet Tunnel Reply: 61 82 E3", message.toMonitorString());
     }
 
     @Test
-    public void getXPressNetThrottleReply() {
+    public void testGetXPressNetThrottleReply() {
         // this test comes from a user log, where the last byte in the 
         // Z21 message incorrectly became the first byte of the XpressNet Reply.
         byte msg[] = {(byte) 0x0E, (byte) 0x00, (byte) 0x40, (byte) 0x00, (byte) 0xEF, (byte) 0x00, (byte) 0x03, (byte) 0x04, (byte) 0x80, (byte) 0x10, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x78};
@@ -104,7 +104,7 @@ public class Z21ReplyTest extends jmri.jmrix.AbstractMessageTestBase {
     }
 
     @Test
-    public void xPressNetThrottleReplyToMonitorString() {
+    public void testXPressNetThrottleReplyToMonitorString() {
         byte msg[] = {(byte) 0x0E, (byte) 0x00, (byte) 0x40, (byte) 0x00, (byte) 0xEF, (byte) 0x00, (byte) 0x03, (byte) 0x04, (byte) 0x80, (byte) 0x10, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x78};
         message = new Z21Reply(msg, 14);
         Assert.assertEquals("Monitor String", "XpressNet Tunnel Reply: Z21 Mobile decoder info reply for address 3: Forward,in 128 Speed Step Mode,Speed Step: 0. Address is Free for Operation. F0 On; F1 Off; F2 Off; F3 Off; F4 Off; F5 Off; F6 Off; F7 Off; F8 Off; F9 Off; F10 Off; F11 Off; F12 Off;  F13 Off; F14 Off; F15 Off; F16 Off; F17 Off; F18 Off; F19 Off; F20 Off; F21 Off; F22 Off; F23 Off; F24 Off; F25 Off; F26 Off; F27 Off; F28 Off; ", message.toMonitorString());
@@ -112,7 +112,7 @@ public class Z21ReplyTest extends jmri.jmrix.AbstractMessageTestBase {
 
     //Test RailCom related methods.
     @Test
-    public void railComReply() {
+    public void testRailComReply() {
         byte msg[] = {(byte) 0x11, (byte) 0x00, (byte) 0x88, (byte) 0x00, (byte) 0x00, (byte) 0x01, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x01, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x05, (byte) 0x06, (byte) 0x07, (byte) 0x08};
         message = new Z21Reply(msg, 17);
         Assert.assertTrue("RailCom Reply", message.isRailComDataChangedMessage());
@@ -122,7 +122,7 @@ public class Z21ReplyTest extends jmri.jmrix.AbstractMessageTestBase {
     }
 
     @Test
-    public void railComEntries() {
+    public void testRailComEntries() {
         byte msg[] = {(byte) 0x11, (byte) 0x00, (byte) 0x88, (byte) 0x00, (byte) 0x00, (byte) 0x01, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x01, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x05, (byte) 0x06, (byte) 0x07, (byte) 0x08};
         message = new Z21Reply(msg, 17);
         Assert.assertEquals("RailCom Entries", 1, message.getNumRailComDataEntries());
@@ -132,14 +132,14 @@ public class Z21ReplyTest extends jmri.jmrix.AbstractMessageTestBase {
     }
 
     @Test
-    public void railCom2Entries() {
+    public void testRailCom2Entries() {
         byte msg[] = {(byte) 0x1E, (byte) 0x00, (byte) 0x88, (byte) 0x00, (byte) 0x00, (byte) 0x01, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x01, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x05, (byte) 0x06, (byte) 0x07, (byte) 0x08, (byte) 0x20, (byte) 0x21, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x05, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x05, (byte) 0x06, (byte) 0x07, (byte) 0x08};
         message = new Z21Reply(msg, 30);
         Assert.assertEquals("RailCom Entries", 2, message.getNumRailComDataEntries());
     }
 
     @Test
-    public void railComAddress() {
+    public void testRailComAddress() {
         byte msg[] = {(byte) 0x1E, (byte) 0x00, (byte) 0x88, (byte) 0x00, (byte) 0x00, (byte) 0x01, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x01, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x05, (byte) 0x06, (byte) 0x07, (byte) 0x08, (byte) 0x20, (byte) 0x21, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x05, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x05, (byte) 0x06, (byte) 0x07, (byte) 0x08};
         message = new Z21Reply(msg, 30);
         Assert.assertTrue("RailCom Address", (new jmri.DccLocoAddress(256, true)).equals(message.getRailComLocoAddress(0)));
@@ -147,35 +147,35 @@ public class Z21ReplyTest extends jmri.jmrix.AbstractMessageTestBase {
     }
 
     @Test
-    public void railComRcvCount() {
+    public void testRailComRcvCount() {
         byte msg[] = {(byte) 0x11, (byte) 0x00, (byte) 0x88, (byte) 0x00, (byte) 0x00, (byte) 0x01, (byte) 0x01, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x05, (byte) 0x06, (byte) 0x07, (byte) 0x08};
         message = new Z21Reply(msg, 17);
         Assert.assertEquals("RailCom Rcv Count", 1, message.getRailComRcvCount(0));
     }
 
     @Test
-    public void railComErrCount() {
+    public void testRailComErrCount() {
         byte msg[] = {(byte) 0x11, (byte) 0x00, (byte) 0x88, (byte) 0x00, (byte) 0x00, (byte) 0x01, (byte) 0x01, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x05, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x06, (byte) 0x07, (byte) 0x08};
         message = new Z21Reply(msg, 17);
         Assert.assertEquals("RailCom Err Count", 5, message.getRailComErrCount(0));
     }
 
     @Test
-    public void railComSpeed() {
+    public void testRailComSpeed() {
         byte msg[] = {(byte) 0x11, (byte) 0x00, (byte) 0x88, (byte) 0x00, (byte) 0x00, (byte) 0x01, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x01, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x05, (byte) 0x06, (byte) 0x07, (byte) 0x08};
         message = new Z21Reply(msg, 17);
         Assert.assertEquals("RailCom Speed", 6, message.getRailComSpeed(0));
     }
 
     @Test
-    public void railComOptions() {
+    public void testRailComOptions() {
         byte msg[] = {(byte) 0x11, (byte) 0x00, (byte) 0x88, (byte) 0x00, (byte) 0x00, (byte) 0x01, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x01, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x05, (byte) 0x06, (byte) 0x07, (byte) 0x08};
         message = new Z21Reply(msg, 17);
         Assert.assertEquals("RailCom Options", 5, message.getRailComOptions(0));
     }
 
     @Test
-    public void railComQos() {
+    public void testRailComQos() {
         byte msg[] = {(byte) 0x11, (byte) 0x00, (byte) 0x88, (byte) 0x00, (byte) 0x00, (byte) 0x01, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x01, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x05, (byte) 0x06, (byte) 0x07, (byte) 0x08};
         message = new Z21Reply(msg, 17);
         Assert.assertEquals("RailCom Qos", 7, message.getRailComQos(0));
@@ -183,7 +183,7 @@ public class Z21ReplyTest extends jmri.jmrix.AbstractMessageTestBase {
 
     //Test System Data related methods.
     @Test
-    public void systemDataChangedReply() {
+    public void testSystemDataChangedReply() {
         byte msg[] = {(byte) 0x14, (byte) 0x00, (byte) 0x84, (byte) 0x00, (byte) 0x00, (byte) 0x01, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x01, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x05, (byte) 0x06, (byte) 0x07, (byte) 0x08, (byte) 0x00, (byte) 0x00, (byte) 0x00};
         message = new Z21Reply(msg, 20);
         Assert.assertTrue("System Data Changed Reply", message.isSystemDataChangedReply());
@@ -193,7 +193,7 @@ public class Z21ReplyTest extends jmri.jmrix.AbstractMessageTestBase {
     }
 
     @Test
-    public void mainCurrentFromSystemDataChangedReply() {
+    public void testMainCurrentFromSystemDataChangedReply() {
         byte msg[] = {(byte) 0x14, (byte) 0x00, (byte) 0x84, (byte) 0x00, (byte) 0x00, (byte) 0x01, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x01, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x05, (byte) 0x06, (byte) 0x07, (byte) 0x08, (byte) 0x00, (byte) 0x00, (byte) 0x00};
         message = new Z21Reply(msg, 20);
         Assert.assertTrue("System Data Changed Reply", message.isSystemDataChangedReply());
@@ -201,7 +201,7 @@ public class Z21ReplyTest extends jmri.jmrix.AbstractMessageTestBase {
     }
 
     @Test
-    public void progCurrentFromSystemDataChangedReply() {
+    public void testProgCurrentFromSystemDataChangedReply() {
         byte msg[] = {(byte) 0x14, (byte) 0x00, (byte) 0x84, (byte) 0x00, (byte) 0x00, (byte) 0x01, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x01, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x05, (byte) 0x06, (byte) 0x07, (byte) 0x08, (byte) 0x00, (byte) 0x00, (byte) 0x00};
         message = new Z21Reply(msg, 20);
         Assert.assertTrue("System Data Changed Reply", message.isSystemDataChangedReply());
@@ -209,7 +209,7 @@ public class Z21ReplyTest extends jmri.jmrix.AbstractMessageTestBase {
     }
 
     @Test
-    public void filteredMainCurrentFromSystemDataChangedReply() {
+    public void testFilteredMainCurrentFromSystemDataChangedReply() {
         byte msg[] = {(byte) 0x14, (byte) 0x00, (byte) 0x84, (byte) 0x00, (byte) 0x00, (byte) 0x01, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x01, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x05, (byte) 0x06, (byte) 0x07, (byte) 0x08, (byte) 0x00, (byte) 0x00, (byte) 0x00};
         message = new Z21Reply(msg, 20);
         Assert.assertTrue("System Data Changed Reply", message.isSystemDataChangedReply());
@@ -217,7 +217,7 @@ public class Z21ReplyTest extends jmri.jmrix.AbstractMessageTestBase {
     }
 
     @Test
-    public void temperatureFromSystemDataChangedReply() {
+    public void testTemperatureFromSystemDataChangedReply() {
         byte msg[] = {(byte) 0x14, (byte) 0x00, (byte) 0x84, (byte) 0x00, (byte) 0x00, (byte) 0x01, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x01, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x05, (byte) 0x06, (byte) 0x07, (byte) 0x08, (byte) 0x00, (byte) 0x00, (byte) 0x00};
         message = new Z21Reply(msg, 20);
         Assert.assertTrue("System Data Changed Reply", message.isSystemDataChangedReply());
@@ -225,7 +225,7 @@ public class Z21ReplyTest extends jmri.jmrix.AbstractMessageTestBase {
     }
 
     @Test
-    public void supplyVoltageFromSystemDataChangedReply() {
+    public void testSupplyVoltageFromSystemDataChangedReply() {
         byte msg[] = {(byte) 0x14, (byte) 0x00, (byte) 0x84, (byte) 0x00, (byte) 0x00, (byte) 0x01, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x01, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x05, (byte) 0x06, (byte) 0x07, (byte) 0x08, (byte) 0x00, (byte) 0x00, (byte) 0x00};
         message = new Z21Reply(msg, 20);
         Assert.assertTrue("System Data Changed Reply", message.isSystemDataChangedReply());
@@ -233,7 +233,7 @@ public class Z21ReplyTest extends jmri.jmrix.AbstractMessageTestBase {
     }
 
     @Test
-    public void vccVoltageFromSystemDataChangedReply() {
+    public void testVccVoltageFromSystemDataChangedReply() {
         byte msg[] = {(byte) 0x14, (byte) 0x00, (byte) 0x84, (byte) 0x00, (byte) 0x00, (byte) 0x01, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x01, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x05, (byte) 0x06, (byte) 0x07, (byte) 0x08, (byte) 0x00, (byte) 0x00, (byte) 0x00};
         message = new Z21Reply(msg, 20);
         Assert.assertTrue("System Data Changed Reply", message.isSystemDataChangedReply());
@@ -241,7 +241,7 @@ public class Z21ReplyTest extends jmri.jmrix.AbstractMessageTestBase {
     }
 
     @Test
-    public void getLocoNetReply() {
+    public void testGetLocoNetReply() {
         byte msg[] = {(byte) 0x11, (byte) 0x00, (byte) 0xA2, (byte) 0x00,
             (byte) 0xEF, (byte) 0x0E, (byte) 0x03, (byte) 0x00, (byte) 0x03,
             (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00,
@@ -255,14 +255,14 @@ public class Z21ReplyTest extends jmri.jmrix.AbstractMessageTestBase {
     }
 
     @Test
-    public void getNullLocoNetReply() {
+    public void testGetNullLocoNetReply() {
         byte msg[] = {(byte) 0x11, (byte) 0x00, (byte) 0x88, (byte) 0x00, (byte) 0x00, (byte) 0x01, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x01, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x05, (byte) 0x06, (byte) 0x07, (byte) 0x08};
         message = new Z21Reply(msg, 17);
         Assert.assertNull("non-LocoNetTunnel LocoNet Reply", message.getLocoNetMessage());
     }
 
     @Test
-    public void MonitorStringLocoNetReply() {
+    public void testMonitorStringLocoNetReply() {
         byte msg[] = {(byte) 0x11, (byte) 0x00, (byte) 0xA2, (byte) 0x00,
             (byte) 0xEF, (byte) 0x0E, (byte) 0x03, (byte) 0x00, (byte) 0x03,
             (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00,
@@ -275,7 +275,7 @@ public class Z21ReplyTest extends jmri.jmrix.AbstractMessageTestBase {
     }
 
     @Test
-    public void MonitorStringSerialNumberReply() {
+    public void testMonitorStringSerialNumberReply() {
         byte msg[] = {(byte) 0x08, (byte) 0x00, (byte) 0x10, (byte) 0x00,
             (byte) 0xAE, (byte) 0xA7, (byte) 0x01, (byte) 0x00};
         message = new Z21Reply(msg, 8);
@@ -283,7 +283,7 @@ public class Z21ReplyTest extends jmri.jmrix.AbstractMessageTestBase {
     }
 
     @Test
-    public void MonitorStringVersionReply() {
+    public void testMonitorStringVersionReply() {
         byte msg[] = {(byte) 0x0C, (byte) 0x00, (byte) 0x1A, (byte) 0x00,
             (byte) 0x00, (byte) 0x02, (byte) 0x00, (byte) 0x00, (byte) 0x32,
             (byte) 0x01, (byte) 0x00, (byte) 0x00};
@@ -292,7 +292,7 @@ public class Z21ReplyTest extends jmri.jmrix.AbstractMessageTestBase {
     }
 
     @Test
-    public void MonitorStringSystemStateReply() {
+    public void testMonitorStringSystemStateReply() {
         byte msg[] = {(byte) 0x14, (byte) 0x00, (byte) 0x84, (byte) 0x00,
             (byte) 0x56, (byte) 0x00, (byte) 0x03, (byte) 0x00, (byte) 0x5D,
             (byte) 0x00, (byte) 0x23, (byte) 0x00, (byte) 0x10, (byte) 0x47,
@@ -303,7 +303,7 @@ public class Z21ReplyTest extends jmri.jmrix.AbstractMessageTestBase {
     }
 
     @Test
-    public void MonitorStringRMFeedbackChangedReply() {
+    public void testMonitorStringRMFeedbackChangedReply() {
         byte msg[] = {(byte) 0x0F, (byte) 0x00, (byte) 0x80, (byte) 0x00,
             (byte) 0x00, (byte) 0x00, (byte) 0xFF, (byte) 0x00, (byte) 0x00,
             (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00,
@@ -340,7 +340,7 @@ public class Z21ReplyTest extends jmri.jmrix.AbstractMessageTestBase {
     }
 
     @Test
-    public void checkIsRMFeedbackChangedReply() {
+    public void testIsRMFeedbackChangedReply() {
         byte msg[] = {(byte) 0x0F, (byte) 0x00, (byte) 0x80, (byte) 0x00,
             (byte) 0x00, (byte) 0x00, (byte) 0xFF, (byte) 0x00, (byte) 0x00,
             (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00,
@@ -427,6 +427,7 @@ public class Z21ReplyTest extends jmri.jmrix.AbstractMessageTestBase {
     }
 
     @AfterEach
+    @Override
     public void tearDown() {
         m = message = null;
         JUnitUtil.tearDown();

--- a/java/test/jmri/jmrix/roco/z21/Z21XNetThrottleTest.java
+++ b/java/test/jmri/jmrix/roco/z21/Z21XNetThrottleTest.java
@@ -54,7 +54,7 @@ public class Z21XNetThrottleTest extends jmri.jmrix.roco.RocoXNetThrottleTest {
         m.setElement(4, 0x00);
         m.setElement(5, 0xE0);
 
-        n = tc.outbound.size();
+        // n = tc.outbound.size();
         t.message(m);
 
         // Sending the reply message should make the throttle change
@@ -85,7 +85,7 @@ public class Z21XNetThrottleTest extends jmri.jmrix.roco.RocoXNetThrottleTest {
         m.setElement(1, 0x04);
         m.setElement(2, 0x05);
 
-        n = tc.outbound.size();
+        // n = tc.outbound.size();
         t.message(m);
         // which sets the status back state back to idle..
     }
@@ -115,7 +115,7 @@ public class Z21XNetThrottleTest extends jmri.jmrix.roco.RocoXNetThrottleTest {
         m.setElement(1, 0x04);
         m.setElement(2, 0x05);
 
-        n = tc.outbound.size();
+        // n = tc.outbound.size();
         t.message(m);
         // which sets the status back state back to idle..
     }
@@ -145,7 +145,7 @@ public class Z21XNetThrottleTest extends jmri.jmrix.roco.RocoXNetThrottleTest {
         m.setElement(1, 0x04);
         m.setElement(2, 0x05);
 
-        n = tc.outbound.size();
+        // n = tc.outbound.size();
         t.message(m);
         // which sets the status back state back to idle..
     }
@@ -175,7 +175,7 @@ public class Z21XNetThrottleTest extends jmri.jmrix.roco.RocoXNetThrottleTest {
         m.setElement(1, 0x04);
         m.setElement(2, 0x05);
 
-        n = tc.outbound.size();
+        // n = tc.outbound.size();
         t.message(m);
         // which sets the status back state back to idle..
     }
@@ -204,7 +204,7 @@ public class Z21XNetThrottleTest extends jmri.jmrix.roco.RocoXNetThrottleTest {
         m.setElement(1, 0x04);
         m.setElement(2, 0x05);
 
-        n = tc.outbound.size();
+        // n = tc.outbound.size();
         t.message(m);
         // which sets the status back state back to idle..
     }
@@ -238,7 +238,7 @@ public class Z21XNetThrottleTest extends jmri.jmrix.roco.RocoXNetThrottleTest {
         m.setElement(7, 0x00);
         m.setElement(8, 0xE4);
 
-        n = tc.outbound.size();
+        // n = tc.outbound.size();
         t.message(m);
         // which sets the status back state back to idle..
     }
@@ -269,7 +269,7 @@ public class Z21XNetThrottleTest extends jmri.jmrix.roco.RocoXNetThrottleTest {
         m.setElement(1, 0x04);
         m.setElement(2, 0x05);
 
-        n = tc.outbound.size();
+        // n = tc.outbound.size();
         t.message(m);
         // which sets the status back state back to idle..
     }


### PR DESCRIPTION
RocoXNetThrottleTest, Z21XNetThrottleTest - comment out unused vars
 
RocoZ21CommandStationTest, Z21MessageTest, Z21ReplyTest - method names start with test lowercase

Z21CanReporterTest -
add error string to JUnitUtil.waitFor
fixes Unchecked/unconfirmed cast