### PR TITLE
Update cbus.swing.modules.base tests

### DIFF
--- a/java/test/jmri/jmrix/can/cbus/swing/modules/AbstractEditNVPaneTest.java
+++ b/java/test/jmri/jmrix/can/cbus/swing/modules/AbstractEditNVPaneTest.java
@@ -1,8 +1,5 @@
 package jmri.jmrix.can.cbus.swing.modules;
 
-import java.awt.GraphicsEnvironment;
-
-import javax.swing.JPanel;
 import javax.swing.event.TableModelEvent;
 
 import jmri.jmrix.can.CanSystemConnectionMemo;
@@ -11,18 +8,19 @@ import jmri.util.JUnitUtil;
 
 import org.junit.Assert;
 import org.junit.jupiter.api.*;
-import org.junit.Assume;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 /**
- * Test simple functioning of CbusNodeInfoPane
+ * Test simple functioning of AbstractEditNVPane
  *
  * @author Andrew Crosland Copyright (C) 2021
  */
+@DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
 public class AbstractEditNVPaneTest {
     
     @Test
     public void testCtor() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+
         CbusNode nd = new CbusNode(memo, 12345);
         int [] nvs = new int[] {1, 1};
         nd.getNodeNvManager().setNVs(nvs);
@@ -31,9 +29,9 @@ public class AbstractEditNVPaneTest {
     }
     
     // Abstract class cannot be instantiated directly
-    public class AbstractEditNVPaneImpl extends AbstractEditNVPane {
+    private static class AbstractEditNVPaneImpl extends AbstractEditNVPane {
 
-        public AbstractEditNVPaneImpl(CbusNodeNVTableDataModel dataModel, CbusNode node) {
+        AbstractEditNVPaneImpl(CbusNodeNVTableDataModel dataModel, CbusNode node) {
             super(dataModel, node);
         }
 
@@ -47,8 +45,8 @@ public class AbstractEditNVPaneTest {
         }
     }
     
-    private CanSystemConnectionMemo memo;
-    private CbusNodeNVTableDataModel model;
+    private CanSystemConnectionMemo memo = null;
+    private CbusNodeNVTableDataModel model = null;
 
     @BeforeEach
     public void setUp() {
@@ -59,8 +57,10 @@ public class AbstractEditNVPaneTest {
 
     @AfterEach
     public void tearDown() {
+        Assertions.assertNotNull(model);
         model.dispose();
         model = null;
+        Assertions.assertNotNull(memo);
         memo.dispose();
         memo = null;
         JUnitUtil.tearDown();

--- a/java/test/jmri/jmrix/can/cbus/swing/modules/CbusConfigPaneProviderTest.java
+++ b/java/test/jmri/jmrix/can/cbus/swing/modules/CbusConfigPaneProviderTest.java
@@ -3,7 +3,6 @@ package jmri.jmrix.can.cbus.swing.modules;
 import jmri.jmrix.can.cbus.node.*;
 import jmri.util.JUnitUtil;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
@@ -17,19 +16,19 @@ public class CbusConfigPaneProviderTest {
     @Test
     public void testCtor() {
         CbusConfigPaneProviderImpl t = new CbusConfigPaneProviderImpl();
-        Assert.assertNotNull("exists",t);
+        Assertions.assertNotNull(t, "exists");
     }
-    
-    // Abstract class cannot be instantiated directly
-    public class CbusConfigPaneProviderImpl extends CbusConfigPaneProvider {
 
-        public CbusConfigPaneProviderImpl() {
+    // Abstract class cannot be instantiated directly
+    private static class CbusConfigPaneProviderImpl extends CbusConfigPaneProvider {
+
+        CbusConfigPaneProviderImpl() {
             super();
         }
 
         @Override
         public String getModuleType() {
-            return null;
+            return "CbusConfigPaneProviderImpl";
         }
         
         @Override

--- a/java/test/jmri/jmrix/can/cbus/swing/modules/UnknownEditNVPaneTest.java
+++ b/java/test/jmri/jmrix/can/cbus/swing/modules/UnknownEditNVPaneTest.java
@@ -1,25 +1,23 @@
 package jmri.jmrix.can.cbus.swing.modules;
 
-import java.awt.GraphicsEnvironment;
-
 import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.jmrix.can.cbus.node.*;
 import jmri.util.JUnitUtil;
 
 import org.junit.Assert;
 import org.junit.jupiter.api.*;
-import org.junit.Assume;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 /**
  * Test simple functioning of CbusNodeInfoPane
  *
  * @author Andrew Crosland Copyright (C) 2021
  */
+@DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
 public class UnknownEditNVPaneTest {
     
-    @org.junit.jupiter.api.Test
+    @Test
     public void testCtor() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         CbusNode nd = new CbusNode(memo, 12345);
         int [] nvs = new int[] {1, 1};
         nd.getNodeNvManager().setNVs(nvs);
@@ -27,8 +25,8 @@ public class UnknownEditNVPaneTest {
         Assert.assertNotNull("exists",t);
     }
     
-    private CanSystemConnectionMemo memo;
-    private CbusNodeNVTableDataModel model;
+    private CanSystemConnectionMemo memo = null;
+    private CbusNodeNVTableDataModel model = null;
 
     @BeforeEach
     public void setUp() {
@@ -39,8 +37,10 @@ public class UnknownEditNVPaneTest {
 
     @AfterEach
     public void tearDown() {
+        Assertions.assertNotNull(model);
         model.dispose();
         model = null;
+        Assertions.assertNotNull(memo);
         memo.dispose();
         memo = null;
         JUnitUtil.tearDown();

--- a/java/test/jmri/jmrix/can/cbus/swing/modules/UnknownPaneProviderTest.java
+++ b/java/test/jmri/jmrix/can/cbus/swing/modules/UnknownPaneProviderTest.java
@@ -1,31 +1,29 @@
 package jmri.jmrix.can.cbus.swing.modules;
 
-import java.awt.GraphicsEnvironment;
-
 import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.jmrix.can.cbus.node.*;
 import jmri.util.JUnitUtil;
 
 import org.junit.Assert;
 import org.junit.jupiter.api.*;
-import org.junit.Assume;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 /**
  * Test simple functioning of CbusNodeInfoPane
  *
  * @author Andrew Crosland Copyright (C) 2021
  */
+@DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
 public class UnknownPaneProviderTest {
     
     @Test
     public void testCtor() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         UnknownPaneProvider t = new UnknownPaneProvider();
         Assert.assertNotNull("exists",t);
     }
     
-    private CanSystemConnectionMemo memo;
-    private CbusNodeNVTableDataModel model;
+    private CanSystemConnectionMemo memo = null;
+    private CbusNodeNVTableDataModel model = null;
 
     @BeforeEach
     public void setUp() {
@@ -36,8 +34,10 @@ public class UnknownPaneProviderTest {
 
     @AfterEach
     public void tearDown() {
+        Assertions.assertNotNull(model);
         model.dispose();
         model = null;
+        Assertions.assertNotNull(memo);
         memo.dispose();
         memo = null;
         JUnitUtil.tearDown();

--- a/java/test/jmri/jmrix/can/cbus/swing/modules/base/Servo8BaseEditNVPaneTest.java
+++ b/java/test/jmri/jmrix/can/cbus/swing/modules/base/Servo8BaseEditNVPaneTest.java
@@ -1,26 +1,23 @@
 package jmri.jmrix.can.cbus.swing.modules.base;
 
-import java.awt.GraphicsEnvironment;
-
 import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.jmrix.can.cbus.node.*;
 import jmri.util.JUnitUtil;
 
 import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 /**
  * Test simple functioning of Servo8BaseEditNVPane
  *
  * @author Andrew Crosland Copyright (C) 2021
  */
+@DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
 public class Servo8BaseEditNVPaneTest {
     
-    @org.junit.jupiter.api.Test
+    @Test
     public void testCtor() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         CbusNode nd = new CbusNode(memo, 12345);
         int [] nvs = new int[] {1, 1};
         nd.getNodeNvManager().setNVs(nvs);
@@ -28,8 +25,8 @@ public class Servo8BaseEditNVPaneTest {
         Assert.assertNotNull("exists",t);
     }
     
-    private CanSystemConnectionMemo memo;
-    private CbusNodeNVTableDataModel model;
+    private CanSystemConnectionMemo memo = null;
+    private CbusNodeNVTableDataModel model = null;
 
     @BeforeEach
     public void setUp() {
@@ -40,8 +37,10 @@ public class Servo8BaseEditNVPaneTest {
 
     @AfterEach
     public void tearDown() {
+        Assertions.assertNotNull(model);
         model.dispose();
         model = null;
+        Assertions.assertNotNull(memo);
         memo.dispose();
         memo = null;
         JUnitUtil.tearDown();

--- a/java/test/jmri/jmrix/can/cbus/swing/modules/base/Servo8BasePaneProviderTest.java
+++ b/java/test/jmri/jmrix/can/cbus/swing/modules/base/Servo8BasePaneProviderTest.java
@@ -1,33 +1,30 @@
 package jmri.jmrix.can.cbus.swing.modules.base;
 
-import java.awt.GraphicsEnvironment;
-
 import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.jmrix.can.cbus.node.*;
 
 import jmri.util.JUnitUtil;
 
 import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 /**
  * Test simple functioning of Servo8BasePaneProvider
  *
  * @author Andrew Crosland Copyright (C) 2021
  */
+@DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
 public class Servo8BasePaneProviderTest {
     
-    @org.junit.jupiter.api.Test
+    @Test
     public void testCtor() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         Servo8BasePaneProvider t = new Servo8BasePaneProvider();
         Assert.assertNotNull("exists",t);
     }
     
-    private CanSystemConnectionMemo memo;
-    private CbusNodeNVTableDataModel model;
+    private CanSystemConnectionMemo memo = null;
+    private CbusNodeNVTableDataModel model = null;
 
     @BeforeEach
     public void setUp() {
@@ -38,8 +35,10 @@ public class Servo8BasePaneProviderTest {
 
     @AfterEach
     public void tearDown() {
+        Assertions.assertNotNull(model);
         model.dispose();
         model = null;
+        Assertions.assertNotNull(memo);
         memo.dispose();
         memo = null;
         JUnitUtil.tearDown();

--- a/java/test/jmri/jmrix/can/cbus/swing/modules/base/Sol8BaseEditNVPaneTest.java
+++ b/java/test/jmri/jmrix/can/cbus/swing/modules/base/Sol8BaseEditNVPaneTest.java
@@ -1,26 +1,23 @@
 package jmri.jmrix.can.cbus.swing.modules.base;
 
-import java.awt.GraphicsEnvironment;
-
 import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.jmrix.can.cbus.node.*;
 import jmri.util.JUnitUtil;
 
 import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 /**
  * Test simple functioning of Sol8BaseEditNVPane
  *
  * @author Andrew Crosland Copyright (C) 2021
  */
+@DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
 public class Sol8BaseEditNVPaneTest {
     
-    @org.junit.jupiter.api.Test
+    @Test
     public void testCtor() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         CbusNode nd = new CbusNode(memo, 12345);
         int [] nvs = new int[] {1, 1};
         nd.getNodeNvManager().setNVs(nvs);
@@ -28,8 +25,8 @@ public class Sol8BaseEditNVPaneTest {
         Assert.assertNotNull("exists",t);
     }
     
-    private CanSystemConnectionMemo memo;
-    private CbusNodeNVTableDataModel model;
+    private CanSystemConnectionMemo memo = null;
+    private CbusNodeNVTableDataModel model = null;
 
     @BeforeEach
     public void setUp() {
@@ -40,8 +37,10 @@ public class Sol8BaseEditNVPaneTest {
 
     @AfterEach
     public void tearDown() {
+        Assertions.assertNotNull(model);
         model.dispose();
         model = null;
+        Assertions.assertNotNull(memo);
         memo.dispose();
         memo = null;
         JUnitUtil.tearDown();

--- a/java/test/jmri/jmrix/can/cbus/swing/modules/base/Sol8BasePaneProviderTest.java
+++ b/java/test/jmri/jmrix/can/cbus/swing/modules/base/Sol8BasePaneProviderTest.java
@@ -1,33 +1,30 @@
 package jmri.jmrix.can.cbus.swing.modules.base;
 
-import java.awt.GraphicsEnvironment;
-
 import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.jmrix.can.cbus.node.*;
 
 import jmri.util.JUnitUtil;
 
 import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 /**
  * Test simple functioning of Sol8BasePaneProvider
  *
  * @author Andrew Crosland Copyright (C) 2021
  */
+@DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
 public class Sol8BasePaneProviderTest {
     
-    @org.junit.jupiter.api.Test
+    @Test
     public void testCtor() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         Sol8BasePaneProvider t = new Sol8BasePaneProvider();
         Assert.assertNotNull("exists",t);
     }
     
-    private CanSystemConnectionMemo memo;
-    private CbusNodeNVTableDataModel model;
+    private CanSystemConnectionMemo memo = null;
+    private CbusNodeNVTableDataModel model = null;
 
     @BeforeEach
     public void setUp() {
@@ -38,8 +35,10 @@ public class Sol8BasePaneProviderTest {
 
     @AfterEach
     public void tearDown() {
+        Assertions.assertNotNull(model);
         model.dispose();
         model = null;
+        Assertions.assertNotNull(memo);
         memo.dispose();
         memo = null;
         JUnitUtil.tearDown();


### PR DESCRIPTION
Update headless checks
NonNull asserts

AbstractEditNVPaneTest - AbstractEditNVPaneImpl can be static class
CbusConfigPaneProviderTest - CbusConfigPaneProviderImpl can be static, do not return null getModuleType()