### PR TITLE
Default ShutDownManager - update to Threadpool

### DIFF
--- a/java/src/jmri/implementation/AbstractShutDownTask.java
+++ b/java/src/jmri/implementation/AbstractShutDownTask.java
@@ -4,8 +4,6 @@ import java.beans.PropertyChangeEvent;
 import javax.annotation.OverridingMethodsMustInvokeSuper;
 import jmri.ShutDownTask;
 
-import jmri.util.LoggingUtil;
-
 /**
  * Abstract ShutDownTask implementation.
  * <p>

--- a/java/src/jmri/managers/DefaultShutDownManager.java
+++ b/java/src/jmri/managers/DefaultShutDownManager.java
@@ -391,6 +391,11 @@ public class DefaultShutDownManager extends Bean implements ShutDownManager {
             task.runEarly();
         }
 
+        @Override // improve error message on failure
+        public String toString(){
+            return task.toString();
+        }
+
     }
 
     private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(DefaultShutDownManager.class);

--- a/java/src/jmri/managers/DefaultShutDownManager.java
+++ b/java/src/jmri/managers/DefaultShutDownManager.java
@@ -8,19 +8,12 @@ import java.awt.event.WindowEvent;
 
 import java.util.*;
 import java.util.concurrent.*;
-import java.util.stream.Collectors;
 
 import jmri.ShutDownManager;
 import jmri.ShutDownTask;
 
 import jmri.beans.Bean;
 import jmri.util.ThreadingUtil;
-
-import org.openide.util.RequestProcessor;
-import org.openide.util.Task;
-import org.openide.util.TaskListener;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * The default implementation of {@link ShutDownManager}. This implementation
@@ -54,13 +47,17 @@ import org.slf4j.LoggerFactory;
 public class DefaultShutDownManager extends Bean implements ShutDownManager {
 
     private static volatile boolean shuttingDown = false;
-    private static final Logger log = LoggerFactory.getLogger(DefaultShutDownManager.class);
+
     private final Set<Callable<Boolean>> callables = new CopyOnWriteArraySet<>();
     private final Set<EarlyTask> earlyRunnables = new CopyOnWriteArraySet<>();
     private final Set<Runnable> runnables = new CopyOnWriteArraySet<>();
+
     protected final Thread shutdownHook;
-    // use up to 8 threads for parallel tasks
-    private static final RequestProcessor RP = new RequestProcessor("On Start/Stop", 8); // NOI18N
+
+    // 30secs to complete EarlyTasks, 30 secs to complete Main tasks.
+    // package private for testing
+    int tasksTimeOutMilliSec = 30000; 
+
     private static final String NO_NULL_TASK = "Shutdown task cannot be null."; // NOI18N
     private static final String PROP_SHUTTING_DOWN = "shuttingDown"; // NOI18N
 
@@ -123,7 +120,7 @@ public class DefaultShutDownManager extends Bean implements ShutDownManager {
         this.callables.remove(s);
         this.runnables.remove(s);
         for (EarlyTask r : earlyRunnables) {
-            if (r._task == s) earlyRunnables.remove(r);
+            if (r.task == s) earlyRunnables.remove(r);
         }
     }
 
@@ -200,16 +197,17 @@ public class DefaultShutDownManager extends Bean implements ShutDownManager {
     }
 
     /**
-     * First asks the shutdown tasks if shutdown is allowed. If not return
-     * false.
-     * <p>
-     * Then run the shutdown tasks, and then terminate the program with status 0
-     * if not aborted. Does not return under normal circumstances. Does return
-     * false if the shutdown was aborted by the user, in which case the program
+     * First asks the shutdown tasks if shutdown is allowed.
+     * If not, return false.
+     * Return false if the shutdown was aborted by the user, in which case the program
      * should continue to operate.
      * <p>
-     * Executes all registered {@link jmri.ShutDownTask}s before closing any
-     * displayable windows.
+     * After this check does not return under normal circumstances.
+     * Closes any displayable windows.
+     * Executes all registered {@link jmri.ShutDownTask}
+     * Runs the Early shutdown tasks, the main shutdown tasks,
+     * then terminates the program with provided status.
+     * <p>
      *
      * @param status integer status on program exit
      * @param exit   true if System.exit() should be called if all tasks are
@@ -237,8 +235,6 @@ public class DefaultShutDownManager extends Bean implements ShutDownManager {
                     return false;
                 }
             }
-            // each shut down tasks must complete within _timeout_ milliseconds
-            int timeout = 30000;
             // close any open windows by triggering a closing event
             // this gives open windows a final chance to perform any cleanup
             if (!GraphicsEnvironment.isHeadless()) {
@@ -255,27 +251,9 @@ public class DefaultShutDownManager extends Bean implements ShutDownManager {
             }
             log.debug("windows completed closing {} milliseconds after starting shutdown", new Date().getTime() - start.getTime());
             // wait for parallel tasks to complete
-            try {
-                if (!earlyRunnables.isEmpty() && !new ProxyTask(new HashSet<>(earlyRunnables).stream()
-                        .map(task -> RP.post(task, 0, Thread.currentThread().getPriority()))
-                        .collect(Collectors.toSet()))
-                                .waitFinished(timeout)) {
-                    log.warn("Terminating without waiting for stop tasks to complete");
-                }
-            } catch (InterruptedException ex) {
-                // do nothing
-            }
-            // wait for parallel tasks to complete
-            try {
-                if (!runnables.isEmpty() && !new ProxyTask(new HashSet<>(runnables).stream()
-                        .map(task -> RP.post(task, 0, Thread.currentThread().getPriority()))
-                        .collect(Collectors.toSet()))
-                                .waitFinished(timeout)) {
-                    log.warn("Terminating without waiting for stop tasks to complete");
-                }
-            } catch (InterruptedException ex) {
-                // do nothing
-            }
+            runShutDownTasks(new HashSet<>(earlyRunnables), "JMRI ShutDown - Early Tasks");
+            runShutDownTasks(runnables, "JMRI ShutDown - Main Tasks");
+
             // success
             log.debug("Shutdown took {} milliseconds.", new Date().getTime() - start.getTime());
             log.info("Normal termination complete");
@@ -285,6 +263,44 @@ public class DefaultShutDownManager extends Bean implements ShutDownManager {
             }
         }
         return false;
+    }
+
+    // blocks the main Thread until tasks complete or timed out
+    private void runShutDownTasks(Set<Runnable> toRun, String threadName ) {
+        Set<Runnable> sDrunnables = new HashSet<>(toRun); // copy list so cannot be modified
+        if ( sDrunnables.isEmpty() ) {
+            return;
+        }
+        // use a custom Executor which checks the Task output for Exceptions.
+        ExecutorService executor = new ShutDownThreadPoolExecutor(sDrunnables.size(), threadName);
+        List<Future<?>> complete = new ArrayList<>();
+        long timeoutEnd = new Date().getTime()+ tasksTimeOutMilliSec;
+
+        
+        sDrunnables.forEach((runnable) -> {
+             complete.add(executor.submit(runnable));
+        });
+
+        executor.shutdown(); // no more tasks allowed from here, starts the threads.
+        while (!executor.isTerminated() && ( timeoutEnd > new Date().getTime() )) {
+            try {
+                // awaitTermination blocks the thread, checking occasionally
+                executor.awaitTermination(50, TimeUnit.MILLISECONDS);
+            } catch (InterruptedException e) {
+                // ignore
+            }
+        }
+
+        // so we're either all complete or timed out.
+        // check if a task timed out, if so log.
+        for ( Future<?> future : complete) {
+            if ( !future.isDone() ) {
+                log.error("Could not complete Shutdown Task in time: {} ", future );
+            }
+        }
+
+        executor.shutdownNow(); // do not leave Threads hanging before exit, force stop.
+
     }
 
     /**
@@ -308,40 +324,75 @@ public class DefaultShutDownManager extends Bean implements ShutDownManager {
         firePropertyChange(PROP_SHUTTING_DOWN, old, state);
     }
 
-    private synchronized static void setStaticShuttingDown(boolean state){
+    // package private so tests can reset
+    synchronized static void setStaticShuttingDown(boolean state){
         shuttingDown = state;
     }
 
-    static final class ProxyTask extends Task implements TaskListener {
-        private int cnt;
+    private static class ShutDownThreadPoolExecutor extends ThreadPoolExecutor {
 
-        public ProxyTask(Collection<? extends Task> waitFor) {
-            super(null);
-            this.cnt = waitFor.size();
-            notifyRunning();
-            waitFor.forEach(t -> t.addTaskListener(this));
+        // use up to 8 threads for parallel tasks
+        // 10 seconds for tasks to enter a thread from queue
+        // set thread name with custom ThreadFactory
+        private ShutDownThreadPoolExecutor(int numberTasks, String threadName) {
+            super(8, 8, 10, TimeUnit.SECONDS,
+                new ArrayBlockingQueue<Runnable>(numberTasks), new ShutDownThreadFactory(threadName));
         }
 
         @Override
-        public synchronized void taskFinished(Task task) {
-            if (--cnt == 0) {
-                notifyFinished();
+        public void afterExecute(Runnable r, Throwable t) {
+            super.afterExecute(r, t);
+            // System.out.println("afterExecute "+ r);
+            if (t == null && r instanceof Future<?>) {
+                try {
+                    Future<?> future = (Future<?>) r;
+                    if (future.isDone()) {
+                        future.get();
+                    }
+                } catch (CancellationException ce) {
+                    t = ce;
+                } catch (ExecutionException ee) {
+                    t = ee.getCause();
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                }
             }
+            if (t != null) {
+                log.error("Issue Completing ShutdownTask : ", t);
+            }
+        }
+    }
+
+    private static class ShutDownThreadFactory implements ThreadFactory {
+        
+        private final String threadName;
+        
+        private ShutDownThreadFactory( String threadName ){
+            super();
+            this.threadName = threadName;
+        }
+        
+        @Override
+        public Thread newThread(Runnable r) {
+            return new Thread(r, threadName);
         }
     }
 
     private static class EarlyTask implements Runnable {
 
-        private final ShutDownTask _task;
+        final ShutDownTask task; // access outside of this class
 
-        EarlyTask(ShutDownTask task) {
-            _task = task;
+        EarlyTask( ShutDownTask runnableTask) {
+            task = runnableTask;
         }
 
         @Override
         public void run() {
-            _task.runEarly();
+            task.runEarly();
         }
+
     }
+
+    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(DefaultShutDownManager.class);
 
 }

--- a/java/test/jmri/managers/DefaultShutDownManagerTest.java
+++ b/java/test/jmri/managers/DefaultShutDownManagerTest.java
@@ -7,8 +7,9 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.awt.Frame;
 import java.awt.GraphicsEnvironment;
-import java.lang.reflect.Field;
 import java.util.concurrent.Callable;
+import java.util.concurrent.*;
+import java.util.Date;
 
 import org.junit.Assert;
 import org.junit.jupiter.api.*;
@@ -25,7 +26,11 @@ import jmri.util.JUnitUtil;
  * @author Paul Bender Copyright 2017
  * @author Randall Wood Copyright 2020
  */
