### PR TITLE
Update some jmrix.can.cbus tests

### DIFF
--- a/java/src/jmri/jmrix/can/cbus/CbusSensor.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusSensor.java
@@ -19,6 +19,12 @@ public class CbusSensor extends AbstractSensor implements CanListener, CbusEvent
     private CbusAddress addrActive;    // go to active state
     private CbusAddress addrInactive;  // go to inactive state
 
+    /**
+     * Create a new CbusSensor.
+     * @param prefix Hardware connection system prefix, excluding the S for Sensor..
+     * @param address String form of {@link CbusAddress}
+     * @param tc System Traffic Controller.
+     */
     public CbusSensor(String prefix, String address, TrafficController tc) {
         super(prefix + "S" + address);
         this.tc = tc;
@@ -28,9 +34,7 @@ public class CbusSensor extends AbstractSensor implements CanListener, CbusEvent
     private final TrafficController tc;
 
     /**
-     * Common initialization for both constructors.
-     * <p>
-     *
+     * Common initialization for constructors.
      */
     private void init(String address) {
         // build local addresses

--- a/java/test/jmri/jmrix/can/CanConstantsTest.java
+++ b/java/test/jmri/jmrix/can/CanConstantsTest.java
@@ -2,7 +2,6 @@ package jmri.jmrix.can;
 
 import jmri.util.JUnitUtil;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.*;
 
 /**
@@ -11,10 +10,12 @@ import org.junit.jupiter.api.*;
  */
 public class CanConstantsTest {
 
+     // no testCtor as class only supplies static methods
+
     @Test
-    public void testCTor() {
-        CanConstants t = new CanConstants();
-        Assert.assertNotNull("exists",t);
+    public void testCanConstants() {
+        Assertions.assertEquals(0,CanConstants.CANRS);
+        Assertions.assertEquals(1,CanConstants.CANUSB);
     }
 
     @BeforeEach

--- a/java/test/jmri/jmrix/can/cbus/CbusAddressTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusAddressTest.java
@@ -199,7 +199,7 @@ public class CbusAddressTest {
         Assert.assertTrue((new CbusAddress("+001")).equals(new CbusAddress("+001")));
         Assert.assertTrue((new CbusAddress("+001")).equals(new CbusAddress("x9800000001")));
         Assert.assertTrue((new CbusAddress("+200001")).equals(new CbusAddress("x9000020001")));
-        Assert.assertFalse((new CbusAddress("+200001")).equals(null));
+        Assert.assertNotNull( new CbusAddress("+200001"));
         Assert.assertFalse((new CbusAddress("+200001")).equals("foo"));
         Assert.assertFalse((new CbusAddress("+001")).equals(new CbusAddress("+002")));
         Assert.assertFalse((new CbusAddress("+N123E123")).equals(new CbusAddress("+N456E123")));
@@ -321,13 +321,13 @@ public class CbusAddressTest {
         Assert.assertEquals("-N34E456;-N34E17","-N34E457;-N34E18",CbusAddress.getIncrement("-N34E456;-N34E17"));
         Assert.assertEquals("-N34E456;+N34E17","-N34E457;+N34E18",CbusAddress.getIncrement("-N34E456;+N34E17"));
     }
-    
+
     @Test
-    public void testhashcode() {
+    public void testCbusAddressHashcode() {
         CbusAddress a = new CbusAddress("X9801D203A4");
         Assert.assertEquals("a hashcode is present",530,a.hashCode());
     }
-    
+
     @Test
     public void testMatchRequest() {
         

--- a/java/test/jmri/jmrix/can/cbus/CbusCabSignalIT.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusCabSignalIT.java
@@ -17,8 +17,8 @@ import org.junit.jupiter.api.*;
  */
 public class CbusCabSignalIT extends jmri.implementation.DefaultCabSignalIT {
 
-    private CanSystemConnectionMemo memo;
-    private TrafficController tc;
+    private CanSystemConnectionMemo memo = null;
+    private TrafficController tc = null;
 
     @BeforeEach
     @Override
@@ -45,9 +45,11 @@ public class CbusCabSignalIT extends jmri.implementation.DefaultCabSignalIT {
     @AfterEach
     @Override
     public void tearDown() {
+        Assertions.assertNotNull(memo);
         memo.dispose();
-        tc.terminateThreads();
         memo = null;
+        Assertions.assertNotNull(tc);
+        tc.terminateThreads();
         tc = null;
         cs.dispose();
         cs = null;

--- a/java/test/jmri/jmrix/can/cbus/CbusCabSignalTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusCabSignalTest.java
@@ -20,8 +20,8 @@ import org.junit.jupiter.api.*;
  */
 public class CbusCabSignalTest extends jmri.implementation.DefaultCabSignalTest {
 
-    private CanSystemConnectionMemo memo;
-    private TrafficController tc;
+    private CanSystemConnectionMemo memo = null;
+    private TrafficController tc = null;
 
     @Test
     @Override
@@ -68,9 +68,11 @@ public class CbusCabSignalTest extends jmri.implementation.DefaultCabSignalTest 
     @AfterEach
     @Override
     public void tearDown() {
+        Assertions.assertNotNull(memo);
+        Assertions.assertNotNull(tc);
         memo.dispose();
-        tc.terminateThreads();
         memo = null;
+        tc.terminateThreads();
         tc = null;
         cs.dispose();
         cs = null;

--- a/java/test/jmri/jmrix/can/cbus/CbusClockControlTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusClockControlTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Date;
+
 import jmri.ClockControl;
 import jmri.InstanceManager;
 import jmri.jmrix.can.CanMessage;
@@ -13,9 +14,8 @@ import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.jmrix.can.TrafficControllerScaffold;
 import jmri.Timebase;
 import jmri.util.JUnitUtil;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+
+import org.junit.jupiter.api.*;
 
 /**
  * @since 4.19.6
@@ -25,13 +25,6 @@ public class CbusClockControlTest {
 
     @Test
     public void testCTor() {
-        t = new CbusClockControl(null);
-        assertThat(t).isNotNull();
-        t.dispose();
-    }
-    
-    @Test
-    public void testCTorMemo() {
         t = new CbusClockControl(memo);
         assertThat(t).isNotNull();
         t.dispose();
@@ -76,7 +69,7 @@ public class CbusClockControlTest {
         
         tb.setInternalMaster(true, false);
         tb.setSynchronize(true, true);
-        
+        Assertions.assertNotNull(tcis);
         assertThat(tcis.outbound.size()).isEqualTo(1);
         assertThat(tcis.outbound.get(0).toString()).isEqualTo("[5f8] CF 39 11 46 00 18 00");
 
@@ -137,22 +130,25 @@ public class CbusClockControlTest {
     
     @Test
     public void testIncomingDoesNotSetDate() {
-        
+
         tb = jmri.InstanceManager.getDefault(Timebase.class);
         tb.setRun(false);
-        
+
         LocalDateTime specificDate = LocalDateTime.of(2020, 04, 24, 17, 57, 0);
         tb.setTime(Date.from( specificDate.atZone( ZoneId.systemDefault()).toInstant())); // a Friday
-        
+
         t = new CbusClockControl(memo);
+        Assertions.assertNotNull(t);
         InstanceManager.setDefault(ClockControl.class, t);
-        
+
         tb.setInternalMaster(false, false);
         tb.setSynchronize(true, true);
-        tb.setMasterName(t.getHardwareClockName());     
-        
+        String clockName = t.getHardwareClockName();
+        Assertions.assertNotNull(clockName);
+        tb.setMasterName(clockName);
+
         assertThat(tb.getTime().toString()).contains("Apr 24 17:57");
-        
+
         // base message
         CanReply send = new CanReply(memo.getTrafficController().getCanid());
         send.setNumDataElements(7);
@@ -194,22 +190,25 @@ public class CbusClockControlTest {
     
     @Test
     public void testIncomingSetDate() {
-        
+
         tb = jmri.InstanceManager.getDefault(Timebase.class);
         tb.setRun(false);
-        
+
         LocalDateTime specificDate = LocalDateTime.of(2020, 04, 24, 17, 57, 0);
         tb.setTime(Date.from( specificDate.atZone( ZoneId.systemDefault()).toInstant())); // a Friday
-        
+
         t = new CbusClockControl(memo);
+        Assertions.assertNotNull(t);
         InstanceManager.setDefault(ClockControl.class, t);
-        
+
         tb.setInternalMaster(false, false);
         tb.setSynchronize(true, true);
-        tb.setMasterName(t.getHardwareClockName());     
-        
+        String clockName = t.getHardwareClockName();
+        Assertions.assertNotNull(clockName);
+        tb.setMasterName(clockName);
+
         assertThat(tb.getTime().toString()).contains("Apr 24 17:57");
-        
+
         // base message
         CanReply send = new CanReply(memo.getTrafficController().getCanid());
         send.setNumDataElements(7);
@@ -258,14 +257,17 @@ public class CbusClockControlTest {
         tb.setTime(Date.from( specificDate.atZone( ZoneId.systemDefault()).toInstant())); // a Friday
         
         t = new CbusClockControl(memo);
+        Assertions.assertNotNull(t);
         InstanceManager.setDefault(ClockControl.class, t);
-        
+
         tb.setInternalMaster(false, false);
         tb.setSynchronize(true, true);
-        tb.setMasterName(t.getHardwareClockName());     
-        
+        String clockName = t.getHardwareClockName();
+        Assertions.assertNotNull(clockName);
+        tb.setMasterName(clockName);     
+
         assertThat(tb.getTime().toString()).contains("Apr 24 17:57");
-        
+
         // base message
         CanReply send = new CanReply(memo.getTrafficController().getCanid());
         send.setNumDataElements(7);
@@ -366,17 +368,16 @@ public class CbusClockControlTest {
             isEqualTo("Speed: x10 02:44 Saturday 10 July Temp: 35");
         
     }
-    
-    private CbusClockControl t;
+
+    private CbusClockControl t = null;
     private Timebase tb;
-    private CanSystemConnectionMemo memo;
-    private TrafficControllerScaffold tcis;
-    
+    private CanSystemConnectionMemo memo = null;
+    private TrafficControllerScaffold tcis = null;
+
     @BeforeEach
     public void setUp() {
         JUnitUtil.setUp();
-        JUnitUtil.resetInstanceManager();
-        
+
         memo = new CanSystemConnectionMemo();
         tcis = new TrafficControllerScaffold();
         memo.setTrafficController(tcis);
@@ -390,9 +391,11 @@ public class CbusClockControlTest {
             tb.dispose();
         }
         t = null;
+        Assertions.assertNotNull(memo);
         memo.dispose();
-        tcis.terminateThreads();
         memo = null;
+        Assertions.assertNotNull(tcis);
+        tcis.terminateThreads();
         tcis = null;
         JUnitUtil.tearDown();
     }

--- a/java/test/jmri/jmrix/can/cbus/CbusCommandStationTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusCommandStationTest.java
@@ -21,27 +21,30 @@ import org.junit.jupiter.api.*;
  */
 public class CbusCommandStationTest {
 
-    private CbusCommandStation t;
-    private CanSystemConnectionMemo memo;
-    private TrafficControllerScaffold lnis;
+    private CbusCommandStation t = null;
+    private CanSystemConnectionMemo memo = null;
+    private TrafficControllerScaffold lnis = null;
 
     @Test
-    public void testCTor() {
+    public void testCtor() {
         Assert.assertNotNull("exists",t);
     }
 
     @Test
-    public void testgetSystemPrefix() {
+    public void testgetCanSystemPrefix() {
+        Assert.assertNotNull(t);
         Assert.assertEquals("sys prefix", "M", t.getSystemPrefix());
     }
 
     @Test
-    public void testgetUserName() {
+    public void testgetCanUserName() {
+        Assert.assertNotNull(t);
         Assert.assertEquals("user name obtainable", "CAN", t.getUserName());
     }
     
     @Test
     public void testgetSimLoopbacktc() {
+        Assert.assertNotNull(memo);
         TrafficControllerScaffoldLoopback tc = new TrafficControllerScaffoldLoopback();
         memo.setTrafficController(tc);
         CbusCommandStation ta = new CbusCommandStation(memo);
@@ -54,7 +57,8 @@ public class CbusCommandStationTest {
     // test originates from loconet
     @Test
     public void testSendPacket() {
-        
+        Assert.assertNotNull(t);
+        Assert.assertNotNull(lnis);
         byte msg[] = jmri.NmraPacket.accDecPktOpsMode(1, 4, 53);
         t.sendPacket(msg, 1);
         Assert.assertEquals("nmra packet 1",
@@ -198,11 +202,13 @@ public class CbusCommandStationTest {
 
     @AfterEach
     public void tearDown() {
-        memo.dispose();
+        Assertions.assertNotNull(lnis);
         lnis.terminateThreads();
+        lnis = null;
+        Assertions.assertNotNull(memo);
+        memo.dispose();
         memo = null;
         t = null;
-        lnis = null;
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrix/can/cbus/CbusConstantsTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusConstantsTest.java
@@ -2,7 +2,6 @@ package jmri.jmrix.can.cbus;
 
 import jmri.util.JUnitUtil;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.*;
 
 /**
@@ -11,10 +10,11 @@ import org.junit.jupiter.api.*;
  */
 public class CbusConstantsTest {
 
+    // no testCtor as class only supplies static methods
+
     @Test
-    public void testCTor() {
-        CbusConstants t = new CbusConstants();
-        Assert.assertNotNull("exists",t);
+    public void testExists() {
+        Assertions.assertEquals(0x90, CbusConstants.CBUS_ACON);
     }
 
     @BeforeEach

--- a/java/test/jmri/jmrix/can/cbus/CbusDccOpsModeProgrammerTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusDccOpsModeProgrammerTest.java
@@ -11,8 +11,8 @@ import org.junit.jupiter.api.*;
  */
 public class CbusDccOpsModeProgrammerTest extends jmri.jmrix.AbstractOpsModeProgrammerTestBase {
 
-    private TrafficControllerScaffold tcis;
-    
+    private TrafficControllerScaffold tcis = null;
+
     @BeforeEach
     @Override
     public void setUp() {
@@ -21,11 +21,15 @@ public class CbusDccOpsModeProgrammerTest extends jmri.jmrix.AbstractOpsModeProg
         CbusDccOpsModeProgrammer t = new CbusDccOpsModeProgrammer(100,true,tcis);
         programmer = t;
     }
-    
+
     @AfterEach
     @Override
     public void tearDown() {
-        programmer = null;
+        if ( programmer != null ) {
+            programmer.dispose();
+            programmer = null;
+        }
+        Assertions.assertNotNull(tcis);
         tcis.terminateThreads();
         tcis = null;
         JUnitUtil.tearDown();

--- a/java/test/jmri/jmrix/can/cbus/CbusDccProgrammerTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusDccProgrammerTest.java
@@ -91,8 +91,8 @@ public class CbusDccProgrammerTest extends jmri.jmrix.AbstractProgrammerTest {
 */
     
     protected Programmer programmer2;
-    private TrafficControllerScaffold tcis;
-    private CanSystemConnectionMemo memo;
+    private TrafficControllerScaffold tcis = null;
+    private CanSystemConnectionMemo memo = null;
 
     @Override
     @BeforeEach
@@ -112,8 +112,10 @@ public class CbusDccProgrammerTest extends jmri.jmrix.AbstractProgrammerTest {
         programmer2.dispose();
         programmer2 = null;
         programmer = null;
+        Assertions.assertNotNull(tcis);
         tcis.terminateThreads();
         tcis = null;
+        Assertions.assertNotNull(memo);
         memo.dispose();
         memo = null;
         JUnitUtil.tearDown();

--- a/java/test/jmri/jmrix/can/cbus/CbusEventInterfaceTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusEventInterfaceTest.java
@@ -26,7 +26,7 @@ public class CbusEventInterfaceTest {
         
     }
     
-    private class TestInterface implements CbusEventInterface{
+    private static class TestInterface implements CbusEventInterface{
         
         @Override
         public jmri.jmrix.can.CanMessage getBeanOnMessage(){
@@ -39,7 +39,6 @@ public class CbusEventInterfaceTest {
         }
     
     }
-    
 
     @BeforeEach
     public void setUp() {

--- a/java/test/jmri/jmrix/can/cbus/CbusEventTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusEventTest.java
@@ -99,6 +99,8 @@ public class CbusEventTest {
     }
     
     @Test
+    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings( value = "EC_UNRELATED_TYPES",
+        justification = "CanReply and CanMessage are CanFrame with custom equals")
     @SuppressWarnings("unlikely-arg-type")
     public void testEquals(){
     

--- a/java/test/jmri/jmrix/can/cbus/CbusFilterTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusFilterTest.java
@@ -33,7 +33,7 @@ public class CbusFilterTest {
     private Vector<Integer> _increments;
     private Vector<Integer> _nodes;
     
-    public class FtTestFilterFrame extends CbusFilterFrame {
+    private class FtTestFilterFrame extends CbusFilterFrame {
         
         public FtTestFilterFrame() {
         super(null,null);
@@ -115,9 +115,7 @@ public class CbusFilterTest {
         Assert.assertEquals("increment filter id values match nodes", expectedNodes, _nodes);
         Assert.assertEquals("increment filter id values match ",expected , _increments);
         
-        t = null;
         tff.dispose();
-        tff = null;
     }
     
     // for use in any future debug
@@ -147,9 +145,6 @@ public class CbusFilterTest {
         t.setFilter(CbusFilterType.CFOUT.ordinal(),true);
         Assert.assertTrue("message 138",t.filter(m)==CbusFilterType.CFOUT.ordinal());
         Assert.assertTrue("message 139",t.filter(r)==CbusFilterType.CFIN.ordinal());
-        t = null;
-        m = null;
-        r = null;
     }
     
     // test opc filters

--- a/java/test/jmri/jmrix/can/cbus/CbusLightManagerTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusLightManagerTest.java
@@ -347,20 +347,21 @@ public class CbusLightManagerTest extends jmri.managers.AbstractLightMgrTestBase
     }
 
     @Test
-    public void testcreateNewLightException() {
-        Assert.assertThrows(IllegalArgumentException.class, () -> ((CbusLightManager)l).createNewLight("",null));
+    public void testcreateNewLightException() throws Exception {
+        Exception ex = Assert.assertThrows(IllegalArgumentException.class, () -> ((CbusLightManager)l).createNewLight("",null));
+        Assertions.assertNotNull(ex);
         JUnitAppender.assertErrorMessageStartsWith("Unable to create CbusLight, System name must start with \"ML\"");
 
     }
 
     @Test
-    public void testvalidSystemNameConfig() {
+    public void testValidSystemNameConfig() {
         Assert.assertTrue(l.validSystemNameConfig("ML+123"));
         Assert.assertFalse(l.validSystemNameConfig(""));
     }
 
-    private CanSystemConnectionMemo memo;
-    private TrafficControllerScaffold tc;
+    private CanSystemConnectionMemo memo = null;
+    private TrafficControllerScaffold tc = null;
 
     @BeforeEach
     @Override
@@ -375,8 +376,10 @@ public class CbusLightManagerTest extends jmri.managers.AbstractLightMgrTestBase
     @AfterEach
     public void tearDown() {
         l.dispose();
+        Assertions.assertNotNull(tc);
         tc.terminateThreads();
         tc = null;
+        Assertions.assertNotNull(memo);
         memo.dispose();
         memo = null;
         JUnitUtil.tearDown();

--- a/java/test/jmri/jmrix/can/cbus/CbusLightTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusLightTest.java
@@ -32,23 +32,22 @@ public class CbusLightTest extends jmri.implementation.AbstractLightTestBase {
     public void checkOnMsgSent() {
         Assert.assertEquals("ON message", "[5f8] 90 01 C8 01 41",
         tcis.outbound.elementAt(tcis.outbound.size() - 1).toString());
-        Assert.assertEquals("ON state", jmri.Light.ON, t.getState());
+        Assert.assertEquals("ON state", Light.ON, t.getState());
     }
 
     @Override
     public void checkOffMsgSent() {
         Assert.assertEquals("OFF message", "[5f8] 91 01 C8 01 41",
         tcis.outbound.elementAt(tcis.outbound.size() - 1).toString());
-        Assert.assertEquals("OFF state", jmri.Light.OFF, t.getState());
+        Assert.assertEquals("OFF state", Light.OFF, t.getState());
     }    
 
     @Test
-    public void testNullEvent() {
-        try {
+    public void testNullEvent() throws Exception {
+        Exception ex = Assertions.assertThrows(NullPointerException.class, () -> {
             t = new CbusLight("ML",null,tcis);
-            Assert.fail("Should have thrown an exception");
-        } catch (NullPointerException e) {
-        }
+        });
+        Assertions.assertNotNull(ex);
     }
 
     @Test

--- a/java/test/jmri/jmrix/can/cbus/CbusMessageTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusMessageTest.java
@@ -2,7 +2,6 @@ package jmri.jmrix.can.cbus;
 
 import jmri.jmrix.can.CanMessage;
 import jmri.jmrix.can.CanReply;
-import jmri.util.JUnitAppender;
 import jmri.util.JUnitUtil;
 
 import org.junit.Assert;
@@ -15,11 +14,7 @@ import org.junit.jupiter.api.*;
  */
 public class CbusMessageTest {
 
-    @Test
-    public void testCTor() {
-        CbusMessage t = new CbusMessage();
-        Assert.assertNotNull("exists",t);
-    }
+    // no testCtor as class only supplies static methods
     
     @Test
     public void testOpcRangeToSTL() {

--- a/java/test/jmri/jmrix/can/cbus/CbusOpCodesTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusOpCodesTest.java
@@ -20,11 +20,7 @@ import org.junit.jupiter.api.*;
  */
 public class CbusOpCodesTest {
 
-    @Test
-    public void testCTor() {
-        CbusOpCodes t = new CbusOpCodes();
-        Assert.assertNotNull("exists",t);
-    }
+    // no testCtor as class only supplies static methods
 
     @Test
     public void testDecode() {

--- a/java/test/jmri/jmrix/can/cbus/CbusPreferencesTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusPreferencesTest.java
@@ -19,7 +19,6 @@ public class CbusPreferencesTest {
     public void testCTor() {
         CbusPreferences t = new CbusPreferences();
         Assert.assertNotNull("exists",t);
-        t = null;
     }
 
     @BeforeEach

--- a/java/test/jmri/jmrix/can/cbus/CbusReporterManagerTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusReporterManagerTest.java
@@ -56,13 +56,14 @@ public class CbusReporterManagerTest extends jmri.managers.AbstractReporterMgrTe
     public String getSystemName(String i) {
         return "MR" + i;
     }
-    
+
     @Test
     @Override
     public void testAutoSystemNames() {
+        Assertions.assertNotNull(tcis);
         Assert.assertEquals("No auto system names",0,tcis.numListeners());
     }
-    
+
     @Test
     public void testGetSetDefaultTimeout() {
         Assert.assertEquals("Default timeout",2000,((CbusReporterManager) l).getTimeout());
@@ -80,7 +81,7 @@ public class CbusReporterManagerTest extends jmri.managers.AbstractReporterMgrTe
         Assert.assertEquals("Column Header matches descriptor key",CbusReporterManager.CBUS_REPORTER_DESCRIPTOR_KEY,nbpd.getColumnHeaderText());
         Assert.assertEquals("Editable if CBUS Reporter",true,nbpd.isEditable(l.provideReporter("123")));
         Assert.assertEquals("Not Editable if null",false,nbpd.isEditable(null));
-        Assert.assertEquals("Default reporter type set in properties",CbusReporterManager.CBUS_DEFAULT_REPORTER_TYPE,nbpd.defaultValue);
+        Assert.assertTrue("Default reporter type set in properties",CbusReporterManager.CBUS_DEFAULT_REPORTER_TYPE.equals(nbpd.defaultValue));
         Assert.assertEquals("reporter property key set",CbusReporterManager.CBUS_REPORTER_DESCRIPTOR_KEY,nbpd.propertyKey);
 
         Assert.assertEquals("Currently 2 options",2,((SelectionPropertyDescriptor)nbpd).getOptions().length);
@@ -124,8 +125,8 @@ public class CbusReporterManagerTest extends jmri.managers.AbstractReporterMgrTe
         otherMemo.dispose();
     }
     
-    private CanSystemConnectionMemo memo;
-    private TrafficControllerScaffold tcis;
+    private CanSystemConnectionMemo memo = null;
+    private TrafficControllerScaffold tcis = null;
 
     @BeforeEach
     @Override
@@ -141,8 +142,10 @@ public class CbusReporterManagerTest extends jmri.managers.AbstractReporterMgrTe
     @AfterEach
     public void tearDown() {
         l = null;
+        Assertions.assertNotNull(tcis);
         tcis.terminateThreads();
         tcis = null;
+        Assertions.assertNotNull(memo);
         memo.dispose();
         memo = null;
         JUnitUtil.tearDown();

--- a/java/test/jmri/jmrix/can/cbus/CbusReporterTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusReporterTest.java
@@ -3,7 +3,6 @@ package jmri.jmrix.can.cbus;
 import jmri.IdTag;
 import jmri.jmrix.can.*;
 import jmri.util.JUnitUtil;
-import jmri.util.JUnitAppender;
 
 import org.junit.Assert;
 import org.junit.jupiter.api.*;
@@ -207,6 +206,7 @@ public class CbusReporterTest extends jmri.implementation.AbstractReporterTestBa
 
         r.setProperty(CbusReporterManager.CBUS_MAINTAIN_SENSOR_DESCRIPTOR_KEY, true);
 
+        Assertions.assertNotNull(memo);
         jmri.SensorManager sm = memo.get(jmri.SensorManager.class);
         jmri.Sensor followerSensor = sm.getBySystemName(sm.createSystemName("+1",sm.getSystemPrefix()));
         Assert.assertNull("No sensor at start",followerSensor);
@@ -244,7 +244,7 @@ public class CbusReporterTest extends jmri.implementation.AbstractReporterTestBa
     }
 
     private TrafficControllerScaffold tcis;
-    private CanSystemConnectionMemo memo;
+    private CanSystemConnectionMemo memo = null;
 
     // ((CbusReporterManager)memo.get(jmri.ReporterManager.class));
 
@@ -268,6 +268,7 @@ public class CbusReporterTest extends jmri.implementation.AbstractReporterTestBa
         if (r!=null) {
             r.dispose();
         }
+        Assertions.assertNotNull(memo);
         memo.dispose();
         memo = null;
         tcis.terminateThreads();

--- a/java/test/jmri/jmrix/can/cbus/CbusSensorManagerTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusSensorManagerTest.java
@@ -392,17 +392,21 @@ public class CbusSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBa
             Assert.assertEquals("System name \"S\" contains invalid character \"S\".", ex.getMessage());
         }
 
-        boolean contains = Assert.assertThrows(JmriException.class,
-            ()->{
-                l.createSystemName("+10", "M2");
-            }).getMessage().contains("System name must start with \"MS\"");
-        Assert.assertTrue("Exception message relevant", contains);
+        Exception ex = Assertions.assertThrows(JmriException.class, ()->{
+            l.createSystemName("+10", "M2");
+        });
+        Assertions.assertNotNull(ex);
+        String msg = ex.getMessage();
+        Assertions.assertNotNull(msg);
+        Assert.assertTrue("Exception message relevant", msg.contains("System name must start with \"MS\""));
 
-        contains = Assert.assertThrows(JmriException.class,
-            ()->{
-                l.createSystemName("+10", "ZZZZZZZZZ");
-            }).getMessage().contains("System name must start with \"MS\"");
-        Assert.assertTrue("Exception message relevant", contains);
+        ex = Assertions.assertThrows(JmriException.class, ()->{
+            l.createSystemName("+10", "ZZZZZZZZZ");
+        });
+        Assertions.assertNotNull(ex);
+        msg = ex.getMessage();
+        Assertions.assertNotNull(msg);
+        Assert.assertTrue("Exception message relevant", msg.contains("System name must start with \"MS\""));
 
     }
 

--- a/java/test/jmri/jmrix/can/cbus/CbusSensorTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusSensorTest.java
@@ -107,14 +107,10 @@ public class CbusSensorTest extends jmri.implementation.AbstractSensorTestBase {
     }
 
     @Test
-    public void testNullEvent() {
-        try {
-            CbusSensor fail = new CbusSensor("MS",null,tcis);
-            Assert.fail("Should have thrown an exception" + fail);
-        } catch (NullPointerException e) {
-        }
+    public void testNullEvent() throws Exception {
+        Exception ex = Assertions.assertThrows(NullPointerException.class, () -> { t = new CbusSensor("M",null,tcis); });
+        Assertions.assertNotNull(ex);
     }
-
 
     @Test
     public void testCTorShortEventSingle() {
@@ -475,7 +471,8 @@ public class CbusSensorTest extends jmri.implementation.AbstractSensorTestBase {
         JUnitUtil.setUp();
         // load dummy TrafficController
         tcis = new TrafficControllerScaffold();
-        t = new CbusSensor("MS", "+1;-1", tcis);
+        t = new CbusSensor("M", "+1;-1", tcis);
+        Assertions.assertEquals("MS+1;-1", t.getSystemName());
     }
 
     @Override

--- a/java/test/jmri/jmrix/can/cbus/CbusTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusTurnoutManagerTest.java
@@ -331,6 +331,7 @@ public class CbusTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest
     @Test
     @Override
     public void testAutoSystemNames() {
+        Assertions.assertNotNull(tcis);
         Assert.assertEquals("No auto system names",0,tcis.numListeners());
     }
 
@@ -346,9 +347,8 @@ public class CbusTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest
         Assert.assertEquals("new outputInterval from manager", 50, l.getMemo().getOutputInterval()); // get from memo
     }
 
-
-    private TrafficControllerScaffold tcis;
-    private CanSystemConnectionMemo memo;
+    private TrafficControllerScaffold tcis = null;
+    private CanSystemConnectionMemo memo = null;
 
     @BeforeEach
     @Override
@@ -362,9 +362,14 @@ public class CbusTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest
 
     @AfterEach
     public void tearDown() {
+        Assertions.assertNotNull(tcis);
+        Assertions.assertNotNull(memo);
+        if ( l!= null ) {
+            l.dispose();
+            l = null;
+        }
         tcis.terminateThreads();
         tcis = null;
-        l.dispose();
         memo.dispose();
         JUnitUtil.tearDown();
 

--- a/java/test/jmri/jmrix/can/cbus/CbusTurnoutTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusTurnoutTest.java
@@ -62,7 +62,7 @@ public class CbusTurnoutTest extends jmri.implementation.AbstractTurnoutTestBase
     }
     
     @Test
-    public void testRequestUpdateSensors() {
+    public void testRequestUpdateSensors() throws Exception {
         
         CanSystemConnectionMemo memo = new CanSystemConnectionMemo();
         memo.setTrafficController(tcis);
@@ -71,31 +71,28 @@ public class CbusTurnoutTest extends jmri.implementation.AbstractTurnoutTestBase
         t.requestUpdateFromLayout();
         Assert.assertEquals(1,tcis.outbound.size());
         tcis.outbound.clear();
-        
-        try {
+
+        Assertions.assertDoesNotThrow( () -> {
             t.provideFirstFeedbackSensor("MS+54321");
-        } catch (jmri.JmriException ex) { }
+        });
         t.setFeedbackMode("ONESENSOR");
         t.requestUpdateFromLayout();
         Assert.assertEquals(2,tcis.outbound.size());
         tcis.outbound.clear();
-        
-        try {
+
+        Assertions.assertDoesNotThrow( () -> {
             t.provideSecondFeedbackSensor("MS+4545");
-        } catch (jmri.JmriException ex) { }
+        });
         t.setFeedbackMode("TWOSENSOR");
         t.requestUpdateFromLayout();
         Assert.assertEquals(3,tcis.outbound.size());
         memo.dispose();
     }    
-    
+
     @Test
-    public void testNullEvent() {
-        try {
-            t = new CbusTurnout("MT",null,tcis);
-            Assert.fail("Should have thrown an exception");
-        } catch (NullPointerException e) {
-        }
+    public void testNullEvent() throws Exception {
+        Exception ex = Assertions.assertThrows(NullPointerException.class, () -> { t = new CbusTurnout("MT",null,tcis); });
+        Assertions.assertEquals(null, ex.getMessage());
     }
     
     @Test
@@ -436,20 +433,21 @@ public class CbusTurnoutTest extends jmri.implementation.AbstractTurnoutTestBase
         m.setElement(3, 0x30);
         m.setElement(4, 0x39);
         
-        CbusTurnout.DELAYED_FEEDBACK_INTERVAL=30;
         t.setFeedbackMode("DELAYED");
+        Assertions.assertEquals(Turnout.UNKNOWN, t.getKnownState());
+        
         ((CbusTurnout)t).message(m);
         JUnitUtil.waitFor(()->{ return(t.getKnownState() == Turnout.INCONSISTENT); }, 
                 "Turnout message goes to INCONSISTENT before THROWN");
         JUnitUtil.waitFor(()->{ return(t.getKnownState() == Turnout.THROWN); }, 
-                "msg Turnout.THROWN didn't arrive");
+                "Turnout.THROWN after delay");
         
         m.setElement(0, 0x91); // ACOF OPC
         ((CbusTurnout)t).message(m);
         JUnitUtil.waitFor(()->{ return(t.getKnownState() == Turnout.INCONSISTENT); }, 
                 "Turnout message goes to INCONSISTENT before CLOSED");
         JUnitUtil.waitFor(()->{ return(t.getKnownState() == Turnout.CLOSED); }, 
-                "msg Turnout.CLOSED didn't arrive");
+                "Turnout.CLOSED after delay");
         
     }
     
@@ -458,8 +456,8 @@ public class CbusTurnoutTest extends jmri.implementation.AbstractTurnoutTestBase
     public void testDelayedTurnoutThrownCanReply() throws jmri.JmriException {
         
         t = new CbusTurnout("MT","+N54321E12345",tcis);
-        CbusTurnout.DELAYED_FEEDBACK_INTERVAL=30;
         t.setFeedbackMode("DELAYED");
+        Assertions.assertEquals(Turnout.UNKNOWN, t.getKnownState());
         
         CanReply m = new CanReply(tcis.getCanid());
         m.setNumDataElements(5);
@@ -481,7 +479,6 @@ public class CbusTurnoutTest extends jmri.implementation.AbstractTurnoutTestBase
     public void testDelayedTurnoutClosedCanReply() throws jmri.JmriException {
         
         t = new CbusTurnout("MT","+N54321E12345",tcis);
-        CbusTurnout.DELAYED_FEEDBACK_INTERVAL=30;
         t.setFeedbackMode("DELAYED");
         
         CanReply r = new CanReply(tcis.getCanid());


### PR DESCRIPTION
CbusSensor - update javadoc to clarify if prefix includes bean type letter.
CbusSensorTest - update test instance CbusSensor system name to correct format

CbusTurnoutTest - remove write to static field
CbusEventTest - SuppressFBWarnings EC_UNRELATED_TYPES for CanFrame
CbusEventInterfaceTest - CbusEventInterface implementation can be static
CbusClockControlTest - remove Ctor test for null memo

Remove some testCtor as classes only suppy static methods.
Improved exception asserts
Multiple nonnull asserts
Renamed some confusing method names