### PR TITLE
ArchitectureTest  / Archunit pattern update

### DIFF
--- a/archunit_ignore_patterns.txt
+++ b/archunit_ignore_patterns.txt
@@ -9,10 +9,6 @@ Constructor <apps\.SystemConsole\.<init>\(\)> gets field <java\.lang\.System.out
 Constructor <apps\.SystemConsole\.<init>\(\)> gets field <java\.lang\.System.err>.*
 Method <apps\.CheckerFrameworkCheck\.test\(\)> gets field <java\.lang\.System\.out>.*
 Method <apps\.FindBugsCheck\.test\(\)\> gets field <java\.lang\.System\.out>.*
-Method <jmri\.jmrit\.XmlFile\.lambda\$dumpElement\$.*\(org\.jdom2\.Element\)> gets field <java\.lang\.System\.out>.*
-Method <jmri\.jmrit\.XmlFile\.lambda\$0\(org\.jdom2\.Element\)> gets field <java\.lang\.System\.out>.*
-Method <jmri\.jmrit\.XmlFileValidateAction\$2\.showFailResults\(java\.awt\.Component, java\.lang\.String\)> gets field <java\.lang\.System\.out>.*
-Method <jmri\.managers\.DefaultShutDownManager\.runShutDownTasks\(boolean\)> gets field <java\.lang\.System\.err>.*
 Method <jmri\.util\.FileUtilSupport\.getPreferencesPath\(\)> gets field <java\.lang\.System\.err>.*
 Method <jmri\.util\.com\.rbnb\.UDPOutputStream\.write\(\[B, int, int\)> gets field <java\.lang\.System\.err>.*
 
@@ -37,6 +33,7 @@ Method <jmri\.UserPreferencesManager\.setWindowSize\(java\.lang\.String, java\.a
 
 # For checkJmriPackageSwing
 Interface <jmri\.CatalogTree> extends interface <javax\.swing\.tree\.TreeModel>.*
+Method <jmri\.CatalogTreeNode\.children\(\)> has generic return type <java\.util\.Enumeration<javax\.swing\.tree\.TreeNode>\>.*
 Method <jmri\.ConditionalAction\.getTimer\(\)> has return type <javax\.swing\.Timer>.*
 Method <jmri\.ConditionalAction\.setTimer\(javax\.swing\.Timer\)> has parameter of type <javax\.swing\.Timer>.*
 Method <jmri\.JmriPlugin\.start\(javax\.swing\.JFrame, javax\.swing\.JMenuBar\)> has parameter of type <javax\.swing\.JFrame>.*

--- a/java/test/jmri/ArchitectureTest.java
+++ b/java/test/jmri/ArchitectureTest.java
@@ -7,8 +7,6 @@ import com.tngtech.archunit.junit.*;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
 
-import jmri.util.swing.BeanSelectPanel;
-
 /**
  * Check the architecture of the JMRI library
  * <p>
@@ -111,6 +109,7 @@ public class ArchitectureTest {
                                 .doNotHaveFullyQualifiedName("jmri.util.swing.JmriMouseMotionListener$1").and()
                                 .doNotHaveFullyQualifiedName("jmri.util.swing.TriStateJCheckBox$1").and()
                                 .doNotHaveFullyQualifiedName("jmri.util.table.JTableWithColumnToolTips$1").and()
+                                .doNotHaveFullyQualifiedName("jmri.util.table.ButtonEditor").and()
                                 .doNotHaveFullyQualifiedName("jmri.util.table.ToggleButtonEditor").and()
                                 .doNotHaveFullyQualifiedName("jmri.web.servlet.frameimage.JmriJFrameServlet")
 
@@ -274,30 +273,30 @@ public class ArchitectureTest {
             .should().dependOnClassesThat().resideInAPackage("org.apache.log4j");
 
     /**
-     * (Try to) confine JDOM to configurexml packages.
-     * (Is this working right? Seems to not flag anything)
-     *  Probably not working because the JDOM classes are not part of initially-read set
+     * Confine JDOM to configurexml packages.
      */
-    @ArchTest // Not complete
-    public static final ArchRule checkJdomOutsideConfigurexml = classes()
-            .that().resideInAPackage("org.jdom2..")
-            .should().onlyBeAccessed().byAnyPackage("..configurexml..");
+    @ArchTest
+    @ArchIgnore // 5792 flags September 2022
+    public static final ArchRule checkJdomOutsideConfigurexml = noClasses()
+        .that().resideOutsideOfPackage("..configurexml..")
+        .should().accessClassesThat().resideInAPackage("org.jdom2..");
 
     /**
-     * (Try to) confine purejavacomm to jmri.jmrix packages.
-     * (Is this working right? Seems to not flag anything; note jmri.jmrit as a test below)
-     *  Probably not working because the purejavacomm classes are not part of initially-read set
+     * Confine purejavacomm to jmri.jmrix packages.
      */
-    @ArchTest // Not complete
-    public static final ArchRule checkPurejavacoomOutsideConfigurexml = classes()
-            .that().resideInAPackage("purejavacomm..")
-            .should().onlyBeAccessed().byAnyPackage("jmri.jmrit");
+    @ArchTest
+    public static final ArchRule checkPurejavacoomOutsideConfigurexml = noClasses()
+        .that().resideOutsideOfPackage("jmri.jmrix..").and()
+        .doNotHaveFullyQualifiedName("apps.util.issuereporter.SystemInfo").and()
+        .doNotHaveFullyQualifiedName("jmri.jmrit.mailreport.ReportContext")
+        .should().accessClassesThat().resideInAPackage("purejavacomm..");
 
     /**
      * Check that *Bundle classes inherit from their parent.
      * (not done yet, not sure how to do it)
      */
-    @ArchTest // Not complete
+    @ArchTest
+    @ArchIgnore // Not complete
     public static final ArchRule checkBundleInheritance = classes()
             .that().areAssignableTo(jmri.Bundle.class)
             .should().haveSimpleNameEndingWith("Bundle");


### PR DESCRIPTION
ArchitectureTest -
fix tests failing in recent ArchUnit 1.0.0.rc1 for not checking any classes

archunit_ignore_patterns.txt -
remove unused ignores
add ignore for missed ocurrence flagged in ArchUnit 1.0.0.rc1