### PR TITLE
Jmri.server.json Test Updates

### DIFF
--- a/java/src/jmri/jmrit/roster/Roster.java
+++ b/java/src/jmri/jmrit/roster/Roster.java
@@ -1459,6 +1459,7 @@ public class Roster extends XmlFile implements RosterGroupSelector, PropertyChan
      *
      * @return the rosterGroups
      */
+    @Nonnull
     public HashMap<String, RosterGroup> getRosterGroups() {
         return new HashMap<>(rosterGroups);
     }

--- a/java/test/jmri/server/json/operations/JsonOperationsSocketServiceTest.java
+++ b/java/test/jmri/server/json/operations/JsonOperationsSocketServiceTest.java
@@ -587,7 +587,7 @@ public class JsonOperationsSocketServiceTest {
         JUnitUtil.tearDown();
     }
 
-    protected class InvalidJsonOperationsSocketService extends JsonOperationsSocketService {
+    static protected class InvalidJsonOperationsSocketService extends JsonOperationsSocketService {
 
         protected final HashMap<String, BeanListener<Train>> invalidBeanListeners = new HashMap<>();
         protected final InvalidBeansListener invalidBeansListener = new InvalidBeansListener();
@@ -598,7 +598,7 @@ public class JsonOperationsSocketServiceTest {
 
         protected class InvalidBeanListener extends BeanListener<Train> {
 
-            public InvalidBeanListener(Train bean) {
+            InvalidBeanListener(Train bean) {
                 super(bean);
             }
 

--- a/java/test/jmri/server/json/roster/JsonRosterSocketServiceTest.java
+++ b/java/test/jmri/server/json/roster/JsonRosterSocketServiceTest.java
@@ -115,7 +115,11 @@ public class JsonRosterSocketServiceTest {
 
         // rename a roster group and verify message sent by listener
         this.connection.sendMessage(null, 0);
-        Roster.getDefault().getRosterGroups().get("NewRosterGroup").setName("AgedRosterGroup");
+
+        var newRosterGroup = Roster.getDefault().getRosterGroups().get("NewRosterGroup");
+        Assertions.assertNotNull(newRosterGroup);
+
+        newRosterGroup.setName("AgedRosterGroup");
         Assert.assertEquals("Single message sent", 1, this.connection.getMessages().size());
         message = this.connection.getMessage();
         Assert.assertNotNull("Message was sent", message);

--- a/java/test/jmri/server/json/signalhead/JsonSignalHeadHttpServiceTest.java
+++ b/java/test/jmri/server/json/signalhead/JsonSignalHeadHttpServiceTest.java
@@ -74,8 +74,8 @@ public class JsonSignalHeadHttpServiceTest extends JsonHttpServiceTestBase<JsonS
         jmri.InstanceManager.getDefault(jmri.SignalHeadManager.class).register(s);
         assertNotNull(s);
 
-        JsonNode result = null;
-        JsonNode message = null;
+        JsonNode result;
+        JsonNode message;
 
         //set signalhead to Green and verify change
         message = mapper.createObjectNode().put(JSON.NAME, userName).put(JSON.STATE, SignalHead.GREEN);
@@ -86,11 +86,10 @@ public class JsonSignalHeadHttpServiceTest extends JsonHttpServiceTestBase<JsonS
 
         // try to set to FLASHLUNAR, which should not be allowed for this signalHead,
         //  so check for error, and verify state does not change
-        result = null;
-        message = null;
         try {
             message = mapper.createObjectNode().put(JSON.NAME, userName).put(JSON.STATE, SignalHead.FLASHLUNAR);
             result = service.doPost(JsonSignalHead.SIGNAL_HEAD, userName, message, new JsonRequest(locale, JSON.V5, JSON.GET, 42));
+            assertNotNull(result);
             fail("Expected exception not thrown");
         } catch (JsonException ex) {
             assertEquals(400, ex.getCode());
@@ -101,12 +100,14 @@ public class JsonSignalHeadHttpServiceTest extends JsonHttpServiceTestBase<JsonS
         // set signalmast to Held, then verify
         message = mapper.createObjectNode().put(JSON.NAME, userName).put(JSON.STATE, SignalHead.HELD);
         result = service.doPost(JsonSignalHead.SIGNAL_HEAD, userName, message, new JsonRequest(locale, JSON.V5, JSON.GET, 42));
+        assertNotNull(result);
         assertEquals(true, s.getHeld());
 
         assertEquals(true, s.getHeld());
         // set signalmast to something other than Held, then verify Held is released
         message = mapper.createObjectNode().put(JSON.NAME, userName).put(JSON.STATE, SignalHead.RED);
         result = service.doPost(JsonSignalHead.SIGNAL_HEAD, userName, message, new JsonRequest(locale, JSON.V5, JSON.GET, 42));
+        assertNotNull(result);
         assertEquals(false, s.getHeld());
     }
 

--- a/java/test/jmri/server/json/throttle/JsonThrottleTest.java
+++ b/java/test/jmri/server/json/throttle/JsonThrottleTest.java
@@ -46,6 +46,7 @@ public class JsonThrottleTest {
         service = new JsonThrottleSocketService(connection);
         try {
             t = JsonThrottle.getThrottle("42", data, service, 42);
+            Assertions.assertNotNull(t);
             Assert.fail("Expected exception not thrown");
         } catch (JsonException ex) {
             Assert.assertEquals("Error code is HTTP Bad Request", 400, ex.getCode());
@@ -58,6 +59,7 @@ public class JsonThrottleTest {
         service = new JsonThrottleSocketService(connection);
         try {
             t = JsonThrottle.getThrottle("42", data, service, 42);
+            Assertions.assertNotNull(t);
             Assert.fail("Expected exception not thrown");
         } catch (JsonException ex) {
             Assert.assertEquals("Error code is HTTP Not Found", 404, ex.getCode());
@@ -84,122 +86,14 @@ public class JsonThrottleTest {
         Throttle throttle = jsonThrottle.getThrottle();
         Assert.assertNotNull("has Throttle", throttle);
 
-        Assert.assertFalse(throttle.getF0());
-        data = connection.getObjectMapper().createObjectNode().put("F0", true);
-        jsonThrottle.onMessage(Locale.ENGLISH, data, service);
-        Assert.assertTrue(throttle.getF0());
-        Assert.assertFalse(throttle.getF1());
-        data = connection.getObjectMapper().createObjectNode().put("F1", true);
-        jsonThrottle.onMessage(Locale.ENGLISH, data, service);
-        Assert.assertTrue(throttle.getF1());
-        Assert.assertFalse(throttle.getF2());
-        data = connection.getObjectMapper().createObjectNode().put("F2", true);
-        jsonThrottle.onMessage(Locale.ENGLISH, data, service);
-        Assert.assertTrue(throttle.getF2());
-        Assert.assertFalse(throttle.getF3());
-        data = connection.getObjectMapper().createObjectNode().put("F3", true);
-        jsonThrottle.onMessage(Locale.ENGLISH, data, service);
-        Assert.assertTrue(throttle.getF3());
-        Assert.assertFalse(throttle.getF4());
-        data = connection.getObjectMapper().createObjectNode().put("F4", true);
-        jsonThrottle.onMessage(Locale.ENGLISH, data, service);
-        Assert.assertTrue(throttle.getF4());
-        Assert.assertFalse(throttle.getF5());
-        data = connection.getObjectMapper().createObjectNode().put("F5", true);
-        jsonThrottle.onMessage(Locale.ENGLISH, data, service);
-        Assert.assertTrue(throttle.getF5());
-        Assert.assertFalse(throttle.getF6());
-        data = connection.getObjectMapper().createObjectNode().put("F6", true);
-        jsonThrottle.onMessage(Locale.ENGLISH, data, service);
-        Assert.assertTrue(throttle.getF6());
-        Assert.assertFalse(throttle.getF7());
-        data = connection.getObjectMapper().createObjectNode().put("F7", true);
-        jsonThrottle.onMessage(Locale.ENGLISH, data, service);
-        Assert.assertTrue(throttle.getF7());
-        Assert.assertFalse(throttle.getF8());
-        data = connection.getObjectMapper().createObjectNode().put("F8", true);
-        jsonThrottle.onMessage(Locale.ENGLISH, data, service);
-        Assert.assertTrue(throttle.getF8());
-        Assert.assertFalse(throttle.getF9());
-        data = connection.getObjectMapper().createObjectNode().put("F9", true);
-        jsonThrottle.onMessage(Locale.ENGLISH, data, service);
-        Assert.assertTrue(throttle.getF9());
-        Assert.assertFalse(throttle.getF10());
-        data = connection.getObjectMapper().createObjectNode().put("F10", true);
-        jsonThrottle.onMessage(Locale.ENGLISH, data, service);
-        Assert.assertTrue(throttle.getF10());
-        Assert.assertFalse(throttle.getF11());
-        data = connection.getObjectMapper().createObjectNode().put("F11", true);
-        jsonThrottle.onMessage(Locale.ENGLISH, data, service);
-        Assert.assertTrue(throttle.getF11());
-        Assert.assertFalse(throttle.getF12());
-        data = connection.getObjectMapper().createObjectNode().put("F12", true);
-        jsonThrottle.onMessage(Locale.ENGLISH, data, service);
-        Assert.assertTrue(throttle.getF12());
-        Assert.assertFalse(throttle.getF13());
-        data = connection.getObjectMapper().createObjectNode().put("F13", true);
-        jsonThrottle.onMessage(Locale.ENGLISH, data, service);
-        Assert.assertTrue(throttle.getF13());
-        Assert.assertFalse(throttle.getF14());
-        data = connection.getObjectMapper().createObjectNode().put("F14", true);
-        jsonThrottle.onMessage(Locale.ENGLISH, data, service);
-        Assert.assertTrue(throttle.getF14());
-        Assert.assertFalse(throttle.getF15());
-        data = connection.getObjectMapper().createObjectNode().put("F15", true);
-        jsonThrottle.onMessage(Locale.ENGLISH, data, service);
-        Assert.assertTrue(throttle.getF15());
-        Assert.assertFalse(throttle.getF16());
-        data = connection.getObjectMapper().createObjectNode().put("F16", true);
-        jsonThrottle.onMessage(Locale.ENGLISH, data, service);
-        Assert.assertTrue(throttle.getF16());
-        Assert.assertFalse(throttle.getF17());
-        data = connection.getObjectMapper().createObjectNode().put("F17", true);
-        jsonThrottle.onMessage(Locale.ENGLISH, data, service);
-        Assert.assertTrue(throttle.getF17());
-        Assert.assertFalse(throttle.getF18());
-        data = connection.getObjectMapper().createObjectNode().put("F18", true);
-        jsonThrottle.onMessage(Locale.ENGLISH, data, service);
-        Assert.assertTrue(throttle.getF18());
-        Assert.assertFalse(throttle.getF19());
-        data = connection.getObjectMapper().createObjectNode().put("F19", true);
-        jsonThrottle.onMessage(Locale.ENGLISH, data, service);
-        Assert.assertTrue(throttle.getF19());
-        Assert.assertFalse(throttle.getF20());
-        data = connection.getObjectMapper().createObjectNode().put("F20", true);
-        jsonThrottle.onMessage(Locale.ENGLISH, data, service);
-        Assert.assertTrue(throttle.getF20());
-        Assert.assertFalse(throttle.getF21());
-        data = connection.getObjectMapper().createObjectNode().put("F21", true);
-        jsonThrottle.onMessage(Locale.ENGLISH, data, service);
-        Assert.assertTrue(throttle.getF21());
-        Assert.assertFalse(throttle.getF22());
-        data = connection.getObjectMapper().createObjectNode().put("F22", true);
-        jsonThrottle.onMessage(Locale.ENGLISH, data, service);
-        Assert.assertTrue(throttle.getF22());
-        Assert.assertFalse(throttle.getF23());
-        data = connection.getObjectMapper().createObjectNode().put("F23", true);
-        jsonThrottle.onMessage(Locale.ENGLISH, data, service);
-        Assert.assertTrue(throttle.getF23());
-        Assert.assertFalse(throttle.getF24());
-        data = connection.getObjectMapper().createObjectNode().put("F24", true);
-        jsonThrottle.onMessage(Locale.ENGLISH, data, service);
-        Assert.assertTrue(throttle.getF24());
-        Assert.assertFalse(throttle.getF25());
-        data = connection.getObjectMapper().createObjectNode().put("F25", true);
-        jsonThrottle.onMessage(Locale.ENGLISH, data, service);
-        Assert.assertTrue(throttle.getF25());
-        Assert.assertFalse(throttle.getF26());
-        data = connection.getObjectMapper().createObjectNode().put("F26", true);
-        jsonThrottle.onMessage(Locale.ENGLISH, data, service);
-        Assert.assertTrue(throttle.getF26());
-        Assert.assertFalse(throttle.getF27());
-        data = connection.getObjectMapper().createObjectNode().put("F27", true);
-        jsonThrottle.onMessage(Locale.ENGLISH, data, service);
-        Assert.assertTrue(throttle.getF27());
-        Assert.assertFalse(throttle.getF28());
-        data = connection.getObjectMapper().createObjectNode().put("F28", true);
-        jsonThrottle.onMessage(Locale.ENGLISH, data, service);
-        Assert.assertTrue(throttle.getF28());
+        for (int i = 0; i<29; i++) { // Functions 0 - 28
+            // System.out.println("testing " +i);
+            Assert.assertFalse(throttle.getFunction(i));
+            data = connection.getObjectMapper().createObjectNode().put("F" + i, true);
+            jsonThrottle.onMessage(Locale.ENGLISH, data, service);
+            Assert.assertTrue(throttle.getFunction(i));
+        }
+
     }
 
     @BeforeEach

--- a/java/test/jmri/server/json/util/JsonUtilHttpServiceTest.java
+++ b/java/test/jmri/server/json/util/JsonUtilHttpServiceTest.java
@@ -11,7 +11,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import java.awt.GraphicsEnvironment;
 import java.io.File;
 
 import javax.servlet.http.HttpServletResponse;
@@ -35,8 +34,8 @@ import jmri.util.node.NodeIdentity;
 import jmri.util.zeroconf.ZeroConfService;
 import jmri.web.server.WebServerPreferences;
 
-import org.junit.Assume;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.io.TempDir;
 
 /**
@@ -95,17 +94,17 @@ public class JsonUtilHttpServiceTest extends JsonHttpServiceTestBase<JsonUtilHtt
         ZeroConfService zcs = ZeroConfService.create(JSON.ZEROCONF_SERVICE_TYPE, 9999);
         JUnitUtil.waitFor(() -> {
             return zcs.isPublished() == false;
-        });
+        }, "zcs.isPublished did not go false");
         zcs.publish();
-        Assume.assumeTrue("Published ZeroConf Service", JUnitUtil.waitFor(() -> {
+        JUnitUtil.waitFor(() -> {
             return zcs.isPublished() == true;
-        }));
+        }, "Published ZeroConf Service");
         assertEquals(service.getNetworkService(JSON.ZEROCONF_SERVICE_TYPE, new JsonRequest (locale, JSON.V5, JSON.GET, 42)), service.doGet(JSON.NETWORK_SERVICE, JSON.ZEROCONF_SERVICE_TYPE,
                         NullNode.getInstance(), new JsonRequest(locale, JSON.V5, JSON.GET, 42)));
         zcs.stop();
         JUnitUtil.waitFor(() -> {
             return zcs.isPublished() == false;
-        });
+        },"zcs.isPublished did not go false after stop");
     }
 
     /**
@@ -218,11 +217,11 @@ public class JsonUtilHttpServiceTest extends JsonHttpServiceTestBase<JsonUtilHtt
         ZeroConfService zcs = ZeroConfService.create(JSON.ZEROCONF_SERVICE_TYPE, 9999);
         JUnitUtil.waitFor(() -> {
             return zcs.isPublished() == false;
-        });
+        },"zcs.isPublished did not go false");
         zcs.publish();
-        Assume.assumeTrue("Published ZeroConf Service", JUnitUtil.waitFor(() -> {
+        JUnitUtil.waitFor(() -> {
             return zcs.isPublished() == true;
-        }));
+        }, "Published ZeroConf Service");
         result = service.getNetworkServices(new JsonRequest(locale, JSON.V5, JSON.GET, 42));
         validate(result);
         assertEquals(1, result.size());
@@ -238,7 +237,7 @@ public class JsonUtilHttpServiceTest extends JsonHttpServiceTestBase<JsonUtilHtt
         zcs.stop();
         JUnitUtil.waitFor(() -> {
             return zcs.isPublished() == false;
-        });
+        },"zcs.isPublished did not go false after stop");
     }
 
     /**
@@ -306,11 +305,11 @@ public class JsonUtilHttpServiceTest extends JsonHttpServiceTestBase<JsonUtilHtt
      */
     @Test
     public void testGetNetworkService() throws JsonException {
-        JsonNode result = null;
+        JsonNode result;
         // non-existent service
         try {
             result = service.getNetworkService("non-existant-service", new JsonRequest(locale, JSON.V5, JSON.GET, 42)); // NOI18N
-            fail("Expected exception not thrown");
+            fail("Expected exception not thrown " + result);
         } catch (JsonException ex) {
             assertEquals(HttpServletResponse.SC_NOT_FOUND, ex.getCode());
         }
@@ -318,11 +317,11 @@ public class JsonUtilHttpServiceTest extends JsonHttpServiceTestBase<JsonUtilHtt
         ZeroConfService zcs = ZeroConfService.create(JSON.ZEROCONF_SERVICE_TYPE, 9999);
         JUnitUtil.waitFor(() -> {
             return zcs.isPublished() == false;
-        });
+        },"zcs.isPublished did not go false");
         zcs.publish();
-        Assume.assumeTrue("Published ZeroConf Service", JUnitUtil.waitFor(() -> {
+        JUnitUtil.waitFor(() -> {
             return zcs.isPublished() == true;
-        }));
+        }, "Published ZeroConf Service");
         result = service.getNetworkService(JSON.ZEROCONF_SERVICE_TYPE, new JsonRequest(locale, JSON.V5, JSON.GET, 42));
         validate(result);
         assertEquals(JSON.NETWORK_SERVICE, result.path(JSON.TYPE).asText());
@@ -337,7 +336,7 @@ public class JsonUtilHttpServiceTest extends JsonHttpServiceTestBase<JsonUtilHtt
         zcs.stop();
         JUnitUtil.waitFor(() -> {
             return zcs.isPublished() == false;
-        });
+        },"zcs.isPublished did not go false after stop");
     }
 
     /**
@@ -360,8 +359,8 @@ public class JsonUtilHttpServiceTest extends JsonHttpServiceTestBase<JsonUtilHtt
      * @throws jmri.server.json.JsonException if the result cannot be validated
      */
     @Test
+    @DisabledIfSystemProperty( named = "java.awt.headless", matches = "true" )
     public void testGetPanel() throws JsonException {
-        Assume.assumeFalse("Needs GUI", GraphicsEnvironment.isHeadless());
         Editor editor = new SwitchboardEditor("test");
         ObjectNode result = service.getPanel(editor, JSON.XML, 42);
         validate(result);
@@ -375,8 +374,8 @@ public class JsonUtilHttpServiceTest extends JsonHttpServiceTestBase<JsonUtilHtt
      * @throws jmri.server.json.JsonException if the result cannot be validated
      */
     @Test
+    @DisabledIfSystemProperty( named = "java.awt.headless", matches = "true" )
     public void testGetPanels_Locale_String() throws JsonException {
-        Assume.assumeFalse("Needs GUI", GraphicsEnvironment.isHeadless());
         Editor editor = new SwitchboardEditor("test");
         JsonNode result = service.getPanels(JSON.XML, 42);
         validate(result);
@@ -390,8 +389,8 @@ public class JsonUtilHttpServiceTest extends JsonHttpServiceTestBase<JsonUtilHtt
      * @throws jmri.server.json.JsonException if the result cannot be validated
      */
     @Test
+    @DisabledIfSystemProperty( named = "java.awt.headless", matches = "true" )
     public void testGetPanels_Locale() throws JsonException {
-        Assume.assumeFalse("Needs GUI", GraphicsEnvironment.isHeadless());
         Editor editor = new SwitchboardEditor("test");
         JsonNode result = service.getPanels(42);
         validate(result);


### PR DESCRIPTION
Roster.java ( actual class, not test ) - Add Nonnull annotation to a method return

JsonRosterSocketServiceTest - Add nonNull asserts
JsonOperationsSocketServiceTest - InvalidJsonOperationsSocketService can be static class
JsonSignalHeadHttpServiceTest - Remove unused calls to set variables null, Add nullChecks
JsonThrottleTest - use loop in functions test to remove deprecated calls
JsonUtilHttpServiceTest - update headless check, add JUnitUtil.waitFor failure messages