### PR TITLE
LogixNG Tests - deregister BlockManager Shutdown Tasks

### DIFF
--- a/java/test/jmri/jmrit/logixng/actions/ActionLightTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ActionLightTest.java
@@ -543,6 +543,7 @@ public class ActionLightTest extends AbstractDigitalActionTestBase {
 
     @After
     public void tearDown() {
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.tearDown();
     }

--- a/java/test/jmri/jmrit/logixng/actions/ActionSensorTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ActionSensorTest.java
@@ -547,6 +547,7 @@ public class ActionSensorTest extends AbstractDigitalActionTestBase {
     @After
     public void tearDown() {
         // JUnitAppender.clearBacklog();    REMOVE THIS!!!
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.tearDown();
     }

--- a/java/test/jmri/jmrit/logixng/actions/ActionTurnoutLockTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ActionTurnoutLockTest.java
@@ -536,6 +536,7 @@ public class ActionTurnoutLockTest extends AbstractDigitalActionTestBase {
 
     @After
     public void tearDown() {
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.tearDown();
     }

--- a/java/test/jmri/jmrit/logixng/actions/ActionTurnoutTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ActionTurnoutTest.java
@@ -545,6 +545,7 @@ public class ActionTurnoutTest extends AbstractDigitalActionTestBase {
 
     @After
     public void tearDown() {
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.tearDown();
     }

--- a/java/test/jmri/jmrit/logixng/util/parser/ExpressionNodeIdentifierTest.java
+++ b/java/test/jmri/jmrit/logixng/util/parser/ExpressionNodeIdentifierTest.java
@@ -86,6 +86,7 @@ public class ExpressionNodeIdentifierTest {
 
     @After
     public void tearDown() {
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.tearDown();
     }

--- a/java/test/jmri/jmrit/logixng/util/parser/FunctionManagerTest.java
+++ b/java/test/jmri/jmrit/logixng/util/parser/FunctionManagerTest.java
@@ -41,6 +41,7 @@ public class FunctionManagerTest {
 
     @After
     public void tearDown() {
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
     

--- a/java/test/jmri/jmrit/logixng/util/parser/RecursiveDescentParserTest.java
+++ b/java/test/jmri/jmrit/logixng/util/parser/RecursiveDescentParserTest.java
@@ -1164,6 +1164,7 @@ public class RecursiveDescentParserTest {
 
     @After
     public void tearDown() {
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.tearDown();
     }

--- a/java/test/jmri/jmrit/logixng/util/parser/swing/FunctionsHelpDialogTest.java
+++ b/java/test/jmri/jmrit/logixng/util/parser/swing/FunctionsHelpDialogTest.java
@@ -29,6 +29,7 @@ public class FunctionsHelpDialogTest {
 
     @After
     public void tearDown() {
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
     


### PR DESCRIPTION
adds JUnitUtil.deregisterBlockManagerShutdownTask();
to tearDown of various LogixNG tests.