### PR TITLE
update some jmri.manager tests

### DIFF
--- a/java/test/jmri/managers/AbstractThrottleManagerTestBase.java
+++ b/java/test/jmri/managers/AbstractThrottleManagerTestBase.java
@@ -152,6 +152,10 @@ public abstract class AbstractThrottleManagerTestBase {
         tm.requestThrottle(addr, throtListen, true);
         JUnitUtil.waitFor(()-> (tm.getThrottleInfo(addr, Throttle.ISFORWARD) != null), "reply didn't arrive");
 
+        Assert.assertTrue(throttleFoundResult);
+        Assert.assertFalse( throttleNotFoundResult );
+        Assert.assertFalse( throttleStealResult );
+
         Assert.assertNotNull("is forward", tm.getThrottleInfo(addr, Throttle.ISFORWARD));
         Assert.assertNotNull("speed setting", tm.getThrottleInfo(addr, Throttle.SPEEDSETTING));
         Assert.assertNotNull("speed increment", tm.getThrottleInfo(addr, Throttle.SPEEDINCREMENT));

--- a/java/test/jmri/managers/DefaultShutDownManagerTest.java
+++ b/java/test/jmri/managers/DefaultShutDownManagerTest.java
@@ -3,6 +3,8 @@ package jmri.managers;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import java.awt.Frame;
 import java.awt.GraphicsEnvironment;
 import java.lang.reflect.Field;
@@ -50,7 +52,12 @@ public class DefaultShutDownManagerTest {
         dsdm.register(task);
         Assert.assertEquals(1, dsdm.getRunnables().size());
         Assert.assertEquals(1, dsdm.getCallables().size());
-        assertThatCode(() -> dsdm.register((ShutDownTask) null)).isInstanceOf(NullPointerException.class);
+        assertThatCode(() -> registerNullShutDownTask(dsdm)).isInstanceOf(NullPointerException.class);
+    }
+
+    @SuppressFBWarnings( value = "NP_NONNULL_PARAM_VIOLATION", justification = "passing null to non-null to check exception")
+    private void registerNullShutDownTask(DefaultShutDownManager d) {
+        d.register((ShutDownTask) null);
     }
 
     @Test
@@ -83,7 +90,12 @@ public class DefaultShutDownManagerTest {
         dsdm.register(task);
         Assert.assertEquals(1, dsdm.getCallables().size());
         Assert.assertEquals(0, dsdm.getRunnables().size());
-        assertThatCode(() -> dsdm.register((Callable<Boolean>) null)).isInstanceOf(NullPointerException.class);
+        assertThatCode(() -> registerNullCallable(dsdm) ).isInstanceOf(NullPointerException.class);
+    }
+
+    @SuppressFBWarnings( value = "NP_NONNULL_PARAM_VIOLATION", justification = "passing null to non-null to check exception")
+    private void registerNullCallable(DefaultShutDownManager d) {
+        d.register((Callable<Boolean>) null);
     }
 
     @Test
@@ -102,6 +114,7 @@ public class DefaultShutDownManagerTest {
     }
 
     @Test
+    @SuppressFBWarnings( value = "NP_NONNULL_PARAM_VIOLATION", justification = "passing null to non-null to check exception")
     public void testRegister_Runnable() {
         Assert.assertEquals(0, dsdm.getRunnables().size());
         Assert.assertEquals(0, dsdm.getCallables().size());
@@ -112,7 +125,12 @@ public class DefaultShutDownManagerTest {
         dsdm.register(task);
         Assert.assertEquals(1, dsdm.getRunnables().size());
         Assert.assertEquals(0, dsdm.getCallables().size());
-        assertThatCode(() -> dsdm.register((Runnable) null)).isInstanceOf(NullPointerException.class);
+        assertThatCode(() -> registerNullRunnable(dsdm) ).isInstanceOf(NullPointerException.class);
+    }
+
+    @SuppressFBWarnings( value = "NP_NONNULL_PARAM_VIOLATION", justification = "passing null to non-null to check exception")
+    private void registerNullRunnable(DefaultShutDownManager d) {
+        d.register((Runnable) null);
     }
 
     @Test

--- a/java/test/jmri/managers/DefaultSignalMastManagerTest.java
+++ b/java/test/jmri/managers/DefaultSignalMastManagerTest.java
@@ -85,8 +85,10 @@ public class DefaultSignalMastManagerTest extends AbstractProvidingManagerTestBa
 
         Exception ex = Assert.assertThrows(JmriException.class, () ->
             mgr.provideRepeater(m2, m1));
+        String message = ex.getMessage();
+        Assertions.assertNotNull(message);
         Assert.assertTrue("wrong way repeater not in exception text",
-            ex.getMessage().contains("repeater already exists the wrong way"));
+            message.contains("repeater already exists the wrong way"));
         jmri.util.JUnitAppender.assertErrorMessage("Signal repeater IM332:IM331 already exists the wrong way");
     }
     

