### PR TITLE
Update NamedBeanComboBox, JmriJTablePersistenceManager, RowSorterUtil Tests

### DIFF
--- a/java/test/jmri/swing/JmriJTablePersistenceManagerTest.java
+++ b/java/test/jmri/swing/JmriJTablePersistenceManagerTest.java
@@ -22,11 +22,8 @@ import jmri.util.JUnitUtil;
 import jmri.util.node.NodeIdentity;
 import jmri.util.prefs.InitializationException;
 
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.*;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.jupiter.api.io.TempDir;
 
 /**
@@ -38,56 +35,33 @@ import org.junit.jupiter.api.io.TempDir;
  */
 public class JmriJTablePersistenceManagerTest {
 
-    @BeforeAll
-    public static void setUpClass() throws Exception {
-    }
-
-    @AfterAll
-    public static void tearDownClass() throws Exception {
-    }
-
-    @BeforeEach
-    public void setUp(@TempDir File folder) throws IOException {
-        JUnitUtil.setUp();
-        JUnitUtil.resetProfileManager(new NullProfile(folder));
-    }
-
-    @AfterEach
-    public void tearDown() {
-        JUnitUtil.tearDown();
-    }
-
     /**
      * Test of persist method, of class JmriJTablePersistenceManager. This tests
      * persistence by verifying that tables get the expected listeners attached.
+     * @throws Exception on test error.
      */
     @Test
-    public void testPersist() {
+    public void testPersist() throws Exception {
         JmriJTablePersistenceManagerSpy instance = new JmriJTablePersistenceManagerSpy();
-        // null table
-        JTable table = null;
-        try {
-            instance.persist(table);
-            Assert.fail("did not throw NPE on null table");
-        } catch (NullPointerException ex) {
-            // passes
-        }
+
+        Exception exc = Assertions.assertThrows(NullPointerException.class,() -> {
+            persistNullTable(instance);
+        });
+        Assertions.assertNotNull(exc);
+
         // null table name
-        table = testTable(null);
-        try {
+        JTable table = testTable(null);
+        exc = Assertions.assertThrows(NullPointerException.class,() -> {
             instance.persist(table);
-            Assert.fail("did not throw NPE on table with null name");
-        } catch (NullPointerException ex) {
-            // passes
-        }
+        });
+        Assertions.assertNotNull(exc, "did not throw NPE on table with null name");
+
         // correct table
         table.setName("test name");
-        try {
+        Assertions.assertDoesNotThrow(() -> {
             instance.persist(table);
-            // passes
-        } catch (NullPointerException ex) {
-            Assert.fail("threw unexpected NPE");
-        }
+        });
+
         int managers = 0;
         int tableListeners = 0;
         int columnListeners = 0;
@@ -108,12 +82,10 @@ public class JmriJTablePersistenceManagerTest {
         Assert.assertEquals(1, tableListeners);
         Assert.assertEquals(1, columnListeners);
         // allow table twice
-        try {
+        Assertions.assertDoesNotThrow(() -> {
             instance.persist(table);
-            // passes
-        } catch (IllegalArgumentException ex) {
-            Assert.fail("threw unexpected IllegalArgumentException");
-        }
+        });
+
         managers = 0;
         tableListeners = 0;
         columnListeners = 0;
@@ -136,20 +108,17 @@ public class JmriJTablePersistenceManagerTest {
         // duplicate table name
         JTable table2 = testTable("test name");
         table2.setRowSorter(new TableRowSorter<>(table2.getModel()));
-        try {
+        
+        exc = Assertions.assertThrows(IllegalArgumentException.class,() -> {
             instance.persist(table2);
-            Assert.fail("Accepted duplicate name");
-        } catch (IllegalArgumentException ex) {
-            // passes
-        }
+        },"Accepted duplicate name");
+        Assertions.assertNotNull(exc, "did not throw NPE on table with null name");
+
         // a second table
         table2.setName("test name 2");
-        try {
+        Assertions.assertDoesNotThrow(() -> {
             instance.persist(table2);
-            // passes
-        } catch (IllegalArgumentException ex) {
-            Assert.fail("threw unexpected IllegalArgumentException");
-        }
+        });
         managers = 0;
         tableListeners = 0;
         columnListeners = 0;
@@ -171,6 +140,14 @@ public class JmriJTablePersistenceManagerTest {
         Assert.assertEquals(1, columnListeners);
     }
 
+    @SuppressWarnings("null")
+    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings( value = {"NP_NONNULL_PARAM_VIOLATION","NP_LOAD_OF_KNOWN_NULL_VALUE"},
+        justification = "testing exception when null passed")
+    private void persistNullTable(JmriJTablePersistenceManagerSpy instance) throws Exception {
+        JTable nullTable = null;
+        instance.persist(nullTable);
+    }
+    
     /**
      * Test of stopPersisting method, of class JmriJTablePersistenceManager.
      */
@@ -178,12 +155,9 @@ public class JmriJTablePersistenceManagerTest {
     public void testStopPersisting() {
         JmriJTablePersistenceManagerSpy instance = new JmriJTablePersistenceManagerSpy();
         JTable table = testTable("test name");
-        try {
+        Assertions.assertDoesNotThrow(() -> {
             instance.persist(table);
-            // passes
-        } catch (NullPointerException ex) {
-            Assert.fail("threw unexpected NPE");
-        }
+        });
         int managers = 0;
         int tableListeners = 0;
         int columnListeners = 0;
@@ -203,12 +177,10 @@ public class JmriJTablePersistenceManagerTest {
         Assert.assertEquals(1, managers);
         Assert.assertEquals(1, tableListeners);
         Assert.assertEquals(1, columnListeners);
-        try {
+        Assertions.assertDoesNotThrow(() -> {
             instance.stopPersisting(table);
-            // passes
-        } catch (NullPointerException ex) {
-            Assert.fail("threw unexpected NPE");
-        }
+        });
+
         for (PropertyChangeListener listener : table.getColumn("c0").getPropertyChangeListeners()) {
             if (listener.equals(instance.getListener(table))) {
                 columnListeners++;
@@ -267,9 +239,11 @@ public class JmriJTablePersistenceManagerTest {
         Assert.assertTrue("Dirty manager", instance.isDirty());
         Assert.assertEquals("Column c1 is default width", table.getColumnModel().getColumn(1).getWidth(), instance.getColumnsMap(table.getName()).get("c1").getPreferredWidth());
         table.getColumnModel().getColumn(1).setPreferredWidth(100);
+        var columnc1 = instance.getColumnsMap(table.getName()).get("c1");
+        Assertions.assertNotNull(columnc1);
         Assert.assertNotEquals("Column c1 width not persisted width",
                 table.getColumnModel().getColumn(1).getPreferredWidth(),
-                instance.getColumnsMap(table.getName()).get("c1").getPreferredWidth());
+                columnc1.getPreferredWidth());
         instance.cacheState(table);
         Assert.assertEquals("Column c1 is 100 width", table.getColumnModel().getColumn(1).getPreferredWidth(), instance.getColumnsMap(table.getName()).get("c1").getPreferredWidth());
     }
@@ -295,12 +269,18 @@ public class JmriJTablePersistenceManagerTest {
         Assert.assertFalse("Clean manager", instance.isDirty());
         Assert.assertEquals("State for column c0 is narrow", 50, instance.getColumnsMap(table.getName()).get("c0").getPreferredWidth());
         Assert.assertEquals("State for column c1 is wide", 100, instance.getColumnsMap(table.getName()).get("c1").getPreferredWidth());
+        
+        var columnc0 = instance.getColumnsMap(table.getName()).get("c0");
+        var columnc1 = instance.getColumnsMap(table.getName()).get("c1");
+        Assertions.assertNotNull(columnc0);
+        Assertions.assertNotNull(columnc1);
+        
         Assert.assertNotEquals("Column c0 width not persisted width",
                 table.getColumnModel().getColumn(0).getPreferredWidth(),
-                instance.getColumnsMap(table.getName()).get("c0").getPreferredWidth());
+                columnc0.getPreferredWidth());
         Assert.assertNotEquals("Column c1 width not persisted width",
                 table.getColumnModel().getColumn(1).getPreferredWidth(),
-                instance.getColumnsMap(table.getName()).get("c1").getPreferredWidth());
+                columnc1.getPreferredWidth());
         instance.resetState(table);
         Assert.assertEquals("Column c0 is 50 width", 50, c0.getPreferredWidth());
         Assert.assertEquals("Column c1 is 100 width", 100, c1.getPreferredWidth());
@@ -338,7 +318,7 @@ public class JmriJTablePersistenceManagerTest {
     @Test
     public void testInitialize_EmptyProfile() {
         Profile profile = ProfileManager.getDefault().getActiveProfile();
-        Assume.assumeNotNull("Profile is not null", profile);
+        Assert.assertNotNull("Profile is not null", profile);
         JmriJTablePersistenceManagerSpy instance = new JmriJTablePersistenceManagerSpy();
         try {
             instance.initialize(profile);
@@ -365,9 +345,14 @@ public class JmriJTablePersistenceManagerTest {
         Profile profile = ProfileManager.getDefault().getActiveProfile();
         Assert.assertNotNull(profile); // test requires non-null profile
         // copy preferences into profile
-        File source = new File(ClassLoader.getSystemResource("jmri/swing/JmriJTablePersistenceManagerTest-user-interface.xml").toURI());
+        var classLoaderUIxml = ClassLoader.getSystemResource("jmri/swing/JmriJTablePersistenceManagerTest-user-interface.xml");
+        Assertions.assertNotNull(classLoaderUIxml);
+        File source = new File(classLoaderUIxml.toURI());
         File target = new File(new File(new File(profile.getPath(), Profile.PROFILE), NodeIdentity.storageIdentity()), Profile.UI_CONFIG);
-        FileUtil.createDirectory(target.getParentFile());
+        Assertions.assertNotNull(target);
+        var parentFile = target.getParentFile();
+        Assertions.assertNotNull(parentFile);
+        FileUtil.createDirectory(parentFile);
         FileUtil.copy(source, target);
         JmriJTablePersistenceManagerSpy instance = new JmriJTablePersistenceManagerSpy();
         try {
@@ -411,10 +396,10 @@ public class JmriJTablePersistenceManagerTest {
     @Test
     @Disabled("test code is incomplete prototype")
     public void testSavePreferences() {
-        System.out.println("savePreferences");
-        Profile profile = null;
-        JmriJTablePersistenceManager instance = new JmriJTablePersistenceManager();
-        instance.savePreferences(profile);
+        // System.out.println("savePreferences");
+        // Profile profile = null;
+        // JmriJTablePersistenceManager instance = new JmriJTablePersistenceManager();
+        // instance.savePreferences(profile);
         // TODO review the generated test code and remove the default call to fail.
         Assert.fail("The test case is a prototype.");
     }
@@ -477,12 +462,10 @@ public class JmriJTablePersistenceManagerTest {
         String name1 = "test name";
         String name2 = "name test";
         JTable table = testTable(name1);
-        try {
+        Assertions.assertDoesNotThrow(() -> {
             instance.persist(table);
-            // passes
-        } catch (NullPointerException ex) {
-            Assert.fail("threw unexpected NPE");
-        }
+        });
+
         Assert.assertNotNull(instance.getListener(name1));
         Assert.assertNull(instance.getListener(name2));
         table.setName(name2);
@@ -594,6 +577,17 @@ public class JmriJTablePersistenceManagerTest {
         table.getColumnModel().getColumn(1).setHeaderValue("c1");
         table.setName(name);
         return table;
+    }
+
+    @BeforeEach
+    public void setUp(@TempDir File folder) throws IOException {
+        JUnitUtil.setUp();
+        JUnitUtil.resetProfileManager(new NullProfile(folder));
+    }
+
+    @AfterEach
+    public void tearDown() {
+        JUnitUtil.tearDown();
     }
 
     private final static class JmriJTablePersistenceManagerSpy extends JmriJTablePersistenceManager {

--- a/java/test/jmri/swing/NamedBeanComboBoxTest.java
+++ b/java/test/jmri/swing/NamedBeanComboBoxTest.java
@@ -1,9 +1,7 @@
 package jmri.swing;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assumptions.assumeThat;
 
-import java.awt.GraphicsEnvironment;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -16,9 +14,7 @@ import com.alexandriasoftware.swing.JInputValidator;
 import com.alexandriasoftware.swing.Validation;
 
 import org.assertj.swing.edt.GuiActionRunner;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 
 import jmri.InstanceManager;
 import jmri.Manager;
@@ -27,25 +23,26 @@ import jmri.SensorManager;
 import jmri.NamedBean.DisplayOptions;
 import jmri.util.JUnitUtil;
 
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
 /**
  *
  * @author Bob Jacobsen Copyright (C) 2017
  * @author Randall Wood Copyright (C) 2019
  */
+@DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
 public class NamedBeanComboBoxTest {
 
     @Test
     public void testSensorSimpleCtor() {
-        assumeThat(GraphicsEnvironment.isHeadless()).isFalse();
-        Manager<Sensor> m = InstanceManager.getDefault(jmri.SensorManager.class);
+        Manager<Sensor> m = InstanceManager.getDefault(SensorManager.class);
         NamedBeanComboBox<Sensor> t = GuiActionRunner.execute(() -> new NamedBeanComboBox<>(m));
         assertThat(t).as("exists").isNotNull();
     }
 
     @Test
     public void testSensorFullCtor() {
-        assumeThat(GraphicsEnvironment.isHeadless()).isFalse();
-        SensorManager m = InstanceManager.getDefault(jmri.SensorManager.class);
+        SensorManager m = InstanceManager.getDefault(SensorManager.class);
         m.provideSensor("IS1").setUserName("Sensor 1");
         Sensor s = m.provideSensor("IS2");
         s.setUserName("Sensor 2");
@@ -53,7 +50,7 @@ public class NamedBeanComboBoxTest {
 
         NamedBeanComboBox<Sensor> t = GuiActionRunner.execute(() -> new NamedBeanComboBox<>(m, s, DisplayOptions.DISPLAYNAME));
 
-        assertThat(t).as("exists").isNotNull();
+        Assertions.assertNotNull(t);
         assertThat(t.getSelectedItem()).isEqualTo(s);
         assertThat(t.getSelectedItemUserName()).isEqualTo("Sensor 2");
         assertThat(t.getSelectedItemSystemName()).isEqualTo("IS2");
@@ -68,8 +65,7 @@ public class NamedBeanComboBoxTest {
 
     @Test
     public void testSensorSelectEntry() {
-        assumeThat(GraphicsEnvironment.isHeadless()).isFalse();
-        SensorManager m = InstanceManager.getDefault(jmri.SensorManager.class);
+        SensorManager m = InstanceManager.getDefault(SensorManager.class);
         Sensor s1 = m.provideSensor("IS1");
         s1.setUserName("Sensor 1");
         Sensor s2 = m.provideSensor("IS2");
@@ -83,7 +79,7 @@ public class NamedBeanComboBoxTest {
             b.setSelectedItem(s3);
             return b;
         });
-        assertThat(t).as("exists").isNotNull();
+        Assertions.assertNotNull(t);
 
         assertThat(t.getSelectedItem()).isEqualTo(s3);
         assertThat(t.getSelectedItemUserName()).isEqualTo("Sensor 3");
@@ -94,7 +90,6 @@ public class NamedBeanComboBoxTest {
 
     @Test
     public void testSensorUserNameMixThatCausedProblems() {
-        assumeThat(GraphicsEnvironment.isHeadless()).isFalse();
         // add an LS manager
         ((jmri.managers.ProxySensorManager) InstanceManager.getDefault(SensorManager.class)).getDefaultManager();
         var lsm = new jmri.jmrix.internal.InternalSensorManager(
@@ -120,7 +115,7 @@ public class NamedBeanComboBoxTest {
             b.setSelectedItem(is102);
             return b;
         });
-        assertThat(t).as("exists").isNotNull();
+        Assertions.assertNotNull(t);
 
         assertThat(t.getSelectedItem()).isEqualTo(is102);
         assertThat(t.getSelectedItemUserName()).isEqualTo("IS102");
@@ -152,8 +147,7 @@ public class NamedBeanComboBoxTest {
 
     @Test
     public void testSensorExcludeSome() {
-        assumeThat(GraphicsEnvironment.isHeadless()).isFalse();
-        SensorManager m = InstanceManager.getDefault(jmri.SensorManager.class);
+        SensorManager m = InstanceManager.getDefault(SensorManager.class);
         Sensor s1 = m.provideSensor("IS1");
         s1.setUserName("Sensor 1");
         Sensor s2 = m.provideSensor("IS2");
@@ -185,8 +179,7 @@ public class NamedBeanComboBoxTest {
 
     @Test
     public void testSensorChangeDisplayMode() {
-        assumeThat(GraphicsEnvironment.isHeadless()).isFalse();
-        SensorManager m = InstanceManager.getDefault(jmri.SensorManager.class);
+        SensorManager m = InstanceManager.getDefault(SensorManager.class);
         Sensor s1 = m.provideSensor("IS1");
         s1.setUserName("Sensor 1");
 
@@ -208,10 +201,9 @@ public class NamedBeanComboBoxTest {
 
     @Test
     public void testSensorSetAndDefaultValidate() {
-        assumeThat(GraphicsEnvironment.isHeadless()).isFalse();
-        Manager<Sensor> m = InstanceManager.getDefault(jmri.SensorManager.class);
+        Manager<Sensor> m = InstanceManager.getDefault(SensorManager.class);
         NamedBeanComboBox<Sensor> t = GuiActionRunner.execute(() -> new NamedBeanComboBox<>(m));
-        assertThat(t).isNotNull();
+        Assertions.assertNotNull(t);
 
         assertThat(t.isValidatingInput()).isTrue();
 
@@ -223,15 +215,14 @@ public class NamedBeanComboBoxTest {
 
     }
 
-    static int countContents;
-    static int countAdded;
-    static int countRemoved;
-    static Manager.ManagerDataEvent<Sensor> lastEvent;
+    private int countContents;
+    private int countAdded;
+    private int countRemoved;
+    private Manager.ManagerDataEvent<Sensor> lastEvent;
 
     @Test
     public void testDataUpdatesForNewDataModel() {
-        assumeThat(GraphicsEnvironment.isHeadless()).isFalse();
-        SensorManager m = InstanceManager.getDefault(jmri.SensorManager.class);
+        SensorManager m = InstanceManager.getDefault(SensorManager.class);
 
         Manager.ManagerDataListener<Sensor> listener = new Manager.ManagerDataListener<Sensor>() {
             @Override
@@ -262,6 +253,7 @@ public class NamedBeanComboBoxTest {
         assertThat(countAdded).isEqualTo(1);
         assertThat(countRemoved).isEqualTo(0);
 
+        Assertions.assertNotNull(lastEvent);
         assertThat(lastEvent.getIndex0()).isEqualTo(0);  // new element 0
         assertThat(lastEvent.getIndex1()).isEqualTo(0);
 
@@ -274,6 +266,7 @@ public class NamedBeanComboBoxTest {
         assertThat(countAdded).isEqualTo(1);
         assertThat(countRemoved).isEqualTo(0);
 
+        Assertions.assertNotNull(lastEvent);
         assertThat(lastEvent.getIndex0()).isEqualTo(1);  // new element 1
         assertThat(lastEvent.getIndex1()).isEqualTo(1);
 
@@ -286,17 +279,17 @@ public class NamedBeanComboBoxTest {
         assertThat(countAdded).isEqualTo(1);
         assertThat(countRemoved).isEqualTo(0);
 
+        Assertions.assertNotNull(lastEvent);
         assertThat(lastEvent.getIndex0()).isEqualTo(0);  // new element 0
         assertThat(lastEvent.getIndex1()).isEqualTo(0);
     }
 
     @Test
     public void testSensorAllowEdit() {
-        assumeThat(GraphicsEnvironment.isHeadless()).isFalse();
         SensorManager m = InstanceManager.getDefault(jmri.SensorManager.class);
         assertThat(m.getNamedBeanSet().isEmpty()).isTrue();
         NamedBeanComboBox<Sensor> t = GuiActionRunner.execute(() -> new NamedBeanComboBox<>(m));
-        assertThat(t).isNotNull();
+        Assertions.assertNotNull(t);
         assertThat(t.isAllowNull()).isFalse();
         assertThat(t.getModel().getSize()).isEqualTo(0);
         GuiActionRunner.execute(() -> {
@@ -325,7 +318,6 @@ public class NamedBeanComboBoxTest {
     public void testSensorEditText()
             throws IllegalAccessException, IllegalArgumentException, InvocationTargetException, NoSuchMethodException,
             SecurityException {
-        assumeThat(GraphicsEnvironment.isHeadless()).isFalse();
         SensorManager m = InstanceManager.getDefault(jmri.SensorManager.class);
         Sensor s1 = m.provideSensor("IS1");
         s1.setUserName("Sensor 1");
@@ -351,7 +343,6 @@ public class NamedBeanComboBoxTest {
     public void testSensorTestProvidingValidity()
             throws IllegalAccessException, IllegalArgumentException, InvocationTargetException, NoSuchMethodException,
             SecurityException {
-        assumeThat(GraphicsEnvironment.isHeadless()).isFalse();
         SensorManager m = InstanceManager.getDefault(jmri.SensorManager.class);
         NamedBeanComboBox<Sensor> t = GuiActionRunner.execute(() -> {
             NamedBeanComboBox<Sensor> b = new NamedBeanComboBox<>(m);
@@ -361,9 +352,9 @@ public class NamedBeanComboBoxTest {
             b.setProviding(true);
             return b;
         });
-        assertThat(t).isNotNull();
+        Assertions.assertNotNull(t);
         JTextField c = GuiActionRunner.execute(() -> (JTextField) t.getEditor().getEditorComponent());
-        assertThat(c).isNotNull();
+        Assertions.assertNotNull(c);
 
         // test with no matching bean and isValidatingInput() == false
         // should always match NONE
@@ -384,6 +375,7 @@ public class NamedBeanComboBoxTest {
         assertThat(c.getText()).isEqualTo("IS1");
         assertThat(((JInputValidator) c.getInputVerifier()).getValidation().getType()).isEqualTo(Validation.Type.NONE);
         Sensor s1 = GuiActionRunner.execute(() -> t.getSelectedItem());
+        Assertions.assertNotNull(s1);
         assertThat(m.getBySystemName("IS1")).isEqualTo(s1);
 
         GuiActionRunner.execute(() -> {
@@ -416,6 +408,7 @@ public class NamedBeanComboBoxTest {
         assertThat(c.getText()).isEqualTo("IS1");
         assertThat(((JInputValidator) c.getInputVerifier()).getValidation().getType()).isEqualTo(Validation.Type.INFORMATION);
         s1 = GuiActionRunner.execute(() -> t.getSelectedItem());
+        Assertions.assertNotNull(s1);
         assertThat(m.getBySystemName("IS1")).isEqualTo(s1);
 
         GuiActionRunner.execute(() -> {
@@ -448,6 +441,7 @@ public class NamedBeanComboBoxTest {
         assertThat(c.getText()).isEqualTo("IS1");
         assertThat(((JInputValidator) c.getInputVerifier()).getValidation().getType()).isEqualTo(Validation.Type.NONE);
         s1 = GuiActionRunner.execute(() -> t.getSelectedItem());
+        Assertions.assertNotNull(s1);
         assertThat(m.getBySystemName("IS1")).isEqualTo(s1);
 
         GuiActionRunner.execute(() -> {
@@ -497,7 +491,6 @@ public class NamedBeanComboBoxTest {
     public void testSensorTestNonProvidingValidity()
             throws IllegalAccessException, IllegalArgumentException, InvocationTargetException, NoSuchMethodException,
             SecurityException {
-        assumeThat(GraphicsEnvironment.isHeadless()).isFalse();
         SensorManager m = InstanceManager.getDefault(jmri.SensorManager.class);
         NamedBeanComboBox<Sensor> t = GuiActionRunner.execute(() -> {
             NamedBeanComboBox<Sensor> b = new NamedBeanComboBox<>(m);
@@ -507,9 +500,9 @@ public class NamedBeanComboBoxTest {
             b.setProviding(false);
             return b;
         });
-        assertThat(t).isNotNull();
+        Assertions.assertNotNull(t);
         JTextField c = GuiActionRunner.execute(() -> ((JTextField) t.getEditor().getEditorComponent()));
-        assertThat(c).isNotNull();
+        Assertions.assertNotNull(c);
 
         // test with no matching bean and isValidatingInput() == false
         // should always match NONE
@@ -642,7 +635,6 @@ public class NamedBeanComboBoxTest {
 
     @Test
     public void testSensorSetBean() {
-        assumeThat(GraphicsEnvironment.isHeadless()).isFalse();
         SensorManager m = InstanceManager.getDefault(jmri.SensorManager.class);
         Sensor s1 = m.provideSensor("IS1");
         s1.setUserName("Sensor 1");
@@ -677,12 +669,11 @@ public class NamedBeanComboBoxTest {
 
     @Test
     public void testSensorNameChange() {
-        assumeThat(GraphicsEnvironment.isHeadless()).isFalse();
         SensorManager m = InstanceManager.getDefault(jmri.SensorManager.class);
         Sensor s1 = m.provideSensor("IS1");
 
         NamedBeanComboBox<Sensor> t = GuiActionRunner.execute(() -> new NamedBeanComboBox<>(m, s1, DisplayOptions.DISPLAYNAME));
-        assertThat(t).isNotNull();
+        Assertions.assertNotNull(t);
         assertThat(t.getSelectedItemDisplayName()).isEqualTo("IS1");
 
         s1.setUserName("Sensor 1");
@@ -699,7 +690,7 @@ public class NamedBeanComboBoxTest {
         s1.setUserName("Sensor 1");
 
         NamedBeanComboBox<Sensor> t = GuiActionRunner.execute(() -> new NamedBeanComboBox<>(m, s1, DisplayOptions.DISPLAYNAME));
-        assertThat(t).isNotNull();
+        Assertions.assertNotNull(t);
         assertThat(t.getItemCount()).isEqualTo(1);
 
         GuiActionRunner.execute(() -> {
@@ -717,10 +708,9 @@ public class NamedBeanComboBoxTest {
 
     @Test
     public void testIsProviding() {
-        assumeThat(GraphicsEnvironment.isHeadless()).isFalse();
         SensorManager m = InstanceManager.getDefault(jmri.SensorManager.class);
         NamedBeanComboBox<Sensor> t = GuiActionRunner.execute(() -> new NamedBeanComboBox<>(m));
-        assertThat(t).isNotNull();
+        Assertions.assertNotNull(t);
         assertThat(t.isProviding()).isTrue();
         t.setProviding(false);
         assertThat(t.isProviding()).isFalse();
@@ -730,16 +720,14 @@ public class NamedBeanComboBoxTest {
 
     @Test
     public void testGetManager() {
-        assumeThat(GraphicsEnvironment.isHeadless()).isFalse();
         SensorManager m = InstanceManager.getDefault(jmri.SensorManager.class);
         NamedBeanComboBox<Sensor> t = GuiActionRunner.execute(() -> new NamedBeanComboBox<>(m));
-        assertThat(t).isNotNull();
+        Assertions.assertNotNull(t);
         assertThat(t.getManager()).as("Manager is as expected").isEqualTo(m);
     }
 
     @Test
     public void testDispose() {
-        assumeThat(GraphicsEnvironment.isHeadless()).isFalse();
         SensorManager m = InstanceManager.getDefault(jmri.SensorManager.class);
         assertThat(m.getPropertyChangeListeners().length).as("Manager has no listeners").isEqualTo(0);
         GuiActionRunner.execute(() -> {

--- a/java/test/jmri/swing/RowSorterUtilTest.java
+++ b/java/test/jmri/swing/RowSorterUtilTest.java
@@ -1,8 +1,11 @@
 package jmri.swing;
 
+import javax.swing.*;
+import javax.swing.table.TableModel;
+import javax.swing.table.TableRowSorter;
+
 import jmri.util.JUnitUtil;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.*;
 
 /**
@@ -11,10 +14,16 @@ import org.junit.jupiter.api.*;
  */
 public class RowSorterUtilTest {
 
+    // no testCtor as tested class only supplies static methods
+
     @Test
-    public void testCTor() {
-        RowSorterUtil t = new RowSorterUtil();
-        Assert.assertNotNull("exists",t);
+    public void testUnsortedByDefault() {
+        JTable table = new JTable();
+        table.setName("Test Sorter Table");
+        RowSorter<? extends TableModel> sorter = new TableRowSorter<>(table.getModel());
+        SortOrder so = RowSorterUtil.getSortOrder(sorter, 0);
+        Assertions.assertNotNull(so);
+        Assertions.assertEquals(SortOrder.UNSORTED, so);
     }
 
     @BeforeEach


### PR DESCRIPTION
RowSorterUtilTest - add test for default sort order

NamedBeanComboBoxTest - 
no need for listener variables to be static
update headless checks
nonNull assertions

JmriJTablePersistenceManagerTest -
remove empty methods
move setUp / tearDown to end of class
update exception assertions
nonNull checks