### PR TITLE
WIP undo proof of concept

### DIFF
--- a/java/src/apps/AppsMainMenu.java
+++ b/java/src/apps/AppsMainMenu.java
@@ -106,6 +106,14 @@ public class AppsMainMenu {
         a.putValue(Action.NAME, Bundle.getMessage("MenuItemPaste"));  // NOI18N
         editMenu.add(a);
 
+        editMenu.add(new JSeparator());
+        editMenu.add(new AbstractAction(Bundle.getMessage("MenuItemUndo")) {  // NOI18N
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                jmri.InstanceManager.getDefault(jmri.UndoManager.class).undoEvent();
+            }
+        });
+
         // prefs
         prefsAction = new apps.gui3.tabbedpreferences.TabbedPreferencesAction(Bundle.getMessage("MenuItemPreferences"));  // NOI18N
 

--- a/java/src/jmri/NamedBeanBundle.properties
+++ b/java/src/jmri/NamedBeanBundle.properties
@@ -285,6 +285,7 @@ MenuItemCut                      = Cut
 MenuItemCopy                     = Copy
 MenuItemCopyAll                  = Copy all
 MenuItemPaste                    = Paste
+MenuItemUndo                     = Undo
 MenuItemPrintSummary             = Print Summary...
 MenuItemPreviewSummary           = Print Preview Summary...
 PrintTable                       = Print Table

--- a/java/src/jmri/UndoManager.java
+++ b/java/src/jmri/UndoManager.java
@@ -1,0 +1,58 @@
+package jmri;
+
+import java.util.*;
+
+import jmri.jmrit.display.layoutEditor.PositionablePointView;
+
+public class UndoManager implements InstanceManagerAutoDefault {
+
+    Queue<UndoObject> undoQueue = Collections.asLifoQueue(new ArrayDeque<>());
+
+    public UndoManager() {
+    }
+
+    public void addUndoEvent(Object source, String key, Object data) {
+        undoQueue.add(new UndoObject(source, key, data));
+        log.info("++++ add {} :: {} :: {}", source, key, data);
+    }
+
+    public void undoEvent() {
+        if (undoQueue.size() == 0) {
+            log.info("Undo Queue is empty");
+            return;
+        }
+
+        UndoObject undo = undoQueue.remove();
+        log.info("---- undo = {} :: {} :: {}", undo.getSource(), undo.getKey(), undo.getData());
+        if (undo.getSource() instanceof PositionablePointView) {
+            ((PositionablePointView)undo.getSource()).undoChange(undo.getKey(), undo.getData());
+        }
+    }
+
+    private static class UndoObject {
+        Object _source;    // The 'this' value from the caller
+        String _key;
+        Object _data;
+
+        public UndoObject(Object source, String key, Object data) {
+            _source = source;
+            _key = key;
+            _data = data;
+        }
+
+        Object getSource() {
+            return _source;
+        }
+
+        String getKey() {
+            return _key;
+        }
+
+        Object getData() {
+            return _data;
+        }
+    }
+
+    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(UndoManager.class);
+}
+

--- a/java/src/jmri/jmrit/display/layoutEditor/PositionablePointView.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/PositionablePointView.java
@@ -119,6 +119,8 @@ public class PositionablePointView extends LayoutTrackView {
     }
 
     private void setTypeAnchor() {
+        addUndoEvent("setType");
+
         setIdent(layoutEditor.getFinder().uniqueName("A", 1));
 
         // type = PointType.ANCHOR;
@@ -149,6 +151,8 @@ public class PositionablePointView extends LayoutTrackView {
     }
 
     private void setTypeEndBumper() {
+        addUndoEvent("setType");
+
         setIdent(layoutEditor.getFinder().uniqueName("EB", 1));
 
         // type = PointType.END_BUMPER;
@@ -168,6 +172,8 @@ public class PositionablePointView extends LayoutTrackView {
     }
 
     private void setTypeEdgeConnector() {
+        addUndoEvent("setType");
+
         setIdent(layoutEditor.getFinder().uniqueName("EC", 1));
 
         // type = PointType.EDGE_CONNECTOR;
@@ -1986,6 +1992,37 @@ public class PositionablePointView extends LayoutTrackView {
         // positionable points don't have blocks...
         // nothing to see here, move along...
     }
+
+    boolean undoActive = false;
+
+    public void undoChange(String key, Object data) {
+        undoActive = true;
+
+        log.info("need to undo {} for {}", key, data);
+        if (key.equals("setType")) {
+            if (data == PointType.ANCHOR) {
+                setTypeAnchor();
+            }
+            if (data == PointType.END_BUMPER) {
+                setTypeEndBumper();
+            }
+            if (data == PointType.EDGE_CONNECTOR) {
+                setTypeEdgeConnector();
+            }
+        }
+
+        undoActive = false;
+    }
+
+    private void addUndoEvent(String key) {
+        log.info("=-=- view type = {}", getType());
+        if (!undoActive) {
+            if (key.equals("setType")) {
+                InstanceManager.getDefault(jmri.UndoManager.class).addUndoEvent(this, key, getType());
+            }
+        }
+    }
+
 
     private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(PositionablePointView.class);
 }


### PR DESCRIPTION
This is one approach to supporting undo within the PanelPro context.

A singleton class uses a LIFO enabled ArrayDeque to store the before data values.  When the Edit &rArr; Undo menu item is selected from the main PanelPro menu, the most recent entry is sent to the source class to undo the change.

The code works but there might be a better approach, especially dealing with the classes.  Maybe generics would help.

In order to maintain data integrity, the basic rule is that every change is captured across all tables and panels that have any sort of relationship.  The UNDO process has to work in exact reverse order.

A simpler approach is a single level undo.  To maintain data integrity the undo data has a very short lifetime, probably less than a minute.