### PR TITLE
Update cbus node tests

### DIFF
--- a/java/test/jmri/jmrix/can/cbus/eventtable/CbusEventBeanDataTest.java
+++ b/java/test/jmri/jmrix/can/cbus/eventtable/CbusEventBeanDataTest.java
@@ -4,14 +4,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.HashSet;
+
 import jmri.Light;
 import jmri.NamedBean;
 import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.jmrix.can.cbus.CbusLightManager;
 import jmri.util.JUnitUtil;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+
+import org.junit.jupiter.api.*;
 
 
 /**
@@ -60,7 +60,7 @@ public class CbusEventBeanDataTest {
         
     }
     
-    private CanSystemConnectionMemo memo;
+    private CanSystemConnectionMemo memo = null;
     
     @BeforeEach
     public void setUp() {
@@ -70,6 +70,7 @@ public class CbusEventBeanDataTest {
 
     @AfterEach
     public void tearDown() {
+        Assertions.assertNotNull(memo);
         memo.dispose();
         memo = null;
         JUnitUtil.tearDown();

--- a/java/test/jmri/jmrix/can/cbus/eventtable/CbusEventTableDataModelTest.java
+++ b/java/test/jmri/jmrix/can/cbus/eventtable/CbusEventTableDataModelTest.java
@@ -9,7 +9,6 @@ import jmri.jmrix.can.TrafficControllerScaffold;
 import jmri.jmrix.can.TrafficControllerScaffoldLoopback;
 import jmri.jmrix.can.cbus.CbusConstants;
 import jmri.jmrix.can.cbus.CbusMessage;
-import jmri.jmrix.can.cbus.CbusPreferences;
 
 import jmri.util.JUnitUtil;
 
@@ -46,6 +45,7 @@ public class CbusEventTableDataModelTest {
         Assert.assertTrue(t.getRowCount()==0);
         
         CanReply m = new CanReply();
+        Assertions.assertNotNull(tcis);
         m.setHeader(tcis.getCanid());
         CbusMessage.setPri(m, CbusConstants.DEFAULT_DYNAMIC_PRIORITY * 4 + CbusConstants.DEFAULT_MINOR_PRIORITY);
         m.setNumDataElements(5);
@@ -92,7 +92,7 @@ public class CbusEventTableDataModelTest {
 
     @Test
     public void testCanMessage() {
-        
+        Assertions.assertNotNull(tcis);
         Assert.assertEquals("no listener to start with",0,tcis.numListeners());
         
         CbusEventTableDataModel t = new CbusEventTableDataModel( memo,4,CbusEventTableDataModel.MAX_COLUMN);
@@ -216,6 +216,7 @@ public class CbusEventTableDataModelTest {
         
         // uses loopback in setvalueat tests
         TrafficControllerScaffold tcisl = new TrafficControllerScaffoldLoopback();
+        Assertions.assertNotNull(memo);
         memo.setTrafficController(tcisl);
         
         CbusEventTableDataModel t = new CbusEventTableDataModel( memo,4,CbusEventTableDataModel.MAX_COLUMN);
@@ -260,7 +261,7 @@ public class CbusEventTableDataModelTest {
         Assert.assertEquals("SESSION_ON_COLUMN 0", 0 ,(int) t.getValueAt(0,CbusEventTableDataModel.SESSION_ON_COLUMN));
         
         t.setValueAt("do button Click",0,CbusEventTableDataModel.ON_BUTTON_COLUMN);
-        JUnitUtil.waitFor(()->{ return(tcisl.outbound.size()>0); }, " outbound 1 didn't arrive");
+        JUnitUtil.waitFor(()->{ return(!tcisl.outbound.isEmpty()); }, " outbound 1 didn't arrive");
         Assert.assertEquals(" 1 outbound increased", 1,(tcisl.outbound.size() ) );
         Assert.assertEquals("table sends on event for short 2003 ", "[5f8] 98 00 00 07 D3",
             tcisl.outbound.elementAt(tcisl.outbound.size() - 1).toString());
@@ -383,9 +384,9 @@ public class CbusEventTableDataModelTest {
         t.dispose();
     
     }
-    
-    private CanSystemConnectionMemo memo;
-    private TrafficControllerScaffold tcis;
+
+    private CanSystemConnectionMemo memo = null;
+    private TrafficControllerScaffold tcis = null;
 
     @BeforeEach
     public void setUp(@TempDir File folder) throws java.io.IOException {
@@ -396,12 +397,13 @@ public class CbusEventTableDataModelTest {
         memo.setTrafficController(tcis);
         JUnitUtil.resetProfileManager(new jmri.profile.NullProfile(folder));
         
-        jmri.InstanceManager.store(new CbusPreferences(),CbusPreferences.class );
     }
 
     @AfterEach
     public void tearDown() {
+        Assertions.assertNotNull(memo);
         memo.dispose();
+        Assertions.assertNotNull(tcis);
         tcis.terminateThreads();
         memo = null;
         tcis = null;

--- a/java/test/jmri/jmrix/can/cbus/node/CbusBasicNodeEventTest.java
+++ b/java/test/jmri/jmrix/can/cbus/node/CbusBasicNodeEventTest.java
@@ -3,9 +3,7 @@ package jmri.jmrix.can.cbus.node;
 import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.util.JUnitUtil;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -20,9 +18,9 @@ public class CbusBasicNodeEventTest {
     public void testCTor() {
         assertThat(new CbusBasicNodeEvent(memo,1,2,3,4)).isNotNull();
     }
-    
-    private CanSystemConnectionMemo memo;
-    
+
+    private CanSystemConnectionMemo memo = null;
+
     @BeforeEach
     public void setUp() {
         JUnitUtil.setUp();
@@ -33,7 +31,7 @@ public class CbusBasicNodeEventTest {
 
     @AfterEach
     public void tearDown() {
-        
+        Assertions.assertNotNull(memo);
         memo.dispose();
         memo = null;
         

--- a/java/test/jmri/jmrix/can/cbus/node/CbusBasicNodeTableFetchTest.java
+++ b/java/test/jmri/jmrix/can/cbus/node/CbusBasicNodeTableFetchTest.java
@@ -1,5 +1,6 @@
 package jmri.jmrix.can.cbus.node;
 
+import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.util.JUnitUtil;
 
 import org.junit.Assert;
@@ -14,7 +15,9 @@ public class CbusBasicNodeTableFetchTest {
 
     @Test
     public void testCTor() {
-        Assert.assertNotNull("exists",new CbusBasicNodeTableFetch(null,1,2));
+        CanSystemConnectionMemo memo = new CanSystemConnectionMemo();
+        Assert.assertNotNull("exists",new CbusBasicNodeTableFetch(memo,1,2));
+        memo.dispose();
     }
     
     @BeforeEach

--- a/java/test/jmri/jmrix/can/cbus/node/CbusBasicNodeTableOperationsTest.java
+++ b/java/test/jmri/jmrix/can/cbus/node/CbusBasicNodeTableOperationsTest.java
@@ -1,5 +1,6 @@
 package jmri.jmrix.can.cbus.node;
 
+import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.util.JUnitUtil;
 
 import org.junit.Assert;
@@ -14,7 +15,9 @@ public class CbusBasicNodeTableOperationsTest {
 
     @Test
     public void testCTor() {
-        Assert.assertNotNull("exists",new CbusBasicNodeTableOperations(null,1,2));
+        CanSystemConnectionMemo memo = new CanSystemConnectionMemo();
+        Assert.assertNotNull("exists",new CbusBasicNodeTableOperations(memo,1,2));
+        memo.dispose();
     }
     
     @BeforeEach

--- a/java/test/jmri/jmrix/can/cbus/node/CbusBasicNodeTableTest.java
+++ b/java/test/jmri/jmrix/can/cbus/node/CbusBasicNodeTableTest.java
@@ -1,5 +1,6 @@
 package jmri.jmrix.can.cbus.node;
 
+import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.util.JUnitUtil;
 
 import org.junit.Assert;
@@ -14,7 +15,9 @@ public class CbusBasicNodeTableTest {
 
     @Test
     public void testCTor() {
-        Assert.assertNotNull("exists",new CbusBasicNodeTable(null,1,2));
+        CanSystemConnectionMemo memo = new CanSystemConnectionMemo();
+        Assert.assertNotNull("exists",new CbusBasicNodeTable(memo,1,2));
+        memo.dispose();
     }
     
     @BeforeEach

--- a/java/test/jmri/jmrix/can/cbus/node/CbusBasicNodeTest.java
+++ b/java/test/jmri/jmrix/can/cbus/node/CbusBasicNodeTest.java
@@ -17,9 +17,14 @@ public class CbusBasicNodeTest {
     public void testCTor() {
         Assert.assertNotNull("exists",new CbusBasicNode(null,123));
     }
-    
-    private CanSystemConnectionMemo memo;
-    
+
+    @Test
+    public void testCTorWithCanMemo() {
+        Assert.assertNotNull("exists",new CbusBasicNode(memo,123));
+    }
+
+    private CanSystemConnectionMemo memo = null;
+
     @BeforeEach
     public void setUp() {
         JUnitUtil.setUp();
@@ -30,7 +35,7 @@ public class CbusBasicNodeTest {
 
     @AfterEach
     public void tearDown() {
-        
+        Assertions.assertNotNull(memo);
         memo.dispose();
         memo = null;
         

--- a/java/test/jmri/jmrix/can/cbus/node/CbusBasicNodeWithManagersTest.java
+++ b/java/test/jmri/jmrix/can/cbus/node/CbusBasicNodeWithManagersTest.java
@@ -17,9 +17,14 @@ public class CbusBasicNodeWithManagersTest {
     public void testCTor() {
         Assert.assertNotNull("exists",new CbusBasicNodeWithManagers(null,123));
     }
-    
-    private CanSystemConnectionMemo memo;
-    
+
+    @Test
+    public void testCbBnWMcTorWithMemo() {
+        Assert.assertNotNull("exists",new CbusBasicNodeWithManagers(memo,123));
+    }
+
+    private CanSystemConnectionMemo memo = null;
+
     @BeforeEach
     public void setUp() {
         JUnitUtil.setUp();
@@ -30,7 +35,7 @@ public class CbusBasicNodeWithManagersTest {
 
     @AfterEach
     public void tearDown() {
-        
+        Assertions.assertNotNull(memo);
         memo.dispose();
         memo = null;
         

--- a/java/test/jmri/jmrix/can/cbus/node/CbusBasicNodeWithMgrsCommandStationTest.java
+++ b/java/test/jmri/jmrix/can/cbus/node/CbusBasicNodeWithMgrsCommandStationTest.java
@@ -8,9 +8,7 @@ import jmri.jmrix.can.TrafficControllerScaffold;
 import jmri.jmrix.can.cbus.CbusPowerManager;
 import jmri.util.JUnitUtil;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 
 /**
  *
@@ -41,10 +39,10 @@ public class CbusBasicNodeWithMgrsCommandStationTest {
     
         t.dispose();
     }
-    
+
     @Test
     public void testSetFlags() throws jmri.JmriException {
-        
+        Assertions.assertNotNull(memo);
         CbusPowerManager pwr = (CbusPowerManager) memo.get(PowerManager.class);
         t = new CbusBasicNodeWithMgrsCommandStation(memo,125);
         t.setCsNum(0); // default CS
@@ -62,8 +60,8 @@ public class CbusBasicNodeWithMgrsCommandStationTest {
     }
     
     private CbusBasicNodeWithMgrsCommandStation t;
-    private CanSystemConnectionMemo memo;
-    private TrafficControllerScaffold tcis;
+    private CanSystemConnectionMemo memo = null;
+    private TrafficControllerScaffold tcis = null;
     
     @BeforeEach
     public void setUp() {
@@ -78,8 +76,9 @@ public class CbusBasicNodeWithMgrsCommandStationTest {
 
     @AfterEach
     public void tearDown() {
-        
+        Assertions.assertNotNull(memo);
         memo.dispose();
+        Assertions.assertNotNull(tcis);
         tcis.terminateThreads();
         memo = null;
         tcis = null;

--- a/java/test/jmri/jmrix/can/cbus/node/CbusNodeConstantsTest.java
+++ b/java/test/jmri/jmrix/can/cbus/node/CbusNodeConstantsTest.java
@@ -12,12 +12,7 @@ import org.junit.jupiter.api.*;
  */
 public class CbusNodeConstantsTest {
 
-    @Test
-    public void testCTor() {
-        CbusNodeConstants t = new CbusNodeConstants();
-        Assert.assertNotNull("exists",t);
-        t = null;
-    }
+    // no testCtor as class only supplies static methods
     
     @Test
     public void testGetBusType() {
@@ -33,7 +28,7 @@ public class CbusNodeConstantsTest {
     }
 
     @Test
-    public void testgetModuleType() {
+    public void testgetModuleTypeFromConstants() {
         Assert.assertEquals("getModuleType 165 29","CANPAN",CbusNodeConstants.getModuleType(165,29));
         Assert.assertEquals("getModuleType 70 4","CANGC4",CbusNodeConstants.getModuleType(70,4));
         Assert.assertEquals("getModuleType 80 2","DUALCAB",CbusNodeConstants.getModuleType(80,2));

--- a/java/test/jmri/jmrix/can/cbus/node/CbusNodeFromFcuTableDataModelTest.java
+++ b/java/test/jmri/jmrix/can/cbus/node/CbusNodeFromFcuTableDataModelTest.java
@@ -22,6 +22,8 @@ public class CbusNodeFromFcuTableDataModelTest {
         
         Assert.assertNotNull("exists",t);
         
+        Assertions.assertEquals(0, tcis.outbound.size(),"no can frames sent by fcu model");
+
         t.dispose();
         
     }
@@ -62,6 +64,8 @@ public class CbusNodeFromFcuTableDataModelTest {
         Assert.assertTrue("default getNodeRowFromNodeNum 1234",t.getNodeRowFromNodeNum(1234) == 1 );
         Assert.assertTrue("default getRowCount 0",t.getRowCount() == 2 );
         
+        Assertions.assertEquals(0, tcis.outbound.size(),"no can frames sent by fcu model");
+
         t.dispose();
 
     }
@@ -98,11 +102,13 @@ public class CbusNodeFromFcuTableDataModelTest {
         t.setValueAt(7,0,CbusNodeFromFcuTableDataModel.NODE_NV_TOTAL_COLUMN);
         Assert.assertTrue("setValueAt does nothing",(Integer)t.getValueAt(0,CbusNodeFromFcuTableDataModel.NODE_NV_TOTAL_COLUMN)== 3 );
         
+        Assertions.assertEquals(0, tcis.outbound.size(),"no can frames sent by fcu model");
+
         t.dispose();
         
     }
-    
-    private CanSystemConnectionMemo memo;
+
+    private CanSystemConnectionMemo memo = null;
     private TrafficControllerScaffold tcis;
 
     @BeforeEach
@@ -111,6 +117,7 @@ public class CbusNodeFromFcuTableDataModelTest {
         memo = new CanSystemConnectionMemo();
         tcis = new TrafficControllerScaffold();
         memo.setTrafficController(tcis);
+        memo.setProtocol(jmri.jmrix.can.CanConfigurationManager.MERGCBUS);
     }
 
     @AfterEach
@@ -118,7 +125,7 @@ public class CbusNodeFromFcuTableDataModelTest {
         
         tcis.terminateThreads();
         tcis = null;
-        
+        Assertions.assertNotNull(memo);
         memo.dispose();
         memo = null;
         JUnitUtil.tearDown();

--- a/java/test/jmri/jmrix/can/cbus/node/CbusNodeNVTableDataModelTest.java
+++ b/java/test/jmri/jmrix/can/cbus/node/CbusNodeNVTableDataModelTest.java
@@ -5,10 +5,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.jmrix.can.TrafficControllerScaffold;
 import jmri.util.JUnitUtil;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 
+import org.junit.jupiter.api.*;
 
 /**
  *
@@ -178,8 +176,8 @@ public class CbusNodeNVTableDataModelTest {
         myNode.dispose();
     }
     
-    private CanSystemConnectionMemo memo;
-    private TrafficControllerScaffold tcis;
+    private CanSystemConnectionMemo memo = null;
+    private TrafficControllerScaffold tcis = null;
     private CbusNodeNVTableDataModel t;
     
 
@@ -196,8 +194,10 @@ public class CbusNodeNVTableDataModelTest {
     @AfterEach
     public void tearDown() {
         t = null;
+        Assertions.assertNotNull(tcis);
         tcis.terminateThreads();
         tcis = null;
+        Assertions.assertNotNull(memo);
         memo.dispose();
         memo = null;
         


### PR DESCRIPTION
CbusNodeConstantsTest - remove testCTor, class only supplies static methods

Use unused memo objects in tests.
Adds various non-Null asserts.