### PR TITLE
Delete all ConditionalNGs of a LogixNG. Add boolean XOR to LogixNG Formula

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -405,6 +405,7 @@
         <a id="LogixNG" name="LogixNG"></a>
         <ul>
           <li>Update the Global Variable table browser to provide detail information.</li>
+          <li>LogixNG Formula now supports the boolean XOR operator <i>^^</i>.</li>
         </ul>
 
     <h3>Meters and MeterFrames</h3>

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -404,6 +404,8 @@
     <h3>LogixNG</h3>
         <a id="LogixNG" name="LogixNG"></a>
         <ul>
+          <li>Fixes a serious bug when deleting a LogixNG. Not all ConditionalNGs of
+          that LogixNG was deleted but that's fixed now.</li>
           <li>Update the Global Variable table browser to provide detail information.</li>
           <li>LogixNG Formula now supports the boolean XOR operator <i>^^</i>.</li>
         </ul>

--- a/java/src/jmri/jmrit/logixng/LogixNGPreferences.java
+++ b/java/src/jmri/jmrit/logixng/LogixNGPreferences.java
@@ -83,25 +83,25 @@ public interface LogixNGPreferences {
 
     /**
      * Set whether row in tree editor should be highlighted or not.
-     * @param value true if the row should be highlighted, false not
+     * @param value true if the row should be highlighted, false otherwise
      */
     public void setTreeEditorHighlightRow(boolean value);
 
     /**
      * Get whether row in tree editor should be highlighted or not.
-     * @return true if the row should be highlighted, false not
+     * @return true if the row should be highlighted, false otherwise
      */
     public boolean getTreeEditorHighlightRow();
 
     /**
-     * Set whether system names should be shown or not.
-     * @param value true if the row should be highlighted, false not
+     * Set whether system names should be shown or not in exceptions.
+     * @param value true if system names should be shown, false otherwise
      */
     public void setShowSystemNameInException(boolean value);
 
     /**
-     * Get whether system names should be shown or not.
-     * @return true if the row should be highlighted, false not
+     * Get whether system names should be shown or not in exceptions.
+     * @return true if the system names should be shown, false otherwise
      */
     public boolean getShowSystemNameInException();
 

--- a/java/src/jmri/jmrit/logixng/implementation/DefaultConditionalNGManager.java
+++ b/java/src/jmri/jmrit/logixng/implementation/DefaultConditionalNGManager.java
@@ -241,19 +241,17 @@ public class DefaultConditionalNGManager extends AbstractManager<ConditionalNG>
             vc.vetoableChange(evt);
         }
     }
-    
+
     /** {@inheritDoc} */
     @Override
 //    @OverridingMethodsMustInvokeSuper
     public final void deleteBean(@Nonnull ConditionalNG conditionalNG, @Nonnull String property) throws PropertyVetoException {
-        for (int i=0; i < conditionalNG.getChildCount(); i++) {
-            FemaleSocket child = conditionalNG.getChild(i);
-            if (child.isConnected()) {
-                MaleSocket maleSocket = child.getConnectedSocket();
-                maleSocket.getManager().deleteBean(maleSocket, property);
-            }
+        FemaleSocket child = conditionalNG.getFemaleSocket();
+        if (child.isConnected()) {
+            MaleSocket maleSocket = child.getConnectedSocket();
+            maleSocket.getManager().deleteBean(maleSocket, property);
         }
-        
+
         // throws PropertyVetoException if vetoed
         fireVetoableChange(property, conditionalNG);
         if (property.equals("DoDelete")) { // NOI18N
@@ -263,7 +261,7 @@ public class DefaultConditionalNGManager extends AbstractManager<ConditionalNG>
             conditionalNG.dispose();
         }
     }
-    
-    
+
+
     private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(DefaultConditionalNGManager.class);
 }