--- a/java/test/jmri/managers/DefaultSignalSystemManagerTest.java
+++ b/java/test/jmri/managers/DefaultSignalSystemManagerTest.java
@@ -1,6 +1,7 @@
 package jmri.managers;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import jmri.InstanceManager;
@@ -22,10 +23,10 @@ public class DefaultSignalSystemManagerTest extends AbstractManagerTestBase<jmri
     @Test
     public void testGetListOfNames() {
         DefaultSignalSystemManager d = (DefaultSignalSystemManager)l;
-        java.util.List<String> l = d.getListOfNames();
-        Assert.assertTrue(l.contains("basic"));
-        Assert.assertTrue(l.contains("AAR-1946"));
-        Assert.assertTrue(l.contains("SPTCO-1960"));
+        List<String> list = d.getListOfNames();
+        Assert.assertTrue(list.contains("basic"));
+        Assert.assertTrue(list.contains("AAR-1946"));
+        Assert.assertTrue(list.contains("SPTCO-1960"));
     }
 
     @Test
@@ -35,8 +36,8 @@ public class DefaultSignalSystemManagerTest extends AbstractManagerTestBase<jmri
 
             // check that mock (test directory) system is present
             DefaultSignalSystemManager d = new DefaultSignalSystemManager(InstanceManager.getDefault(InternalSystemConnectionMemo.class));
