### PR TITLE
more Test Updates, jmrix.can.cbus.swing

### DIFF
--- a/java/test/jmri/jmrix/can/TrafficControllerScaffoldLoopback.java
+++ b/java/test/jmri/jmrix/can/TrafficControllerScaffoldLoopback.java
@@ -19,13 +19,17 @@ public class TrafficControllerScaffoldLoopback extends TrafficControllerScaffold
     // forwards to any listeners
     @Override
     public void forwardMessage(AbstractMRListener l, AbstractMRMessage r) {
-        ((CanListener) l).message((CanMessage) r);
+        if ( l instanceof CanListener && r instanceof CanMessage ) {
+            ((CanListener) l).message((CanMessage) r);
+        }
     }
 
     // forwards to any listeners
     @Override
     public void forwardReply(AbstractMRListener l, AbstractMRReply r) {
-        ((CanListener) l).reply((CanReply) r);
+        if ( l instanceof CanListener && r instanceof CanReply ) {
+            ((CanListener) l).reply((CanReply) r);
+        }
     }
 
     @Override

--- a/java/test/jmri/jmrix/can/cbus/swing/console/CbusConsoleDecodeOptionsPaneTest.java
+++ b/java/test/jmri/jmrix/can/cbus/swing/console/CbusConsoleDecodeOptionsPaneTest.java
@@ -1,8 +1,8 @@
 package jmri.jmrix.can.cbus.swing.console;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.nio.file.Path;
 
@@ -10,11 +10,8 @@ import jmri.jmrix.can.*;
 import jmri.util.JUnitUtil;
 import jmri.util.JmriJFrame;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.netbeans.jemmy.operators.JCheckBoxOperator;
 import org.netbeans.jemmy.operators.JFrameOperator;
