### PR TITLE
Update CbusAllocate Node Number Test

### DIFF
--- a/java/src/jmri/jmrix/can/cbus/node/CbusAllocateNodeNumber.java
+++ b/java/src/jmri/jmrix/can/cbus/node/CbusAllocateNodeNumber.java
@@ -18,6 +18,7 @@ import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.jmrix.can.CanReply;
 import jmri.jmrix.can.cbus.CbusConstants;
 import jmri.jmrix.can.cbus.CbusMessage;
+import jmri.jmrix.can.cbus.CbusPreferences;
 import jmri.jmrix.can.cbus.CbusSend;
 import java.util.TimerTask;
 import jmri.util.TimerUtil;
@@ -244,7 +245,7 @@ public class CbusAllocateNodeNumber implements CanListener {
                 clearSendSNNTimeout();
                 // if nodes are allowed to be added to node table, add.
                 // this is done here so any known parameters can be passed directly rather than re-requested
-                if ( jmri.InstanceManager.getDefault(jmri.jmrix.can.cbus.CbusPreferences.class).getAddNodes() ) {
+                if ( ((CbusPreferences)_memo.get(CbusPreferences.class)).getAddNodes() ) {
                     int nodeNum = m.getElement(1) * 256 + m.getElement(2);
                     nodeModel.setRequestNodeDisplay(nodeNum);
                     // provide will add to table

--- a/java/src/jmri/jmrix/can/cbus/simulator/CbusSimulatedModuleProvider.java
+++ b/java/src/jmri/jmrix/can/cbus/simulator/CbusSimulatedModuleProvider.java
@@ -6,6 +6,7 @@ import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
 import jmri.jmrix.can.CanSystemConnectionMemo;
+import jmri.jmrix.can.cbus.node.CbusNode;
 import jmri.jmrix.can.cbus.node.CbusNodeConstants;
 
 import jmri.spi.JmriServiceProviderInterface;
@@ -47,7 +48,7 @@ public abstract class CbusSimulatedModuleProvider implements JmriServiceProvider
      * This may include Node Parameters, Node Variables, events and event variables.
      * @param node the Node to set to.
      */
-    public abstract void configureDummyNode(@Nonnull CbusDummyNode node);
+    public abstract void configureDummyNode(@Nonnull CbusNode node);
     
     /**
      * Descriptive String of Module Type.

--- a/java/src/jmri/jmrix/can/cbus/simulator/moduletypes/CbusMax.java
+++ b/java/src/jmri/jmrix/can/cbus/simulator/moduletypes/CbusMax.java
@@ -3,7 +3,7 @@ package jmri.jmrix.can.cbus.simulator.moduletypes;
 import javax.annotation.Nonnull;
 
 import jmri.jmrix.can.cbus.node.CbusNodeEvent;
-import jmri.jmrix.can.cbus.simulator.CbusDummyNode;
+import jmri.jmrix.can.cbus.node.CbusNode;
 import jmri.jmrix.can.cbus.simulator.CbusSimulatedModuleProvider;
 
 import org.openide.util.lookup.ServiceProvider;
@@ -27,7 +27,7 @@ public class CbusMax extends CbusSimulatedModuleProvider {
     }
 
     @Override
-    public void configureDummyNode(@Nonnull CbusDummyNode node) {
+    public void configureDummyNode(@Nonnull CbusNode node) {
         // 255 parameters could have unintended future
         // consequences so staying with the standard 20
         // for now

--- a/java/src/jmri/jmrix/can/cbus/simulator/moduletypes/MergCanmiosvo.java
+++ b/java/src/jmri/jmrix/can/cbus/simulator/moduletypes/MergCanmiosvo.java
@@ -3,7 +3,7 @@ package jmri.jmrix.can.cbus.simulator.moduletypes;
 import javax.annotation.Nonnull;
 
 import jmri.jmrix.can.cbus.simulator.CbusSimulatedModuleProvider;
-import jmri.jmrix.can.cbus.simulator.CbusDummyNode;
+import jmri.jmrix.can.cbus.node.CbusNode;
 
 import static jmri.jmrix.can.cbus.CbusConstants.MANU_MERG;
 
@@ -27,7 +27,7 @@ public class MergCanmiosvo extends CbusSimulatedModuleProvider {
     }
     
     @Override
-    public void configureDummyNode(@Nonnull CbusDummyNode node) {
+    public void configureDummyNode(@Nonnull CbusNode node) {
         int[] _params = new int[]{
             20, /* 0 num parameters   */
             MANU_MERG, /* 1 manufacturer ID   */

--- a/java/src/jmri/jmrix/can/cbus/simulator/moduletypes/MergCanpan.java
+++ b/java/src/jmri/jmrix/can/cbus/simulator/moduletypes/MergCanpan.java
@@ -2,7 +2,7 @@ package jmri.jmrix.can.cbus.simulator.moduletypes;
 
 import static jmri.jmrix.can.cbus.CbusConstants.MANU_MERG;
 
-import jmri.jmrix.can.cbus.simulator.CbusDummyNode;
+import jmri.jmrix.can.cbus.node.CbusNode;
 import jmri.jmrix.can.cbus.simulator.CbusSimulatedModuleProvider;
 
 import org.openide.util.lookup.ServiceProvider;
@@ -25,7 +25,7 @@ public class MergCanpan extends CbusSimulatedModuleProvider {
     }
 
     @Override
-    public void configureDummyNode(CbusDummyNode node) {
+    public void configureDummyNode(CbusNode node) {
         int[] _params = new int[]{
             20, /* 0 num parameters   */
             MANU_MERG, /* 1 manufacturer ID   */

--- a/java/src/jmri/jmrix/can/cbus/simulator/moduletypes/SprogPiSprog3.java
+++ b/java/src/jmri/jmrix/can/cbus/simulator/moduletypes/SprogPiSprog3.java
@@ -5,7 +5,7 @@ import javax.annotation.Nonnull;
 import static jmri.jmrix.can.cbus.CbusConstants.MTYP_CANPiSPRG3;
 import static jmri.jmrix.can.cbus.CbusConstants.SPROG_DCC;
 
-import jmri.jmrix.can.cbus.simulator.CbusDummyNode;
+import jmri.jmrix.can.cbus.node.CbusNode;
 import jmri.jmrix.can.cbus.simulator.CbusSimulatedModuleProvider;
 
 import org.openide.util.lookup.ServiceProvider;
@@ -29,7 +29,7 @@ public class SprogPiSprog3 extends CbusSimulatedModuleProvider {
     }
 
     @Override
-    public void configureDummyNode(@Nonnull CbusDummyNode node) {
+    public void configureDummyNode(@Nonnull CbusNode node) {
         int[] _params = new int[]{ 
             20, /* 0 num parameters   */
             SPROG_DCC, /* 1 manufacturer ID   */

--- a/java/src/jmri/jmrix/can/cbus/simulator/moduletypes/SprogPiSprog3Plus.java
+++ b/java/src/jmri/jmrix/can/cbus/simulator/moduletypes/SprogPiSprog3Plus.java
@@ -5,7 +5,7 @@ import javax.annotation.Nonnull;
 import static jmri.jmrix.can.cbus.CbusConstants.MTYP_CANSPROG3P;
 import static jmri.jmrix.can.cbus.CbusConstants.SPROG_DCC;
 
-import jmri.jmrix.can.cbus.simulator.CbusDummyNode;
+import jmri.jmrix.can.cbus.node.CbusNode;
 import jmri.jmrix.can.cbus.simulator.CbusSimulatedModuleProvider;
 
 import org.openide.util.lookup.ServiceProvider;
@@ -29,7 +29,7 @@ public class SprogPiSprog3Plus extends CbusSimulatedModuleProvider {
     }
 
     @Override
-    public void configureDummyNode(@Nonnull CbusDummyNode node) {
+    public void configureDummyNode(@Nonnull CbusNode node) {
         int[] _params = new int[]{ 
             20, /* 0 num parameters   */
             SPROG_DCC, /* 1 manufacturer ID   */

--- a/java/test/jmri/jmrix/can/cbus/CbusTrafficControllerScaffold.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusTrafficControllerScaffold.java
@@ -1,0 +1,64 @@
+package jmri.jmrix.can.cbus;
+
+import java.util.List;
+
+import jmri.jmrix.AbstractMessage;
+
+/**
+ * TrafficControllerScaffold for jmrix.can.cbus classes.
+ * @author Steve Young Copyright (C) 2022
+ */
+public class CbusTrafficControllerScaffold extends jmri.jmrix.can.TrafficControllerScaffold {
+
+    /**
+     * Create a new TC Scaffold and set the System Connection to use it.
+     * @param memo the System Connection to use with this Traffic Controller.
+     */
+    public CbusTrafficControllerScaffold(jmri.jmrix.can.CanSystemConnectionMemo memo){
+        super();
+        memo.setTrafficController(CbusTrafficControllerScaffold.this);
+    }
+
+    /**
+     * Get a String translation of Outbound messages. e.g.
+     * Outbound 3
+     * Request Node in Setup Parameters RQNP  : [5f8] 10
+     * Request Module Name RQMN  : [5f8] 11
+     * Set Node Number SNN NN:65432  : [5f8] 42 FF 98
+     * 
+     * @return human readable form of outbound message queue.
+     */
+    public String getTranslatedOutbound() {
+        return getFormatted(outbound,"Outbound ");
+    }
+
+    /**
+     * Get a String translation of Inbound messages. e.g.
+     * Inbound 2
+     * Node Acknowledges Write WRACK NN:1234  : [5f8] 59 04 D2
+     * Node Number of Events NUMEV NN:1234  Events: 2 : [5f8] 74 04 D2 02
+     * 
+     * @return human readable form of inbound message queue.
+     */
+    public String getTranslatedInbound() {
+        return getFormatted(inbound,"Inbound ");
+    }
+
+    private String getFormatted(List<?> messages, String direction) {
+        StringBuilder sb = new StringBuilder(direction);
+        sb.append(messages.size());
+        messages.forEach((singleMessage) -> {
+            sb.append(System.lineSeparator());
+            AbstractMessage msg = (AbstractMessage)singleMessage;
+            if (CbusOpCodes.isKnownOpc(msg) ) {
+                sb.append(Bundle.getMessage("CBUS_" + CbusOpCodes.decodeopc(msg)));
+                sb.append(" ").append(CbusOpCodes.decodeopc(msg));
+            }
+            sb.append(" ").append(CbusOpCodes.decode(msg));
+            sb.append(" : ").append(singleMessage.toString());
+        });
+        sb.append(System.lineSeparator());
+        return sb.toString();
+    }
+
+}

--- a/java/test/jmri/jmrix/can/cbus/node/CbusAllocateNodeNumberTest.java
+++ b/java/test/jmri/jmrix/can/cbus/node/CbusAllocateNodeNumberTest.java
@@ -1,14 +1,12 @@
 package jmri.jmrix.can.cbus.node;
 
 import java.io.IOException;
-import java.nio.file.Path;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import java.io.File;
 
 import jmri.jmrix.can.*;
-import jmri.jmrix.can.cbus.CbusConfigurationManager;
-import jmri.jmrix.can.cbus.CbusConstants;
-import jmri.jmrix.can.cbus.CbusPreferences;
+import jmri.jmrix.can.cbus.*;
+import jmri.jmrix.can.cbus.simulator.moduletypes.MergCanpan;
+
 import jmri.util.JUnitAppender;
 import jmri.util.JUnitUtil;
 import jmri.util.swing.JemmyUtil;
@@ -45,18 +43,24 @@ public class CbusAllocateNodeNumberTest {
     @Test
     @DisabledIfSystemProperty(named = "java.awt.headless", matches = "true")
     public void testDisplayDialogue() {
+        ((CbusPreferences)memo.get(CbusPreferences.class)).setAddNodes(false);
         t = new CbusAllocateNodeNumber(memo,nodeModel);
-        assertThat(t).isNotNull();
+        assertNotNull(t);
         
+        CbusNode node789 = nodeModel.provideNodeByNodeNum(789);
+        assertNotNull(node789);
+        // configure dummy node as CANPAN so no parameters are requested for it
+        new MergCanpan().configureDummyNode(node789);
+
         // create a thread that waits to close the dialog box opened later
         Thread dialog_thread = new Thread(() -> {
             // constructor for jdo will wait until the dialog is visible
             JDialogOperator jdo = new JDialogOperator(Bundle.getMessage("NdEntrNumTitle",String.valueOf(1234)));
             
             JLabelOperator labelOper = new JLabelOperator(jdo, Bundle.getMessage("NdRqNdDetails"));
-            assertThat(labelOper).isNotNull();
+            assertNotNull(labelOper);
             
-            JUnitUtil.waitFor(()->{ return( tcis.outbound.size() == 1); }, "1 outbound " + tcis.outbound);
+            JUnitUtil.waitFor(()->{ return( tcis.outbound.size() == 1); }, "1 outbound " + tcis.getTranslatedOutbound());
             assertEquals("[5f8] 10", tcis.outbound.elementAt(0).toString(),"Request node parameters(RQNP)");
 
             CanReply rs = new CanReply();
@@ -72,9 +76,9 @@ public class CbusAllocateNodeNumberTest {
             t.reply(rs);
             
             JLabelOperator labelOper2 = new JLabelOperator(jdo, CbusNodeConstants.getManu(1));
-            assertThat(labelOper2).isNotNull();
+            assertNotNull(labelOper2);
             
-            JUnitUtil.waitFor(()->{ return( tcis.outbound.size() == 2); }, "2 outbound " + tcis.outbound);
+            JUnitUtil.waitFor(()->{ return( tcis.outbound.size() == 2); }, "2 outbound " + tcis.getTranslatedOutbound());
             assertEquals("[5f8] 11", tcis.outbound.elementAt(1).toString(),"Request module name (RQMN)");
             
             CanReply rsn = new CanReply();
@@ -90,22 +94,22 @@ public class CbusAllocateNodeNumberTest {
             t.reply(rsn);
             
             JLabelOperator labelOper3 = new JLabelOperator(jdo, "Manufacturer 1 CANCATFLAP");
-            assertThat(labelOper3).isNotNull();
+            assertNotNull(labelOper3);
             
             JSpinnerOperator spinner = new JSpinnerOperator(jdo, 0);
             
             JTextFieldOperator jtfo = new JTextFieldOperator(spinner);
-            assertThat(jtfo.getText()).isEqualTo("1234");
+            assertEquals("1234",jtfo.getText());
             
             jtfo.setText("123");
             JLabelOperator labelOper4 = new JLabelOperator(jdo, CbusNodeConstants.getReservedModule(123));
-            assertThat(labelOper4).isNotNull();
+            assertNotNull(labelOper4);
             
-            assertThat(nodeModel.provideNodeByNodeNum(789)).isNotNull();
+            
             jtfo.setText("789");
             JLabelOperator labelOper5 = new JLabelOperator(jdo, 
                 Bundle.getMessage("NdNumInUse",nodeModel.getNodeNumberName(789)));
-            assertThat(labelOper5).isNotNull();
+            assertNotNull(labelOper5);
             
             CanMessage rmes = new CanMessage(tcis.getCanid());
             rmes.setNumDataElements(1);
@@ -115,6 +119,7 @@ public class CbusAllocateNodeNumberTest {
             jtfo.setText("65432");
             
             JemmyUtil.pressButton(jdo, "OK");
+            jdo.waitClosed();
             
         });
         dialog_thread.setName("CbusAllocateNodeNumber Dialog Close Thread");
@@ -139,9 +144,17 @@ public class CbusAllocateNodeNumberTest {
         
         JUnitUtil.waitFor(()->{return !(dialog_thread.isAlive());}, "checkCbus Allocate Node Num Dialog finished");
         
+        JUnitUtil.waitFor(()->{ return( tcis.outbound.size() >2); }, "Outbound did not increase: " + tcis.getTranslatedOutbound());
+        assertEquals("[5f8] 42 FF 98", tcis.outbound.elementAt(2).toString(),"3rd message not right " + tcis.getTranslatedOutbound());
         
-        assertEquals("[5f8] 42 FF 98", tcis.outbound.elementAt(2).toString());
+        t.dispose();
+
+    }
+
+    @Test
+    public void testAddNodes() {
         
+        t = new CbusAllocateNodeNumber(memo,nodeModel);
         ((CbusPreferences)memo.get(CbusPreferences.class)).setAddNodes(true);
         
         CanReply rsna = new CanReply();
@@ -152,8 +165,8 @@ public class CbusAllocateNodeNumberTest {
         t.reply(rsna);
         
         // check that RTSTAT sent to command stations
-        JUnitUtil.waitFor(()->{ return( tcis.outbound.size() >3); }, "TCIS count did not increase");
-        assertThat(tcis.outbound.elementAt(3).toString()).isEqualTo("[5f8] 0C");
+        JUnitUtil.waitFor(()->{ return( !tcis.outbound.isEmpty()); }, "TCIS count did not increase " + tcis.getTranslatedOutbound());
+        assertEquals("[5f8] 0C", tcis.outbound.elementAt(0).toString());
         
         assertNotNull(nodeModel.getNodeByNodeNum(65432));
         
@@ -170,17 +183,17 @@ public class CbusAllocateNodeNumberTest {
         r.setNumDataElements(1);
         r.setElement(0, CbusConstants.CBUS_HLT); // Bus Halt Command, to be ignored.
         t.message(r); // ignored as not interested in this OPC
-        assertThat(tcis.outbound.size()).isEqualTo(0);
+        assertEquals(0, tcis.outbound.size());
         r.setElement(0, CbusConstants.CBUS_QNN); // All Modules respond to Query Node Numbers
         r.setExtended(true);
         t.message(r); // ignored as Extended
-        assertThat(tcis.outbound.size()).isEqualTo(0);
+        assertEquals(0, tcis.outbound.size());
         
         r.setExtended(false);
         t.message(r); // output expected to be a Request Params Setup
         
-        assertThat(tcis.outbound.size()).isEqualTo(1);
-        assertThat(tcis.outbound.elementAt(0).toString()).isEqualTo("[5f8] 10");
+        assertEquals(1, tcis.outbound.size());
+        assertEquals("[5f8] 10", tcis.outbound.elementAt(0).toString(), tcis.getTranslatedOutbound());
         
         t.dispose();
         
@@ -204,6 +217,7 @@ public class CbusAllocateNodeNumberTest {
             jtfo.setText("12345");
             
             JemmyUtil.pressButton(jdo, "OK");
+            jdo.waitClosed();
             
         });
         
@@ -215,6 +229,7 @@ public class CbusAllocateNodeNumberTest {
             JDialogOperator jdoo = new JDialogOperator(Bundle.getMessage("WarningTitle"));
             
             JemmyUtil.pressButton(jdoo, "OK");
+            jdoo.waitClosed();
             
         });
         
@@ -244,19 +259,18 @@ public class CbusAllocateNodeNumberTest {
     }        
     
     private CanSystemConnectionMemo memo;
-    private TrafficControllerScaffold tcis;
+    private CbusTrafficControllerScaffold tcis;
     private CbusAllocateNodeNumber t;
     private CbusNodeTableDataModel nodeModel;
 
     @BeforeEach
-    public void setUp(@TempDir Path tempDir) throws IOException  {
+    public void setUp(@TempDir File tempDir) throws IOException  {
         JUnitUtil.setUp();
         JUnitUtil.resetInstanceManager();
-        JUnitUtil.resetProfileManager( new jmri.profile.NullProfile( tempDir.toFile()));
+        JUnitUtil.resetProfileManager( new jmri.profile.NullProfile( tempDir));
         
         memo = new CanSystemConnectionMemo();
-        tcis = new TrafficControllerScaffold();
-        memo.setTrafficController(tcis);
+        tcis = new CbusTrafficControllerScaffold(memo);
         memo.setProtocol(jmri.jmrix.can.CanConfigurationManager.SPROGCBUS);
         ((CbusPreferences)memo.get(CbusPreferences.class)).setAllocateNNListener(false);
         nodeModel = ((CbusConfigurationManager)memo.get(CbusConfigurationManager.class))


### PR DESCRIPTION
Adds CbusTrafficControllerScaffold - 
extension of jmrix.can.TrafficControllerScaffold with methods for translating message queue contents with CbusOpCodes.

Updates CbusSimulatedModuleProvider -
Interface to configure CbusNode ( which CbusDummyNode extends from )

CbusAllocateNodeNumberTest -
use CbusTrafficControllerScaffold
set parameters for Node 789 by using a Node simulation.
use tcis.getTranslatedOutbound() in failure text
break large test into smaller tests