### PR TITLE
update some more jmrix.can.cbus tests

### DIFF
--- a/java/test/jmri/jmrix/can/cbus/simulator/CbusDummyCSSessionTest.java
+++ b/java/test/jmri/jmrix/can/cbus/simulator/CbusDummyCSSessionTest.java
@@ -29,7 +29,7 @@ public class CbusDummyCSSessionTest {
         Assert.assertNotNull("exists",t);        
         
         t.sendPloc();
-        JUnitUtil.waitFor(()->{ return(tc.inbound.size()>0); }, "ploc didn't arrive");
+        JUnitUtil.waitFor(()->{ return(!tc.inbound.isEmpty()); }, "ploc didn't arrive");
         Assert.assertEquals("ploc sent", "[5f8] E1 01 C4 D2 80 00 00",
         tc.inbound.elementAt(tc.inbound.size() - 1).toString());
         
@@ -48,10 +48,9 @@ public class CbusDummyCSSessionTest {
         t.dispose();
         cs.dispose();
     }
-    
+
     private TrafficControllerScaffold tc;
-    private CanSystemConnectionMemo memo;
-    
+    private CanSystemConnectionMemo memo = null;
 
     @BeforeEach
     public void setUp() {
@@ -66,6 +65,7 @@ public class CbusDummyCSSessionTest {
     public void tearDown() {
         
         tc.terminateThreads();
+        Assertions.assertNotNull(memo);
         memo.dispose();
         tc = null;
         memo = null;

--- a/java/test/jmri/jmrix/can/cbus/simulator/CbusDummyNodeTest.java
+++ b/java/test/jmri/jmrix/can/cbus/simulator/CbusDummyNodeTest.java
@@ -37,11 +37,15 @@ public class CbusDummyNodeTest {
         CbusDummyNode t = new CbusDummyNode(memo, 1 );
         
         Assert.assertTrue("1 listener",tcis.numListeners()==1);
-        
-        Assert.assertTrue("start getDelay", ((CbusSimCanListener) t.getCanListener()).getDelay()>0);
-        ((CbusSimCanListener) t.getCanListener()).setDelay(7);
-        Assert.assertEquals("getSetDelay", 7,((CbusSimCanListener) t.getCanListener()).getDelay());
-        
+
+        var listen = t.getCanListener();
+        Assertions.assertTrue(listen instanceof CbusSimCanListener );
+        CbusSimCanListener nodeListener = (CbusSimCanListener) listen;
+
+        Assert.assertTrue("start getDelay", nodeListener.getDelay()>0);
+        nodeListener.setDelay(7);
+        Assert.assertEquals("getSetDelay", 7,nodeListener.getDelay());
+
         t.dispose();
         Assert.assertTrue("0 listeners after dispose",tcis.numListeners()==0);
     }
@@ -50,12 +54,15 @@ public class CbusDummyNodeTest {
     public void testNodeRequestNumber() {
         
         CbusDummyNode t = new MergCanpan().getNewDummyNode( memo, 1);
-        ((CbusSimCanListener) t.getCanListener()).setDelay(0);
+        var listen = t.getCanListener();
+        Assertions.assertTrue(listen instanceof CbusSimCanListener );
+        CbusSimCanListener nodeListener = (CbusSimCanListener) listen;
+        nodeListener.setDelay(0);
         
-        Assert.assertFalse("start getProcessIn", ((CbusSimCanListener) t.getCanListener()).getProcessIn() );
-        Assert.assertTrue("start getProcessOut", ((CbusSimCanListener) t.getCanListener()).getProcessOut() );
-        Assert.assertTrue("start getSendIn", ((CbusSimCanListener) t.getCanListener()).getSendIn() );
-        Assert.assertFalse("start getSendOut", ((CbusSimCanListener) t.getCanListener()).getSendOut() );
+        Assert.assertFalse("start getProcessIn", nodeListener.getProcessIn() );
+        Assert.assertTrue("start getProcessOut", nodeListener.getProcessOut() );
+        Assert.assertTrue("start getSendIn", nodeListener.getSendIn() );
+        Assert.assertFalse("start getSendOut", nodeListener.getSendOut() );
         Assert.assertFalse("start getsendsWRACKonNVSET", t.getnvWriteInLearnOnly());
         
         Assert.assertFalse("is a CANPAN getsendsWRACKonNVSET",t.getsendsWRACKonNVSET());
@@ -73,16 +80,16 @@ public class CbusDummyNodeTest {
             tcis.inbound.elementAt(tcis.inbound.size() - 1).toString());
         // node in setup mode awaiting node allocation frame or further setup info request
         
-        ((CbusSimCanListener) t.getCanListener()).setSendOut(true);
-        ((CbusSimCanListener) t.getCanListener()).setSendIn(false);
-        Assert.assertTrue(" getSendOut", ((CbusSimCanListener) t.getCanListener()).getSendOut() );
-        Assert.assertFalse(" getSendIn", ((CbusSimCanListener) t.getCanListener()).getSendIn() );
+        nodeListener.setSendOut(true);
+        nodeListener.setSendIn(false);
+        Assert.assertTrue(" getSendOut", nodeListener.getSendOut() );
+        Assert.assertFalse(" getSendIn", nodeListener.getSendIn() );
         
-        ((CbusSimCanListener) t.getCanListener()).setProcessIn(true);
-        ((CbusSimCanListener) t.getCanListener()).setProcessOut(false);
+        nodeListener.setProcessIn(true);
+        nodeListener.setProcessOut(false);
         
-        Assert.assertTrue("start getProcessIn", ((CbusSimCanListener) t.getCanListener()).getProcessIn() );
-        Assert.assertFalse("start getProcessOut", ((CbusSimCanListener) t.getCanListener()).getProcessOut() );
+        Assert.assertTrue("start getProcessIn", nodeListener.getProcessIn() );
+        Assert.assertFalse("start getProcessOut", nodeListener.getProcessOut() );
         
         CanReply r = new CanReply();
         r.setHeader(tcis.getCanid());
@@ -103,13 +110,13 @@ public class CbusDummyNodeTest {
         Assert.assertEquals("node responds with parameters setup", "[5f8] EF A5 59 1D 80 0D 01 01",
             tcis.outbound.elementAt(tcis.outbound.size() - 1).toString());
         
-        ((CbusSimCanListener) t.getCanListener()).setProcessIn(false);
-        ((CbusSimCanListener) t.getCanListener()).setProcessOut(true);
+        nodeListener.setProcessIn(false);
+        nodeListener.setProcessOut(true);
         
-        ((CbusSimCanListener) t.getCanListener()).setSendOut(false);
-        ((CbusSimCanListener) t.getCanListener()).setSendIn(true);
-        Assert.assertFalse(" getSendOut f", ((CbusSimCanListener) t.getCanListener()).getSendOut() );
-        Assert.assertTrue(" getSendIn t", ((CbusSimCanListener) t.getCanListener()).getSendIn() );
+        nodeListener.setSendOut(false);
+        nodeListener.setSendIn(true);
+        Assert.assertFalse(" getSendOut f", nodeListener.getSendOut() );
+        Assert.assertTrue(" getSendIn t", nodeListener.getSendIn() );
         
         r = new CanReply();
         r.setHeader(tcis.getCanid());
@@ -163,7 +170,9 @@ public class CbusDummyNodeTest {
         
         // dummy CANPAN
         CbusDummyNode t = new MergCanpan().getNewDummyNode(memo, 1234);
-        ((CbusSimCanListener) t.getCanListener()).setDelay(0);
+        var listen = t.getCanListener();
+        Assertions.assertTrue(listen instanceof CbusSimCanListener );
+        ((CbusSimCanListener) listen).setDelay(0);
         t.setNodeInFLiMMode(true);
         
         // get event variables with knowledge of index
@@ -197,7 +206,9 @@ public class CbusDummyNodeTest {
         
         // dummy CANPAN
         CbusDummyNode t = new MergCanpan().getNewDummyNode(memo, 1234);
-        ((CbusSimCanListener) t.getCanListener()).setDelay(0);
+        var listen = t.getCanListener();
+        Assertions.assertTrue(listen instanceof CbusSimCanListener );
+        ((CbusSimCanListener) listen).setDelay(0);
         t.setNodeInFLiMMode(true);
         
         // get node variable
@@ -281,7 +292,9 @@ public class CbusDummyNodeTest {
     public void testNodeLearnEvent() {
         
         CbusDummyNode t = new MergCanpan().getNewDummyNode(memo, 1234);
-        ((CbusSimCanListener) t.getCanListener()).setDelay(0);
+        var listen = t.getCanListener();
+        Assertions.assertTrue(listen instanceof CbusSimCanListener );
+        ((CbusSimCanListener) listen).setDelay(0);
         t.setNodeInFLiMMode(true);
         
         Assert.assertEquals(" 0 outbound not increased", 0,(tcis.outbound.size() ) );
@@ -482,7 +495,9 @@ public class CbusDummyNodeTest {
     public void testNodeLearnTwoEventsThenDelete() {
     
         CbusDummyNode t = new MergCanpan().getNewDummyNode(memo, 1234);
-        ((CbusSimCanListener) t.getCanListener()).setDelay(0);
+        var listen = t.getCanListener();
+        Assertions.assertTrue(listen instanceof CbusSimCanListener );
+        ((CbusSimCanListener) listen).setDelay(0);
         t.setNodeInFLiMMode(true);
         
         // frame to set node into learn
@@ -583,7 +598,9 @@ public class CbusDummyNodeTest {
     public void testResponseToNameRequest() {
     
         CbusDummyNode t = new MergCanpan().getNewDummyNode(memo, 1234);
-        ((CbusSimCanListener) t.getCanListener()).setDelay(0);
+        var listen = t.getCanListener();
+        Assertions.assertTrue(listen instanceof CbusSimCanListener );
+        ((CbusSimCanListener) listen).setDelay(0);
         t.setNodeInFLiMMode(true);
         t.setNodeInSetupMode(true);
         

--- a/java/test/jmri/jmrix/can/cbus/simulator/CbusSimulatorTest.java
+++ b/java/test/jmri/jmrix/can/cbus/simulator/CbusSimulatorTest.java
@@ -5,25 +5,23 @@ import jmri.util.JUnitUtil;
 import org.junit.Assert;
 import org.junit.jupiter.api.*;
 
-// import org.slf4j.Logger;
-// import org.slf4j.LoggerFactory;
-
 /**
  *
  * @author Paul Bender Copyright (C) 2017
  * @author Steve Young Copyright (c) 2019
  */
 public class CbusSimulatorTest {
-    
-    private CbusSimulator t;
+
+    private CbusSimulator t = null;
 
     @Test
     public void testCTor() {
         Assert.assertNotNull("exists",t);
     }
-    
+
     @Test
     public void testStartedCounts() {
+        Assertions.assertNotNull(t);
         Assert.assertTrue("cs 1 ", t.getNumCS() == 1);
         Assert.assertTrue("No nodes auto started ", t.getNumNd() == 0);
         Assert.assertTrue("ev 1 ", t.getNumEv() == 1);
@@ -35,6 +33,7 @@ public class CbusSimulatorTest {
     
     @Test
     public void testgetNew() {
+        Assertions.assertNotNull(t);
         Assert.assertNotNull("cs get new", t.getNewCS());
         Assert.assertNotNull("ev get new", t.getNewEv());
         
@@ -51,7 +50,9 @@ public class CbusSimulatorTest {
 
     @AfterEach
     public void tearDown() {
+        Assertions.assertNotNull(t);
         t.dispose();
+        t = null;
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrix/can/cbus/swing/CbusCommonSwingTest.java
+++ b/java/test/jmri/jmrix/can/cbus/swing/CbusCommonSwingTest.java
@@ -19,13 +19,8 @@ import org.junit.jupiter.api.Test;
 */
 public class CbusCommonSwingTest  {
 
-    @Test
-    @DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
-    public void testInitComponents() throws Exception{
-        // for now, just makes sure there isn't an exception.
-        assertThat(new CbusCommonSwing()).isNotNull();
-    }
-    
+    // class only provides static methods, no need for constructor test
+
     @Test
     public void testJTextFieldFromCbusEvState(){
     

--- a/java/test/jmri/jmrix/can/cbus/swing/CbusEventHighlightFrameTest.java
+++ b/java/test/jmri/jmrix/can/cbus/swing/CbusEventHighlightFrameTest.java
@@ -1,38 +1,36 @@
 package jmri.jmrix.can.cbus.swing;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import java.awt.GraphicsEnvironment;
 import jmri.jmrix.can.CanMessage;
 import jmri.jmrix.can.CanReply;
 import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.jmrix.can.cbus.CbusConstants;
 import jmri.jmrix.can.cbus.swing.console.CbusConsolePane;
 import jmri.util.JUnitUtil;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
-import org.junit.jupiter.api.Test;
 
 /**
  * Test simple functioning of CbusEventHighlightFrame
  *
  * @author Paul Bender Copyright (C) 2016
  */
+@DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
 public class CbusEventHighlightFrameTest extends jmri.util.JmriJFrameTestBase{
 
     @Test
-    @DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
     public void testPaneCtor() {
         CbusConsolePane pane = new CbusConsolePane();
         CbusEventHighlightFrame cbframe = new CbusEventHighlightFrame(pane,null);
-        assertThat(cbframe).isNotNull();
+        assertNotNull(cbframe);
     }
     
     @Test
-    @DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
     public void testCanMessage() {
+        assertNotNull(t);
         CanMessage m = new CanMessage(123,1);
         m.setElement(0, 1);
         assertEquals(-1,t.highlight(m),"No Highlight CanMessage by default");
@@ -40,8 +38,8 @@ public class CbusEventHighlightFrameTest extends jmri.util.JmriJFrameTestBase{
     }
     
     @Test
-    @DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
     public void testCanReply() {
+        assertNotNull(t);
         CanReply r = new CanReply(123);
         r.setNumDataElements(1);
         r.setElement(0, 1);
@@ -50,7 +48,6 @@ public class CbusEventHighlightFrameTest extends jmri.util.JmriJFrameTestBase{
     }
     
     @Test
-    @DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
     public void testEnableWithCanReplyAndConsole() {
         
         CanSystemConnectionMemo memo = new CanSystemConnectionMemo();
@@ -58,15 +55,15 @@ public class CbusEventHighlightFrameTest extends jmri.util.JmriJFrameTestBase{
         CbusConsolePane pane = new CbusConsolePane();
         pane.initComponents(memo,false);
         CbusEventHighlightFrame cbframe = new CbusEventHighlightFrame(pane,null);
-        
-        assertThat(cbframe.getTitle().startsWith("CAN CBUS Console ")).isTrue();
-                
+
+        Assertions.assertTrue(cbframe.getTitle().startsWith("CAN CBUS Console "));
+
         CanReply r = new CanReply(123);
         r.setNumDataElements(1);
         r.setElement(0, 1);
         assertEquals(-1,cbframe.highlight(r),"No Highlight CanReply by default");
 
-        assertThat(pane.monTextPaneCbus.getText().isEmpty());
+        Assertions.assertTrue(pane.monTextPaneCbus.getText().isEmpty());
 
         // highlight short event 1 On, either direction
         cbframe.enable(0, 0, true, 1, true, CbusConstants.EVENT_ON, CbusConstants.EVENT_DIR_EITHER);
@@ -81,31 +78,23 @@ public class CbusEventHighlightFrameTest extends jmri.util.JmriJFrameTestBase{
     }
     
     @Test
-    @DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
     public void testColours() {
-        assertThat(t.getColor(0)).isNotNull();
-        assertThat(t.getColor(1)).isNotNull();
-        assertThat(t.getColor(2)).isNotNull();
-        assertThat(t.getColor(3)).isNotNull();
+        assertNotNull(t);
+        assertNotNull(t.getColor(0));
+        assertNotNull(t.getColor(1));
+        assertNotNull(t.getColor(2));
+        assertNotNull(t.getColor(3));
     
     }
-    
-    private CbusEventHighlightFrame t;
+
+    private CbusEventHighlightFrame t = null;
 
     @BeforeEach
     @Override
     public void setUp() {
         JUnitUtil.setUp();
-        if(!GraphicsEnvironment.isHeadless()){
-            t = new CbusEventHighlightFrame();
-            frame = t;
-        }
-    }
-
-    @AfterEach
-    @Override
-    public void tearDown() {
-        super.tearDown();    
+        t = new CbusEventHighlightFrame();
+        frame = t;
     }
 
 }

--- a/java/test/jmri/jmrix/can/cbus/swing/CbusMenuTest.java
+++ b/java/test/jmri/jmrix/can/cbus/swing/CbusMenuTest.java
@@ -4,10 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.util.JUnitUtil;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
-import org.junit.jupiter.api.Test;
 
 /**
  * Test simple functioning of CbusMenu
@@ -16,9 +15,7 @@ import org.junit.jupiter.api.Test;
  */
 public class CbusMenuTest {
 
-
-    // private TrafficController tc = null;
-    private CanSystemConnectionMemo m;
+    private CanSystemConnectionMemo m = null;
  
     @Test
     @DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
@@ -30,7 +27,7 @@ public class CbusMenuTest {
     @BeforeEach
     public void setUp() {
         JUnitUtil.setUp();
-        // tc = new TestTrafficController();
+
         m = new CanSystemConnectionMemo();
         m.setSystemPrefix("ABC");
 
@@ -38,9 +35,10 @@ public class CbusMenuTest {
 
     @AfterEach
     public void tearDown() { 
+        Assertions.assertNotNull(m);
         m.dispose();
         m = null;
         JUnitUtil.tearDown();
-        // tc = null;
+
     }
 }

--- a/java/test/jmri/jmrix/can/cbus/swing/CbusSendEventPaneTest.java
+++ b/java/test/jmri/jmrix/can/cbus/swing/CbusSendEventPaneTest.java
@@ -3,16 +3,14 @@ package jmri.jmrix.can.cbus.swing;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.awt.GraphicsEnvironment;
 import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.jmrix.can.TrafficControllerScaffold;
 import jmri.jmrix.can.cbus.swing.console.CbusConsolePane;
 import jmri.util.JUnitUtil;
 import jmri.util.JmriJFrame;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
-import org.junit.jupiter.api.Test;
+
 import org.netbeans.jemmy.operators.JButtonOperator;
 import org.netbeans.jemmy.operators.JFrameOperator;
 import org.netbeans.jemmy.operators.JRadioButtonOperator;
@@ -24,10 +22,10 @@ import org.netbeans.jemmy.operators.JTextFieldOperator;
  * @author Paul Bender Copyright (C) 2016
  * @author Steve Young Copyright (C) 2020
 */
+@DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
 public class CbusSendEventPaneTest  {
 
     @Test
-    @DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
     public void testInitComponents() throws Exception{
         // for now, just makes sure there isn't an exception.
         CbusSendEventPane t = new CbusSendEventPane(mainConsolePane);
@@ -35,7 +33,6 @@ public class CbusSendEventPaneTest  {
     }
     
     @Test
-    @DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
     public void testSendEvents() throws Exception{
         // for now, just makes sure there isn't an exception.
         CbusSendEventPane t = new CbusSendEventPane(mainConsolePane);
@@ -52,6 +49,7 @@ public class CbusSendEventPaneTest  {
         
         new JRadioButtonOperator(jfo,Bundle.getMessage("InitialStateOff")).setSelected(true);
         new JButtonOperator(jfo,Bundle.getMessage("ButtonSend")).doClick();
+        Assertions.assertNotNull(tc);
         assertThat( tc.outbound.size()).isEqualTo(1);
         assertEquals("[5f8] 99 00 00 00 01",tc.outbound.get(0).toString());
         
@@ -69,31 +67,30 @@ public class CbusSendEventPaneTest  {
     }
     
     
-    private CanSystemConnectionMemo memo;
-    private TrafficControllerScaffold tc;
-    private CbusConsolePane mainConsolePane;
+    private CanSystemConnectionMemo memo = null;
+    private TrafficControllerScaffold tc = null;
+    private CbusConsolePane mainConsolePane = null;
 
     @BeforeEach
     public void setUp() {
         JUnitUtil.setUp();
-        if(!GraphicsEnvironment.isHeadless()){
-            memo = new CanSystemConnectionMemo();
-            tc = new TrafficControllerScaffold();
-            memo.setTrafficController(tc);
-            mainConsolePane = new CbusConsolePane();
-            mainConsolePane.initComponents(memo,false);
-        }
+        memo = new CanSystemConnectionMemo();
+        tc = new TrafficControllerScaffold();
+        memo.setTrafficController(tc);
+        mainConsolePane = new CbusConsolePane();
+        mainConsolePane.initComponents(memo,false);
     }
 
     @AfterEach
     public void tearDown() {
-        if(!GraphicsEnvironment.isHeadless()){
-            mainConsolePane.dispose();
-            tc.terminateThreads();
-            memo.dispose();
-            tc = null;
-            memo = null;
-        }
+        Assertions.assertNotNull(mainConsolePane);
+        mainConsolePane.dispose();
+        Assertions.assertNotNull(tc);
+        tc.terminateThreads();
+        Assertions.assertNotNull(memo);
+        memo.dispose();
+        tc = null;
+        memo = null;
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrix/can/cbus/swing/bootloader/CbusBootloaderPaneTest.java
+++ b/java/test/jmri/jmrix/can/cbus/swing/bootloader/CbusBootloaderPaneTest.java
@@ -1,22 +1,21 @@
 package jmri.jmrix.can.cbus.swing.bootloader;
 
-import java.awt.GraphicsEnvironment;
-
 import jmri.jmrix.can.cbus.CbusPreferences;
 import jmri.util.JUnitUtil;
 
-import org.junit.Assume;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 /**
  * Tests for the BootloaderPane class
  *
  * @author Bob Andrew Crosland (C) 2020
  */
+@DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
 public class CbusBootloaderPaneTest extends jmri.util.swing.JmriPanelTest {
 
-    private jmri.jmrix.can.CanSystemConnectionMemo memo;
-    private jmri.jmrix.can.TrafficController tcis;
+    private jmri.jmrix.can.CanSystemConnectionMemo memo = null;
+    private jmri.jmrix.can.TrafficController tcis = null;
 
     @Override 
     @Test
@@ -27,7 +26,6 @@ public class CbusBootloaderPaneTest extends jmri.util.swing.JmriPanelTest {
 
     @Test
     public void testInitComponentsNoArgs() throws Exception{
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         // for now, just makes ure there isn't an exception.
         ((CbusBootloaderPane) panel).initComponents();
     }
@@ -56,8 +54,9 @@ public class CbusBootloaderPaneTest extends jmri.util.swing.JmriPanelTest {
     @AfterEach
     @Override
     public void tearDown() {
-        
+        Assertions.assertNotNull(tcis);
         tcis.terminateThreads();
+        Assertions.assertNotNull(memo);
         memo.dispose();
         tcis = null;
         memo = null;

--- a/java/test/jmri/jmrix/can/cbus/swing/bootloader/CbusPicHexFileTest.java
+++ b/java/test/jmri/jmrix/can/cbus/swing/bootloader/CbusPicHexFileTest.java
@@ -1,6 +1,8 @@
 package jmri.jmrix.can.cbus.swing.bootloader;
 
-import org.junit.*;
+import jmri.util.JUnitUtil;
+
+import org.junit.jupiter.api.*;
 
 /**
  * Tests for the CbusPicHexFile class
@@ -9,10 +11,20 @@ import org.junit.*;
  */
 public class CbusPicHexFileTest {
 
-    @org.junit.jupiter.api.Test
+    @Test
     public void testCTor() {
         HexFile f = new HexFile("cbusPicHexFileTest");
-        Assert.assertNotNull("exists",f);
+        Assertions.assertNotNull(f, "exists");
     }
-    
+
+    @BeforeEach
+    public void setUp() {
+        JUnitUtil.setUp();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        JUnitUtil.tearDown();
+    }
+
 }

--- a/java/test/jmri/jmrix/can/cbus/swing/cbusslotmonitor/CbusSlotMonitorPaneTest.java
+++ b/java/test/jmri/jmrix/can/cbus/swing/cbusslotmonitor/CbusSlotMonitorPaneTest.java
@@ -48,7 +48,7 @@ public class CbusSlotMonitorPaneTest extends jmri.util.swing.JmriPanelTest {
         f.pack();
         f.setVisible(true);
         
-        
+        Assertions.assertNotNull(tcis);
         CanReply r = new CanReply();
         r.setHeader(tcis.getCanid());
         r.setNumDataElements(3);
@@ -99,9 +99,9 @@ public class CbusSlotMonitorPaneTest extends jmri.util.swing.JmriPanelTest {
         smPanel.dispose();
         
     }
-    
-    private CanSystemConnectionMemo memo;
-    private TrafficControllerScaffold tcis;
+
+    private CanSystemConnectionMemo memo = null;
+    private TrafficControllerScaffold tcis = null;
 
     @Override
     @BeforeEach
@@ -119,9 +119,11 @@ public class CbusSlotMonitorPaneTest extends jmri.util.swing.JmriPanelTest {
     @Override
     @AfterEach
     public void tearDown() { 
+        Assertions.assertNotNull(tcis);
+        tcis.terminateThreads();
+        Assertions.assertNotNull(memo);
         memo.dispose();
         memo=null;
-        tcis.terminateThreads();
         tcis=null;
         JUnitUtil.tearDown();
     }

--- a/java/test/jmri/jmrix/can/cbus/swing/configtool/ConfigToolPaneTest.java
+++ b/java/test/jmri/jmrix/can/cbus/swing/configtool/ConfigToolPaneTest.java
@@ -1,7 +1,5 @@
 package jmri.jmrix.can.cbus.swing.configtool;
 
-import java.awt.GraphicsEnvironment;
-
 import jmri.jmrix.can.CanMessage;
 import jmri.jmrix.can.CanReply;
 import jmri.jmrix.can.CanSystemConnectionMemo;
@@ -11,24 +9,24 @@ import jmri.util.JUnitUtil;
 
 import org.junit.Assert;
 import org.junit.jupiter.api.*;
-import org.junit.Assume;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.netbeans.jemmy.operators.*;
 /**
  *
  * @author Paul Bender Copyright (C) 2017
  * @author Steve Young Copyright (C) 2019
  */
+@DisabledIfSystemProperty(named = "java.awt.headless", matches = "true")
 public class ConfigToolPaneTest extends jmri.util.swing.JmriPanelTest {
 
     @Test
     public void testInitComp() {
-        
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        
+
         Assert.assertEquals("no listener to start with",0,tcis.numListeners());
         
         ((ConfigToolPane)panel).initComponents(memo);
         
+        Assertions.assertNotNull(tcis);
         Assert.assertEquals("listening",1,tcis.numListeners());
         
         Assert.assertNotNull("exists", panel);
@@ -88,8 +86,8 @@ public class ConfigToolPaneTest extends jmri.util.swing.JmriPanelTest {
     private String getStringCaptureTwo( JFrameOperator jfo ){
         return ( new JTextFieldOperator(jfo,1).getText() );
     }
-    
-    private CanSystemConnectionMemo memo; 
+
+    private CanSystemConnectionMemo memo = null; 
     private TrafficControllerScaffold tcis;
  
     @Override
@@ -110,8 +108,10 @@ public class ConfigToolPaneTest extends jmri.util.swing.JmriPanelTest {
     public void tearDown() {
         JUnitUtil.resetWindows(false,false);
         panel.dispose();
+        Assertions.assertNotNull(tcis);
         Assert.assertEquals("no listener after dispose",0,tcis.numListeners());
         tcis.terminateThreads();
+        Assertions.assertNotNull(memo);
         memo.dispose();
         tcis = null;
         memo = null;


### PR DESCRIPTION
CbusPicHexFileTest - add setUp / tearDown methods
CbusCommonSwingTest - class only provides static methods, no need for constructor test
CbusDummyNodeTest - add CbusSimCanListener instance asserts

Updates a few headless checks.
Various non-null asserts.