### PR TITLE
WIP - Move invisible windows to main screen

### DIFF
--- a/java/src/apps/Apps.java
+++ b/java/src/apps/Apps.java
@@ -364,6 +364,9 @@ public class Apps extends JPanel implements PropertyChangeListener, WindowListen
         if (InstanceManager.getDefault(LogixNGPreferences.class).getStartLogixNGOnStartup()) {
             logixNG_Manager.activateAllLogixNGs();
         }
+        if (!GraphicsEnvironment.isHeadless()) {
+            JmriJFrame.checkWindowPositions();
+        }
 
         log.debug("End constructor");
     }

--- a/java/src/apps/AppsBase.java
+++ b/java/src/apps/AppsBase.java
@@ -122,6 +122,9 @@ public abstract class AppsBase {
         if (InstanceManager.getDefault(LogixNGPreferences.class).getStartLogixNGOnStartup()) {
             logixNG_Manager.activateAllLogixNGs();
         }
+        if (!java.awt.GraphicsEnvironment.isHeadless()) {
+            jmri.util.JmriJFrame.checkWindowPositions();
+        }
     }
 
     /**

--- a/java/src/jmri/configurexml/LoadXmlConfigAction.java
+++ b/java/src/jmri/configurexml/LoadXmlConfigAction.java
@@ -83,6 +83,9 @@ public class LoadXmlConfigAction extends LoadStoreBaseAction {
                         }
                     }
                 }
+                if (!java.awt.GraphicsEnvironment.isHeadless()) {
+                    jmri.util.JmriJFrame.checkWindowPositions();
+                }
             } catch (JmriException e) {
                 log.error("Unhandled problem in loadFile", e);  // NOI18N
             }

--- a/java/src/jmri/util/JmriJFrame.java
+++ b/java/src/jmri/util/JmriJFrame.java
@@ -1174,10 +1174,12 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
         final int minHeight = 50;
 
         for (GraphicsDevice gd : GraphicsEnvironment.getLocalGraphicsEnvironment().getScreenDevices()) {
+            int width = Math.min(minWidth, frame.getWidth());
+            int height = Math.min(minHeight, frame.getHeight());
             if (frame.getLocation().getX() >= gd.getDefaultConfiguration().getBounds().getMinX()
-                    && frame.getLocation().getX()+minWidth < gd.getDefaultConfiguration().getBounds().getMaxX()
+                    && frame.getLocation().getX()+width <= gd.getDefaultConfiguration().getBounds().getMaxX()
                     && frame.getLocation().getY() >= gd.getDefaultConfiguration().getBounds().getMinY()
-                    && frame.getLocation().getY()+minHeight < gd.getDefaultConfiguration().getBounds().getMaxY()) {
+                    && frame.getLocation().getY()+height <= gd.getDefaultConfiguration().getBounds().getMaxY()) {
                 return true;
             }
         }

--- a/java/src/jmri/util/UtilBundle.properties
+++ b/java/src/jmri/util/UtilBundle.properties
@@ -62,3 +62,7 @@ CompareUtil_CompareOperation_Equal              = is equal to
 CompareUtil_CompareOperation_GreaterThanOrEqual = is greater than or equal to
 CompareUtil_CompareOperation_GreaterThan        = is greater than
 CompareUtil_CompareOperation_NotEqual           = is not equal to
+
+JmriJFrame_UnreachableWindows       = Unreachable windows
+JmriJFrame_MoveSelectedWindows      = Move selected windows
+JmriJFrame_MoveAllWindows           = Move all windows


### PR DESCRIPTION
When a panel is loaded, check if all JmriJFrame's are visible on any screen. If not, give the user the option to move any or all the invisible windows to the main screen.