### PR TITLE
LogixNG - Print system names

### DIFF
--- a/java/src/jmri/jmrit/beantable/AbstractLogixNGTableAction.java
+++ b/java/src/jmri/jmrit/beantable/AbstractLogixNGTableAction.java
@@ -53,6 +53,7 @@ public abstract class AbstractLogixNGTableAction<E extends NamedBean> extends Ab
     static final String PRINT_ERROR_HANDLING_OPTION = "jmri.jmrit.logixng.ErrorHandling";
     static final String PRINT_NOT_CONNECTED_OPTION = "jmri.jmrit.logixng.NotConnectedSockets";
     static final String PRINT_LOCAL_VARIABLES_OPTION = "jmri.jmrit.logixng.LocalVariables";
+    static final String PRINT_SYSTEM_NAMES_OPTION = "jmri.jmrit.logixng.SystemNames";
 
     JTextArea _textContent;
 
@@ -805,6 +806,7 @@ public abstract class AbstractLogixNGTableAction<E extends NamedBean> extends Ab
             _printTreeSettings._printErrorHandling = prefMgr.getSimplePreferenceState(PRINT_ERROR_HANDLING_OPTION);
             _printTreeSettings._printNotConnectedSockets = prefMgr.getSimplePreferenceState(PRINT_NOT_CONNECTED_OPTION);
             _printTreeSettings._printLocalVariables = prefMgr.getSimplePreferenceState(PRINT_LOCAL_VARIABLES_OPTION);
+            _printTreeSettings._printSystemNames = prefMgr.getSimplePreferenceState(PRINT_SYSTEM_NAMES_OPTION);
         });
     }
 
@@ -987,6 +989,19 @@ public abstract class AbstractLogixNGTableAction<E extends NamedBean> extends Ab
             }
         });
         checkBoxPanel.add(printLocalVariables);
+
+        JCheckBox printSystemNames = new JCheckBox(Bundle.getMessage("LogixNG_Browse_PrintSystemNames"));
+        printSystemNames.setSelected(_printTreeSettings._printSystemNames);
+        printSystemNames.addChangeListener((event) -> {
+            if (_printTreeSettings._printSystemNames != printSystemNames.isSelected()) {
+                _printTreeSettings._printSystemNames = printSystemNames.isSelected();
+                InstanceManager.getOptionalDefault(UserPreferencesManager.class).ifPresent((prefMgr) -> {
+                    prefMgr.setSimplePreferenceState(PRINT_SYSTEM_NAMES_OPTION, printSystemNames.isSelected());
+                });
+                updateBrowserText();
+            }
+        });
+        checkBoxPanel.add(printSystemNames);
 
         return checkBoxPanel;
     }

--- a/java/src/jmri/jmrit/beantable/BeanTableBundle.properties
+++ b/java/src/jmri/jmrit/beantable/BeanTableBundle.properties
@@ -802,6 +802,7 @@ LogixNG_Browse_PrintLineNumbers         = Print line numbers
 LogixNG_Browse_PrintErrorHandling       = Print error handling
 LogixNG_Browse_PrintNotConnectedSocket  = Print not connected sockets
 LogixNG_Browse_PrintLocalVariables      = Print local variables
+LogixNG_Browse_PrintSystemNames         = Print system names
 LogixNG_Browse_HelpText                 = The text file formatting is based on using a monospace font.
 
 LogixNG_FileButtonHint               = Click to select a file from disk

--- a/java/src/jmri/jmrit/logixng/AbortConditionalNGExecutionException.java
+++ b/java/src/jmri/jmrit/logixng/AbortConditionalNGExecutionException.java
@@ -5,31 +5,25 @@ import jmri.JmriException;
 /**
  * This exception is thrown when the current excection of a ConditionalNG
  * should be aborted.
- * 
+ *
  * @author Daniel Bergqvist 2020
  */
 public class AbortConditionalNGExecutionException extends JmriException {
 
-    /**
-     * Creates a new instance of <code>AbortConditionalNGExecutionException</code> without detail message.
-     */
-    public AbortConditionalNGExecutionException() {
-    }
-
-    /**
-     * Constructs an instance of <code>AbortConditionalNGExecutionException</code> with the specified detail message.
-     * @param msg the detail message.
-     */
-    public AbortConditionalNGExecutionException(String msg) {
-        super(msg);
-    }
+    private final MaleSocket _maleSocket;
 
     /**
      * Constructs an instance of <code>AbortConditionalNGExecutionException</code>
      * with a cause exception.
-     * @param e the cause of this exception
+     * @param maleSocket  the male socket where the exception is thrown
+     * @param e           the cause of this exception
      */
-    public AbortConditionalNGExecutionException(Exception e) {
+    public AbortConditionalNGExecutionException(MaleSocket maleSocket, Exception e) {
         super(e);
+        _maleSocket = maleSocket;
+    }
+
+    public MaleSocket getMaleSocket() {
+        return _maleSocket;
     }
 }

--- a/java/src/jmri/jmrit/logixng/Base.java
+++ b/java/src/jmri/jmrit/logixng/Base.java
@@ -606,6 +606,7 @@ public interface Base extends PropertyChangeProvider {
         public boolean _printErrorHandling = true;
         public boolean _printNotConnectedSockets = true;
         public boolean _printLocalVariables = true;
+        public boolean _printSystemNames = false;
     }
 
 }

