### PR TITLE
Update some jmri tests

### DIFF
--- a/java/test/jmri/AnalogIOTest.java
+++ b/java/test/jmri/AnalogIOTest.java
@@ -43,11 +43,11 @@ public class AnalogIOTest {
     }
 
     
-    private class MyAnalogIO extends AbstractNamedBean implements AnalogIO {
+    private static class MyAnalogIO extends AbstractNamedBean implements AnalogIO {
 
         double _value = 0.0;
         
-        public MyAnalogIO(String sys) {
+        private MyAnalogIO(String sys) {
             super(sys);
         }
         

--- a/java/test/jmri/BeanSettingTest.java
+++ b/java/test/jmri/BeanSettingTest.java
@@ -14,14 +14,10 @@ public class BeanSettingTest {
 
     @Test
     public void testCtorNullBean() {
-        // JUnit 5 assertThrows would be good here
-        boolean thrown = false;
-        try {
-            new BeanSetting(null, 0);
-        } catch (NullPointerException ex) {
-            thrown = true;
-        }
-        Assert.assertTrue("Expected exception thrown", thrown);
+        Exception ex = Assertions.assertThrows(NullPointerException.class, () -> {
+            Assertions.assertNotNull(new BeanSetting(null, 0));
+        });
+        Assertions.assertNotNull(ex, "Expected exception thrown");
     }
 
     @Test

--- a/java/test/jmri/ConditionalVariableTest.java
+++ b/java/test/jmri/ConditionalVariableTest.java
@@ -133,9 +133,9 @@ public class ConditionalVariableTest {
         bean = InstanceManager.getDefault(SignalHeadManager.class).getSignalHead("IH1");
         otherBean = InstanceManager.getDefault(SignalHeadManager.class).getSignalHead("IH2");
         cv = new ConditionalVariable(false, Conditional.Operator.AND, Conditional.Type.SIGNAL_HEAD_RED, "IH1", false);
-        Assert.assertTrue("getNamedBean() returns correct bean", bean.equals(((NamedBeanHandle)cv.getNamedBean()).getBean()));
+        Assertions.assertEquals( bean, ((NamedBeanHandle)cv.getNamedBean()).getBean(), "getNamedBean() returns correct bean");
         cv.setName("IH2");
-        Assert.assertTrue("setName() sets correct bean", otherBean.equals(((NamedBeanHandle)cv.getNamedBean()).getBean()));
+        Assertions.assertEquals( otherBean, ((NamedBeanHandle)cv.getNamedBean()).getBean(),"setName() sets correct bean");
         Assert.assertTrue("toString() returns correct value",
                 "Signal Head \"IH2\" Appearance is \"Red\"".equals(cv.toString()));
         cv.setType(Conditional.Type.SIGNAL_HEAD_LIT);
@@ -257,7 +257,7 @@ public class ConditionalVariableTest {
         Assert.assertTrue("getNamedBeanData() returns null", cv.getNamedBeanData() == null);
         cv.setDataString(otherBean.getUserName());
         cv.setName(otherDeviceName);
-        Assert.assertTrue("getDataString() returns correct string", otherBean.getUserName().equals(cv.getDataString()));
+        Assertions.assertEquals( otherBean.getUserName(), cv.getDataString(), "getDataString() returns correct string");
         Assert.assertTrue("getNamedBeanData() returns correct bean", otherBean.equals(cv.getNamedBeanData()));
     }
 
@@ -968,7 +968,7 @@ public class ConditionalVariableTest {
      * A conditional variable there the method getBean() always return null.
      * Used to test ConditionalVariable.evaluate().
      */
-    private class ConditionalVariable_BeanAlwaysNull extends ConditionalVariable {
+    private static class ConditionalVariable_BeanAlwaysNull extends ConditionalVariable {
 
         ConditionalVariable_BeanAlwaysNull(boolean not, Operator opern, Conditional.Type type, String name, boolean trigger) {
             super(not, opern, type, name, trigger);

--- a/java/test/jmri/IdTagTest.java
+++ b/java/test/jmri/IdTagTest.java
@@ -32,9 +32,9 @@ public class IdTagTest {
 
     }
 
-    class TestIdTag extends jmri.implementation.AbstractNamedBean implements IdTag,Reportable {
+    private static class TestIdTag extends jmri.implementation.AbstractNamedBean implements IdTag,Reportable {
 
-       public TestIdTag(String systemName){
+       private TestIdTag(String systemName){
            super(systemName);
        }
 

--- a/java/test/jmri/NamedBeanHandleManagerTest.java
+++ b/java/test/jmri/NamedBeanHandleManagerTest.java
@@ -14,14 +14,11 @@ import org.junit.Assert;
 public class NamedBeanHandleManagerTest {
 
     @Test
-    public void testCreate() {
-    }
-
-    @Test
     public void testNameBeanManager() throws JmriException {
-        SensorManager sm = jmri.InstanceManager.sensorManagerInstance();
-        TurnoutManager tm = jmri.InstanceManager.turnoutManagerInstance();
-        MemoryManager mm = jmri.InstanceManager.memoryManagerInstance();
+        SensorManager sm = InstanceManager.getDefault(SensorManager.class);
+        TurnoutManager tm = InstanceManager.getDefault(TurnoutManager.class);
+        MemoryManager mm = InstanceManager.getDefault(MemoryManager.class);
+        Assertions.assertNotNull(nbhm);
 
         String name = "MyUserName";
         Sensor s1 = sm.provideSensor("IS1");
@@ -86,14 +83,14 @@ public class NamedBeanHandleManagerTest {
         jmri.util.JUnitAppender.assertWarnMessage("updateBeanFromUserToSystem requires non-blank user name: \"ISno_user_name\" not renamed");
     }
 
-    jmri.NamedBeanHandleManager nbhm;
+    private NamedBeanHandleManager nbhm = null;
 
     @BeforeEach
     public void setUp() throws Exception {
         JUnitUtil.setUp();
         JUnitUtil.resetInstanceManager();
-        jmri.InstanceManager.store(new jmri.NamedBeanHandleManager(), jmri.NamedBeanHandleManager.class);
-        nbhm = jmri.InstanceManager.getDefault(jmri.NamedBeanHandleManager.class);
+        InstanceManager.store(new NamedBeanHandleManager(), NamedBeanHandleManager.class);
+        nbhm = InstanceManager.getDefault(NamedBeanHandleManager.class);
     }
 
     @AfterEach

--- a/java/test/jmri/PathTest.java
+++ b/java/test/jmri/PathTest.java
@@ -30,7 +30,7 @@ public class PathTest {
     public void testLoad() {
         Path p = new Path();
 
-        TurnoutManager sm = jmri.InstanceManager.turnoutManagerInstance();
+        TurnoutManager sm = InstanceManager.getDefault(TurnoutManager.class);
         Turnout s = sm.provideTurnout("IT12");
 
         p.addSetting(new BeanSetting(s, "IT12", Turnout.CLOSED));
@@ -42,7 +42,7 @@ public class PathTest {
 
     @Test
     public void testEquals() {
-        TurnoutManager sm = jmri.InstanceManager.turnoutManagerInstance();
+        TurnoutManager sm = InstanceManager.getDefault(TurnoutManager.class);
         Turnout s1 = sm.provideTurnout("IT12");
         Turnout s2 = sm.provideTurnout("IT14");
         
@@ -92,7 +92,7 @@ public class PathTest {
     public void testCheck() throws JmriException {
         Path p = new Path();
 
-        TurnoutManager sm = jmri.InstanceManager.turnoutManagerInstance();
+        TurnoutManager sm = InstanceManager.getDefault(TurnoutManager.class);
         Turnout s = sm.provideTurnout("IT12");
 
         p.addSetting(new BeanSetting(s, "IT12", Turnout.CLOSED));
@@ -104,12 +104,12 @@ public class PathTest {
     }
 
     @Test
-    public void testToString() throws JmriException {
+    public void testPathToString() throws JmriException {
         Path p = new Path();
 
         Assert.assertEquals("Path: <no block>: ", p.toString());
 
-        TurnoutManager sm = jmri.InstanceManager.turnoutManagerInstance();
+        TurnoutManager sm = InstanceManager.getDefault(TurnoutManager.class);
         Turnout s = sm.provideTurnout("IT12");
 
         p.addSetting(new BeanSetting(s, "IT12", Turnout.CLOSED));
@@ -165,7 +165,7 @@ public class PathTest {
         jmri.util.JUnitUtil.setUp();
         
         jmri.util.JUnitUtil.resetInstanceManager();
-        jmri.InstanceManager.store(new jmri.NamedBeanHandleManager(), jmri.NamedBeanHandleManager.class);
+        InstanceManager.store(new NamedBeanHandleManager(), NamedBeanHandleManager.class);
     }
 
     @AfterEach

--- a/java/test/jmri/SelectionPropertyDescriptorTest.java
+++ b/java/test/jmri/SelectionPropertyDescriptorTest.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.BeforeEach;
 public class SelectionPropertyDescriptorTest {
     
     @Test
-    public void testCTor() {
+    public void testCtor() {
         SelectionPropertyDescriptorImpl t = new SelectionPropertyDescriptorImpl();
         Assert.assertNotNull("exists",t);
     }
@@ -49,9 +49,9 @@ public class SelectionPropertyDescriptorTest {
         Assert.assertEquals("column header set","Column Header Text",t.getColumnHeaderText());
     }
 
-    private class SelectionPropertyDescriptorImpl extends SelectionPropertyDescriptor {
+    private static class SelectionPropertyDescriptorImpl extends SelectionPropertyDescriptor {
 
-        public SelectionPropertyDescriptorImpl() {
+        private SelectionPropertyDescriptorImpl() {
             super("TEST_PROPERTY_KEY", new String[]{"A","B","C"}, new String[]{"A Tip","B Tip","C Tip"}, "B");
         }
         

--- a/java/test/jmri/StringIOTest.java
+++ b/java/test/jmri/StringIOTest.java
@@ -35,12 +35,11 @@ public class StringIOTest {
           jmri.util.JUnitUtil.tearDown();
     }
 
-    
-    private class MyStringIO extends AbstractNamedBean implements StringIO {
+    private static class MyStringIO extends AbstractNamedBean implements StringIO {
 
         String _value = "";
         
-        public MyStringIO(String sys) {
+        private MyStringIO(String sys) {
             super(sys);
         }
         


### PR DESCRIPTION
AnalogIOTest - class MyAnalogIO can be static
IdTagTest - class TestIdTag can be static
SelectionPropertyDescriptorTest - class SelectionPropertyDescriptorImpl can be static
StringIOTest - class MyStringIO can be static

BeanSettingTest - update exception assertion
PathTest - tweak method name

ConditionalVariableTest - 
avoid NPE by using assertEquals
class ConditionalVariable_BeanAlwaysNull can be static

NamedBeanHandleManagerTest -
remove unused method
nonNull assert