### PR TITLE
Update some Layout Editor Dialog tests

### DIFF
--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/EnterGridSizesDialogTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/EnterGridSizesDialogTest.java
@@ -1,15 +1,16 @@
 package jmri.jmrit.display.layoutEditor.LayoutEditorDialogs;
 
-import java.awt.GraphicsEnvironment;
 import java.awt.geom.Rectangle2D;
 import javax.swing.JTextField;
 
 import jmri.jmrit.display.EditorFrameOperator;
 import jmri.jmrit.display.layoutEditor.LayoutEditor;
 import jmri.util.JUnitUtil;
-import jmri.util.junit.rules.RetryRule;
-import org.junit.*;
-import org.junit.rules.Timeout;
+
+import org.junit.Assert;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
 import org.netbeans.jemmy.operators.JButtonOperator;
 import org.netbeans.jemmy.operators.JFrameOperator;
 import org.netbeans.jemmy.operators.JLabelOperator;
@@ -20,56 +21,18 @@ import org.netbeans.jemmy.operators.JTextFieldOperator;
  *
  * @author George Warner Copyright (C) 2019
  */
+@Timeout(10)
+@DisabledIfSystemProperty(named = "java.awt.headless", matches = "true")
 public class EnterGridSizesDialogTest {
-
-    private static LayoutEditor layoutEditor = null;
-    private static EnterGridSizesDialog enterGridSizesDialog = null;
-
-    @Rule
-    public Timeout globalTimeout = Timeout.seconds(10); // 10 second timeout for methods in this test class.
-
-    @Rule    // allow 2 retries of intermittent tests
-    public RetryRule retryRule = new RetryRule(2); // allow 2 retries
-
-    /*
-     * This is called before each test
-     */
-    @Before
-    public void setUp() {
-        JUnitUtil.setUp();
-        if (!GraphicsEnvironment.isHeadless()) {
-            layoutEditor = new LayoutEditor();
-            enterGridSizesDialog = new EnterGridSizesDialog(layoutEditor);
-            layoutEditor.setPanelBounds(new Rectangle2D.Double(0, 0, 640, 480));
-            layoutEditor.setVisible(true);
-        }
-    }
-
-    /*
-     * This is called after each test
-     */
-    @After
-    public void tearDown() {
-        if (!GraphicsEnvironment.isHeadless()) {
-            EditorFrameOperator efo = new EditorFrameOperator(layoutEditor);
-            efo.closeFrameWithConfirmations();
-            layoutEditor = null;
-            enterGridSizesDialog = null;
-        }
-        JUnitUtil.deregisterBlockManagerShutdownTask();
-        JUnitUtil.tearDown();
-    }
 
     @Test
     public void testCtor() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         Assert.assertNotNull("layoutEditor exists", layoutEditor);
         Assert.assertNotNull("EnterGridSizesDialog exists", enterGridSizesDialog);
     }
 
     @Test
     public void testEnterGridSizesCanceled() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
 
         enterGridSizesDialog.enterGridSizes();
         JFrameOperator jFrameOperator = new JFrameOperator(Bundle.getMessage("SetGridSizes"));
