### PR TITLE
Adjust timing for DCS240+ prog track read

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -76,7 +76,9 @@
 
         <h4>LocoNet</h4>
             <ul>
-                <li></li>
+                <li>The DCS240+ doesn't accept service-mode read
+                    requests for about 350-400msec after the completion of the prior one.
+                    A short delay has been added to handle this.</li>
             </ul>
 
         <h4>Maple</h4>

--- a/java/src/jmri/jmrix/loconet/SlotManager.java
+++ b/java/src/jmri/jmrix/loconet/SlotManager.java
@@ -57,7 +57,8 @@ public class SlotManager extends AbstractProgrammer implements LocoNetListener, 
 
     public int serviceModeReplyDelay = 20;  // this is public to allow changes via script and tests
 
-    public int opsModeReplyDelay = 100;  // this is public to allow changes via script and tests
+    public int opsModeReplyDelay = 100;  // this is public to allow changes via script and tests. Adjusted by UsbDcs210PlusAdapter
+
     /**
      * slotMapEntry - a from to pair of slot numbers defining a valid range of loco/system slots
      * TODO add slottype, eg systemslot, std slot, expanded slot etc

--- a/java/src/jmri/jmrix/loconet/SlotManager.java
+++ b/java/src/jmri/jmrix/loconet/SlotManager.java
@@ -54,6 +54,10 @@ public class SlotManager extends AbstractProgrammer implements LocoNetListener, 
     static public int postProgDelay = 100; // this is public to allow changes via script
 
     public int slotScanInterval = 50; // this is public to allow changes via script and tests
+
+    public int serviceModeReplyDelay = 20;  // this is public to allow changes via script and tests
+
+    public int opsModeReplyDelay = 100;  // this is public to allow changes via script and tests
     /**
      * slotMapEntry - a from to pair of slot numbers defining a valid range of loco/system slots
      * TODO add slottype, eg systemslot, std slot, expanded slot etc
@@ -857,7 +861,7 @@ public class SlotManager extends AbstractProgrammer implements LocoNetListener, 
     }
 
     /**
-     * Scedule a delayed slot read.
+     * Schedule a delayed slot read.
      * @param slotNo - the slot.
      * @param delay - delay in msecs.
      */
@@ -1491,9 +1495,9 @@ public class SlotManager extends AbstractProgrammer implements LocoNetListener, 
      * @param status The error code, if any
      */
     protected void sendProgrammingReply(ProgListener p, int value, int status) {
-        int delay = 20;  // value in service mode
+        int delay = serviceModeReplyDelay;  // value in service mode
         if (!mServiceMode) {
-            delay = 100;  // value in ops mode
+            delay = opsModeReplyDelay;  // value in ops mode
         }
 
         // delay and run on GUI thread

--- a/java/src/jmri/jmrix/loconet/usb_dcs210Plus/UsbDcs210PlusAdapter.java
+++ b/java/src/jmri/jmrix/loconet/usb_dcs210Plus/UsbDcs210PlusAdapter.java
@@ -81,6 +81,7 @@ public class UsbDcs210PlusAdapter extends LocoBufferAdapter {
             this.getSystemConnectionMemo().configureCommandStation(commandStationType,
                     mTurnoutNoRetry, mTurnoutExtraSpace, mTranspondingAvailable, mInterrogateAtStart);  // never transponding!
             this.getSystemConnectionMemo().configureManagersPR2();
+            this.getSystemConnectionMemo().getSlotManager().serviceModeReplyDelay = 500;
 
             // start operation
             packets.startThreads();
@@ -110,6 +111,7 @@ public class UsbDcs210PlusAdapter extends LocoBufferAdapter {
                     mTurnoutNoRetry, mTurnoutExtraSpace, mTranspondingAvailable, mInterrogateAtStart);
 
             this.getSystemConnectionMemo().configureManagersMS100();
+            this.getSystemConnectionMemo().getSlotManager().serviceModeReplyDelay = 500;
 
             // start operation
             packets.startThreads();


### PR DESCRIPTION
The DCS240+ doesn't accept service-mode read requests for about 350-400msec after the completion of the prior one.  This PR adds a delay to JMRI processing to adapt to this.