-            java.util.List<String> l = d.getListOfNames();
-            Assert.assertTrue(l.contains(SignalSystemTestUtil.getMockSystemName()));
+            List<String> list = d.getListOfNames();
+            Assert.assertTrue(list.contains(SignalSystemTestUtil.getMockSystemName()));
 
         } finally {
             SignalSystemTestUtil.deleteMockSystem();
@@ -70,11 +71,11 @@ public class DefaultSignalSystemManagerTest extends AbstractManagerTestBase<jmri
     @Test
     public void testUniqueNames() {
         DefaultSignalSystemManager d = (DefaultSignalSystemManager)l;
-        java.util.List<String> l = d.getListOfNames();
-        for (int i = 0; i < l.size(); i++) {
-            for (int j = 0; j < l.size(); j++) {
-                if ((i != j) && (l.get(i).equals(l.get(j)))) {
-                    Assert.fail("Found " + l.get(i) + " at " + i + " and " + j);
+        List<String> list = d.getListOfNames();
+        for (int i = 0; i < list.size(); i++) {
+            for (int j = 0; j < list.size(); j++) {
+                if ((i != j) && (list.get(i).equals(list.get(j)))) {
+                    Assert.fail("Found " + list.get(i) + " at " + i + " and " + j);
                 }
             }
         }
@@ -83,11 +84,13 @@ public class DefaultSignalSystemManagerTest extends AbstractManagerTestBase<jmri
     @Test
     public void testUniqueSystemNames() {
         DefaultSignalSystemManager d = (DefaultSignalSystemManager)l;
-        java.util.List<String> l = d.getListOfNames();
-        for (int i = 0; i < l.size(); i++) {
-            jmri.SignalSystem si = d.getSystem(l.get(i));
-            for (int j = 0; j < l.size(); j++) {
-                jmri.SignalSystem sj = d.getSystem(l.get(j));
+        List<String> list = d.getListOfNames();
+        for (int i = 0; i < list.size(); i++) {
+            SignalSystem si = d.getSystem(list.get(i));
+            Assertions.assertNotNull(si);
+            for (int j = 0; j < list.size(); j++) {
+                SignalSystem sj = d.getSystem(list.get(j));
+                Assertions.assertNotNull(sj);
                 if ((i != j) && (si.getSystemName().equals(sj.getSystemName()))) {
                     Assert.fail("Found system name " + si.getSystemName() + " at " + i + " and " + j);
                 }
@@ -98,12 +101,15 @@ public class DefaultSignalSystemManagerTest extends AbstractManagerTestBase<jmri
     @Test
     public void testUniqueUserNames() {
         DefaultSignalSystemManager d = (DefaultSignalSystemManager)l;
-        java.util.List<String> l = d.getListOfNames();
-        for (int i = 0; i < l.size(); i++) {
-            jmri.SignalSystem si = d.getSystem(l.get(i));
-            for (int j = 0; j < l.size(); j++) {
-                jmri.SignalSystem sj = d.getSystem(l.get(j));
-                if ((i != j) && (si.getUserName().equals(sj.getUserName()))) {
+        List<String> list = d.getListOfNames();
+        for (int i = 0; i < list.size(); i++) {
+            SignalSystem si = d.getSystem(list.get(i));
+            Assertions.assertNotNull(si);
+            for (int j = 0; j < list.size(); j++) {
+                SignalSystem sj = d.getSystem(list.get(j));
+                Assertions.assertNotNull(sj);
+                String siUserName = si.getUserName();
+                if ((i != j) && (siUserName != null) && (siUserName.equals(sj.getUserName()))) {
                     Assert.fail("Found user name " + si.getUserName() + " at " + i + " and " + j);
                 }
             }

--- a/java/test/jmri/managers/configurexml/AbstractNamedBeanManagerConfigXMLTest.java
+++ b/java/test/jmri/managers/configurexml/AbstractNamedBeanManagerConfigXMLTest.java
@@ -1,5 +1,7 @@
 package jmri.managers.configurexml;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import jmri.NamedBean;
 import jmri.implementation.AbstractNamedBean;
 import jmri.util.JUnitUtil;
@@ -39,7 +41,7 @@ public class AbstractNamedBeanManagerConfigXMLTest {
         };
 
         from.setProperty("foo", "bar");
-        from.setProperty("biff", Boolean.valueOf(true));
+        from.setProperty("biff", true);
 
         // create element for properties
         Element p = new Element("test");
@@ -67,7 +69,7 @@ public class AbstractNamedBeanManagerConfigXMLTest {
 
         // and test
         Assert.assertEquals("bar", to.getProperty("foo"));
-        Assert.assertEquals(Boolean.valueOf(true), to.getProperty("biff"));
+        Assert.assertTrue( (Boolean)to.getProperty("biff"));
 
     }
 
@@ -119,7 +121,7 @@ public class AbstractNamedBeanManagerConfigXMLTest {
 
         // and test
         Assert.assertEquals(null, to.getProperty("foo"));
-        Assert.assertTrue(to.getPropertyKeys()!=null);
+        Assert.assertNotNull(to.getPropertyKeys());
         Assert.assertEquals(0, to.getPropertyKeys().size());
 
     }
@@ -147,7 +149,7 @@ public class AbstractNamedBeanManagerConfigXMLTest {
         };
 
         from.setProperty("foo", null);
-        from.setProperty("biff", Boolean.valueOf(true));
+        from.setProperty("biff", true);
 
         // create element for properties
         Element p = new Element("test");
@@ -175,7 +177,7 @@ public class AbstractNamedBeanManagerConfigXMLTest {
 
         // and test
         Assert.assertEquals(null, to.getProperty("foo"));
-        Assert.assertEquals(Boolean.valueOf(true), to.getProperty("biff"));
+        Assert.assertTrue((Boolean)to.getProperty("biff"));
 
     }
 
@@ -230,8 +232,9 @@ public class AbstractNamedBeanManagerConfigXMLTest {
         Assert.assertEquals("foo", x.getSystemName(e));
 
     }
-    
+
     @Test
+    @SuppressFBWarnings( value = "NP_LOAD_OF_KNOWN_NULL_VALUE", justification = "ok to pass null if type is set")
     public void testCheckedNamedBeanName() {
         AbstractNamedBeanManagerConfigXML x = new NamedBeanManagerConfigXMLTest();
 
@@ -247,6 +250,8 @@ public class AbstractNamedBeanManagerConfigXMLTest {
     }
 
     @Test
+    @SuppressFBWarnings( value = {"NP_LOAD_OF_KNOWN_NULL_VALUE","NP_NONNULL_PARAM_VIOLATION"},
+        justification = "ok to pass null if type is set")
     public void testCheckedNamedBeanReference() {
         AbstractNamedBeanManagerConfigXML x = new NamedBeanManagerConfigXMLTest();
 
@@ -263,6 +268,8 @@ public class AbstractNamedBeanManagerConfigXMLTest {
     }
 
     @Test
+    @SuppressFBWarnings( value = {"NP_LOAD_OF_KNOWN_NULL_VALUE","NP_NONNULL_PARAM_VIOLATION"},
+        justification = "ok to pass null if type is set")
     public void testCheckedNamedBeanHandle() {
         AbstractNamedBeanManagerConfigXML x = new NamedBeanManagerConfigXMLTest();
         jmri.util.JUnitUtil.resetInstanceManager();
@@ -291,7 +298,7 @@ public class AbstractNamedBeanManagerConfigXMLTest {
         JUnitUtil.tearDown();
     }
 
-    private class NamedBeanManagerConfigXMLTest extends AbstractNamedBeanManagerConfigXML {
+    private static class NamedBeanManagerConfigXMLTest extends AbstractNamedBeanManagerConfigXML {
 
         @Override
         public boolean load(Element shared, Element perNode) {


### PR DESCRIPTION
AbstractThrottleManagerTestBase - use unused vars

DefaultShutDownManagerTest - SuppressFBWarnings NP_NONNULL_PARAM_VIOLATION as testing exceptions
 
DefaultSignalMastManagerTest.java - assert exception message not null
 
DefaultSignalSystemManagerTest.java - rename local vars named l as already defined in super class
 
AbstractNamedBeanManagerConfigXMLTest -
tweak usages of Boolean casts
SuppressFBWarnings NP_LOAD_OF_KNOWN_NULL_VALUE, NP_NONNULL_PARAM_VIOLATION as ok to pass null if type set
private class can be static