### PR TITLE
Add testGetMenus to JmriPanel Test

### DIFF
--- a/java/test/jmri/util/swing/JmriPanelTest.java
+++ b/java/test/jmri/util/swing/JmriPanelTest.java
@@ -44,6 +44,11 @@ public class JmriPanelTest {
         Assert.assertEquals("title", title, panel.getTitle());
     }
 
+    @Test
+    public void testGetMenus() {
+        Assertions.assertNotNull(panel.getMenus());
+    }
+
     @BeforeEach
     public void setUp() {
         JUnitUtil.setUp();

--- a/java/test/jmri/util/swing/JmriPanelTest.java
+++ b/java/test/jmri/util/swing/JmriPanelTest.java
@@ -27,7 +27,6 @@ public class JmriPanelTest {
         panel.initComponents();
     }
 
-    @DisabledIfSystemProperty(named = "java.awt.headless", matches = "true")
     @Test
     public void testAccessibility() throws Exception{
         panel.initComponents();
@@ -45,6 +44,7 @@ public class JmriPanelTest {
     }
 
     @Test
+    @DisabledIfSystemProperty(named = "java.awt.headless", matches = "true")
     public void testGetMenus() {
         Assertions.assertNotNull(panel.getMenus());
     }

--- a/java/test/jmri/util/swing/JmriPanelTest.java
+++ b/java/test/jmri/util/swing/JmriPanelTest.java
@@ -27,6 +27,7 @@ public class JmriPanelTest {
         panel.initComponents();
     }
 
+    @DisabledIfSystemProperty(named = "java.awt.headless", matches = "true")
     @Test
     public void testAccessibility() throws Exception{
         panel.initComponents();


### PR DESCRIPTION
Marked WIP until tests pass.
3 Initial test failures with

```
Error:    CbusEventTablePaneTest>JmriPanelTest.testGetMenus:49 » NullPointer
Error:    NodeConfigToolPaneTest>JmriPanelTest.testGetMenus:49 » NullPointer
Error:    NceConsistEditPanelTest>JmriPanelTest.testGetMenus:49 » MissingResource Resour...
```