### PR TITLE
MergMessage / CAN tweaks

### DIFF
--- a/java/src/jmri/jmrix/can/AbstractCanTrafficController.java
+++ b/java/src/jmri/jmrix/can/AbstractCanTrafficController.java
@@ -79,7 +79,7 @@ abstract public class AbstractCanTrafficController
         byte msg[] = new byte[lengthOfByteStream(hm)];
 
         // add header
-        int offset = addHeaderToOutput(msg, hm);
+        int offset = addHeaderToOutput(msg, hm); // always returns 0
 
         // add data content
         int len = hm.getNumDataElements();
@@ -222,9 +222,7 @@ abstract public class AbstractCanTrafficController
         distributeOneReply(msg, mLastSender);
 
         if (!msg.isUnsolicited()) {
-            if (log.isDebugEnabled()) {
-                log.debug("switch on state {}", mCurrentState);
-            }
+            log.debug("switch on state {}", mCurrentState);
             // effect on transmit:
             switch (mCurrentState) {
 
@@ -280,9 +278,7 @@ abstract public class AbstractCanTrafficController
                 default: {
                     replyInDispatch = false;
                     if (allowUnexpectedReply == true) {
-                        if (log.isDebugEnabled()) {
-                            log.debug("Allowed unexpected reply received in state: {} was {}", mCurrentState, msg.toString());
-                        }
+                        log.debug("Allowed unexpected reply received in state: {} was {}", mCurrentState, msg);
                     } else {
                         unexpectedReplyStateError(mCurrentState,msg.toString());
                     }

--- a/java/test/jmri/jmrix/can/adapters/gridconnect/canrs/MergMessageTest.java
+++ b/java/test/jmri/jmrix/can/adapters/gridconnect/canrs/MergMessageTest.java
@@ -1,7 +1,7 @@
 package jmri.jmrix.can.adapters.gridconnect.canrs;
 
 import jmri.jmrix.can.CanMessage;
-import jmri.jmrix.can.TrafficControllerScaffold;
+import jmri.util.JUnitAppender;
 import jmri.util.JUnitUtil;
 
 import org.junit.Assert;
@@ -51,11 +51,26 @@ public class MergMessageTest extends jmri.jmrix.AbstractMessageTestBase {
         Assert.assertEquals("extended format 4 byte", ":X91A85678R12345678;", g.toString());
     }
 
+    @Test
+    public void testByteOutOfRange() {
+            g.setByte(-99, 0);
+            JUnitAppender.assertErrorMessageStartsWith("Byte value -99 out of range 0-255 for MergMessage data payload");
+            
+            g.setByte(321, 0);
+            JUnitAppender.assertErrorMessageStartsWith("Byte value 321 out of range 0-255 for MergMessage data payload");
+            
+            g.setByte(0xAA, 22);
+            JUnitAppender.assertErrorMessageStartsWith("Byte Index 22 out of range 0-7 for MergMessage data payload");
+            
+            g.setByte(0xAA, -1);
+            JUnitAppender.assertErrorMessageStartsWith("Byte Index -1 out of range 0-7 for MergMessage data payload");
+    }
+
     @Override
     @BeforeEach
     public void setUp() {
-        jmri.util.JUnitUtil.setUp();
-        new TrafficControllerScaffold();
+        JUnitUtil.setUp();
+
         CanMessage msg = new CanMessage(0x123);
         msg.setExtended(false);
         msg.setRtr(false);
@@ -68,6 +83,7 @@ public class MergMessageTest extends jmri.jmrix.AbstractMessageTestBase {
         m = g = new MergMessage(msg);
     }
 
+    @Override
     @AfterEach
     public void tearDown() {
         m = g = null;

--- a/java/test/jmri/jmrix/can/adapters/gridconnect/canrs/MergTrafficControllerTest.java
+++ b/java/test/jmri/jmrix/can/adapters/gridconnect/canrs/MergTrafficControllerTest.java
@@ -4,6 +4,7 @@ import java.io.*;
 
 import jmri.jmrix.*;
 import jmri.jmrix.can.*;
+import jmri.util.JUnitAppender;
 import jmri.util.JUnitUtil;
 
 import org.junit.Assert;
@@ -110,6 +111,27 @@ public class MergTrafficControllerTest extends jmri.jmrix.can.adapters.gridconne
         ltc.disconnectPort(pcs);
         memo.dispose();
 
+    }
+
+    @Test
+    public void testGetNewMessage() {
+        Assertions.assertInstanceOf(MergMessage.class, ((MergTrafficController)tc).newMessage());
+    } 
+
+    @Test
+    public void testErrorOnIncorrectReply() {
+        ((MergTrafficController)tc).decodeFromHardware(new NotAMergReply());
+        JUnitAppender.assertErrorMessageStartsWith("NotAMergReply is not a MergReply");
+    }
+
+    private static class NotAMergReply extends AbstractMRReply {
+        NotAMergReply(){
+            super("NotAMergReply");
+        }
+        @Override
+        protected int skipPrefix(int index) {
+            return 0;
+        }
     }
 
     @Override


### PR DESCRIPTION
MergMessage -
Improve constructor
Simplify debug
add error with exception traceback when setByte Byte Index out of range.

AbstractCanTrafficController - simplify debug

MergMessageTest - add tests for setByte out of range
MergTrafficControllerTest - add a few new tests