### PR TITLE
update Load store tests - User Profile in temp directory

### DIFF
--- a/java/test/jmri/configurexml/LoadAndStoreTestBase.java
+++ b/java/test/jmri/configurexml/LoadAndStoreTestBase.java
@@ -5,6 +5,7 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStreamReader;
+import java.io.IOException;
 import java.util.stream.Stream;
 
 import jmri.ConfigureManager;
@@ -17,6 +18,7 @@ import jmri.util.JUnitUtil;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.provider.Arguments;
 
 /**
@@ -363,9 +365,9 @@ public class LoadAndStoreTestBase {
     }
 
     @BeforeEach
-    public void setUp() {
+    public void setUp(@TempDir java.io.File tempDir) throws IOException  {
         JUnitUtil.setUp();
-        JUnitUtil.resetProfileManager();
+        JUnitUtil.resetProfileManager( new jmri.profile.NullProfile( tempDir));
         JUnitUtil.resetInstanceManager();
         JUnitUtil.initConfigureManager();
         JUnitUtil.initInternalTurnoutManager();

--- a/java/test/jmri/implementation/configurexml/LoadAndStoreTest.java
+++ b/java/test/jmri/implementation/configurexml/LoadAndStoreTest.java
@@ -1,12 +1,14 @@
 package jmri.implementation.configurexml;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.stream.Stream;
 
 import jmri.*;
 import jmri.implementation.MockCommandStation;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -43,8 +45,8 @@ public class LoadAndStoreTest extends jmri.configurexml.LoadAndStoreTestBase {
 
     @BeforeEach
     @Override
-    public void setUp() {
-        super.setUp();
+    public void setUp(@TempDir java.io.File tempDir) throws IOException  {
+        super.setUp(tempDir);
         // for DCC Signals
         InstanceManager.store(new MockCommandStation("N"), CommandStation.class);
     }

--- a/java/test/jmri/jmrit/display/layoutEditor/LoadAndStoreTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LoadAndStoreTest.java
@@ -3,12 +3,13 @@ package jmri.jmrit.display.layoutEditor;
 import java.io.*;
 import java.util.stream.Stream;
 
+import jmri.InstanceManager;
 import jmri.util.*;
 import jmri.jmrit.display.Editor;
 
 import org.junit.Assert;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -43,7 +44,7 @@ public class LoadAndStoreTest extends jmri.configurexml.LoadAndStoreTestBase {
         super(SaveType.User, true);
     }
 
-    static boolean done;
+    private boolean done;
 
     /**
      * Wait for the layout editor block processing to take place. This is quite
@@ -55,35 +56,35 @@ public class LoadAndStoreTest extends jmri.configurexml.LoadAndStoreTestBase {
         done = false;
         ThreadingUtil.runOnGUIDelayed(() -> done = true, 2500);
         JUnitUtil.waitFor(() -> {
-            return jmri.InstanceManager.getDefault(LayoutBlockManager.class).stabilised || done;
-        });
+            return InstanceManager.getDefault(LayoutBlockManager.class).stabilised || done;
+        },"LayoutBlockManager stabilised || done");
 
         // need to do two separate ones because of waitFor limit
         done = false;
         ThreadingUtil.runOnGUIDelayed(() -> done = true, 2500);
         JUnitUtil.waitFor(() -> {
-            return jmri.InstanceManager.getDefault(LayoutBlockManager.class).stabilised || done;
-        });
-        if ( ! jmri.InstanceManager.getDefault(LayoutBlockManager.class).stabilised ) {
+            return InstanceManager.getDefault(LayoutBlockManager.class).stabilised || done;
+        },"LayoutBlockManager stabilised || done");
+        if ( ! InstanceManager.getDefault(LayoutBlockManager.class).stabilised ) {
             log.debug("not stabilized after check");
         }
 
         // and wait yet another 2 sec before writing out
         done = false;
-        jmri.util.ThreadingUtil.runOnGUIDelayed(()->{
+        ThreadingUtil.runOnGUIDelayed(()->{
                 done = true;
             }, 2000);
-        jmri.util.JUnitUtil.waitFor(()->{return done;});
+        JUnitUtil.waitFor(()->{return done;},"GUI wait did not complete");
 
         if ( ! jmri.InstanceManager.getDefault(LayoutBlockManager.class).stabilised ) {
             log.debug(" still not stabilized");
         }
 
         done = false;
-        jmri.util.ThreadingUtil.runOnGUIDelayed(()->{
+        ThreadingUtil.runOnGUIDelayed(()->{
                 done = true;
             }, 2000);
-        jmri.util.JUnitUtil.waitFor(()->{return done;});
+        JUnitUtil.waitFor(()->{return done;},"next GUI wait did not complete");
 
         if ( ! jmri.InstanceManager.getDefault(LayoutBlockManager.class).stabilised ) {
             log.debug(" nor now");
@@ -104,7 +105,7 @@ public class LoadAndStoreTest extends jmri.configurexml.LoadAndStoreTestBase {
 
         done = false;
         ThreadingUtil.runOnGUIDelayed(() -> done = true, 1000);
-        JUnitUtil.waitFor(() -> done);
+        JUnitUtil.waitFor(() -> done,"1 sec gui delay incomplete");
 
         storeAndCompareImage(file);
     }
@@ -152,8 +153,11 @@ public class LoadAndStoreTest extends jmri.configurexml.LoadAndStoreTestBase {
     }
 
     protected void findAndComparePngFiles(String name, File inFile, File outFile, int index, String subdir) throws IOException {
-        File compFile = new File(inFile.getCanonicalFile().getParentFile().
-                getParent() + "/loadref/" + subdir + "/" + name + "." + index + ".png");
+        File parent = inFile.getCanonicalFile().getParentFile(); 
+        Assertions.assertNotNull(parent);
+        String filepath = parent.getParent();
+        Assertions.assertNotNull(filepath);
+        File compFile = new File(filepath + "/loadref/" + subdir + "/" + name + "." + index + ".png");
 
         int checkVal = compareImageFiles(compFile, outFile);
         if (checkVal != 0) {
@@ -211,8 +215,8 @@ public class LoadAndStoreTest extends jmri.configurexml.LoadAndStoreTestBase {
 
     @BeforeEach
     @Override
-    public void setUp() {
-        super.setUp();
+    public void setUp(@TempDir java.io.File tempDir) throws IOException  {
+        super.setUp(tempDir);
         JUnitUtil.initLayoutBlockManager();
     }
 

--- a/java/test/jmri/jmrit/display/panelEditor/LoadAndStoreTest.java
+++ b/java/test/jmri/jmrit/display/panelEditor/LoadAndStoreTest.java
@@ -9,6 +9,7 @@ import jmri.jmrit.display.Editor;
 import org.junit.Assert;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -43,7 +44,7 @@ public class LoadAndStoreTest extends jmri.configurexml.LoadAndStoreTestBase {
         super(SaveType.User, true);
     }
 
-    static boolean done;
+    private boolean done;
 
     /**
      * Also writes out image files from these for later offline checking.This
@@ -59,7 +60,7 @@ public class LoadAndStoreTest extends jmri.configurexml.LoadAndStoreTestBase {
 
         done = false;
         ThreadingUtil.runOnGUIDelayed(() -> done = true, 2000);
-        JUnitUtil.waitFor(() -> done);
+        JUnitUtil.waitFor(() -> done,"2secs GUI wait did not complete");
 
         storeAndCompareImage(file);
     }
@@ -166,8 +167,8 @@ public class LoadAndStoreTest extends jmri.configurexml.LoadAndStoreTestBase {
 
     @BeforeEach
     @Override
-    public void setUp() {
-        super.setUp();
+    public void setUp(@TempDir java.io.File tempDir) throws IOException  {
+        super.setUp(tempDir);
         JUnitUtil.initLayoutBlockManager();
     }
 

--- a/java/test/jmri/jmrit/logixng/configurexml/LoadAndStoreTest.java
+++ b/java/test/jmri/jmrit/logixng/configurexml/LoadAndStoreTest.java
@@ -3,16 +3,17 @@ package jmri.jmrit.logixng.configurexml;
 import jmri.configurexml.*;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.stream.Stream;
 
 import jmri.InstanceManager;
 import jmri.jmrit.logixng.LogixNG_Manager;
 import jmri.jmrix.loconet.*;
 import jmri.jmrix.mqtt.MqttSystemConnectionMemo;
-import jmri.util.JUnitUtil;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -55,8 +56,8 @@ public class LoadAndStoreTest extends LoadAndStoreTestBase {
 
     @BeforeEach
     @Override
-    public void setUp() {
-        super.setUp();
+    public void setUp(@TempDir java.io.File tempDir) throws IOException  {
+        super.setUp(tempDir);
 
         LocoNetInterfaceScaffold lnis = new LocoNetInterfaceScaffold();
         SlotManager sm = new SlotManager(lnis);

--- a/java/test/jmri/jmrit/swing/meter/LoadAndStoreTest.java
+++ b/java/test/jmri/jmrit/swing/meter/LoadAndStoreTest.java
@@ -1,12 +1,10 @@
 package jmri.jmrit.swing.meter;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.stream.Stream;
 
-import org.junit.Assert;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -54,19 +52,10 @@ public class LoadAndStoreTest extends jmri.configurexml.LoadAndStoreTestBase {
         super(SaveType.User, true);
     }
     
-    @TempDir 
-    protected java.nio.file.Path tempDir;
-
     @BeforeEach
     @Override
-    public void setUp() {
-        super.setUp();
-        try {
-            JUnitUtil.resetProfileManager( new jmri.profile.NullProfile( tempDir.toFile()));
-        }
-        catch (java.io.IOException e){
-            Assert.fail("Unable to create temp directory");
-        }
+    public void setUp(@TempDir java.io.File tempDir) throws IOException  {
+        super.setUp(tempDir);
         
         // This test requires a registred connection config since ProxyMeterManager
         // auto creates system meter managers using the connection configs.

--- a/java/test/jmri/jmrix/loconet/configurexml/LoadAndStoreTest.java
+++ b/java/test/jmri/jmrix/loconet/configurexml/LoadAndStoreTest.java
@@ -3,10 +3,12 @@ package jmri.jmrix.loconet.configurexml;
 import jmri.jmrix.loconet.*;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -54,8 +56,8 @@ public class LoadAndStoreTest extends jmri.configurexml.LoadAndStoreTestBase {
      */
     @BeforeEach
     @Override
