### PR TITLE
LocoNet Monitor Slots - Add Save to csv

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -76,7 +76,7 @@
 
         <h4>LocoNet</h4>
             <ul>
-                <li></li>
+                <li>Slot Monitor Table can be saved to CSV File via new File Menu.</li>
             </ul>
 
         <h4>Maple</h4>

--- a/java/src/jmri/NamedBeanBundle.properties
+++ b/java/src/jmri/NamedBeanBundle.properties
@@ -285,6 +285,8 @@ MenuItemLoad                     = Load
 FileMenuItemLoad                 = Load table content and panels...
 FileMenuItemStore                = Store ALL table content and panels...
 FileMenuItemHistory              = Show file history
+ExportCsvAll                     = Export to CSV File - Entire Table
+ExportCsvView                    = Export to CSV File - Current View
 
 # from jmrit/Bundle, to access from jmrix/nce as well
 MenuTools                        = Tools

--- a/java/src/jmri/jmrix/can/cbus/CbusBundle.properties
+++ b/java/src/jmri/jmrix/can/cbus/CbusBundle.properties
@@ -276,9 +276,6 @@ SendToggleTip           = Toggle between sending On and Off events.
 
 NewTsl                  = New Turnout / Sensor / Light
 
-ExportCsvAll            = Export to CSV File - Entire Table
-ExportCsvView           = Export to CSV File - Current View
-
 SaveEvSession           = Save / Restore Events between sessions
 ResetSessionCount       = Reset Session Count
 

--- a/java/src/jmri/jmrix/loconet/slotmon/SlotMonDataModel.java
+++ b/java/src/jmri/jmrix/loconet/slotmon/SlotMonDataModel.java
@@ -52,7 +52,7 @@ public class SlotMonDataModel extends javax.swing.table.AbstractTableModel imple
         this.memo = memo;
 
         // connect to SlotManager for updates
-        memo.getSlotManager().addSlotListener(this);
+        memo.getSlotManager().addSlotListener(SlotMonDataModel.this);
 
         // start update process
         memo.getSlotManager().update();
@@ -591,6 +591,7 @@ public class SlotMonDataModel extends javax.swing.table.AbstractTableModel imple
         }
     }
 
+    // gets called on SlotMonPane.dispose
     public void dispose() {
         memo.getSlotManager().removeSlotListener(this);
     }

--- a/java/src/jmri/jmrix/loconet/slotmon/SlotMonPane.java
+++ b/java/src/jmri/jmrix/loconet/slotmon/SlotMonPane.java
@@ -2,22 +2,18 @@ package jmri.jmrix.loconet.slotmon;
 
 import java.awt.FlowLayout;
 import java.awt.event.ActionEvent;
-import javax.swing.BoxLayout;
-import javax.swing.JButton;
-import javax.swing.JCheckBox;
-import javax.swing.JPanel;
-import javax.swing.JScrollPane;
-import javax.swing.JTable;
-import javax.swing.RowFilter;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.swing.*;
 import javax.swing.table.TableCellEditor;
 import javax.swing.table.TableColumnModel;
 import javax.swing.table.TableRowSorter;
+
 import jmri.InstanceManager;
 import jmri.jmrix.loconet.LnConstants;
-import jmri.jmrix.loconet.LocoNetSystemConnectionMemo;
 import jmri.swing.JmriJTablePersistenceManager;
-import jmri.util.table.ButtonEditor;
-import jmri.util.table.ButtonRenderer;
+import jmri.util.table.*;
 
 /**
  * Frame providing a command station slot manager.
@@ -213,6 +209,24 @@ public class SlotMonPane extends jmri.jmrix.loconet.swing.LnPanel {
             }
         };
         sorter.setRowFilter(rf);
+    }
+
+    @Override
+    public List<JMenu> getMenus() {
+        List<JMenu> menuList = new ArrayList<>();
+        menuList.add(getFileMenu());
+        return menuList;
+    }
+
+    private JMenu getFileMenu(){
+        JMenu fileMenu = new JMenu(Bundle.getMessage("MenuFile")); // NOI18N
+        fileMenu.add(new JTableToCsvAction((Bundle.getMessage("ExportCsvAll")),
+            null, slotModel, "Slot_Monitor_All.csv", new int[]{
+            SlotMonDataModel.ESTOPCOLUMN})); // NOI18N
+        fileMenu.add(new JTableToCsvAction((Bundle.getMessage("ExportCsvView")),
+            slotTable, slotModel, "Slot_Monitor_View.csv", new int[]{
+            SlotMonDataModel.ESTOPCOLUMN})); // NOI18N
+        return fileMenu;
     }
 
 }

--- a/java/src/jmri/jmrix/loconet/slotmon/TODO
+++ b/java/src/jmri/jmrix/loconet/slotmon/TODO
@@ -1,5 +1,0 @@
-
-
-When SlotMonFrame is closed, it doesn't disconnect from the SlotManager.  Is this an error?
-Does it leak memory?
-


### PR DESCRIPTION
LocoNet SlotMonPane -
Adds File Menu with 2 options -
Export to CSV File - Entire Table
Export to CSV File - Current View
E-Stop column is not included in the export.