### PR TITLE
Selection prop descriptor not use swing

### DIFF
--- a/java/src/jmri/SelectionPropertyDescriptor.java
+++ b/java/src/jmri/SelectionPropertyDescriptor.java
@@ -4,7 +4,6 @@ import java.util.Arrays;
 import java.util.List;
 
 import javax.annotation.Nonnull;
-import javax.swing.JComboBox;
 
 /**
  * Implementation of NamedBeanPropertyDescriptor for multiple choice properties.
@@ -32,18 +31,7 @@ public abstract class SelectionPropertyDescriptor extends NamedBeanPropertyDescr
         values = options;
         valueToolTips = optionTips;
     }
-    
-    /** 
-     * Get the Class of the property.
-     * <p>
-     * SelectionPropertyDescriber uses JComboBox.class
-     * @return JComboBox.class.
-     */
-    @Override
-    public Class<?> getValueClass() {
-        return JComboBox.class;
-    }
-    
+
     /**
      * Get the property options.
      * Should be same length as getOptionToolTips()

--- a/java/src/jmri/jmrit/beantable/BeanTableDataModel.java
+++ b/java/src/jmri/jmrit/beantable/BeanTableDataModel.java
@@ -230,6 +230,9 @@ abstract public class BeanTableDataModel<T extends NamedBean> extends AbstractTa
                 if (desc == null) {
                     return null;
                 }
+                if ( desc instanceof SelectionPropertyDescriptor ){
+                    return JComboBox.class;
+                }
                 return desc.getValueClass();
         }
     }

--- a/java/test/jmri/SelectionPropertyDescriptorTest.java
+++ b/java/test/jmri/SelectionPropertyDescriptorTest.java
@@ -23,12 +23,6 @@ public class SelectionPropertyDescriptorTest {
     }
 
     @Test
-    public void testGetValueClass() {
-        SelectionPropertyDescriptorImpl t = new SelectionPropertyDescriptorImpl();
-        assertEquals(javax.swing.JComboBox.class, t.getValueClass());
-    }
-
-    @Test
     public void testGetOptions() {
         SelectionPropertyDescriptorImpl t = new SelectionPropertyDescriptorImpl();
         assertArrayEquals(new String[]{"A","B","C"}, t.getOptions());


### PR DESCRIPTION
BeanTableDataModel -
If column is SelectionPropertyDescriptor use JComboBox as per existing code in BeanTable

SelectionPropertyDescriptor -
remove JComboBox as class type, may be presented otherwise.
removes a core JMRI directory reliance on swing