### PR TITLE
minor update Warrant Test

### DIFF
--- a/java/test/jmri/jmrit/logix/WarrantTest.java
+++ b/java/test/jmri/jmrit/logix/WarrantTest.java
@@ -223,7 +223,7 @@ public class WarrantTest {
 
         // wait for done
         JUnitUtil.waitFor(() -> {
-            return warrant.getRunningMessage().equals(Bundle.getMessage("Idle"));
+            return Bundle.getMessage("Idle").equals(warrant.getRunningMessage());
         }, "warrant not done");
 
         JUnitAppender.assertWarnMessageStartingWith("block: West Path distance or SpeedProfile unreliable! pathDist= 200.0,");
@@ -303,6 +303,7 @@ public class WarrantTest {
         path = new OPath("SouthToWest", south, null, south.getPortalByName("SouthWest"), settings);
         south.addPath(path);
 
+        Assertions.assertNotNull(bSouth);
         bSouth.setLength(100);
 
         settings = new ArrayList<>();
@@ -320,8 +321,11 @@ public class WarrantTest {
         sEast = _sensorMgr.newSensor("IS2", "EastSensor");
         sNorth = _sensorMgr.newSensor("IS3", "NorthSensor");
         sSouth = _sensorMgr.newSensor("IS4", "SouthSensor");
+        Assertions.assertNotNull(bWest);
         bWest.setSensor("WestSensor");
+        Assertions.assertNotNull(bEast);
         bEast.setSensor("IS2");
+        Assertions.assertNotNull(bNorth);
         bNorth.setSensor("NorthSensor");
         bSouth.setSensor("IS4");
         warrant = new Warrant("IW0", "AllTestWarrant");


### PR DESCRIPTION
reverse order of equals to prevent NPE
`WarrantTest.testWarrant:225 Exception while waiting for "warrant not done" java.lang.NullPointerException`
Add some nonNull assertions