### PR TITLE
Check for edge connector and nx references before deleting le panels

### DIFF
--- a/java/src/jmri/jmrit/display/PanelDeleteAction.java
+++ b/java/src/jmri/jmrit/display/PanelDeleteAction.java
@@ -53,6 +53,11 @@ public class PanelDeleteAction extends AbstractAction {
             if (panelName != null && !panelName.isEmpty()) {
                 Editor selected = InstanceManager.getDefault(EditorManager.class).get(panelName);
                 if (selected != null) {
+                    if (selected instanceof jmri.jmrit.display.layoutEditor.LayoutEditor) {
+                        if (!((jmri.jmrit.display.layoutEditor.LayoutEditor)selected).canDeletePanel()) {
+                            return;
+                        }
+                    }
                     if (selected instanceof jmri.jmrit.display.panelEditor.PanelEditor ||
                              selected instanceof jmri.jmrit.display.switchboardEditor.SwitchboardEditor) {
                         selected.getTargetFrame().dispose();

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorBundle.properties
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorBundle.properties
@@ -574,6 +574,11 @@ Question7 = Are you sure you want to remove this ray from the turntable, along w
 Warn1 = Warning - Connectivities for Block "{0}" in Panels "{1}" and "{2}" are not compatible.
 Warn2 = Bean Settings needed for Block operation could not be created. Check that all Turnouts have been assigned.
 
+# Active panel relationships during panel delete request
+PanelRelationshipsError = The panel delete request is denied due to active relationships.\n
+ActiveEdgeConnector = - Edge connector {0} is linked to panel "{1}"\n
+ActiveEntryExit = - Panel is used by EntryExit\n
+
 # rename panel error messages
 CanNotRename = Can not rename panel with the same name as an existing panel
 PanelExist = Panel name already exists!


### PR DESCRIPTION
If a LE panel with active edge connectors is deleted, a subsequent store has NPE failures.  When the resulting file is loaded, file validation fails.

Existing EntryExit pairs are broken but the the store/load process logs the errors on the system console and fails gracefully.