### PR TITLE
CbusSimulator - Access via memo

### DIFF
--- a/java/src/jmri/jmrix/can/cbus/CbusCommandStation.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusCommandStation.java
@@ -7,8 +7,6 @@ import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.jmrix.can.TrafficController;
 import jmri.jmrix.can.cbus.node.CbusNode;
 import jmri.jmrix.can.cbus.node.CbusNodeTableDataModel;
-import jmri.jmrix.can.cbus.simulator.CbusSimulator;
-import jmri.util.ThreadingUtil;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -28,17 +26,11 @@ public class CbusCommandStation implements CommandStation {
     public CbusCommandStation(CanSystemConnectionMemo memo) {
         tc = memo.getTrafficController();
         adapterMemo = memo;
-        // todo - wrong place to start CbusSimulator, move to CbusConfiguration?
-        if ( ( tc != null ) && ( tc.getClass().getName().contains("Loopback")) ) {
-            ThreadingUtil.runOnLayout(() -> {
-                CbusSimulator sim = new jmri.jmrix.can.cbus.simulator.CbusSimulator(adapterMemo);
-                log.debug("sim {}",sim);
-            });
-        }
+        
     }
     
     private final TrafficController tc;
-    private CanSystemConnectionMemo adapterMemo;
+    private final CanSystemConnectionMemo adapterMemo;
 
     /**
      * Send a specific packet to the rails.

--- a/java/src/jmri/jmrix/can/cbus/simulator/CbusSimulator.java
+++ b/java/src/jmri/jmrix/can/cbus/simulator/CbusSimulator.java
@@ -96,7 +96,7 @@ public class CbusSimulator implements jmri.Disposable {
     /**
      * Disposes of all simulated objects.
      * CanListeners can be removed and command stations can stop session timers.
-     * Does not 
+     * Does not remove instance from InstanceManager or CAN memo.
      */
     @Override
     public void dispose() {

--- a/java/src/jmri/jmrix/can/cbus/simulator/CbusSimulator.java
+++ b/java/src/jmri/jmrix/can/cbus/simulator/CbusSimulator.java
@@ -1,5 +1,7 @@
 package jmri.jmrix.can.cbus.simulator;
 
+import javax.annotation.Nonnull;
+
 import java.util.ArrayList;
 import jmri.jmrix.can.CanSystemConnectionMemo;
 
@@ -20,29 +22,30 @@ import org.slf4j.LoggerFactory;
  * @see CbusDummyNode
  * @since 4.15.2
  */
-public class CbusSimulator {
+public class CbusSimulator implements jmri.Disposable {
 
     private final CanSystemConnectionMemo memo;
     public ArrayList<CbusDummyCS> _csArr;
     public ArrayList<CbusDummyNode> _ndArr;
     public ArrayList<CbusEventResponder> _evResponseArr;
 
-    public CbusSimulator(CanSystemConnectionMemo sysmemo){
+    public CbusSimulator(@Nonnull CanSystemConnectionMemo sysmemo){
         memo = sysmemo;
-        // todo - store in memo, not instance
-        jmri.InstanceManager.store(this,CbusSimulator.class);
+        _csArr = new ArrayList<>();
+        _ndArr = new ArrayList<>();
+        _evResponseArr = new ArrayList<>();
         init();
     }
-    
+
     public final void init(){
         log.info("Starting CBUS Network Simulation Tools");
-        _csArr = new ArrayList<>();
+        
         _csArr.add(new CbusDummyCS(memo)); // type, id, memo
         
-        _ndArr = new ArrayList<>();
+        
         // _ndArr.add(new CbusDummyNode(0,165,0,0,memo)); // nn, manufacturer, type, canid, memo
         
-        _evResponseArr = new ArrayList<>();
+        
         _evResponseArr.add(new CbusEventResponder(memo) );
     }
     
@@ -90,29 +93,29 @@ public class CbusSimulator {
         return newcs;
     }
 
-    // removes CanListeners
-    // resets all command stations to stop any session timers
+    /**
+     * Disposes of all simulated objects.
+     * CanListeners can be removed and command stations can stop session timers.
+     * Does not 
+     */
+    @Override
     public void dispose() {
-        log.info("Stopping all CBUS Simulation Tools");
-        for (int i = 0; i < _csArr.size(); i++) {
-            _csArr.get(i).dispose();
-            _csArr.set(i,null);
+        log.info("Stopping {} Simulations",_csArr.size()+_ndArr.size()+_evResponseArr.size());
+        for ( CbusDummyCS cs : _csArr ) {
+            cs.dispose();
         }
-        _csArr = null;
-        
-        for (int i = 0; i < _ndArr.size(); i++) {
-            _ndArr.get(i).dispose();
-            _ndArr.set(i,null);
-        }        
-        _ndArr = null;
-        
-        for (int i = 0; i < _evResponseArr.size(); i++) {
-            _evResponseArr.get(i).dispose();
-            _evResponseArr.set(i,null);
-        } 
-        _evResponseArr = null;
-        
-        jmri.InstanceManager.deregister(this, CbusSimulator.class);
+        _csArr.clear();
+
+        for ( CbusDummyNode cs : _ndArr ) {
+            cs.dispose();
+        }
+        _ndArr.clear();
+
+        for ( CbusEventResponder cs : _evResponseArr ) {
+            cs.dispose();
+        }
+        _evResponseArr.clear();
+
     }
 
     private static final Logger log = LoggerFactory.getLogger(CbusSimulator.class);

--- a/java/src/jmri/jmrix/can/cbus/swing/simulator/SimulatorPane.java
+++ b/java/src/jmri/jmrix/can/cbus/swing/simulator/SimulatorPane.java
@@ -7,6 +7,7 @@ import java.util.List;
 import javax.swing.*;
 
 import jmri.jmrix.can.CanSystemConnectionMemo;
+import jmri.jmrix.can.cbus.CbusConfigurationManager;
 import jmri.jmrix.can.cbus.simulator.CbusSimulator;
 
 // import org.slf4j.Logger;
@@ -39,15 +40,10 @@ public class SimulatorPane extends jmri.jmrix.can.swing.CanPanel {
     @Override
     public void initComponents(CanSystemConnectionMemo memo) {
         super.initComponents(memo);
-        
-        // todo - run on memo, not instance
-        _sim = jmri.InstanceManager.getNullableDefault(CbusSimulator.class);
-         
-        if ( _sim == null ) {
-            jmri.util.ThreadingUtil.runOnLayout( ()->{
-                _sim = new CbusSimulator(memo);
-            });
+        if ( memo == null){
+            throw new IllegalStateException("memo should not be null here");
         }
+        _sim = memo.get(CbusSimulator.class);
         init();
     }
 
@@ -178,8 +174,9 @@ public class SimulatorPane extends jmri.jmrix.can.swing.CanPanel {
     @Override
     public void dispose() {
         super.dispose();
-        if ( _disposeSimOnWindowClose ) {
-            _sim.dispose();
+        if ( memo != null && _disposeSimOnWindowClose ) {
+            ((CbusConfigurationManager)memo.get(CbusConfigurationManager.class))
+                .disposeOf(_sim, CbusSimulator.class);
         }
     }
 

--- a/java/src/jmri/jmrix/can/cbus/swing/simulator/SimulatorPane.java
+++ b/java/src/jmri/jmrix/can/cbus/swing/simulator/SimulatorPane.java
@@ -4,6 +4,7 @@ import java.awt.event.ActionEvent;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.annotation.Nonnull;
 import javax.swing.*;
 
 import jmri.jmrix.can.CanSystemConnectionMemo;
@@ -38,11 +39,8 @@ public class SimulatorPane extends jmri.jmrix.can.swing.CanPanel {
      * {@inheritDoc}
      */
     @Override
-    public void initComponents(CanSystemConnectionMemo memo) {
+    public void initComponents(@Nonnull CanSystemConnectionMemo memo) {
         super.initComponents(memo);
-        if ( memo == null){
-            throw new IllegalStateException("memo should not be null here");
-        }
         _sim = memo.get(CbusSimulator.class);
         init();
     }

--- a/java/test/jmri/jmrix/can/cbus/CbusCommandStationTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusCommandStationTest.java
@@ -1,17 +1,11 @@
 package jmri.jmrix.can.cbus;
 
-import jmri.InstanceManager;
 import jmri.jmrix.can.CanSystemConnectionMemo;
-import jmri.jmrix.can.cbus.simulator.CbusSimulator;
 import jmri.jmrix.can.TrafficControllerScaffold;
-import jmri.jmrix.can.TrafficControllerScaffoldLoopback;
 import jmri.util.JUnitUtil;
 
 import org.junit.Assert;
 import org.junit.jupiter.api.*;
-
-// import org.slf4j.Logger;
-// import org.slf4j.LoggerFactory;
 
 /**
  *
@@ -42,18 +36,6 @@ public class CbusCommandStationTest {
         Assert.assertEquals("user name obtainable", "CAN", t.getUserName());
     }
     
-    @Test
-    public void testgetSimLoopbacktc() {
-        Assert.assertNotNull(memo);
-        TrafficControllerScaffoldLoopback tc = new TrafficControllerScaffoldLoopback();
-        memo.setTrafficController(tc);
-        CbusCommandStation ta = new CbusCommandStation(memo);
-        Assert.assertNotNull("exists",ta);
-        Assert.assertNotNull(InstanceManager.getDefault(CbusSimulator.class));
-        
-        tc.terminateThreads();
-    }
-
     // test originates from loconet
     @Test
     public void testSendPacket() {
@@ -212,6 +194,6 @@ public class CbusCommandStationTest {
         JUnitUtil.tearDown();
     }
 
-    // private final static Logger log = LoggerFactory.getLogger(CbusCommandStationTest.class);
+    // private final static org.slf4j.Logger.Logger log = org.slf4j.Logger.LoggerFactory.getLogger(CbusCommandStationTest.class);
 
 }

--- a/java/test/jmri/jmrix/can/cbus/CbusConfigurationManagerTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusConfigurationManagerTest.java
@@ -8,6 +8,7 @@ import jmri.*;
 import jmri.jmrix.can.*;
 import jmri.jmrix.can.cbus.eventtable.CbusEventTableDataModel;
 import jmri.jmrix.can.cbus.node.CbusNodeTableDataModel;
+import jmri.jmrix.can.cbus.simulator.CbusSimulator;
 import jmri.util.JUnitUtil;
 
 import org.junit.jupiter.api.*;
@@ -178,6 +179,7 @@ public class CbusConfigurationManagerTest {
         toReturn.add(LightManager.class);
         toReturn.add(CabSignalManager.class);
         toReturn.add(CbusPredefinedMeters.class);
+        toReturn.add(CbusSimulator.class);
         return toReturn;
     }
     
@@ -196,6 +198,22 @@ public class CbusConfigurationManagerTest {
         assertNull(memo.getFromMap(classToTest));
         assertEquals(0, tcis.numListeners(),"All listeners removed " + tcis.getListeners());
     
+    }
+
+    @Test
+    public void testGetDisposeSimulator() {
+        
+        CbusSimulator simA = memo.getFromMap(CbusSimulator.class);
+        assertNull(simA);
+        CbusSimulator sim = memo.get(CbusSimulator.class);
+        assertNotNull(sim);
+        simA = memo.getFromMap(CbusSimulator.class);
+        assertNotNull(simA);
+        assertTrue(sim == simA);
+        
+        t.disposeOf(sim, CbusSimulator.class);
+        simA = memo.getFromMap(CbusSimulator.class);
+        assertNull(simA);
     }
 
     private CanSystemConnectionMemo memo;

--- a/java/test/jmri/jmrix/can/cbus/simulator/CbusSimulatorTest.java
+++ b/java/test/jmri/jmrix/can/cbus/simulator/CbusSimulatorTest.java
@@ -1,5 +1,7 @@
 package jmri.jmrix.can.cbus.simulator;
 
+import jmri.jmrix.can.CanSystemConnectionMemo;
+import jmri.jmrix.can.cbus.CbusTrafficControllerScaffold;
 import jmri.util.JUnitUtil;
 
 import org.junit.Assert;
@@ -29,6 +31,11 @@ public class CbusSimulatorTest {
         Assert.assertNotNull("cs get ", t.getCS(0));
        //  Assert.assertNotNull("nd get ", t.getNd(0));
         Assert.assertNotNull("ev get ", t.getEv(0));
+        
+        t.dispose();
+        Assertions.assertEquals(0, t._csArr.size());
+        Assertions.assertEquals(0, t._csArr.size());
+        Assertions.assertEquals(0, t._csArr.size());
     }
     
     @Test
@@ -40,12 +47,23 @@ public class CbusSimulatorTest {
         Assert.assertTrue("cs 2 ", t.getNumCS() == 2);
         Assert.assertTrue("ev 2 ", t.getNumEv() == 2);        
         
+        t.dispose();
+        Assertions.assertEquals(0, t._csArr.size());
+        Assertions.assertEquals(0, t._csArr.size());
+        Assertions.assertEquals(0, t._csArr.size());
     }
 
+    private CanSystemConnectionMemo memo;
+    // private CbusTrafficControllerScaffold tcis;
+    
     @BeforeEach
     public void setUp() {
         JUnitUtil.setUp();
-        t = new CbusSimulator(null);
+        memo = new CanSystemConnectionMemo();
+        // tcis = new CbusTrafficControllerScaffold(memo);
+        // memo.setTrafficController(tcis);
+        memo.setProtocol(jmri.jmrix.can.CanConfigurationManager.MERGCBUS);
+        t = memo.get(CbusSimulator.class);
     }
 
     @AfterEach
@@ -53,6 +71,11 @@ public class CbusSimulatorTest {
         Assertions.assertNotNull(t);
         t.dispose();
         t = null;
+        // Assertions.assertNotNull(tcis);
+        // tcis.terminateThreads();
+        Assertions.assertNotNull(memo);
+        memo.dispose();
+        memo = null;
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrix/can/cbus/swing/simulator/SimulatorPaneTest.java
+++ b/java/test/jmri/jmrix/can/cbus/swing/simulator/SimulatorPaneTest.java
@@ -80,6 +80,7 @@ public class SimulatorPaneTest extends jmri.util.swing.JmriPanelTest {
         memo = new CanSystemConnectionMemo();
         tcis = new TrafficControllerScaffold();
         memo.setTrafficController(tcis);
+        memo.setProtocol(jmri.jmrix.can.CanConfigurationManager.MERGCBUS);
 
         panel = new SimulatorPane();
     }


### PR DESCRIPTION
CbusSimulator instances now memo managed via CbusConfigurationManager, rather than InstanceManager.
Enables multi-CBUS connection Simulator support.
CbusSimulation instance startup from within CbusCommandStation removed.