### PR TITLE
update some Jmrix / Direct tests

### DIFF
--- a/java/test/jmri/jmrix/AbstractConnectionConfigTestBase.java
+++ b/java/test/jmri/jmrix/AbstractConnectionConfigTestBase.java
@@ -37,6 +37,7 @@ abstract public class AbstractConnectionConfigTestBase {
     public void testGetInfo(){
         Assume.assumeNotNull("adapter set", cc.getAdapter());
         Assert.assertNotNull("has info", cc.getInfo());
+        jmri.util.JUnitAppender.suppressErrorMessage("No usable ports returned");
     }
 
     @Test

--- a/java/test/jmri/jmrix/AbstractConnectionConfigTestBase.java
+++ b/java/test/jmri/jmrix/AbstractConnectionConfigTestBase.java
@@ -37,7 +37,6 @@ abstract public class AbstractConnectionConfigTestBase {
     public void testGetInfo(){
         Assume.assumeNotNull("adapter set", cc.getAdapter());
         Assert.assertNotNull("has info", cc.getInfo());
-        jmri.util.JUnitAppender.suppressErrorMessage("No usable ports returned");
     }
 
     @Test

--- a/java/test/jmri/jmrix/AbstractMRReplyTest.java
+++ b/java/test/jmri/jmrix/AbstractMRReplyTest.java
@@ -12,10 +12,11 @@ import org.junit.jupiter.api.*;
  */
 public class AbstractMRReplyTest extends AbstractMessageTestBase {
 
-    AbstractMRReply testMsg;
+    AbstractMRReply testMsg = null;
 
     @Test
     public void testSimpleMatch1() {
+        Assertions.assertNotNull(testMsg);
         Assert.assertEquals("match", 0, testMsg.match("foo"));
     }
 
@@ -92,6 +93,7 @@ public class AbstractMRReplyTest extends AbstractMessageTestBase {
     }
 
     @AfterEach
+    @Override
     public void tearDown() {
         m = testMsg = null;
         JUnitUtil.tearDown();

--- a/java/test/jmri/jmrix/AbstractPortControllerTestBase.java
+++ b/java/test/jmri/jmrix/AbstractPortControllerTestBase.java
@@ -17,17 +17,19 @@ public abstract class AbstractPortControllerTestBase {
 
     @Test
     public void testisDirtyNotNPE() {
-        apc.isDirty();
+        Assertions.assertNotNull(apc);
+        Assertions.assertDoesNotThrow(() -> { apc.isDirty(); });
     }
 
     @Test
     public void testDefaultMethod() {
+        Assertions.assertNotNull(apc);
         Assert.assertFalse("default false", apc.isOptionTypeText("foo"));
         jmri.util.JUnitAppender.assertErrorMessage("did not find option foo for type");
     }
 
     // from here down is testing infrastructure
-    protected AbstractPortController apc;
+    protected AbstractPortController apc = null;
 
     @BeforeEach
     public void setUp() {

--- a/java/test/jmri/jmrix/AbstractSerialPortControllerScaffold.java
+++ b/java/test/jmri/jmrix/AbstractSerialPortControllerScaffold.java
@@ -16,9 +16,9 @@ import jmri.SystemConnectionMemo;
 public class AbstractSerialPortControllerScaffold extends AbstractSerialPortController {
 
     DataOutputStream ostream;  // Traffic controller writes to this
-    DataInputStream tostream; // so we can read it from this
+    public DataInputStream tostream; // so we can read it from this
 
-    DataOutputStream tistream; // tests write to this
+    public DataOutputStream tistream; // tests write to this
     DataInputStream istream;  // so the traffic controller can read from this
    
     @Override

--- a/java/test/jmri/jmrix/NetworkConfigExceptionTest.java
+++ b/java/test/jmri/jmrix/NetworkConfigExceptionTest.java
@@ -14,12 +14,12 @@ import org.junit.jupiter.api.*;
 public class NetworkConfigExceptionTest {
 
    @Test
-   public void ConstructorTest(){
+   public void testCtor(){
       Assert.assertNotNull("NetworkConfigException constructor",new NetworkConfigException());
    }
 
    @Test
-   public void StringConstructorTest(){
+   public void testStringConstructor(){
       Assert.assertNotNull("NetworkConfigException string constructor",new NetworkConfigException("test exception"));
    }
 

--- a/java/test/jmri/jmrix/SerialConfigExceptionTest.java
+++ b/java/test/jmri/jmrix/SerialConfigExceptionTest.java
@@ -14,12 +14,12 @@ import org.junit.jupiter.api.*;
 public class SerialConfigExceptionTest {
 
    @Test
-   public void ConstructorTest(){
+   public void testCtor(){
       Assert.assertNotNull("SerialConfigException constructor",new SerialConfigException());
    }
 
    @Test
-   public void StringConstructorTest(){
+   public void testStringConstructor(){
       Assert.assertNotNull("SerialConfigException string constructor",new SerialConfigException("test exception"));
    }
 

--- a/java/test/jmri/jmrix/direct/MakePacketTest.java
+++ b/java/test/jmri/jmrix/direct/MakePacketTest.java
@@ -1,6 +1,8 @@
 package jmri.jmrix.direct;
 
 import jmri.NmraPacket;
+import jmri.util.JUnitUtil;
+
 import org.junit.Assert;
 import org.junit.jupiter.api.*;
 
@@ -12,12 +14,7 @@ import org.junit.jupiter.api.*;
 public class MakePacketTest {
 
     @Test
-    public void testCreate() {
-    }
-
-    @Test
     public void testSimplePacket() {
-        int[] result = new int[100];
 
         byte buffer[] = new byte[3];
         boolean test_retval;
@@ -26,7 +23,7 @@ public class MakePacketTest {
         buffer[0] = 0;
         buffer[1] = 1;
         buffer[2] = 0 ^ 1;
-        result = MakePacket.createStream(buffer);
+        int[] result = MakePacket.createStream(buffer);
         /**
          * resulting stream should be in hex 55 55 55 c6 c6 c6 c6 c6 c6 c6 c6 96
          * c6 c6 c6 5c
@@ -53,7 +50,6 @@ public class MakePacketTest {
 
     @Test
     public void testPreamble() {
-        int[] result = new int[100];
         byte buffer[] = new byte[3];
         boolean test_retval;
         test_retval = MakePacket.setPreambleLength(20);
@@ -66,7 +62,7 @@ public class MakePacketTest {
         buffer[0] = 0;
         buffer[1] = 1;
         buffer[2] = 0 ^ 1;
-        result = MakePacket.createStream(buffer);
+        int[] result = MakePacket.createStream(buffer);
         Assert.assertEquals("preamble", 85, result[3]);
 
         test_retval = MakePacket.setPreambleLength(16);
@@ -75,6 +71,7 @@ public class MakePacketTest {
          */
         Assert.assertEquals("preamble not mutply of 5", false, test_retval);
         test_retval = MakePacket.setPreambleLength(15);
+        Assertions.assertTrue(test_retval);
 
     }
 
@@ -90,7 +87,6 @@ public class MakePacketTest {
     @Test
     @Disabled("Disabled in JUnit 3")
     public void testAll3BytePacket() {
-        int[] result = new int[100];
         byte i, j;
         byte buffer[] = new byte[3];
         boolean test_retval;
@@ -102,7 +98,7 @@ public class MakePacketTest {
                 buffer[0] = i;
                 buffer[1] = j;
                 buffer[2] = (byte) (buffer[0] ^ buffer[1]);
-                result = MakePacket.createStream(buffer);
+                int[] result = MakePacket.createStream(buffer);
                 if (result[0] == 0) {
                     Assert.assertEquals("test all -  invalid lenght", 10, result[0]);
                 }
@@ -123,9 +119,9 @@ public class MakePacketTest {
     @Test
     @Disabled("Disabled in JUnit 3")
     public void testAllSpeed128Packets() {
-        int[] result = new int[100];
+        int[] result;
         int addressRange, speedRange;
-        byte buffer[] = new byte[6];
+        byte buffer[];
         boolean test_retval, Direction;
         Direction = true; /*Set direction to forwards */
 
@@ -175,9 +171,7 @@ public class MakePacketTest {
     @Test
     @Disabled("Disabled in JUnit 3")
     public void testAllOpsCvWrite() {
-        int[] result = new int[100];
         int addressRange, cvNum, data;
-        byte buffer[] = new byte[6];
         boolean test_retval;
 
         test_retval = MakePacket.setPreambleLength(15);
@@ -186,9 +180,9 @@ public class MakePacketTest {
         for (addressRange = 0; addressRange < 10239; addressRange++) {
             for (cvNum = 2; cvNum < 512; cvNum++) {
                 for (data = 0; data < 127; data++) {
-                    buffer = NmraPacket.opsCvWriteByte(addressRange, true, cvNum, data);
+                    byte[] buffer = NmraPacket.opsCvWriteByte(addressRange, true, cvNum, data);
 
-                    result = MakePacket.createStream(buffer);
+                    int[] result = MakePacket.createStream(buffer);
                     if (result[0] == 0) {
                         Assert.assertEquals("test ops CV write (long addresses) -  invalid lenght", 10, result[0]);
                     }
@@ -205,6 +199,16 @@ public class MakePacketTest {
                 }
             }
         }
+    }
+
+    @BeforeEach
+    public void setUp() {
+        JUnitUtil.setUp();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        JUnitUtil.tearDown();
     }
 
 }

--- a/java/test/jmri/jmrix/direct/ReplyTest.java
+++ b/java/test/jmri/jmrix/direct/ReplyTest.java
@@ -18,6 +18,7 @@ public class ReplyTest extends jmri.jmrix.AbstractMessageTestBase {
     }
 
     @AfterEach
+    @Override
     public void tearDown() {
         m = null;
         JUnitUtil.tearDown();

--- a/java/test/jmri/jmrix/direct/ThrottleTest.java
+++ b/java/test/jmri/jmrix/direct/ThrottleTest.java
@@ -366,7 +366,10 @@ public class ThrottleTest extends jmri.jmrix.AbstractThrottleTest {
         // prepare an interface
         DirectSystemConnectionMemo m = new DirectSystemConnectionMemo();
 
-        m.getTrafficController().connectPort(new jmri.jmrix.AbstractSerialPortControllerScaffold(m));
+        jmri.jmrix.AbstractSerialPortControllerScaffold aspcs = new jmri.jmrix.AbstractSerialPortControllerScaffold(m);
+        Assertions.assertNotNull(aspcs.tostream);
+        Assertions.assertNotNull(aspcs.tistream);
+        m.getTrafficController().connectPort(aspcs);
         jmri.CommandStation cs = jmri.InstanceManager.getDefault(jmri.CommandStation.class);
         jmri.InstanceManager.setDefault(jmri.ThrottleManager.class, new ThrottleManager(m));
         instance = new Throttle(new jmri.DccLocoAddress(5, false), cs);

--- a/java/test/jmri/jmrix/direct/serial/SerialDriverAdapterTest.java
+++ b/java/test/jmri/jmrix/direct/serial/SerialDriverAdapterTest.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.*;
 public class SerialDriverAdapterTest {
 
    @Test
-   public void ConstructorTest(){
+   public void testCtor(){
       Assert.assertNotNull("SerialDriverAdapter constructor",new SerialDriverAdapter());
    }
 

--- a/java/test/jmri/jmrix/direct/simulator/SimulatorAdapterTest.java
+++ b/java/test/jmri/jmrix/direct/simulator/SimulatorAdapterTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.*;
 public class SimulatorAdapterTest {
 
    @Test
-   public void ConstructorTest(){
+   public void testCtor(){
       Assert.assertNotNull("SimulatorAdapter constructor", new SimulatorAdapter());
    }
 


### PR DESCRIPTION
**jmrix**
AbstractConnectionConfigTestBase - suppress error message
AbstractMRReplyTest - add nonnull assert
AbstractPortControllerTestBase - add nonnull, assertDoesNotThrow asserts
AbstractSerialPortControllerScaffold - make data streams public
NetworkConfigExceptionTest, SerialConfigExceptionTest -method names start lowercase

**jmrix.direct**
ConnectionConfigManagerTest -
remove unused methods
SuppressFBWarnings on passing null to check exception
improved exception assertions
no need to resetInstanceManager following each test

MakePacketTest -
remove unused method
unused store to var
add beforeEach / afterEach

ReplyTest - add override annotation
ThrottleTest - use AbstractSerialPortControllerScaffold stream fields
SerialDriverAdapterTest, SimulatorAdapterTest - method name starts lowercase