-    public void setUp() {
-        super.setUp();
+    public void setUp(@TempDir java.io.File tempDir) throws IOException  {
+        super.setUp(tempDir);
 
         // 1st LocoNet connection L
         memo1 = new LocoNetSystemConnectionMemo();

--- a/java/test/jmri/jmrix/openlcb/configurexml/LoadAndStoreTest.java
+++ b/java/test/jmri/jmrix/openlcb/configurexml/LoadAndStoreTest.java
@@ -4,10 +4,12 @@ import jmri.configurexml.LoadAndStoreTestBase;
 import jmri.jmrix.openlcb.*;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -53,8 +55,8 @@ public class LoadAndStoreTest extends LoadAndStoreTestBase {
     @BeforeEach
     @SuppressWarnings("deprecated") // OlcbInterface(NodeID, Connection)
     @Override
-    public void setUp() {
-        super.setUp();
+    public void setUp(@TempDir java.io.File tempDir) throws IOException  {
+        super.setUp(tempDir);
         nodeID = new NodeID(new byte[]{1, 0, 0, 0, 0, 0});
 
         messages = new ArrayList<>();


### PR DESCRIPTION
All LoadAndStoreTests - use Temporary Directory for User Profile
See #11320 

I was in middle of looking at the layoutEditor / panelEditor tests, so this also includes

**layoutEditor** LoadAndStoreTest -
boolean flag should not be static
add JUnitUtil.waitFor failure text
add nonnull assertions to file paths

**panelEditor** LoadAndStoreTest -
boolean flag should not be static.
Add JUnitUtil.waitFor failure text