### PR TITLE
Update beantable Maintenance tests

### DIFF
--- a/java/test/jmri/jmrit/beantable/BeanTableDataModelTest.java
+++ b/java/test/jmri/jmrit/beantable/BeanTableDataModelTest.java
@@ -52,9 +52,9 @@ public class BeanTableDataModelTest extends AbstractBeanTableDataModelBase<Senso
     }
 
     // An implementation of BeanTableModel which can be used in testing.
-    private class BeanTableDataModelImpl extends SensorTableDataModel {
+    private static class BeanTableDataModelImpl extends SensorTableDataModel {
 
-        public BeanTableDataModelImpl(Manager<Sensor> mgr){
+        private BeanTableDataModelImpl(Manager<Sensor> mgr){
             super(mgr);
         }
         

--- a/java/test/jmri/jmrit/beantable/BlockTableActionTest.java
+++ b/java/test/jmri/jmrit/beantable/BlockTableActionTest.java
@@ -2,7 +2,6 @@ package jmri.jmrit.beantable;
 
 import jmri.util.gui.GuiLafPreferencesManager;
 
-import javax.swing.JFrame;
 import javax.swing.JPopupMenu;
 import javax.swing.JTextField;
 
@@ -315,7 +314,7 @@ public class BlockTableActionTest extends AbstractTableActionBase<Block> {
 
         //and press create
         JemmyUtil.pressButton(jf, Bundle.getMessage("ButtonCreate"));
-        JUnitUtil.waitFor(() -> { return InstanceManager.getDefault(BlockManager.class).getObjectCount()>0;  });
+        JUnitUtil.waitFor(() -> InstanceManager.getDefault(BlockManager.class).getObjectCount()>0 ,"Block created");
 
         JemmyUtil.pressButton( jf, Bundle.getMessage("ButtonCancel"));
         jf.waitClosed();

--- a/java/test/jmri/jmrit/beantable/MaintenanceTest.java
+++ b/java/test/jmri/jmrit/beantable/MaintenanceTest.java
@@ -2,29 +2,23 @@ package jmri.jmrit.beantable;
 
 import jmri.*;
 import jmri.util.*;
-import jmri.util.junit.rules.RetryRule;
 
-import java.awt.GraphicsEnvironment;
+import org.junit.Assert;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
-import org.junit.*;
-import org.junit.rules.Timeout;
-
+import org.netbeans.jemmy.operators.JButtonOperator;
 import org.netbeans.jemmy.operators.JDialogOperator;
 
 /**
  *
  * @author Paul Bender Copyright (C) 2017
  */
+@Timeout(10)
 public class MaintenanceTest {
 
-    @Rule
-    public Timeout globalTimeout = Timeout.seconds(10);
-
-    @Rule
-    public RetryRule retryRule = new RetryRule(1); // allow 1 retry
-
     @Test
-    public void testCTor() {
+    public void testCtor() {
         Maintenance t = new Maintenance();
         Assert.assertNotNull("exists", t);
     }
@@ -88,70 +82,77 @@ public class MaintenanceTest {
         Assert.assertEquals("Listeners", listeners, result[3]);
     }
 
-    // @Test - testing for dialog fails when run separately
+    @Test
+    @DisabledIfSystemProperty(named = "java.awt.headless", matches = "true")
     public void testDeviceReportPressed() throws InterruptedException {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         Thread t = new Thread(() -> {
             // constructor for jdo will wait until the dialog is visible
             JDialogOperator jdo = new JDialogOperator(Maintenance.rbm.getString("CrossReferenceTitle"));
-            jdo.close();
+            JButtonOperator jbo = new JButtonOperator(jdo,"OK");
+            ThreadingUtil.runOnGUI(() -> jbo.push() );
+            jdo.waitClosed();
         });
         t.setName("Cross Reference Dialog Close Thread");
         t.start();
-        JmriJFrame parent = new jmri.util.JmriJFrame("DeviceReportParent");
+        JmriJFrame parent = new JmriJFrame("DeviceReportParent");
         ThreadingUtil.runOnGUI(() -> {
             Maintenance.deviceReportPressed("IS1", parent);
         });
-        t.join(); // only proceed when all done
+        JUnitUtil.waitFor(() -> !t.isAlive(), "Thread did not complete "+t.getName());
         JUnitUtil.dispose(parent);
     }
 
-    // @Test - testing for dialog fails when run separately
+    @Test
+    @DisabledIfSystemProperty(named = "java.awt.headless", matches = "true")
     public void testFindOrphansPressed() throws InterruptedException {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         Thread t = new Thread(() -> {
             // constructor for jdo will wait until the dialog is visible
             JDialogOperator jdo = new JDialogOperator(Maintenance.rbm.getString("OrphanTitle"));
-            jdo.close();
+            JButtonOperator jbo = new JButtonOperator(jdo,"OK");
+            ThreadingUtil.runOnGUI(() -> jbo.push() );
+            jdo.waitClosed();
         });
         t.setName("Find Orphan Dialog Close Thread");
         t.start();
-        JmriJFrame parent = new jmri.util.JmriJFrame("FindOrphansParent");
+        JmriJFrame parent = new JmriJFrame("FindOrphansParent");
         ThreadingUtil.runOnGUI(() -> {
             Maintenance.findOrphansPressed(parent);
         });
-        t.join(); // only proceed when all done
+        JUnitUtil.waitFor(() -> !t.isAlive(), "Thread did not complete "+t.getName());
         JUnitUtil.dispose(parent);
     }
 
-    //@Test
+    @Test
+    @DisabledIfSystemProperty(named = "java.awt.headless", matches = "true")
     public void testFindEmptyPressed() throws InterruptedException {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         Thread t = new Thread(() -> {
             // constructor for jdo will wait until the dialog is visible
             JDialogOperator jdo = new JDialogOperator(Maintenance.rbm.getString("EmptyConditionalTitle"));
-            jdo.close();
+            JButtonOperator jbo = new JButtonOperator(jdo,"OK");
+            ThreadingUtil.runOnGUI(() -> jbo.push() );
+            jdo.waitClosed();
         });
         t.setName("Find Empty Dialog Close Thread");
         t.start();
-        JmriJFrame parent = new jmri.util.JmriJFrame("FindEmptyParent");
+        JmriJFrame parent = new JmriJFrame("FindEmptyParent");
         ThreadingUtil.runOnGUI(() -> {
             Maintenance.findEmptyPressed(parent);
         });
-        t.join(); // only proceed when all done
+
+        JUnitUtil.waitFor(() -> !t.isAlive(), "Thread did not complete "+t.getName());
         JUnitUtil.dispose(parent);
     }
 
-    @Before
+    @BeforeEach
     public void setUp() {
         JUnitUtil.setUp();
-        jmri.util.JUnitUtil.resetProfileManager();
+        JUnitUtil.resetProfileManager();
         JUnitUtil.initConfigureManager();
         JUnitUtil.initInternalTurnoutManager();
         JUnitUtil.initInternalSensorManager();
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         JUnitUtil.resetWindows(false, false);
         JUnitUtil.deregisterBlockManagerShutdownTask();


### PR DESCRIPTION
Maintenance - Readability, minor Netbeans lint

MaintenanceTest -
update to JUnit5
remove deprecated calls
re-enable some Tests

BeanTableDataModelTest - class BeanTableDataModelImpl can be static
BlockTableActionTest - add JUnitUtil.waitFor failure message