### PR TITLE
Update symbolicprog Tests

### DIFF
--- a/java/test/jmri/jmrit/symbolicprog/ArithmeticQualifierTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/ArithmeticQualifierTest.java
@@ -26,7 +26,7 @@ public class ArithmeticQualifierTest {
     }
 
     // start of base tests
-    class TestArithmeticQualifier extends ArithmeticQualifier {
+    private static class TestArithmeticQualifier extends ArithmeticQualifier {
 
         TestArithmeticQualifier(VariableValue watchedVal, int value, String relation) {
             super(watchedVal, value, relation);
@@ -133,7 +133,7 @@ public class ArithmeticQualifierTest {
     }
 
     protected HashMap<String, CvValue> createCvMap() {
-        HashMap<String, CvValue> m = new HashMap<String, CvValue>();
+        HashMap<String, CvValue> m = new HashMap<>();
         return m;
     }
 

--- a/java/test/jmri/jmrit/symbolicprog/CsvImporterTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/CsvImporterTest.java
@@ -21,14 +21,14 @@ public class CsvImporterTest {
     public File makeTempFile(String contents) throws IOException {
         // create a file
         FileUtil.createDirectory(FileUtil.getUserFilesPath() + "temp");
-        File f = new java.io.File(FileUtil.getUserFilesPath() + "temp" + File.separator + "CsvImporter.test.xml");
+        File f = new File(FileUtil.getUserFilesPath() + "temp" + File.separator + "CsvImporter.test.xml");
         // recreate it
         if (f.exists()) {
-            f.delete();
+            Assertions.assertTrue(f.delete());
         }
-        PrintStream p = new PrintStream(new FileOutputStream(f));
-        p.print(contents);
-        p.close();
+        try (PrintStream p = new PrintStream(new FileOutputStream(f))) {
+            p.print(contents);
+        }
 
         return f;
     }

--- a/java/test/jmri/jmrit/symbolicprog/FnMapPanelESUTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/FnMapPanelESUTest.java
@@ -42,8 +42,8 @@ public class FnMapPanelESUTest {
     }
 
     jmri.Programmer p;
-    CvTableModel cvtm;
-    VariableTableModel tableModel;
+    CvTableModel cvtm = null;
+    VariableTableModel tableModel = null;
     
     @BeforeEach
     public void setUp() {
@@ -62,8 +62,10 @@ public class FnMapPanelESUTest {
     @AfterEach
     public void tearDown() {
         p = null;
+        Assertions.assertNotNull(tableModel);
         tableModel.dispose();
         tableModel = null;
+        Assertions.assertNotNull(cvtm);
         cvtm.dispose();
         cvtm = null; 
 

--- a/java/test/jmri/jmrit/symbolicprog/FnMapPanelTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/FnMapPanelTest.java
@@ -25,7 +25,7 @@ public class FnMapPanelTest {
                 new String[]{"Name", "Value"},
                 new CvTableModel(new JLabel(""), p)
         );
-        List<Integer> varsUsed = null;
+        List<Integer> varsUsed = new java.util.ArrayList<>();
         Element model = new Element("model");
 
         FnMapPanel t = new FnMapPanel(tableModel, varsUsed, model);
@@ -40,7 +40,7 @@ public class FnMapPanelTest {
                 new String[]{"Name", "Value"},
                 new CvTableModel(new JLabel(""), p)
         );
-        List<Integer> varsUsed = null;
+        List<Integer> varsUsed = new java.util.ArrayList<>();
         Element model = new Element("model");
         model.setAttribute("numFns", "28");
 
@@ -51,7 +51,7 @@ public class FnMapPanelTest {
     @BeforeEach
     public void setUp() {
         JUnitUtil.setUp();
-        jmri.util.JUnitUtil.initDebugProgrammerManager();
+        JUnitUtil.initDebugProgrammerManager();
     }
 
     @AfterEach

--- a/java/test/jmri/jmrit/symbolicprog/LokProgImporterTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/LokProgImporterTest.java
@@ -24,11 +24,11 @@ public class LokProgImporterTest {
         File f = new java.io.File(FileUtil.getUserFilesPath() + "temp" + File.separator + "CsvImporter.test.xml");
         // recreate it
         if (f.exists()) {
-            f.delete();
+            Assertions.assertTrue(f.delete());
         }
-        PrintStream p = new PrintStream(new FileOutputStream(f));
-        p.print(contents);
-        p.close();
+        try (PrintStream p = new PrintStream(new FileOutputStream(f))) {
+            p.print(contents);
+        }
 
         return f;
     }

--- a/java/test/jmri/jmrit/symbolicprog/Pr1ImporterTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/Pr1ImporterTest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.*;
  */
 public class Pr1ImporterTest {
 
-    class Pr1ImporterDummy extends Pr1Importer {
+    private static class Pr1ImporterDummy extends Pr1Importer {
 
         Pr1ImporterDummy(File f) throws java.io.IOException {
             super(f);
@@ -35,7 +35,7 @@ public class Pr1ImporterTest {
         File f = new java.io.File(FileUtil.getUserFilesPath() + "temp" + File.separator + "Pr1Importer.test.xml");
         // recreate it
         if (f.exists()) {
-            f.delete();
+            Assertions.assertTrue(f.delete());
         }
         try (PrintStream p = new PrintStream(new FileOutputStream(f))) {
             p.print(contents);

--- a/java/test/jmri/jmrit/symbolicprog/QualifierAdderTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/QualifierAdderTest.java
@@ -36,7 +36,7 @@ public class QualifierAdderTest {
         return var;
     }
 
-    class TestArithmeticQualifier extends ArithmeticQualifier {
+    private static class TestArithmeticQualifier extends ArithmeticQualifier {
 
         TestArithmeticQualifier(VariableValue watchedVal, int value, String relation) {
             super(watchedVal, value, relation);
@@ -53,8 +53,7 @@ public class QualifierAdderTest {
     }
 
     protected HashMap<String, CvValue> createCvMap() {
-        HashMap<String, CvValue> m = new HashMap<String, CvValue>();
-        return m;
+        return new HashMap<>();
     }
 
     /**

--- a/java/test/jmri/jmrit/symbolicprog/QualifierAdderTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/QualifierAdderTest.java
@@ -301,6 +301,20 @@ public class QualifierAdderTest {
         jmri.util.JUnitAppender.assertErrorMessage("Arithmetic EQ operation when watched value doesn't exist");
     }
 
+    @Test
+    public void testArithmeticQualifierImplementation() {
+        HashMap<String, CvValue> v = createCvMap();
+        CvValue cv = new CvValue("81", p);
+        cv.setValue(3);
+        v.put("81", cv);
+        // create a variable pointed at CV 81, check name
+        VariableValue variable = makeVar("label check", "comment", "", false, false, false, false, "81", "XXVVVVVV", 0, 255, v, null, "item check");
+
+        // test exists
+        ArithmeticQualifier aq1 = new TestArithmeticQualifier(variable, 1, "ne");
+        Assertions.assertNotNull(aq1);
+    }
+
     @BeforeEach
     public void setUp() {
         JUnitUtil.setUp();

--- a/java/test/jmri/jmrit/symbolicprog/QualifierCombinerTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/QualifierCombinerTest.java
@@ -26,11 +26,11 @@ public class QualifierCombinerTest {
     ProgDebugger p = new ProgDebugger();
     CvTableModel cvtable;
     VariableTableModel model;
-    VariableValue v1;
-    VariableValue v2;
-    VariableValue v3;
+    // VariableValue v1;
+    // VariableValue v2;
+    // VariableValue v3;
 
-    class TestArithmeticQualifier extends ArithmeticQualifier {
+    private static class TestArithmeticQualifier extends ArithmeticQualifier {
 
         TestArithmeticQualifier(VariableValue watchedVal, int value, String relation) {
             super(watchedVal, value, relation);
@@ -59,7 +59,7 @@ public class QualifierCombinerTest {
         ArithmeticQualifier aq1 = new TestArithmeticQualifier(variable, 10, "ge");
         ArithmeticQualifier aq2 = new TestArithmeticQualifier(variable, 20, "le");
 
-        ArrayList<Qualifier> q=new ArrayList<Qualifier>();
+        ArrayList<Qualifier> q=new ArrayList<>();
         q.add(aq1);
         q.add(aq2);
         QualifierCombiner qc = new QualifierCombiner(q);
@@ -93,7 +93,7 @@ public class QualifierCombinerTest {
         ArithmeticQualifier aq1 = new TestArithmeticQualifier(variable, 1, "ne");
         ArithmeticQualifier aq2 = new TestArithmeticQualifier(variable, 7, "ne");
 
-        ArrayList<Qualifier> q=new ArrayList<Qualifier>();
+        ArrayList<Qualifier> q=new ArrayList<>();
         q.add(aq1);
         q.add(aq2);
         QualifierCombiner qc = new QualifierCombiner(q);
@@ -119,8 +119,7 @@ public class QualifierCombinerTest {
     }
 
     protected HashMap<String, CvValue> createCvMap() {
-        HashMap<String, CvValue> m = new HashMap<String, CvValue>();
-        return m;
+        return new HashMap<>();
     }
 
     VariableValue makeVar(String label, String comment, String cvName,
@@ -184,9 +183,9 @@ public class QualifierCombinerTest {
         model.setRow(1, el2);
         model.setRow(1, el3);
 
-        v1 = model.findVar("one");
-        v2 = model.findVar("two");
-        v3 = model.findVar("three");
+        // v1 = model.findVar("one");
+        // v2 = model.findVar("two");
+        // v3 = model.findVar("three");
     }
 
     @AfterEach

--- a/java/test/jmri/jmrit/symbolicprog/QuantumCvMgrImporterTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/QuantumCvMgrImporterTest.java
@@ -24,11 +24,11 @@ public class QuantumCvMgrImporterTest {
         File f = new java.io.File(FileUtil.getUserFilesPath() + "temp" + File.separator + "CsvImporter.test.xml");
         // recreate it
         if (f.exists()) {
-            f.delete();
+            Assertions.assertTrue(f.delete());
         }
-        PrintStream p = new PrintStream(new FileOutputStream(f));
-        p.print(contents);
-        p.close();
+        try (PrintStream p = new PrintStream(new FileOutputStream(f))) {
+            p.print(contents);
+        }
 
         return f;
     }

--- a/java/test/jmri/jmrit/symbolicprog/tabbedframe/PaneProgFrameTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/tabbedframe/PaneProgFrameTest.java
@@ -183,10 +183,10 @@ public class PaneProgFrameTest {
         p.dispatchEvent(new WindowEvent(p, WindowEvent.WINDOW_CLOSING));
     }
 
-    // static variables for internal classes to report their interpretations
-    static String result = null;
-    static int colCount = -1;
-    static int varCount = -1;
+    // variables for internal classes to report their interpretations
+    String result = "";
+    int colCount = -1;
+    int varCount = -1;
 
     // static variables for the test XML structures
     Element root = null;
@@ -194,6 +194,10 @@ public class PaneProgFrameTest {
 
     // provide a test document in the above static variables
     void setupDoc() {
+        Assertions.assertNull( result);
+        Assertions.assertEquals(-1, colCount);
+        Assertions.assertEquals(-1, varCount);
+
         // create a JDOM tree with just some elements
         root = new Element("programmer-config");
         doc = new Document(root);
@@ -258,6 +262,9 @@ public class PaneProgFrameTest {
         JUnitUtil.setUp();
         JUnitUtil.resetProfileManager();
         JUnitUtil.initRosterConfigManager();
+        result = null;
+        colCount = -1;
+        varCount = -1;
     }
 
     @AfterEach

--- a/java/test/jmri/jmrit/symbolicprog/tabbedframe/PaneProgPaneTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/tabbedframe/PaneProgPaneTest.java
@@ -2,7 +2,6 @@ package jmri.jmrit.symbolicprog.tabbedframe;
 
 import static org.junit.Assert.*;
 
-import java.awt.GraphicsEnvironment;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.event.WindowEvent;
@@ -22,13 +21,14 @@ import org.jdom2.Document;
 import org.jdom2.Element;
 import org.junit.Assert;
 import org.junit.jupiter.api.*;
-import org.junit.Assume;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * @author Bob Jacobsen Copyright 2001, 2002, 2003, 2004
  */
+@DisabledIfSystemProperty(named = "java.awt.headless", matches = "true")
 public class PaneProgPaneTest {
 
     ProgDebugger p = new ProgDebugger();
@@ -36,7 +36,6 @@ public class PaneProgPaneTest {
     // test creating columns in a pane
     @Test
     public void testColumn() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         setupDoc();
         PaneProgFrame pFrame = new PaneProgFrame(null, new RosterEntry(),
                 "test frame", "programmers/Basic.xml",
@@ -70,7 +69,6 @@ public class PaneProgPaneTest {
     // test specifying variables in columns
     @Test
     public void testVariables() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         setupDoc();  // make sure XML document is ready
         PaneProgFrame pFrame = new PaneProgFrame(null, new RosterEntry(),
                 "test frame", "programmers/Basic.xml",
@@ -102,7 +100,6 @@ public class PaneProgPaneTest {
     // test storage of programming info in list
     @Test
     public void testVarListFill() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         setupDoc();  // make sure XML document is ready
         PaneProgFrame pFrame = new PaneProgFrame(null, new RosterEntry(),
                 "test frame", "programmers/Basic.xml",
@@ -148,7 +145,6 @@ public class PaneProgPaneTest {
     // test storage of programming info in list
     @Test
     public void testPaneRead() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         log.debug("testPaneRead starts");
         // initialize the system
         setupDoc();  // make sure XML document is ready
@@ -205,7 +201,6 @@ public class PaneProgPaneTest {
 
     @Test
     public void testPaneWrite() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         log.debug("testPaneWrite starts");
         // initialize the system
         setupDoc();  // make sure XML document is ready
@@ -265,7 +260,6 @@ public class PaneProgPaneTest {
     // test counting of read operations needed
     @Test
     public void testPaneReadOpCount() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         log.debug("testPaneReadOpCount starts");
         // initialize the system
         setupDoc();  // make sure XML document is ready
@@ -329,7 +323,9 @@ public class PaneProgPaneTest {
         Assert.assertEquals("number of changed CVs to write ", 0, progPane.countOpsNeeded(false, true));
 
         // mark some as needing to be written
-        (cvModel.allCvMap().get("1")).setValue(12);
+        var getKey1 = cvModel.allCvMap().get("1");
+        Assertions.assertNotNull(getKey1);
+        getKey1.setValue(12);
 
         Assert.assertEquals("modified all CVs to read ", 29, progPane.countOpsNeeded(true, false));
         Assert.assertEquals("modified all CVs to write ", 29, progPane.countOpsNeeded(false, false));
@@ -337,7 +333,9 @@ public class PaneProgPaneTest {
         Assert.assertEquals("modified changed CVs to read ", 1, progPane.countOpsNeeded(true, true));
         Assert.assertEquals("modified changed CVs to write ", 1, progPane.countOpsNeeded(false, true));
 
-        (cvModel.allCvMap().get("69")).setValue(12);
+        var getKey69 = cvModel.allCvMap().get("69");
+        Assertions.assertNotNull(getKey69);
+        getKey69.setValue(12);
         // careful - might change more than one CV!
 
         Assert.assertEquals("spdtbl all CVs to read ", 29, progPane.countOpsNeeded(true, false));
@@ -351,9 +349,9 @@ public class PaneProgPaneTest {
     }
 
     // static variables for internal classes to report their interpretations
-    static String result = null;
-    static int colCount = -1;
-    static int varCount = -1;
+    private String result = null;
+    private int colCount = -1;
+    private int varCount = -1;
 
     // static variables for the test XML structures
     Element root = null;
@@ -364,6 +362,9 @@ public class PaneProgPaneTest {
 
     // provide a test document in the above static variables
     void setupDoc() {
+        Assertions.assertNull(result);
+        Assertions.assertEquals(-1,colCount);
+        Assertions.assertEquals(-1,varCount);
         // create a JDOM tree with just some elements
         root = new Element("programmer-config");
         doc = new Document(root);
@@ -428,6 +429,9 @@ public class PaneProgPaneTest {
         JUnitUtil.setUp();
         jmri.util.JUnitUtil.resetProfileManager();
         JUnitUtil.initRosterConfigManager();
+        result = null;
+        colCount = -1;
+        varCount = -1;
     }
 
     @AfterEach


### PR DESCRIPTION
ArithmeticQualifierTest - class TestArithmeticQualifier can be static

CsvImporterTest, assert Delete, use try to close PrintStream

LokProgImporterTest, Assert file deletion use try with reources on PrintStream

QuantumCvMgrImporterTest - assert file deletion use try with resources on PrintStream

QualifierCombinerTest - class TestArithmeticQualifier can be static, comment out unused vars

QualifierAdderTest - class TestArithmeticQualifier can be static, use the TestArithmeticQualifier

PaneProgFrameTest - no need for listener variables to be static, read listener variables

PaneProgPaneTest - no need for listener variables to be static, read listener variables
NonNull assertions, update headless check

FnMapPanelESUTest - add nonNull asserts

FnMapPanelTest - do not pass known-null value

Pr1ImporterTest - class Pr1ImporterDummy can be static, Assert file deletion