### PR TITLE
Add LogixNG expression AnalogExpressionLocalVariable

### DIFF
--- a/java/src/jmri/jmrit/logixng/expressions/AnalogExpressionLocalVariable.java
+++ b/java/src/jmri/jmrit/logixng/expressions/AnalogExpressionLocalVariable.java
@@ -1,0 +1,128 @@
+package jmri.jmrit.logixng.expressions;
+
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.util.*;
+
+import jmri.*;
+import jmri.jmrit.logixng.*;
+import jmri.jmrit.logixng.util.LogixNG_SelectString;
+
+/**
+ * Reads a local variable.
+ *
+ * @author Daniel Bergqvist Copyright 2022
+ */
+public class AnalogExpressionLocalVariable extends AbstractAnalogExpression
+        implements PropertyChangeListener {
+
+    private final LogixNG_SelectString _selectNamedBean =
+            new LogixNG_SelectString(this, this);
+
+    public AnalogExpressionLocalVariable(String sys, String user)
+            throws BadUserNameException, BadSystemNameException {
+
+        super(sys, user);
+    }
+
+    @Override
+    public Base getDeepCopy(Map<String, String> systemNames, Map<String, String> userNames) throws JmriException {
+        AnalogExpressionManager manager = InstanceManager.getDefault(AnalogExpressionManager.class);
+        String sysName = systemNames.get(getSystemName());
+        String userName = userNames.get(getSystemName());
+        if (sysName == null) sysName = manager.getAutoSystemName();
+        AnalogExpressionLocalVariable copy = new AnalogExpressionLocalVariable(sysName, userName);
+        copy.setComment(getComment());
+        _selectNamedBean.copy(copy._selectNamedBean);
+        return manager.registerExpression(copy).deepCopyChildren(this, systemNames, userNames);
+    }
+
+    public LogixNG_SelectString getSelectNamedBean() {
+        return _selectNamedBean;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Category getCategory() {
+        return Category.ITEM;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public double evaluate() throws JmriException {
+        String localVariable = _selectNamedBean.evaluateValue(getConditionalNG());
+        if (localVariable == null) return 0.0;
+
+        Object value = getConditionalNG().getSymbolTable().getValue(localVariable);
+        if (value != null) {
+            return jmri.util.TypeConversionUtil.convertToDouble(value, false);
+        } else {
+            return 0.0;
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public FemaleSocket getChild(int index)
+            throws IllegalArgumentException, UnsupportedOperationException {
+        throw new UnsupportedOperationException("Not supported.");
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int getChildCount() {
+        return 0;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getShortDescription(Locale locale) {
+        return Bundle.getMessage(locale, "AnalogExpressionLocalVariable_Short");
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getLongDescription(Locale locale) {
+        return Bundle.getMessage(locale, "AnalogExpressionLocalVariable_Long", _selectNamedBean.getDescription(locale));
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void setup() {
+        // Do nothing
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void registerListenersForThisClass() {
+        // Do nothing
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void unregisterListenersForThisClass() {
+        // Do nothing
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void propertyChange(PropertyChangeEvent evt) {
+        if (getTriggerOnChange()) {
+            getConditionalNG().execute();
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void disposeMe() {
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void getUsageDetail(int level, NamedBean bean, List<NamedBeanUsageReport> report, NamedBean cdl) {
+        log.debug("getUsageReport :: AnalogExpressionLocalVariable: bean = {}, report = {}", cdl, report);
+    }
+
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(AnalogExpressionLocalVariable.class);
+
+}

--- a/java/src/jmri/jmrit/logixng/expressions/AnalogFactory.java
+++ b/java/src/jmri/jmrit/logixng/expressions/AnalogFactory.java
@@ -22,11 +22,12 @@ public class AnalogFactory implements AnalogExpressionFactory {
                 Set.of(
                         new AbstractMap.SimpleEntry<>(Category.ITEM, AnalogExpressionAnalogIO.class),
                         new AbstractMap.SimpleEntry<>(Category.ITEM, AnalogExpressionConstant.class),
+                        new AbstractMap.SimpleEntry<>(Category.ITEM, AnalogExpressionLocalVariable.class),
                         new AbstractMap.SimpleEntry<>(Category.ITEM, AnalogExpressionMemory.class),
                         new AbstractMap.SimpleEntry<>(Category.COMMON, AnalogFormula.class),
                         new AbstractMap.SimpleEntry<>(Category.ITEM, TimeSinceMidnight.class)
                 );
-        
+
         return analogExpressionClasses;
     }
 

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionBundle.properties
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionBundle.properties
@@ -9,6 +9,9 @@ AnalogExpressionAnalogIO_Short  = AnalogIO
 AnalogExpressionAnalogIO_Long   = Get AnalogIO {0}
 AnalogIO_AnalogIOInUseAnalogIOExpressionVeto  = AnalogIO is in use by AnalogIO expression "{0}"
 
+AnalogExpressionLocalVariable_Short = Local variable as analog value
+AnalogExpressionLocalVariable_Long  = Get local variable {0} as analog value
+
 AnalogExpressionMemory_Short    = Memory as analog value
 AnalogExpressionMemory_Long     = Get memory {0} as analog value
 # Memory_MemoryInUseMemoryExpressionVeto  = Memory is in use by Memory expression "{0}"

--- a/java/src/jmri/jmrit/logixng/expressions/configurexml/AnalogExpressionLocalVariableXml.java
+++ b/java/src/jmri/jmrit/logixng/expressions/configurexml/AnalogExpressionLocalVariableXml.java
@@ -1,0 +1,61 @@
+package jmri.jmrit.logixng.expressions.configurexml;
+
+import jmri.*;
+import jmri.configurexml.JmriConfigureXmlException;
+import jmri.jmrit.logixng.AnalogExpressionManager;
+import jmri.jmrit.logixng.expressions.AnalogExpressionLocalVariable;
+import jmri.jmrit.logixng.util.configurexml.LogixNG_SelectStringXml;
+
+import org.jdom2.Element;
+
+/**
+ * Handle XML configuration for ActionLightXml objects.
+ *
+ * @author Bob Jacobsen Copyright: Copyright (c) 2004, 2008, 2010
+ * @author Daniel Bergqvist Copyright (C) 2022
+ */
+public class AnalogExpressionLocalVariableXml extends jmri.managers.configurexml.AbstractNamedBeanManagerConfigXML {
+
+    public AnalogExpressionLocalVariableXml() {
+    }
+
+    /**
+     * Default implementation for storing the contents of a SE8cSignalHead
+     *
+     * @param o Object to store, of type TripleLightSignalHead
+     * @return Element containing the complete info
+     */
+    @Override
+    public Element store(Object o) {
+        AnalogExpressionLocalVariable p = (AnalogExpressionLocalVariable) o;
+
+        Element element = new Element("AnalogExpressionLocalVariable");
+        element.setAttribute("class", this.getClass().getName());
+        element.addContent(new Element("systemName").addContent(p.getSystemName()));
+
+        storeCommon(p, element);
+
+        var selectLocalVariableXml = new LogixNG_SelectStringXml();
+        element.addContent(selectLocalVariableXml.store(p.getSelectNamedBean(), "localVariable"));
+
+        return element;
+    }
+
+    @Override
+    public boolean load(Element shared, Element perNode) throws JmriConfigureXmlException {     // Test class that inherits this class throws exception
+        String sys = getSystemName(shared);
+        String uname = getUserName(shared);
+        AnalogExpressionLocalVariable h;
+        h = new AnalogExpressionLocalVariable(sys, uname);
+
+        loadCommon(h, shared);
+
+        var selectLocalVariableXml = new LogixNG_SelectStringXml();
+        selectLocalVariableXml.load(shared.getChild("localVariable"), h.getSelectNamedBean());
+
+        InstanceManager.getDefault(AnalogExpressionManager.class).registerExpression(h);
+        return true;
+    }
+
+//    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(AnalogExpressionLocalVariableXml.class);
+}

--- a/java/src/jmri/jmrit/logixng/expressions/swing/AnalogExpressionLocalVariableSwing.java
+++ b/java/src/jmri/jmrit/logixng/expressions/swing/AnalogExpressionLocalVariableSwing.java
@@ -1,0 +1,85 @@
+package jmri.jmrit.logixng.expressions.swing;
+
+import java.util.List;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+
+import jmri.*;
+import jmri.jmrit.logixng.Base;
+import jmri.jmrit.logixng.AnalogExpressionManager;
+import jmri.jmrit.logixng.MaleSocket;
+import jmri.jmrit.logixng.expressions.AnalogExpressionLocalVariable;
+import jmri.jmrit.logixng.util.swing.LogixNG_SelectStringSwing;
+
+/**
+ * Configures an AnalogExpressionLocalVariable object with a Swing JPanel.
+ *
+ * @author Daniel Bergqvist Copyright 2022
+ */
+public class AnalogExpressionLocalVariableSwing extends AbstractAnalogExpressionSwing {
+
+    private LogixNG_SelectStringSwing _selectLocalVariableSwing;
+
+
+    @Override
+    protected void createPanel(@CheckForNull Base object, @Nonnull JPanel buttonPanel) {
+        AnalogExpressionLocalVariable action = (AnalogExpressionLocalVariable)object;
+
+        panel = new JPanel();
+
+        _selectLocalVariableSwing = new LogixNG_SelectStringSwing(getJDialog(), this);
+
+        JPanel _tabbedPaneNamedBean;
+        if (action != null) {
+            _tabbedPaneNamedBean = _selectLocalVariableSwing.createPanel(action.getSelectNamedBean());
+        } else {
+            _tabbedPaneNamedBean = _selectLocalVariableSwing.createPanel(null);
+        }
+
+        panel.add(new JLabel(Bundle.getMessage("AnalogExpressionLocalVariable_LocalVariable")));
+        panel.add(_tabbedPaneNamedBean);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean validate(@Nonnull List<String> errorMessages) {
+        AnalogExpressionLocalVariable expression = new AnalogExpressionLocalVariable("IQAE1", null);
+        _selectLocalVariableSwing.validate(expression.getSelectNamedBean(), errorMessages);
+        return errorMessages.isEmpty();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public MaleSocket createNewObject(@Nonnull String systemName, @CheckForNull String userName) {
+        AnalogExpressionLocalVariable expression = new AnalogExpressionLocalVariable(systemName, userName);
+        updateObject(expression);
+        return InstanceManager.getDefault(AnalogExpressionManager.class).registerExpression(expression);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void updateObject(@Nonnull Base object) {
+        if (! (object instanceof AnalogExpressionLocalVariable)) {
+            throw new IllegalArgumentException("object must be an AnalogExpressionLocalVariable but is a: "+object.getClass().getName());
+        }
+        AnalogExpressionLocalVariable expression = (AnalogExpressionLocalVariable)object;
+        _selectLocalVariableSwing.updateObject(expression.getSelectNamedBean());
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String toString() {
+        return Bundle.getMessage("AnalogExpressionLocalVariable_Short");
+    }
+
+    @Override
+    public void dispose() {
+    }
+
+
+//    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(AnalogExpressionLocalVariableSwing.class);
+
+}

--- a/java/src/jmri/jmrit/logixng/expressions/swing/DigitalExpressionSwingBundle.properties
+++ b/java/src/jmri/jmrit/logixng/expressions/swing/DigitalExpressionSwingBundle.properties
@@ -15,6 +15,8 @@ AnalogExpressionConstant_NotANumber     = The value "{0}" is not a number
 AnalogFormula_Formula                   = Formula
 AnalogFormula_InvalidFormula            = Formula is invalid:  "{0}"
 
+AnalogExpressionLocalVariable_LocalVariable = Local variable
+
 And_Info                                = <html>                    \
 Evaluate All<br>                                                    \
 All the connected sockets are evaluated.                            \

--- a/java/test/jmri/jmrit/logixng/CreateLogixNGTreeScaffold.java
+++ b/java/test/jmri/jmrit/logixng/CreateLogixNGTreeScaffold.java
@@ -4130,6 +4130,11 @@ public class CreateLogixNGTreeScaffold {
         maleSocket.setEnabled(false);
         doAnalogAction.getChild(0).connect(maleSocket);
 
+        AnalogExpressionLocalVariable analogExpressionLocalVariable = new AnalogExpressionLocalVariable(analogExpressionManager.getAutoSystemName(), null);
+        maleSocket = analogExpressionManager.registerExpression(analogExpressionLocalVariable);
+        maleSocket.setEnabled(false);
+        analogFormula.getChild(0).connect(maleSocket);
+
         AnalogActionLightIntensity analogActionLightIntensity = new AnalogActionLightIntensity(analogActionManager.getAutoSystemName(), null);
         maleSocket = analogActionManager.registerAction(analogActionLightIntensity);
         maleSocket.setEnabled(false);

--- a/java/test/jmri/jmrit/logixng/implementation/DefaultFemaleAnalogExpressionSocketTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/DefaultFemaleAnalogExpressionSocketTest.java
@@ -90,6 +90,7 @@ public class DefaultFemaleAnalogExpressionSocketTest extends FemaleSocketTestBas
         List<Class<? extends Base>> classes = new ArrayList<>();
         classes.add(jmri.jmrit.logixng.expressions.AnalogExpressionAnalogIO.class);
         classes.add(jmri.jmrit.logixng.expressions.AnalogExpressionConstant.class);
+        classes.add(jmri.jmrit.logixng.expressions.AnalogExpressionLocalVariable.class);
         classes.add(jmri.jmrit.logixng.expressions.AnalogExpressionMemory.class);
         classes.add(jmri.jmrit.logixng.expressions.TimeSinceMidnight.class);
         map.put(Category.ITEM, classes);

--- a/xml/schema/logixng/analog-expressions/analog-expressions-4.23.1.xsd
+++ b/xml/schema/logixng/analog-expressions/analog-expressions-4.23.1.xsd
@@ -27,6 +27,7 @@
 
   <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/analog-expressions/expression-analogio-4.23.1.xsd"/>
   <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/analog-expressions/expression-constant-4.23.1.xsd"/>
+  <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/analog-expressions/expression-local-variable-5.1.4.xsd"/>
   <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/analog-expressions/expression-memory-4.23.1.xsd"/>
   <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/analog-expressions/formula-4.23.1.xsd"/>
   <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/analog-expressions/time-since-midnight-4.23.1.xsd"/>
@@ -47,6 +48,7 @@
 
             <xs:element name="AnalogExpressionAnalogIO"  type="LogixNG_AnalogExpression_AnalogIOType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="AnalogExpressionConstant"  type="LogixNG_AnalogExpression_ConstantType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="AnalogExpressionLocalVariable"  type="LogixNG_AnalogExpression_LocalVariableType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="AnalogExpressionMemory"    type="LogixNG_AnalogExpression_MemoryType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="AnalogFormula"             type="LogixNG_AnalogExpression_FormulaType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="TimeSinceMidnight"         type="LogixNG_AnalogExpression_TimeSinceMidnightType" minOccurs="0" maxOccurs="unbounded" />

--- a/xml/schema/logixng/analog-expressions/expression-local-variable-5.1.4.xsd
+++ b/xml/schema/logixng/analog-expressions/expression-local-variable-5.1.4.xsd
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="../schema2xhtml.xsl" type="text/xsl"?>
+
+<!-- This schema is part of JMRI. Copyright 2018.                           -->
+<!--                                                                        -->
+<!-- JMRI is free software; you can redistribute it and/or modify it under  -->
+<!-- the terms of version 2 of the GNU General Public License as published  -->
+<!-- by the Free Software Foundation. See the "COPYING" file for a copy     -->
+<!-- of this license.                                                       -->
+<!--                                                                        -->
+<!-- JMRI is distributed in the hope that it will be useful, but WITHOUT    -->
+<!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
+<!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
+<!-- for more details.                                                      -->
+
+<!-- This file contains definitions for LogixNG                             -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:xsi ="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:docbook="http://docbook.org/ns/docbook"
+           xmlns:jmri="http://jmri.org/xml/schema/JMRIschema"
+           xsi:schemaLocation="
+                http://jmri.org/xml/schema/JMRIschema http://jmri.org/xml/schema/JMRIschema.xsd
+                http://docbook.org/ns/docbook http://jmri.org/xml/schema/docbook/docbook.xsd
+            "
+        >
+
+    <xs:complexType name="LogixNG_AnalogExpression_LocalVariableType">
+      <xs:annotation>
+        <xs:documentation>
+          Define the XML stucture for storing the contents of a AnalogExpressionLocalVariable class.
+        </xs:documentation>
+        <xs:appinfo>
+            <jmri:usingclass configurexml="true">jmri.jmrit.logixng.analog.expressions.configurexml.AnalogExpressionLocalVariableXml</jmri:usingclass>
+        </xs:appinfo>
+      </xs:annotation>
+        
+            <xs:sequence>
+
+              <xs:element name="systemName" type="systemNameType" minOccurs="1" maxOccurs="1"/>
+              <xs:element name="userName" type="userNameType" minOccurs="0" maxOccurs="1"/>
+              <xs:element name="comment" type="commentType" minOccurs="0" maxOccurs="unbounded"/>
+
+              <xs:element name="localVariable" type="LogixNG_SelectStringType" minOccurs="0" maxOccurs="1" />
+
+              <xs:element name="MaleSocket" type="LogixNG_MaleSocket_Type" minOccurs="0" maxOccurs="1"/>
+
+            </xs:sequence>
+            
+            <xs:attribute name="class" type="classType" use="required"/>
+        
+    </xs:complexType>
+
+</xs:schema>


### PR DESCRIPTION
@dsand47 
This PR adds the new LogixNG expression `Local variable as analog value`.

See this message:
https://groups.io/g/jmriusers/message/208156

If possible, it would be good if this PR could be included in the next test release.