### PR TITLE
Reduce mDNS logging of normal conditions as warnings

### DIFF
--- a/default.lcf
+++ b/default.lcf
@@ -95,9 +95,12 @@ log4j.category.org.jdom2.transform=SEVERE
 # Turn off logging for Java JMDNS; if logs SEVERE and WARNING excessively
 # log4j.category.javax.jmdns=OFF
 log4j.category.javax.jmdns.impl.DNSIncoming=ERROR
+log4j.category.javax.jmdns.impl.DNSRecord=ERROR
 log4j.category.javax.jmdns.impl.constants.DNSRecordClass=ERROR
 log4j.category.javax.jmdns.impl.constants.DNSRecordType=ERROR
 log4j.category.javax.jmdns.impl.DNSIncoming$MessageInputStream=ERROR
+log4j.category.javax.jmdns.impl.JmDNSImpl=ERROR
+log4j.category.javax.jmdns.impl.tasks.state.DNSStateTask=ERROR
 
 # Examples of changing priority of specific categories (classes, packages):
 #


### PR DESCRIPTION
mDNS/Bonjour issues warnings if a mDNS service and client are on the same machine.  This is a normal condition for e.g. JMRI serving as a hub to other applications.  This PR turns those warnings off.