+@Timeout(10)
 public class DefaultShutDownManagerTest {
+
+    private ConcurrentMap<String, String> concurrentRuns = new ConcurrentHashMap<>();
+    private ConcurrentMap<String, String> concurrentEarlyRuns = new ConcurrentHashMap<>();
 
     private int runs;
     private DefaultShutDownManager dsdm;
@@ -182,18 +187,8 @@ public class DefaultShutDownManagerTest {
 
     @Test
     public void testShutDownisNotInterruptedByShutDownTask() {
-        dsdm.register(new AbstractShutDownTask("test") {
-
-            @Override
-            public Boolean call() {
-                return true;
-            }
-
-            @Override
-            public void run() {
-                runs++;
-            }});
-        dsdm.shutdown(0, false);
+        dsdm.register(new CallTrueShutDownTask("testShutDownisNotInterruptedByShutDownTask"));
+        Assertions.assertFalse(dsdm.shutdown(0, false));
         assertThat(dsdm.isShuttingDown()).isTrue();
         assertThat(runs).isEqualTo(1);
     }
@@ -233,27 +228,200 @@ public class DefaultShutDownManagerTest {
         assertThat(InstanceManager.getNullableDefault(ShutDownManager.class)).isNotNull();
     }
 
+    @Test
+    public void testShutDownTaskTakesTooLong() {
+        dsdm.register(new TakesOneSecondShutDownTask("testShutDownTaskTakesTooLong"));
+        Assertions.assertFalse(dsdm.shutdown(0, false));
+        JUnitAppender.assertErrorMessageStartsWith("Could not complete Shutdown Task in time:");
+        Assertions.assertTrue(dsdm.isShuttingDown());
+        JUnitUtil.waitFor(() -> { return runs == 2; } , "Second runs++ call eventually triggered");
+    }
+
+    @Test
+    public void testEarlyShutDownTaskTakesTooLong() {
+        dsdm.register(new TakesOneSecondEarlyShutDownTask("testEarlyShutDownTaskTakesTooLong"));
+        Assertions.assertFalse(dsdm.shutdown(0, false));
+        JUnitAppender.assertErrorMessageStartsWith("Could not complete Shutdown Task in time:");
+        Assertions.assertTrue(dsdm.isShuttingDown());
+        JUnitUtil.waitFor(() -> { return runs == 2; } , "Second runs++ call eventually triggered");
+    }
+
+    @Test
+    public void testShutDownTaskThrowsException() {
+        dsdm.register(new ThrowsExceptionShutDownTask("testShutDownTaskThrowsException"));
+        Assertions.assertFalse(dsdm.shutdown(0, false));
+        JUnitAppender.assertErrorMessageStartsWith("Issue Completing ShutdownTask :");
+        Assertions.assertTrue(dsdm.isShuttingDown());
+        Assertions.assertEquals( 1, runs, "run triggered");
+    }
+
+    @Test
+    public void testMoreThanEightTasks() {
+        concurrentRuns = new ConcurrentHashMap<>(41);
+        for ( int i=0; i<30; i++ ){
+            dsdm.register(new CallTrueShutDownTask("testMoreThanEightTasks"+i));
+        }
+        Assertions.assertEquals(30, dsdm.getRunnables().size());
+        Assertions.assertFalse(dsdm.shutdown(0, false));
+        Assertions.assertTrue(dsdm.isShuttingDown());
+        // Assertions.assertEquals(30, runs); // fails often with a few missing
+        // JUnitUtil.waitFor times out every now and then, so we use concurrentRuns
+        Assertions.assertEquals(30, concurrentRuns.size(),"all runs triggered");
+    }
+
+    @Test
+    public void testManagerDoesNotUseFullTimeOutWhenComplete() {
+        Date start = new Date();
+        dsdm.register(new CallTrueShutDownTask("testManagerDoesNotUseFullTimeOutWhenComplete"));
+        dsdm.shutdown(0, false);
+        Assertions.assertTrue(dsdm.isShuttingDown());
+        JUnitUtil.waitFor(() -> runs == 1 , "run triggered");
+        long testTime = new Date().getTime() - start.getTime();
+        Assertions.assertTrue(testTime < dsdm.tasksTimeOutMilliSec*2,
+            "Completed before earlytimeout and mainTimeout");
+    }
+
+    @Test
+    public void testEarlyTasks() {
+        concurrentEarlyRuns = new ConcurrentHashMap<>(3);
+        concurrentRuns = new ConcurrentHashMap<>(3);
+        dsdm.tasksTimeOutMilliSec = 250;
+        dsdm.register(new EarlyShutDownTask("testEarlyTasks"));
+
+        Thread t1 = new Thread(() -> {
+            dsdm.shutdown(0, false);
+        });
+        t1.setName("testEarlyTasksShutdown");
+        t1.start();
+
+        JUnitUtil.waitFor(() -> concurrentEarlyRuns.size() == 1 , "early run triggered");
+        Assertions.assertEquals(0, concurrentRuns.size(),"early run triggered before main run");
+        JUnitUtil.waitFor(() -> concurrentRuns.size() == 1 , "run triggered");
+        JUnitUtil.waitFor(()->{return !(t1.isAlive());}, "shutdown thread completed");
+    }
+
+    private class CallTrueShutDownTask extends AbstractShutDownTask {
+    
+        CallTrueShutDownTask(String id){
+            super("Call True Task " + id );
+        }
+        
+        @Override
+        public Boolean call() {
+            return true;
+        }
+
+        @Override
+        public void run() {
+            runs++;
+            concurrentRuns.putIfAbsent(this.getName(), this.getName());
+        }
+    
+    }
+
+    private class ThrowsExceptionShutDownTask extends AbstractShutDownTask {
+
+        ThrowsExceptionShutDownTask(String id){
+            super("Throws NPE Task " + id );
+        }
+        
+        @Override
+        public Boolean call() {
+            return true;
+        }
+
+        @Override
+        public void run() {
+            runs++;
+            throw new NullPointerException("ThrowsExceptionShutDownTask " + getName());
+        }
+    
+    }
+
+    private class TakesOneSecondShutDownTask extends AbstractShutDownTask {
+    
+        TakesOneSecondShutDownTask(String id){
+            super("Takes Too Long " + id );
+        }
+        
+        @Override
+        public Boolean call() {
+            return true;
+        }
+
+        @Override
+        public void run() {
+            runs++;
+            JUnitUtil.waitFor(1000);
+            runs++;
+        }
+    
+    }
+
+    private class TakesOneSecondEarlyShutDownTask extends AbstractShutDownTask {
+    
+        TakesOneSecondEarlyShutDownTask(String id){
+            super("Early SDT Takes Too Long " + id );
+        }
+
+        @Override
+        public Boolean call() {
+            return true;
+        }
+
+        @Override
+        public void runEarly() {
+            runs++;
+            JUnitUtil.waitFor(1000);
+            runs++;
+        }
+
+        @Override
+        public void run() {
+            // does nothing
+        }
+        
+    }
+
+    private class EarlyShutDownTask extends AbstractShutDownTask {
+
+        EarlyShutDownTask(String id){
+            super("EarlyShutDownTask " + id );
+        }
+        
+        @Override
+        public Boolean call() {
+            return true;
+        }
+        
+        @Override
+        public void runEarly() {
+            concurrentEarlyRuns.putIfAbsent(this.getName(), this.getName());
+            JUnitUtil.waitFor(100);
+        }
+
+        @Override
+        public void run() {
+            concurrentRuns.putIfAbsent(this.getName(), this.getName());
+        }
+
+    }
+
     @BeforeEach
     public void setUp() {
         JUnitUtil.setUp();
         dsdm = new DefaultShutDownManager();
+        dsdm.tasksTimeOutMilliSec = 100; // normal default 30000 msecs but this is a test
         runs = 0;
         InstanceManager.getDefault(jmri.configurexml.ShutdownPreferences.class).setEnableStoreCheck(false);
     }
 
     @AfterEach
     public void tearDown() {
-        try {
-            Class<?> c = jmri.managers.DefaultShutDownManager.class;
-            Field f = c.getDeclaredField("shuttingDown");
-            f.setAccessible(true);
-            f.set(dsdm, false);
-        } catch (NoSuchFieldException | IllegalArgumentException | IllegalAccessException x) {
-            log.error("Failed to reset DefaultShutDownManager shuttingDown field", x);
-        }
+        DefaultShutDownManager.setStaticShuttingDown(false);
         JUnitUtil.tearDown();
     }
 
-    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(DefaultShutDownManagerTest.class);
+    // private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(DefaultShutDownManagerTest.class);
 
 }


### PR DESCRIPTION
Updates main Shutdown blocking Thread to use a custom Threadpool Executor.

Removes ShutDown `WARNING: Illegal reflective access by org.openide.util.RequestProcessor$TopLevelThreadGroup`

enables testing of error reporting of timeouts / exceptions in task code.