### PR TITLE
fix SimpleClockBundle_fr , update error msg for dateformat

### DIFF
--- a/java/src/jmri/jmrit/simpleclock/SimpleClockBundle.properties
+++ b/java/src/jmri/jmrit/simpleclock/SimpleClockBundle.properties
@@ -72,6 +72,6 @@ IncorrectRate = Rate {0} is outside of reasonable range {1} - {2}
 BeanNameTime = Time
 
 # for more info on the following format, see
-# http://java.sun.com/j2se/1.4.2/docs/api/java/text/SimpleDateFormat.html
+# https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/text/SimpleDateFormat.html
 TimeStorageFormat = h:mm a
 StartupSimpleClockAction=Open Fast Clock Configuration

--- a/java/src/jmri/jmrit/simpleclock/SimpleClockBundle_ca.properties
+++ b/java/src/jmri/jmrit/simpleclock/SimpleClockBundle_ca.properties
@@ -62,6 +62,6 @@ NonIntegerError = Error d'entrada el rellotge f\u00edsic necessita un valor ente
 BeanNameTime = Temps
 
 # for more info on the following format, see
-# http://java.sun.com/j2se/1.4.2/docs/api/java/text/SimpleDateFormat.html
+# https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/text/SimpleDateFormat.html
 TimeStorageFormat = h:mm a
 StartupSimpleClockAction=Obre Configuraci\u00f3 de Velocitat del Rellotge

--- a/java/src/jmri/jmrit/simpleclock/SimpleClockBundle_cs.properties
+++ b/java/src/jmri/jmrit/simpleclock/SimpleClockBundle_cs.properties
@@ -58,7 +58,7 @@ NonIntegerError = Chyba v zad\u00e1n\u00ed - va\u0161e hardwarov\u00e9 hodiny po
 BeanNameTime = \u010cas
 
 # for more info on the following format, see
-# http://java.sun.com/j2se/1.4.2/docs/api/java/text/SimpleDateFormat.html
+# https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/text/SimpleDateFormat.html
 TimeStorageFormat = HH:mm
 DisplayOnOff=Zobrazit tla\u010d\u00edtko Spustit/Zastavit na hodin\u00e1ch
 StartBoxLabel=Spustit s modelov\u00fdmi hodinami

--- a/java/src/jmri/jmrit/simpleclock/SimpleClockBundle_da.properties
+++ b/java/src/jmri/jmrit/simpleclock/SimpleClockBundle_da.properties
@@ -58,6 +58,6 @@ NonIntegerError    = Fejl i indtastningen - Your hardware clock requires an inte
 BeanNameTime        = Tid
 
 # for more info on the following format, see
-# http://java.sun.com/j2se/1.4.2/docs/api/java/text/SimpleDateFormat.html
+# https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/text/SimpleDateFormat.html
 TimeStorageFormat   = h:mm a
 StartupSimpleClockAction=\u00c5bn Hurtig Ur Konfiguration

--- a/java/src/jmri/jmrit/simpleclock/SimpleClockBundle_de.properties
+++ b/java/src/jmri/jmrit/simpleclock/SimpleClockBundle_de.properties
@@ -61,6 +61,6 @@ NonIntegerErrorCantChangeSource = Systemuhr ben\u00f6tigt einen ganzzahligen Zei
 BeanNameTime = Zeit
 
 # for more info on the following format, see
-# http://java.sun.com/j2se/1.4.2/docs/api/java/text/SimpleDateFormat.html
+# https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/text/SimpleDateFormat.html
 TimeStorageFormat = h:mm a
 StartupSimpleClockAction=\u00d6ffne Spieluhrkonfigurator

--- a/java/src/jmri/jmrit/simpleclock/SimpleClockBundle_es.properties
+++ b/java/src/jmri/jmrit/simpleclock/SimpleClockBundle_es.properties
@@ -73,6 +73,6 @@ ButtonStoreClock = Store Time Source and Start Up Options
 BeanNameTime = Time
 
 # for more info on the following format, see
-# http://java.sun.com/j2se/1.4.2/docs/api/java/text/SimpleDateFormat.html
+# https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/text/SimpleDateFormat.html
 TimeStorageFormat = h:mm a
 StartupSimpleClockAction=Abrir configuración del reloj a escala