--- a/java/src/jmri/jmrit/logixng/LogixNGPreferences.java
+++ b/java/src/jmri/jmrit/logixng/LogixNGPreferences.java
@@ -4,7 +4,7 @@ import jmri.jmrit.logixng.MaleSocket.ErrorHandlingType;
 
 /**
  * Preferences for LogixNG
- * 
+ *
  * @author Daniel Bergqvist Copyright 2018
  */
 public interface LogixNGPreferences {
@@ -26,7 +26,7 @@ public interface LogixNGPreferences {
      * Save the preferences
      */
     public void save();
-    
+
     /**
      * Set whenether LogixNG should be started when the program starts or a
      * panel is loaded.
@@ -92,5 +92,17 @@ public interface LogixNGPreferences {
      * @return true if the row should be highlighted, false not
      */
     public boolean getTreeEditorHighlightRow();
+
+    /**
+     * Set whether system names should be shown or not.
+     * @param value true if the row should be highlighted, false not
+     */
+    public void setShowSystemNames(boolean value);
+
+    /**
+     * Get whether system names should be shown or not.
+     * @return true if the row should be highlighted, false not
+     */
+    public boolean getShowSystemNames();
 
 }

--- a/java/src/jmri/jmrit/logixng/LogixNGPreferences.java
+++ b/java/src/jmri/jmrit/logixng/LogixNGPreferences.java
@@ -97,12 +97,12 @@ public interface LogixNGPreferences {
      * Set whether system names should be shown or not.
      * @param value true if the row should be highlighted, false not
      */
-    public void setShowSystemNames(boolean value);
+    public void setShowSystemNameInException(boolean value);
 
     /**
      * Get whether system names should be shown or not.
      * @return true if the row should be highlighted, false not
      */
-    public boolean getShowSystemNames();
+    public boolean getShowSystemNameInException();
 
 }

--- a/java/src/jmri/jmrit/logixng/implementation/AbstractMaleSocket.java
+++ b/java/src/jmri/jmrit/logixng/implementation/AbstractMaleSocket.java
@@ -415,6 +415,10 @@ public abstract class AbstractMaleSocket implements MaleSocket {
             }
             writer.append(currentIndent);
             writer.append(getLongDescription(locale));
+            if (settings._printSystemNames) {
+                writer.append(" ::: ");
+                writer.append(this.getSystemName());
+            }
             if (settings._printDisplayName) {
                 writer.append(" ::: ");
                 writer.append(Bundle.getMessage("LabelDisplayName"));

--- a/java/src/jmri/jmrit/logixng/implementation/AbstractMaleSocket.java
+++ b/java/src/jmri/jmrit/logixng/implementation/AbstractMaleSocket.java
@@ -634,7 +634,7 @@ public abstract class AbstractMaleSocket implements MaleSocket {
                     ErrorHandlingDialog dialog = new ErrorHandlingDialog();
                     return dialog.showDialog(item, message);
                 });
-                if (abort) throw new AbortConditionalNGExecutionException(e);
+                if (abort) throw new AbortConditionalNGExecutionException(this, e);
                 break;
 
             case LogError:
@@ -650,7 +650,7 @@ public abstract class AbstractMaleSocket implements MaleSocket {
 
             case AbortExecution:
                 log.error("item {}, {} thrown an exception: {}", item.toString(), getObject().toString(), e, e);
-                throw new AbortConditionalNGExecutionException(e);
+                throw new AbortConditionalNGExecutionException(this, e);
 
             default:
                 throw e;
@@ -678,7 +678,7 @@ public abstract class AbstractMaleSocket implements MaleSocket {
                     ErrorHandlingDialog_MultiLine dialog = new ErrorHandlingDialog_MultiLine();
                     return dialog.showDialog(item, message, messageList);
                 });
-                if (abort) throw new AbortConditionalNGExecutionException(e);
+                if (abort) throw new AbortConditionalNGExecutionException(this, e);
                 break;
 
             case LogError:
@@ -694,7 +694,7 @@ public abstract class AbstractMaleSocket implements MaleSocket {
 
             case AbortExecution:
                 log.error("item {}, {} thrown an exception: {}", item.toString(), getObject().toString(), e, e);
-                throw new AbortConditionalNGExecutionException(e);
+                throw new AbortConditionalNGExecutionException(this, e);
 
             default:
                 throw e;
@@ -716,7 +716,7 @@ public abstract class AbstractMaleSocket implements MaleSocket {
                     ErrorHandlingDialog dialog = new ErrorHandlingDialog();
                     return dialog.showDialog(item, message);
                 });
-                if (abort) throw new AbortConditionalNGExecutionException(e);
+                if (abort) throw new AbortConditionalNGExecutionException(this, e);
                 break;
 
             case LogError:
@@ -733,7 +733,7 @@ public abstract class AbstractMaleSocket implements MaleSocket {
                 throw e;
 
             case AbortExecution:
-                throw new AbortConditionalNGExecutionException(e);
+                throw new AbortConditionalNGExecutionException(this, e);
 
             default:
                 throw e;

--- a/java/src/jmri/jmrit/logixng/implementation/DefaultConditionalNG.java
+++ b/java/src/jmri/jmrit/logixng/implementation/DefaultConditionalNG.java
@@ -160,7 +160,7 @@ public class DefaultConditionalNG extends AbstractBase
                 log.info("ConditionalNG {} was aborted during execute: {}",
                         conditionalNG.getSystemName(), e.getCause(), e.getCause());
             } catch (AbortConditionalNGExecutionException e) {
-                if (InstanceManager.getDefault(LogixNGPreferences.class).getShowSystemNames()) {
+                if (InstanceManager.getDefault(LogixNGPreferences.class).getShowSystemNameInException()) {
                     log.warn("ConditionalNG {} was aborted during execute in the item {}: {}",
                             conditionalNG.getSystemName(), e.getMaleSocket().getSystemName(), e.getCause(), e.getCause());
                 } else {

--- a/java/src/jmri/jmrit/logixng/implementation/DefaultConditionalNG.java
+++ b/java/src/jmri/jmrit/logixng/implementation/DefaultConditionalNG.java
@@ -160,10 +160,13 @@ public class DefaultConditionalNG extends AbstractBase
                 log.info("ConditionalNG {} was aborted during execute: {}",
                         conditionalNG.getSystemName(), e.getCause(), e.getCause());
             } catch (AbortConditionalNGExecutionException e) {
-//                LoggingUtil.warnOnce(log, "ConditionalNG {} got an exception during execute: {}",
-//                        conditionalNG.getSystemName(), e, e);
-                log.warn("ConditionalNG {} was aborted during execute: {}",
-                        conditionalNG.getSystemName(), e.getCause(), e.getCause());
+                if (InstanceManager.getDefault(LogixNGPreferences.class).getShowSystemNames()) {
+                    log.warn("ConditionalNG {} was aborted during execute in the item {}: {}",
+                            conditionalNG.getSystemName(), e.getMaleSocket().getSystemName(), e.getCause(), e.getCause());
+                } else {
+                    log.warn("ConditionalNG {} was aborted during execute: {}",
+                            conditionalNG.getSystemName(), e.getCause(), e.getCause());
+                }
             } catch (JmriException | RuntimeException e) {
 //                LoggingUtil.warnOnce(log, "ConditionalNG {} got an exception during execute: {}",
 //                        conditionalNG.getSystemName(), e, e);

--- a/java/src/jmri/jmrit/logixng/implementation/DefaultLogixNGPreferences.java
+++ b/java/src/jmri/jmrit/logixng/implementation/DefaultLogixNGPreferences.java
@@ -15,20 +15,19 @@ import jmri.profile.ProfileUtils;
  */
 public final class DefaultLogixNGPreferences extends PreferencesBean implements LogixNGPreferences {
 
-    public static final String START_LOGIXNG_ON_LOAD = "startLogixNGOnStartup";
-    public static final String USE_GENERIC_FEMALE_SOCKETS = "useGenericFemaleSockets";
-    public static final String INSTALL_DEBUGGER = "installDebugger";
-    public static final String SHOW_SYSTEM_USER_NAMES = "showSystemUserNames";
-    public static final String ERROR_HANDLING_TYPE = "errorHandlingType";
-    public static final String TREE_EDITOR_HIGHLIGHT_ROW = "treeEditorHighlightRow";
-    public static final String SHOW_SYSTEM_NAMES = "showSystemNames";
+    private static final String START_LOGIXNG_ON_LOAD = "startLogixNGOnStartup";
+    private static final String INSTALL_DEBUGGER = "installDebugger";
+    private static final String SHOW_SYSTEM_USER_NAMES = "showSystemUserNames";
+    private static final String ERROR_HANDLING_TYPE = "errorHandlingType";
+    private static final String TREE_EDITOR_HIGHLIGHT_ROW = "treeEditorHighlightRow";
+    private static final String SHOW_SYSTEM_NAME_IN_EXCEPTION = "showSystemNameInExceptions";
 
     private boolean _startLogixNGOnLoad = true;
     private boolean _showSystemUserNames = false;
     private boolean _installDebugger = true;
     private ErrorHandlingType _errorHandlingType = ErrorHandlingType.ShowDialogBox;
     private boolean _treeEditorHighlightRow = false;
-    private boolean _showSystemNames = false;
+    private boolean _showSystemNameInException = false;
 
 
     public DefaultLogixNGPreferences() {
@@ -46,7 +45,7 @@ public final class DefaultLogixNGPreferences extends PreferencesBean implements 
         _errorHandlingType = ErrorHandlingType.valueOf(
                 sharedPreferences.get(ERROR_HANDLING_TYPE, _errorHandlingType.name()));
         _treeEditorHighlightRow = sharedPreferences.getBoolean(TREE_EDITOR_HIGHLIGHT_ROW, _treeEditorHighlightRow);
-        _showSystemNames = sharedPreferences.getBoolean(SHOW_SYSTEM_NAMES, _showSystemNames);
+        _showSystemNameInException = sharedPreferences.getBoolean(SHOW_SYSTEM_NAME_IN_EXCEPTION, _showSystemNameInException);
 
         setIsDirty(false);
     }
@@ -65,7 +64,7 @@ public final class DefaultLogixNGPreferences extends PreferencesBean implements 
         if (getTreeEditorHighlightRow() != prefs.getTreeEditorHighlightRow()) {
             return true;
         }
-        if (getShowSystemNames() != prefs.getShowSystemNames()) {
+        if (getShowSystemNameInException() != prefs.getShowSystemNameInException()) {
             return true;
         }
         return (getErrorHandlingType() != prefs.getErrorHandlingType());
@@ -78,7 +77,7 @@ public final class DefaultLogixNGPreferences extends PreferencesBean implements 
         setShowSystemUserNames(prefs.getShowSystemUserNames());
         this.setErrorHandlingType(prefs.getErrorHandlingType());
         setTreeEditorHighlightRow(prefs.getTreeEditorHighlightRow());
-        setShowSystemNames(prefs.getShowSystemNames());
+        setShowSystemNameInException(prefs.getShowSystemNameInException());
     }
 
     @Override
@@ -89,7 +88,7 @@ public final class DefaultLogixNGPreferences extends PreferencesBean implements 
         sharedPreferences.putBoolean(SHOW_SYSTEM_USER_NAMES, this.getShowSystemUserNames());
         sharedPreferences.put(ERROR_HANDLING_TYPE, this.getErrorHandlingType().name());
         sharedPreferences.putBoolean(TREE_EDITOR_HIGHLIGHT_ROW, this.getTreeEditorHighlightRow());
-        sharedPreferences.putBoolean(SHOW_SYSTEM_NAMES, this.getShowSystemNames());
+        sharedPreferences.putBoolean(SHOW_SYSTEM_NAME_IN_EXCEPTION, this.getShowSystemNameInException());
         setIsDirty(false);
     }
 
@@ -149,14 +148,14 @@ public final class DefaultLogixNGPreferences extends PreferencesBean implements 
     }
 
     @Override
-    public void setShowSystemNames(boolean value) {
-        _showSystemNames = value;
+    public void setShowSystemNameInException(boolean value) {
+        _showSystemNameInException = value;
         setIsDirty(true);
     }
 
     @Override
-    public boolean getShowSystemNames() {
-        return _showSystemNames;
+    public boolean getShowSystemNameInException() {
+        return _showSystemNameInException;
     }
 
 //    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LogixNGPreferences.class);

--- a/java/src/jmri/jmrit/logixng/implementation/DefaultLogixNGPreferences.java
+++ b/java/src/jmri/jmrit/logixng/implementation/DefaultLogixNGPreferences.java
@@ -21,12 +21,14 @@ public final class DefaultLogixNGPreferences extends PreferencesBean implements 
     public static final String SHOW_SYSTEM_USER_NAMES = "showSystemUserNames";
     public static final String ERROR_HANDLING_TYPE = "errorHandlingType";
     public static final String TREE_EDITOR_HIGHLIGHT_ROW = "treeEditorHighlightRow";
+    public static final String SHOW_SYSTEM_NAMES = "showSystemNames";
 
     private boolean _startLogixNGOnLoad = true;
     private boolean _showSystemUserNames = false;
     private boolean _installDebugger = true;
     private ErrorHandlingType _errorHandlingType = ErrorHandlingType.ShowDialogBox;
     private boolean _treeEditorHighlightRow = false;
+    private boolean _showSystemNames = false;
 
 
     public DefaultLogixNGPreferences() {
@@ -44,35 +46,8 @@ public final class DefaultLogixNGPreferences extends PreferencesBean implements 
         _errorHandlingType = ErrorHandlingType.valueOf(
                 sharedPreferences.get(ERROR_HANDLING_TYPE, _errorHandlingType.name()));
         _treeEditorHighlightRow = sharedPreferences.getBoolean(TREE_EDITOR_HIGHLIGHT_ROW, _treeEditorHighlightRow);
+        _showSystemNames = sharedPreferences.getBoolean(SHOW_SYSTEM_NAMES, _showSystemNames);
 
-/*
-        this.allowRemoteConfig = sharedPreferences.getBoolean(ALLOW_REMOTE_CONFIG, this.allowRemoteConfig);
-        this.clickDelay = sharedPreferences.getInt(CLICK_DELAY, this.clickDelay);
-        this.simple = sharedPreferences.getBoolean(SIMPLE, this.simple);
-        this.railroadName = sharedPreferences.get(RAILROAD_NAME, this.railroadName);
-        this.readonlyPower = sharedPreferences.getBoolean(READONLY_POWER, this.readonlyPower);
-        this.refreshDelay = sharedPreferences.getInt(REFRESH_DELAY, this.refreshDelay);
-        this.useAjax = sharedPreferences.getBoolean(USE_AJAX, this.useAjax);
-        this.disableFrames = sharedPreferences.getBoolean(DISABLE_FRAME_SERVER, this.disableFrames);
-        this.redirectFramesToPanels = sharedPreferences.getBoolean(REDIRECT_FRAMES, this.redirectFramesToPanels);
-        try {
-            Preferences frames = sharedPreferences.node(DISALLOWED_FRAMES);
-            if (frames.keys().length != 0) {
-                this.disallowedFrames.clear();
-                for (String key : frames.keys()) { // throws BackingStoreException
-                    String frame = frames.get(key, null);
-                    if (frame != null && !frame.trim().isEmpty()) {
-                        this.disallowedFrames.add(frame);
-                    }
-                }
-            }
-        } catch (BackingStoreException ex) {
-            // this is expected if sharedPreferences have not been written previously,
-            // so do nothing.
-        }
-        this.port = sharedPreferences.getInt(PORT, this.port);
-        this.useZeroConf = sharedPreferences.getBoolean(USE_ZERO_CONF, this.useZeroConf);
-*/
         setIsDirty(false);
     }
 
@@ -90,6 +65,9 @@ public final class DefaultLogixNGPreferences extends PreferencesBean implements 
         if (getTreeEditorHighlightRow() != prefs.getTreeEditorHighlightRow()) {
             return true;
         }
+        if (getShowSystemNames() != prefs.getShowSystemNames()) {
+            return true;
+        }
         return (getErrorHandlingType() != prefs.getErrorHandlingType());
     }
 
@@ -100,6 +78,7 @@ public final class DefaultLogixNGPreferences extends PreferencesBean implements 
         setShowSystemUserNames(prefs.getShowSystemUserNames());
         this.setErrorHandlingType(prefs.getErrorHandlingType());
         setTreeEditorHighlightRow(prefs.getTreeEditorHighlightRow());
+        setShowSystemNames(prefs.getShowSystemNames());
     }
 
     @Override
@@ -110,6 +89,7 @@ public final class DefaultLogixNGPreferences extends PreferencesBean implements 
         sharedPreferences.putBoolean(SHOW_SYSTEM_USER_NAMES, this.getShowSystemUserNames());
         sharedPreferences.put(ERROR_HANDLING_TYPE, this.getErrorHandlingType().name());
         sharedPreferences.putBoolean(TREE_EDITOR_HIGHLIGHT_ROW, this.getTreeEditorHighlightRow());
+        sharedPreferences.putBoolean(SHOW_SYSTEM_NAMES, this.getShowSystemNames());
         setIsDirty(false);
     }
 
@@ -166,6 +146,17 @@ public final class DefaultLogixNGPreferences extends PreferencesBean implements 
     @Override
     public boolean getTreeEditorHighlightRow() {
         return _treeEditorHighlightRow;
+    }
+
+    @Override
+    public void setShowSystemNames(boolean value) {
+        _showSystemNames = value;
+        setIsDirty(true);
+    }
+
+    @Override
+    public boolean getShowSystemNames() {
+        return _showSystemNames;
     }
 
 //    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LogixNGPreferences.class);

--- a/java/src/jmri/jmrit/logixng/tools/swing/LogixNGPreferencesPanel.java
+++ b/java/src/jmri/jmrit/logixng/tools/swing/LogixNGPreferencesPanel.java
@@ -30,7 +30,7 @@ public class LogixNGPreferencesPanel extends JPanel implements PreferencesPanel 
     JCheckBox _installDebuggerCheckBox;
     JCheckBox _showSystemUserNamesCheckBox;
     JCheckBox _treeEditorHighlightRow;
-    JCheckBox _showSystemNames;
+    JCheckBox _showSystemNameInException;
     private JComboBox<ErrorHandlingType> _errorHandlingComboBox;
 
 
@@ -64,7 +64,7 @@ public class LogixNGPreferencesPanel extends JPanel implements PreferencesPanel 
         preferences.setShowSystemUserNames(_showSystemUserNamesCheckBox.isSelected());
         preferences.setTreeEditorHighlightRow(_treeEditorHighlightRow.isSelected());
         preferences.setErrorHandlingType(_errorHandlingComboBox.getItemAt(_errorHandlingComboBox.getSelectedIndex()));
-        preferences.setShowSystemNames(_showSystemNames.isSelected());
+        preferences.setShowSystemNameInException(_showSystemNameInException.isSelected());
         return didSet;
     }
 
@@ -83,8 +83,8 @@ public class LogixNGPreferencesPanel extends JPanel implements PreferencesPanel 
         _treeEditorHighlightRow = new JCheckBox(Bundle.getMessage("LabelTreeEditorHighlightRow"));
         _treeEditorHighlightRow.setToolTipText(Bundle.getMessage("ToolTipTreeEditorHighlightRow"));
 
-        _showSystemNames = new JCheckBox(Bundle.getMessage("LabelShowSystemNames"));
-        _showSystemNames.setToolTipText(Bundle.getMessage("ToolTipShowSystemNames"));
+        _showSystemNameInException = new JCheckBox(Bundle.getMessage("LabelShowSystemNameInException"));
+        _showSystemNameInException.setToolTipText(Bundle.getMessage("ToolTipShowSystemNameInException"));
 
         JPanel gridPanel = new JPanel(new GridLayout(0, 1));
 
@@ -92,13 +92,13 @@ public class LogixNGPreferencesPanel extends JPanel implements PreferencesPanel 
         gridPanel.add(_installDebuggerCheckBox);
         gridPanel.add(_showSystemUserNamesCheckBox);
         gridPanel.add(_treeEditorHighlightRow);
-        gridPanel.add(_showSystemNames);
+        gridPanel.add(_showSystemNameInException);
 
         _startLogixNGOnLoadCheckBox.setSelected(preferences.getStartLogixNGOnStartup());
         _installDebuggerCheckBox.setSelected(preferences.getInstallDebugger());
         _showSystemUserNamesCheckBox.setSelected(preferences.getShowSystemUserNames());
         _treeEditorHighlightRow.setSelected(preferences.getTreeEditorHighlightRow());
-        _showSystemNames.setSelected(preferences.getShowSystemNames());
+        _showSystemNameInException.setSelected(preferences.getShowSystemNameInException());
 
         _errorHandlingComboBox = new JComboBox<>();
         for (ErrorHandlingType type : ErrorHandlingType.values()) {

--- a/java/src/jmri/jmrit/logixng/tools/swing/LogixNGPreferencesPanel.java
+++ b/java/src/jmri/jmrit/logixng/tools/swing/LogixNGPreferencesPanel.java
@@ -18,21 +18,22 @@ import jmri.util.swing.JComboBoxUtil;
 
 /**
  * Preferences panel for LogixNG
- * 
+ *
  * @author Daniel Bergqvist Copyright 2018
  */
 @ServiceProvider(service = PreferencesPanel.class)
 public class LogixNGPreferencesPanel extends JPanel implements PreferencesPanel {
-    
+
     private final DefaultLogixNGPreferences preferences;
-    
+
     JCheckBox _startLogixNGOnLoadCheckBox;
     JCheckBox _installDebuggerCheckBox;
     JCheckBox _showSystemUserNamesCheckBox;
     JCheckBox _treeEditorHighlightRow;
+    JCheckBox _showSystemNames;
     private JComboBox<ErrorHandlingType> _errorHandlingComboBox;
-    
-    
+
+
     public LogixNGPreferencesPanel() {
         LogixNGPreferences prefs = InstanceManager.getDefault(LogixNGPreferences.class);
         if (!(prefs instanceof DefaultLogixNGPreferences)) {
@@ -48,14 +49,6 @@ public class LogixNGPreferencesPanel extends JPanel implements PreferencesPanel 
         add(getStartupPanel());
         add(new JTitledSeparator(Bundle.getMessage("TitleTimeDiagramColorsPanel")));
         add(getTimeDiagramColorsPanel());
-//        add(new JTitledSeparator(Bundle.getMessage("TitleNetworkPanel")));
-//        add(networkPanel());
-//        add(new JTitledSeparator(Bundle.getMessage("TitleControllersPanel")));
-//        add(allowedControllers());
-        
-//        this.setLayout(new BoxLayout(this, BoxLayout.PAGE_AXIS));
-//        add(new JTitledSeparator(Bundle.getMessage("TitleRailroadNamePreferences")));
-//        add(getLogixNGPanel());
     }
 
     /**
@@ -71,9 +64,10 @@ public class LogixNGPreferencesPanel extends JPanel implements PreferencesPanel 
         preferences.setShowSystemUserNames(_showSystemUserNamesCheckBox.isSelected());
         preferences.setTreeEditorHighlightRow(_treeEditorHighlightRow.isSelected());
         preferences.setErrorHandlingType(_errorHandlingComboBox.getItemAt(_errorHandlingComboBox.getSelectedIndex()));
+        preferences.setShowSystemNames(_showSystemNames.isSelected());
         return didSet;
     }
-    
+
     private JPanel getStartupPanel() {
         JPanel panel = new JPanel();
 
@@ -89,18 +83,23 @@ public class LogixNGPreferencesPanel extends JPanel implements PreferencesPanel 
         _treeEditorHighlightRow = new JCheckBox(Bundle.getMessage("LabelTreeEditorHighlightRow"));
         _treeEditorHighlightRow.setToolTipText(Bundle.getMessage("ToolTipTreeEditorHighlightRow"));
 
+        _showSystemNames = new JCheckBox(Bundle.getMessage("LabelShowSystemNames"));
+        _showSystemNames.setToolTipText(Bundle.getMessage("ToolTipShowSystemNames"));
+
         JPanel gridPanel = new JPanel(new GridLayout(0, 1));
-        
+
         gridPanel.add(_startLogixNGOnLoadCheckBox);
         gridPanel.add(_installDebuggerCheckBox);
         gridPanel.add(_showSystemUserNamesCheckBox);
         gridPanel.add(_treeEditorHighlightRow);
-        
+        gridPanel.add(_showSystemNames);
+
         _startLogixNGOnLoadCheckBox.setSelected(preferences.getStartLogixNGOnStartup());
         _installDebuggerCheckBox.setSelected(preferences.getInstallDebugger());
         _showSystemUserNamesCheckBox.setSelected(preferences.getShowSystemUserNames());
         _treeEditorHighlightRow.setSelected(preferences.getTreeEditorHighlightRow());
-        
+        _showSystemNames.setSelected(preferences.getShowSystemNames());
+
         _errorHandlingComboBox = new JComboBox<>();
         for (ErrorHandlingType type : ErrorHandlingType.values()) {
             // ErrorHandlingType.Default cannot be used as default
@@ -113,7 +112,7 @@ public class LogixNGPreferencesPanel extends JPanel implements PreferencesPanel 
         }
         JComboBoxUtil.setupComboBoxMaxRows(_errorHandlingComboBox);
         gridPanel.add(_errorHandlingComboBox);
-        
+
         panel.setLayout(new FlowLayout(FlowLayout.CENTER, 40, 0));
         panel.add(gridPanel);
 
@@ -123,7 +122,7 @@ public class LogixNGPreferencesPanel extends JPanel implements PreferencesPanel 
     private JPanel getTimeDiagramColorsPanel() {
         return new JPanel();
     }
-    
+
     @Override
     public String getPreferencesItem() {
         return "LOGIXNG"; // NOI18N

--- a/java/src/jmri/jmrit/logixng/tools/swing/LogixNGSwingBundle.properties
+++ b/java/src/jmri/jmrit/logixng/tools/swing/LogixNGSwingBundle.properties
@@ -31,13 +31,13 @@ LabelStartLogixNGOnLoad     = Start LogixNGs on load
 LabelInstallDebugger        = Install debugger
 LabelShowSystemUserNames    = Show system names and user names
 LabelTreeEditorHighlightRow = Highlight row in ConditionalNG editor
-LabelShowSystemNames        = Show system names in exceptions
+LabelShowSystemNameInException = Show system names in exceptions
 
 ToolTipStartLogixNGOnLoad   = Should LogixNG start when the panels are loaded?
 ToolTipLabelInstallDebugger = Install the debugger?
 ToolTipLabeShowSystemUserNames  = Should system names and user names be visible for actions and expressions?
 ToolTipTreeEditorHighlightRow = Should highlight row in ConditionalNG editor?
-ToolTipShowSystemNames      = Should system names be shown in exceptions?
+ToolTipShowSystemNameInException = Should system names be shown in exceptions?
 
 LabelButtonAddJarFile       = Add JAR File
 LabelButtonRemoveJarFile    = Remove JAR File

--- a/java/src/jmri/jmrit/logixng/tools/swing/LogixNGSwingBundle.properties
+++ b/java/src/jmri/jmrit/logixng/tools/swing/LogixNGSwingBundle.properties
@@ -31,11 +31,13 @@ LabelStartLogixNGOnLoad     = Start LogixNGs on load
 LabelInstallDebugger        = Install debugger
 LabelShowSystemUserNames    = Show system names and user names
 LabelTreeEditorHighlightRow = Highlight row in ConditionalNG editor
+LabelShowSystemNames        = Show system names in exceptions
 
 ToolTipStartLogixNGOnLoad   = Should LogixNG start when the panels are loaded?
 ToolTipLabelInstallDebugger = Install the debugger?
 ToolTipLabeShowSystemUserNames  = Should system names and user names be visible for actions and expressions?
 ToolTipTreeEditorHighlightRow = Should highlight row in ConditionalNG editor?
+ToolTipShowSystemNames      = Should system names be shown in exceptions?
 
 LabelButtonAddJarFile       = Add JAR File
 LabelButtonRemoveJarFile    = Remove JAR File

--- a/java/test/jmri/jmrit/logixng/AbortConditionalNGExecutionExceptionTest.java
+++ b/java/test/jmri/jmrit/logixng/AbortConditionalNGExecutionExceptionTest.java
@@ -9,17 +9,17 @@ import org.junit.Test;
 
 /**
  * Test AbortConditionalNGExecutionException
- * 
+ *
  * @author Daniel Bergqvist 2021
  */
 public class AbortConditionalNGExecutionExceptionTest {
 
     @Test
     public void testCtor() {
-        AbortConditionalNGExecutionException t = new AbortConditionalNGExecutionException();
+        AbortConditionalNGExecutionException t = new AbortConditionalNGExecutionException(null, null);
         Assert.assertNotNull("not null", t);
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() {
@@ -30,5 +30,5 @@ public class AbortConditionalNGExecutionExceptionTest {
     public void tearDown() {
         JUnitUtil.tearDown();
     }
-    
+
 }


### PR DESCRIPTION
@sidlo64 @dsand47 
See https://jmri-developers.groups.io/g/jmri/message/7727

This PR adds two things:

- If the LogixNG preference `Show system name in exceptions` is checked, when an exception occurs and the user selects Abort, the system name of the action/expression will be printed.

- If the LogixNG Browse option `Print system names` is checked, the system names of the actions/expressions will be printed.

@sidlo64 
Does this solve the issue you have?