### PR TITLE
CBUS Configuration -  improve access to memo-owned instances

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -21,7 +21,7 @@
 
         <h4>CBUS</h4>
             <ul>
-                <li></li>
+                <li>Improved Node Manager and Event Table support for multiple CBUS Connections.</li>
             </ul>
 
         <h4>C/MRI</h4>

--- a/java/src/jmri/jmrix/can/cbus/CbusConfigurationManager.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusConfigurationManager.java
@@ -1,9 +1,14 @@
 package jmri.jmrix.can.cbus;
 
+import java.util.List;
 import java.util.ResourceBundle;
+
+import javax.annotation.Nonnull;
 
 import jmri.*;
 import jmri.jmrix.can.CanSystemConnectionMemo;
+import jmri.jmrix.can.cbus.node.CbusNodeTableDataModel;
+import jmri.jmrix.can.cbus.eventtable.CbusEventTableDataModel;
 
 // import org.slf4j.Logger;
 // import org.slf4j.LoggerFactory;
@@ -22,64 +27,69 @@ import jmri.jmrix.can.CanSystemConnectionMemo;
  * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
  *
  * @author Bob Jacobsen Copyright (C) 2009
+ * @author Steve Young Copyright (C) 2022
  */
-public class CbusConfigurationManager extends jmri.jmrix.can.ConfigurationManager {
+public class CbusConfigurationManager extends jmri.jmrix.can.ConfigurationManager implements Disposable {
 
-    public CbusConfigurationManager(CanSystemConnectionMemo memo) {
+    /**
+     * Create a new CbusConfigurationManager.
+     * A Supporting class to configure the {@link jmri.jmrix.can.CanSystemConnectionMemo}
+     * for the {@link jmri.jmrix.can.cbus} classes.
+     * @param memo Connection to configure.
+     */
+    public CbusConfigurationManager(@Nonnull CanSystemConnectionMemo memo) {
         super(memo);
-        addToConfigMgr();
+        storeToMemoAndInstance(CbusConfigurationManager.this, CbusConfigurationManager.class);
         cf = new jmri.jmrix.can.cbus.swing.CbusComponentFactory(adapterMemo);
         InstanceManager.store(cf, jmri.jmrix.swing.ComponentFactory.class);
     }
-    
-    protected final void addToConfigMgr() {
-        InstanceManager.store(this, CbusConfigurationManager.class);
-    }
 
     private final jmri.jmrix.swing.ComponentFactory cf;
+
+    // configureManagers() startup order
+    private static final List<Class<?>> DEFAULT_CLASSES = List.of(
+        CbusPreferences.class, 
+        PowerManager.class,
+        SensorManager.class,
+        // SensorManager before TurnoutManager so that listener can be added
+        CommandStation.class,
+        // CommandStation before TurnoutManager so that Raw Turnout Operator available
+        TurnoutManager.class,
+        ThrottleManager.class,
+        CbusPredefinedMeters.class,
+        ReporterManager.class,
+        LightManager.class,
+        CabSignalManager.class,
+        // Clock Control initialised last so CbusSensorManager exists, otherwise
+        // InternalSensorManager is deafult SensorManager when ISCLOCKRUNNING is provided.
+        ClockControl.class);
 
     /**
      * {@inheritDoc}
      */
     @Override
     public void configureManagers() {
-        
-        InstanceManager.store(getCbusPreferences(), CbusPreferences.class);
-        InstanceManager.store(getPowerManager(), jmri.PowerManager.class);
-        
-        InstanceManager.setSensorManager(getSensorManager());
 
-        InstanceManager.setTurnoutManager(getTurnoutManager());
-
-        InstanceManager.setThrottleManager(getThrottleManager());
+        for (Class<?> listClass : DEFAULT_CLASSES ) {
+            provide(listClass);
+        }
 
         // We register a programmer based on whether the hardware is available,
         // not whether the functionality is available
-        if (getProgrammerManager().isAddressedModeHardwareAvailable()) {
-            InstanceManager.store(getProgrammerManager(), jmri.AddressedProgrammerManager.class);
+        CbusDccProgrammerManager pm = getProgrammerManager();
+        if ( pm !=null ) {
+            if (pm.isAddressedModeHardwareAvailable()) {
+                storeToMemoAndInstance(pm, AddressedProgrammerManager.class);
+            }
+            if (pm.isGlobalProgrammerHardwareAvailable()) {
+                storeToMemoAndInstance(pm, GlobalProgrammerManager.class);
+            }
         }
-        if (getProgrammerManager().isGlobalProgrammerHardwareAvailable()) {
-            InstanceManager.store(getProgrammerManager(), GlobalProgrammerManager.class);
-        }
-        
-        getPredefinedMeters();
-        
-        InstanceManager.store(getCommandStation(), jmri.CommandStation.class);
 
-        InstanceManager.setReporterManager(getReporterManager());
-
-        InstanceManager.setLightManager(getLightManager());
-        
-        InstanceManager.setDefault(CabSignalManager.class,getCabSignalManager());
-        
-        // Clock Control initialised last so CbusSensorManager is first, not
-        // InternalSensorManager when ISCLOCKRUNNING may be created.
-        InstanceManager.setDefault(ClockControl.class, getClockControl());
-        
         if (getConsistManager() != null) {
-            InstanceManager.store(getConsistManager(), jmri.ConsistManager.class);
+            storeToMemoAndInstance(getConsistManager(), ConsistManager.class);
         }
-        
+
     }
 
     /**
@@ -92,33 +102,15 @@ public class CbusConfigurationManager extends jmri.jmrix.can.ConfigurationManage
     public boolean provides(Class<?> type) {
         if (adapterMemo.getDisabled()) {
             return false;
-        } else if (type.equals(jmri.AddressedProgrammerManager.class)) {
+        } else if (type.equals(AddressedProgrammerManager.class)) {
             return getProgrammerManager().isAddressedModePossible();
-        } else if (type.equals(jmri.GlobalProgrammerManager.class)) {
+        } else if (type.equals(GlobalProgrammerManager.class)) {
             return getProgrammerManager().isGlobalProgrammerAvailable();
-        } else if (type.equals(jmri.ThrottleManager.class)) {
+        } else if (type.equals(ConsistManager.class)) {
             return true;
-        } else if (type.equals(jmri.PowerManager.class)) {
-            return true;
-        } else if (type.equals(jmri.SensorManager.class)) {
-            return true;
-        } else if (type.equals(jmri.TurnoutManager.class)) {
-            return true;
-        } else if (type.equals(jmri.ReporterManager.class)) {
-            return true;
-        } else if (type.equals(jmri.LightManager.class)) {
-            return true;
-        } else if (type.equals(jmri.CommandStation.class)) {
-            return true;
-        } else if (type.equals(CbusPreferences.class)) {
-            return true;
-        } else if (type.equals(CabSignalManager.class)) {
-            return true;
-        } else if (type.equals(jmri.ConsistManager.class)) {
-            return true;
+        } else {
+            return DEFAULT_CLASSES.contains(type);
         }
-        
-        return false; // nothing, by default
     }
 
     /**
@@ -129,188 +121,28 @@ public class CbusConfigurationManager extends jmri.jmrix.can.ConfigurationManage
     public <T> T get(Class<?> T) {
         if (adapterMemo.getDisabled()) {
             return null;
-        } else if (T.equals(jmri.AddressedProgrammerManager.class)
+        } else if (T.equals(AddressedProgrammerManager.class)
                 && getProgrammerManager().isAddressedModePossible()) {
             return (T) getProgrammerManager();
-        } else if (T.equals(jmri.GlobalProgrammerManager.class)
+        } else if (T.equals(GlobalProgrammerManager.class)
                 && getProgrammerManager().isGlobalProgrammerAvailable()) {
             return (T) getProgrammerManager();
-        } else if (T.equals(jmri.ThrottleManager.class)) {
-            return (T) getThrottleManager();
-        } else if (T.equals(jmri.PowerManager.class)) {
-            return (T) getPowerManager();
-        } else if (T.equals(jmri.SensorManager.class)) {
-            return (T) getSensorManager();
-        } else if (T.equals(jmri.TurnoutManager.class)) {
-            return (T) getTurnoutManager();
-        } else if (T.equals(jmri.ReporterManager.class)) {
-            return (T) getReporterManager();
-        } else if (T.equals(jmri.LightManager.class)) {
-            return (T) getLightManager();
-        } else if (T.equals(jmri.CommandStation.class)) {
-            return (T) getCommandStation();
-        } else if (T.equals(CbusPreferences.class)) {
-            return (T) getCbusPreferences();
-        } else if (T.equals(CabSignalManager.class)) {
-            return (T) getCabSignalManager();
-        } else if (T.equals(jmri.ConsistManager.class)) {
+        } else if (T.equals(ConsistManager.class)) {
             return (T) getConsistManager();
+        } else if ( DEFAULT_CLASSES.contains(T) ) {
+            return provide(T);
         }
         return null; // nothing, by default
-        
     }
 
     private CbusDccProgrammerManager programmerManager;
 
-    public CbusDccProgrammerManager getProgrammerManager() {
-        if (programmerManager == null) {
+    private CbusDccProgrammerManager getProgrammerManager() {
+        if (programmerManager == null && !adapterMemo.getDisabled()) {
             programmerManager = new CbusDccProgrammerManager(
                     new CbusDccProgrammer(adapterMemo), adapterMemo);
         }
         return programmerManager;
-    }
-
-    public void setProgrammerManager(CbusDccProgrammerManager p) {
-        programmerManager = p;
-    }
-
-    protected CbusPowerManager powerManager;
-
-    public CbusPowerManager getPowerManager() {
-        if (adapterMemo.getDisabled()) {
-            return null;
-        }
-        if (powerManager == null) {
-            powerManager = new CbusPowerManager(adapterMemo);
-        }
-        return powerManager;
-    }
-    
-    protected CbusClockControl clockControl;
-    
-    public CbusClockControl getClockControl() {
-        if (adapterMemo.getDisabled()) {
-            return null;
-        }
-        if (clockControl == null) {
-            clockControl = new CbusClockControl(adapterMemo);
-        }
-        return clockControl;
-    
-    }
-
-    protected ThrottleManager throttleManager;
-
-    public ThrottleManager getThrottleManager() {
-        if (adapterMemo.getDisabled()) {
-            return null;
-        }
-        if (throttleManager == null) {
-            throttleManager = new CbusThrottleManager(adapterMemo);
-        }
-        return throttleManager;
-    }
-
-    public void setThrottleManager(ThrottleManager t) {
-        throttleManager = t;
-    }
-
-    protected CbusTurnoutManager turnoutManager;
-
-    public CbusTurnoutManager getTurnoutManager() {
-        if (adapterMemo.getDisabled()) {
-            return null;
-        }
-        if (turnoutManager == null) {
-            turnoutManager = new CbusTurnoutManager(adapterMemo);
-        }
-        return turnoutManager;
-    }
-
-    protected CbusSensorManager sensorManager;
-
-    public CbusSensorManager getSensorManager() {
-        if (adapterMemo.getDisabled()) {
-            return null;
-        }
-        if (sensorManager == null) {
-            sensorManager = new CbusSensorManager(adapterMemo);
-        }
-        return sensorManager;
-    }
-
-    protected CbusReporterManager reporterManager = null;
-
-    public CbusReporterManager getReporterManager() {
-        if (adapterMemo.getDisabled()) {
-            return null;
-        }
-        if (reporterManager == null) {
-            reporterManager = new CbusReporterManager(adapterMemo);
-        }
-        return reporterManager;
-    }
-
-    protected CbusLightManager lightManager = null;
-
-    public CbusLightManager getLightManager() {
-        if (adapterMemo.getDisabled()) {
-            return null;
-        }
-        if (lightManager == null) {
-            lightManager = new CbusLightManager(adapterMemo);
-        }
-        return lightManager;
-    }
-
-    protected CbusCommandStation commandStation;
-
-    public CbusCommandStation getCommandStation() {
-        if (adapterMemo.getDisabled()) {
-            return null;
-        }
-        if (commandStation == null) {
-            commandStation = new CbusCommandStation(adapterMemo);
-        }
-        return commandStation;
-    }
-    
-    protected CbusPredefinedMeters predefinedMeters;
-    
-    public CbusPredefinedMeters getPredefinedMeters() {
-        if (adapterMemo.getDisabled()) {
-            return null;
-        }
-        if (predefinedMeters == null) {
-            InstanceManager.setMeterManager(new jmri.managers.AbstractMeterManager(adapterMemo));
-            predefinedMeters = new CbusPredefinedMeters(adapterMemo);
-        }
-        return predefinedMeters;
-    }
-    
-    private CbusPreferences cbusPreferences = null;
-
-    public CbusPreferences getCbusPreferences() {
-        if (adapterMemo.getDisabled()) {
-            return null;
-        }
-        if (cbusPreferences == null) {
-            cbusPreferences = new CbusPreferences();
-            InstanceManager.store( cbusPreferences, CbusPreferences.class );
-        }
-        return cbusPreferences;
-    }
-    
-    protected CbusCabSignalManager cabSignalManager = null;
-
-    public CbusCabSignalManager getCabSignalManager() {
-        if ( adapterMemo.getDisabled() ) {
-            return null;
-        }
-        if (cabSignalManager == null) {
-            cabSignalManager = new CbusCabSignalManager(adapterMemo);
-        }
-        return cabSignalManager;
     }
 
     protected CbusConsistManager consistManager = null;
@@ -322,12 +154,12 @@ public class CbusConfigurationManager extends jmri.jmrix.can.ConfigurationManage
      * 
      * @return ConsistManager object
      */
-    public ConsistManager getConsistManager() {
+    private ConsistManager getConsistManager() {
         if ( adapterMemo.getDisabled() ) {
             return null;
         }
         if (consistManager == null) {
-            consistManager = new CbusConsistManager(get(jmri.CommandStation.class));
+            consistManager = new CbusConsistManager(get(CommandStation.class));
             if (adapterMemo.getProgModeSwitch() == ProgModeSwitch.EITHER) {
                 // Could be either programmer or command station
                 if (getProgrammerManager().isAddressedModePossible()) {
@@ -346,49 +178,90 @@ public class CbusConfigurationManager extends jmri.jmrix.can.ConfigurationManage
     }
 
     /**
+     * Provide a new Class instance.
+     * <p>
+     * NOT for general use outside of this class, although public so that
+     * classes like CbusEventTablePane can get a CbusEventTableDataModel
+     * when started.
+     * <p>
+     * If a class is NOT auto-created by the normal get,
+     * it can be provided with this method.
+     * Adds provided class to memo class object map,
+     * AND InstanceManager.
+     * @param <T> class type.
+     * @param T class type.
+     * @return class object, or null if unavailable.
+     */
+    public <T> T provide(@Nonnull Class<?> T){
+        if (adapterMemo.getDisabled()) {
+            return null;
+        }
+        T existing = adapterMemo.getFromMap(T); // if already in object map, use it
+        if ( existing !=null ) {
+            return existing;
+        }
+        if (T.equals(CbusNodeTableDataModel.class)) {
+            storeToMemoAndInstance(new CbusNodeTableDataModel(adapterMemo,10), CbusNodeTableDataModel.class);
+        } else if (T.equals(CbusEventTableDataModel.class)) {
+            storeToMemoAndInstance(new CbusEventTableDataModel(adapterMemo,10), CbusEventTableDataModel.class);
+        } else if (T.equals(CbusPreferences.class)) {
+            storeToMemoAndInstance(new CbusPreferences(), CbusPreferences.class);
+        } else if (T.equals(PowerManager.class)) {
+            storeToMemoAndInstance(new CbusPowerManager(adapterMemo), PowerManager.class);
+        } else if (T.equals(CommandStation.class)) {
+            storeToMemoAndInstance(new CbusCommandStation(adapterMemo), CommandStation.class);
+        } else if (T.equals(ThrottleManager.class)) {
+            storeToMemoAndInstance(new CbusThrottleManager(adapterMemo), ThrottleManager.class);
+        } else if (T.equals(CabSignalManager.class)) {
+            storeToMemoAndInstanceDefault(new CbusCabSignalManager(adapterMemo), CabSignalManager.class);
+        } else if (T.equals(ClockControl.class) ) {
+            storeToMemoAndInstanceDefault(new CbusClockControl(adapterMemo), ClockControl.class);
+        } else if (T.equals(SensorManager.class) ) {
+            adapterMemo.store(new CbusSensorManager(adapterMemo), SensorManager.class);
+            InstanceManager.setSensorManager(adapterMemo.getFromMap(T));
+        } else if (T.equals(TurnoutManager.class) ) {
+            adapterMemo.store(new CbusTurnoutManager(adapterMemo), TurnoutManager.class);
+            InstanceManager.setTurnoutManager(adapterMemo.getFromMap(T));
+        } else if (T.equals(ReporterManager.class) ) {
+            adapterMemo.store(new CbusReporterManager(adapterMemo), ReporterManager.class);
+            InstanceManager.setReporterManager(adapterMemo.getFromMap(T));
+        } else if (T.equals(LightManager.class) ) {
+            adapterMemo.store(new CbusLightManager(adapterMemo), LightManager.class);
+            InstanceManager.setLightManager(adapterMemo.getFromMap(T));
+        } else if (T.equals(CbusPredefinedMeters.class) ) {
+            InstanceManager.setMeterManager(new jmri.managers.AbstractMeterManager(adapterMemo));
+            storeToMemoAndInstance(new CbusPredefinedMeters(adapterMemo), CbusPredefinedMeters.class);
+        }
+        return adapterMemo.getFromMap(T); // if class not in map, class not provided.
+    }
+
+    private <T> void storeToMemoAndInstance(@Nonnull T item, @Nonnull Class<T> type){
+        adapterMemo.store(item, type); // store with memo
+        InstanceManager.store(item, type); // and with InstanceManager
+    }
+
+    private <T> void storeToMemoAndInstanceDefault(@Nonnull T item, @Nonnull Class<T> type){
+        adapterMemo.store(item, type); // store with memo
+        InstanceManager.setDefault( type, item); // and with InstanceManager
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Override
     public void dispose() {
+
+        // classed stored in the memo classObjectMap will be deregisted from
+        // InstanceManager on memo disposal, and will also have their 
+        // dispose method called if they implement jmri.Disposable.
         
-        if (cf != null) {
-            InstanceManager.deregister(cf, jmri.jmrix.swing.ComponentFactory.class);
-        }
-        if (powerManager != null) {
-            InstanceManager.deregister(powerManager, jmri.jmrix.can.cbus.CbusPowerManager.class);
-        }
-        if (clockControl != null) {
-            InstanceManager.deregister(clockControl, ClockControl.class);
-        }
-        if (turnoutManager != null) {
-            InstanceManager.deregister(turnoutManager, jmri.jmrix.can.cbus.CbusTurnoutManager.class);
-        }
-        if (sensorManager != null) {
-            InstanceManager.deregister(sensorManager, jmri.jmrix.can.cbus.CbusSensorManager.class);
-        }
-        if (reporterManager != null) {
-            InstanceManager.deregister(reporterManager, jmri.jmrix.can.cbus.CbusReporterManager.class);
-        }
-        if (lightManager != null) {
-            InstanceManager.deregister(lightManager, jmri.jmrix.can.cbus.CbusLightManager.class);
-        }
-        if (throttleManager != null) {
-            InstanceManager.deregister((CbusThrottleManager) throttleManager, jmri.jmrix.can.cbus.CbusThrottleManager.class);
-        }
-        if (commandStation != null) {
-            InstanceManager.deregister(commandStation, jmri.CommandStation.class);
-        }
-        if (predefinedMeters != null) {
-            predefinedMeters.dispose();
-        }
-        if (cbusPreferences != null) {
-            InstanceManager.deregister(cbusPreferences, jmri.jmrix.can.cbus.CbusPreferences.class);
-        }
-        if (cabSignalManager != null) {
-            InstanceManager.deregister(cabSignalManager, jmri.jmrix.can.cbus.CbusCabSignalManager.class);
-        }
+        InstanceManager.deregister(cf, jmri.jmrix.swing.ComponentFactory.class);
+
         if (consistManager != null) {
             InstanceManager.deregister(consistManager, ConsistManager.class);
+        }
+        if (programmerManager != null) {
+            programmerManager.dispose();
         }
         InstanceManager.deregister(this, CbusConfigurationManager.class);
     }
@@ -400,7 +273,7 @@ public class CbusConfigurationManager extends jmri.jmrix.can.ConfigurationManage
     protected ResourceBundle getActionModelResourceBundle() {
         return ResourceBundle.getBundle("jmri.jmrix.can.CanActionListBundle");
     }
-    
+
     // private static final Logger log = LoggerFactory.getLogger(CbusConfigurationManager.class);
 
 }

--- a/java/src/jmri/jmrix/can/cbus/CbusDccProgrammerManager.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusDccProgrammerManager.java
@@ -24,12 +24,12 @@ public class CbusDccProgrammerManager extends DefaultProgrammerManager {
     private boolean _isAddressedModePossible = true;
     private boolean _isGlobalProgrammerAvailable = true;
     
-    private CbusPreferences prefs;
+    private final CbusPreferences prefs;
 
     public CbusDccProgrammerManager(Programmer serviceModeProgrammer, CanSystemConnectionMemo memo) {
         super(serviceModeProgrammer, memo);
         tc = memo.getTrafficController();
-        prefs = jmri.InstanceManager.getDefault(jmri.jmrix.can.cbus.CbusPreferences.class);
+        prefs = memo.get(jmri.jmrix.can.cbus.CbusPreferences.class);
         log.info("Preferences for programmers start as: global {} addressed {}", prefs.isGlobalProgrammerAvailable(), prefs.isAddressedModePossible());
         validateProgrammingModes(memo);
         log.info("Preferences for programmers now: global {} addressed {}", prefs.isGlobalProgrammerAvailable(), prefs.isAddressedModePossible());

--- a/java/src/jmri/jmrix/can/cbus/CbusPredefinedMeters.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusPredefinedMeters.java
@@ -121,7 +121,7 @@ public class CbusPredefinedMeters implements CanListener, Disposable {
     
     private class UpdateTask extends MeterUpdateTask {
     
-        public UpdateTask(int interval) {
+        protected UpdateTask(int interval) {
             super(interval);
         }
     
@@ -136,7 +136,7 @@ public class CbusPredefinedMeters implements CanListener, Disposable {
             _eventToListenCurrent = 1; // hard coded at present
             _eventToListenVoltage = 2; // hard coded at present
             _eventToListenCurrentExtra = 3; // hard coded at present
-            CbusNodeTableDataModel cs =  jmri.InstanceManager.getNullableDefault(CbusNodeTableDataModel.class);
+            CbusNodeTableDataModel cs =  _memo.get(CbusNodeTableDataModel.class);
             if (cs != null) {
                 CbusNode csnode = cs.getCsByNum(0);
                 if (csnode!=null) {

--- a/java/src/jmri/jmrix/can/cbus/CbusThrottleManager.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusThrottleManager.java
@@ -1,21 +1,19 @@
 package jmri.jmrix.can.cbus;
 
 import java.util.*;
+import java.awt.GraphicsEnvironment;
+
 import javax.swing.JDialog;
 import javax.swing.JOptionPane;
-import jmri.DccLocoAddress;
-import jmri.DccThrottle;
-import jmri.LocoAddress;
-import jmri.SpeedStepMode;
-import jmri.ThrottleListener;
-import jmri.ThrottleListener.DecisionType;
+
+import jmri.*;
 import jmri.jmrit.throttle.ThrottlesPreferences;
 import jmri.jmrix.AbstractThrottleManager;
-import jmri.jmrix.can.CanListener;
-import jmri.jmrix.can.CanMessage;
-import jmri.jmrix.can.CanReply;
-import jmri.jmrix.can.CanSystemConnectionMemo;
-import jmri.jmrix.can.TrafficController;
+import jmri.jmrix.can.*;
+import jmri.util.TimerUtil;
+import jmri.util.ThreadingUtil;
+
+import static jmri.ThrottleListener.DecisionType;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -28,15 +26,15 @@ import org.slf4j.LoggerFactory;
  * @author Steve Young Copyright (C) 2019
  * @author Andrew Crosland Copyright (C) 2021
  */
-public class CbusThrottleManager extends AbstractThrottleManager implements CanListener {
+public class CbusThrottleManager extends AbstractThrottleManager implements CanListener, Disposable {
 
     private boolean _handleExpected = false;
     private boolean _handleExpectedSecondLevelRequest = false;
     private int _intAddr;
     private DccLocoAddress _dccAddr;
     protected int THROTTLE_TIMEOUT = 5000;
-    private JDialog canErrorDialog;
-    private JDialog invalidErrorDialog;
+    private boolean canErrorDialogVisible;
+    private boolean invalidErrorDialogVisible;
     private boolean _singleThrottleInUse = false; // For single throttle support
 
     private final HashMap<Integer, CbusThrottle> softThrottles = new HashMap<>(CbusConstants.CBUS_MAX_SLOTS);
@@ -53,7 +51,7 @@ public class CbusThrottleManager extends AbstractThrottleManager implements CanL
      */
     @Override
     public void dispose() {
-        tc.removeCanListener(this);
+        removeTc(tc);
         stopThrottleRequestTimer();
     }
 
@@ -98,7 +96,7 @@ public class CbusThrottleManager extends AbstractThrottleManager implements CanL
             // station. Throttle object will be notified by Command Station
             log.debug("Requesting {} session for loco {}",decision,_dccAddr);
             if (_dccAddr.isLongAddress()) {
-                _intAddr = _intAddr | 0xC000;
+                _intAddr |= 0xC000;
             }
             CanMessage msg;
 
@@ -211,14 +209,6 @@ public class CbusThrottleManager extends AbstractThrottleManager implements CanL
         }
     }
 
-    private boolean isCanErrorDialogVisible(){
-        return canErrorDialog!=null && canErrorDialog.isVisible();
-    }
-
-    private boolean isInvalidErrorDialogVisible(){
-        return invalidErrorDialog!=null && invalidErrorDialog.isVisible();
-    }
-
     /**
      * {@inheritDoc}
      */
@@ -230,21 +220,15 @@ public class CbusThrottleManager extends AbstractThrottleManager implements CanL
             return;
         }
         int opc = m.getElement(0);
-        int rcvdIntAddr;
-        boolean rcvdIsLong;
         int handle = m.getElement(1);
-
-        DccLocoAddress rcvdDccAddr;
-        String errStr = "";
 
         switch (opc) {
             case CbusConstants.CBUS_PLOC:
-                rcvdIntAddr = (m.getElement(2) & 0x3f) * 256 + m.getElement(3);
-                rcvdIsLong = (m.getElement(2) & 0xc0) != 0;
-                rcvdDccAddr = new DccLocoAddress(rcvdIntAddr, rcvdIsLong);
+                int rcvdIntAddr = (m.getElement(2) & 0x3f) * 256 + m.getElement(3);
+                boolean rcvdIsLong = (m.getElement(2) & 0xc0) != 0;
+                DccLocoAddress rcvdDccAddr = new DccLocoAddress(rcvdIntAddr, rcvdIsLong);
                 log.debug("Throttle manager received PLOC with session {} for address {}",m.getElement(1),rcvdIntAddr);
-                if ((_handleExpected)
-                    && rcvdDccAddr.equals(_dccAddr)) {
+                if ((_handleExpected) && rcvdDccAddr.equals(_dccAddr)) {
                     log.debug("PLOC was expected");
                     // We're expecting an engine report and it matches our address
                     stopThrottleRequestTimer();
@@ -270,166 +254,16 @@ public class CbusThrottleManager extends AbstractThrottleManager implements CanL
                     }
 
                     // Initialise new throttle from PLOC data to allow taking over moving trains
-                    CbusThrottle throttle;
-                    throttle = new CbusThrottle((CanSystemConnectionMemo) adapterMemo, rcvdDccAddr, handle);
+                    CbusThrottle throttle = new CbusThrottle((CanSystemConnectionMemo) adapterMemo, rcvdDccAddr, handle);
                     notifyThrottleKnown(throttle, rcvdDccAddr);
                     throttle.throttleInit(m.getElement(4), m.getElement(5), m.getElement(6), m.getElement(7));
                     softThrottles.put(handle, throttle);
                     _handleExpected = false;
                 }
                 break;
-
             case CbusConstants.CBUS_ERR:
-                rcvdIntAddr = (m.getElement(1) & 0x3f) * 256 + m.getElement(2);
-                rcvdIsLong = (m.getElement(1) & 0xc0) != 0;
-                rcvdDccAddr = new DccLocoAddress(rcvdIntAddr, rcvdIsLong);
-                int errCode = m.getElement(3);
-
-                log.debug("Throttle manager received ERR {} for loco {}", errStr, rcvdDccAddr);
-
-                switch (errCode) {
-                    case CbusConstants.ERR_LOCO_STACK_FULL:
-                    case CbusConstants.ERR_LOCO_ADDRESS_TAKEN:
-                        if ( errCode == CbusConstants.ERR_LOCO_STACK_FULL ){
-                            errStr = Bundle.getMessage("ERR_LOCO_STACK_FULL") + " " + rcvdIntAddr;
-                        } else {
-                            errStr = Bundle.getMessage("ERR_LOCO_ADDRESS_TAKEN", rcvdIntAddr);
-                        }
-
-                        log.debug("handlexpected {} _dccAddr {} got {} ", _handleExpected, _dccAddr, rcvdDccAddr);
-
-                        if ((_handleExpected) && rcvdDccAddr.equals(_dccAddr)) {
-
-                            // We were expecting an engine report and it matches our address
-                            log.debug("Failed throttle request due to ERR");
-                            _handleExpected = false;
-                            stopThrottleRequestTimer();
-
-                            // if this is the result of a share or steal request,
-                            // we need to stop here and inform the ThrottleListener
-                            if ( _handleExpectedSecondLevelRequest ){
-                                failedThrottleRequest(_dccAddr, errStr);
-                                return;
-                            }
-
-                            // so this is the message from the 1st normal request
-                            // now we check the command station,
-                            // and notify the ThrottleListener ()
-
-                            boolean steal = false;
-                            boolean share = false;
-
-                            CbusCommandStation cs = (CbusCommandStation) jmri.InstanceManager.getNullableDefault(jmri.CommandStation.class);
-
-                            if ( cs != null ) {
-                                log.debug("cs says can steal {}, can share {}", cs.isStealAvailable(), cs.isShareAvailable() );
-                                steal = cs.isStealAvailable();
-                                share = cs.isShareAvailable();
-                            }
-
-                            if ( !steal && !share ){
-                                failedThrottleRequest(_dccAddr, errStr);
-                            }
-                            else if ( steal && share ){
-                                notifyDecisionRequest(_dccAddr, DecisionType.STEAL_OR_SHARE);
-                            }
-                            else if ( steal ){
-                                notifyDecisionRequest(_dccAddr, DecisionType.STEAL);
-                            }
-                            else { // must be share
-                                notifyDecisionRequest(_dccAddr, DecisionType.SHARE);
-                            }
-                        } else {
-                            log.debug("ERR address not matched");
-                        }
-                        break;
-
-                    case CbusConstants.ERR_SESSION_NOT_PRESENT:
-                        // most likely called via a command station being reset or
-                        // coming back online
-                        errStr = Bundle.getMessage("ERR_SESSION_NOT_PRESENT",handle) ;
-                        log.warn(errStr);
-
-                        if ((_handleExpected) && rcvdDccAddr.equals(_dccAddr)) {
-                            // We were expecting an engine report and it matches our address
-                            _handleExpected = false;
-                            failedThrottleRequest(_dccAddr, Bundle.getMessage("CBUS_ERROR") + errStr);
-                            log.warn("Session not present when expecting a session number");
-                        }
-
-                        // check if it's a JMRI throttle session,
-                        // Inform the throttle associated with this session handle, if any
-                        for (Map.Entry<Integer, CbusThrottle> entry : softThrottles.entrySet()) {
-                            CbusThrottle throttle = entry.getValue();
-                            if (throttle.getHandle() == handle) {
-                                log.warn("Cancelling JMRI Throttle Session {} for loco {}",
-                                    handle,
-                                    throttle.getLocoAddress().toString()
-                                );
-                                attemptRecoverThrottle(throttle);
-                                break;
-                            }
-                        }
-                        break;
-                    case CbusConstants.ERR_CONSIST_EMPTY:
-                        errStr = Bundle.getMessage("ERR_CONSIST_EMPTY") + " " + handle;
-                        log.warn(errStr);
-                        break;
-                    case CbusConstants.ERR_LOCO_NOT_FOUND:
-                        log.warn("{} {}", Bundle.getMessage("ERR_LOCO_NOT_FOUND"), handle);
-                        break;
-                    case CbusConstants.ERR_CAN_BUS_ERROR:
-                        log.error(Bundle.getMessage("ERR_CAN_BUS_ERROR"));
-                        if (!java.awt.GraphicsEnvironment.isHeadless() && !isCanErrorDialogVisible()){
-                            jmri.util.ThreadingUtil.runOnGUI(() -> {
-                                JOptionPane pane = new JOptionPane(Bundle.getMessage("ERR_CAN_BUS_ERROR"));
-                                pane.setMessageType(JOptionPane.ERROR_MESSAGE);
-                                canErrorDialog = pane.createDialog(null, Bundle.getMessage("CBUS_ERROR"));
-                                canErrorDialog.setModal(false);
-                                canErrorDialog.setVisible(true);
-                            });
-                        }
-                        return;
-                    case CbusConstants.ERR_INVALID_REQUEST:
-                        log.error(Bundle.getMessage("ERR_INVALID_REQUEST"));
-                        if (!java.awt.GraphicsEnvironment.isHeadless() && !isInvalidErrorDialogVisible()){
-                            jmri.util.ThreadingUtil.runOnGUI(() -> {
-                                JOptionPane pane = new JOptionPane(Bundle.getMessage("ERR_INVALID_REQUEST"));
-                                pane.setMessageType(JOptionPane.ERROR_MESSAGE);
-                                invalidErrorDialog = pane.createDialog(null, Bundle.getMessage("CBUS_ERROR"));
-                                invalidErrorDialog.setModal(false);
-                                invalidErrorDialog.setVisible(true);
-                            });
-                        }
-                        return;
-                    case CbusConstants.ERR_SESSION_CANCELLED:
-                        // There will be a session cancelled error for the other throttle(s)
-                        // when you are stealing, but as you don't yet have a session id, it
-                        // won't match so you will ignore it, then a PLOC will come with that
-                        // session id and your requested loco number which is giving it to you.
-
-                        log.debug(Bundle.getMessage("ERR_SESSION_CANCELLED",handle));
-
-                        // Inform the throttle associated with this session handle, if any
-                        for (Map.Entry<Integer, CbusThrottle> entry : softThrottles.entrySet()) {
-                            CbusThrottle throttle = entry.getValue();
-                            if (throttle.getHandle() == handle) {
-                                if (throttle.isStolen()){ // already actioned
-                                    log.debug("external steal already actioned, returning");
-                                    return;
-                                }
-                                log.warn("External Steal / Cancel for loco {} Session {} ",throttle.getLocoAddress(), handle );
-                                attemptRecoverThrottle(throttle);
-                                break;
-                            }
-                        }
-                        break;
-                    default:
-                        log.error("{} error code: {}", Bundle.getMessage("ERR_UNKNOWN"), errCode);
-                        break;
-                }
+                handleErr(m);
                 break;
-
             case CbusConstants.CBUS_DSPD:
                 // Find a throttle corresponding to the handle
                 for (Map.Entry<Integer, CbusThrottle> entry : softThrottles.entrySet()) {
@@ -485,8 +319,174 @@ public class CbusThrottleManager extends AbstractThrottleManager implements CanL
                     }
                 }
                 break;
-
             default:
+                break;
+        }
+    }
+
+    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(value="SLF4J_SIGN_ONLY_FORMAT",
+                                                        justification="I18N of log message")
+    private void handleErr(CanReply m) {
+        int handle = m.getElement(1);
+        int rcvdIntAddr = (m.getElement(1) & 0x3f) * 256 + m.getElement(2);
+        boolean rcvdIsLong = (m.getElement(1) & 0xc0) != 0;
+        // DccLocoAddress rcvdDccAddr = new DccLocoAddress(rcvdIntAddr, rcvdIsLong);
+        int errCode = m.getElement(3);
+        
+        boolean responseForUs = ((_handleExpected) && new DccLocoAddress(rcvdIntAddr, rcvdIsLong).equals(_dccAddr));
+
+        switch (errCode) {
+            case CbusConstants.ERR_LOCO_STACK_FULL:
+            case CbusConstants.ERR_LOCO_ADDRESS_TAKEN:
+                
+                String errStr;
+                if ( errCode == CbusConstants.ERR_LOCO_STACK_FULL ){
+                    errStr = Bundle.getMessage("ERR_LOCO_STACK_FULL") + " " + rcvdIntAddr;
+                } else {
+                    errStr = Bundle.getMessage("ERR_LOCO_ADDRESS_TAKEN", rcvdIntAddr);
+                }
+
+                // log.debug("handlexpected {} _dccAddr {} got {} ", _handleExpected, _dccAddr, rcvdDccAddr);
+
+                if (responseForUs) { // We were expecting an engine report and it matches our address
+                    log.debug("Failed throttle request due to ERR");
+                    _handleExpected = false;
+                    stopThrottleRequestTimer();
+
+                    // if this is the result of a share or steal request,
+                    // we need to stop here and inform the ThrottleListener
+                    if ( _handleExpectedSecondLevelRequest ){
+                        failedThrottleRequest(_dccAddr, errStr);
+                        return;
+                    }
+
+                    // so this is the message from the 1st normal request
+                    // now we check the command station,
+                    // and notify the ThrottleListener ()
+
+                    boolean steal = false;
+                    boolean share = false;
+
+                    CbusCommandStation cs = memo.get(CommandStation.class);
+
+                    if ( cs != null ) {
+                        log.debug("cs says can steal {}, can share {}", cs.isStealAvailable(), cs.isShareAvailable() );
+                        steal = cs.isStealAvailable();
+                        share = cs.isShareAvailable();
+                    }
+
+                    if ( !steal && !share ){
+                        failedThrottleRequest(_dccAddr, errStr);
+                    }
+                    else if ( steal && share ){
+                        notifyDecisionRequest(_dccAddr, DecisionType.STEAL_OR_SHARE);
+                    }
+                    else if ( steal ){
+                        notifyDecisionRequest(_dccAddr, DecisionType.STEAL);
+                    }
+                    else { // must be share
+                        notifyDecisionRequest(_dccAddr, DecisionType.SHARE);
+                    }
+                } else {
+                    log.debug("ERR address not matched");
+                }
+                break;
+
+            case CbusConstants.ERR_SESSION_NOT_PRESENT:
+                // most likely called via a command station being reset or
+                // coming back online
+                log.warn("{}",Bundle.getMessage("ERR_SESSION_NOT_PRESENT",handle));
+
+                if (responseForUs) {
+                    // We were expecting an engine report and it matches our address
+                    _handleExpected = false;
+                    failedThrottleRequest(_dccAddr, Bundle.getMessage("CBUS_ERROR")
+                        + Bundle.getMessage("ERR_SESSION_NOT_PRESENT",handle));
+                    log.warn("Session not present when expecting a session number");
+                }
+
+                // check if it's a JMRI throttle session,
+                // Inform the throttle associated with this session handle, if any
+                for (Map.Entry<Integer, CbusThrottle> entry : softThrottles.entrySet()) {
+                    CbusThrottle throttle = entry.getValue();
+                    if (throttle.getHandle() == handle) {
+                        log.warn("Cancelling JMRI Throttle Session {} for loco {}",
+                            handle,
+                            throttle.getLocoAddress().toString()
+                        );
+                        attemptRecoverThrottle(throttle);
+                        break;
+                    }
+                }
+                break;
+            case CbusConstants.ERR_CONSIST_EMPTY:
+                log.warn("{} {}",Bundle.getMessage("ERR_CONSIST_EMPTY"), handle);
+                break;
+            case CbusConstants.ERR_LOCO_NOT_FOUND:
+                log.warn("{} {}", Bundle.getMessage("ERR_LOCO_NOT_FOUND"), handle);
+                break;
+            case CbusConstants.ERR_CAN_BUS_ERROR:
+                log.error("{}",Bundle.getMessage("ERR_CAN_BUS_ERROR"));
+                if (!GraphicsEnvironment.isHeadless() && !canErrorDialogVisible ) {
+                    
+                    ThreadingUtil.runOnGUI(() -> {
+                        canErrorDialogVisible = true;
+                        JOptionPane pane = new JOptionPane(Bundle.getMessage("ERR_CAN_BUS_ERROR"));
+                        pane.setMessageType(JOptionPane.ERROR_MESSAGE);
+                        JDialog canErrorDialog = pane.createDialog(null, Bundle.getMessage("CBUS_ERROR"));
+                        
+                        pane.addPropertyChangeListener(JOptionPane.VALUE_PROPERTY, ignored -> {
+                            canErrorDialog.dispose();
+                            canErrorDialogVisible = false;
+                        });
+                        
+                        
+                        canErrorDialog.setModal(false);
+                        canErrorDialog.setVisible(true);
+                    });
+                }
+                return;
+            case CbusConstants.ERR_INVALID_REQUEST:
+                log.error("{}", Bundle.getMessage("ERR_INVALID_REQUEST"));
+                if (!GraphicsEnvironment.isHeadless() && !invalidErrorDialogVisible){
+                    ThreadingUtil.runOnGUI(() -> {
+                        invalidErrorDialogVisible = true;
+                        JOptionPane pane = new JOptionPane(Bundle.getMessage("ERR_INVALID_REQUEST"));
+                        pane.setMessageType(JOptionPane.ERROR_MESSAGE);
+                        JDialog invalidErrorDialog = pane.createDialog(null, Bundle.getMessage("CBUS_ERROR"));
+                        pane.addPropertyChangeListener(JOptionPane.VALUE_PROPERTY, ignored -> {
+                            invalidErrorDialog.dispose();
+                            invalidErrorDialogVisible = false;
+                        });
+                        invalidErrorDialog.setModal(false);
+                        invalidErrorDialog.setVisible(true);
+                    });
+                }
+                return;
+            case CbusConstants.ERR_SESSION_CANCELLED:
+                // There will be a session cancelled error for the other throttle(s)
+                // when you are stealing, but as you don't yet have a session id, it
+                // won't match so you will ignore it, then a PLOC will come with that
+                // session id and your requested loco number which is giving it to you.
+
+                log.debug("{}", Bundle.getMessage("ERR_SESSION_CANCELLED",handle));
+
+                // Inform the throttle associated with this session handle, if any
+                for (Map.Entry<Integer, CbusThrottle> entry : softThrottles.entrySet()) {
+                    CbusThrottle throttle = entry.getValue();
+                    if (throttle.getHandle() == handle) {
+                        if (throttle.isStolen()){ // already actioned
+                            log.debug("external steal already actioned, returning");
+                            return;
+                        }
+                        log.warn("External Steal / Cancel for loco {} Session {} ",throttle.getLocoAddress(), handle );
+                        attemptRecoverThrottle(throttle);
+                        break;
+                    }
+                }
+                break;
+            default:
+                log.error("{} error code: {}", Bundle.getMessage("ERR_UNKNOWN"), errCode);
                 break;
         }
     }
@@ -518,30 +518,25 @@ public class CbusThrottleManager extends AbstractThrottleManager implements CanL
         boolean steal = false;
         boolean share = false;
 
-        CbusCommandStation cs = (CbusCommandStation) jmri.InstanceManager.getNullableDefault(jmri.CommandStation.class);
+        CbusCommandStation cs = memo.get(CommandStation.class);
         if ( cs != null ) {
             log.debug("cs says can steal {}, can share {}", cs.isStealAvailable(), cs.isShareAvailable() );
             steal = cs.isStealAvailable();
             share = cs.isShareAvailable();
         }
-        if (jmri.InstanceManager.getNullableDefault(ThrottlesPreferences.class) == null) {
-            log.debug("Creating new ThrottlesPreference Instance");
-            jmri.InstanceManager.store(new ThrottlesPreferences(), ThrottlesPreferences.class);
-        }
-        ThrottlesPreferences tp = jmri.InstanceManager.getDefault(ThrottlesPreferences.class);
 
-        if (share && tp.isSilentShare()){
+        if (share && InstanceManager.getDefault(ThrottlesPreferences.class).isSilentShare()){
             // share is available on command station AND silent share preference checked
             log.info("Requesting Silent Share loco {} to regain a session",throttle.getLocoAddress());
-            jmri.util.ThreadingUtil.runOnLayoutDelayed( () -> {
+            ThreadingUtil.runOnLayoutDelayed( () -> {
                 startThrottleRequestTimer(true);
                 requestThrottleSetup(throttle.getLocoAddress(), DecisionType.SHARE);
             },1000);
         }
-        else if (steal && tp.isSilentSteal()) {
+        else if (steal && InstanceManager.getDefault(ThrottlesPreferences.class).isSilentSteal()) {
             // steal is available on command station AND silent steal preference checked
             log.info("Requesting Silent Steal loco {} to regain a session",throttle.getLocoAddress());
-            jmri.util.ThreadingUtil.runOnLayoutDelayed( () -> {
+            ThreadingUtil.runOnLayoutDelayed( () -> {
                 startThrottleRequestTimer(true);
                 requestThrottleSetup(throttle.getLocoAddress(), DecisionType.STEAL);
             },1000);
@@ -580,22 +575,22 @@ public class CbusThrottleManager extends AbstractThrottleManager implements CanL
     }
 
     /**
-     * Short and long address spaces overlap and are not unique
+     * Short and long address spaces overlap and are not unique.
      */
     @Override
     public boolean addressTypeUnique() {
         return false;
     }
 
-    /*
-     * Local method for deciding short/long address
+    /**
+     * Local method for deciding short/long address.
      */
     static boolean isLongAddress(int num) {
         return (num >= 128);
     }
 
     /**
-     * Hardware has a stealing implementation
+     * Hardware has a stealing implementation.
      * {@inheritDoc}
      */
     @Override
@@ -604,7 +599,7 @@ public class CbusThrottleManager extends AbstractThrottleManager implements CanL
     }
 
     /**
-     * Hardware has a sharing implementation
+     * Hardware has a sharing implementation.
      * {@inheritDoc}
      */
     @Override
@@ -613,7 +608,7 @@ public class CbusThrottleManager extends AbstractThrottleManager implements CanL
     }
 
     /**
-     * CBUS Hardware will make its own decision on preferred option
+     * CBUS Hardware will make its own decision on preferred option.
      * <p>
      * This is the default for scripts that do NOT have a GUI for asking what to do when
      * a steal / share decision is required.
@@ -632,19 +627,13 @@ public class CbusThrottleManager extends AbstractThrottleManager implements CanL
                 // steal has been disabled in command station
                 responseThrottleDecision(address, null, DecisionType.SHARE );
                 break;
-            case STEAL_OR_SHARE:
-                if (jmri.InstanceManager.getNullableDefault(ThrottlesPreferences.class) == null) {
-                    log.debug("Creating new ThrottlesPreference Instance");
-                    jmri.InstanceManager.store(new ThrottlesPreferences(), ThrottlesPreferences.class);
-                }   ThrottlesPreferences tp = jmri.InstanceManager.getDefault(ThrottlesPreferences.class);
-                if ( tp.isSilentSteal() ){
+            default: // case STEAL_OR_SHARE:
+                if ( InstanceManager.getDefault(ThrottlesPreferences.class).isSilentSteal() ){
                     responseThrottleDecision(address, null, DecisionType.STEAL );
                 }
                 else {
                     responseThrottleDecision(address, null, DecisionType.SHARE );
-                }   break;
-            default:
-                log.error("Question type {} unknown",question);
+                }
                 break;
         }
     }
@@ -674,7 +663,7 @@ public class CbusThrottleManager extends AbstractThrottleManager implements CanL
                 timeout(isRecovery);
             }
         };
-        jmri.util.TimerUtil.schedule(throttleRequestTimer, ( THROTTLE_TIMEOUT ) );
+        TimerUtil.schedule(throttleRequestTimer, ( THROTTLE_TIMEOUT ) );
     }
 
     private void stopThrottleRequestTimer(){
@@ -726,7 +715,7 @@ public class CbusThrottleManager extends AbstractThrottleManager implements CanL
      * {@inheritDoc}
      */
     @Override
-    public boolean disposeThrottle(DccThrottle t, jmri.ThrottleListener l) {
+    public boolean disposeThrottle(DccThrottle t, ThrottleListener l) {
         log.debug("disposeThrottle called for {}", t);
         if (t instanceof CbusThrottle) {
             log.debug("Cbus Dispose calling abstract Throttle manager dispose");

--- a/java/src/jmri/jmrix/can/cbus/CbusThrottleManager.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusThrottleManager.java
@@ -558,7 +558,8 @@ public class CbusThrottleManager extends AbstractThrottleManager implements CanL
     }
 
     /**
-     * Any address is potentially a long address
+     * Any address is potentially a long address.
+     * {@inheritDoc}
      */
     @Override
     public boolean canBeLongAddress(int address) {
@@ -566,8 +567,8 @@ public class CbusThrottleManager extends AbstractThrottleManager implements CanL
     }
 
     /**
-     * Address 127 and below is a short address
-     *
+     * Address 127 and below is a short address.
+     * {@inheritDoc}
      */
     @Override
     public boolean canBeShortAddress(int address) {
@@ -576,6 +577,8 @@ public class CbusThrottleManager extends AbstractThrottleManager implements CanL
 
     /**
      * Short and long address spaces overlap and are not unique.
+     * @return always false.
+     * {@inheritDoc}
      */
     @Override
     public boolean addressTypeUnique() {
@@ -584,6 +587,8 @@ public class CbusThrottleManager extends AbstractThrottleManager implements CanL
 
     /**
      * Local method for deciding short/long address.
+     * @param num the address number
+     * @return true if address equal to or greater than 128.
      */
     static boolean isLongAddress(int num) {
         return (num >= 128);

--- a/java/src/jmri/jmrix/can/cbus/eventtable/CbusEventTableDataModel.java
+++ b/java/src/jmri/jmrix/can/cbus/eventtable/CbusEventTableDataModel.java
@@ -2,7 +2,10 @@ package jmri.jmrix.can.cbus.eventtable;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+
+import jmri.Disposable;
 import jmri.InstanceManager;
+import jmri.ShutDownManager;
 import jmri.jmrix.can.CanListener;
 import jmri.jmrix.can.CanMessage;
 import jmri.jmrix.can.CanReply;
@@ -21,37 +24,33 @@ import org.slf4j.LoggerFactory;
  * @author Steve Young (c) 2018 2019
  * 
  */
-public class CbusEventTableDataModel extends CbusBasicEventTableModel implements CanListener {
+public class CbusEventTableDataModel extends CbusBasicEventTableModel implements CanListener, Disposable {
 
     
-    private final CbusPreferences preferences;
-    private final ShutDownTask shutDownTask;
+    private CbusPreferences preferences;
+    private ShutDownTask shutDownTask;
     
     public CbusEventTableDataModel(CanSystemConnectionMemo memo, int row, int column) {
-        super(memo);
-        log.info("Starting MERG CBUS Event Table");
-        
-        addTc(_memo);
-        
-        
-        preferences = jmri.InstanceManager.getNullableDefault(jmri.jmrix.can.cbus.CbusPreferences.class);
-        
-        checkRestoreEvents();
-        
-        shutDownTask = new CbusEventTableShutdownTask("CbusEventTableShutdownTask",this);
-        jmri.InstanceManager.getDefault(jmri.ShutDownManager.class).register(shutDownTask);
-        ta.updatejmricols();
-        
+        this(memo, row);
     }
+
+    /**
+     * Create a new CbusEventTableDataModel.
+     * @param memo System Connection.
+     * @param initialRowSize initial array size.
+     */
+    public CbusEventTableDataModel(CanSystemConnectionMemo memo, int initialRowSize) {
+        super(memo, initialRowSize);
+        if (memo !=null) {
+            log.info("Starting {} Event Table",memo.getProtocol());
+            preferences = memo.get(jmri.jmrix.can.cbus.CbusPreferences.class);
+            shutDownTask = new CbusEventTableShutdownTask("CbusEventTableShutdownTask "+memo.getSystemPrefix(),this);
+            InstanceManager.getDefault(ShutDownManager.class).register(shutDownTask);
+        }
+        addTc(_memo);
+        checkRestoreEvents();
+        ta.updatejmricols();
     
-    public final static void checkCreateNewEventModel(CanSystemConnectionMemo memo){
-        CbusEventTableDataModel model = InstanceManager.getNullableDefault(CbusEventTableDataModel.class);
-        if (model == null) {        
-            ThreadingUtil.runOnLayout(() -> {
-                CbusEventTableDataModel eventModel = new CbusEventTableDataModel(memo, 5, CbusEventTableDataModel.MAX_COLUMN);
-                InstanceManager.store(eventModel, CbusEventTableDataModel.class);
-            });
-        }    
     }
     
     private void checkRestoreEvents(){
@@ -64,7 +63,7 @@ public class CbusEventTableDataModel extends CbusBasicEventTableModel implements
      * De-register the shut down task which saves table details.
      */
     public void skipSaveOnDispose(){
-        jmri.InstanceManager.getDefault(jmri.ShutDownManager.class).deregister(shutDownTask);
+        InstanceManager.getDefault(ShutDownManager.class).deregister(shutDownTask);
     }
     
     /**
@@ -174,7 +173,7 @@ public class CbusEventTableDataModel extends CbusBasicEventTableModel implements
     }
     
     /**
-     * Remove all events from table
+     * Remove all events from table.
      */
     protected void clearAllEvents() {
         _mainArray = new ArrayList<>();
@@ -188,6 +187,7 @@ public class CbusEventTableDataModel extends CbusBasicEventTableModel implements
      * Disconnect from the CBUS.
      * Check and trigger if need to save table to xml.
      */
+    @Override
     public void dispose() {
         ta.dispose();
         

--- a/java/src/jmri/jmrix/can/cbus/eventtable/CbusEventTableXmlAction.java
+++ b/java/src/jmri/jmrix/can/cbus/eventtable/CbusEventTableXmlAction.java
@@ -24,8 +24,8 @@ public class CbusEventTableXmlAction {
     // if a CBUS Event xml file is found
     // import table data into it
     protected static void restoreEventsFromXmlTablestart(CbusEventTableDataModel model) {
-
-        CbusEventTableXmlFile x = new CbusEventTableXmlFile();
+        log.debug("restore events from conn {}",model._memo);
+        CbusEventTableXmlFile x = new CbusEventTableXmlFile(model._memo);
         File file = x.getFile(false);
         if (file == null) {
             return;
@@ -99,7 +99,7 @@ public class CbusEventTableXmlAction {
     private static void layoutEventsToXml(CbusEventTableDataModel model) {
 
         log.info("Saving {} CBUS Event xml file.", model._memo.getUserName() ); // NOI18N
-        CbusEventTableXmlFile x = new CbusEventTableXmlFile();
+        CbusEventTableXmlFile x = new CbusEventTableXmlFile(model._memo);
 
         Element root = new Element("CbusEventDetails"); // NOI18N
         root.setAttribute("noNamespaceSchemaLocation",  // NOI18N

--- a/java/src/jmri/jmrix/can/cbus/eventtable/CbusEventTableXmlFile.java
+++ b/java/src/jmri/jmrix/can/cbus/eventtable/CbusEventTableXmlFile.java
@@ -1,8 +1,22 @@
 package jmri.jmrix.can.cbus.eventtable;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.BasicFileAttributes;
+
+import java.nio.file.*;
+
+import javax.annotation.Nonnull;
+
 import jmri.jmrit.XmlFile;
+import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.util.FileUtil;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Class to provide access to the EventTableData.xml file.
@@ -10,13 +24,38 @@ import jmri.util.FileUtil;
  */
 public class CbusEventTableXmlFile extends XmlFile {
 
-    public static String getDefaultFileName() {
-        return getFileLocation() + getFileName();
+    final CanSystemConnectionMemo memo;
+
+    public CbusEventTableXmlFile(@Nonnull CanSystemConnectionMemo memo){
+        this.memo = memo;
     }
 
+    /**
+     * Get the full filename, including directory.
+     * @return String of file path.
+     */
+    public String getDefaultFileName() {
+        return getFileLocation() + File.separator + getFileName();
+    }
+
+    /**
+     * Get the Event Table Filename, no directory.
+     * @return just the filename.
+     */
+    public String getFileName() {
+        return "EventTableData.xml";  // NOI18N
+    }
+
+    /**
+     * Get the XML File for this connection.
+     * Migrates from previous single instance Event Table.
+     * @param store true to create new File if File does not exist.
+     * @return File, or if store is false and File not found, returns null.
+     */
     public File getFile(boolean store) {
         // Verify that directory:cbus exists
         FileUtil.createDirectory(getFileLocation());
+        migrateFileLocation();
 
         File file = findFile(getDefaultFileName());
         if (file == null && store) {
@@ -25,16 +64,51 @@ public class CbusEventTableXmlFile extends XmlFile {
         return file;
     }
 
-    public static String getFileName() {
-        return "EventTableData.xml";  // NOI18N
-    }
-
     /**
-     * Absolute path to location of TimeTable files.
+     * Absolute path to directory of Event Table file.
+     * No trailing file separator.
      *
      * @return path to location
      */
-    public static String getFileLocation() {
-        return FileUtil.getUserFilesPath() + "cbus" + File.separator;  // NOI18N
+    public String getFileLocation() {
+        return FileUtil.getUserFilesPath() + "cbus" + File.separator + memo.getSystemPrefix() ;  // NOI18N
     }
+
+    protected final String oldFileLocation = FileUtil.getUserFilesPath() + "cbus" ;
+
+    private void migrateFileLocation(){
+        if ( findFile(oldFileLocation + File.separator + getFileName()) == null ){
+            return;
+        }
+        try {
+            migrate(Paths.get(oldFileLocation), getFileLocation(), memo.getSystemPrefix() );
+            log.warn("Migrated existing CBUS Event Table Data to {}", memo.getUserName());
+        } catch(IOException e){
+            log.error("Unable to migrate CBUS Data ",e);
+        }
+    }
+
+    // also used in CbusNodeBackupFile for migrating to multi-system file support.
+    public static void migrate(Path fromPath, String newLocation,
+        String systemPrefix) throws IOException {
+
+        String oldCbusDirectory = File.separator + "cbus" + File.separator;
+        String newCbusDirectory = oldCbusDirectory + systemPrefix + File.separator; 
+
+        Files.walkFileTree(fromPath, new SimpleFileVisitor<Path>() {
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                String fileString = file.toAbsolutePath().toString();
+                if ( ! fileString.contains(newLocation) ) { // not in new directory
+                    String newPathString = fileString.replace( oldCbusDirectory  , newCbusDirectory);
+                    Files.copy(file, Paths.get(newPathString), StandardCopyOption.REPLACE_EXISTING);
+                    Files.delete(file);
+                }
+                return FileVisitResult.CONTINUE;
+            }
+        });
+    }
+
+    private final static Logger log = LoggerFactory.getLogger(CbusEventTableXmlFile.class);
+
 }

--- a/java/src/jmri/jmrix/can/cbus/node/CbusNodeSingleEventTableDataModel.java
+++ b/java/src/jmri/jmrix/can/cbus/node/CbusNodeSingleEventTableDataModel.java
@@ -1,10 +1,12 @@
 package jmri.jmrix.can.cbus.node;
 
-import java.util.Arrays;
 import java.util.ArrayList;
+import java.util.Arrays;
+
 import javax.annotation.CheckForNull;
 import javax.swing.JTable;
 import javax.swing.JTextField;
+
 import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.jmrix.can.cbus.swing.nodeconfig.CbusNodeEditEventFrame;
 import jmri.util.ThreadingUtil;
@@ -319,7 +321,7 @@ public class CbusNodeSingleEventTableDataModel extends javax.swing.table.Abstrac
 
     @CheckForNull
     private CbusNode getEventNode(){
-        CbusNodeTableDataModel nodeModel = jmri.InstanceManager.getDefault(CbusNodeTableDataModel.class);
+        CbusNodeTableDataModel nodeModel = _memo.get(CbusNodeTableDataModel.class);
         return nodeModel.getNodeByNodeNum( _ndEv.getParentNn() );
     }
     

--- a/java/src/jmri/jmrix/can/cbus/node/CbusNodeTableDataModel.java
+++ b/java/src/jmri/jmrix/can/cbus/node/CbusNodeTableDataModel.java
@@ -25,7 +25,8 @@ import org.slf4j.LoggerFactory;
  * @author Steve Young (c) 2019
  * 
  */
-public class CbusNodeTableDataModel extends CbusBasicNodeTableFetch implements CanListener, PropertyChangeListener {
+public class CbusNodeTableDataModel extends CbusBasicNodeTableFetch
+    implements CanListener, PropertyChangeListener, jmri.Disposable {
 
     private final CbusSend send;
     private ArrayList<Integer> _nodesFound;
@@ -33,21 +34,33 @@ public class CbusNodeTableDataModel extends CbusBasicNodeTableFetch implements C
     protected CbusPreferences preferences;
 
     public CbusNodeTableDataModel(@Nonnull CanSystemConnectionMemo memo, int row, int column) {
-        super(memo,row,column);
-        log.debug("Starting MERG CBUS Node Table");
-        _mainArray = new ArrayList<>();
-        _nodesFound = new ArrayList<>();
+        this(memo,row);
+    }
 
+    /**
+     * Create a new CbusNodeTableDataModel.
+     * @param memo system connection.
+     * @param initialArraySize initial Array Size.
+     */
+    public CbusNodeTableDataModel(@Nonnull CanSystemConnectionMemo memo, int initialArraySize ) {
+        super(memo, initialArraySize, 0);
+        log.debug("Starting MERG CBUS Node Table memo \"{}\" ",memo);
+        _nodesFound = new ArrayList<>(initialArraySize);
         // connect to the CanInterface
         addTc(memo);
         
         send = new CbusSend(memo);
 
+        startup();
     }
     
-    public void startup(){
-        
-        preferences = jmri.InstanceManager.getDefault(CbusPreferences.class);
+    private void startup(){
+
+        preferences = _memo.get(CbusPreferences.class);
+        if (preferences == null ) {
+            log.error("no prefs");
+            return;
+        }
         
         setBackgroundAllocateListener( preferences.getAllocateNNListener() );
         if ( preferences.getStartupSearchForCs() ) {
@@ -243,7 +256,7 @@ public class CbusNodeTableDataModel extends CbusBasicNodeTableFetch implements C
      * @param timeout value in msec to wait for responses
      */
     private void setSearchForNodesTimeout( int timeout) {
-        _nodesFound = new ArrayList<>();
+        _nodesFound = new ArrayList<>(5);
         searchForNodesTask = new TimerTask() {
             @Override
             public void run() {
@@ -275,10 +288,10 @@ public class CbusNodeTableDataModel extends CbusBasicNodeTableFetch implements C
      */
     public void startupSearchNodeXmlFile() {
         // ensure preferences will be found for read
-        FileUtil.createDirectory(CbusNodeBackupFile.getFileLocation());
+        FileUtil.createDirectory(new CbusNodeBackupFile(_memo).getFileLocation());
         // create an array of file names from node dir in preferences, then loop
-        List<String> names = new ArrayList<>();
-        File fp = new File(CbusNodeBackupFile.getFileLocation());
+        List<String> names = new ArrayList<>(5);
+        File fp = new File(new CbusNodeBackupFile(_memo).getFileLocation());
         if (fp.exists()) {
             String[] fpList = fp.list(new XmlFilenameFilter());
             if (fpList !=null ) {
@@ -306,6 +319,7 @@ public class CbusNodeTableDataModel extends CbusBasicNodeTableFetch implements C
      * <p>
      * Cancel outstanding Timers
      */
+    @Override
     public void dispose() {
         
         clearSearchForNodesTimeout();

--- a/java/src/jmri/jmrix/can/cbus/swing/console/CbusConsolePane.java
+++ b/java/src/jmri/jmrix/can/cbus/swing/console/CbusConsolePane.java
@@ -4,12 +4,15 @@ import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.event.ActionEvent;
 import java.util.concurrent.ConcurrentLinkedDeque;
+
 import javax.swing.*;
 import javax.swing.text.BadLocationException;
 import javax.swing.text.DefaultHighlighter;
 import javax.swing.text.Highlighter;
+
 import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.jmrix.can.TrafficController;
+import jmri.jmrix.can.cbus.CbusConfigurationManager;
 import jmri.jmrix.can.cbus.eventtable.CbusEventTableDataModel;
 import jmri.jmrix.can.cbus.swing.CbusEventHighlightFrame;
 import jmri.jmrix.can.cbus.swing.CbusSendEventPane;
@@ -123,7 +126,7 @@ public class CbusConsolePane extends jmri.jmrix.can.swing.CanPanel {
         tc = memo.getTrafficController();
         decodePane = new CbusConsoleDecodeOptionsPane(this);
         if (launchEvTable){
-            CbusEventTableDataModel.checkCreateNewEventModel(memo);
+            ((CbusConfigurationManager)memo.get(CbusConfigurationManager.class)).provide(CbusEventTableDataModel.class);
         }
         init();
     }
@@ -267,7 +270,7 @@ public class CbusConsolePane extends jmri.jmrix.can.swing.CanPanel {
     }
 
     private void processLogBuffer() {
-        while (logBuffer.size()>0){
+        while (!logBuffer.isEmpty()){
             CbusConsoleLogEntry next = logBuffer.removeFirst();
 
             final int start = monTextPaneCbus.getText().length();
@@ -306,7 +309,7 @@ public class CbusConsolePane extends jmri.jmrix.can.swing.CanPanel {
 
     // A private subclass of the default highlight painter
     private class CbusHighlightPainter extends DefaultHighlighter.DefaultHighlightPainter {
-        public CbusHighlightPainter(Color color) {
+        protected CbusHighlightPainter(Color color) {
             super(color);
         }
     }

--- a/java/src/jmri/jmrix/can/cbus/swing/modeswitcher/SprogCbusModeSwitcherFrame.java
+++ b/java/src/jmri/jmrix/can/cbus/swing/modeswitcher/SprogCbusModeSwitcherFrame.java
@@ -51,7 +51,7 @@ public class SprogCbusModeSwitcherFrame extends JmriJFrame
         _memo = memo;
         _pms = memo.getProgModeSwitch();
         
-        preferences = jmri.InstanceManager.getDefault(jmri.jmrix.can.cbus.CbusPreferences.class);
+        preferences = memo.get(jmri.jmrix.can.cbus.CbusPreferences.class);
 
         pm = (CbusDccProgrammerManager)InstanceManager.getNullableDefault(GlobalProgrammerManager.class);
         

--- a/java/src/jmri/jmrix/can/cbus/swing/nodeconfig/CbusNodeTablePane.java
+++ b/java/src/jmri/jmrix/can/cbus/swing/nodeconfig/CbusNodeTablePane.java
@@ -10,14 +10,15 @@ import javax.swing.event.TableModelEvent;
 import javax.swing.table.TableCellRenderer;
 import javax.swing.table.TableRowSorter;
 import jmri.jmrix.can.CanSystemConnectionMemo;
+import jmri.jmrix.can.cbus.CbusConfigurationManager;
 import jmri.jmrix.can.cbus.node.CbusNodeTableDataModel;
 import jmri.jmrix.can.cbus.swing.CbusCommonSwing;
 import jmri.util.ThreadingUtil;
 import jmri.util.swing.XTableColumnModel;
 import jmri.util.table.*;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+// import org.slf4j.Logger;
+// import org.slf4j.LoggerFactory;
 
 /**
  * Pane providing a CBUS node table.
@@ -37,11 +38,8 @@ public class CbusNodeTablePane extends JPanel {
     private final DateFormat DATE_FORMAT = new SimpleDateFormat("HH:mm EEE d MMM");
     
     public void initComponents(CanSystemConnectionMemo memo) {
-        try {
-            nodeModel = jmri.InstanceManager.getDefault(CbusNodeTableDataModel.class);
-        } catch (NullPointerException e) {
-            log.error("Unable to get Node Table from Instance Manager");
-        }
+        nodeModel = ((CbusConfigurationManager)memo.get(CbusConfigurationManager.class))
+            .provide(CbusNodeTableDataModel.class);
         
         init();
         
@@ -161,6 +159,6 @@ public class CbusNodeTablePane extends JPanel {
         nodeTable = null;
     }
 
-    private final static Logger log = LoggerFactory.getLogger(CbusNodeTablePane.class);
+    // private final static Logger log = LoggerFactory.getLogger(CbusNodeTablePane.class);
 
 }

--- a/java/test/jmri/jmrix/can/cbus/CbusConfigurationManagerTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusConfigurationManagerTest.java
@@ -1,17 +1,21 @@
 package jmri.jmrix.can.cbus;
 
 import java.io.IOException;
-import java.nio.file.Path;
+import java.io.File;
+import java.util.Collection;
 
-import jmri.InstanceManager;
-import jmri.MeterManager;
+import jmri.*;
 import jmri.jmrix.can.*;
-import jmri.jmrix.can.cbus.swing.modeswitcher.SprogCbusSprog3PlusModeSwitcherFrame;
+import jmri.jmrix.can.cbus.eventtable.CbusEventTableDataModel;
+import jmri.jmrix.can.cbus.node.CbusNodeTableDataModel;
 import jmri.util.JUnitUtil;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  *
@@ -23,128 +27,186 @@ public class CbusConfigurationManagerTest {
 
     @Test
     public void testCTor() {
-        t = new CbusConfigurationManager(memo);
-        Assert.assertNotNull("exists",t);
+        assertNotNull(t, "exists");
     }
-    
+
     @Test
     public void testDisabled() {
 
         memo.setDisabled(true);
         
-        Assert.assertNotNull("exists",t);
+        assertNotNull(t);
         
-        Assert.assertFalse( t.provides(jmri.PowerManager.class) );
+        assertFalse( t.provides(PowerManager.class) );
         
-        Assert.assertNull( t.get(jmri.PowerManager.class) );
+        assertNull( t.get(PowerManager.class) );
         
-        Assert.assertNull( t.getPowerManager() );
-        Assert.assertNull( t.getThrottleManager() );
-        Assert.assertNull( t.getTurnoutManager() );
-        Assert.assertNull( t.getSensorManager() );
-        Assert.assertNull( t.getReporterManager() );
-        Assert.assertNull( t.getLightManager() );
-        Assert.assertNull( t.getCommandStation() );
-        Assert.assertNull( t.getCbusPreferences() );
-        Assert.assertNull( t.getCabSignalManager() );
+        assertNull( t.get(PowerManager.class) );
+        assertNull( t.get(ThrottleManager.class) );
+        assertNull( t.get(TurnoutManager.class) );
+        assertNull( t.get(SensorManager.class) );
+        assertNull( t.get(ReporterManager.class) );
+        assertNull( t.get(LightManager.class) );
+        assertNull( t.get(CommandStation.class) );
+        assertNull( t.get(CbusPreferences.class) );
+        assertNull( t.get(CabSignalManager.class) );
         
     }
-    
+
     @Test
     public void testProvides() {
         
-        Assert.assertTrue( t.provides(jmri.AddressedProgrammerManager.class) );
-        Assert.assertTrue( t.provides(jmri.GlobalProgrammerManager.class) );
-        Assert.assertTrue( t.provides(jmri.ThrottleManager.class) );
-        Assert.assertTrue( t.provides(jmri.PowerManager.class) );
-        Assert.assertTrue( t.provides(jmri.SensorManager.class) );
-        Assert.assertTrue( t.provides(jmri.TurnoutManager.class) );
-        Assert.assertTrue( t.provides(jmri.ReporterManager.class) );
-        Assert.assertTrue( t.provides(jmri.LightManager.class) );
-        Assert.assertTrue( t.provides(jmri.CommandStation.class) );
-        Assert.assertTrue( t.provides(CbusPreferences.class) );
-        Assert.assertTrue( t.provides(jmri.CabSignalManager.class) );
+        assertTrue( t.provides(AddressedProgrammerManager.class) );
+        assertTrue( t.provides(GlobalProgrammerManager.class) );
+        assertTrue( t.provides(ThrottleManager.class) );
+        assertTrue( t.provides(PowerManager.class) );
+        assertTrue( t.provides(SensorManager.class) );
+        assertTrue( t.provides(TurnoutManager.class) );
+        assertTrue( t.provides(ReporterManager.class) );
+        assertTrue( t.provides(LightManager.class) );
+        assertTrue( t.provides(CommandStation.class) );
+        assertTrue( t.provides(CbusPreferences.class) );
+        assertTrue( t.provides(CabSignalManager.class) );
+        assertTrue( t.provides(ConsistManager.class) );
+        assertTrue( t.provides(ClockControl.class) );
         
-        Assert.assertFalse( t.provides(jmri.jmrix.can.cbus.CbusSensor.class) );
+        assertFalse( t.provides(CbusNodeTableDataModel.class) ); // not created by default
+        assertFalse( t.provides(CbusEventTableDataModel.class) ); // not created by default
         
-    }    
-    
+        assertFalse( t.provides(CbusSensor.class) );
+        
+    }
+
     @Test
     public void testGet() {
         
-        Assert.assertNull( t.get(jmri.jmrix.can.cbus.CbusSensor.class) );
+        assertNull( t.get(jmri.jmrix.can.cbus.CbusSensor.class) );
 
-        Assert.assertNotNull( t.get(jmri.AddressedProgrammerManager.class) );
-        Assert.assertNotNull( t.get(jmri.GlobalProgrammerManager.class) );
-        Assert.assertNotNull( t.get(jmri.ThrottleManager.class) );
-        Assert.assertNotNull( t.get(jmri.PowerManager.class) );
-        Assert.assertNotNull( t.get(jmri.SensorManager.class) );
-        Assert.assertNotNull( t.get(jmri.TurnoutManager.class) );
-        Assert.assertNotNull( t.get(jmri.ReporterManager.class) );
-        Assert.assertNotNull( t.get(jmri.LightManager.class) );
-        Assert.assertNotNull( t.get(jmri.CommandStation.class) );
-        Assert.assertNotNull( t.get(CbusPreferences.class) );
-        Assert.assertNotNull( t.get(jmri.CabSignalManager.class) );
+        assertNotNull( t.get(AddressedProgrammerManager.class) );
+        assertNotNull( t.get(GlobalProgrammerManager.class) );
+        assertNotNull( t.get(ThrottleManager.class) );
+        assertNotNull( t.get(PowerManager.class) );
+        assertNotNull( t.get(SensorManager.class) );
+        assertNotNull( t.get(TurnoutManager.class) );
+        assertNotNull( t.get(ReporterManager.class) );
+        assertNotNull( t.get(LightManager.class) );
+        assertNotNull( t.get(CommandStation.class) );
+        assertNotNull( t.get(CbusPreferences.class) );
+        assertNotNull( t.get(CabSignalManager.class) );
         
-    }    
+        assertNull( t.get(CbusNodeTableDataModel.class) );
+        assertNull( t.get(CbusEventTableDataModel.class) );
+        
+        assertNull( t.provide(CbusSensor.class) );
+    }
+
+    @Test
+    public void testConfigureDisabled() {
+        memo.setDisabled(true);
+        t.configureManagers();
+        assertNull( t.get(LightManager.class) );
+        assertEquals(0, tcis.numListeners(),"No listeners " + tcis.getListeners());
     
+    }
+
+    @Test
+    public void testProvideEventModel() {
+        assertFalse(memo.provides(CbusEventTableDataModel.class));
+        CbusEventTableDataModel evModel = t.provide(CbusEventTableDataModel.class);
+        assertNotNull( evModel );
+        assertNotNull( memo.get(CbusEventTableDataModel.class),"event table found in memo" );
+        assertTrue((memo.get(CbusEventTableDataModel.class) == evModel)," same ev model");
+        assertTrue(memo.provides(CbusEventTableDataModel.class));
+        evModel.skipSaveOnDispose();
+    }
+
+    @Test
+    public void testProvideNodeModel() {
+        assertFalse(memo.provides(CbusNodeTableDataModel.class));
+        assertNotNull( t.provide(CbusNodeTableDataModel.class) );
+        assertTrue(memo.provides(CbusNodeTableDataModel.class));
+        assertNotNull( memo.get(CbusNodeTableDataModel.class),"node table found in memo" );
+        assertTrue((memo.get(CbusNodeTableDataModel.class) == t.provide(CbusNodeTableDataModel.class))," same node model");
+    }
+
     @Test
     public void testGetMeters() {
         t.configureManagers();
-        Assert.assertNotNull( InstanceManager.getDefault(MeterManager.class).getBySystemName("MVCBUSCurrentMeter") );
-        Assert.assertNotNull( InstanceManager.getDefault(MeterManager.class).getBySystemName("MVCBUSVoltageMeter") );
+        assertNotNull( InstanceManager.getDefault(MeterManager.class).getBySystemName("MVCBUSCurrentMeter") );
+        assertNotNull( InstanceManager.getDefault(MeterManager.class).getBySystemName("MVCBUSVoltageMeter") );
+    }
+
+    @Test
+    public void testNodeEventManagerDispose(){
+        assertEquals(0, tcis.numListeners(),"no tcis listeners after memo creation");
+        ((CbusNodeTableDataModel)t.provide(CbusNodeTableDataModel.class)).setBackgroundAllocateListener(false);
+        assertEquals(1, tcis.numListeners(),"1 tcis listeners");
+        ((CbusEventTableDataModel)t.provide(CbusEventTableDataModel.class)).skipSaveOnDispose();
+        assertEquals(2, tcis.numListeners(),"2 tcis listeners");
+        memo.dispose();
+        assertEquals(0, tcis.numListeners(),"All listeners removed " + tcis.getListeners());
+    }
+
+    @Test
+    public void testDisposeAllManagers() {
+        assertEquals(0, tcis.numListeners(),"no tcis listeners after memo creation");
+        ((CbusNodeTableDataModel)t.provide(CbusNodeTableDataModel.class)).setBackgroundAllocateListener(false);
+        ((CbusEventTableDataModel)t.provide(CbusEventTableDataModel.class)).skipSaveOnDispose();
+
+        assertEquals(2, tcis.numListeners(),"2 tcis listeners");
+    
+        memo.configureManagers();
+
+        assertTrue(tcis.numListeners() > 5,"6 tcis listeners as of April 2022");
+        
+        memo.dispose();
+
+        assertEquals(0, tcis.numListeners(),"All listeners removed " + tcis.getListeners());
+        
     }
     
-    @Test
-    public void testgetClasses() {
-        
-        CbusDccProgrammerManager prm = new CbusDccProgrammerManager( new CbusDccProgrammer(memo), memo);
-        t.setProgrammerManager(prm);
-        Assert.assertTrue("programme manager",prm == t.get(jmri.GlobalProgrammerManager.class) );
-        
-        CbusPowerManager pm = t.getPowerManager();
-        Assert.assertTrue("powermanager",pm == t.get(jmri.PowerManager.class) );
-        
-        CbusThrottleManager tm = new CbusThrottleManager(memo);
-        t.setThrottleManager(tm);
-        Assert.assertTrue("throttlemanager",tm == t.get(jmri.ThrottleManager.class) );
-        
-        CbusTurnoutManager tom = t.getTurnoutManager();
-        Assert.assertTrue("turnoutmanager",tom == t.get(jmri.TurnoutManager.class) );
-        
-        CbusSensorManager sm = t.getSensorManager();
-        Assert.assertTrue("sensormanager",sm == t.get(jmri.SensorManager.class) );
-
-        CbusReporterManager rm = t.getReporterManager();
-        Assert.assertTrue("reportermanager",rm == t.get(jmri.ReporterManager.class) );        
-
-        CbusLightManager lm = t.getLightManager();
-        Assert.assertTrue("lightmanager",lm == t.get(jmri.LightManager.class) );
-
-        CbusCommandStation cs = t.getCommandStation();
-        Assert.assertTrue("CommandStation",cs == t.get(jmri.CommandStation.class) );        
-        
-        CbusPreferences cbpref = t.getCbusPreferences();
-        Assert.assertTrue("CbusPreferences",cbpref == t.get(CbusPreferences.class) );
-        
-        CbusCabSignalManager csm = t.getCabSignalManager();
-        Assert.assertTrue("CbusCabSignalManager",csm == t.get(jmri.CabSignalManager.class) );
-        
+    public static Collection<Class<?>> classData() {
+        Collection<Class<?>> toReturn = new java.util.HashSet<>(12);
+        toReturn.add(CbusPreferences.class);
+        toReturn.add(PowerManager.class);
+        toReturn.add(CommandStation.class);
+        toReturn.add(ThrottleManager.class);
+        toReturn.add(ClockControl.class);
+        toReturn.add(SensorManager.class);
+        toReturn.add(TurnoutManager.class);
+        toReturn.add(ReporterManager.class);
+        toReturn.add(LightManager.class);
+        toReturn.add(CabSignalManager.class);
+        toReturn.add(CbusPredefinedMeters.class);
+        return toReturn;
     }
-        
+    
+    @ParameterizedTest(name = "{arguments}")
+    @MethodSource("classData")
+    public void testGetClass(Class<?> classToTest ) {
+    
+        assertEquals(0, tcis.numListeners(),"no tcis listeners before test");
+
+        assertNull(memo.getFromMap(classToTest));
+        assertNotNull(memo.get(classToTest));
+        assertNotNull(memo.getFromMap(classToTest), classToTest.getCanonicalName() + " not added to memo classObjectMap");
+        assertNotNull(InstanceManager.getNullableDefault(classToTest));
+
+        memo.dispose();
+        assertNull(memo.getFromMap(classToTest));
+        assertEquals(0, tcis.numListeners(),"All listeners removed " + tcis.getListeners());
+    
+    }
+
     private CanSystemConnectionMemo memo;
     private TrafficControllerScaffold tcis; // needed for DCC programming mgr?
     private CbusConfigurationManager t;
-    private CbusPreferences prefs;
-    
-    @TempDir
-    protected Path tempDir;
-    
+
     @BeforeEach
-    public void setUp() throws IOException {
+    public void setUp(@TempDir File tempDir) throws IOException  {
         JUnitUtil.setUp();
         JUnitUtil.resetInstanceManager();
-        JUnitUtil.resetProfileManager( new jmri.profile.NullProfile( tempDir.toFile()));
+        JUnitUtil.resetProfileManager( new jmri.profile.NullProfile( tempDir));
 
         // This test requires a registred connection config since ProxyMeterManager
         // auto creates system meter managers using the connection configs.
@@ -157,16 +219,16 @@ public class CbusConfigurationManagerTest {
         memo = new CanSystemConnectionMemo();
         tcis = new TrafficControllerScaffold();
         memo.setTrafficController(tcis);
-        prefs = new CbusPreferences();
-        
-        jmri.InstanceManager.store(prefs,CbusPreferences.class );
-        
-        t = new CbusConfigurationManager(memo);
+        memo.setProtocol(ConfigurationManager.MERGCBUS);
+        t = memo.get(CbusConfigurationManager.class);
     }
 
     @AfterEach
     public void tearDown() {
-        
+        CbusEventTableDataModel evmod = memo.get( CbusEventTableDataModel.class);
+        if ( evmod != null ) {
+            evmod.skipSaveOnDispose();
+        }
         t.dispose();
         tcis.terminateThreads();
         memo.dispose();

--- a/java/test/jmri/jmrix/can/cbus/CbusDccProgrammerManagerTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusDccProgrammerManagerTest.java
@@ -1,7 +1,7 @@
 package jmri.jmrix.can.cbus;
 
 import java.io.IOException;
-import java.nio.file.Path;
+import java.io.File;
 
 import jmri.jmrix.can.*;
 import jmri.jmrix.can.cbus.swing.modeswitcher.SprogCbusSprog3PlusModeSwitcherFrame;
@@ -69,20 +69,17 @@ public class CbusDccProgrammerManagerTest {
     private CanSystemConnectionMemo memo;
     private CbusPreferences prefs;
 
-    @TempDir
-    protected Path tempDir;
-    
     @BeforeEach
-    public void setUp() throws IOException {
+    public void setUp( @TempDir File tempDir ) throws IOException {
         JUnitUtil.setUp();
         JUnitUtil.resetInstanceManager();
-        JUnitUtil.resetProfileManager( new jmri.profile.NullProfile( tempDir.toFile()));
-        
+        JUnitUtil.resetProfileManager( new jmri.profile.NullProfile( tempDir));
+
         tc = new TrafficControllerScaffold();
         memo = new CanSystemConnectionMemo();
         memo.setTrafficController(tc);
-        prefs = new CbusPreferences();
-        jmri.InstanceManager.store(prefs,CbusPreferences.class );
+        memo.setProtocol(ConfigurationManager.SPROGCBUS);
+        prefs = memo.get(CbusPreferences.class);
     }
 
     @AfterEach

--- a/java/test/jmri/jmrix/can/cbus/CbusPredefinedMetersTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusPredefinedMetersTest.java
@@ -34,16 +34,18 @@ public class CbusPredefinedMetersTest {
 
         // This test requires a registred connection config since ProxyMeterManager
         // auto creates system meter managers using the connection configs.
-        InstanceManager.setDefault(jmri.jmrix.ConnectionConfigManager.class, new jmri.jmrix.ConnectionConfigManager());
+
+       /* InstanceManager.setDefault(jmri.jmrix.ConnectionConfigManager.class, new jmri.jmrix.ConnectionConfigManager());
         jmri.jmrix.NetworkPortAdapter pa = new jmri.jmrix.can.adapters.gridconnect.net.MergNetworkDriverAdapter();
         pa.setSystemPrefix("M");
         jmri.jmrix.ConnectionConfig cc = new jmri.jmrix.can.adapters.gridconnect.net.MergConnectionConfig(pa);
         InstanceManager.getDefault(jmri.jmrix.ConnectionConfigManager.class).add(cc);
-
+*/
         memo = new CanSystemConnectionMemo();
         tcis = new TrafficControllerScaffold();
         memo.setTrafficController(tcis);
-        mm = new CbusPredefinedMeters(memo);
+        memo.setProtocol(jmri.jmrix.can.CanConfigurationManager.MERGCBUS);
+        mm = memo.get(CbusPredefinedMeters.class);
     }
 
     @AfterEach
@@ -57,15 +59,21 @@ public class CbusPredefinedMetersTest {
     }
 
     public double getCurrent() {
-        return InstanceManager.getDefault(MeterManager.class).getBySystemName("MVCBUSCurrentMeter").getKnownAnalogValue();
+        var meter = InstanceManager.getDefault(MeterManager.class).getBySystemName("MVCBUSCurrentMeter");
+        Assertions.assertNotNull(meter);
+        return meter.getKnownAnalogValue();
     }
 
     public double getCurrentExtra() {
-        return InstanceManager.getDefault(MeterManager.class).getBySystemName("MVCBUSCurrentMeter2").getKnownAnalogValue();
+        var meter = InstanceManager.getDefault(MeterManager.class).getBySystemName("MVCBUSCurrentMeter2");
+        Assertions.assertNotNull(meter);
+        return meter.getKnownAnalogValue();
     }
 
     public double getVoltage() {
-        return InstanceManager.getDefault(MeterManager.class).getBySystemName("MVCBUSVoltageMeter").getKnownAnalogValue();
+        var meter = InstanceManager.getDefault(MeterManager.class).getBySystemName("MVCBUSVoltageMeter");
+        Assertions.assertNotNull(meter);
+        return meter.getKnownAnalogValue();
     }
 
     private void enable() {
@@ -90,9 +98,12 @@ public class CbusPredefinedMetersTest {
         disable();
         Assert.assertEquals("not listening",0,tcis.numListeners());
 
-        CbusNodeTableDataModel nodeModel = new CbusNodeTableDataModel(memo, 3,CbusNodeTableDataModel.MAX_COLUMN);
-        jmri.InstanceManager.setDefault(CbusNodeTableDataModel.class,nodeModel );
-        Assert.assertEquals("node table listening",1,tcis.numListeners());
+        ((CbusPreferences)memo.get(CbusPreferences.class)).setAllocateNNListener(false);
+        ((CbusPreferences)memo.get(CbusPreferences.class)).setNodeBackgroundFetchDelay(0);
+        CbusNodeTableDataModel nodeModel = ((CbusConfigurationManager)memo.get(CbusConfigurationManager.class))
+            .provide(CbusNodeTableDataModel.class);
+
+        Assertions.assertEquals(1,tcis.numListeners(),"node table listening "+tcis.getListeners());
         enable();
         Assert.assertEquals("mm listening",2,tcis.numListeners());
         disable();
@@ -115,8 +126,10 @@ public class CbusPredefinedMetersTest {
     @Test
     public void testMultiMCanReply(){
 
-        CbusNodeTableDataModel nodeModel = new CbusNodeTableDataModel(memo, 3,CbusNodeTableDataModel.MAX_COLUMN);
-        jmri.InstanceManager.setDefault(CbusNodeTableDataModel.class,nodeModel );
+        ((CbusPreferences)memo.get(CbusPreferences.class)).setAllocateNNListener(false);
+        ((CbusPreferences)memo.get(CbusPreferences.class)).setNodeBackgroundFetchDelay(0);
+        CbusNodeTableDataModel nodeModel = ((CbusConfigurationManager)memo.get(CbusConfigurationManager.class))
+            .provide(CbusNodeTableDataModel.class);
 
         CbusNode testCs = nodeModel.provideNodeByNodeNum(54321);
         testCs.setCsNum(0);
@@ -215,8 +228,10 @@ public class CbusPredefinedMetersTest {
     @Test
     public void testMultiMExtraCanReply(){
 
-        CbusNodeTableDataModel nodeModel = new CbusNodeTableDataModel(memo, 3,CbusNodeTableDataModel.MAX_COLUMN);
-        jmri.InstanceManager.setDefault(CbusNodeTableDataModel.class,nodeModel );
+        ((CbusPreferences)memo.get(CbusPreferences.class)).setAllocateNNListener(false);
+        ((CbusPreferences)memo.get(CbusPreferences.class)).setNodeBackgroundFetchDelay(0);
+        CbusNodeTableDataModel nodeModel = ((CbusConfigurationManager)memo.get(CbusConfigurationManager.class))
+            .provide(CbusNodeTableDataModel.class);
 
         CbusNode testCs = nodeModel.provideNodeByNodeNum(54321);
         testCs.setCsNum(0);
@@ -315,8 +330,10 @@ public class CbusPredefinedMetersTest {
     @Test
     public void testMultiMVoltCanReply(){
 
-        CbusNodeTableDataModel nodeModel = new CbusNodeTableDataModel(memo, 3,CbusNodeTableDataModel.MAX_COLUMN);
-        jmri.InstanceManager.setDefault(CbusNodeTableDataModel.class,nodeModel );
+        ((CbusPreferences)memo.get(CbusPreferences.class)).setAllocateNNListener(false);
+        ((CbusPreferences)memo.get(CbusPreferences.class)).setNodeBackgroundFetchDelay(0);
+        CbusNodeTableDataModel nodeModel = ((CbusConfigurationManager)memo.get(CbusConfigurationManager.class))
+            .provide(CbusNodeTableDataModel.class);
 
         CbusNode testCs = nodeModel.provideNodeByNodeNum(54321);
         testCs.setCsNum(0);

--- a/java/test/jmri/jmrix/can/cbus/eventtable/CbusEventTableXmlActionTest.java
+++ b/java/test/jmri/jmrix/can/cbus/eventtable/CbusEventTableXmlActionTest.java
@@ -4,14 +4,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.nio.file.Path;
+
 import jmri.jmrix.can.CanSystemConnectionMemo;
-import jmri.jmrix.can.TrafficControllerScaffold;
-import jmri.jmrix.can.cbus.CbusPreferences;
+
 import jmri.util.JUnitAppender;
 import jmri.util.JUnitUtil;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.io.TempDir;
 
 /**
@@ -34,7 +33,7 @@ public class CbusEventTableXmlActionTest {
     @Test
     public void testLoadGoodFile() throws java.io.IOException, java.text.ParseException {
         
-        CbusEventTableXmlFile x = new CbusEventTableXmlFile();
+        CbusEventTableXmlFile x = new CbusEventTableXmlFile(memo);
 
         java.io.File dir = new java.io.File("java/test/jmri/jmrix/can/cbus/eventtable/");
         java.io.File systemFile = new java.io.File(dir, "EventTableData-1.xml");
@@ -85,7 +84,7 @@ public class CbusEventTableXmlActionTest {
     @Test
     public void testLoadBadFile() throws java.io.IOException {
         
-        CbusEventTableXmlFile x = new CbusEventTableXmlFile();
+        CbusEventTableXmlFile x = new CbusEventTableXmlFile(memo);
 
         java.io.File dir = new java.io.File("java/test/jmri/jmrix/can/cbus/eventtable/");
         java.io.File systemFile = new java.io.File(dir, "EventTableData-2.xml");
@@ -170,25 +169,17 @@ public class CbusEventTableXmlActionTest {
         assertThat(te.getDate()).isNull();
     }
     
-    
     private CbusEventTableDataModel model;
-    private TrafficControllerScaffold tcis;
-    private CanSystemConnectionMemo memo;
-    
-    @TempDir 
-    protected Path tempDir;
+    private CanSystemConnectionMemo memo = null;
 
     @BeforeEach
-    public void setUp() throws java.io.IOException {
+    public void setUp( @TempDir Path tempDir ) throws java.io.IOException {
         JUnitUtil.setUp();
         JUnitUtil.resetInstanceManager();
         JUnitUtil.resetProfileManager( new jmri.profile.NullProfile( tempDir.toFile()));
         
-        tcis = new TrafficControllerScaffold();
         memo = new CanSystemConnectionMemo();
-        memo.setTrafficController(tcis);
-        jmri.InstanceManager.store(new CbusPreferences(),CbusPreferences.class );
-        model = new CbusEventTableDataModel( memo,4,CbusEventTableDataModel.MAX_COLUMN);
+        model = new CbusEventTableDataModel( memo, 2);
       
     }
 
@@ -199,10 +190,9 @@ public class CbusEventTableXmlActionTest {
         
         CbusEventTableShutdownTask task = new CbusEventTableShutdownTask("Test Dispose",model);
         task.run();
+        Assertions.assertNotNull(memo);
         memo.dispose();
         memo = null;
-        tcis.terminateThreads();
-        tcis = null;
         
         JUnitUtil.tearDown();
 

--- a/java/test/jmri/jmrix/can/cbus/eventtable/CbusEventTableXmlFileTest.java
+++ b/java/test/jmri/jmrix/can/cbus/eventtable/CbusEventTableXmlFileTest.java
@@ -1,11 +1,18 @@
 package jmri.jmrix.can.cbus.eventtable;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
 
-import jmri.util.JUnitUtil;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import jmri.jmrix.can.CanSystemConnectionMemo;
+import jmri.jmrix.can.cbus.CbusConfigurationManager;
+import jmri.jmrix.can.cbus.node.CbusNodeTableDataModel;
+
+import jmri.util.*;
+import jmri.util.JUnitAppender;
+
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  *
@@ -16,19 +23,68 @@ public class CbusEventTableXmlFileTest {
 
     @Test
     public void testCTor() {
-        CbusEventTableXmlFile t = new CbusEventTableXmlFile();
-        assertThat(t).isNotNull();
+        CbusEventTableXmlFile t = new CbusEventTableXmlFile(memo);
+        Assertions.assertNotNull(t,"exists");
+    }
+
+    @Test
+    public void testProvideNewFile() {
+        CbusEventTableXmlFile t = new CbusEventTableXmlFile(memo);
+        Assertions.assertNull(t.getFile(false),"file not created");
+        Assertions.assertNotNull(t.getFile(true),"file created");
+    }
+
+    @Test
+    public void testMigratedFile() {
+
+        Assertions.assertNotNull(memo);
+        CbusEventTableXmlFile x = new CbusEventTableXmlFile(memo);
+
+        File dir = new File("java/test/jmri/jmrix/can/cbus/eventtable/");
+        File systemFile = new File(dir, "EventTableData-1.xml");
+
+        FileUtil.createDirectory(x.oldFileLocation);
+        
+        File newFile = new File (x.oldFileLocation, x.getFileName());
+
+        try {
+            java.nio.file.Files.copy(systemFile.toPath(), newFile.toPath(), 
+                java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+        }
+        catch (IOException ex){
+            Assertions.fail("Could not copy temp file to path ", ex );
+        }
+
+        CbusEventTableXmlAction.restoreEventsFromXmlTablestart(model);
+        Assertions.assertEquals(3, model.getRowCount());
+        JUnitAppender.assertWarnMessage("Migrated existing CBUS Event Table Data to CAN");
         
     }
-    
+
+    private CbusEventTableDataModel model = null;
+    private CanSystemConnectionMemo memo = null;
+
     @BeforeEach
-    public void setUp() {
+    public void setUp( @TempDir Path tempDir ) throws java.io.IOException {
         JUnitUtil.setUp();
+        JUnitUtil.resetProfileManager( new jmri.profile.NullProfile( tempDir.toFile()));
+        
+        // tcis = new TrafficControllerScaffold();
+        memo = new CanSystemConnectionMemo();
+        memo.setProtocol(jmri.jmrix.can.CanConfigurationManager.MERGCBUS);
+        // memo.setTrafficController(tcis);
+        
+        ((CbusConfigurationManager)memo.get(CbusConfigurationManager.class)).provide(CbusEventTableDataModel.class);
+        model = memo.get(CbusEventTableDataModel.class);
+        model.skipSaveOnDispose();
     }
 
     @AfterEach
     public void tearDown() {
         JUnitUtil.tearDown();
+        Assertions.assertNotNull(memo);
+        memo.dispose();
+        memo = null;
     }
 
     // private final static Logger log = LoggerFactory.getLogger(CbusEventTableXmlFileTest.class);

--- a/java/test/jmri/jmrix/can/cbus/node/CbusNodeBackupFileTest.java
+++ b/java/test/jmri/jmrix/can/cbus/node/CbusNodeBackupFileTest.java
@@ -1,9 +1,13 @@
 package jmri.jmrix.can.cbus.node;
 
-import jmri.util.JUnitUtil;
+import java.io.File;
+import java.nio.file.Path;
 
-import org.junit.Assert;
+import jmri.jmrix.can.CanSystemConnectionMemo;
+import jmri.util.*;
+
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  *
@@ -13,18 +17,69 @@ import org.junit.jupiter.api.*;
 public class CbusNodeBackupFileTest {
 
     @Test
-    public void testCTor() {
-        CbusNodeStats t = new CbusNodeStats(null);
-        Assert.assertNotNull("exists",t);
+    public void testCTorNull() {
+        CbusNodeBackupFile t = new CbusNodeBackupFile(null);
+        Assertions.assertNotNull(t,"exists");
     }
-    
+
+    @Test
+    public void testCTorMemo() {
+        CbusNodeBackupFile t = new CbusNodeBackupFile(memo);
+        Assertions.assertNotNull(t,"exists");
+    }
+
+    @Test
+    public void testDeleteNodeNotExist() {
+        CbusNodeBackupFile t = new CbusNodeBackupFile(memo);
+        Assertions.assertNotNull(t,"exists");
+        Assertions.assertTrue(t.deleteFile(999));
+    }
+
+    @Test
+    public void testProvideNewFile() {
+        CbusNodeBackupFile t = new CbusNodeBackupFile(memo);
+        Assertions.assertNull(t.getFile(777, false),"file not created");
+        Assertions.assertNotNull(t.getFile(777, true),"file created");
+    }
+
+    @Test
+    public void testMigrate()  throws java.io.IOException {
+        CbusNode node = new CbusNode(memo,41376);
+        CbusNodeBackupManager t = new CbusNodeBackupManager(node);
+        CbusNodeBackupFile nbaf = new CbusNodeBackupFile(memo);
+        
+        java.io.File dir = new java.io.File("java/test/jmri/jmrix/can/cbus/node/");
+        java.io.File systemFile = new java.io.File(dir, "41376.xml");
+        
+        FileUtil.createDirectory(nbaf.oldFileLocation);
+        File newFile = new File (nbaf.oldFileLocation, "41376.xml");
+        
+        java.nio.file.Files.copy(systemFile.toPath(), newFile.toPath(), 
+            java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+        Assertions.assertEquals(0, t.getBackups().size(),"File should not be loaded");
+        
+        t.doLoad();
+        Assertions.assertEquals(14, t.getBackups().size(), "File loaded");
+
+        JUnitAppender.assertWarnMessage("Migrated existing CBUS Node Data to CAN");
+
+    }
+
+    private CanSystemConnectionMemo memo = null;
+
     @BeforeEach
-    public void setUp() {
+    public void setUp( @TempDir Path tempDir ) throws java.io.IOException {
         JUnitUtil.setUp();
+        JUnitUtil.resetProfileManager( new jmri.profile.NullProfile( tempDir.toFile()));
+        memo = new CanSystemConnectionMemo();
+        memo.configureManagers(); // no manager but will register memo to instancemanager
     }
 
     @AfterEach
     public void tearDown() {
+        Assertions.assertNotNull(memo);
+        memo.dispose();
+        memo = null;
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrix/can/cbus/node/CbusNodeBackupManagerTest.java
+++ b/java/test/jmri/jmrix/can/cbus/node/CbusNodeBackupManagerTest.java
@@ -3,6 +3,8 @@ package jmri.jmrix.can.cbus.node;
 import java.io.File;
 import java.util.ArrayList;
 
+import jmri.jmrix.can.CanSystemConnectionMemo;
+import jmri.jmrix.can.ConfigurationManager;
 import jmri.util.JUnitAppender;
 import jmri.util.JUnitUtil;
 
@@ -136,7 +138,7 @@ public class CbusNodeBackupManagerTest {
         Assert.assertEquals("backup node NVs","01", t.getBackups().get(4).getNodeNvManager().getNvHexString());
         
         
-        ArrayList tempList = t.getBackups().get(4).getNodeEventManager().getEventArray();
+        ArrayList<CbusNodeEvent> tempList = t.getBackups().get(4).getNodeEventManager().getEventArray();
         Assert.assertNotNull("Ev Array Not Null", tempList);
         
         
@@ -155,7 +157,7 @@ public class CbusNodeBackupManagerTest {
     }
     
     @Test
-    public void TestSaveFile() throws java.text.ParseException, java.io.IOException {
+    public void testSaveFile() throws java.text.ParseException, java.io.IOException {
         
         CbusNode node = new CbusNode(null,41375);
         CbusNodeBackupManager t = new CbusNodeBackupManager(node);
@@ -215,7 +217,7 @@ public class CbusNodeBackupManagerTest {
             "A5591D800D01010D0D0100080000000000000101", t.getBackups().get(5).getNodeParamManager().getParameterHexString());
         Assert.assertEquals("backup node NVs","01", t.getBackups().get(5).getNodeNvManager().getNvHexString());
         
-        ArrayList tempList = t.getBackups().get(5).getNodeEventManager().getEventArray();
+        ArrayList<CbusNodeEvent> tempList = t.getBackups().get(5).getNodeEventManager().getEventArray();
         Assert.assertNotNull("Ev Array Not Null", tempList);
         
         Assert.assertEquals("backup node events",
@@ -234,12 +236,12 @@ public class CbusNodeBackupManagerTest {
     }
     
     @Test
-    public void TestTrimBackups() throws java.text.ParseException, java.io.IOException {
+    public void testTrimBackups() throws java.text.ParseException, java.io.IOException {
         
-        jmri.jmrix.can.cbus.CbusPreferences pref = new jmri.jmrix.can.cbus.CbusPreferences();
-        jmri.InstanceManager.setDefault(jmri.jmrix.can.cbus.CbusPreferences.class,pref );
+        Assertions.assertNotNull(memo);
+        jmri.jmrix.can.cbus.CbusPreferences pref = memo.get( jmri.jmrix.can.cbus.CbusPreferences.class);
         
-        CbusNode node = new CbusNode(null,41376);
+        CbusNode node = new CbusNode(memo,41376);
         CbusNodeBackupManager t = new CbusNodeBackupManager(node);
         
         java.io.File dir = new java.io.File("java/test/jmri/jmrix/can/cbus/node/");
@@ -326,7 +328,7 @@ public class CbusNodeBackupManagerTest {
     }
     
     @Test
-    public void TestFailedBackups() throws java.text.ParseException, java.io.IOException {
+    public void testFailedBackups() throws java.text.ParseException, java.io.IOException {
         
         CbusNode node = new CbusNode(null,41377);
         CbusNodeBackupManager t = new CbusNodeBackupManager(node);
@@ -373,7 +375,7 @@ public class CbusNodeBackupManagerTest {
     }
     
     @Test
-    public void TestMalfordmedFile() throws java.text.ParseException, java.io.IOException {
+    public void testMalfordmedFile() throws java.text.ParseException, java.io.IOException {
         
         CbusNode node = new CbusNode(null,41378);
         CbusNodeBackupManager t = new CbusNodeBackupManager(node);
@@ -388,15 +390,23 @@ public class CbusNodeBackupManagerTest {
         JUnitAppender.assertErrorMessageStartsWith("File invalid: org.jdom2.input.JDOMParseException: Error on line 6:");
         
     }
-    
+
+    private CanSystemConnectionMemo memo = null;
+
     @BeforeEach
     public void setUp(@TempDir File folder) throws java.io.IOException {
         JUnitUtil.setUp();
         JUnitUtil.resetProfileManager(new jmri.profile.NullProfile(folder));
+        memo = new CanSystemConnectionMemo();
+        memo.setProtocol(ConfigurationManager.MERGCBUS);
+        memo.configureManagers();
     }
 
     @AfterEach
     public void tearDown() {
+        Assertions.assertNotNull(memo);
+        memo.dispose();
+        memo = null;
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrix/can/cbus/node/CbusNodeEventManagerTest.java
+++ b/java/test/jmri/jmrix/can/cbus/node/CbusNodeEventManagerTest.java
@@ -6,7 +6,7 @@ import jmri.jmrix.can.CanMessage;
 import jmri.jmrix.can.CanReply;
 import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.jmrix.can.TrafficControllerScaffold;
-import jmri.jmrix.can.cbus.CbusConstants;
+import jmri.jmrix.can.cbus.*;
 import jmri.util.JUnitUtil;
 
 import org.junit.Assert;
@@ -168,7 +168,11 @@ public class CbusNodeEventManagerTest {
         tcis = new TrafficControllerScaffold();
         memo.setTrafficController(tcis);
         
-        nodeModel = new CbusNodeTableDataModel(memo, 3,CbusNodeTableDataModel.MAX_COLUMN);
+        memo.setProtocol(jmri.jmrix.can.CanConfigurationManager.MERGCBUS);
+
+        ((CbusPreferences)memo.get(CbusPreferences.class)).setNodeBackgroundFetchDelay(0);
+        nodeModel = ((CbusConfigurationManager)memo.get(CbusConfigurationManager.class))
+            .provide(CbusNodeTableDataModel.class);
         
         nodeToEdit = nodeModel.provideNodeByNodeNum(7961);
         t = nodeToEdit.getNodeEventManager();

--- a/java/test/jmri/jmrix/can/cbus/node/CbusNodeEventTableDataModelTest.java
+++ b/java/test/jmri/jmrix/can/cbus/node/CbusNodeEventTableDataModelTest.java
@@ -1,14 +1,14 @@
 package jmri.jmrix.can.cbus.node;
 
-import java.awt.GraphicsEnvironment;
-
 import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.jmrix.can.TrafficControllerScaffold;
+import jmri.jmrix.can.cbus.CbusConfigurationManager;
+import jmri.jmrix.can.cbus.CbusPreferences;
 import jmri.util.JUnitUtil;
 
 import org.junit.Assert;
 import org.junit.jupiter.api.*;
-import org.junit.Assume;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 /**
  *
@@ -58,10 +58,10 @@ public class CbusNodeEventTableDataModelTest {
     
     
     @Test
+    @DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
     public void testNodeWithNewEv() {
         
         // not headless as setValueAt triggers window open
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         
         jmri.jmrix.can.cbus.swing.nodeconfig.NodeConfigToolPane mainpane = new 
             jmri.jmrix.can.cbus.swing.nodeconfig.NodeConfigToolPane();
@@ -119,11 +119,11 @@ public class CbusNodeEventTableDataModelTest {
 
         
     }    
-    
-    private CbusNodeTableDataModel nodeModel;
-    private CanSystemConnectionMemo memo;
-    private TrafficControllerScaffold tcis;
-    
+
+    private CbusNodeTableDataModel nodeModel = null;
+    private CanSystemConnectionMemo memo = null;
+    private TrafficControllerScaffold tcis = null;
+
     @BeforeEach
     public void setUp() {
         JUnitUtil.setUp();
@@ -132,17 +132,22 @@ public class CbusNodeEventTableDataModelTest {
         tcis = new TrafficControllerScaffold();
         memo.setTrafficController(tcis);
         
-        nodeModel = new CbusNodeTableDataModel(memo, 3,CbusNodeTableDataModel.MAX_COLUMN);
-        jmri.InstanceManager.setDefault(jmri.jmrix.can.cbus.node.CbusNodeTableDataModel.class,nodeModel );
+        memo.setProtocol(jmri.jmrix.can.CanConfigurationManager.SPROGCBUS);
+
+        ((CbusPreferences)memo.get(CbusPreferences.class)).setNodeBackgroundFetchDelay(0);
+        nodeModel = ((CbusConfigurationManager)memo.get(CbusConfigurationManager.class))
+            .provide(CbusNodeTableDataModel.class);
     }
 
     @AfterEach
     public void tearDown() {
-        
+        Assertions.assertNotNull(nodeModel);
         nodeModel.dispose();
         nodeModel = null;
         
+        Assertions.assertNotNull(tcis);
         tcis.terminateThreads();
+        Assertions.assertNotNull(memo);
         memo.dispose();
         memo = null;
         tcis = null;

--- a/java/test/jmri/jmrix/can/cbus/node/CbusNodeNVManagerTest.java
+++ b/java/test/jmri/jmrix/can/cbus/node/CbusNodeNVManagerTest.java
@@ -4,7 +4,7 @@ import jmri.jmrix.can.CanMessage;
 import jmri.jmrix.can.CanReply;
 import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.jmrix.can.TrafficControllerScaffold;
-import jmri.jmrix.can.cbus.CbusConstants;
+import jmri.jmrix.can.cbus.*;
 import jmri.util.JUnitAppender;
 import jmri.util.JUnitUtil;
 
@@ -202,7 +202,11 @@ public class CbusNodeNVManagerTest {
         tcis = new TrafficControllerScaffold();
         memo.setTrafficController(tcis);
         
-        nodeModel = new CbusNodeTableDataModel(memo, 3,CbusNodeTableDataModel.MAX_COLUMN);
+        memo.setProtocol(jmri.jmrix.can.CanConfigurationManager.MERGCBUS);
+
+        ((CbusPreferences)memo.get(CbusPreferences.class)).setNodeBackgroundFetchDelay(0);
+        nodeModel = ((CbusConfigurationManager)memo.get(CbusConfigurationManager.class))
+            .provide(CbusNodeTableDataModel.class);
         
         nodeToEdit = nodeModel.provideNodeByNodeNum(7423);
         t = nodeToEdit.getNodeNvManager();

--- a/java/test/jmri/jmrix/can/cbus/node/CbusNodeTest.java
+++ b/java/test/jmri/jmrix/can/cbus/node/CbusNodeTest.java
@@ -6,7 +6,7 @@ import jmri.jmrix.can.CanMessage;
 import jmri.jmrix.can.CanReply;
 import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.jmrix.can.TrafficControllerScaffold;
-import jmri.jmrix.can.cbus.CbusConstants;
+import jmri.jmrix.can.cbus.*;
 import jmri.util.JUnitUtil;
 import jmri.util.JUnitAppender;
 
@@ -471,8 +471,8 @@ public class CbusNodeTest {
     public void testFetchEventsFromCanWithNodeTable() {
         
         // needs table model adding to check for any other nodes in learn mode
-        CbusNodeTableDataModel tModel = new CbusNodeTableDataModel(
-            memo, 3,CbusNodeTableDataModel.MAX_COLUMN);
+        CbusNodeTableDataModel tModel = ((CbusConfigurationManager)memo.get(CbusConfigurationManager.class))
+            .provide(CbusNodeTableDataModel.class);
         
         CbusNode t = tModel.provideNodeByNodeNum(12345);
         // set node to 3 ev vars per event( param 5) , 0 NV's ( param 6)
@@ -714,6 +714,7 @@ public class CbusNodeTest {
         memo = new CanSystemConnectionMemo();
         tcis = new TrafficControllerScaffold();
         memo.setTrafficController(tcis);
+        memo.setProtocol(jmri.jmrix.can.CanConfigurationManager.MERGCBUS);
         
     }
 

--- a/java/test/jmri/jmrix/can/cbus/swing/console/CbusConsolePaneTest.java
+++ b/java/test/jmri/jmrix/can/cbus/swing/console/CbusConsolePaneTest.java
@@ -1,9 +1,6 @@
 package jmri.jmrix.can.cbus.swing.console;
 
-import jmri.jmrix.can.CanMessage;
-import jmri.jmrix.can.CanReply;
-import jmri.jmrix.can.CanSystemConnectionMemo;
-import jmri.jmrix.can.TrafficControllerScaffold;
+import jmri.jmrix.can.*;
 import jmri.jmrix.can.cbus.CbusConstants;
 import jmri.jmrix.can.cbus.eventtable.CbusEventTableDataModel;
 import jmri.util.JUnitUtil;
@@ -52,7 +49,7 @@ public class CbusConsolePaneTest extends jmri.util.swing.JmriPanelTest {
         m.setNumDataElements(1);
         m.setElement(0, CbusConstants.CBUS_RTON);
         cbPanel.decodePane.message(m);
-        JUnitUtil.waitFor(() ->{ return !getCbusPaneText(jfo).isEmpty(); });
+        JUnitUtil.waitFor(() ->{ return !getCbusPaneText(jfo).isEmpty(); },"pane text still empty");
 
         Assertions.assertTrue( getCbusPaneText(jfo).contains("RTON"), 
             "RTON logged in console");
@@ -87,7 +84,7 @@ public class CbusConsolePaneTest extends jmri.util.swing.JmriPanelTest {
         CanReply r = new CanReply();
         r.setRtr(true);
         cbPanel.decodePane.reply(r);
-        JUnitUtil.waitFor(() ->{ return !getCbusPaneText(jfo).isEmpty(); });
+        JUnitUtil.waitFor(() ->{ return !getCbusPaneText(jfo).isEmpty(); },"pane text still empty");
         Assertions.assertTrue( getCbusPaneText(jfo).contains("RTR:R"), 
             "RTR CanReply logged in console");
         
@@ -96,7 +93,7 @@ public class CbusConsolePaneTest extends jmri.util.swing.JmriPanelTest {
         
         cbPanel.decodePane.reply(r);
         
-        JUnitUtil.waitFor(() ->{ return !getCbusPaneText(jfo).isEmpty(); });
+        JUnitUtil.waitFor(() ->{ return !getCbusPaneText(jfo).isEmpty(); },"pane text still empty");
         Assertions.assertTrue( getCbusPaneText(jfo).contains("RTR:N"), 
             "Non-RTR CanReply logged in console");
         
@@ -105,7 +102,7 @@ public class CbusConsolePaneTest extends jmri.util.swing.JmriPanelTest {
         clearCbusPaneText(jfo);
         
         cbPanel.decodePane.reply(r);
-        JUnitUtil.waitFor(() ->{ return !getCbusPaneText(jfo).isEmpty(); });
+        JUnitUtil.waitFor(() ->{ return !getCbusPaneText(jfo).isEmpty(); },"pane text still empty");
         Assertions.assertTrue( getCbusPaneText(jfo).contains("RTR:R"), 
             "RTR CanReply 0 length logged in console");
         
@@ -117,7 +114,7 @@ public class CbusConsolePaneTest extends jmri.util.swing.JmriPanelTest {
         clearCbusPaneText(jfo);
         
         cbPanel.decodePane.message(m);
-        JUnitUtil.waitFor(() ->{ return !getCbusPaneText(jfo).isEmpty(); });
+        JUnitUtil.waitFor(() ->{ return !getCbusPaneText(jfo).isEmpty(); },"pane text still empty");
         Assertions.assertTrue( getCbusPaneText(jfo).contains("RTR:R"), 
             "RTR CanMessage 0 length logged in console");
         
@@ -139,7 +136,7 @@ public class CbusConsolePaneTest extends jmri.util.swing.JmriPanelTest {
 
     private void clearCbusPaneText(JFrameOperator jfoo){
         new JTextAreaOperator(jfoo,1).setText("");
-        JUnitUtil.waitFor(() ->{ return getCbusPaneText(jfoo).isEmpty(); });
+        JUnitUtil.waitFor(() ->{ return getCbusPaneText(jfoo).isEmpty(); },"pane text still empty");
     }
 
     private String getCbusPaneText(JFrameOperator jfoo){
@@ -157,6 +154,7 @@ public class CbusConsolePaneTest extends jmri.util.swing.JmriPanelTest {
         memo = new CanSystemConnectionMemo();
         tc = new TrafficControllerScaffold();
         memo.setTrafficController(tc);
+        memo.setProtocol(ConfigurationManager.MERGCBUS);
         panel = cbPanel = new CbusConsolePane();
         helpTarget="package.jmri.jmrix.can.cbus.swing.console.CbusConsoleFrame";
         title="CBUS Console";
@@ -166,7 +164,7 @@ public class CbusConsolePaneTest extends jmri.util.swing.JmriPanelTest {
     @Override
     public void tearDown() {
         
-        CbusEventTableDataModel evMod = jmri.InstanceManager.getNullableDefault(CbusEventTableDataModel.class);
+        CbusEventTableDataModel evMod = memo.get(CbusEventTableDataModel.class);
         if ( evMod != null){
             evMod.skipSaveOnDispose();
             evMod.dispose();

--- a/java/test/jmri/jmrix/can/cbus/swing/modeswitcher/SprogCbusModeSwitcherFrameTest.java
+++ b/java/test/jmri/jmrix/can/cbus/swing/modeswitcher/SprogCbusModeSwitcherFrameTest.java
@@ -1,32 +1,25 @@
 package jmri.jmrix.can.cbus.swing.modeswitcher;
 
-import java.awt.GraphicsEnvironment;
-
-import jmri.GlobalProgrammerManager;
 import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.jmrix.can.TrafficControllerScaffold;
-import jmri.jmrix.can.cbus.CbusDccProgrammer;
-import jmri.jmrix.can.cbus.CbusDccProgrammerManager;
-import jmri.jmrix.can.cbus.CbusPreferences;
 import jmri.util.JUnitUtil;
 
-import org.junit.Assume;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 /**
  * Tests for the ModeSwitcherPane class
  *
  * @author Andrew Crosland (C) 2020
  */
+@DisabledIfSystemProperty(named = "java.awt.headless", matches = "true")
 public class SprogCbusModeSwitcherFrameTest extends jmri.util.JmriJFrameTestBase {
 
-    CanSystemConnectionMemo memo;
-    CbusDccProgrammer prog;
-    jmri.jmrix.can.TrafficController tc;
+    private CanSystemConnectionMemo memo = null;
+    private jmri.jmrix.can.TrafficController tc = null;
     
     @Test
     public void testInitSetup () throws Exception{
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         // for now, just makes ure there isn't an exception.
         ((SprogCbusModeSwitcherFrame) frame).initSetup();
     }
@@ -36,26 +29,22 @@ public class SprogCbusModeSwitcherFrameTest extends jmri.util.JmriJFrameTestBase
     public void setUp() {
         JUnitUtil.setUp();
         
-        jmri.InstanceManager.setDefault(jmri.jmrix.can.cbus.CbusPreferences.class,new CbusPreferences() );
-
         tc = new TrafficControllerScaffold();
         memo = new CanSystemConnectionMemo();
+        memo.setProtocol(jmri.jmrix.can.ConfigurationManager.SPROGCBUS);
         memo.setTrafficController(tc);
-        prog = new CbusDccProgrammer(tc);
-       
-        jmri.InstanceManager.setDefault(GlobalProgrammerManager.class,new CbusDccProgrammerManager(prog, memo) );
-        if (!GraphicsEnvironment.isHeadless()) {
-            frame = new SprogCbusModeSwitcherFrame(memo, "SPROB CBUS Mode Switcher Frame test");
-        }
+        memo.configureManagers();
+        frame = new SprogCbusModeSwitcherFrame(memo, "SPROG CBUS Mode Switcher Frame test");
     }
 
     @AfterEach
     @Override
     public void tearDown() {
-        prog = null;
+        Assertions.assertNotNull(tc);
         tc.terminateThreads();
-        memo.dispose();
         tc = null;
+        Assertions.assertNotNull(memo);
+        memo.dispose();
         memo = null;
         super.tearDown();
     }

--- a/java/test/jmri/jmrix/can/cbus/swing/modeswitcher/SprogCbusSimpleModeSwitcherFrameTest.java
+++ b/java/test/jmri/jmrix/can/cbus/swing/modeswitcher/SprogCbusSimpleModeSwitcherFrameTest.java
@@ -1,69 +1,67 @@
 package jmri.jmrix.can.cbus.swing.modeswitcher;
 
-import java.awt.GraphicsEnvironment;
-
 import jmri.*;
 import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.jmrix.can.TrafficControllerScaffold;
-import jmri.jmrix.can.cbus.CbusDccProgrammer;
 import jmri.jmrix.can.cbus.CbusDccProgrammerManager;
 import jmri.jmrix.can.cbus.CbusPreferences;
 import jmri.util.JUnitUtil;
 
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 /**
  * Tests for the ModeSwitcherPane class
  *
  * @author Andrew Crosland (C) 2020
  */
+@DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
 public class SprogCbusSimpleModeSwitcherFrameTest extends jmri.util.JmriJFrameTestBase {
 
-    CanSystemConnectionMemo memo;
-    CbusDccProgrammer prog;
-    jmri.jmrix.can.TrafficController tc;
-    CbusPreferences preferences;
-    CbusDccProgrammerManager pm;
+    private CanSystemConnectionMemo memo = null;
+    private jmri.jmrix.can.TrafficController tc = null;
+    private CbusPreferences preferences = null;
+    private CbusDccProgrammerManager pm;
 
     @Test
     public void testInitComponents () throws Exception{
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         // for now, just makes ure there isn't an exception.
         ((SprogCbusSimpleModeSwitcherFrame) frame).initComponents();
     }
 
     @Test
     public void testPrefProg () throws Exception {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
 
         // Create global programer and matching preferences
         pm = (CbusDccProgrammerManager)InstanceManager.getNullableDefault(GlobalProgrammerManager.class);
+        Assertions.assertNotNull(pm);
         pm.setGlobalProgrammerAvailable(true);
         pm.setAddressedModePossible(false);
+        Assertions.assertNotNull(preferences);
         preferences.setProgrammersAvailable(true, false);
 
         SprogCbusSimpleModeSwitcherFrame f = ((SprogCbusSimpleModeSwitcherFrame) frame);
 
         f.initComponents();
-        Assert.assertEquals(f.mode, SprogCbusSimpleModeSwitcherFrame.PROG_MODE);
+        Assert.assertEquals(SprogCbusSimpleModeSwitcherFrame.PROG_MODE, f.mode);
     }
 
     @Test
     public void testPrefCmd () throws Exception {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
 
         // Create addressed programer and matching preferences
         pm = (CbusDccProgrammerManager)InstanceManager.getNullableDefault(GlobalProgrammerManager.class);
+        Assertions.assertNotNull(pm);
         pm.setGlobalProgrammerAvailable(false);
         pm.setAddressedModePossible(true);
+        Assertions.assertNotNull(preferences);
         preferences.setProgrammersAvailable(false, true);
 
         SprogCbusSimpleModeSwitcherFrame f = ((SprogCbusSimpleModeSwitcherFrame) frame);
 
         f.initComponents();
-        Assert.assertEquals(f.mode, SprogCbusSimpleModeSwitcherFrame.CMD_MODE);
+        Assert.assertEquals( SprogCbusSimpleModeSwitcherFrame.CMD_MODE, f.mode);
     }
 
     @BeforeEach
@@ -71,21 +69,15 @@ public class SprogCbusSimpleModeSwitcherFrameTest extends jmri.util.JmriJFrameTe
     public void setUp() {
         JUnitUtil.setUp();
 
-        jmri.InstanceManager.setDefault(jmri.jmrix.can.cbus.CbusPreferences.class,new CbusPreferences() );
-
         tc = new TrafficControllerScaffold();
         memo = new CanSystemConnectionMemo();
         memo.setTrafficController(tc);
-        prog = new CbusDccProgrammer(tc);
+        memo.setProtocol(jmri.jmrix.can.CanConfigurationManager.SPROGCBUS);
+        memo.configureManagers();
 
-        preferences = jmri.InstanceManager.getDefault(jmri.jmrix.can.cbus.CbusPreferences.class);
+        preferences = memo.get(jmri.jmrix.can.cbus.CbusPreferences.class);
 
-        jmri.InstanceManager.setDefault(GlobalProgrammerManager.class,new CbusDccProgrammerManager(prog, memo) );
-        jmri.InstanceManager.setDefault(AddressedProgrammerManager.class,new CbusDccProgrammerManager(prog, memo) );
-
-        if (!GraphicsEnvironment.isHeadless()) {
-            frame = new SprogCbusSimpleModeSwitcherFrame(memo);
-        }
+        frame = new SprogCbusSimpleModeSwitcherFrame(memo);
     }
 
     @AfterEach
@@ -93,10 +85,11 @@ public class SprogCbusSimpleModeSwitcherFrameTest extends jmri.util.JmriJFrameTe
     public void tearDown() {
         pm = null;
         preferences = null;
-        prog = null;
+        Assertions.assertNotNull(tc);
         tc.terminateThreads();
-        memo.dispose();
         tc = null;
+        Assertions.assertNotNull(memo);
+        memo.dispose();
         memo = null;
         JUnitUtil.clearShutDownManager();
         super.tearDown();

--- a/java/test/jmri/jmrix/can/cbus/swing/modeswitcher/SprogCbusSprog3PlusModeSwitcherFrameTest.java
+++ b/java/test/jmri/jmrix/can/cbus/swing/modeswitcher/SprogCbusSprog3PlusModeSwitcherFrameTest.java
@@ -1,76 +1,72 @@
 package jmri.jmrix.can.cbus.swing.modeswitcher;
 
-import java.awt.GraphicsEnvironment;
-
 import jmri.*;
 import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.jmrix.can.TrafficControllerScaffold;
-import jmri.jmrix.can.cbus.CbusDccProgrammer;
 import jmri.jmrix.can.cbus.CbusDccProgrammerManager;
 import jmri.jmrix.can.cbus.CbusPreferences;
 import jmri.util.JUnitUtil;
 
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 /**
  * Tests for the ModeSwitcherPane class
  *
  * @author Andrew Crosland (C) 2020
  */
+@DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
 public class SprogCbusSprog3PlusModeSwitcherFrameTest extends jmri.util.JmriJFrameTestBase {
 
-    CanSystemConnectionMemo memo;
-    CbusDccProgrammer prog;
-    jmri.jmrix.can.TrafficController tc;
-    CbusPreferences preferences;
-    CbusDccProgrammerManager pm;
+    private CanSystemConnectionMemo memo = null;
+    private jmri.jmrix.can.TrafficController tc = null;
+    private CbusPreferences preferences = null;
+    private CbusDccProgrammerManager pm;
 
     @Test
     public void testInitComponents () throws Exception{
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         // for now, just makes ure there isn't an exception.
-        ((SprogCbusSprog3PlusModeSwitcherFrame) frame).initComponents();
+        frame.initComponents();
     }
 
     @Test
     public void testPrefOff () throws Exception {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
 
         // Create global programer and matching preferences
+        Assertions.assertNotNull(preferences);
         preferences.setProgTrackMode(SprogCbusSprog3PlusModeSwitcherFrame.PROG_OFF_MODE);
 
         SprogCbusSprog3PlusModeSwitcherFrame f = ((SprogCbusSprog3PlusModeSwitcherFrame) frame);
 
         f.initComponents();
-        Assert.assertEquals(f.mode, SprogCbusSprog3PlusModeSwitcherFrame.PROG_OFF_MODE);
+        Assert.assertEquals( SprogCbusSprog3PlusModeSwitcherFrame.PROG_OFF_MODE, f.mode);
     }
 
     @Test
     public void testPrefOn () throws Exception {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
 
         // Create global programer and matching preferences
+        Assertions.assertNotNull(preferences);
         preferences.setProgTrackMode(SprogCbusSprog3PlusModeSwitcherFrame.PROG_ON_MODE);
 
         SprogCbusSprog3PlusModeSwitcherFrame f = ((SprogCbusSprog3PlusModeSwitcherFrame) frame);
 
         f.initComponents();
-        Assert.assertEquals(f.mode, SprogCbusSprog3PlusModeSwitcherFrame.PROG_ON_MODE);
+        Assert.assertEquals( SprogCbusSprog3PlusModeSwitcherFrame.PROG_ON_MODE, f.mode);
     }
 
     @Test
     public void testPrefAr () throws Exception {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
 
         // Create global programer and matching preferences
+        Assertions.assertNotNull(preferences);
         preferences.setProgTrackMode(SprogCbusSprog3PlusModeSwitcherFrame.PROG_AR_MODE);
 
         SprogCbusSprog3PlusModeSwitcherFrame f = ((SprogCbusSprog3PlusModeSwitcherFrame) frame);
 
         f.initComponents();
-        Assert.assertEquals(f.mode, SprogCbusSprog3PlusModeSwitcherFrame.PROG_AR_MODE);
+        Assert.assertEquals( SprogCbusSprog3PlusModeSwitcherFrame.PROG_AR_MODE, f.mode);
     }
 
     @BeforeEach
@@ -78,24 +74,20 @@ public class SprogCbusSprog3PlusModeSwitcherFrameTest extends jmri.util.JmriJFra
     public void setUp() {
         JUnitUtil.setUp();
 
-        jmri.InstanceManager.setDefault(jmri.jmrix.can.cbus.CbusPreferences.class,new CbusPreferences() );
-
         tc = new TrafficControllerScaffold();
         memo = new CanSystemConnectionMemo();
         memo.setTrafficController(tc);
-        prog = new CbusDccProgrammer(tc);
+        memo.setProtocol(jmri.jmrix.can.CanConfigurationManager.SPROGCBUS);
+        memo.configureManagers();
 
-        preferences = jmri.InstanceManager.getDefault(jmri.jmrix.can.cbus.CbusPreferences.class);
-
-        jmri.InstanceManager.setDefault(GlobalProgrammerManager.class,new CbusDccProgrammerManager(prog, memo) );
-        jmri.InstanceManager.setDefault(AddressedProgrammerManager.class,new CbusDccProgrammerManager(prog, memo) );
+        preferences = memo.get(CbusPreferences.class);
         pm = (CbusDccProgrammerManager)InstanceManager.getNullableDefault(GlobalProgrammerManager.class);
+
+        Assertions.assertNotNull(pm);
         pm.mySetGlobalProgrammerAvailable(true);
         pm.setAddressedModePossible(true);
 
-        if (!GraphicsEnvironment.isHeadless()) {
-            frame = new SprogCbusSprog3PlusModeSwitcherFrame(memo);
-        }
+        frame = new SprogCbusSprog3PlusModeSwitcherFrame(memo);
     }
 
     @AfterEach
@@ -103,10 +95,11 @@ public class SprogCbusSprog3PlusModeSwitcherFrameTest extends jmri.util.JmriJFra
     public void tearDown() {
         pm = null;
         preferences = null;
-        prog = null;
+        Assertions.assertNotNull(tc);
         tc.terminateThreads();
-        memo.dispose();
         tc = null;
+        Assertions.assertNotNull(memo);
+        memo.dispose();
         memo = null;
         JUnitUtil.clearShutDownManager();
         super.tearDown();

--- a/java/test/jmri/jmrix/can/cbus/swing/nodeconfig/CbusNodeBackupsPaneTest.java
+++ b/java/test/jmri/jmrix/can/cbus/swing/nodeconfig/CbusNodeBackupsPaneTest.java
@@ -3,17 +3,19 @@ package jmri.jmrix.can.cbus.swing.nodeconfig;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.nio.file.Path;
+import java.io.File;
+
 import jmri.jmrix.can.CanSystemConnectionMemo;
+import jmri.jmrix.can.cbus.CbusConfigurationManager;
+import jmri.jmrix.can.cbus.CbusPreferences;
 import jmri.jmrix.can.cbus.node.CbusNode;
 import jmri.jmrix.can.cbus.node.CbusNodeTableDataModel;
 import jmri.util.JUnitUtil;
 import jmri.util.JmriJFrame;
 import jmri.util.swing.JemmyUtil;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.netbeans.jemmy.operators.*;
 
@@ -40,6 +42,7 @@ public class CbusNodeBackupsPaneTest {
     @DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
     public void testTableData() {
 
+        Assertions.assertNotNull(nodeToEdit);
         nodeToEdit.getNodeBackupManager().doLoad();
         
         t = new CbusNodeBackupsPane(null);
@@ -75,23 +78,21 @@ public class CbusNodeBackupsPaneTest {
     
     private CbusNodeBackupsPane t;
     
-    private CbusNodeTableDataModel nodeModel;
-    private CbusNode nodeToEdit;
-    private CanSystemConnectionMemo memo;
-    // private TrafficControllerScaffold tcis;
-    
-    @TempDir 
-    protected Path tempDir;
-    
+    private CbusNodeTableDataModel nodeModel = null;
+    private CbusNode nodeToEdit = null;
+    private CanSystemConnectionMemo memo = null;
+
     @BeforeEach
-    public void setUp() throws java.io.IOException {
+    public void setUp(@TempDir File tempDir) throws java.io.IOException {
         JUnitUtil.setUp();
         JUnitUtil.resetInstanceManager();
-        JUnitUtil.resetProfileManager(new jmri.profile.NullProfile(tempDir.toFile()));
+        JUnitUtil.resetProfileManager(new jmri.profile.NullProfile(tempDir));
         memo = new CanSystemConnectionMemo();
+        memo.setProtocol(jmri.jmrix.can.CanConfigurationManager.SPROGCBUS);
         
-        nodeModel = new CbusNodeTableDataModel(memo, 3,CbusNodeTableDataModel.MAX_COLUMN);
-        jmri.InstanceManager.setDefault(CbusNodeTableDataModel.class,nodeModel );
+        ((CbusPreferences)memo.get(CbusPreferences.class)).setNodeBackgroundFetchDelay(0);
+        nodeModel = ((CbusConfigurationManager)memo.get(CbusConfigurationManager.class))
+            .provide(CbusNodeTableDataModel.class);
         nodeToEdit = nodeModel.provideNodeByNodeNum(256);
         // set node to 3 node vars , param6
         nodeToEdit.getNodeParamManager().setParameters(new int[]{8,1,2,3,4,5,3,7,8});
@@ -100,8 +101,11 @@ public class CbusNodeBackupsPaneTest {
 
     @AfterEach
     public void tearDown() {
+        Assertions.assertNotNull(nodeModel);
         nodeModel.dispose();
+        Assertions.assertNotNull(nodeToEdit);
         nodeToEdit.dispose();
+        Assertions.assertNotNull(memo);
         memo.dispose();
         memo = null;
        

--- a/java/test/jmri/jmrix/can/cbus/swing/nodeconfig/CbusNodeConfigTabTest.java
+++ b/java/test/jmri/jmrix/can/cbus/swing/nodeconfig/CbusNodeConfigTabTest.java
@@ -1,16 +1,16 @@
 package jmri.jmrix.can.cbus.swing.nodeconfig;
 
-import java.awt.GraphicsEnvironment;
-
 import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.jmrix.can.TrafficControllerScaffold;
+import jmri.jmrix.can.cbus.CbusConfigurationManager;
+import jmri.jmrix.can.cbus.CbusPreferences;
 import jmri.jmrix.can.cbus.node.CbusNode;
 import jmri.jmrix.can.cbus.node.CbusNodeTableDataModel;
 import jmri.util.JUnitUtil;
 
 import org.junit.Assert;
 import org.junit.jupiter.api.*;
-import org.junit.Assume;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 /**
  * Test simple functioning of CbusNodeConfigTab
@@ -18,26 +18,24 @@ import org.junit.Assume;
  * @author Paul Bender Copyright (C) 2016
  * @author Steve Young Copyright (C) 2020
  */
+@DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
 public class CbusNodeConfigTabTest {
 
-    private class testClass extends CbusNodeConfigTab {
-        
-        private testClass( NodeConfigToolPane pane ){
+    private static class TestClass extends CbusNodeConfigTab {
+
+        private TestClass( NodeConfigToolPane pane ){
             super(pane);
-        
         }
-    
+
         @Override
-        protected void changedNode( CbusNode node ) {
-        }
-    
-    
+        protected void changedNode( CbusNode node ) {}
+
     }
     
     @Test
     public void testCtor() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        testClass t = new testClass(null);
+
+        TestClass t = new TestClass(null);
         Assert.assertNotNull("exists",t);
         Assert.assertNotNull("exists",nodeToEdit);
         t.dispose();
@@ -45,19 +43,18 @@ public class CbusNodeConfigTabTest {
     
     @Test
     public void testInit() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        
-        testClass t = new testClass(null);
+
+        TestClass t = new TestClass(null);
         t.setNode(nodeToEdit); // node num 256
         
         Assert.assertNotNull("exists",t);
         t.dispose();
     }
     
-    private CanSystemConnectionMemo memo;
-    private TrafficControllerScaffold tcis;
-    private CbusNodeTableDataModel nodeModel;
-    private CbusNode nodeToEdit;
+    private CanSystemConnectionMemo memo = null;
+    private TrafficControllerScaffold tcis = null;
+    private CbusNodeTableDataModel nodeModel = null;
+    private CbusNode nodeToEdit = null;
 
     @BeforeEach
     public void setUp() {
@@ -66,9 +63,12 @@ public class CbusNodeConfigTabTest {
         memo = new CanSystemConnectionMemo();
         tcis = new TrafficControllerScaffold();
         memo.setTrafficController(tcis);
+        memo.setProtocol(jmri.jmrix.can.CanConfigurationManager.SPROGCBUS);
         
-        nodeModel = new CbusNodeTableDataModel(memo, 3,CbusNodeTableDataModel.MAX_COLUMN);
-        jmri.InstanceManager.setDefault(CbusNodeTableDataModel.class,nodeModel );
+        ((CbusPreferences)memo.get(CbusPreferences.class)).setNodeBackgroundFetchDelay(0);
+        nodeModel = ((CbusConfigurationManager)memo.get(CbusConfigurationManager.class))
+            .provide(CbusNodeTableDataModel.class);
+        
         nodeToEdit = nodeModel.provideNodeByNodeNum(256);
         // set node to 3 node vars , param6
         nodeToEdit.getNodeParamManager().setParameters(new int[]{8,1,2,3,4,5,3,7,8});
@@ -77,9 +77,13 @@ public class CbusNodeConfigTabTest {
 
     @AfterEach
     public void tearDown() {
+        Assertions.assertNotNull(nodeToEdit);
         nodeToEdit.dispose();
+        Assertions.assertNotNull(nodeModel);
         nodeModel.dispose();
+        Assertions.assertNotNull(tcis);
         tcis.terminateThreads();
+        Assertions.assertNotNull(memo);
         memo.dispose();
         memo = null;
         tcis = null;

--- a/java/test/jmri/jmrix/can/cbus/swing/nodeconfig/CbusNodeEditEventFrameTest.java
+++ b/java/test/jmri/jmrix/can/cbus/swing/nodeconfig/CbusNodeEditEventFrameTest.java
@@ -1,9 +1,8 @@
 package jmri.jmrix.can.cbus.swing.nodeconfig;
 
-import java.awt.GraphicsEnvironment;
-
 import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.jmrix.can.TrafficControllerScaffold;
+import jmri.jmrix.can.cbus.CbusConfigurationManager;
 import jmri.jmrix.can.cbus.CbusPreferences;
 import jmri.jmrix.can.cbus.node.CbusNode;
 import jmri.jmrix.can.cbus.node.CbusNodeEvent;
@@ -12,7 +11,7 @@ import jmri.util.JUnitUtil;
 
 import org.junit.Assert;
 import org.junit.jupiter.api.*;
-import org.junit.Assume;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.netbeans.jemmy.operators.JButtonOperator;
 import org.netbeans.jemmy.operators.JFrameOperator;
 
@@ -22,30 +21,29 @@ import org.netbeans.jemmy.operators.JFrameOperator;
  * @author Paul Bender Copyright (C) 2016
  * @author Steve Young Copyright (C) 2019
  */
-public class CbusNodeEditEventFrameTest {
+@DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
+public class CbusNodeEditEventFrameTest extends jmri.util.JmriJFrameTestBase {
  
     @Test
     public void testInitComponentsWithMainPaneAndMemo() {
-        
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        
-        
+
+        Assertions.assertNotNull(nodeModel);
         CbusNode nodeWithEventToEdit = nodeModel.provideNodeByNodeNum(256);
 
         // short event 7 on node 256, no index, 4 ev vars
         CbusNodeEvent eventToEdit = new CbusNodeEvent(memo,0,7,256,-1,4);
         nodeWithEventToEdit.getNodeEventManager().addNewEvent(eventToEdit);
         
-        t.initComponents(memo,nodeWithEventToEdit.getNodeEventManager().getNodeEventByArrayID(0)); // memo, event to edit
+        ((CbusNodeEditEventFrame)frame).initComponents(memo,nodeWithEventToEdit.getNodeEventManager().getNodeEventByArrayID(0)); // memo, event to edit
         
-        Assert.assertEquals("title","Edit Event EN:7 on Node 256",t.getTitle());
-        Assert.assertFalse("node / event select spinners not dirty",t.spinnersDirty() );
-        Assert.assertTrue("event 7 ",t.getEventVal()==7);
-        Assert.assertTrue("node 0 ",t.getNodeVal()==0);
+        Assert.assertEquals("title","Edit Event EN:7 on Node 256",frame.getTitle());
+        Assert.assertFalse("node / event select spinners not dirty",((CbusNodeEditEventFrame)frame).spinnersDirty() );
+        Assert.assertTrue("event 7 ",((CbusNodeEditEventFrame)frame).getEventVal()==7);
+        Assert.assertTrue("node 0 ",((CbusNodeEditEventFrame)frame).getNodeVal()==0);
         
         
         // Find new window by name
-        JFrameOperator jfo = new JFrameOperator( t.getTitle() );
+        JFrameOperator jfo = new JFrameOperator( frame.getTitle() );
         
         Assert.assertFalse(getEditButtonEnabled(jfo));
         Assert.assertTrue(getDeleteButtonEnabled(jfo));
@@ -61,44 +59,49 @@ public class CbusNodeEditEventFrameTest {
         return ( new JButtonOperator(jfo,Bundle.getMessage("ButtonDelete")).isEnabled() );
     }
     
-    private CbusNodeEditEventFrame t;
-    private CanSystemConnectionMemo memo;
-    private TrafficControllerScaffold tcis;
-    private NodeConfigToolPane mainpane;
-    private CbusNodeTableDataModel nodeModel;
+    private CanSystemConnectionMemo memo = null;
+    private TrafficControllerScaffold tcis = null;
+    private NodeConfigToolPane mainpane = null;
+    private CbusNodeTableDataModel nodeModel = null;
 
     @BeforeEach
+    @Override
     public void setUp() {
         JUnitUtil.setUp();
         JUnitUtil.resetInstanceManager();
         
-        if (!GraphicsEnvironment.isHeadless()){
-            
-            memo = new CanSystemConnectionMemo();
-            
-            tcis = new TrafficControllerScaffold();
-            memo.setTrafficController(tcis);
-        
-            nodeModel = new CbusNodeTableDataModel(memo, 3,CbusNodeTableDataModel.MAX_COLUMN);
-            jmri.InstanceManager.setDefault(CbusNodeTableDataModel.class,nodeModel );
-            jmri.InstanceManager.store(new CbusPreferences(),CbusPreferences.class );
-            mainpane = new NodeConfigToolPane();
-            mainpane.initComponents(memo);
-            t = new CbusNodeEditEventFrame(mainpane);
-        }
+        memo = new CanSystemConnectionMemo();
+
+        tcis = new TrafficControllerScaffold();
+        memo.setTrafficController(tcis);
+        memo.setProtocol(jmri.jmrix.can.CanConfigurationManager.MERGCBUS);
+
+        ((CbusPreferences)memo.get(CbusPreferences.class)).setNodeBackgroundFetchDelay(0);
+        nodeModel = ((CbusConfigurationManager)memo.get(CbusConfigurationManager.class))
+            .provide(CbusNodeTableDataModel.class);
+        mainpane = new NodeConfigToolPane();
+        mainpane.initComponents(memo);
+        frame = new CbusNodeEditEventFrame(mainpane);
+
     }
 
     @AfterEach
+    @Override
     public void tearDown() {
-        if (!GraphicsEnvironment.isHeadless()) {
-            memo.dispose();
-            t.dispose();
-            mainpane.dispose();
-            nodeModel.dispose();
-            tcis.terminateThreads();
-        }
+
+        Assertions.assertNotNull(memo);
+        memo.dispose();
+        Assertions.assertNotNull(frame);
+        frame.dispose();
+        Assertions.assertNotNull(mainpane);
+        mainpane.dispose();
+        Assertions.assertNotNull(nodeModel);
+        nodeModel.dispose();
+        Assertions.assertNotNull(tcis);
+        tcis.terminateThreads();
+
         mainpane = null;
-        t = null;
+        frame = null;
         nodeModel = null;
         memo = null;
         tcis = null;

--- a/java/test/jmri/jmrix/can/cbus/swing/nodeconfig/CbusNodeEditNVarPaneTest.java
+++ b/java/test/jmri/jmrix/can/cbus/swing/nodeconfig/CbusNodeEditNVarPaneTest.java
@@ -1,9 +1,7 @@
 package jmri.jmrix.can.cbus.swing.nodeconfig;
 
-import java.awt.GraphicsEnvironment;
-
-import jmri.jmrix.can.CanSystemConnectionMemo;
-import jmri.jmrix.can.TrafficControllerScaffold;
+import jmri.jmrix.can.*;
+import jmri.jmrix.can.cbus.CbusConfigurationManager;
 import jmri.jmrix.can.cbus.CbusPreferences;
 import jmri.jmrix.can.cbus.node.CbusNode;
 import jmri.jmrix.can.cbus.node.CbusNodeTableDataModel;
@@ -11,7 +9,7 @@ import jmri.util.JUnitUtil;
 
 import org.junit.Assert;
 import org.junit.jupiter.api.*;
-import org.junit.Assume;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 /**
  * Test simple functioning of CbusNodeEditNVarFrame
@@ -19,11 +17,11 @@ import org.junit.Assume;
  * @author Paul Bender Copyright (C) 2016 2019
  * @author Steve Young Copyright (C) 2019
  */
+@DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
 public class CbusNodeEditNVarPaneTest {
     
     @Test
     public void testCtorWithMain() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         NodeConfigToolPane mainpane = new NodeConfigToolPane();
         
         t = new CbusNodeEditNVarPane(mainpane);
@@ -33,13 +31,13 @@ public class CbusNodeEditNVarPaneTest {
     
     @Test
     public void testInit() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         NodeConfigToolPane mainpane = new NodeConfigToolPane();
-        
-        CbusNodeTableDataModel nodeModel = new CbusNodeTableDataModel(memo, 3,CbusNodeTableDataModel.MAX_COLUMN);
-        jmri.InstanceManager.setDefault(CbusNodeTableDataModel.class,nodeModel );
-        jmri.InstanceManager.setDefault(jmri.jmrix.can.cbus.CbusPreferences.class,new CbusPreferences() );
-        
+
+        Assertions.assertNotNull(memo);
+        ((CbusPreferences)memo.get(CbusPreferences.class)).setNodeBackgroundFetchDelay(0);
+        CbusNodeTableDataModel nodeModel = ((CbusConfigurationManager)memo.get(CbusConfigurationManager.class))
+            .provide(CbusNodeTableDataModel.class);
+
         mainpane.initComponents(memo);
         
         
@@ -58,8 +56,8 @@ public class CbusNodeEditNVarPaneTest {
 
     }
 
-    private CanSystemConnectionMemo memo;
-    private TrafficControllerScaffold tcis;
+    private CanSystemConnectionMemo memo = null;
+    private TrafficControllerScaffold tcis = null;
     private CbusNodeEditNVarPane t;
 
     @BeforeEach
@@ -68,14 +66,16 @@ public class CbusNodeEditNVarPaneTest {
         memo = new CanSystemConnectionMemo();
         tcis = new TrafficControllerScaffold();
         memo.setTrafficController(tcis);
-        
+        memo.setProtocol(ConfigurationManager.MERGCBUS);
     }
 
     @AfterEach
     public void tearDown() {
         t = null;
+        Assertions.assertNotNull(memo);
         memo.dispose();
         memo=null;
+        Assertions.assertNotNull(tcis);
         tcis.terminateThreads();
         tcis=null;
         JUnitUtil.tearDown();

--- a/java/test/jmri/jmrix/can/cbus/swing/nodeconfig/CbusNodeRestoreFcuFrameTest.java
+++ b/java/test/jmri/jmrix/can/cbus/swing/nodeconfig/CbusNodeRestoreFcuFrameTest.java
@@ -1,15 +1,15 @@
 package jmri.jmrix.can.cbus.swing.nodeconfig;
 
-import java.awt.GraphicsEnvironment;
-
 import jmri.jmrix.can.CanSystemConnectionMemo;
+import jmri.jmrix.can.cbus.CbusConfigurationManager;
 import jmri.jmrix.can.cbus.CbusPreferences;
 import jmri.jmrix.can.cbus.node.CbusNodeTableDataModel;
 import jmri.util.JUnitUtil;
 
 import org.junit.Assert;
 import org.junit.jupiter.api.*;
-import org.junit.Assume;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
 import org.netbeans.jemmy.operators.JButtonOperator;
 import org.netbeans.jemmy.operators.JFrameOperator;
 
@@ -19,16 +19,15 @@ import org.netbeans.jemmy.operators.JFrameOperator;
  * @author Paul Bender Copyright (C) 2016, 2019
  * @author Steve Young Copyright (C) 2019
  */
+@DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
 public class CbusNodeRestoreFcuFrameTest extends jmri.util.JmriJFrameTestBase {
     
     @Test
     public void testInit() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        
-        CbusNodeTableDataModel nodeModel = new CbusNodeTableDataModel(memo, 3,CbusNodeTableDataModel.MAX_COLUMN);
-        jmri.InstanceManager.setDefault(CbusNodeTableDataModel.class,nodeModel );
-        
-        jmri.InstanceManager.setDefault(jmri.jmrix.can.cbus.CbusPreferences.class,new CbusPreferences() );
+        Assertions.assertNotNull(memo);
+        ((CbusPreferences)memo.get(CbusPreferences.class)).setNodeBackgroundFetchDelay(0);
+        CbusNodeTableDataModel nodeModel = ((CbusConfigurationManager)memo.get(CbusConfigurationManager.class))
+            .provide(CbusNodeTableDataModel.class);
         
         NodeConfigToolPane mainpane = new NodeConfigToolPane();
         mainpane.initComponents(memo);
@@ -58,7 +57,7 @@ public class CbusNodeRestoreFcuFrameTest extends jmri.util.JmriJFrameTestBase {
         return ( new JButtonOperator(jfo,Bundle.getMessage("UpdateNodeButton")).isEnabled() );
     }
     
-    CanSystemConnectionMemo memo;
+    private CanSystemConnectionMemo memo = null;
 
 
     @BeforeEach
@@ -67,15 +66,15 @@ public class CbusNodeRestoreFcuFrameTest extends jmri.util.JmriJFrameTestBase {
         JUnitUtil.setUp();
 
         memo = new CanSystemConnectionMemo();
-        if(!GraphicsEnvironment.isHeadless()){
-           frame = new CbusNodeRestoreFcuFrame(null);
-        }
+        memo.setProtocol(jmri.jmrix.can.CanConfigurationManager.MERGCBUS);
+        frame = new CbusNodeRestoreFcuFrame(null);
 
     }
 
     @AfterEach
     @Override
     public void tearDown() {
+        Assertions.assertNotNull(memo);
         memo.dispose();
         memo = null;
         super.tearDown();

--- a/java/test/jmri/jmrix/can/cbus/swing/nodeconfig/CbusNodeSetupPaneTest.java
+++ b/java/test/jmri/jmrix/can/cbus/swing/nodeconfig/CbusNodeSetupPaneTest.java
@@ -1,16 +1,14 @@
 package jmri.jmrix.can.cbus.swing.nodeconfig;
 
-import java.awt.GraphicsEnvironment;
-
 import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.jmrix.can.TrafficControllerScaffold;
+import jmri.jmrix.can.cbus.CbusConfigurationManager;
 import jmri.jmrix.can.cbus.node.CbusNode;
 import jmri.jmrix.can.cbus.node.CbusNodeTableDataModel;
 import jmri.util.JUnitUtil;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.*;
-import org.junit.Assume;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 /**
  * Test simple functioning of CbusNodeSetupPane
@@ -18,44 +16,41 @@ import org.junit.Assume;
  * @author Paul Bender Copyright (C) 2016
  * @author Steve Young Copyright (C) 2019
  */
+@DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
 public class CbusNodeSetupPaneTest {
 
     @Test
     public void testCtor() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         CbusNodeSetupPane t = new CbusNodeSetupPane(null);
-        Assert.assertNotNull("exists",t);
-        Assert.assertNotNull("exists",nodeToEdit);
+        Assertions.assertNotNull(t);
+        Assertions.assertNotNull(nodeToEdit);
     }
-    
+
     @Test
     public void testInit() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        
+
         CbusNodeSetupPane t = new CbusNodeSetupPane(null);
         t.setNode(nodeToEdit); // node num 256
         
-        Assert.assertNotNull("exists",t);
-        
-        nodeModel.dispose();
+        Assertions.assertNotNull(t);
 
     }
     
-    private CanSystemConnectionMemo memo;
-    private TrafficControllerScaffold tcis;
-    private CbusNodeTableDataModel nodeModel;
-    private CbusNode nodeToEdit;
+    private CanSystemConnectionMemo memo = null;
+    private TrafficControllerScaffold tcis = null;
+    private CbusNodeTableDataModel nodeModel = null;
+    private CbusNode nodeToEdit = null;
 
     @BeforeEach
     public void setUp() {
         JUnitUtil.setUp();
         JUnitUtil.resetInstanceManager();
         memo = new CanSystemConnectionMemo();
+        memo.setProtocol(jmri.jmrix.can.CanConfigurationManager.MERGCBUS);
         tcis = new TrafficControllerScaffold();
         memo.setTrafficController(tcis);
-        
-        nodeModel = new CbusNodeTableDataModel(memo, 3,CbusNodeTableDataModel.MAX_COLUMN);
-        jmri.InstanceManager.setDefault(CbusNodeTableDataModel.class,nodeModel );
+        memo.register();
+        nodeModel = ((CbusConfigurationManager)memo.get(CbusConfigurationManager.class)).provide(CbusNodeTableDataModel.class);
         nodeToEdit = nodeModel.provideNodeByNodeNum(256);
         // set node to 3 node vars , param6
         nodeToEdit.getNodeParamManager().setParameters(new int[]{8,1,2,3,4,5,3,7,8});
@@ -64,9 +59,13 @@ public class CbusNodeSetupPaneTest {
 
     @AfterEach
     public void tearDown() {
+        Assertions.assertNotNull(nodeToEdit);
         nodeToEdit.dispose();
+        Assertions.assertNotNull(nodeModel);
         nodeModel.dispose();
+        Assertions.assertNotNull(tcis);
         tcis.terminateThreads();
+        Assertions.assertNotNull(memo);
         memo.dispose();
         memo = null;
         tcis = null;

--- a/java/test/jmri/jmrix/can/cbus/swing/nodeconfig/NodeConfigToolPaneTest.java
+++ b/java/test/jmri/jmrix/can/cbus/swing/nodeconfig/NodeConfigToolPaneTest.java
@@ -1,16 +1,15 @@
 package jmri.jmrix.can.cbus.swing.nodeconfig;
 
-import java.awt.GraphicsEnvironment;
-
 import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.jmrix.can.TrafficControllerScaffold;
+import jmri.jmrix.can.cbus.CbusConfigurationManager;
 import jmri.jmrix.can.cbus.CbusPreferences;
 import jmri.jmrix.can.cbus.node.CbusNodeTableDataModel;
 import jmri.util.JUnitUtil;
 
 import org.junit.Assert;
 import org.junit.jupiter.api.*;
-import org.junit.Assume;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 /**
  * Test simple functioning of NodeConfigToolPane
@@ -21,13 +20,13 @@ import org.junit.Assume;
 public class NodeConfigToolPaneTest extends jmri.util.swing.JmriPanelTest {
 
     @Test
+    @DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
     public void testInitComp() {
-        
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        
-        CbusNodeTableDataModel nodeModel = new CbusNodeTableDataModel(memo, 3,CbusNodeTableDataModel.MAX_COLUMN);
-        jmri.InstanceManager.setDefault(CbusNodeTableDataModel.class,nodeModel );
-        jmri.InstanceManager.setDefault(jmri.jmrix.can.cbus.CbusPreferences.class,new CbusPreferences() );
+
+        Assertions.assertNotNull(memo);
+        ((CbusPreferences)memo.get(CbusPreferences.class)).setNodeBackgroundFetchDelay(0);
+        CbusNodeTableDataModel nodeModel = ((CbusConfigurationManager)memo.get(CbusConfigurationManager.class))
+            .provide(CbusNodeTableDataModel.class);
         
         NodeConfigToolPane nodeConfigpanel = new NodeConfigToolPane();
         nodeConfigpanel.initComponents(memo);
@@ -39,8 +38,8 @@ public class NodeConfigToolPaneTest extends jmri.util.swing.JmriPanelTest {
 
     }
     
-    private CanSystemConnectionMemo memo;
-    private TrafficControllerScaffold tcis;
+    private CanSystemConnectionMemo memo = null;
+    private TrafficControllerScaffold tcis = null;
 
     @BeforeEach
     @Override
@@ -50,7 +49,7 @@ public class NodeConfigToolPaneTest extends jmri.util.swing.JmriPanelTest {
         memo = new CanSystemConnectionMemo();
         tcis = new TrafficControllerScaffold();
         memo.setTrafficController(tcis);
-        
+        memo.setProtocol(jmri.jmrix.can.CanConfigurationManager.MERGCBUS);
         panel = new NodeConfigToolPane();
         title = Bundle.getMessage("MenuItemNodeConfig");
         helpTarget = "package.jmri.jmrix.can.cbus.swing.nodeconfig.NodeConfigToolPane";
@@ -59,8 +58,9 @@ public class NodeConfigToolPaneTest extends jmri.util.swing.JmriPanelTest {
     @AfterEach
     @Override
     public void tearDown() {
-        
+        Assertions.assertNotNull(tcis);
         tcis.terminateThreads();
+        Assertions.assertNotNull(memo);
         memo.dispose();
         tcis = null;
         memo = null;


### PR DESCRIPTION
Currently, with 2 CBUS Connections, the menu items for Event Table / Node Manager will get a singleton InstanceManager Table Model.
One of the connections will be incorrect and refer to the other connection, so this needs to be by memo, not InstanceManager.

Migration of other CBUS classes to use the memo object to follow, InstanceManager access should continue to work fine for user scripts etc.

CbusConfigurationManager -
Instances now saved to memo along with InstanceManager
add master provide method to reduce duplicate code

All classes -
use memo instances of CbusEventTableDataModel / CbusNodeTableDataModel / CbusPreferences instead of InstanceManager

CbusEventTablePane, NodeConfigToolPane -
use new method of getting memo instance of CbusEventTableDataModel

CbusNodeTableDataModel -
implement Disposable
pass memo to CbusNodeBackupFile

CbusNodeBackupFile, CbusEventTableXmlFile - 
use System Letter in directory file is stored in

CbusThrottleManager -
improve dialog visible flags
move Command Station CanReply feedbacking using CbusConstants.CBUS_ERR OPC to own method