### PR TITLE
XmlFile dumpElement to log.info

### DIFF
--- a/java/src/jmri/jmrit/XmlFile.java
+++ b/java/src/jmri/jmrit/XmlFile.java
@@ -279,7 +279,7 @@ public abstract class XmlFile {
      */
     static public void dumpElement(@Nonnull Element name) {
         name.getChildren().forEach((element) -> {
-            System.out.println(" Element: " + element.getName() + " ns: " + element.getNamespace());
+            log.info(" Element: {} ns: {}", element.getName(), element.getNamespace());
         });
     }
 


### PR DESCRIPTION
use log.info instead of System.out
Discovered while looking at updating ArchUnit to a more recent version