--- a/java/src/jmri/jmrit/logixng/implementation/DefaultLogixNGManager.java
+++ b/java/src/jmri/jmrit/logixng/implementation/DefaultLogixNGManager.java
@@ -425,7 +425,7 @@ public class DefaultLogixNGManager extends AbstractManager<LogixNG>
     @Override
 //    @OverridingMethodsMustInvokeSuper
     public final void deleteBean(@Nonnull LogixNG logixNG, @Nonnull String property) throws PropertyVetoException {
-        for (int i=0; i < logixNG.getNumConditionalNGs(); i++) {
+        for (int i=logixNG.getNumConditionalNGs()-1; i >= 0; i--) {
             ConditionalNG child = logixNG.getConditionalNG(i);
             InstanceManager.getDefault(ConditionalNG_Manager.class).deleteBean(child, property);
         }

--- a/java/src/jmri/jmrit/logixng/util/parser/RecursiveDescentParser.java
+++ b/java/src/jmri/jmrit/logixng/util/parser/RecursiveDescentParser.java
@@ -117,7 +117,8 @@ public class RecursiveDescentParser {
 
     private final Rule rule1 = new Rule1();
     private final Rule rule2 = new Rule2();
-    private final Rule rule3 = new Rule3();
+    private final Rule rule3a = new Rule3a();
+    private final Rule rule3b = new Rule3b();
     private final Rule rule4 = new Rule4();
     private final Rule rule5 = new Rule5();
     private final Rule rule6 = new Rule6();
@@ -189,12 +190,12 @@ public class RecursiveDescentParser {
     }
 
 
-    // Rule2 is ternary. <rule3> | <rule3> ? <rule2> : <rule2>
+    // Rule2 is ternary. <rule3a> | <rule3a> ? <rule2> : <rule2>
     private class Rule2 implements Rule {
 
         @Override
         public ExpressionNodeAndState parse(State state) throws ParserException {
-            ExpressionNodeAndState leftSide = rule3.parse(state);
+            ExpressionNodeAndState leftSide = rule3a.parse(state);
             if (leftSide == null) {
                 return null;
             }
@@ -203,7 +204,7 @@ public class RecursiveDescentParser {
                     && ((newState._token._tokenType == TokenType.TERNARY_QUESTION_MARK))) {
 
                 newState = next(newState);
-                ExpressionNodeAndState middleSide = rule3.parse(newState);
+                ExpressionNodeAndState middleSide = rule3a.parse(newState);
 
                 newState = middleSide._state;
 
@@ -211,7 +212,7 @@ public class RecursiveDescentParser {
                         && ((newState._token._tokenType == TokenType.TERNARY_COLON))) {
 
                     newState = next(newState);
-                    ExpressionNodeAndState rightRightSide = rule3.parse(newState);
+                    ExpressionNodeAndState rightRightSide = rule3a.parse(newState);
 
                     ExpressionNode exprNode = new ExpressionNodeTernaryOperator(
                             leftSide._exprNode, middleSide._exprNode, rightRightSide._exprNode);
@@ -227,8 +228,36 @@ public class RecursiveDescentParser {
 
 
     // Logical OR
-    // <rule3> ::= <rule4> | <rule4> || <rule4>
-    private class Rule3 implements Rule {
+    // <rule3a> ::= <rule3b> | <rule3b> || <rule3b>
+    private class Rule3a implements Rule {
+
+        @Override
+        public ExpressionNodeAndState parse(State state) throws ParserException {
+            ExpressionNodeAndState leftSide = rule3b.parse(state);
+            if (leftSide == null) {
+                return null;
+            }
+            State newState = leftSide._state;
+            while ((newState._token != null)
+                    && ((newState._token._tokenType == TokenType.BOOLEAN_OR))) {
+
+                TokenType operatorTokenType = newState._token._tokenType;
+                newState = next(newState);
+                ExpressionNodeAndState rightSide = rule3b.parse(newState);
+
+                ExpressionNode exprNode = new ExpressionNodeBooleanOperator(operatorTokenType, leftSide._exprNode, rightSide._exprNode);
+                leftSide = new ExpressionNodeAndState(exprNode, rightSide._state);
+                newState = rightSide._state;
+            }
+            return leftSide;
+        }
+
+    }
+
+
+    // Logical OR
+    // <rule3b> ::= <rule4> | <rule4> || <rule4>
+    private class Rule3b implements Rule {
 
         @Override
         public ExpressionNodeAndState parse(State state) throws ParserException {
@@ -238,7 +267,7 @@ public class RecursiveDescentParser {
             }
             State newState = leftSide._state;
             while ((newState._token != null)
-                    && ((newState._token._tokenType == TokenType.BOOLEAN_OR))) {
+                    && ((newState._token._tokenType == TokenType.BOOLEAN_XOR))) {
 
                 TokenType operatorTokenType = newState._token._tokenType;
                 newState = next(newState);

--- a/java/src/jmri/jmrit/logixng/util/parser/TokenType.java
+++ b/java/src/jmri/jmrit/logixng/util/parser/TokenType.java
@@ -2,7 +2,7 @@ package jmri.jmrit.logixng.util.parser;
 
 /**
  * Types of tokens.
- * 
+ *
  * https://introcs.cs.princeton.edu/java/11precedence/
  */
 
@@ -29,6 +29,7 @@ public enum TokenType {
     TERNARY_QUESTION_MARK,   // ?
     TERNARY_COLON,           // :
     BOOLEAN_OR,         // ||
+    BOOLEAN_XOR,        // ^^  (Requested by Bob M)
     BOOLEAN_AND,        // &&
     BINARY_OR,          // |
     BINARY_XOR,         // ^

--- a/java/test/jmri/jmrit/logixng/util/parser/ExpressionNodeBooleanOperatorTest.java
+++ b/java/test/jmri/jmrit/logixng/util/parser/ExpressionNodeBooleanOperatorTest.java
@@ -15,24 +15,24 @@ import org.junit.Test;
 
 /**
  * Test ParsedExpression
- * 
+ *
  * @author Daniel Bergqvist 2019
  */
 public class ExpressionNodeBooleanOperatorTest {
 
     @Test
     public void testCtor() throws ParserException {
-        
+
         ExpressionNode exprTrue = new ExpressionNodeTrue();
         ExpressionNode exprFalse = new ExpressionNodeFalse();
-        
+
         Token token = new Token(TokenType.NONE, "1", 0);
         ExpressionNodeFloatingNumber expressionNumber = new ExpressionNodeFloatingNumber(token);
         ExpressionNodeBooleanOperator t = new ExpressionNodeBooleanOperator(TokenType.BOOLEAN_NOT, null, expressionNumber);
         Assert.assertNotNull("exists", t);
-        
+
         AtomicBoolean hasThrown = new AtomicBoolean(false);
-        
+
         // Test right side is null
         try {
             new ExpressionNodeBooleanOperator(TokenType.BOOLEAN_NOT, null, null);
@@ -40,7 +40,7 @@ public class ExpressionNodeBooleanOperatorTest {
             hasThrown.set(true);
         }
         Assert.assertTrue("exception is thrown", hasThrown.get());
-        
+
         // Test invalid token
         try {
             new ExpressionNodeBooleanOperator(TokenType.BINARY_AND, null, null);
@@ -48,7 +48,7 @@ public class ExpressionNodeBooleanOperatorTest {
             hasThrown.set(true);
         }
         Assert.assertTrue("exception is thrown", hasThrown.get());
-        
+
         // AND requires two operands
         try {
             new ExpressionNodeBooleanOperator(TokenType.BOOLEAN_AND, null, exprTrue);
@@ -56,7 +56,7 @@ public class ExpressionNodeBooleanOperatorTest {
             hasThrown.set(true);
         }
         Assert.assertTrue("exception is thrown", hasThrown.get());
-        
+
         // OR requires two operands
         hasThrown.set(false);
         try {
@@ -65,7 +65,7 @@ public class ExpressionNodeBooleanOperatorTest {
             hasThrown.set(true);
         }
         Assert.assertTrue("exception is thrown", hasThrown.get());
-        
+
         // NOT requires only one operands
         hasThrown.set(false);
         try {
@@ -74,7 +74,7 @@ public class ExpressionNodeBooleanOperatorTest {
             hasThrown.set(true);
         }
         Assert.assertTrue("exception is thrown", hasThrown.get());
-        
+
         // BINARY_AND is an unsupported operator
         hasThrown.set(false);
         try {
@@ -84,10 +84,10 @@ public class ExpressionNodeBooleanOperatorTest {
         }
         Assert.assertTrue("exception is thrown", hasThrown.get());
     }
-    
+
     @Test
     public void testCalculate() throws Exception {
-        
+
         ExpressionNode exprTrue1 = new ExpressionNodeTrue();
         ExpressionNode exprTrue2 = new ExpressionNodeTrue();
         ExpressionNode exprTrue3 = new ExpressionNodeIntegerNumber(new Token(TokenType.NONE, "1", 0));
@@ -96,15 +96,15 @@ public class ExpressionNodeBooleanOperatorTest {
         ExpressionNode exprFalse3 = new ExpressionNodeIntegerNumber(new Token(TokenType.NONE, "0", 0));
         ExpressionNode expr12_34 = new ExpressionNodeFloatingNumber(new Token(TokenType.NONE, "12.34", 0));
         ExpressionNode expr25_46 = new ExpressionNodeFloatingNumber(new Token(TokenType.NONE, "25.46", 0));
-       
-        
+
+
         SymbolTable symbolTable = new DefaultSymbolTable(new DefaultConditionalNG("IQC1", null));
-        
+
         Assert.assertFalse("calculate() gives the correct value",
                 (Boolean)new ExpressionNodeBooleanOperator(TokenType.BOOLEAN_NOT, null, exprTrue1).calculate(symbolTable));
         Assert.assertTrue("calculate() gives the correct value",
                 (Boolean)new ExpressionNodeBooleanOperator(TokenType.BOOLEAN_NOT, null, exprFalse1).calculate(symbolTable));
-        
+
         Assert.assertTrue("calculate() gives the correct value",
                 (Boolean)new ExpressionNodeBooleanOperator(TokenType.BOOLEAN_AND, exprTrue1, exprTrue2).calculate(symbolTable));
         Assert.assertFalse("calculate() gives the correct value",
@@ -113,7 +113,7 @@ public class ExpressionNodeBooleanOperatorTest {
                 (Boolean)new ExpressionNodeBooleanOperator(TokenType.BOOLEAN_AND, exprFalse1, exprFalse2).calculate(symbolTable));
         Assert.assertFalse("calculate() gives the correct value",
                 (Boolean)new ExpressionNodeBooleanOperator(TokenType.BOOLEAN_AND, exprFalse1, exprTrue1).calculate(symbolTable));
-        
+
         Assert.assertTrue("calculate() gives the correct value",
                 (Boolean)new ExpressionNodeBooleanOperator(TokenType.BOOLEAN_OR, exprTrue1, exprTrue2).calculate(symbolTable));
         Assert.assertTrue("calculate() gives the correct value",
@@ -122,7 +122,7 @@ public class ExpressionNodeBooleanOperatorTest {
                 (Boolean)new ExpressionNodeBooleanOperator(TokenType.BOOLEAN_OR, exprFalse1, exprFalse1).calculate(symbolTable));
         Assert.assertTrue("calculate() gives the correct value",
                 (Boolean)new ExpressionNodeBooleanOperator(TokenType.BOOLEAN_OR, exprFalse1, exprTrue1).calculate(symbolTable));
-        
+
         // Test non boolean operands
         Assert.assertTrue("calculate() gives the correct value",
                 (Boolean)new ExpressionNodeBooleanOperator(TokenType.BOOLEAN_OR, exprTrue3, exprTrue2).calculate(symbolTable));
@@ -132,9 +132,9 @@ public class ExpressionNodeBooleanOperatorTest {
                 (Boolean)new ExpressionNodeBooleanOperator(TokenType.BOOLEAN_OR, exprFalse1, exprFalse3).calculate(symbolTable));
         Assert.assertTrue("calculate() gives the correct value",
                 (Boolean)new ExpressionNodeBooleanOperator(TokenType.BOOLEAN_OR, exprFalse3, exprTrue3).calculate(symbolTable));
-        
+
         AtomicBoolean hasThrown = new AtomicBoolean(false);
-        
+
         // ExpressionNodeBooleanOperator requires two operands that can be booleans
         hasThrown.set(false);
         try {
@@ -143,7 +143,7 @@ public class ExpressionNodeBooleanOperatorTest {
             hasThrown.set(true);
         }
         Assert.assertTrue("exception is thrown", hasThrown.get());
-        
+
         // ExpressionNodeBooleanOperator requires two operands that can be booleans
         hasThrown.set(false);
         try {
@@ -152,7 +152,7 @@ public class ExpressionNodeBooleanOperatorTest {
             hasThrown.set(true);
         }
         Assert.assertTrue("exception is thrown", hasThrown.get());
-        
+
         // Test unsupported token type
         hasThrown.set(false);
         try {
@@ -164,15 +164,15 @@ public class ExpressionNodeBooleanOperatorTest {
         }
         Assert.assertTrue("exception is thrown", hasThrown.get());
     }
-    
+
     @Test
     public void testGetDefinitionString() throws ParserException, NoSuchFieldException, IllegalArgumentException, IllegalAccessException {
-        
+
         ExpressionNode exprTrue1 = new ExpressionNodeTrue();
         ExpressionNode exprTrue2 = new ExpressionNodeTrue();
         ExpressionNode exprFalse1 = new ExpressionNodeFalse();
         ExpressionNode exprFalse2 = new ExpressionNodeFalse();
-        
+
         Assert.assertEquals("getDefinitionString() gives the correct value",
                 "!(true)",
                 new ExpressionNodeBooleanOperator(TokenType.BOOLEAN_NOT, null, exprTrue1)
@@ -181,7 +181,7 @@ public class ExpressionNodeBooleanOperatorTest {
                 "!(false)",
                 new ExpressionNodeBooleanOperator(TokenType.BOOLEAN_NOT, null, exprFalse1)
                         .getDefinitionString());
-        
+
         Assert.assertEquals("getDefinitionString() gives the correct value",
                 "(true)&&(true)",
                 new ExpressionNodeBooleanOperator(TokenType.BOOLEAN_AND, exprTrue1, exprTrue2)
@@ -198,7 +198,7 @@ public class ExpressionNodeBooleanOperatorTest {
                 "(false)&&(true)",
                 new ExpressionNodeBooleanOperator(TokenType.BOOLEAN_AND, exprFalse1, exprTrue1)
                         .getDefinitionString());
-        
+
         Assert.assertEquals("getDefinitionString() gives the correct value",
                 "(true)||(true)",
                 new ExpressionNodeBooleanOperator(TokenType.BOOLEAN_OR, exprTrue1, exprTrue2)
@@ -215,9 +215,26 @@ public class ExpressionNodeBooleanOperatorTest {
                 "(false)||(true)",
                 new ExpressionNodeBooleanOperator(TokenType.BOOLEAN_OR, exprFalse1, exprTrue1)
                         .getDefinitionString());
-        
+
+        Assert.assertEquals("getDefinitionString() gives the correct value",
+                "(true)^^(true)",
+                new ExpressionNodeBooleanOperator(TokenType.BOOLEAN_XOR, exprTrue1, exprTrue2)
+                        .getDefinitionString());
+        Assert.assertEquals("getDefinitionString() gives the correct value",
+                "(true)^^(false)",
+                new ExpressionNodeBooleanOperator(TokenType.BOOLEAN_XOR, exprTrue1, exprFalse1)
+                        .getDefinitionString());
+        Assert.assertEquals("getDefinitionString() gives the correct value",
+                "(false)^^(false)",
+                new ExpressionNodeBooleanOperator(TokenType.BOOLEAN_XOR, exprFalse1, exprFalse2)
+                        .getDefinitionString());
+        Assert.assertEquals("getDefinitionString() gives the correct value",
+                "(false)^^(true)",
+                new ExpressionNodeBooleanOperator(TokenType.BOOLEAN_XOR, exprFalse1, exprTrue1)
+                        .getDefinitionString());
+
         AtomicBoolean hasThrown = new AtomicBoolean(false);
-        
+
         // Test unsupported token type
         hasThrown.set(false);
         try {
@@ -229,7 +246,7 @@ public class ExpressionNodeBooleanOperatorTest {
         }
         Assert.assertTrue("exception is thrown", hasThrown.get());
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() {
@@ -241,5 +258,5 @@ public class ExpressionNodeBooleanOperatorTest {
         LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/util/parser/RecursiveDescentParserTest.java
+++ b/java/test/jmri/jmrit/logixng/util/parser/RecursiveDescentParserTest.java
@@ -391,7 +391,7 @@ public class RecursiveDescentParserTest {
     }
 
 
-    // Rule2 is ternary. <rule3> | <rule3> ? <rule2> : <rule2>
+    // Rule2 is ternary. <rule3a> | <rule3a> ? <rule2> : <rule2>
     @Test
     public void testRule2() throws JmriException {
         SymbolTable symbolTable = new DefaultSymbolTable(new DefaultConditionalNG("IQC1", null));
@@ -427,9 +427,9 @@ public class RecursiveDescentParserTest {
 
 
     // Logical OR
-    // <rule3> ::= <rule4> | <rule4> || <rule4>
+    // <rule3a> ::= <rule3b> | <rule3b> || <rule3b>
     @Test
-    public void testRule3() throws JmriException {
+    public void testRule3a() throws JmriException {
         SymbolTable symbolTable = new DefaultSymbolTable(new DefaultConditionalNG("IQC1", null));
         Map<String, Variable> variables = new HashMap<>();
         RecursiveDescentParser t = new RecursiveDescentParser(variables);
@@ -444,6 +444,29 @@ public class RecursiveDescentParserTest {
 
         exprNode = t.parseExpression("(2 < 2) || (1 > 2)");
         Assert.assertEquals("expression matches", "((IntNumber:2)<(IntNumber:2))||((IntNumber:1)>(IntNumber:2))", exprNode.getDefinitionString());
+        Assert.assertFalse("calculate is correct", (Boolean)exprNode.calculate(symbolTable));
+
+    }
+
+
+    // Logical XOR
+    // <rule3b> ::= <rule4> | <rule4> || <rule4>
+    @Test
+    public void testRule3b() throws JmriException {
+        SymbolTable symbolTable = new DefaultSymbolTable(new DefaultConditionalNG("IQC1", null));
+        Map<String, Variable> variables = new HashMap<>();
+        RecursiveDescentParser t = new RecursiveDescentParser(variables);
+
+        ExpressionNode exprNode = t.parseExpression("(1 < 2) ^^ (5 > 2)");
+        Assert.assertEquals("expression matches", "((IntNumber:1)<(IntNumber:2))^^((IntNumber:5)>(IntNumber:2))", exprNode.getDefinitionString());
+        Assert.assertFalse("calculate is correct", (Boolean)exprNode.calculate(symbolTable));
+
+        exprNode = t.parseExpression("(1 < 2) ^^ (1 > 2)");
+        Assert.assertEquals("expression matches", "((IntNumber:1)<(IntNumber:2))^^((IntNumber:1)>(IntNumber:2))", exprNode.getDefinitionString());
+        Assert.assertTrue("calculate is correct", (Boolean)exprNode.calculate(symbolTable));
+
+        exprNode = t.parseExpression("(2 < 2) ^^ (1 > 2)");
+        Assert.assertEquals("expression matches", "((IntNumber:2)<(IntNumber:2))^^((IntNumber:1)>(IntNumber:2))", exprNode.getDefinitionString());
         Assert.assertFalse("calculate is correct", (Boolean)exprNode.calculate(symbolTable));
 
     }


### PR DESCRIPTION
@dsand47 @devel-bobm 

@devel-bobm requested a boolean XOR operator for LogixNG formula and this PR adds the `^^` boolean XOR operator.

This PR fixes the JavaDoc errors in PR #11450.

This PR fixes Issue #11495, Incomplete delete of LogixNG. The problem was this code in `deleteBean()` in the LogixNG_Manager:
```
for (int i=0; i < logixNG.getNumConditionalNGs(); i++) {
    ConditionalNG child = logixNG.getConditionalNG(i);
    InstanceManager.getDefault(ConditionalNG_Manager.class).deleteBean(child, property);
}
```
When `property` is `DoDelete`, the ConditionalNG is deleted and removed. So this loop removes the first, the third, the fifth and so on. I changed the loop to do the removal from the end instead so now it works. I'm very surprised we haven't discovered this bug before.