@@ -80,7 +43,6 @@ public class EnterGridSizesDialogTest {
 
     @Test
     public void testEnterGridSizes() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
 
         enterGridSizesDialog.enterGridSizes();
         JFrameOperator jFrameOperator = new JFrameOperator(Bundle.getMessage("SetGridSizes"));
@@ -139,4 +101,37 @@ public class EnterGridSizesDialogTest {
         layoutEditor.gContext.setGridSize2nd(oldGridSize2nd);
         Assert.assertEquals("old grid size 2nd", oldGridSize2nd, layoutEditor.gContext.getGridSize2nd());
     }
+
+    private LayoutEditor layoutEditor = null;
+    private EnterGridSizesDialog enterGridSizesDialog = null;
+
+    /*
+     * This is called before each test
+     */
+    @BeforeEach
+    public void setUp() {
+        JUnitUtil.setUp();
+
+        layoutEditor = new LayoutEditor(this.getClass().getName());
+        enterGridSizesDialog = new EnterGridSizesDialog(layoutEditor);
+        layoutEditor.setPanelBounds(new Rectangle2D.Double(0, 0, 640, 480));
+        layoutEditor.setVisible(true);
+
+    }
+
+    /*
+     * This is called after each test
+     */
+    @AfterEach
+    public void tearDown() {
+
+        // new EditorFrameOperator(layoutEditor).closeFrameWithConfirmations();
+        layoutEditor.dispose();
+        layoutEditor = null;
+        enterGridSizesDialog = null;
+
+        JUnitUtil.deregisterBlockManagerShutdownTask();
+        JUnitUtil.tearDown();
+    }
+
 }

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/LayoutTrackDrawingOptionsDialogTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/LayoutTrackDrawingOptionsDialogTest.java
@@ -1,50 +1,47 @@
 package jmri.jmrit.display.layoutEditor.LayoutEditorDialogs;
 
-import java.awt.GraphicsEnvironment;
-
 import jmri.util.JUnitUtil;
 
 import jmri.jmrit.display.EditorFrameOperator;
 import jmri.jmrit.display.layoutEditor.LayoutEditor;
 import jmri.jmrit.display.layoutEditor.LayoutTrackDrawingOptions;
-import org.junit.Assert;
-import org.junit.Assume;
+
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 /**
  *
  * @author Paul Bender Copyright (C) 2017
  */
