### PR TITLE
Display tests

### DIFF
--- a/java/test/jmri/jmrit/display/AbstractEditorTestBase.java
+++ b/java/test/jmri/jmrit/display/AbstractEditorTestBase.java
@@ -1,12 +1,13 @@
 package jmri.jmrit.display;
 
-import java.awt.GraphicsEnvironment;
 import javax.swing.UIManager;
+
 import jmri.util.JUnitUtil;
 import jmri.util.SystemType;
+
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.netbeans.jemmy.operators.JMenuOperator;
 
 /**
@@ -23,8 +24,9 @@ abstract public class AbstractEditorTestBase<T extends Editor> {
     protected T e = null;
 
     @Test
+    @DisabledIfSystemProperty(named = "java.awt.headless", matches = "true" )
     public void checkFileMenuExists() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+
         e.setVisible(true);
         EditorFrameOperator jfo = new EditorFrameOperator(e);
         JMenuOperator jmo = new JMenuOperator(jfo, Bundle.getMessage("MenuFile"));
@@ -33,16 +35,18 @@ abstract public class AbstractEditorTestBase<T extends Editor> {
 
     @Test
     @Disabled("The test sometimes has trouble finding the file menu")
+    @DisabledIfSystemProperty(named = "java.awt.headless", matches = "true" )
     public void checkFileDeleteMenuItem() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+
         e.setVisible(true);
         EditorFrameOperator jfo = new EditorFrameOperator(e);
         jfo.deleteViaFileMenuWithConfirmations();
     }
 
     @Test
+    @DisabledIfSystemProperty(named = "java.awt.headless", matches = "true" )
     public void checkWindowMenuExists() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+
         e.setVisible(true);
         EditorFrameOperator jfo = new EditorFrameOperator(e);
         JMenuOperator jmo = new JMenuOperator(jfo, Bundle.getMessage("MenuWindow"));
@@ -51,8 +55,9 @@ abstract public class AbstractEditorTestBase<T extends Editor> {
     }
 
     @Test
+    @DisabledIfSystemProperty(named = "java.awt.headless", matches = "true" )
     public void checkHelpMenuExists() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+
         e.setVisible(true);
         EditorFrameOperator jfo = new EditorFrameOperator(e);
         JMenuOperator jmo = new JMenuOperator(jfo, Bundle.getMessage("MenuHelp"));
@@ -67,14 +72,15 @@ abstract public class AbstractEditorTestBase<T extends Editor> {
     }
 
     @Test
+    @DisabledIfSystemProperty(named = "java.awt.headless", matches = "true" )
     @Disabled("This test seems to be reliable on Linux, but fails on Windows (appveyor)")
     public void testSetSize() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+
         java.awt.Dimension d0 = e.getSize();
         e.setSize(100, 100);
         JUnitUtil.waitFor(() -> {
             return d0 != e.getSize();
-        });
+        },"dimension still equals initial editor size");
         java.awt.Dimension d = e.getSize();
         // the java.awt.Dimension stores the values as floating point
         // numbers, but setSize expects integer parameters.
@@ -83,8 +89,9 @@ abstract public class AbstractEditorTestBase<T extends Editor> {
     }
 
     @Test
+    @DisabledIfSystemProperty(named = "java.awt.headless", matches = "true" )
     public void testChangeView() throws Positionable.DuplicateIdException {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+
         // create a new Positionable Label on the existing editor (e);
         PositionableLabel to = new PositionableLabel("one", e);
         to.setBounds(80, 80, 40, 40);

--- a/java/test/jmri/jmrit/display/BlockContentsIconTest.java
+++ b/java/test/jmri/jmrit/display/BlockContentsIconTest.java
@@ -1,7 +1,5 @@
 package jmri.jmrit.display;
 
-import java.awt.GraphicsEnvironment;
-
 import javax.swing.JFrame;
 
 import jmri.BlockManager;
@@ -14,7 +12,7 @@ import jmri.util.junit.annotations.ToDo;
 import org.apache.log4j.Level;
 import org.junit.jupiter.api.*;
 import org.junit.Assert;
-import org.junit.Assume;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.netbeans.jemmy.QueueTool;
 
 /**
@@ -22,11 +20,12 @@ import org.netbeans.jemmy.QueueTool;
  *
  * @author Paul Bender Copyright (C) 2016
  */
