### PR TITLE
Ij UTF-8 encoding

### DIFF
--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="Encoding" native2AsciiForPropertiesFiles="true" defaultCharsetForPropertiesFiles="UTF-8">
+  <component name="Encoding" defaultCharsetForPropertiesFiles="UTF-8">
     <file url="PROJECT" charset="UTF-8" />
   </component>
 </project>

--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
+<project version="5">
   <component name="Encoding" defaultCharsetForPropertiesFiles="UTF-8">
     <file url="PROJECT" charset="UTF-8" />
   </component>


### PR DESCRIPTION
Since Java 11 ascii encoding is no longer required. This PR applies to the IntelliJ 2022 IDE settings only.
Existing files might have encoding, but this setting will prevent unnecessary encoding from UTF-8 on newer edits.