### PR TITLE
Improve Global Variable table browser content

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -404,7 +404,7 @@
     <h3>LogixNG</h3>
         <a id="LogixNG" name="LogixNG"></a>
         <ul>
-          <li></li>
+          <li>Update the Global Variable table browser to provide detail information.</li>
         </ul>
 
     <h3>Meters and MeterFrames</h3>

--- a/java/src/jmri/jmrit/beantable/AbstractLogixNGTableAction.java
+++ b/java/src/jmri/jmrit/beantable/AbstractLogixNGTableAction.java
@@ -94,6 +94,8 @@ public abstract class AbstractLogixNGTableAction<E extends NamedBean> extends Ab
 
     protected abstract String getBeanText(E bean);
 
+    protected abstract String getBrowserTitle();
+
     protected abstract String getAddTitleKey();
 
     protected abstract String getCreateButtonHintKey();
@@ -823,7 +825,7 @@ public abstract class AbstractLogixNGTableAction<E extends NamedBean> extends Ab
      * Create and initialize the conditionalNGs browser window.
      */
     void makeBrowserWindow() {
-        JmriJFrame condBrowserFrame = new JmriJFrame(Bundle.getMessage("LogixNG_Browse_Title"), false, true);   // NOI18N
+        JmriJFrame condBrowserFrame = new JmriJFrame(this.getBrowserTitle(), false, true);
 
         condBrowserFrame.addWindowListener(new WindowAdapter() {
             @Override
@@ -949,7 +951,6 @@ public abstract class AbstractLogixNGTableAction<E extends NamedBean> extends Ab
                 updateBrowserText();
             }
         });
-        checkBoxPanel.add(printLineNumbers);
 
         JCheckBox printErrorHandling = new JCheckBox(Bundle.getMessage("LogixNG_Browse_PrintErrorHandling"));
         printErrorHandling.setSelected(_printTreeSettings._printErrorHandling);
@@ -962,7 +963,6 @@ public abstract class AbstractLogixNGTableAction<E extends NamedBean> extends Ab
                 updateBrowserText();
             }
         });
-        checkBoxPanel.add(printErrorHandling);
 
         JCheckBox printNotConnectedSockets = new JCheckBox(Bundle.getMessage("LogixNG_Browse_PrintNotConnectedSocket"));
         printNotConnectedSockets.setSelected(_printTreeSettings._printNotConnectedSockets);
@@ -975,7 +975,6 @@ public abstract class AbstractLogixNGTableAction<E extends NamedBean> extends Ab
                 });
             }
         });
-        checkBoxPanel.add(printNotConnectedSockets);
 
         JCheckBox printLocalVariables = new JCheckBox(Bundle.getMessage("LogixNG_Browse_PrintLocalVariables"));
         printLocalVariables.setSelected(_printTreeSettings._printLocalVariables);
@@ -988,7 +987,6 @@ public abstract class AbstractLogixNGTableAction<E extends NamedBean> extends Ab
                 });
             }
         });
-        checkBoxPanel.add(printLocalVariables);
 
         JCheckBox printSystemNames = new JCheckBox(Bundle.getMessage("LogixNG_Browse_PrintSystemNames"));
         printSystemNames.setSelected(_printTreeSettings._printSystemNames);
@@ -1001,7 +999,14 @@ public abstract class AbstractLogixNGTableAction<E extends NamedBean> extends Ab
                 updateBrowserText();
             }
         });
-        checkBoxPanel.add(printSystemNames);
+
+        if (this instanceof LogixNGTableAction || this instanceof LogixNGModuleTableAction) {
+            checkBoxPanel.add(printLineNumbers);
+            checkBoxPanel.add(printErrorHandling);
+            checkBoxPanel.add(printNotConnectedSockets);
+            checkBoxPanel.add(printLocalVariables);
+            checkBoxPanel.add(printSystemNames);
+        }
 
         return checkBoxPanel;
     }

--- a/java/src/jmri/jmrit/beantable/BeanTableBundle.properties
+++ b/java/src/jmri/jmrit/beantable/BeanTableBundle.properties
@@ -122,26 +122,28 @@ SysNameToolTip                       = <html>Enter System Name for this new item
 AddEntryToolTipLine1                 = <html>{0} {1} use one of these patterns:<br>{2}</html>
 
 # leave 1 space at the end of the following values to display nicely in Border