+@DisabledIfSystemProperty(named = "java.awt.headless", matches = "true")
 public class LayoutTrackDrawingOptionsDialogTest {
 
-    private LayoutEditor le;
+    private LayoutEditor le = null;
+
     @Test
     public void testCTor() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutTrackDrawingOptions ltdo = new LayoutTrackDrawingOptions("test");
         LayoutTrackDrawingOptionsDialog t = new LayoutTrackDrawingOptionsDialog(le,false,ltdo);
-        Assert.assertNotNull("exists",t);
-        le.dispose();
+        Assertions.assertNotNull(t, "exists");
+        
     }
 
     @BeforeEach
     public void setUp() {
         JUnitUtil.setUp();
         JUnitUtil.resetProfileManager();
-        if(!GraphicsEnvironment.isHeadless()) {
-            le = new LayoutEditor("Layout Track Drawing Options Dialog Test Layout");
-            le.setVisible(true);
-        }
+        le = new LayoutEditor(this.getClass().getName());
+        le.setVisible(true);
     }
 
     @AfterEach
     public void tearDown() {
-        if(le!=null){
-            EditorFrameOperator efo = new EditorFrameOperator(le);
-            efo.closeFrameWithConfirmations();
-        }
+        Assertions.assertNotNull(le);
+        // new EditorFrameOperator(le).closeFrameWithConfirmations();
+        le.dispose();
+        le = null;
+
         JUnitUtil.deregisterBlockManagerShutdownTask();
-        jmri.jmrit.display.EditorFrameOperator.clearEditorFrameOperatorThreads();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/MoveSelectionDialogTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/MoveSelectionDialogTest.java
@@ -1,15 +1,14 @@
 package jmri.jmrit.display.layoutEditor.LayoutEditorDialogs;
 
-import java.awt.GraphicsEnvironment;
 import java.awt.geom.Rectangle2D;
 import javax.swing.JTextField;
 
-import jmri.jmrit.display.EditorFrameOperator;
 import jmri.jmrit.display.layoutEditor.LayoutEditor;
 import jmri.util.JUnitUtil;
-import jmri.util.junit.rules.RetryRule;
-import org.junit.*;
-import org.junit.rules.Timeout;
+
+import org.junit.Assert;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.netbeans.jemmy.operators.JButtonOperator;
 import org.netbeans.jemmy.operators.JFrameOperator;
 import org.netbeans.jemmy.operators.JLabelOperator;
@@ -20,57 +19,18 @@ import org.netbeans.jemmy.operators.JTextFieldOperator;
  *
  * @author George Warner Copyright (C) 2019
  */
+@Timeout(10)
+@DisabledIfSystemProperty(named = "java.awt.headless", matches = "true")
 public class MoveSelectionDialogTest {
-
-    private static LayoutEditor layoutEditor = null;
-    private static MoveSelectionDialog moveSelectionDialog = null;
-
-    @Rule
-    public Timeout globalTimeout = Timeout.seconds(10); // 10 second timeout for methods in this test class.
-
-    @Rule    // allow 2 retries of intermittent tests
-    public RetryRule retryRule = new RetryRule(2); // allow 2 retries
-
-    /*
-     * This is called before each test
-     */
-    @Before
-    public void setUp() {
-        JUnitUtil.setUp();
-        if (!GraphicsEnvironment.isHeadless()) {
-            layoutEditor = new LayoutEditor();
-            layoutEditor.setVisible(true);
-            moveSelectionDialog = new MoveSelectionDialog(layoutEditor);
-            layoutEditor.setPanelBounds(new Rectangle2D.Double(0, 0, 640, 480));
-        }
-    }
-
-    /*
-     * This is called after each test
-     */
-    @After
-    public void tearDown() {
-        if (!GraphicsEnvironment.isHeadless()) {
-            EditorFrameOperator efo = new EditorFrameOperator(layoutEditor);
-            efo.closeFrameWithConfirmations();
-            layoutEditor = null;
-            moveSelectionDialog = null;
-        }
-        JUnitUtil.deregisterBlockManagerShutdownTask();
-        JUnitUtil.tearDown();
-    }
 
     @Test
     public void testCtor() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         Assert.assertNotNull("layoutEditor exists", layoutEditor);
         Assert.assertNotNull("MoveSelectionDialog exists", moveSelectionDialog);
     }
 
     @Test
     public void testMoveSelectionCanceled() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-
         moveSelectionDialog.moveSelection();
         JFrameOperator jFrameOperator = new JFrameOperator(Bundle.getMessage("TranslateSelection"));
 
@@ -80,7 +40,6 @@ public class MoveSelectionDialogTest {
 
     @Test
     public void testMoveSelection() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
 
         moveSelectionDialog.moveSelection();
         JFrameOperator jFrameOperator = new JFrameOperator(Bundle.getMessage("TranslateSelection"));
@@ -125,4 +84,34 @@ public class MoveSelectionDialogTest {
         moveSelectionButtonOperator.doClick();
         jFrameOperator.waitClosed();    // make sure the dialog actually closed
     }
+
+    private LayoutEditor layoutEditor = null;
+    private MoveSelectionDialog moveSelectionDialog = null;
+
+    /**
+     * This is called before each test.
+     */
+    @BeforeEach
+    public void setUp() {
+        JUnitUtil.setUp();
+        layoutEditor = new LayoutEditor(this.getClass().getName());
+        layoutEditor.setVisible(true);
+        moveSelectionDialog = new MoveSelectionDialog(layoutEditor);
+        layoutEditor.setPanelBounds(new Rectangle2D.Double(0, 0, 640, 480));
+    }
+
+    /**
+     * This is called after each test.
+     */
+    @AfterEach
+    public void tearDown() {
+        // new jmri.jmrit.display.EditorFrameOperator(layoutEditor).closeFrameWithConfirmations();
+        Assertions.assertNotNull(layoutEditor);
+        layoutEditor.dispose();
+        layoutEditor = null;
+        moveSelectionDialog = null;
+        JUnitUtil.deregisterBlockManagerShutdownTask();
+        JUnitUtil.tearDown();
+    }
+
 }


### PR DESCRIPTION
**EnterGridSizesDialogTest**, **MoveSelectionDialogTest** -
layoutEditor / Dialog should not be static
update to JUnit5
Remove RetryRule
move setUp / tearDown to bottom of class

**LayoutTrackDrawingOptionsDialogTest** -
update headless checks
assert not null