### PR TITLE
Float loops in Tests

### DIFF
--- a/java/test/jmri/jmrix/AbstractThrottleManagerTest.java
+++ b/java/test/jmri/jmrix/AbstractThrottleManagerTest.java
@@ -13,9 +13,8 @@ import org.junit.jupiter.api.*;
  */
 public class AbstractThrottleManagerTest extends jmri.managers.AbstractThrottleManagerTestBase {
 
-    AbstractThrottleManager t = null;
-    SystemConnectionMemo memo;
-    DebugThrottle throttle;
+    private SystemConnectionMemo memo;
+    private DebugThrottle throttle;
 
     @BeforeEach
     @Override
@@ -24,9 +23,13 @@ public class AbstractThrottleManagerTest extends jmri.managers.AbstractThrottleM
         memo = Mockito.mock(SystemConnectionMemo.class);
         Mockito.when(memo.getUserName()).thenReturn("Test");
         Mockito.when(memo.getSystemPrefix()).thenReturn("T");
-        tm = t = new AbstractThrottleManager(memo) {
+        tm = new AbstractThrottleManager(memo) {
             @Override
             public void requestThrottleSetup(jmri.LocoAddress a, boolean control) {
+                if (!(a instanceof DccLocoAddress)){
+                    Assertions.fail("DebugThrottle needs a dcclocoaddress : " + a );
+                    return;
+                }
                 throttle = new DebugThrottle((DccLocoAddress) a, adapterMemo);
                 notifyThrottleKnown(throttle, a);
             }
@@ -51,7 +54,7 @@ public class AbstractThrottleManagerTest extends jmri.managers.AbstractThrottleM
     @AfterEach
     public void tearDown() {
         memo = null;
-        tm = t = null;
+        tm = null;
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrix/AbstractThrottleTest.java
+++ b/java/test/jmri/jmrix/AbstractThrottleTest.java
@@ -1,7 +1,5 @@
 package jmri.jmrix;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.io.File;
@@ -11,7 +9,6 @@ import jmri.DccLocoAddress;
 import jmri.InstanceManager;
 import jmri.LocoAddress;
 import jmri.SpeedStepMode;
-import jmri.ThrottleListener;
 import jmri.jmrit.roster.RosterEntry;
 import jmri.util.JUnitAppender;
 
@@ -718,8 +715,7 @@ public class AbstractThrottleTest {
      */
     @Test
     public void testAddPropertyChangeListener() {
-        PropertyChangeListener l = null;
-        instance.addPropertyChangeListener(l);
+        instance.addPropertyChangeListener(null);
     }
 
     /**
@@ -736,8 +732,7 @@ public class AbstractThrottleTest {
      */
     @Test
     public void testDispose_ThrottleListener() {
-        ThrottleListener l = null;
-        instance.dispose(l);
+        instance.dispose(null);
     }
 
     /**
@@ -745,8 +740,7 @@ public class AbstractThrottleTest {
      */
     @Test
     public void testDispatch_ThrottleListener() {
-        ThrottleListener l = null;
-        instance.dispatch(l);
+        instance.dispatch(null);
     }
 
     /**
@@ -754,8 +748,7 @@ public class AbstractThrottleTest {
      */
     @Test
     public void testRelease_ThrottleListener() {
-        ThrottleListener l = null;
-        instance.release(l);
+        instance.release(null);
     }
 
     /**
@@ -1542,8 +1535,8 @@ public class AbstractThrottleTest {
      */
     @Test
     public void testSetRosterEntry() {
-        BasicRosterEntry re = null;
-        instance.setRosterEntry(re);
+        instance.setRosterEntry(null);
+        Assertions.assertNull(instance.getRosterEntry());
     }
 
     /**
@@ -1551,9 +1544,8 @@ public class AbstractThrottleTest {
      */
     @Test
     public void testGetRosterEntry() {
-        BasicRosterEntry expResult = null;
         BasicRosterEntry result = instance.getRosterEntry();
-        Assert.assertEquals(expResult, result);
+        Assert.assertNull( result);
     }
 
     /**
@@ -1565,11 +1557,11 @@ public class AbstractThrottleTest {
         float incre = 1.0f / 126.0f;
         float speed = incre;
         // Cannot get speeedStep 1. range is 2 to 127
-        int i = 2;
-        while (speed < 0.999f) {
+        for ( int i=2; i < 128; i++ ) {
             int result = instance.intSpeed(speed);
+            // System.out.println("speed="+speed+" step="+result+" i="+i);
             log.debug("speed= {} step= {}", speed, result);
-            Assert.assertEquals("speed step ", i++, result);
+            Assert.assertEquals("speed step ", i, result);
             speed += incre;
         }
     }
@@ -1579,7 +1571,7 @@ public class AbstractThrottleTest {
      */
     @Test
     public void testGetSpeed_float_int() {
-        float speed = 0.001F;
+
         int maxStepHi = 127;
         int maxStepLo = 28;
         Assert.assertEquals("Idle", 0, AbstractThrottle.intSpeed(0.0F, maxStepHi));
@@ -1590,8 +1582,11 @@ public class AbstractThrottleTest {
         Assert.assertEquals("Emergency", 1, AbstractThrottle.intSpeed(-0.001F, maxStepLo));
         Assert.assertEquals("Full Speed", maxStepHi, AbstractThrottle.intSpeed(1.0F, maxStepHi));
         Assert.assertEquals("Full Speed", maxStepLo, AbstractThrottle.intSpeed(1.0F, maxStepLo));
-        while (speed < 1.1F) { // loop ~ 1100 times
+
+        for ( int i = 1; i < 1100; i++) { // loop ~ 1100 times
+            float speed = i / 1000f;
             int result = AbstractThrottle.intSpeed(speed, maxStepHi);
+            // System.out.println("i"+i+" speed="+speed+" result="+result );
             Assert.assertNotSame(speed + "(" + maxStepHi + " steps) should not idle", 0, result);
             Assert.assertNotSame(speed + "(" + maxStepHi + " steps) should not eStop", 1, result);
             Assert.assertTrue(speed + "(" + maxStepHi + " steps) should not exceed " + maxStepHi, result <= maxStepHi);
@@ -1599,7 +1594,6 @@ public class AbstractThrottleTest {
             Assert.assertNotSame(speed + "(" + maxStepLo + " steps) should not idle", 0, result);
             Assert.assertNotSame(speed + "(" + maxStepLo + " steps) should not eStop", 1, result);
             Assert.assertTrue(speed + "(" + maxStepLo + " steps) should not exceed " + maxStepLo, result <= maxStepLo);
-            speed = speed + 0.001F;
         }
     }
 

--- a/java/test/jmri/jmrix/loconet/Ib1ThrottleTest.java
+++ b/java/test/jmri/jmrix/loconet/Ib1ThrottleTest.java
@@ -60,16 +60,7 @@ public class Ib1ThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     public void testGetSpeed_float() {
         // set speed step mode to 128.
         instance.setSpeedStepMode(jmri.SpeedStepMode.NMRA_DCC_128);
-        Assert.assertEquals("Full Speed", 127, ((LocoNetThrottle)instance).intSpeed(1.0F));
-        float incre = 1.0f / 126.0f;
-        float speed = incre;
-        // Cannot get speeedStep 1. range is 2 to 127
-        int i = 2;
-        while (speed < 0.999f) {
-            int result = ((LocoNetThrottle)instance).intSpeed(speed);
-            Assert.assertEquals("speed step ", i++, result);
-            speed += incre;
-        }
+        super.testGetSpeed_float();
     }
 
     /**

--- a/java/test/jmri/jmrix/loconet/Ib2ThrottleTest.java
+++ b/java/test/jmri/jmrix/loconet/Ib2ThrottleTest.java
@@ -60,16 +60,7 @@ public class Ib2ThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     public void testGetSpeed_float() {
         // set speed step mode to 128.
         instance.setSpeedStepMode(jmri.SpeedStepMode.NMRA_DCC_128);
-        Assert.assertEquals("Full Speed", 127, ((LocoNetThrottle)instance).intSpeed(1.0F));
-        float incre = 1.0f / 126.0f;
-        float speed = incre;
-        // Cannot get speeedStep 1. range is 2 to 127
-        int i = 2;
-        while (speed < 0.999f) {
-            int result = ((LocoNetThrottle)instance).intSpeed(speed);
-            Assert.assertEquals("speed step ", i++, result);
-            speed += incre;
-        }
+        super.testGetSpeed_float();
     }
 
     /**

--- a/java/test/jmri/jmrix/loconet/LocoNetThrottleTest.java
+++ b/java/test/jmri/jmrix/loconet/LocoNetThrottleTest.java
@@ -6,7 +6,6 @@ import jmri.SpeedStepMode;
 
 import org.junit.Assert;
 import org.junit.jupiter.api.*;
-import org.mockito.Mockito;
 
 public class LocoNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
 
@@ -134,20 +133,8 @@ public class LocoNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     public void testGetSpeed_float() {
         // set speed step mode to 128.
         instance.setSpeedStepMode(jmri.SpeedStepMode.NMRA_DCC_128);
-        Assert.assertEquals("Full Speed", 127, ((LocoNetThrottle)instance).intSpeed(1.0F));
-        float incre = 1.0f / 126.0f;
-        float speed = incre;
-        // Cannot get speeedStep 1. range is 2 to 127
-        int i = 2;
-        while (speed < 0.999f) {
-            int result = ((LocoNetThrottle)instance).intSpeed(speed);
-            Assert.assertEquals("speed step ", i++, result);
-            speed += incre;
-        }
+        super.testGetSpeed_float();
     }
-
-
-
 
     /**
      * Test of setF0 method, of class AbstractThrottle.

--- a/java/test/jmri/jmrix/loconet/Pr2ThrottleTest.java
+++ b/java/test/jmri/jmrix/loconet/Pr2ThrottleTest.java
@@ -53,13 +53,13 @@ public class Pr2ThrottleTest extends jmri.jmrix.AbstractThrottleTest {
         // set speed step mode to 28 (PR2Throttle does not support 128?)
         instance.setSpeedStepMode(jmri.SpeedStepMode.NMRA_DCC_28);
         Assert.assertEquals("Full Speed", 124, ((Pr2Throttle)instance).intSpeed(1.0F)); // 124 from class source
-        float incre = 1.F/(112F-1F); // not clear where the -1 comes from
+        float incre = 1.F/111F;
         float speed = incre;
         // Shouldn't be able to get get speeedStep 1., but this class code allows it.
-        int i = 1;
-        while (speed < 0.999f) {
+        for ( int i=1; i < 112; i++ ) {
             int result = ((Pr2Throttle)instance).intSpeed(speed) -12 ; // -12 from class source
-            Assert.assertEquals("speed step from "+speed, i++, result);
+            // System.out.println("speed="+speed+" step="+result+" i="+i);
+            Assert.assertEquals("speed step from "+speed, i, result);
             speed += incre;
         }
     }


### PR DESCRIPTION
AbstractThrottleTest -
remove pass of known null values
use int in loop rather than float

Ib1ThrottleTest, Ib2ThrottleTest - use super testGetSpeed_float

Pr2ThrottleTest - use int to increment loop value, not float

AbstractThrottleManagerTest -
no need for 2 variables with AbstractThrottleManager instance
ensure DebugThrottle is passed a DccLocoAddress