-LabelTurnoutNumber                   = Turnout 1 
-LabelSecondNumber                    = Turnout 2 
-LabelGreenTurnoutNumber              = Green output 
-LabelYellowTurnoutNumber             = Yellow output 
-LabelRedTurnoutNumber                = Red output 
-LabelLunarTurnoutNumber              = Lunar output 
-LabelBlueTurnoutNumber               = Blue output 
-LabelFlashGreenTurnoutNumber         = Flashing Green output 
-LabelFlashYellowTurnoutNumber        = Flashing Yellow output 
-LabelFlashRedTurnoutNumber           = Flashing Red output 
-LabelDarkTurnoutNumber               = Dark output 
-LabelSignalheadNumber                = Signal Head ID 
+# The trailing space has been changed to a UTF string at 5.1.6.  This way the space
+# is retained when using an editor that removes trailing spaces.
+LabelTurnoutNumber                   = Turnout 1\u0020
+LabelSecondNumber                    = Turnout 2\u0020
+LabelGreenTurnoutNumber              = Green output\u0020
+LabelYellowTurnoutNumber             = Yellow output\u0020
+LabelRedTurnoutNumber                = Red output\u0020
+LabelLunarTurnoutNumber              = Lunar output\u0020
+LabelBlueTurnoutNumber               = Blue output\u0020
+LabelFlashGreenTurnoutNumber         = Flashing Green output\u0020
+LabelFlashYellowTurnoutNumber        = Flashing Yellow output\u0020
+LabelFlashRedTurnoutNumber           = Flashing Red output\u0020
+LabelDarkTurnoutNumber               = Dark output\u0020
+LabelSignalheadNumber                = Signal Head ID\u0020
 LabelAspectType                      = Aspect
 LabelAspects                         = Aspects
 LabelMaxSpeed                        = Max Speed
-LabelTurnoutClosedAppearance         = Appearance when Closed 
-LabelTurnoutThrownAppearance         = Appearance when Thrown 
+LabelTurnoutClosedAppearance         = Appearance when Closed\u0020
+LabelTurnoutThrownAppearance         = Appearance when Thrown\u0020
 LabelNumberToAdd                     = Number of items:
 LabelAutoSysName                     = Automatically generate System Name
-LabelAspectNumbering                 = Appearance Numbering 
+LabelAspectNumbering                 = Appearance Numbering\u0020
 
 SystemConnectionLabel                = System Connection:
 LightSystemHint                      = Select a system connection for the new Light
@@ -583,9 +585,9 @@ UpdateToSystemName                   = Do you want to update references to this 
 #Used with the add/edit SignalHead
 HomeSignal                           = Home
 DistantSignal                        = Distant
-UseAs                                = Signal Head Positioning 
+UseAs                                = Signal Head Positioning\u0020
 InputNum                             = Input{0}
-NumberOfAppearances                  = Number of Outputs/Appearances 
+NumberOfAppearances                  = Number of Outputs/Appearances\u0020
 HeadType                             = Head Type
 OutputComment                        = {0}:{1}:{2}
 SignalHeadSysNameTooltip             = Enter system name for this new Signal Head, e.g. LH12
@@ -638,7 +640,7 @@ DisableAspectsLabel                  = Disable specific Aspects
 DisableAspect                        = Disable Aspect
 
 MatrixBitsLabel                      = Number of logic outputs
-MatrixOutputLabel                    = Output {0} 
+MatrixOutputLabel                    = Output {0}\u0020
 AspectMastBitsWarning                = Matrix is incomplete or showing duplicates.\nHint: at least {0} outputs needed for {1} active Aspects.
 AspectMatrixHeaderLabel              = For each enabled Aspect, check a unique combination of Outputs 1 to {0}:
 AspectMatrixHeaderTooltip            = Box checked = On = Closed; unchecked = Off = Thrown
@@ -797,7 +799,13 @@ LogixNGError31                       = Copy of LogixNG "{0}" in progress.  Pleas
 LogixNGError32                       = Cannot edit two LogixNGs at the same time. Please complete edit of LogixNG "{0}" and try again.
 # LogixNGWarn8                         = Conditionals in Logix "{0}" ({1}) cannot be edited.\nGo to the Sensor Group Table to edit sensor groups.
 
-LogixNG_Browse_Title                    = LogixNG/Module Browser
+LogixNG_Browse_Title                    = LogixNG Browser
+LogixNG_Module_Browse_Title             = LogixNG Module Browser
+LogixNG_Table_Browse_Title              = LogixNG Table Browser
+LogixNG_GlobalVar_Browse_Title          = LogixNG Global Variable Browser
+LogixNG_GlobalVar_Browse_Header         = Global Variable: {0} - {1} :: initial type = {2}
+LogixNG_GlobalVar_Browse_Value          = \n    value:\u0020\u0020
+
 LogixNG_Browse_PrintLineNumbers         = Print line numbers
 LogixNG_Browse_PrintErrorHandling       = Print error handling
 LogixNG_Browse_PrintNotConnectedSocket  = Print not connected sockets