+@DisabledIfSystemProperty(named = "java.awt.headless", matches = "true" )
 public class BlockContentsIconTest extends PositionableLabelTest {
 
     @Test
     public void testNamedIconCtor() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+
         NamedIcon icon = new NamedIcon("resources/icons/redTransparentBox.gif", "box"); // 13x13
         BlockContentsIcon bci = new BlockContentsIcon(icon, editor);
         bci.setIcon(icon);
@@ -35,7 +34,7 @@ public class BlockContentsIconTest extends PositionableLabelTest {
 
     @Test
     public void testShowRosterEntry() throws Exception {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+
         JFrame jf = new JmriJFrame();
         jf.setTitle("Expect Roster Entry");
         jf.getContentPane().setLayout(new java.awt.FlowLayout());
@@ -46,7 +45,7 @@ public class BlockContentsIconTest extends PositionableLabelTest {
 
         jmri.jmrit.roster.RosterEntry re = jmri.jmrit.roster.RosterEntry.fromFile(new java.io.File("java/test/jmri/jmrit/roster/ACL1012-Schema.xml"));
 
-        jmri.InstanceManager.getDefault(BlockManager.class).getBlock("IB1").setValue(re);
+        jmri.InstanceManager.getDefault(BlockManager.class).provide("IB1").setValue(re);
         new QueueTool().waitEmpty(100);
 
         jf.pack();
@@ -60,7 +59,7 @@ public class BlockContentsIconTest extends PositionableLabelTest {
 
     @Test
     public void testShowIdTag() throws Exception {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+
         JFrame jf = new JmriJFrame();
         jf.setTitle("Expect Roster Entry");
         jf.getContentPane().setLayout(new java.awt.FlowLayout());
@@ -71,7 +70,7 @@ public class BlockContentsIconTest extends PositionableLabelTest {
 
         jmri.IdTag tag = new jmri.implementation.DefaultIdTag("1234");
 
-        jmri.InstanceManager.getDefault(BlockManager.class).getBlock("IB1").setValue(tag);
+        jmri.InstanceManager.getDefault(BlockManager.class).provide("IB1").setValue(tag);
         new QueueTool().waitEmpty(100);
 
         jf.pack();
@@ -90,7 +89,7 @@ public class BlockContentsIconTest extends PositionableLabelTest {
     public void testGetAndSetScale() {
         // the test in the parent class fails if there is no icon for the
         // blockcontents.
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+
         NamedIcon icon = new NamedIcon("resources/icons/redTransparentBox.gif", "box"); // 13x13
         ((BlockContentsIcon) p).setIcon(icon);
         Assert.assertEquals("Default Scale", 1.0D, p.getScale(), 0.0);
@@ -102,7 +101,7 @@ public class BlockContentsIconTest extends PositionableLabelTest {
     @Override
     @ToDo("The test in the parent class fails if there is no icon set")
     public void testGetAndSetRotationDegrees() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+
         NamedIcon icon = new NamedIcon("resources/icons/redTransparentBox.gif", "box"); // 13x13
         ((BlockContentsIcon) p).setIcon(icon);
         p.rotate(50);
@@ -114,15 +113,14 @@ public class BlockContentsIconTest extends PositionableLabelTest {
     public void setUp() {
         super.setUp();
         JUnitUtil.initConfigureManager();
-        if (!GraphicsEnvironment.isHeadless()) {
-            editor = new EditorScaffold();
-            jmri.Block block = jmri.InstanceManager.getDefault(BlockManager.class).provideBlock("IB1");
-            BlockContentsIcon bci = new BlockContentsIcon("foo", editor);
-            bci.setBlock(new jmri.NamedBeanHandle<>("IB1", block));
-            // set the memory value for testClone in PositionableTestBase
-            bci.setMemory("IB1");
-            p = to = bci;
-        }
+
+        jmri.Block block = jmri.InstanceManager.getDefault(BlockManager.class).provideBlock("IB1");
+        BlockContentsIcon bci = new BlockContentsIcon("foo", editor);
+        bci.setBlock(new jmri.NamedBeanHandle<>("IB1", block));
+        // set the memory value for testClone in PositionableTestBase
+        bci.setMemory("IB1");
+        p = to = bci;
+
     }
 
     @AfterEach

--- a/java/test/jmri/jmrit/display/EditorFrameOperator.java
+++ b/java/test/jmri/jmrit/display/EditorFrameOperator.java
@@ -1,6 +1,9 @@
 package jmri.jmrit.display;
 
 import javax.swing.JFrame;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import org.netbeans.jemmy.operators.JButtonOperator;
 import org.netbeans.jemmy.operators.JDialogOperator;
 import org.netbeans.jemmy.operators.JFrameOperator;
@@ -23,8 +26,8 @@ public class EditorFrameOperator extends JFrameOperator {
        super(frame);
     }
 
-    private static final String hideThreadName = "EditorFrameOperator: Hide Dialog Close Thread";
-    private static final String deleteThreadName = "EditorFrameOperator: Delete Dialog Close Thread";
+    private static final String HIDE_THREAD_NAME = "EditorFrameOperator: Hide Dialog Close Thread";
+    private static final String DELETE_THREAD_NAME = "EditorFrameOperator: Delete Dialog Close Thread";
 
     public void closeFrameWithConfirmations(){
         // if OK to here, close window
@@ -40,43 +43,53 @@ public class EditorFrameOperator extends JFrameOperator {
 
     }
 
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings( value = "DE_MIGHT_IGNORE",
-        justification = "exceptions in operator threads not considered an error")
     private void dismissClosingDialogs(){
         // the reminder dialog doesn't appear every time we close, so put
         // pressing the button in that dialog into a thread by itself.  If
         // the dialog appears, it will get clicked, but it's not an error
         // if it doesn't appear.
         Thread t = new Thread( () -> {
-            try {
-                JDialogOperator d = new JDialogOperator(Bundle.getMessage("PanelHideTitle"));
-                // Find the button that deletes the panel
-                JButtonOperator bo = new JButtonOperator(d,Bundle.getMessage("ButtonHide"));
-
-                // Click button to delete panel and close window
-                bo.push();
-            } catch (Exception e) {
-                // exceptions in this thread are not considered an error.
-            }
+            triggerPanelHideOperators();
         });
-        t.setName(hideThreadName);
+        t.setName(HIDE_THREAD_NAME);
         t.start();
 
         Thread t2 = new Thread( () -> {
-            try {
-                JDialogOperator d = new JDialogOperator(Bundle.getMessage("DeleteVerifyTitle"));
-                // Find the button that deletes the panel
-                JButtonOperator bo = new JButtonOperator(d,Bundle.getMessage("ButtonYesDelete"));
-
-                // Click button to delete panel and close window
-                bo.push();
-            } catch (Exception e) {
-                // exceptions in this thread are not considered an error.
-            }
+            triggerDeleteYesOperators();
         });
-        t2.setName(deleteThreadName);
+        t2.setName(DELETE_THREAD_NAME);
         t2.start();
 
+    }
+
+    @SuppressFBWarnings( value = {"DCN_NULLPOINTER_EXCEPTION", "DE_MIGHT_IGNORE"},
+        justification = "ok for JDialog not to be present")
+    private void triggerPanelHideOperators() {
+        try {
+            JDialogOperator d = new JDialogOperator(Bundle.getMessage("PanelHideTitle"));
+            // Find the button that deletes the panel
+            JButtonOperator bo = new JButtonOperator(d,Bundle.getMessage("ButtonHide"));
+
+            // Click button to delete panel and close window
+            bo.push();
+        } catch (NullPointerException e) {
+            // exceptions in this thread are not considered an error.
+        }
+    }
+
+    @SuppressFBWarnings( value = {"DCN_NULLPOINTER_EXCEPTION", "DE_MIGHT_IGNORE"},
+        justification = "ok for JDialog not to be present")
+    private void triggerDeleteYesOperators() {
+        try {
+            JDialogOperator d = new JDialogOperator(Bundle.getMessage("DeleteVerifyTitle"));
+            // Find the button that deletes the panel
+            JButtonOperator bo = new JButtonOperator(d,Bundle.getMessage("ButtonYesDelete"));
+
+            // Click button to delete panel and close window
+            bo.push();
+        } catch (NullPointerException e) {
+            // exceptions in this thread are not considered an error.
+        }
     }
 
     /**
@@ -84,7 +97,8 @@ public class EditorFrameOperator extends JFrameOperator {
      * to clean up any threads that have been left hanging.
      */
     public static void clearEditorFrameOperatorThreads() {
-        jmri.util.JUnitUtil.removeMatchingThreads(hideThreadName);
-        jmri.util.JUnitUtil.removeMatchingThreads(deleteThreadName);
+        jmri.util.JUnitUtil.removeMatchingThreads(HIDE_THREAD_NAME);
+        jmri.util.JUnitUtil.removeMatchingThreads(DELETE_THREAD_NAME);
     }
+
 }

--- a/java/test/jmri/jmrit/display/EditorIconFrameTest.java
+++ b/java/test/jmri/jmrit/display/EditorIconFrameTest.java
@@ -55,16 +55,12 @@ public class EditorIconFrameTest {
         e.setVisible(true);
         EditorFrameOperator jfo = new EditorFrameOperator(e);
 
+        JFrame frame = e.getIconFrame(inputString);
         if(expectNull) {
-           if("Text".equals(inputString) ) {
-              // "Text" pops up a modal JOptionPane, we need to close it.
-           }
-           JFrame frame = e.getIconFrame(inputString);
-           Assert.assertNull(inputString + " Editor expects null return value", frame);
+            Assert.assertNull(inputString + " Editor expects null return value", frame);
         } else {
-           JFrame frame = e.getIconFrame(inputString);
-           Assert.assertNotNull(inputString + " Editor available", frame );
-           frame.dispose();
+            Assert.assertNotNull(inputString + " Editor available", frame );
+            frame.dispose();
         }
 
         jfo.requestClose();

--- a/java/test/jmri/jmrit/display/PositionableLabelTest.java
+++ b/java/test/jmri/jmrit/display/PositionableLabelTest.java
@@ -8,11 +8,9 @@ import java.awt.Color;
 import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.Font;
-import java.awt.GraphicsEnvironment;
 import java.awt.Point;
 import java.awt.event.ActionEvent;
 import java.io.File;
-import java.io.IOException;
 
 import javax.swing.JButton;
 import javax.swing.JFrame;
@@ -30,7 +28,7 @@ import jmri.util.JmriJFrame;
 
 import org.junit.jupiter.api.*;
 import org.junit.Assert;
-import org.junit.Assume;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.netbeans.jemmy.ComponentChooser;
 import org.netbeans.jemmy.QueueTool;
 import org.netbeans.jemmy.operators.JLabelOperator;
@@ -48,21 +46,19 @@ import org.netbeans.jemmy.operators.JLabelOperator;
  *
  * @author Bob Jacobsen Copyright 2015
  */
+@DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
 public class PositionableLabelTest extends PositionableTestBase {
 
     PositionableLabel to = null;
 
     @Test
     public void testSmallPanel() throws Positionable.DuplicateIdException {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-
-        editor = new EditorScaffold("PositionableLabel Test Panel");
 
         JFrame jf = new JFrame();
-        JPanel p = new JPanel();
-        jf.getContentPane().add(p);
-        p.setPreferredSize(new Dimension(200, 200));
-        p.setLayout(null);
+        JPanel jpanel = new JPanel();
+        jf.getContentPane().add(jpanel);
+        jpanel.setPreferredSize(new Dimension(200, 200));
+        jpanel.setLayout(null);
 
         // test button in upper left
         JButton doButton = new JButton("change label");
@@ -74,15 +70,15 @@ public class PositionableLabelTest extends PositionableTestBase {
             }
         });
         doButton.setBounds(0, 0, 120, 40);
-        p.add(doButton);
+        jpanel.add(doButton);
 
         to = new PositionableLabel("one", editor);
         to.setBounds(80, 80, 40, 40);
         editor.putItem(to);
         to.setDisplayLevel(Editor.LABELS);
-        Assert.assertEquals("Display Level ", to.getDisplayLevel(), Editor.LABELS);
+        Assertions.assertEquals(Editor.LABELS, to.getDisplayLevel(), "Display Level ");
 
-        p.add(to);
+        jpanel.add(to);
 
         jf.pack();
         jf.setVisible(true);
@@ -92,7 +88,6 @@ public class PositionableLabelTest extends PositionableTestBase {
     // The file used was written with 4.0.1, and behaves as expected from panel names
     @Test
     public void testBackgroundColorFile() throws Exception {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
 
         // make four windows
         InstanceManager.getDefault(ConfigureManager.class)
@@ -153,7 +148,6 @@ public class PositionableLabelTest extends PositionableTestBase {
     // Explicit tests of PositionableLabel features
     @Test
     public void testDisplayTransparent() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
 
         JFrame f = new JFrame();
         f.getContentPane().setBackground(Color.blue);
@@ -161,7 +155,7 @@ public class PositionableLabelTest extends PositionableTestBase {
 
         NamedIcon icon = new NamedIcon("resources/icons/redTransparentBox.gif", "box"); // 13x13
 
-        PositionableLabel label = new PositionableLabel(icon, null);
+        PositionableLabel label = new PositionableLabel(icon, editor);
 
         f.add(label);
         f.pack();
@@ -179,9 +173,9 @@ public class PositionableLabelTest extends PositionableTestBase {
 
         // now check that background shows through
         // Need to find the icon location first
-        Point p = SwingUtilities.convertPoint(label, 0, 0, f.getContentPane());
+        Point point = SwingUtilities.convertPoint(label, 0, 0, f.getContentPane());
 
-        val = getDisplayedContent(f.getContentPane(), label.getSize(), p);
+        val = getDisplayedContent(f.getContentPane(), label.getSize(), point);
 
         Assert.assertEquals("frame arraylength", 13 * 13, val.length);
 
@@ -195,7 +189,6 @@ public class PositionableLabelTest extends PositionableTestBase {
 
     @Test
     public void testDisplayTransparent45degrees() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
 
         JFrame f = new JFrame();
         f.getContentPane().setBackground(Color.blue);
@@ -203,7 +196,7 @@ public class PositionableLabelTest extends PositionableTestBase {
 
         NamedIcon icon = new NamedIcon("resources/icons/redTransparentBox.gif", "box"); // 13x13
 
-        PositionableLabel label = new PositionableLabel(icon, null);
+        PositionableLabel label = new PositionableLabel(icon, editor);
 
         f.add(label);
         f.pack();
@@ -229,9 +222,9 @@ public class PositionableLabelTest extends PositionableTestBase {
 
         // now check that background shows through
         // Need to find the icon location first
-        Point p = SwingUtilities.convertPoint(label, 0, 0, f.getContentPane());
+        Point point = SwingUtilities.convertPoint(label, 0, 0, f.getContentPane());
 
-        val = getDisplayedContent(f.getContentPane(), label.getSize(), p);
+        val = getDisplayedContent(f.getContentPane(), label.getSize(), point);
 
         Assert.assertEquals("frame arraylength", 19 * 19, val.length);
         assertImageNinePoints("icon", val, label.getSize(),
@@ -243,7 +236,7 @@ public class PositionableLabelTest extends PositionableTestBase {
     }
 
     // c.f. http://www.ssec.wisc.edu/~tomw/java/unicode.html#x2580
-    final String sampleText = "  \u25CF  "; // note spaces
+    final static String SAMPLE_TEXT_U25CF = "  \u25CF  "; // note spaces
 
     // FULL BLOCK \u2588
     // BLACK SQUARE \u25A0
@@ -253,13 +246,12 @@ public class PositionableLabelTest extends PositionableTestBase {
     // HEAVY MULTIPLICATION X \u2716
     @Test
     public void testDisplayText() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
 
         JFrame f = new JFrame();
         f.getContentPane().setBackground(Color.blue);
         f.setUndecorated(true); // skip frame decoration, which can force a min size.
 
-        PositionableLabel label = new PositionableLabel(sampleText, null);
+        PositionableLabel label = new PositionableLabel(SAMPLE_TEXT_U25CF, editor);
         label.setForeground(Color.black); // this is a direct set, not through the UI
         label.setFont(new Font(Font.MONOSPACED, Font.PLAIN, 12));
 
@@ -280,9 +272,9 @@ public class PositionableLabelTest extends PositionableTestBase {
 
         // now check that background shows through
         // Need to find the icon location first
-        Point p = SwingUtilities.convertPoint(label, 0, 0, f.getContentPane());
+        Point point = SwingUtilities.convertPoint(label, 0, 0, f.getContentPane());
 
-        val = getDisplayedContent(f.getContentPane(), label.getSize(), p);
+        val = getDisplayedContent(f.getContentPane(), label.getSize(), point);
 
         assertImageNinePoints("icon", val, label.getSize(),
                 Pixel.BLUE, Pixel.BLUE, Pixel.BLUE,
@@ -294,13 +286,12 @@ public class PositionableLabelTest extends PositionableTestBase {
 
     @Test
     public void testDisplayTextRotated90() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
 
         JFrame f = new JFrame();
         f.getContentPane().setBackground(Color.blue);
         f.setUndecorated(true); // skip frame decoration, which can force a min size.
 
-        PositionableLabel label = new PositionableLabel(sampleText, null);
+        PositionableLabel label = new PositionableLabel(SAMPLE_TEXT_U25CF, editor);
         label.setForeground(Color.black); // this is a direct set, not through the UI
         label.setFont(new Font(Font.MONOSPACED, Font.PLAIN, 12));
 
@@ -326,9 +317,9 @@ public class PositionableLabelTest extends PositionableTestBase {
 
         // now check that background shows through
         // Need to find the icon location first
-        Point p = SwingUtilities.convertPoint(label, 0, 0, f.getContentPane());
+        Point point = SwingUtilities.convertPoint(label, 0, 0, f.getContentPane());
 
-        val = getDisplayedContent(f.getContentPane(), label.getSize(), p);
+        val = getDisplayedContent(f.getContentPane(), label.getSize(), point);
 
         assertImageNinePoints("icon", val, label.getSize(),
                 Pixel.BLUE, Pixel.BLUE, Pixel.BLUE,
@@ -340,13 +331,12 @@ public class PositionableLabelTest extends PositionableTestBase {
 
     @Test
     public void testDisplayTextRotated45() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
 
         JFrame f = new JFrame();
         f.getContentPane().setBackground(Color.blue);
         f.setUndecorated(true); // skip frame decoration, which can force a min size.
 
-        PositionableLabel label = new PositionableLabel(sampleText, null);
+        PositionableLabel label = new PositionableLabel(SAMPLE_TEXT_U25CF, editor);
         label.setForeground(Color.black); // this is a direct set, not through the UI
         label.setFont(new Font(Font.MONOSPACED, Font.PLAIN, 12));
 
@@ -369,9 +359,9 @@ public class PositionableLabelTest extends PositionableTestBase {
 
         // now check that background shows through
         // Need to find the icon location first
-        Point p = SwingUtilities.convertPoint(label, 0, 0, f.getContentPane());
+        Point point = SwingUtilities.convertPoint(label, 0, 0, f.getContentPane());
 
-        val = getDisplayedContent(f.getContentPane(), label.getSize(), p);
+        val = getDisplayedContent(f.getContentPane(), label.getSize(), point);
 
         assertImageNinePoints("icon", val, label.getSize(),
                 Pixel.BLUE, Pixel.BLUE, Pixel.BLUE,
@@ -387,12 +377,12 @@ public class PositionableLabelTest extends PositionableTestBase {
         super.setUp();
         JUnitUtil.initConfigureManager();
         JUnitUtil.initDefaultUserMessagePreferences();
-        if (!GraphicsEnvironment.isHeadless()) {
-            editor = new EditorScaffold();
-            p = to = new PositionableLabel("one", editor);
-            NamedIcon icon = new NamedIcon("resources/icons/redTransparentBox.gif", "box"); // 13x13
-            to.setIcon(icon);
-        }
+
+        editor = new EditorScaffold("PositionableLabel Test Panel");
+        p = to = new PositionableLabel("one", editor);
+        NamedIcon icon = new NamedIcon("resources/icons/redTransparentBox.gif", "box"); // 13x13
+        to.setIcon(icon);
+
     }
 
     @Override

--- a/java/test/jmri/jmrit/display/PositionableTestBase.java
+++ b/java/test/jmri/jmrit/display/PositionableTestBase.java
@@ -1,7 +1,6 @@
 package jmri.jmrit.display;
 
 import java.awt.event.WindowListener;
-import java.awt.GraphicsEnvironment;
 
 import javax.swing.JPanel;
 import javax.annotation.OverridingMethodsMustInvokeSuper;
@@ -11,7 +10,7 @@ import jmri.util.JUnitUtil;
 
 import org.junit.jupiter.api.*;
 import org.junit.Assert;
-import org.junit.Assume;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 /**
  * Base class for tests for Positionable objects.
@@ -65,9 +64,9 @@ abstract public class PositionableTestBase {
     }
 
     @Test
+    @DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
     public void testGetAndSetPositionable() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        Assert.assertTrue("Defalt Positionable", p.isPositionable());
+        Assert.assertTrue("Default Positionable", p.isPositionable());
         p.setPositionable(false);
         Assert.assertFalse("Positionable after set false", p.isPositionable());
         p.setPositionable(true);
@@ -75,9 +74,9 @@ abstract public class PositionableTestBase {
     }
 
     @Test
+    @DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
     public void testGetAndSetEditable() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        Assert.assertTrue("Defalt Editable", p.isEditable());
+        Assert.assertTrue("Default Editable", p.isEditable());
         p.setEditable(false);
         Assert.assertFalse("Editable after set false", p.isEditable());
         p.setEditable(true);
@@ -85,9 +84,9 @@ abstract public class PositionableTestBase {
     }
 
     @Test
+    @DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
     public void testGetAndSetShowToolTip() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        Assert.assertTrue("Defalt ShowToolTip", p.showToolTip());
+        Assert.assertTrue("Default ShowToolTip", p.showToolTip());
         p.setShowToolTip(false);
         Assert.assertFalse("showToolTip after set false", p.showToolTip());
         p.setShowToolTip(true);
@@ -95,16 +94,16 @@ abstract public class PositionableTestBase {
     }
 
     @Test
+    @DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
     public void testGetAndSetToolTip() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         Assert.assertNull("default tool tip", p.getToolTip());
         p.setToolTip(new ToolTip("hello",0,0,null));
         Assert.assertNotNull("tool tip after set", p.getToolTip());
     }
 
     @Test
+    @DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
     public void testGetAndSetViewCoordinates() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         Assert.assertTrue("Default View Coordinates", p.getViewCoordinates());
         p.setViewCoordinates(false);
         Assert.assertFalse("View Coordinates after set false", p.getViewCoordinates());
@@ -113,9 +112,9 @@ abstract public class PositionableTestBase {
     }
 
     @Test
+    @DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
     public void testGetAndSetControlling() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        Assert.assertTrue("Defalt ShowToolTip", p.isControlling());
+        Assert.assertTrue("Default ShowToolTip", p.isControlling());
         p.setControlling(false);
         Assert.assertFalse("Controlling after set false", p.isControlling());
         p.setControlling(true);
@@ -123,9 +122,9 @@ abstract public class PositionableTestBase {
     }
 
     @Test
+    @DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
     public void testGetAndSetHidden() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        Assert.assertFalse("Defalt Hidden", p.isHidden());
+        Assert.assertFalse("Default Hidden", p.isHidden());
         p.setHidden(true);
         Assert.assertTrue("Hidden after set true", p.isHidden());
         p.setHidden(false);
@@ -133,15 +132,15 @@ abstract public class PositionableTestBase {
     }
 
     @Test
+    @DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
     public void testGetAndSetDisplayLevel(){
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         p.setDisplayLevel(2);
         Assert.assertEquals("Display Level",2,p.getDisplayLevel());
     }
 
     @Test
+    @DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
     public void testGetAndSetEditor(){
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         Editor es = new EditorScaffold();
         p.setEditor(es);
         Assert.assertEquals("Editor",es,p.getEditor());
@@ -149,8 +148,8 @@ abstract public class PositionableTestBase {
     }
 
     @Test
+    @DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
     public void testClone() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         p.deepClone();
 
         // this next line is consistently failing (on all object types).
@@ -161,59 +160,59 @@ abstract public class PositionableTestBase {
     }
 
     @Test
+    @DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
     public void testMaxWidth() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         Assert.assertTrue("Max Width",0<=p.maxWidth());
     }
 
     @Test
+    @DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
     public void testMaxHeight() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         Assert.assertTrue("Max Height",0<=p.maxHeight());
     }
 
     @Test
+    @DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
     public void testGetAndSetScale(){
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         Assert.assertEquals("Default Scale",1.0D,p.getScale(),0.0);
         p.setScale(5.0D);
         Assert.assertEquals("Scale",5.0D,p.getScale(),0.0);
     }
 
     @Test
+    @DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
     public void testGetAndSetRotationDegrees(){
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         p.rotate(50);
         Assert.assertEquals("Degrees",50,p.getDegrees());
     }
 
     @Test
+    @DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
     public void testGetTextComponent(){
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         Assert.assertNotNull("text component",p.getTextComponent());
     }
 
     @Test
+    @DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
     public void testStoreItem(){
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         Assert.assertTrue("Store Item",p.storeItem());
     }
 
     @Test
+    @DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
     public void testDoViemMenu(){
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         Assert.assertTrue("Do Viem Menu",p.doViemMenu());
     }
 
     @Test
+    @DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
     public void testGetNameString(){
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         Assert.assertNotNull("Name String",p.getNameString());
     }
 
     @Test
+    @DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
     public void testShow() throws Positionable.DuplicateIdException {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
 
         JFrame jf = new jmri.util.JmriJFrame("Positionable Target Panel");
         JPanel panel = new JPanel();
@@ -224,7 +223,7 @@ abstract public class PositionableTestBase {
         editor.putItem(p);
         p.setDisplayLevel(jmri.jmrit.display.Editor.LABELS);
 
-        Assert.assertEquals("Display Level ", p.getDisplayLevel(), jmri.jmrit.display.Editor.LABELS);
+        Assertions.assertEquals(jmri.jmrit.display.Editor.LABELS, p.getDisplayLevel(), "Display Level ");
 
         editor.setLocation(150, 150);
 

--- a/java/test/jmri/jmrit/display/TurnoutIconWindowTest.java
+++ b/java/test/jmri/jmrit/display/TurnoutIconWindowTest.java
@@ -1,7 +1,5 @@
 package jmri.jmrit.display;
 
-import java.awt.GraphicsEnvironment;
-
 import jmri.NamedBeanHandle;
 import jmri.Turnout;
 import jmri.jmrit.catalog.NamedIcon;
@@ -9,7 +7,7 @@ import jmri.util.JUnitUtil;
 
 import org.junit.jupiter.api.*;
 import org.junit.Assert;
-import org.junit.Assume;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.netbeans.jemmy.operators.JComponentOperator;
 import org.netbeans.jemmy.operators.JFrameOperator;
 
@@ -18,19 +16,18 @@ import org.netbeans.jemmy.operators.JFrameOperator;
  *
  * @author Bob Jacobsen Copyright 2009, 2010
  */
+@DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
 public class TurnoutIconWindowTest {
 
     @Test
     public void testPanelEditor() throws Exception {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+
         jmri.jmrit.display.panelEditor.PanelEditor panel
                 = new jmri.jmrit.display.panelEditor.PanelEditor("TurnoutIconWindowTest.testPanelEditor");
 
-        panel.getTargetPanel();
-
         TurnoutIcon icon = new TurnoutIcon(panel);
         Turnout sn = jmri.InstanceManager.turnoutManagerInstance().provideTurnout("IT1");
-        icon.setTurnout(new NamedBeanHandle<Turnout>("IT1", sn));
+        icon.setTurnout(new NamedBeanHandle<>("IT1", sn));
 
         icon.setDisplayLevel(Editor.TURNOUTS);
 
@@ -83,11 +80,9 @@ public class TurnoutIconWindowTest {
 
     @Test
     public void testLayoutEditor() throws Exception {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+
         jmri.jmrit.display.layoutEditor.LayoutEditor panel
                 = new jmri.jmrit.display.layoutEditor.LayoutEditor("TurnoutIconWindowTest.testLayoutEditor");
-
-        panel.getTargetPanel();
 
         TurnoutIcon icon = new TurnoutIcon(panel);
         icon.setDisplayLevel(Editor.TURNOUTS);
@@ -141,7 +136,7 @@ public class TurnoutIconWindowTest {
     }
 
     @BeforeEach
-    public void setUp() throws Exception {
+    public void setUp() {
         JUnitUtil.setUp();
         jmri.util.JUnitUtil.resetProfileManager();
         JUnitUtil.initInternalTurnoutManager();
@@ -149,7 +144,7 @@ public class TurnoutIconWindowTest {
     }
 
     @AfterEach
-    public void tearDown() throws Exception {
+    public void tearDown() {
         JUnitUtil.resetWindows(false,false);
         JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();


### PR DESCRIPTION
AbstractEditorTestBase and others - update headless check to annotation, preventing beforeAll / afterAll calls

BlockContentsIconTest - use provide over getBlock
TurnoutIconWindowTest - remove unused calls to panel.getTargetPanel();
EditorIconFrameTest - remove unused check for Text inputString
PositionableTestBase - order assertEquals

EditorFrameOperator -
Thread name Strings to static
SuppressFBWarnings in private method

PositionableLabelTest -
use existing super EditorScaffold
rename local variables hiding field
pass editor, not null to nonNull
order assertEquals
sampleText string can be static