### PR TITLE
Add "Paste copy" to the ConditionalNG editor

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -408,6 +408,9 @@
           that LogixNG was deleted but that's fixed now.</li>
           <li>Update the Global Variable table browser to provide detail information.</li>
           <li>LogixNG Formula now supports the boolean XOR operator <i>^^</i>.</li>
+          <li>The ConditionalNG editor and the Module editor now have the option
+          <i>Paste copy</i>. With it, you can paste from the clipboard as many times
+          as needed.</li>
         </ul>
 
     <h3>Meters and MeterFrames</h3>

--- a/java/src/jmri/jmrit/logixng/tools/swing/LogixNGSwingBundle.properties
+++ b/java/src/jmri/jmrit/logixng/tools/swing/LogixNGSwingBundle.properties
@@ -161,6 +161,7 @@ PopupMenuRemove     = Remove
 PopupMenuCut        = Cut
 PopupMenuCopy       = Copy
 PopupMenuPaste      = Paste
+PopupMenuPasteCopy  = Paste copy
 PopupMenuEnable     = Enable
 PopupMenuDisable    = Disable
 PopupMenuLock       = Lock


### PR DESCRIPTION
@dsand47 
The ConditionalNG editor and the Module editor now have the option `Paste copy`. With it, you can paste from the clipboard as many times as needed.

`Paste` has Ctrl+V (Cmd+V), so `Paste copy` got Ctrl+Shift+V (Ctrl+Shift+Cmd)

It's a response to: https://groups.io/g/jmriusers/topic/94209163

This PR also fixes a bug which happens if the user presses `Ctrl+V` without anything in the clipboard.