### PR TITLE
WIP - Add support for LogixNG to trigger reverse route

### DIFF
--- a/java/src/jmri/Route.java
+++ b/java/src/jmri/Route.java
@@ -383,6 +383,15 @@ public interface Route extends NamedBean {
     public void setRoute();
 
     /**
+     * Set the reverse Route.
+     * <p>
+     * Sets all Route Turnouts to the reverse directed state in the Route definition.
+     */
+    public default void setReverseRoute() {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    /**
      * Activate the Route.
      * <p>
      * This starts route processing by connecting to inputs, etc. A Route must

--- a/java/src/jmri/jmrit/logixng/actions/ActionBundle.properties
+++ b/java/src/jmri/jmrit/logixng/actions/ActionBundle.properties
@@ -461,10 +461,11 @@ Timeout_Short               = Timeout
 Timeout_Long                = Execute {1} if not {0} within {2}
 Timeout_Long_Indirect       = Execute {1} if not {0} within {2} of unit {3}
 
-TriggerRoute_Short          = Route
-TriggerRoute_Long           = Trigger route {0} to {1}
-TriggerRoute_TriggerRoute   = Trigger route
-TriggerRoute_LogixInUseVeto = Logix is in use by Enable Logix action "{0}"
+TriggerRoute_Short                  = Route
+TriggerRoute_Long                   = {1} {0}
+TriggerRoute_TriggerRoute           = Trigger route
+TriggerRoute_TriggerReverseRoute    = Trigger reverse route
+TriggerRoute_LogixInUseVeto         = Logix is in use by Enable Logix action "{0}"
 
 Turnout_Short               = Turnout
 Turnout_Long                = Set turnout {0} to state {1}

--- a/java/src/jmri/jmrit/logixng/actions/TriggerRoute.java
+++ b/java/src/jmri/jmrit/logixng/actions/TriggerRoute.java
@@ -4,16 +4,11 @@ import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.*;
 
-import javax.annotation.Nonnull;
-
 import jmri.*;
 import jmri.jmrit.logixng.*;
 import jmri.jmrit.logixng.util.*;
 import jmri.jmrit.logixng.util.parser.*;
-import jmri.jmrit.logixng.util.parser.ExpressionNode;
-import jmri.jmrit.logixng.util.parser.RecursiveDescentParser;
 import jmri.util.ThreadingUtil;
-import jmri.util.TypeConversionUtil;
 
 /**
  * This action triggers a route.
@@ -71,16 +66,21 @@ public class TriggerRoute extends AbstractDigitalAction
     @Override
     public void execute() throws JmriException {
         Route route = _selectNamedBean.evaluateNamedBean(getConditionalNG());
-
         if (route == null) return;
 
         Operation oper = _selectEnum.evaluateEnum(getConditionalNG());
+        if (oper == null) return;
 
         ThreadingUtil.runOnLayoutWithJmriException(() -> {
-            if (oper == Operation.TriggerRoute) {
-                route.setRoute();
-            } else {
-                throw new IllegalArgumentException("invalid oper: " + oper.name());
+            switch (oper) {
+                case TriggerRoute:
+                    route.setRoute();
+                    break;
+                case TriggerReverseRoute:
+                    route.setReverseRoute();
+                    break;
+                default:
+                    throw new IllegalArgumentException("invalid oper: " + oper.name());
             }
         });
     }
@@ -135,7 +135,8 @@ public class TriggerRoute extends AbstractDigitalAction
 
 
     public enum Operation {
-        TriggerRoute(Bundle.getMessage("TriggerRoute_TriggerRoute"));
+        TriggerRoute(Bundle.getMessage("TriggerRoute_TriggerRoute")),
+        TriggerReverseRoute(Bundle.getMessage("TriggerRoute_TriggerReverseRoute"));
 
         private final String _text;
 

--- a/java/src/jmri/jmrit/logixng/actions/swing/DigitalActionSwingBundle.properties
+++ b/java/src/jmri/jmrit/logixng/actions/swing/DigitalActionSwingBundle.properties
@@ -148,7 +148,7 @@ TableForEachSwing_LocalVariable     = Local variable
 
 Timeout_Components                  = Timeout delay {0} with unit {1}
 
-TriggerRoute_Components             = Trigger route {0} to {1}
+TriggerRoute_Components             = {1} {0}
 
 LogData_LogToLog                    = Log to the log
 LogData_LogToScriptOutput           = Log to the Script Output

--- a/java/test/jmri/jmrit/logixng/CreateLogixNGTreeScaffold.java
+++ b/java/test/jmri/jmrit/logixng/CreateLogixNGTreeScaffold.java
@@ -2727,6 +2727,12 @@ public class CreateLogixNGTreeScaffold {
         maleSocket = digitalActionManager.registerAction(triggerRoute);
         actionManySocket.getChild(indexAction++).connect(maleSocket);
 
+        triggerRoute = new TriggerRoute(digitalActionManager.getAutoSystemName(), null);
+        triggerRoute.setComment("A comment");
+        triggerRoute.getSelectEnum().setEnum(TriggerRoute.Operation.TriggerReverseRoute);
+        maleSocket = digitalActionManager.registerAction(triggerRoute);
+        actionManySocket.getChild(indexAction++).connect(maleSocket);
+
 
 
         ifThenElse = new IfThenElse(digitalActionManager.getAutoSystemName(), null);

--- a/xml/schema/logixng/digital-actions/trigger-route-4.23.1.xsd
+++ b/xml/schema/logixng/digital-actions/trigger-route-4.23.1.xsd
@@ -59,6 +59,7 @@
                 <xs:simpleType>
                   <xs:restriction base="xs:token">
                     <xs:enumeration value="TriggerRoute"/>
+                    <xs:enumeration value="TriggerReverseRoute"/>
                   </xs:restriction>
                 </xs:simpleType>
               </xs:element>


### PR DESCRIPTION
See https://groups.io/g/jmriusers/message/206633

This PR is WIP since `jmri.Route` doesn't yet support reverse route. I have added a default method `setReverseRoute()` to `jmri.Route` that simply throws an UnsupportedOperationException to be able to test this PR.