### PR TITLE
Update jmri.beans Tests

### DIFF
--- a/java/test/jmri/beans/ArbitraryBeanTest.java
+++ b/java/test/jmri/beans/ArbitraryBeanTest.java
@@ -6,9 +6,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 
 import jmri.util.JUnitUtil;
 
@@ -17,7 +15,7 @@ import jmri.util.JUnitUtil;
  */
 public class ArbitraryBeanTest {
 
-    private ArbitraryBeanImpl bean;
+    private ArbitraryBeanImpl bean = null;
     private final static String AP = "arbitraryProperty";
     private final static String DP = "definedProperty";
     private final static String AIP = "arbitraryIndexedProperty";
@@ -37,6 +35,7 @@ public class ArbitraryBeanTest {
 
     @Test
     public void testSetProperty() {
+        Assertions.assertNotNull(bean);
         assertThat(bean).hasFieldOrProperty(DP);
         assertThat(bean.hasProperty(AP)).isFalse();
         assertThat(bean.getDefinedProperty()).isNull();
@@ -54,6 +53,7 @@ public class ArbitraryBeanTest {
 
     @Test
     public void testSetIndexedProperty() {
+        Assertions.assertNotNull(bean);
         assertThat(bean.hasIndexedProperty(DIP)).isTrue();
         assertThat(bean.getDefinedIndexedProperty()).isEmpty();
         assertThat(bean.hasIndexedProperty(AIP)).isFalse();
@@ -70,6 +70,7 @@ public class ArbitraryBeanTest {
 
     @Test
     public void testGetPropertyNames() {
+        Assertions.assertNotNull(bean);
         assertThat(bean.getPropertyNames())
                 .contains(DP, DIP)
                 .doesNotContain(AP, AIP);

--- a/java/test/jmri/beans/ArbitraryPropertySupportTest.java
+++ b/java/test/jmri/beans/ArbitraryPropertySupportTest.java
@@ -137,6 +137,18 @@ public class ArbitraryPropertySupportTest {
         assertEquals(NEW_VALUE, instance.getProperty(NEW_PROPERTY));
     }
 
+    @Test
+    public void testUnboundBeanImpl () {
+        UnboundBeanImpl t = new UnboundBeanImpl();
+        assertEquals(OLD_VALUE, t.getStringProperty());
+        t.setStringProperty(STRING_PROPERTY);
+        assertEquals(STRING_PROPERTY, t.getStringProperty());
+
+        t.setIndexedProperty(1, NEW_PROPERTY);
+        assertEquals(OLD_VALUE,t.getIndexedProperty(0));
+        assertEquals(NEW_PROPERTY,t.getIndexedProperty(1));
+    }
+
     @BeforeEach
     public void setUp() {
         JUnitUtil.setUp();

--- a/java/test/jmri/beans/ArbitraryPropertySupportTest.java
+++ b/java/test/jmri/beans/ArbitraryPropertySupportTest.java
@@ -1,15 +1,14 @@
 package jmri.beans;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.junit.jupiter.api.Test;
+import jmri.util.JUnitUtil;
+
+import org.junit.jupiter.api.*;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  *
@@ -34,17 +33,15 @@ public class ArbitraryPropertySupportTest {
     @Test
     public void testGetIndexedProperty() {
         ArbitraryPropertySupport instance = (new UnboundBeanImpl()).aps();
+        assertNotNull(instance);
         assertEquals(null, instance.getIndexedProperty(NOT_A_PROPERTY, 0));
         assertEquals(OLD_VALUE, instance.getIndexedProperty(INDEXED_PROPERTY, 0));
-        // Really wish we were using JUnit 4 with its ability to assert that an
-        // expected Exception was thrown
-        boolean outOfBounds = false;
-        try {
+
+        Exception ex = assertThrows(IndexOutOfBoundsException.class,() -> {
             instance.getIndexedProperty(INDEXED_PROPERTY, 1);
-        } catch (IndexOutOfBoundsException ex) {
-            outOfBounds = true;
-        }
-        assertTrue(outOfBounds);
+        });
+        assertNotNull(ex);
+
         assertEquals(OLD_VALUE, instance.getIndexedProperty(MAPPED_INDEXED, 0));
         assertEquals(null, instance.getIndexedProperty(MAPPED_INDEXED, 1));
     }
@@ -55,6 +52,7 @@ public class ArbitraryPropertySupportTest {
     @Test
     public void testGetProperty() {
         ArbitraryPropertySupport instance = (new UnboundBeanImpl()).aps();
+        assertNotNull(instance);
         assertEquals(null, instance.getProperty(NOT_A_PROPERTY));
         assertEquals(OLD_VALUE, instance.getProperty(STRING_PROPERTY));
         assertEquals(OLD_VALUE, instance.getProperty(MAPPED_STRING));
@@ -66,6 +64,7 @@ public class ArbitraryPropertySupportTest {
     @Test
     public void testGetPropertyNames() {
         ArbitraryPropertySupport instance = (new UnboundBeanImpl()).aps();
+        assertNotNull(instance);
         Set<String> expResult = new HashSet<>(6);
         expResult.add(CLASS); // defined in Object
         expResult.add(PROPERTY_NAMES); // defined in UnboundBean
@@ -138,12 +137,22 @@ public class ArbitraryPropertySupportTest {
         assertEquals(NEW_VALUE, instance.getProperty(NEW_PROPERTY));
     }
 
-    public class UnboundBeanImpl extends UnboundArbitraryBean {
+    @BeforeEach
+    public void setUp() {
+        JUnitUtil.setUp();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        JUnitUtil.tearDown();
+    }
+
+    private static class UnboundBeanImpl extends UnboundArbitraryBean {
 
         private String stringProperty = OLD_VALUE;
         private final ArrayList<String> indexedProperty = new ArrayList<>();
 
-        public UnboundBeanImpl() {
+        UnboundBeanImpl() {
             this.indexedProperty.add(0, OLD_VALUE);
             this.setProperty(MAPPED_STRING, OLD_VALUE);
             this.setIndexedProperty(MAPPED_INDEXED, 0, OLD_VALUE);

--- a/java/test/jmri/beans/BeanTest.java
+++ b/java/test/jmri/beans/BeanTest.java
@@ -153,7 +153,7 @@ public class BeanTest {
     }
 
     @BeforeEach
-    public void setup() {
+    public void setUp() {
         JUnitUtil.setUp();
         changed = false;
         bean = new Bean() {

--- a/java/test/jmri/beans/BeanUtilTest.java
+++ b/java/test/jmri/beans/BeanUtilTest.java
@@ -307,12 +307,12 @@ public class BeanUtilTest {
      * properties, while InterfaceTarget and Target use standard JavaBeans APIs
      * and conventions.
      */
-    public class InterfaceTarget extends UnboundBean {
+    private static class InterfaceTarget extends UnboundBean {
 
         private String stringProperty = OLD_VALUE;
         private final ArrayList<String> indexedProperty = new ArrayList<>();
 
-        public InterfaceTarget() {
+        private InterfaceTarget() {
             this.indexedProperty.add(0, OLD_VALUE);
         }
 
@@ -345,20 +345,20 @@ public class BeanUtilTest {
      * the "*Introspected*" tests, but are exposed using jmri.beans.BeanUtil
      * methods in other tests.
      */
-    public class ArbitraryTarget extends UnboundArbitraryBean {
+    private static class ArbitraryTarget extends UnboundArbitraryBean {
 
-        public ArbitraryTarget() {
+        private ArbitraryTarget() {
             this.setProperty(STRING_PROPERTY, OLD_VALUE);
             this.setIndexedProperty(INDEXED_PROPERTY, 0, OLD_VALUE);
         }
     }
 
-    public class Target {
+    private static class Target {
 
         private String stringProperty = OLD_VALUE;
         private final ArrayList<String> indexedProperty = new ArrayList<>();
 
-        public Target() {
+        private Target() {
             this.indexedProperty.add(0, OLD_VALUE);
         }
 
@@ -389,7 +389,7 @@ public class BeanUtilTest {
     /*
      * A simple listener class to avoid too many anonymous identical objects.
      */
-    private class Listener implements PropertyChangeListener {
+    private static class Listener implements PropertyChangeListener {
 
         @Override
         public void propertyChange(PropertyChangeEvent evt) {

--- a/java/test/jmri/beans/BeanUtilTest.java
+++ b/java/test/jmri/beans/BeanUtilTest.java
@@ -12,6 +12,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import jmri.util.JUnitUtil;
 
 /**
@@ -299,6 +301,30 @@ public class BeanUtilTest {
         assertThat(BeanUtil.contains(listeners, l1)).isTrue();
         assertThat(BeanUtil.contains(listeners, l2)).isTrue();
         assertThat(BeanUtil.contains(listeners, l3)).isFalse();
+    }
+
+    @Test
+    public void testInterfaceTargetImpl () {
+        InterfaceTarget t = new InterfaceTarget();
+        assertEquals(OLD_VALUE, t.getStringProperty());
+        t.setStringProperty(STRING_PROPERTY);
+        assertEquals(STRING_PROPERTY, t.getStringProperty());
+
+        t.setIndexedProperty(1, CLASS);
+        assertEquals(OLD_VALUE,t.getIndexedProperty(0));
+        assertEquals(CLASS,t.getIndexedProperty(1));
+    }
+
+    @Test
+    public void testTargetImpl () {
+        Target t = new Target();
+        assertEquals(OLD_VALUE, t.getStringProperty());
+        t.setStringProperty(STRING_PROPERTY);
+        assertEquals(STRING_PROPERTY, t.getStringProperty());
+
+        t.setIndexedProperty(1, CLASS);
+        assertEquals(OLD_VALUE,t.getIndexedProperty(0));
+        assertEquals(CLASS,t.getIndexedProperty(1));
     }
 
     /*

--- a/java/test/jmri/beans/IdentifiableTest.java
+++ b/java/test/jmri/beans/IdentifiableTest.java
@@ -2,9 +2,7 @@ package jmri.beans;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 
 import jmri.util.JUnitUtil;
 
@@ -12,15 +10,15 @@ import jmri.util.JUnitUtil;
  * @author Randall Wood Copyright 2020
  */
 public class IdentifiableTest {
-    
-    private Identifiable bean;
+
+    private Identifiable bean = null;
 
     @BeforeEach
     public void setUp() {
         JUnitUtil.setUp();
         bean = () -> "bean";
     }
-    
+
     @AfterEach
     public void tearDown() {
         JUnitUtil.tearDown();
@@ -28,7 +26,8 @@ public class IdentifiableTest {
 
     @Test
     public void testGetId() {
+        Assertions.assertNotNull(bean);
         assertThat(bean.getId()).isEqualTo("bean");
     }
-    
+
 }

--- a/java/test/jmri/beans/MutableIdentifiableTest.java
+++ b/java/test/jmri/beans/MutableIdentifiableTest.java
@@ -2,9 +2,7 @@ package jmri.beans;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 
 import jmri.util.JUnitUtil;
 
@@ -13,7 +11,7 @@ import jmri.util.JUnitUtil;
  */
 public class MutableIdentifiableTest {
 
-    private MutableIdentifiable bean;
+    private MutableIdentifiable bean = null;
 
     @BeforeEach
     public void setUp() {
@@ -40,6 +38,7 @@ public class MutableIdentifiableTest {
 
     @Test
     public void testSetId() {
+        Assertions.assertNotNull(bean);
         assertThat(bean.getId()).isEqualTo("bean");
         bean.setId("changed");
         assertThat(bean.getId()).isEqualTo("changed");

--- a/java/test/jmri/beans/PreferencesBeanTest.java
+++ b/java/test/jmri/beans/PreferencesBeanTest.java
@@ -152,9 +152,9 @@ public class PreferencesBeanTest {
         assertThat(bean.isDirty()).isTrue();
     }
 
-    private class PreferencesBeanImpl extends PreferencesBean {
+    private static class PreferencesBeanImpl extends PreferencesBean {
 
-        public PreferencesBeanImpl(Profile prfl) {
+        private PreferencesBeanImpl(Profile prfl) {
             super(prfl);
         }
 

--- a/java/test/jmri/beans/PropertyChangeSupportTest.java
+++ b/java/test/jmri/beans/PropertyChangeSupportTest.java
@@ -201,7 +201,7 @@ public class PropertyChangeSupportTest {
     }
 
     @BeforeEach
-    public void setup() {
+    public void setUp() {
         JUnitUtil.setUp();
         instance = new PropertyChangeSupport();
         listener = new TestPropertyChangeListener();

--- a/java/test/jmri/beans/SwingPropertyChangeListenerTest.java
+++ b/java/test/jmri/beans/SwingPropertyChangeListenerTest.java
@@ -10,9 +10,7 @@ import javax.swing.SwingUtilities;
 import jmri.util.JUnitUtil;
 
 import org.assertj.swing.edt.GuiActionRunner;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 
 /**
  *
@@ -37,8 +35,13 @@ public class SwingPropertyChangeListenerTest {
     public void testPropertyChangeOnEDT() {
         s = new SwingPropertyChangeListener(l, true);
         assertThat(notifiedOnEDT).isFalse();
-        GuiActionRunner.execute(() -> s.propertyChange(e));
+        GuiActionRunner.execute(() -> { triggerPropChange(s); } );
         assertThat(notifiedOnEDT).isTrue();
+    }
+
+    private void triggerPropChange(SwingPropertyChangeListener s) {
+        Assertions.assertNotNull(s);
+        s.propertyChange(e);
     }
 
     /**

--- a/java/test/jmri/beans/UnboundArbitraryBeanTest.java
+++ b/java/test/jmri/beans/UnboundArbitraryBeanTest.java
@@ -1,15 +1,14 @@
 package jmri.beans;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.junit.jupiter.api.Test;
+import jmri.util.JUnitUtil;
+
+import org.junit.jupiter.api.*;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  *
@@ -36,15 +35,12 @@ public class UnboundArbitraryBeanTest {
         UnboundArbitraryBean instance = new UnboundBeanImpl();
         assertEquals(null, instance.getIndexedProperty(NOT_A_PROPERTY, 0));
         assertEquals(OLD_VALUE, instance.getIndexedProperty(INDEXED_PROPERTY, 0));
-        // Really wish we were using JUnit 4 with its ability to assert that an
-        // expected Exception was thrown
-        boolean outOfBounds = false;
-        try {
+
+        Exception ex = assertThrows(IndexOutOfBoundsException.class,() -> {
             instance.getIndexedProperty(INDEXED_PROPERTY, 1);
-        } catch (IndexOutOfBoundsException ex) {
-            outOfBounds = true;
-        }
-        assertTrue(outOfBounds);
+        });
+        assertNotNull(ex);
+
         assertEquals(OLD_VALUE, instance.getIndexedProperty(MAPPED_INDEXED, 0));
         assertEquals(null, instance.getIndexedProperty(MAPPED_INDEXED, 1));
     }
@@ -138,12 +134,22 @@ public class UnboundArbitraryBeanTest {
         assertEquals(NEW_VALUE, instance.getProperty(NEW_PROPERTY));
     }
 
-    public class UnboundBeanImpl extends UnboundArbitraryBean {
+    @BeforeEach
+    public void setUp() {
+        JUnitUtil.setUp();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        JUnitUtil.tearDown();
+    }
+
+    private static class UnboundBeanImpl extends UnboundArbitraryBean {
 
         private String stringProperty = OLD_VALUE;
         private final ArrayList<String> indexedProperty = new ArrayList<>();
 
-        public UnboundBeanImpl() {
+        private UnboundBeanImpl() {
             this.indexedProperty.add(0, OLD_VALUE);
             this.setProperty(MAPPED_STRING, OLD_VALUE);
             this.setIndexedProperty(MAPPED_INDEXED, 0, OLD_VALUE);

--- a/java/test/jmri/beans/UnboundArbitraryBeanTest.java
+++ b/java/test/jmri/beans/UnboundArbitraryBeanTest.java
@@ -134,6 +134,18 @@ public class UnboundArbitraryBeanTest {
         assertEquals(NEW_VALUE, instance.getProperty(NEW_PROPERTY));
     }
 
+    @Test
+    public void testUnboundBeanImpl () {
+        UnboundBeanImpl t = new UnboundBeanImpl();
+        assertEquals(OLD_VALUE, t.getStringProperty());
+        t.setStringProperty(STRING_PROPERTY);
+        assertEquals(STRING_PROPERTY, t.getStringProperty());
+
+        t.setIndexedProperty(1, NEW_PROPERTY);
+        assertEquals(OLD_VALUE,t.getIndexedProperty(0));
+        assertEquals(NEW_PROPERTY,t.getIndexedProperty(1));
+    }
+
     @BeforeEach
     public void setUp() {
         JUnitUtil.setUp();

--- a/java/test/jmri/beans/UnboundBeanTest.java
+++ b/java/test/jmri/beans/UnboundBeanTest.java
@@ -132,6 +132,18 @@ public class UnboundBeanTest {
         assertNull(instance.getProperty(NEW_PROPERTY));
     }
 
+    @Test
+    public void testUnboundBeanImpl () {
+        UnboundBeanImpl t = new UnboundBeanImpl();
+        assertEquals(OLD_VALUE, t.getStringProperty());
+        t.setStringProperty(STRING_PROPERTY);
+        assertEquals(STRING_PROPERTY, t.getStringProperty());
+
+        t.setIndexedProperty(1, NEW_PROPERTY);
+        assertEquals(OLD_VALUE,t.getIndexedProperty(0));
+        assertEquals(NEW_PROPERTY,t.getIndexedProperty(1));
+    }
+
     @BeforeEach
     public void setUp() {
         JUnitUtil.setUp();

--- a/java/test/jmri/beans/UnboundBeanTest.java
+++ b/java/test/jmri/beans/UnboundBeanTest.java
@@ -1,15 +1,14 @@
 package jmri.beans;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.junit.jupiter.api.Test;
+import jmri.util.JUnitUtil;
+
+import org.junit.jupiter.api.*;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  *
@@ -36,15 +35,12 @@ public class UnboundBeanTest {
         UnboundBean instance = new UnboundBeanImpl();
         assertNull(instance.getIndexedProperty(NOT_A_PROPERTY, 0));
         assertEquals(OLD_VALUE, instance.getIndexedProperty(INDEXED_PROPERTY, 0));
-        // Really wish we were using JUnit 4 with its ability to assert that an
-        // expected Exception was thrown
-        boolean outOfBounds = false;
-        try {
+
+        Exception ex = assertThrows(IndexOutOfBoundsException.class,() -> {
             instance.getIndexedProperty(INDEXED_PROPERTY, 1);
-        } catch (IndexOutOfBoundsException ex) {
-            outOfBounds = true;
-        }
-        assertTrue(outOfBounds);
+        });
+        assertNotNull(ex);
+
         assertNull(instance.getIndexedProperty(MAPPED_INDEXED, 0));
         assertNull(instance.getIndexedProperty(MAPPED_INDEXED, 1));
     }
@@ -136,12 +132,22 @@ public class UnboundBeanTest {
         assertNull(instance.getProperty(NEW_PROPERTY));
     }
 
-    public class UnboundBeanImpl extends UnboundBean {
+    @BeforeEach
+    public void setUp() {
+        JUnitUtil.setUp();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        JUnitUtil.tearDown();
+    }
+
+    private static class UnboundBeanImpl extends UnboundBean {
 
         private String stringProperty = OLD_VALUE;
         private final ArrayList<String> indexedProperty = new ArrayList<>();
 
-        public UnboundBeanImpl() {
+        private UnboundBeanImpl() {
             this.indexedProperty.add(0, OLD_VALUE);
             this.setProperty(MAPPED_STRING, OLD_VALUE);
             this.setIndexedProperty(MAPPED_INDEXED, 0, OLD_VALUE);

--- a/java/test/jmri/beans/VetoableChangeSupportTest.java
+++ b/java/test/jmri/beans/VetoableChangeSupportTest.java
@@ -21,8 +21,8 @@ public class VetoableChangeSupportTest {
 
     private VetoableChangeSupport instance;
     private TestVetoableChangeListener listener;
-    private static String PROPERTY = "property";
-    private static String VETO = "veto";
+    private final static String PROPERTY = "property";
+    private final static String VETO = "veto";
 
     @Test
     public void testFireVetoableChange_String_int_boolean_boolean() {
@@ -152,7 +152,7 @@ public class VetoableChangeSupportTest {
     }
 
     @BeforeEach
-    public void setup() {
+    public void setUp() {
         JUnitUtil.setUp();
         instance = new VetoableChangeSupport();
         listener = new TestVetoableChangeListener();


### PR DESCRIPTION
ArbitraryPropertySupportTest, UnboundArbitraryBeanTest, UnboundBeanTest -
add setUp / tearDown methods
update exception assertion
nonNull assertions
Implementation class can be static

ArbitraryBeanTest, IdentifiableTest, MutableIdentifiableTest - nonNull asserts
SwingPropertyChangeListenerTest - Assert changeListener not null within lambda
PreferencesBeanTest - Implementation class can be static
BeanTest, PropertyChangeSupportTest - tweak method name