### PR TITLE
Verify Layout Editor slip turnout selections

### DIFF
--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorBundle.properties
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorBundle.properties
@@ -556,7 +556,7 @@ Error16 = Error - Cannot attach Memory to Block because no memory is defined for
 Error17 = Error - Reporter manager not available. Cannot add Reporter Icon.
 Error18 = Error - Could not provide Reporter "{0}". Cannot add Reporter Icon.
 Error19 = Error - Missing Name for Sensor "{0}". Please fill in all fields.
-Error20 = Error - One slip turnout is empty\nBoth turnouts must be empty or have two different turnouts assigned.
+Error20 = Error - One slip turnout is empty.\nBoth turnouts must be empty or have two different turnouts assigned.
 
 
 # question messages

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorBundle.properties
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorBundle.properties
@@ -556,6 +556,8 @@ Error16 = Error - Cannot attach Memory to Block because no memory is defined for
 Error17 = Error - Reporter manager not available. Cannot add Reporter Icon.
 Error18 = Error - Could not provide Reporter "{0}". Cannot add Reporter Icon.
 Error19 = Error - Missing Name for Sensor "{0}". Please fill in all fields.
+Error20 = Error - One slip turnout is empty\nBoth turnouts must be empty or have two different turnouts assigned.
+
 
 # question messages
 Question1 = Are you sure you want to remove this turnout from the panel, along with any connected Track Segments?

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/LayoutSlipEditor.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/LayoutSlipEditor.java
@@ -444,6 +444,17 @@ public class LayoutSlipEditor extends LayoutTurnoutEditor {
             ts.updateStatesFromCombo();
         }
 
+        // Verify that there are no turnouts or two turnouts.  A single turnout is an error.
+        var turnoutNameA = layoutSlip.getTurnoutName();
+        var turnoutNameB = layoutSlip.getTurnoutBName();
+        if ((turnoutNameA.isEmpty() && !turnoutNameB.isEmpty()) ||
+                (turnoutNameB.isEmpty() && !turnoutNameA.isEmpty())) {
+            JOptionPane.showMessageDialog(editLayoutSlipFrame,
+                    Bundle.getMessage("Error20"),
+                    Bundle.getMessage("ErrorTitle"), JOptionPane.ERROR_MESSAGE);
+            return;
+        }
+
         // set hidden
         boolean oldHidden = layoutSlipView.isHidden();
         layoutSlipView.setHidden(editLayoutSlipHiddenBox.isSelected());


### PR DESCRIPTION
Layout editor slips require two turnouts.  During the edit process, no turnouts and two turnouts are valid conditions.  A single turnout can cause a NPE in LayoutBlock.