### PR TITLE
Update spotbugs to 4.7.2

### DIFF
--- a/.spotbugs-check.xml
+++ b/.spotbugs-check.xml
@@ -11,6 +11,8 @@
            <Bug pattern="IS2_INCONSISTENT_SYNC" />
            <Bug pattern="OVERRIDING_METHODS_MUST_INVOKE_SUPER" />
            <Bug pattern="DCN_NULLPOINTER_EXCEPTION" /> <!-- 327 cases -->
+           <Bug pattern="FL_FLOATS_AS_LOOP_COUNTERS" />
+           <Bug pattern="SSD_DO_NOT_USE_INSTANCE_LOCK_ON_SHARED_STATIC_DATA" />
         </Or>
      </Match>
 
@@ -21,7 +23,6 @@
            <Bug pattern="IS2_INCONSISTENT_SYNC" />
            <Bug pattern="NO_NOTIFY_NOT_NOTIFYALL" />
            <Bug pattern="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE" />
-           <Bug pattern="ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD" />
            <Bug pattern="UW_UNCOND_WAIT" />
            <Bug pattern="WA_NOT_IN_LOOP" />
         </Or>

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -583,6 +583,6 @@
     <h3>Miscellaneous</h3>
         <a id="Misc" name="Misc"></a>
         <ul>
-            <li></li>
+            <li>SpotBugs has been updated to 4.7.1</li>
         </ul>
 

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -583,6 +583,6 @@
     <h3>Miscellaneous</h3>
         <a id="Misc" name="Misc"></a>
         <ul>
-            <li>SpotBugs has been updated to 4.7.1</li>
+            <li>SpotBugs has been updated to 4.7.2</li>
         </ul>
 

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
                     <plugin>
                         <groupId>com.github.spotbugs</groupId>
                         <artifactId>spotbugs-maven-plugin</artifactId>
-                        <version>4.5.0.0</version>
+                        <version>4.7.1</version>
                         <configuration>
                             <plugins>
                                 <plugin>
@@ -474,7 +474,7 @@
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
-                <version>4.5.0.0</version>
+                <version>4.7.1</version>
                 <!-- configured to fail on medium priority bugs (needs to be done two places)-->
                 <configuration>
                     <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
                     <plugin>
                         <groupId>com.github.spotbugs</groupId>
                         <artifactId>spotbugs-maven-plugin</artifactId>
-                        <version>4.7.1</version>
+                        <version>4.7.2.0</version>
                         <configuration>
                             <plugins>
                                 <plugin>
@@ -474,7 +474,7 @@
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
-                <version>4.7.1</version>
+                <version>4.7.2.0</version>
                 <!-- configured to fail on medium priority bugs (needs to be done two places)-->
                 <configuration>
                     <plugins>


### PR DESCRIPTION
Suppress FL_FLOATS_AS_LOOP_COUNTERS , SSD_DO_NOT_USE_INSTANCE_LOCK_ON_SHARED_STATIC_DATA
Remove suppressal of  ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD

Spotbugs 4.7.2 uses SLF4J API 2.0.0 .
This version logs a version mis-match exception for Spotbugs runs, 
however does not affect the analysis and serves as a gentle reminder for JMRI to update at some point.
```
tests-spotbugs:
 [spotbugs] Executing SpotBugs FindBugsTask from ant task
 [spotbugs] Running SpotBugs...
 [spotbugs] Unexpected problem occured during version sanity check
 [spotbugs] Reported exception:
 [spotbugs] java.lang.AbstractMethodError: Receiver class org.apache.logging.slf4j.SLF4JServiceProvider does not define or inherit an implementation of the resolved method 'abstract java.lang.String getRequestedApiVersion()' of interface org.slf4j.spi.SLF4JServiceProvider.
 [spotbugs]     at org.slf4j.LoggerFactory.versionSanityCheck(LoggerFactory.java:297)
 [spotbugs]     at org.slf4j.LoggerFactory.performInitialization(LoggerFactory.java:141)
 [spotbugs]     at org.slf4j.LoggerFactory.getProvider(LoggerFactory.java:421)
 [spotbugs]     at org.slf4j.LoggerFactory.getILoggerFactory(LoggerFactory.java:407)
 [spotbugs]     at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:356)
 [spotbugs]     at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:382)
 [spotbugs]     at edu.umd.cs.findbugs.FindBugs2.<clinit>(FindBugs2.java:96)
```