### PR TITLE
Fix bug in LogixNGTableTableAction

### DIFF
--- a/java/src/jmri/jmrit/beantable/LogixNGTableTableAction.java
+++ b/java/src/jmri/jmrit/beantable/LogixNGTableTableAction.java
@@ -155,11 +155,8 @@ public class LogixNGTableTableAction extends AbstractLogixNGTableAction<NamedTab
                 maxColumnWidth = Math.max(maxColumnWidth, columnWidth[col]);
             }
         }
-        StringBuilder columnLine = new StringBuilder();
-        while (columnLine.length()+2 < maxColumnWidth) {
-            columnLine.append("----------------------");
-        }
-        String columnPadding = String.format("%"+Integer.toString(maxColumnWidth)+"s", "");
+        String columnLine = "-".repeat(maxColumnWidth+2);
+        String columnPadding = " ".repeat(maxColumnWidth);
         StringBuilder sb = new StringBuilder();
         sb.append("+");
         for (int col=0; col <= bean.numColumns(); col++) {


### PR DESCRIPTION
@dsand47 
A friend noticed a bug in LogixNG. When the CSV file in https://github.com/JMRI/JMRI/pull/11303#issuecomment-1211535189 is loaded in a LogixNG table and the user selects "Browse", an exception occurs.

This PR fixes the bug. It also simplifies the code by using the Java 11 method `repeat()`.