### PR TITLE
ProxySensorManager - pull resistance by hardware type

### DIFF
--- a/java/src/jmri/jmrit/beantable/BeanTableDataModel.java
+++ b/java/src/jmri/jmrit/beantable/BeanTableDataModel.java
@@ -1411,7 +1411,7 @@ abstract public class BeanTableDataModel<T extends NamedBean> extends AbstractTa
 
     private class BtComboboxEditor extends jmri.jmrit.symbolicprog.ValueEditor {
 
-        public BtComboboxEditor(){
+        BtComboboxEditor(){
             super();
         }
 
@@ -1443,7 +1443,7 @@ abstract public class BeanTableDataModel<T extends NamedBean> extends AbstractTa
 
     private class BtValueRenderer implements TableCellRenderer {
 
-        public BtValueRenderer() {
+        BtValueRenderer() {
             super();
         }
 

--- a/java/src/jmri/jmrit/beantable/sensor/SensorTableDataModel.java
+++ b/java/src/jmri/jmrit/beantable/sensor/SensorTableDataModel.java
@@ -24,6 +24,7 @@ import jmri.Manager;
 import jmri.NamedBean;
 import jmri.Sensor;
 import jmri.SensorManager;
+import jmri.managers.ProxySensorManager;
 import jmri.jmrit.beantable.BeanTableDataModel;
 import jmri.util.swing.XTableColumnModel;
 import org.slf4j.Logger;
@@ -265,7 +266,11 @@ public class SensorTableDataModel extends BeanTableDataModel<Sensor> {
             case INACTIVEDELAY:
                 return !sen.getUseDefaultTimerSettings();
             case PULLUPCOL:
-                return (((SensorManager) getManager()).isPullResistanceConfigurable());
+                if ( getManager() instanceof ProxySensorManager ) {
+                    return ((ProxySensorManager)getManager()).isPullResistanceConfigurable(name);
+                }
+                return (((SensorManager) getManager()).isPullResistanceConfigurable()); // proxymanager always false
+                
             default:
                 return super.isCellEditable(row, col);
         }
@@ -314,7 +319,7 @@ public class SensorTableDataModel extends BeanTableDataModel<Sensor> {
      * Small class to ensure type-safety of references otherwise lost to type erasure
      */
     static private class PullResistanceComboBox extends JComboBox<Sensor.PullResistance> {
-        public PullResistanceComboBox(Sensor.PullResistance[] values) { super(values); }
+        PullResistanceComboBox(Sensor.PullResistance[] values) { super(values); }
     }
 
     /**

--- a/java/src/jmri/managers/ProxySensorManager.java
+++ b/java/src/jmri/managers/ProxySensorManager.java
@@ -125,5 +125,15 @@ public class ProxySensorManager extends AbstractProvidingProxyManager<Sensor>
        return false;
     }
 
+    /**
+     * Do the sensor objects provided by the manager for this system name
+     * support configuring an internal pull up or pull down resistor?
+     * @param systemName to select correct manager
+     * @return true if pull up/pull down configuration is supported
+     */
+    public boolean isPullResistanceConfigurable(String systemName){
+        return ((SensorManager) getManagerOrDefault(systemName)).isPullResistanceConfigurable();
+    }
+
     // private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ProxySensorManager.class);
 }


### PR DESCRIPTION
Fixes SensorTable All tab - supported hardware unable to edit PullResistance JComboBox

ProxySensorManager - add isPullResistanceConfigurable(String systemName)
SensorTableDataModel - if proxy SensorManager, use correct manager to query isPullResistanceConfigurable

Fixes some public constructors in private class