### PR TITLE
Test SimpleTimebase Bundle Time Formats

### DIFF
--- a/java/test/jmri/jmrit/simpleclock/SimpleTimebaseTest.java
+++ b/java/test/jmri/jmrit/simpleclock/SimpleTimebaseTest.java
@@ -1,8 +1,12 @@
 package jmri.jmrit.simpleclock;
 
 import java.beans.*;
+import java.io.*;
+import java.net.URISyntaxException;
+import java.text.SimpleDateFormat;
 import java.time.Instant;
 import java.util.Date;
+import java.util.Properties;
 
 import org.junit.jupiter.api.*;
 import org.junit.Assert;
@@ -186,6 +190,55 @@ public class SimpleTimebaseTest {
         Assert.assertTrue("delta lt 150 (nominal value)", delta < 150);
 
         p.dispose();
+    }
+
+    @Test
+    public void testBundleTimeStorageFormats() {
+        String classToSearchFor = "SimpleTimebase.class";
+        try {
+            var resource = SimpleTimebase.class.getResource(classToSearchFor);
+            if (resource != null) {
+                String s = resource.toURI().getPath();
+                if (s != null) {
+                    checkTimeStorageFormatsInFolder(new File(
+                        s.substring(0, s.length() - classToSearchFor.length())));
+                } else {
+                    Assertions.fail("No Path for " + resource.getFile());
+                }
+            } else {
+                Assertions.fail("No Resource for " + classToSearchFor);
+            }
+        } catch (URISyntaxException | IOException ex) {
+            Assertions.fail("Exception for SimpleTimebaseTest testBundleTimeStorageFormats", ex);
+        }
+    }
+
+    private void checkTimeStorageFormatsInFolder(@javax.annotation.Nonnull File folder) throws IOException {
+        // System.out.println("checking folder " + folder.getPath());
+        File[] files = folder.listFiles();
+        if (files != null){
+            for(File file : files) {
+                // System.out.println("checking file " + file);
+                if(file.getName().endsWith(".properties")) {
+                    Properties prop = new Properties();
+                    try (FileInputStream instream = new FileInputStream(file)) {
+                        prop.load(instream);
+                    }
+                    String dateFormat = prop.getProperty("TimeStorageFormat"); // NOI18N
+                    if (dateFormat != null){
+                        try {
+                            SimpleDateFormat timeStorageFormat = new SimpleDateFormat( dateFormat);
+                            // System.out.println("DateFormat ok " + dateFormat +" "+ timeStorageFormat);
+                            Assertions.assertTrue(true,"Message format ok: " + timeStorageFormat);
+                        } catch (IllegalArgumentException e) {
+                            Assertions.fail("Could not convert TimeStorageFormat to SimpleDateFormat in " + file, e);
+                        }
+                    } // not a problem if Bundle goes not contain key
+                } // not a problem if file does not end with .properties
+            } // end of file loop
+        } else {
+            Assertions.fail("Null listFiles in folder " + folder);
+        }
     }
 
     @BeforeEach


### PR DESCRIPTION
Checks all Bundle classes in same folder as SimpleTimebase.class for Bundle key TimeStorageFormat
If a returned String is not a SimpleDateFormat, the test fails.

Currently failing Win CI 
```
Failures: 
Error:    SimpleTimebaseTest.testBundleTimeStorageFormats:203->checkTimeStorageFormatsInFolder:234 Could not convert TimeStorageFormat to SimpleDateFormat in D:\a\JMRI\JMRI\target\classes\jmri\jmrit\simpleclock\SimpleClockBundle_fr.properties
```

and Headless 
```
Failures: 
Error:    SimpleTimebaseTest.testBundleTimeStorageFormats:203->checkTimeStorageFormatsInFolder:234 Could not convert TimeStorageFormat to SimpleDateFormat in /home/runner/work/JMRI/JMRI/target/classes/jmri/jmrit/simpleclock/SimpleClockBundle_fr.properties
```

as expected due to #11549 , marked WIP.
