### PR TITLE
Fix bug in LogixNG action IfThenElse

### DIFF
--- a/java/src/jmri/jmrit/logixng/actions/IfThenElse.java
+++ b/java/src/jmri/jmrit/logixng/actions/IfThenElse.java
@@ -88,7 +88,7 @@ public class IfThenElse extends AbstractDigitalAction
 
         // Ensure the copy has as many childs as myself
         while (copy.getChildCount() < this.getChildCount()) {
-            copy.doSocketOperation(copy.getChildCount()-1, FemaleSocketOperation.InsertAfter);
+            copy.doSocketOperation(copy.getChildCount()-2, FemaleSocketOperation.InsertAfter);
         }
 
         return manager.registerAction(copy).deepCopyChildren(this, systemNames, userNames);


### PR DESCRIPTION
Closes #11468

@dsand47 
The bug was that a new socket cannot be added after the last socket, since the last socket is the Else socket.