### PR TITLE
Don't clear Lock Position and Disable when changing CPE->PE

### DIFF
--- a/java/src/jmri/jmrit/display/Editor.java
+++ b/java/src/jmri/jmrit/display/Editor.java
@@ -1015,10 +1015,10 @@ abstract public class Editor extends JmriJFrame implements JmriMouseListener, Jm
                 }
             }
             ed.setAllEditable(isEditable());
-            ed.setAllPositionable(allPositionable());
+            //ed.setAllPositionable(allPositionable());
             //ed.setShowCoordinates(showCoordinates());
             ed.setAllShowToolTip(showToolTip());
-            ed.setAllControlling(allControlling());
+            //ed.setAllControlling(allControlling());
             ed.setShowHidden(isVisible());
             ed.setPanelMenuVisible(frame.getJMenuBar().isVisible());
             ed.setScroll(getScrollable());


### PR DESCRIPTION
Don't clear Lock Position and Disable for all the Positionable when changing from Control Panel Editor to Panel Editor.

See: https://jmri-developers.groups.io/g/jmri/topic/93011349

@dsand47 
Do you think this PR can have any unexpected side effects? I'm not sure I understand how this code should work.