--- a/java/src/jmri/jmrit/simpleclock/SimpleClockBundle_fr.properties
+++ b/java/src/jmri/jmrit/simpleclock/SimpleClockBundle_fr.properties
@@ -62,6 +62,6 @@ NonIntegerError = Erreur dans l'entr\u00e9e - Votre horloge mat\u00e9rielle n\u0
 BeanNameTime = Heure
 
 # Pour plus d'informations sur le format suivant, voir
-# Http://java.sun.com/j2se/1.4.2/docs/api/java/text/SimpleDateFormat.html
-TimeStorageFormat = HH: mn a
+# https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/text/SimpleDateFormat.html
+TimeStorageFormat = HH: mm a
 StartupSimpleClockAction=Ouvrir Configuration Horloge Rapide

--- a/java/src/jmri/jmrit/simpleclock/SimpleClockBundle_it.properties
+++ b/java/src/jmri/jmrit/simpleclock/SimpleClockBundle_it.properties
@@ -60,6 +60,6 @@ NonIntegerError = Errore nel dato - orologio Hardware richiede un valore intero.
 BeanNameTime = Orario
 
 # for more info on the following format, see
-# http://java.sun.com/j2se/1.4.2/docs/api/java/text/SimpleDateFormat.html
+# https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/text/SimpleDateFormat.html
 TimeStorageFormat = h:mm a
 StartupSimpleClockAction=Apri Configurazione Orologio Accellerato

--- a/java/src/jmri/jmrit/simpleclock/SimpleClockBundle_nl.properties
+++ b/java/src/jmri/jmrit/simpleclock/SimpleClockBundle_nl.properties
@@ -59,6 +59,6 @@ NonIntegerError = Fout in ingevoerde waarde - Klok vereist een geheel getal.
 BeanNameTime = Tijd
 
 # for more info on the following format, see
-# http://java.sun.com/j2se/1.4.2/docs/api/java/text/SimpleDateFormat.html
+# https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/text/SimpleDateFormat.html
 TimeStorageFormat = h:mm a
 StartupSimpleClockAction=Open Klokconfiguratie

--- a/java/src/jmri/jmrit/simpleclock/SimpleTimebase.java
+++ b/java/src/jmri/jmrit/simpleclock/SimpleTimebase.java
@@ -720,12 +720,13 @@ public class SimpleTimebase extends jmri.implementation.AbstractNamedBean implem
 
     void updateMemory(Date date) {
         if (timeStorageFormat == null) {
+            String pattern = java.util.ResourceBundle.getBundle("jmri.jmrit.simpleclock.SimpleClockBundle")
+                .getString("TimeStorageFormat");
             try {
-                timeStorageFormat = new java.text.SimpleDateFormat(
-               java.util.ResourceBundle.getBundle("jmri.jmrit.simpleclock.SimpleClockBundle")
-                    .getString("TimeStorageFormat"));
+                timeStorageFormat = new java.text.SimpleDateFormat(pattern);
             } catch (IllegalArgumentException e) {
-                log.info("Dropping back to default time format due to exception", e);
+                log.info("Unable to parse date format time format: {}",pattern);
+                log.info("Dropping back to default time format (h:mm a) due to exception", e);
                 timeStorageFormat = new java.text.SimpleDateFormat("h:mm a");
             }
         }

--- a/java/src/jmri/jmrit/simpleclock/SimpleTimebase.java
+++ b/java/src/jmri/jmrit/simpleclock/SimpleTimebase.java
@@ -725,8 +725,9 @@ public class SimpleTimebase extends jmri.implementation.AbstractNamedBean implem
             try {
                 timeStorageFormat = new java.text.SimpleDateFormat(pattern);
             } catch (IllegalArgumentException e) {
-                log.info("Unable to parse date format time format: {}",pattern);
-                log.info("Dropping back to default time format (h:mm a) due to exception", e);
+                log.info("Unable to parse date / time format: {}",pattern);
+                log.info("For supported formats see https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/text/SimpleDateFormat.html");
+                log.info("Dropping back to default time format (h:mm a) 4:56 PM, due to exception", e);
                 timeStorageFormat = new java.text.SimpleDateFormat("h:mm a");
             }
         }


### PR DESCRIPTION
"HH: mn a" is not a SimpleDateFormat, updated French Bundle to "HH: mm a"
see https://groups.io/g/jmriusers/message/209644

SimpleTimebase - Improve logging when unable to parse date format

update links to SimpleTimebase JavaDoc