### PR TITLE
Default ShutDown Manager - prevent CME

### DIFF
--- a/java/src/jmri/managers/DefaultShutDownManager.java
+++ b/java/src/jmri/managers/DefaultShutDownManager.java
@@ -7,7 +7,7 @@ import java.awt.GraphicsEnvironment;
 import java.awt.event.WindowEvent;
 
 import java.util.*;
-import java.util.concurrent.Callable;
+import java.util.concurrent.*;
 import java.util.stream.Collectors;
 
 import jmri.ShutDownManager;
@@ -55,8 +55,8 @@ public class DefaultShutDownManager extends Bean implements ShutDownManager {
 
     private static volatile boolean shuttingDown = false;
     private static final Logger log = LoggerFactory.getLogger(DefaultShutDownManager.class);
-    private final Set<Callable<Boolean>> callables = new HashSet<>();
-    private final Set<Runnable> runnables = new HashSet<>();
+    private final Set<Callable<Boolean>> callables = new CopyOnWriteArraySet<>();
+    private final Set<Runnable> runnables = new CopyOnWriteArraySet<>();
     protected final Thread shutdownHook;
     // use up to 8 threads for parallel tasks
     private static final RequestProcessor RP = new RequestProcessor("On Start/Stop", 8); // NOI18N


### PR DESCRIPTION
See https://github.com/JMRI/JMRI/pull/11464#issuecomment-1259545319

prevent ConcurrentModificationException by
moving callables / runnables from HashSet to CopyOnWriteArraySet

@danielb987 this is has not thrown the CME's on 5 Windows CI runs running the overnight HOM,
https://github.com/icklesteve/JMRI/actions/runs/3139924918