@@ -32,7 +29,7 @@ public class CbusConsoleDecodeOptionsPaneTest  {
     public void testInitComponents() throws Exception{
         // for now, just makes sure there isn't an exception.
         CbusConsoleDecodeOptionsPane t = new CbusConsoleDecodeOptionsPane(mainConsolePane);
-        assertThat(t).isNotNull();
+        assertNotNull(t);
         t.dispose();
     }
     
@@ -123,9 +120,9 @@ public class CbusConsoleDecodeOptionsPaneTest  {
     @TempDir 
     protected Path tempDir;
     
-    private CanSystemConnectionMemo memo;
-    private TrafficControllerScaffold tc;
-    private CbusConsolePane mainConsolePane;
+    private CanSystemConnectionMemo memo = null;
+    private TrafficControllerScaffold tc = null;
+    private CbusConsolePane mainConsolePane = null;
 
     @BeforeEach
     public void setUp() {
@@ -144,9 +141,13 @@ public class CbusConsoleDecodeOptionsPaneTest  {
 
     @AfterEach
     public void tearDown() {
+        assertNotNull(mainConsolePane);
         mainConsolePane.dispose();
+        assertNotNull(tc);
         tc.terminateThreads();
+        assertNotNull(memo);
         memo.dispose();
+        mainConsolePane = null;
         tc = null;
         memo = null;
         

--- a/java/test/jmri/jmrix/can/cbus/swing/console/CbusConsoleDisplayOptionsPaneTest.java
+++ b/java/test/jmri/jmrix/can/cbus/swing/console/CbusConsoleDisplayOptionsPaneTest.java
@@ -1,14 +1,11 @@
 package jmri.jmrix.can.cbus.swing.console;
 
-import java.awt.GraphicsEnvironment;
-
 import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.jmrix.can.TrafficControllerScaffold;
 import jmri.util.JUnitUtil;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.*;
-import org.junit.Assume;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 /**
  * Test simple functioning of CbusConsoleDisplayOptionsPane
@@ -16,20 +13,20 @@ import org.junit.Assume;
  * @author Paul Bender Copyright (C) 2016
  * @author Steve Young Copyright (C) 2020
 */
+@DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
 public class CbusConsoleDisplayOptionsPaneTest  {
 
     @Test
     public void testInitComponents() throws Exception{
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         // for now, just makes sure there isn't an exception.
         CbusConsoleDisplayOptionsPane t = new CbusConsoleDisplayOptionsPane(mainConsolePane);
-        Assert.assertNotNull("exists",t);
+        Assertions.assertNotNull(t);
         
     }
     
-    private CanSystemConnectionMemo memo;
-    private TrafficControllerScaffold tc;
-    private CbusConsolePane mainConsolePane;
+    private CanSystemConnectionMemo memo = null;
+    private TrafficControllerScaffold tc = null;
+    private CbusConsolePane mainConsolePane = null;
 
     @BeforeEach
     public void setUp() {
@@ -43,9 +40,13 @@ public class CbusConsoleDisplayOptionsPaneTest  {
 
     @AfterEach
     public void tearDown() {
+        Assertions.assertNotNull(mainConsolePane);
         mainConsolePane.dispose();
+        Assertions.assertNotNull(tc);
         tc.terminateThreads();
+        Assertions.assertNotNull(memo);
         memo.dispose();
+        mainConsolePane = null;
         tc = null;
         memo = null;
         

--- a/java/test/jmri/jmrix/can/cbus/swing/console/CbusConsoleLoggingPaneTest.java
+++ b/java/test/jmri/jmrix/can/cbus/swing/console/CbusConsoleLoggingPaneTest.java
@@ -1,14 +1,11 @@
 package jmri.jmrix.can.cbus.swing.console;
 
-import java.awt.GraphicsEnvironment;
-
 import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.jmrix.can.TrafficControllerScaffold;
 import jmri.util.JUnitUtil;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.*;
-import org.junit.Assume;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 /**
  * Test simple functioning of CbusConsoleLoggingPane
@@ -16,20 +13,20 @@ import org.junit.Assume;
  * @author Paul Bender Copyright (C) 2016
  * @author Steve Young Copyright (C) 2020
 */
+@DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
 public class CbusConsoleLoggingPaneTest  {
 
     @Test
     public void testInitComponents() throws Exception{
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         // for now, just makes sure there isn't an exception.
         CbusConsoleLoggingPane t = new CbusConsoleLoggingPane(mainConsolePane);
-        Assert.assertNotNull("exists",t);
+        Assertions.assertNotNull(t);
         
     }
     
-    private CanSystemConnectionMemo memo;
-    private TrafficControllerScaffold tc;
-    private CbusConsolePane mainConsolePane;
+    private CanSystemConnectionMemo memo = null;
+    private TrafficControllerScaffold tc = null;
+    private CbusConsolePane mainConsolePane = null;
 
     @BeforeEach
     public void setUp() {
@@ -43,9 +40,13 @@ public class CbusConsoleLoggingPaneTest  {
 
     @AfterEach
     public void tearDown() {
+        Assertions.assertNotNull(mainConsolePane);
         mainConsolePane.dispose();
+        Assertions.assertNotNull(tc);
         tc.terminateThreads();
+        Assertions.assertNotNull(memo);
         memo.dispose();
+        mainConsolePane = null;
         tc = null;
         memo = null;
         

--- a/java/test/jmri/jmrix/can/cbus/swing/console/CbusConsolePacketPaneTest.java
+++ b/java/test/jmri/jmrix/can/cbus/swing/console/CbusConsolePacketPaneTest.java
@@ -1,14 +1,11 @@
 package jmri.jmrix.can.cbus.swing.console;
 
-import java.awt.GraphicsEnvironment;
-
 import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.jmrix.can.TrafficControllerScaffold;
 import jmri.util.JUnitUtil;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.*;
-import org.junit.Assume;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 /**
  * Test simple functioning of CbusConsolePacketPane
@@ -16,20 +13,21 @@ import org.junit.Assume;
  * @author Paul Bender Copyright (C) 2016
  * @author Steve Young Copyright (C) 2020
 */
+@DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
 public class CbusConsolePacketPaneTest  {
 
     @Test
     public void testInitComponents() throws Exception{
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+
         // for now, just makes sure there isn't an exception.
         CbusConsolePacketPane t = new CbusConsolePacketPane(mainConsolePane);
-        Assert.assertNotNull("exists",t);
+        Assertions.assertNotNull(t);
         
     }
     
-    private CanSystemConnectionMemo memo;
-    private TrafficControllerScaffold tc;
-    private CbusConsolePane mainConsolePane;
+    private CanSystemConnectionMemo memo = null;
+    private TrafficControllerScaffold tc = null;
+    private CbusConsolePane mainConsolePane = null;
 
     @BeforeEach
     public void setUp() {
@@ -43,9 +41,13 @@ public class CbusConsolePacketPaneTest  {
 
     @AfterEach
     public void tearDown() {
+        Assertions.assertNotNull(mainConsolePane);
         mainConsolePane.dispose();
+        Assertions.assertNotNull(tc);
         tc.terminateThreads();
+        Assertions.assertNotNull(memo);
         memo.dispose();
+        mainConsolePane = null;
         tc = null;
         memo = null;
         

--- a/java/test/jmri/jmrix/can/cbus/swing/console/CbusConsoleStatsPaneTest.java
+++ b/java/test/jmri/jmrix/can/cbus/swing/console/CbusConsoleStatsPaneTest.java
@@ -1,14 +1,11 @@
 package jmri.jmrix.can.cbus.swing.console;
 
-import java.awt.GraphicsEnvironment;
-
 import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.jmrix.can.TrafficControllerScaffold;
 import jmri.util.JUnitUtil;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.*;
-import org.junit.Assume;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 /**
  * Test simple functioning of CbusConsoleStatsPane
@@ -16,20 +13,20 @@ import org.junit.Assume;
  * @author Paul Bender Copyright (C) 2016
  * @author Steve Young Copyright (C) 2020
 */
+@DisabledIfSystemProperty(named = "java.awt.headless", matches = "true" )
 public class CbusConsoleStatsPaneTest  {
 
     @Test
     public void testInitComponents() throws Exception{
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         // for now, just makes sure there isn't an exception.
         CbusConsoleStatsPane t = new CbusConsoleStatsPane(mainConsolePane);
-        Assert.assertNotNull("exists",t);
+        Assertions.assertNotNull(t);
         
     }
     
-    private CanSystemConnectionMemo memo;
-    private TrafficControllerScaffold tc;
-    private CbusConsolePane mainConsolePane;
+    private CanSystemConnectionMemo memo = null;
+    private TrafficControllerScaffold tc = null;
+    private CbusConsolePane mainConsolePane = null;
 
     @BeforeEach
     public void setUp() {
@@ -43,14 +40,17 @@ public class CbusConsoleStatsPaneTest  {
 
     @AfterEach
     public void tearDown() {
+        Assertions.assertNotNull(mainConsolePane);
         mainConsolePane.dispose();
+        Assertions.assertNotNull(tc);
         tc.terminateThreads();
+        Assertions.assertNotNull(memo);
         memo.dispose();
+        mainConsolePane = null;
         tc = null;
         memo = null;
         
         JUnitUtil.tearDown();
     }
-
 
 }

--- a/java/test/jmri/jmrix/can/cbus/swing/eventrequestmonitor/CbusEventRequestDataModelTest.java
+++ b/java/test/jmri/jmrix/can/cbus/swing/eventrequestmonitor/CbusEventRequestDataModelTest.java
@@ -142,7 +142,7 @@ public class CbusEventRequestDataModelTest {
         
         t.setValueAt("do button Click",0,CbusEventRequestDataModel.STATUS_REQUEST_BUTTON_COLUMN);
         
-        JUnitUtil.waitFor(()->{ return(tcis.outbound.size()>0); }, " outbound 1 didn't arrive");
+        JUnitUtil.waitFor(()->{ return(!tcis.outbound.isEmpty()); }, " outbound 1 didn't arrive");
         Assert.assertEquals(" 1 outbound increased", 1,(tcis.outbound.size() ) );
         Assert.assertEquals("table sends request event for long 7 node 1234 ", "[5f8] 92 04 D2 00 07",
             tcis.outbound.elementAt(tcis.outbound.size() - 1).toString());
@@ -199,7 +199,7 @@ public class CbusEventRequestDataModelTest {
     }
     
     private TrafficControllerScaffold tcis;
-    private CanSystemConnectionMemo memo;
+    private CanSystemConnectionMemo memo = null;
 
     @BeforeEach
     public void setUp() {
@@ -214,6 +214,7 @@ public class CbusEventRequestDataModelTest {
     @AfterEach
     public void tearDown() {        
         tcis.terminateThreads();
+        Assertions.assertNotNull(memo);
         memo.dispose();
         tcis = null;
         memo = null;

--- a/java/test/jmri/jmrix/can/cbus/swing/eventrequestmonitor/CbusEventRequestTablePaneTest.java
+++ b/java/test/jmri/jmrix/can/cbus/swing/eventrequestmonitor/CbusEventRequestTablePaneTest.java
@@ -1,35 +1,32 @@
 package jmri.jmrix.can.cbus.swing.eventrequestmonitor;
 
-import java.awt.GraphicsEnvironment;
-
 import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.jmrix.can.TrafficControllerScaffold;
 import jmri.util.JUnitUtil;
 
 import org.junit.Assert;
 import org.junit.jupiter.api.*;
-import org.junit.Assume;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 /**
  * Test simple functioning of CbusEventRequestTablePane
  *
  * @author Paul Bender Copyright (C) 2016
  */
+@DisabledIfSystemProperty(named = "java.awt.headless", matches = "true")
 public class CbusEventRequestTablePaneTest {
 
-    private CanSystemConnectionMemo memo;
-    private TrafficControllerScaffold tcis;
+    private CanSystemConnectionMemo memo = null;
+    private TrafficControllerScaffold tcis = null;
     
     @Test
     public void testCtor() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         CbusEventRequestTablePane t = new CbusEventRequestTablePane();
         Assert.assertNotNull("exists", t);
     }
     
     @Test
     public void testDisplayEventRequest() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         CbusEventRequestTablePane t = new CbusEventRequestTablePane();
         t.initComponents(memo);
         
@@ -47,7 +44,9 @@ public class CbusEventRequestTablePaneTest {
 
     @AfterEach
     public void tearDown() {
+        Assertions.assertNotNull(memo);
         memo.dispose();
+        Assertions.assertNotNull(tcis);
         tcis.terminateThreads();
         memo = null;
         tcis = null;

--- a/java/test/jmri/jmrix/can/cbus/swing/eventtable/CbusEventBeanCellRendererTest.java
+++ b/java/test/jmri/jmrix/can/cbus/swing/eventtable/CbusEventBeanCellRendererTest.java
@@ -5,9 +5,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.awt.Component;
 import java.util.HashSet;
+
 import javax.swing.JPanel;
 import javax.swing.JTable;
 import javax.swing.JTextField;
+
 import jmri.Light;
 import jmri.Sensor;
 import jmri.Turnout;
@@ -18,10 +20,9 @@ import jmri.jmrix.can.cbus.CbusSensorManager;
 import jmri.jmrix.can.cbus.CbusTurnoutManager;
 import jmri.jmrix.can.cbus.eventtable.CbusEventBeanData;
 import jmri.util.JUnitUtil;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
-import org.junit.jupiter.api.Test;
 
 /**
  * Test simple functioning of CbusEventBeanCellRenderer
@@ -35,7 +36,7 @@ public class CbusEventBeanCellRendererTest  {
     @DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
     public void testInitComponents() throws Exception{
         // for now, just makes sure there isn't an exception.
-        assertThat(new CbusEventBeanCellRenderer(null,20)).isNotNull();
+        assertThat(new CbusEventBeanCellRenderer(new JTextField(),20)).isNotNull();
     }
     
     @Test
@@ -159,7 +160,7 @@ public class CbusEventBeanCellRendererTest  {
     }
     
     
-    private CanSystemConnectionMemo memo;
+    private CanSystemConnectionMemo memo = null;
 
     @BeforeEach
     public void setUp() {
@@ -169,6 +170,7 @@ public class CbusEventBeanCellRendererTest  {
 
     @AfterEach
     public void tearDown() {
+        Assertions.assertNotNull(memo);
         memo.dispose();
         memo = null;
         JUnitUtil.tearDown();

--- a/java/test/jmri/jmrix/can/cbus/swing/eventtable/CbusEventTablePrintActionTest.java
+++ b/java/test/jmri/jmrix/can/cbus/swing/eventtable/CbusEventTablePrintActionTest.java
@@ -5,6 +5,7 @@ import java.nio.file.Path;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.jmrix.can.cbus.eventtable.CbusEventTableDataModel;
 import jmri.util.JUnitUtil;
 import org.junit.jupiter.api.AfterEach;
@@ -28,8 +29,8 @@ public class CbusEventTablePrintActionTest {
     @Test
     public void testCTor() {
         
-        CbusEventTableDataModel eventModel = new CbusEventTableDataModel(null,0,0);
-        // assertThat(t).isNotNull();
+        CanSystemConnectionMemo memo = new CanSystemConnectionMemo();
+        CbusEventTableDataModel eventModel = new CbusEventTableDataModel(memo,0);
         
         CbusEventTablePrintAction t = new CbusEventTablePrintAction("PreviewTable",
         eventModel,"CBUS Event Table Print Preview Test",true);
@@ -38,14 +39,15 @@ public class CbusEventTablePrintActionTest {
         
         eventModel.skipSaveOnDispose();
         eventModel.dispose();
+        memo.dispose();
         
     }
     
     @Test
     @DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
     public void testPreview() {
-        
-        CbusEventTableDataModel eventModel = new CbusEventTableDataModel(null,0,0);
+        CanSystemConnectionMemo memo = new CanSystemConnectionMemo();
+        CbusEventTableDataModel eventModel = new CbusEventTableDataModel(memo, 2);
         // assertThat(t).isNotNull();
         
         eventModel.provideEvent(0, 7);
@@ -67,6 +69,7 @@ public class CbusEventTablePrintActionTest {
         
         eventModel.skipSaveOnDispose();
         eventModel.dispose();
+        memo.dispose();
         
     }
     

--- a/java/test/jmri/jmrix/can/cbus/swing/eventtable/CbusEventTablePrintActionTest.java
+++ b/java/test/jmri/jmrix/can/cbus/swing/eventtable/CbusEventTablePrintActionTest.java
@@ -5,7 +5,6 @@ import java.nio.file.Path;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.jmrix.can.cbus.eventtable.CbusEventTableDataModel;
 import jmri.util.JUnitUtil;
 import org.junit.jupiter.api.AfterEach;
@@ -29,8 +28,8 @@ public class CbusEventTablePrintActionTest {
     @Test
     public void testCTor() {
         
-        CanSystemConnectionMemo memo = new CanSystemConnectionMemo();
-        CbusEventTableDataModel eventModel = new CbusEventTableDataModel(memo,0);
+        CbusEventTableDataModel eventModel = new CbusEventTableDataModel(null,0,0);
+        // assertThat(t).isNotNull();
         
         CbusEventTablePrintAction t = new CbusEventTablePrintAction("PreviewTable",
         eventModel,"CBUS Event Table Print Preview Test",true);
@@ -39,15 +38,14 @@ public class CbusEventTablePrintActionTest {
         
         eventModel.skipSaveOnDispose();
         eventModel.dispose();
-        memo.dispose();
         
     }
     
     @Test
     @DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
     public void testPreview() {
-        CanSystemConnectionMemo memo = new CanSystemConnectionMemo();
-        CbusEventTableDataModel eventModel = new CbusEventTableDataModel(memo, 2);
+        
+        CbusEventTableDataModel eventModel = new CbusEventTableDataModel(null,0,0);
         // assertThat(t).isNotNull();
         
         eventModel.provideEvent(0, 7);
@@ -69,7 +67,6 @@ public class CbusEventTablePrintActionTest {
         
         eventModel.skipSaveOnDispose();
         eventModel.dispose();
-        memo.dispose();
         
     }
     

--- a/java/test/jmri/jmrix/can/cbus/swing/nodeconfig/CbusNodeEventTablePaneTest.java
+++ b/java/test/jmri/jmrix/can/cbus/swing/nodeconfig/CbusNodeEventTablePaneTest.java
@@ -1,7 +1,5 @@
 package jmri.jmrix.can.cbus.swing.nodeconfig;
 
-import java.awt.GraphicsEnvironment;
-
 import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.jmrix.can.cbus.node.CbusNode;
 import jmri.jmrix.can.cbus.node.CbusNodeEvent;
@@ -11,7 +9,7 @@ import jmri.util.JUnitUtil;
 
 import org.junit.Assert;
 import org.junit.jupiter.api.*;
-import org.junit.Assume;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.netbeans.jemmy.operators.JFrameOperator;
 import org.netbeans.jemmy.operators.JTableOperator;
 
@@ -21,18 +19,17 @@ import org.netbeans.jemmy.operators.JTableOperator;
  * @author Paul Bender Copyright (C) 2016
  * @author Steve Young Copyright (C) 2019
  */
+@DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
 public class CbusNodeEventTablePaneTest {
 
     @Test
     public void testCtor() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         t = new CbusNodeEventTablePane(null);
         Assert.assertNotNull("exists",t);
     }
     
     @Test
     public void testCtorWithModelAndInit() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
 
         nodeModel = new CbusNodeEventTableDataModel(null, memo, 3,CbusNodeEventTableDataModel.MAX_COLUMN);
         
@@ -49,7 +46,6 @@ public class CbusNodeEventTablePaneTest {
     
     @Test
     public void testSetNode() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
 
         nodeModel = new CbusNodeEventTableDataModel(null, memo, 3,CbusNodeEventTableDataModel.MAX_COLUMN);
         
@@ -95,7 +91,7 @@ public class CbusNodeEventTablePaneTest {
     }
     
     private CbusNodeEventTablePane t;
-    private CanSystemConnectionMemo memo;
+    private CanSystemConnectionMemo memo = null;
     private CbusNodeEventTableDataModel nodeModel;
 
     @BeforeEach
@@ -108,6 +104,7 @@ public class CbusNodeEventTablePaneTest {
     public void tearDown() {
         t = null;
         nodeModel = null;
+        Assertions.assertNotNull(memo);
         memo.dispose();
         memo = null;
         JUnitUtil.tearDown();

--- a/java/test/jmri/jmrix/can/cbus/swing/simulator/SimulatorPaneTest.java
+++ b/java/test/jmri/jmrix/can/cbus/swing/simulator/SimulatorPaneTest.java
@@ -24,32 +24,6 @@ import org.netbeans.jemmy.operators.*;
  */
 public class SimulatorPaneTest extends jmri.util.swing.JmriPanelTest {
 
-    private CanSystemConnectionMemo memo; 
-    private TrafficControllerScaffold tcis;
- 
-    @Override
-    @BeforeEach
-    public void setUp() {
-        JUnitUtil.setUp();
-        title = Bundle.getMessage("MenuItemNetworkSim");
-        helpTarget = "package.jmri.jmrix.can.cbus.swing.simulator.SimulatorPane";
-        memo = new CanSystemConnectionMemo();
-        tcis = new TrafficControllerScaffold();
-        memo.setTrafficController(tcis);
-        
-        panel = new SimulatorPane();
-    }
-    
-    @Override
-    @AfterEach
-    public void tearDown() {
-        tcis.terminateThreads();
-        memo.dispose();
-        tcis = null;
-        memo = null;
-        super.tearDown();
-    }
-
     @DisabledIfSystemProperty(named = "java.awt.headless", matches = "true")
     @Test
     public void testInitComp() {
@@ -92,6 +66,34 @@ public class SimulatorPaneTest extends jmri.util.swing.JmriPanelTest {
     
     private boolean getResetCsButtonEnabled( JFrameOperator jfo ){
         return ( new JButtonOperator(jfo, Bundle.getMessage("Reset")).isEnabled() );
+    }
+
+    private CanSystemConnectionMemo memo = null; 
+    private TrafficControllerScaffold tcis = null;
+ 
+    @Override
+    @BeforeEach
+    public void setUp() {
+        JUnitUtil.setUp();
+        title = Bundle.getMessage("MenuItemNetworkSim");
+        helpTarget = "package.jmri.jmrix.can.cbus.swing.simulator.SimulatorPane";
+        memo = new CanSystemConnectionMemo();
+        tcis = new TrafficControllerScaffold();
+        memo.setTrafficController(tcis);
+
+        panel = new SimulatorPane();
+    }
+
+    @Override
+    @AfterEach
+    public void tearDown() {
+        Assertions.assertNotNull(tcis);
+        tcis.terminateThreads();
+        Assertions.assertNotNull(memo);
+        memo.dispose();
+        tcis = null;
+        memo = null;
+        super.tearDown();
     }
 
 }


### PR DESCRIPTION
Update headless checks
Add non-null asserts

CbusEventBeanCellRendererTest - pass new JTextField to nonnull argument
SimulatorPaneTest - move setUp / tearDown to bottom of class
TrafficControllerScaffoldLoopback - Assert Can objects