--- a/java/src/jmri/jmrit/beantable/LogixNGGlobalVariableTableAction.java
+++ b/java/src/jmri/jmrit/beantable/LogixNGGlobalVariableTableAction.java
@@ -130,6 +130,7 @@ public class LogixNGGlobalVariableTableAction extends AbstractLogixNGTableAction
         return false;
     }
 
+    @SuppressWarnings("unchecked")  // Checked cast is not possible due to type erasure
     @Override
     protected String getBeanText(GlobalVariable e) {
         var content = new StringBuilder(Bundle.getMessage("LogixNG_GlobalVar_Browse_Header",

--- a/java/src/jmri/jmrit/beantable/LogixNGGlobalVariableTableAction.java
+++ b/java/src/jmri/jmrit/beantable/LogixNGGlobalVariableTableAction.java
@@ -4,6 +4,8 @@ import java.awt.Container;
 import java.awt.FlowLayout;
 import java.awt.event.ItemEvent;
 import java.beans.PropertyVetoException;
+import java.util.List;
+import java.util.Map;
 
 import javax.annotation.Nonnull;
 import javax.swing.*;
@@ -130,7 +132,36 @@ public class LogixNGGlobalVariableTableAction extends AbstractLogixNGTableAction
 
     @Override
     protected String getBeanText(GlobalVariable e) {
-        return e.toString();
+        var content = new StringBuilder(Bundle.getMessage("LogixNG_GlobalVar_Browse_Header",
+                e.getSystemName(),
+                e.getUserName(),
+                e.getInitialValueType()));
+        content.append(Bundle.getMessage("LogixNG_GlobalVar_Browse_Value"));
+        var value = e.getValue();
+
+        if (value instanceof Map) {
+            var map = ((Map<? extends Object, ? extends Object>)value);
+            for (var entry : map.entrySet()) {
+                var line = String.format("%n        %s -> %s",
+                        entry.getKey(),
+                        entry.getValue());
+                content.append(line);
+            }
+        } else if (value instanceof List) {
+            var list = ((List<? extends Object>)value);
+            for (int i=0; i < list.size(); i++) {
+                var line = String.format("%n        %s", list.get(i));
+                content.append(line);
+            }
+        } else {
+            content.append(value);
+        }
+        return content.toString();
+    }
+
+    @Override
+    protected String getBrowserTitle() {
+        return Bundle.getMessage("LogixNG_GlobalVar_Browse_Title");
     }
 
     @Override

--- a/java/src/jmri/jmrit/beantable/LogixNGModuleTableAction.java
+++ b/java/src/jmri/jmrit/beantable/LogixNGModuleTableAction.java
@@ -130,6 +130,11 @@ public class LogixNGModuleTableAction extends AbstractLogixNGTableAction<jmri.jm
     }
 
     @Override
+    protected String getBrowserTitle() {
+        return Bundle.getMessage("LogixNG_Module_Browse_Title");
+    }
+
+    @Override
     protected String getAddTitleKey() {
         return "TitleAddLogixNGModule";
     }

--- a/java/src/jmri/jmrit/beantable/LogixNGTableAction.java
+++ b/java/src/jmri/jmrit/beantable/LogixNGTableAction.java
@@ -166,6 +166,11 @@ public class LogixNGTableAction extends AbstractLogixNGTableAction<LogixNG> {
     }
 
     @Override
+    protected String getBrowserTitle() {
+        return Bundle.getMessage("LogixNG_Browse_Title");
+    }
+
+    @Override
     protected String getAddTitleKey() {
         return "TitleAddLogixNG";
     }

--- a/java/src/jmri/jmrit/beantable/LogixNGTableTableAction.java
+++ b/java/src/jmri/jmrit/beantable/LogixNGTableTableAction.java
@@ -183,6 +183,11 @@ public class LogixNGTableTableAction extends AbstractLogixNGTableAction<NamedTab
     }
 
     @Override
+    protected String getBrowserTitle() {
+        return Bundle.getMessage("LogixNG_Table_Browse_Title");
+    }
+
+    @Override
     protected String getAddTitleKey() {
         return "TitleLogixNGTableTable";
     }


### PR DESCRIPTION
- Provide detail when using the Global Variable table browser selection.
- Change the LogixNG table browsers to use a table specific window title.
- Remove the browser options from the Table and Global Variable browser windows.
