### PR TITLE
Roster Table update attribute access ( last operated column )

### DIFF
--- a/java/src/jmri/jmrit/roster/RosterEntry.java
+++ b/java/src/jmri/jmrit/roster/RosterEntry.java
@@ -96,6 +96,8 @@ public class RosterEntry extends ArbitraryBean implements RosterObject, BasicRos
     public static final String SHUNTING_FUNCTION = "IsShuntingOn"; // NOI18N
     public static final String SPEED_PROFILE = "speedprofile"; // NOI18N
     public static final String SOUND_LABEL = "soundlabel"; // NOI18N
+    public static final String ATTRIBUTE_OPERATING_DURATION = "OperatingDuration"; // NOI18N
+    public static final String ATTRIBUTE_LAST_OPERATED = "LastOperated"; // NOI18N
 
     // members to remember all the info
     protected String _fileName = null;
@@ -1489,7 +1491,7 @@ public class RosterEntry extends ArbitraryBean implements RosterObject, BasicRos
         try {
             //int textSpace = w.getCharactersPerLine() - 1; // could be used to truncate line.
             // for now, text just flows to next line
-            String thisText = "";
+            String thisText;
             String thisLine = "";
 
             // start each entry on a new line
@@ -1798,9 +1800,8 @@ public class RosterEntry extends ArbitraryBean implements RosterObject, BasicRos
             } else {
                 //Piece too long to fit. Extract a piece the size of the textSpace
                 //and check for farthest right space for word wrapping.
-                if (log.isDebugEnabled()) {
-                    log.debug("token: /{}/", commentToken);
-                }
+                log.debug("token: /{}/", commentToken);
+
                 while (startIndex < commentToken.length()) {
                     String tokenPiece = commentToken.substring(startIndex, startIndex + textSpace);
                     if (log.isDebugEnabled()) {
@@ -1816,9 +1817,8 @@ public class RosterEntry extends ArbitraryBean implements RosterObject, BasicRos
                         //If there is at least one space, extract up to and including the
                         //last space and put in the vector as well as a line feed
                         endIndex = tokenPiece.lastIndexOf(" ") + 1;
-                        if (log.isDebugEnabled()) {
-                            log.debug("tokenPiece /{}/ {} {}", tokenPiece, startIndex, endIndex);
-                        }
+                        log.debug("tokenPiece /{}/ {} {}", tokenPiece, startIndex, endIndex);
+
                         textVector.addElement(tokenPiece.substring(0, endIndex));
                         textVector.addElement(newLine);
                         startIndex += endIndex;

--- a/java/src/jmri/jmrit/roster/swing/Bundle.properties
+++ b/java/src/jmri/jmrit/roster/swing/Bundle.properties
@@ -29,3 +29,6 @@ RosterFrameAction = Open Roster
 ProgrammerType = Programmer Type
 PrintSelection = Print Entry...
 PreviewSelection = Preview Entry...
+
+OperatingDuration = Operating Duration
+LastOperated = Last Operated

--- a/java/src/jmri/jmrit/roster/swing/RosterTable.java
+++ b/java/src/jmri/jmrit/roster/swing/RosterTable.java
@@ -1,16 +1,21 @@
 package jmri.jmrit.roster.swing;
 
-import jmri.util.gui.GuiLafPreferencesManager;
+import com.fasterxml.jackson.databind.util.StdDateFormat;
+
+import java.awt.Component;
 import java.awt.Rectangle;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.MouseEvent;
 import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.Enumeration;
 import java.util.List;
+
 import javax.swing.BoxLayout;
 import javax.swing.DefaultCellEditor;
 import javax.swing.JCheckBoxMenuItem;
@@ -28,11 +33,13 @@ import javax.swing.event.RowSorterEvent;
 import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.TableColumn;
 import javax.swing.table.TableRowSorter;
+
 import jmri.InstanceManager;
 import jmri.jmrit.roster.Roster;
 import jmri.jmrit.roster.RosterEntry;
 import jmri.jmrit.roster.RosterEntrySelector;
 import jmri.jmrit.roster.rostergroup.RosterGroupSelector;
+import jmri.util.gui.GuiLafPreferencesManager;
 import jmri.util.swing.JmriPanel;
 import jmri.util.swing.JmriMouseAdapter;
 import jmri.util.swing.JmriMouseEvent;
@@ -96,41 +103,15 @@ public class RosterTable extends JmriPanel implements RosterEntrySelector, Roste
         dataTable.setAutoResizeMode(JTable.AUTO_RESIZE_OFF);
 
         dataTable.setColumnModel(columnModel);
-        dataModel.setColumnModel(columnModel);
+        // dataModel.setColumnModel(columnModel);
         dataTable.createDefaultColumnsFromModel();
         dataTable.setAutoCreateColumnsFromModel(false);
 
-        // format the last updated date time
-        columnModel.getColumnByModelIndex(RosterTableModel.DATEUPDATECOL).setCellRenderer(new DefaultTableCellRenderer() {
-            @Override
-            protected void setValue(Object value) {
-                if (value != null && value instanceof Date) {
-                    super.setValue(DateFormat.getDateTimeInstance().format((Date) value));
-                } else {
-                    super.setValue(value);
-                }
-            }
-        });
+        // format the last updated date time, last operated date time.
+        dataTable.setDefaultRenderer(Date.class, new DateTimeCellRenderer());
 
         TableColumn tc = columnModel.getColumnByModelIndex(RosterTableModel.PROTOCOL);
         columnModel.setColumnVisible(tc, false);
-
-        for (String s : Roster.getDefault().getAllAttributeKeys()) {
-            if (!s.contains("RosterGroup") && !s.toLowerCase().startsWith("sys") && !s.toUpperCase().startsWith("VSD")) { // NOI18N
-                String[] r = s.split("(?=\\p{Lu})"); // NOI18N
-                StringBuilder sb = new StringBuilder();
-                sb.append(r[0].trim());
-                for (int j = 1; j < r.length; j++) {
-                    sb.append(" ");
-                    sb.append(r[j].trim());
-                }
-                TableColumn c = new TableColumn(dataModel.getColumnCount());
-                c.setHeaderValue((sb.toString()).trim());
-                dataTable.addColumn(c);
-                dataModel.addColumn(c.getHeaderValue());
-                columnModel.setColumnVisible(c, false);
-            }
-        }
 
         // resize columns as requested
         resetColumnWidths();
@@ -154,6 +135,7 @@ public class RosterTable extends JmriPanel implements RosterEntrySelector, Roste
         dataTable.getTableHeader().addMouseListener(JmriMouseListener.adapt(mouseHeaderListener));
 
         dataTable.setDefaultEditor(Object.class, new RosterCellEditor());
+        dataTable.setDefaultEditor(Date.class, new DateTimeCellEditor());
 
         tableSelectionListener = (ListSelectionEvent e) -> {
             if (!e.getValueIsAdjusting()) {
@@ -196,6 +178,7 @@ public class RosterTable extends JmriPanel implements RosterEntrySelector, Roste
             dataModel.dispose();
         }
         dataModel = null;
+        dataTable.getSelectionModel().removeListSelectionListener(tableSelectionListener);
         dataTable = null;
         super.dispose();
     }
@@ -402,4 +385,54 @@ public class RosterTable extends JmriPanel implements RosterEntrySelector, Roste
             return re.getId().equals(dataModel.getValueAt(sorter.convertRowIndexToModel(dataTable.getSelectedRow()), RosterTableModel.IDCOL));
         }
     }
+
+    private class DateTimeCellRenderer extends DefaultTableCellRenderer {
+        @Override
+        protected void setValue(Object value) {
+            if ( value instanceof Date) {
+                super.setValue(DateFormat.getDateTimeInstance().format((Date) value));
+            } else {
+                super.setValue(value);
+            }
+        }
+    }
+
+    private class DateTimeCellEditor extends RosterCellEditor {
+
+        public DateTimeCellEditor() {
+            super();
+        }
+        
+        private final static String EDITOR_DATE_FORMAT =  "yyyy-MM-dd hh:mm";
+        private Date startDate = new Date();
+
+        @Override
+        public Component getTableCellEditorComponent(JTable table, Object value, boolean isSelected, int row, int col) {
+            if (!(value instanceof Date) ) {
+                value = new Date(); // field pre-populated if currently empty to show entry format
+            }
+            startDate = (Date)value;
+            String formatted = new SimpleDateFormat(EDITOR_DATE_FORMAT).format((Date)value);
+            ((JTextField)editorComponent).setText(formatted);
+            editorComponent.setToolTipText("e.g. 2022-12-25 12:34");
+            return editorComponent;
+        }
+
+        @Override
+        public Object getCellEditorValue() {
+            String o = (String)super.getCellEditorValue();
+            if ( o.isBlank() ) { // user cancels the date / time
+                return null;
+            }
+            SimpleDateFormat fm = new SimpleDateFormat(EDITOR_DATE_FORMAT);
+            try {
+                // get Date in local time before passing to StdDateFormat
+                startDate = fm.parse(o.trim());
+            } catch (ParseException e) {
+            } // return value unchanged in case of user mis-type
+            return new StdDateFormat().format(startDate);
+        }
+
+    }
+
 }

--- a/java/src/jmri/jmrit/roster/swing/RosterTable.java
+++ b/java/src/jmri/jmrit/roster/swing/RosterTable.java
@@ -397,7 +397,7 @@ public class RosterTable extends JmriPanel implements RosterEntrySelector, Roste
         }
     }
 
-    private class DateTimeCellEditor extends RosterCellEditor {
+    private static class DateTimeCellEditor extends RosterCellEditor {
 
         public DateTimeCellEditor() {
             super();

--- a/java/src/jmri/jmrit/roster/swing/RosterTable.java
+++ b/java/src/jmri/jmrit/roster/swing/RosterTable.java
@@ -386,7 +386,7 @@ public class RosterTable extends JmriPanel implements RosterEntrySelector, Roste
         }
     }
 
-    private class DateTimeCellRenderer extends DefaultTableCellRenderer {
+    private static class DateTimeCellRenderer extends DefaultTableCellRenderer {
         @Override
         protected void setValue(Object value) {
             if ( value instanceof Date) {
@@ -397,12 +397,12 @@ public class RosterTable extends JmriPanel implements RosterEntrySelector, Roste
         }
     }
 
-    private static class DateTimeCellEditor extends RosterCellEditor {
+    private class DateTimeCellEditor extends RosterCellEditor {
 
         public DateTimeCellEditor() {
             super();
         }
-        
+
         private final static String EDITOR_DATE_FORMAT =  "yyyy-MM-dd hh:mm";
         private Date startDate = new Date();
 

--- a/java/src/jmri/jmrix/AbstractThrottle.java
+++ b/java/src/jmri/jmrix/AbstractThrottle.java
@@ -17,6 +17,8 @@ import jmri.Throttle;
 import jmri.ThrottleListener;
 import jmri.beans.PropertyChangeSupport;
 
+import jmri.jmrit.roster.RosterEntry;
+
 import javax.annotation.Nonnull;
 import javax.annotation.concurrent.GuardedBy;
 
@@ -810,7 +812,7 @@ abstract public class AbstractThrottle extends PropertyChangeSupport implements 
             return;
         }
         stopClock();
-        String currentDurationString = re.getAttribute("OperatingDuration");
+        String currentDurationString = re.getAttribute(RosterEntry.ATTRIBUTE_OPERATING_DURATION);
         long currentDuration = 0;
         if (currentDurationString == null) {
             currentDurationString = "0";
@@ -822,8 +824,8 @@ abstract public class AbstractThrottle extends PropertyChangeSupport implements 
             log.warn("current stored duration is not a valid number \"{} \"", currentDurationString);
         }
         currentDuration = currentDuration + durationRunning;
-        re.putAttribute("OperatingDuration", "" + currentDuration);
-        re.putAttribute("LastOperated", new StdDateFormat().format(new Date()));
+        re.putAttribute(RosterEntry.ATTRIBUTE_OPERATING_DURATION, "" + currentDuration);
+        re.putAttribute(RosterEntry.ATTRIBUTE_LAST_OPERATED, new StdDateFormat().format(new Date()));
         //Only store if the roster entry isn't open.
         if (!re.isOpen()) {
             re.store();

--- a/java/test/jmri/jmrit/roster/PrintRosterActionTest.java
+++ b/java/test/jmri/jmrit/roster/PrintRosterActionTest.java
@@ -1,27 +1,41 @@
 package jmri.jmrit.roster;
 
-import java.awt.GraphicsEnvironment;
-
 import jmri.util.JUnitUtil;
 import jmri.util.JmriJFrame;
 
 import org.junit.Assert;
 import org.junit.jupiter.api.*;
-import org.junit.Assume;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.netbeans.jemmy.operators.JFrameOperator;
 
 /**
  *
  * @author Paul Bender Copyright (C) 2017
  */
+@DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
 public class PrintRosterActionTest {
 
     @Test
     public void testCTor() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         JmriJFrame jf = new JmriJFrame("TestPrintWindow");
         jmri.util.swing.WindowInterface wi = jf;
         PrintRosterAction t = new PrintRosterAction("test print roster",wi);
         Assert.assertNotNull("exists",t);
+
+        // add a RosterEntry
+        RosterEntry r = RosterEntryImplementations.id1();
+        Roster.getDefault().addEntry(r);
+
+        t.setPreview(true);
+
+        jmri.util.ThreadingUtil.runOnGUI(() -> {
+            t.actionPerformed(null);
+        } );
+        JFrameOperator jfo = new JFrameOperator(Bundle.getMessage("TitleDecoderProRoster")+" "+Bundle.getMessage("ALLENTRIES"));
+        Assert.assertNotNull(jfo);
+        jfo.requestClose();
+        jfo.waitClosed();
+
         JUnitUtil.dispose(jf);
     }
 
@@ -29,6 +43,7 @@ public class PrintRosterActionTest {
     public void setUp() {
         JUnitUtil.setUp();
         JUnitUtil.resetProfileManager();
+        JUnitUtil.initRosterConfigManager();
     }
 
     @AfterEach

--- a/java/test/jmri/jmrit/roster/RosterEntryImplementations.java
+++ b/java/test/jmri/jmrit/roster/RosterEntryImplementations.java
@@ -1,0 +1,93 @@
+package jmri.jmrit.roster;
+
+import org.jdom2.Element;
+
+/**
+ * Static Roster Entries for use in Testing.
+ * Implementations originally from jmri.jmrit.roster.swing.RosterTableModelTest
+ * @author Bob Jacobsen Copyright (C) 2009
+ * @author Steve Young Copyright (C) 2022
+ */
+public class RosterEntryImplementations {
+
+    // class only provides static methods
+    private RosterEntryImplementations(){}
+
+    public final static RosterEntry id1() {
+        Element e = new Element("locomotive")
+            .setAttribute("id", "id 1")
+            .setAttribute("fileName", "file here")
+            .setAttribute("roadNumber", "431")
+            .setAttribute("roadName", "SP")
+            .setAttribute("mfg", "Athearn")
+            .setAttribute("dccAddress", "1234")
+            .addContent(new org.jdom2.Element("decoder")
+                    .setAttribute("family", "91")
+                    .setAttribute("model", "33")
+            )
+            .addContent(new org.jdom2.Element("locoaddress")
+                    .addContent(new org.jdom2.Element("dcclocoaddress")
+                            .setAttribute("number", "12")
+                            .setAttribute("longaddress", "yes")
+                    )
+            ); // end create element
+        return new NoWarnRosterEntry(e);
+    }
+
+    public final static RosterEntry id2() {
+        Element e = new Element("locomotive")
+            .setAttribute("id", "id 2")
+            .setAttribute("fileName", "file here")
+            .setAttribute("roadNumber", "431")
+            .setAttribute("roadName", "SP")
+            .setAttribute("mfg", "Athearn")
+            .addContent(new org.jdom2.Element("decoder")
+                    .setAttribute("family", "91")
+                    .setAttribute("model", "34")
+            )
+            .addContent(new org.jdom2.Element("locoaddress")
+                    .addContent(new org.jdom2.Element("dcclocoaddress")
+                            .setAttribute("number", "13")
+                            .setAttribute("longaddress", "yes")
+                    )
+            ); // end create element
+        return new NoWarnRosterEntry(e);
+    }
+
+    public final static RosterEntry id3() {
+        Element e = new Element("locomotive")
+            .setAttribute("id", "id 3")
+            .setAttribute("fileName", "file here")
+            .setAttribute("roadNumber", "431")
+            .setAttribute("roadName", "SP")
+            .setAttribute("mfg", "Athearn")
+            .addContent(new org.jdom2.Element("decoder")
+                    .setAttribute("family", "91")
+                    .setAttribute("model", "35")
+            )
+            .addContent(new org.jdom2.Element("locoaddress")
+                    .addContent(new org.jdom2.Element("dcclocoaddress")
+                            .setAttribute("number", "14")
+                            .setAttribute("longaddress", "yes")
+                    )
+            ); // end create element
+        return new NoWarnRosterEntry(e);
+    }
+
+    public static class NoWarnRosterEntry extends RosterEntry {
+
+        public NoWarnRosterEntry( Element e){
+            super(e);
+        }
+
+        @Override
+        protected void warnShortLong(String s) {
+        }
+
+        @Override
+        public void updateFile() {
+        }
+
+    }
+
+}

--- a/java/test/jmri/jmrit/roster/swing/RosterTableModelTest.java
+++ b/java/test/jmri/jmrit/roster/swing/RosterTableModelTest.java
@@ -2,9 +2,9 @@ package jmri.jmrit.roster.swing;
 
 import jmri.jmrit.roster.Roster;
 import jmri.jmrit.roster.RosterEntry;
+import jmri.jmrit.roster.RosterEntryImplementations;
 import jmri.util.JUnitUtil;
 
-import org.jdom2.Element;
 import org.junit.Assert;
 import org.junit.jupiter.api.*;
 
@@ -20,21 +20,63 @@ public class RosterTableModelTest {
         RosterTableModel t = new RosterTableModel();
 
         Assert.assertEquals(NENTRIES, t.getRowCount());
+        t.dispose();
     }
 
     @Test
-    public void testTableWidth() throws Exception {
-        RosterTableModel t = new RosterTableModel();
+    public void testColumnCount() throws Exception {
+        RosterTableModel t = new RosterTableModel(true); // set Editable
 
         // hard-coded value is number of columns expected
-        Assert.assertEquals(t.getColumnCount(), t.getColumnCount());
+        // 11 normal columns + 4 attribute columns
+        Assert.assertEquals(15, t.getColumnCount());
+        
+        
+        Assertions.assertTrue(t.isCellEditable(0, RosterTableModel.IDCOL));
+        Assertions.assertFalse(t.isCellEditable(0, RosterTableModel.ADDRESSCOL));
+        Assertions.assertFalse(t.isCellEditable(0, RosterTableModel.ICONCOL));
+        Assertions.assertFalse(t.isCellEditable(0, RosterTableModel.DECODERCOL));
+        Assertions.assertTrue(t.isCellEditable(0, RosterTableModel.ROADNAMECOL));
+        Assertions.assertTrue(t.isCellEditable(0, RosterTableModel.ROADNUMBERCOL));
+        Assertions.assertTrue(t.isCellEditable(0, RosterTableModel.MFGCOL));
+        Assertions.assertTrue(t.isCellEditable(0, RosterTableModel.MODELCOL));
+        Assertions.assertTrue(t.isCellEditable(0, RosterTableModel.OWNERCOL));
+        Assertions.assertFalse(t.isCellEditable(0, RosterTableModel.DATEUPDATECOL));
+        Assertions.assertFalse(t.isCellEditable(0, RosterTableModel.PROTOCOL));
+        
+        Assertions.assertTrue(t.isCellEditable(0, RosterTableModel.NUMCOL));
+        Assertions.assertTrue(t.isCellEditable(0, RosterTableModel.NUMCOL+1));
+        Assertions.assertTrue(t.isCellEditable(0, RosterTableModel.NUMCOL+2));
+        Assertions.assertTrue(t.isCellEditable(0, RosterTableModel.NUMCOL+3));
+        
+        t.dispose();
     }
 
     @Test
     public void testColumnName() throws Exception {
-        RosterTableModel t = new RosterTableModel();
+        RosterTableModel t = new RosterTableModel(null); // no rosterGroup
 
-        Assert.assertEquals("DCC Address", t.getColumnName(RosterTableModel.ADDRESSCOL));
+        Assert.assertEquals(Bundle.getMessage("FieldID"), t.getColumnName( RosterTableModel.IDCOL));
+        Assert.assertEquals(Bundle.getMessage("FieldDCCAddress"), t.getColumnName(RosterTableModel.ADDRESSCOL));
+        Assert.assertEquals(Bundle.getMessage("FieldIcon"), t.getColumnName(RosterTableModel.ICONCOL));
+        Assert.assertEquals(Bundle.getMessage("FieldDecoderModel"), t.getColumnName(RosterTableModel.DECODERCOL));
+        Assert.assertEquals(Bundle.getMessage("FieldRoadName"), t.getColumnName(RosterTableModel.ROADNAMECOL));
+        Assert.assertEquals(Bundle.getMessage("FieldRoadNumber"), t.getColumnName(RosterTableModel.ROADNUMBERCOL));
+        Assert.assertEquals(Bundle.getMessage("FieldManufacturer"), t.getColumnName(RosterTableModel.MFGCOL));
+        Assert.assertEquals(Bundle.getMessage("FieldModel"), t.getColumnName(RosterTableModel.MODELCOL));
+        Assert.assertEquals(Bundle.getMessage("FieldOwner"), t.getColumnName(RosterTableModel.OWNERCOL));
+        Assert.assertEquals(Bundle.getMessage("FieldDateUpdated"), t.getColumnName(RosterTableModel.DATEUPDATECOL));
+        Assert.assertEquals(Bundle.getMessage("FieldProtocol"), t.getColumnName(RosterTableModel.PROTOCOL));
+
+        // the roster entries have 4 attributes
+        Assert.assertEquals("key a", t.getColumnName(RosterTableModel.NUMCOL));
+        Assert.assertEquals("key b", t.getColumnName(RosterTableModel.NUMCOL+1));
+        Assert.assertEquals("key c", t.getColumnName(RosterTableModel.NUMCOL+2));
+        Assert.assertEquals("key d", t.getColumnName(RosterTableModel.NUMCOL+3));
+
+        Assert.assertEquals("<UNKNOWN>", t.getColumnName(RosterTableModel.NUMCOL+4));
+        
+        t.dispose();
     }
 
     @Test
@@ -52,99 +94,128 @@ public class RosterTableModelTest {
         Assert.assertEquals("id 3", t.getValueAt(2, RosterTableModel.IDCOL));
         Assert.assertEquals(14, (int)t.getValueAt(2, RosterTableModel.ADDRESSCOL));
         Assert.assertEquals("35", t.getValueAt(2, RosterTableModel.DECODERCOL));
+        
+        Assert.assertEquals("DCC Long", t.getValueAt(2, RosterTableModel.PROTOCOL));
+        
+        
+        Assert.assertEquals("value 11", t.getValueAt(1, RosterTableModel.NUMCOL));
+        Assert.assertEquals("value 12", t.getValueAt(1, RosterTableModel.NUMCOL+1));
+        Assert.assertEquals("value 13", t.getValueAt(1, RosterTableModel.NUMCOL+2));
+        Assert.assertEquals("value 14", t.getValueAt(1, RosterTableModel.NUMCOL+3));
+
+        t.dispose();
+    }
+    
+    @Test
+    public void testSetValueAt() {
+        RosterTableModel t = new RosterTableModel(true); // editable
+        Assert.assertEquals("id 1", t.getValueAt(0, RosterTableModel.IDCOL));
+        t.setValueAt("A New Id 1", 0, RosterTableModel.IDCOL);
+        t.setValueAt("A New Id 1", 0, RosterTableModel.IDCOL);
+        Assert.assertEquals("A New Id 1", t.getValueAt(0, RosterTableModel.IDCOL));
+        
+        Assert.assertEquals("SP", t.getValueAt(0, RosterTableModel.ROADNAMECOL));
+        t.setValueAt("A New RoadName", 0, RosterTableModel.ROADNAMECOL);
+        Assert.assertEquals("A New RoadName", t.getValueAt(0, RosterTableModel.ROADNAMECOL));
+        
+        Assert.assertEquals("431", t.getValueAt(0, RosterTableModel.ROADNUMBERCOL));
+        t.setValueAt("99", 0, RosterTableModel.ROADNUMBERCOL);
+        Assert.assertEquals("99", t.getValueAt(0, RosterTableModel.ROADNUMBERCOL));
+        
+        Assert.assertEquals("Athearn", t.getValueAt(0, RosterTableModel.MFGCOL));
+        t.setValueAt("My MFG", 0, RosterTableModel.MFGCOL);
+        Assert.assertEquals("My MFG", t.getValueAt(0, RosterTableModel.MFGCOL));
+        
+        Assert.assertEquals("", t.getValueAt(0, RosterTableModel.MODELCOL));
+        t.setValueAt("Model Ref", 0, RosterTableModel.MODELCOL);
+        Assert.assertEquals("Model Ref", t.getValueAt(0, RosterTableModel.MODELCOL));
+        
+        Assert.assertEquals("", t.getValueAt(0, RosterTableModel.OWNERCOL));
+        t.setValueAt("Its my train!", 0, RosterTableModel.OWNERCOL);
+        Assert.assertEquals("Its my train!", t.getValueAt(0, RosterTableModel.OWNERCOL));
+        
+        
+        Assert.assertEquals("value 1", t.getValueAt(0, RosterTableModel.NUMCOL));
+        t.setValueAt("new value 1", 0, RosterTableModel.NUMCOL);
+        Assert.assertEquals("new value 1", t.getValueAt(0, RosterTableModel.NUMCOL));
+        
+        Assert.assertEquals("", t.getValueAt(0, RosterTableModel.NUMCOL+1));
+        t.setValueAt("new value B1", 0, RosterTableModel.NUMCOL+1);
+        Assert.assertEquals("new value B1", t.getValueAt(0, RosterTableModel.NUMCOL+1));
+        
+        Assert.assertEquals("", t.getValueAt(0, RosterTableModel.NUMCOL+2));
+        t.setValueAt("new value C2", 0, RosterTableModel.NUMCOL+2);
+        Assert.assertEquals("new value C2", t.getValueAt(0, RosterTableModel.NUMCOL+2));
+        
+        t.setValueAt("", 0, RosterTableModel.NUMCOL+2);
+        Assert.assertEquals("", t.getValueAt(0, RosterTableModel.NUMCOL+2));
+        
+        Assert.assertEquals("", t.getValueAt(0, RosterTableModel.NUMCOL+3));
+        t.setValueAt("new value D3", 0, RosterTableModel.NUMCOL+3);
+        Assert.assertEquals("new value D3", t.getValueAt(0, RosterTableModel.NUMCOL+3));
+        
+        t.setValueAt(null, 0, RosterTableModel.NUMCOL+3);
+        Assert.assertEquals("", t.getValueAt(0, RosterTableModel.NUMCOL+3));
+
+    }
+    
+    @Test
+    public void testLastOperatedAttributes() {
+        Roster.getDefault().getEntry(0).deleteAttribute("key a");
+        Roster.getDefault().getEntry(0).putAttribute(RosterEntry.ATTRIBUTE_LAST_OPERATED, "2022-10-31T06:22:00.000+00:00");
+        Roster.getDefault().getEntry(0).putAttribute(RosterEntry.ATTRIBUTE_OPERATING_DURATION, "54321");
+        
+        Roster.getDefault().getEntry(2).putAttribute(RosterEntry.ATTRIBUTE_LAST_OPERATED, "Not a Date / Time");
+        
+        Roster.getDefault().getEntry(1).deleteAttribute("key a");
+        Roster.getDefault().getEntry(1).deleteAttribute("key b");
+        Roster.getDefault().getEntry(1).deleteAttribute("key c");
+        Roster.getDefault().getEntry(1).deleteAttribute("key d");
+        
+        RosterTableModel t = new RosterTableModel(true); // set Editable
+
+        // hard-coded value is number of columns expected
+        // 11 normal columns + 2 attribute columns
+        Assert.assertEquals(13, t.getColumnCount());
+        Assert.assertEquals(java.util.Date.class,(Class)t.getColumnClass(RosterTableModel.NUMCOL));
+        
+        Assert.assertNotNull(t.getValueAt(0, RosterTableModel.NUMCOL));
+        Assert.assertNull(t.getValueAt(1, RosterTableModel.NUMCOL));
+        Assert.assertNull(t.getValueAt(2, RosterTableModel.NUMCOL));
+        
+        Assert.assertEquals(Bundle.getMessage(RosterEntry.ATTRIBUTE_LAST_OPERATED),t.getColumnName(RosterTableModel.NUMCOL));
+        Assert.assertEquals(Bundle.getMessage(RosterEntry.ATTRIBUTE_OPERATING_DURATION),t.getColumnName(RosterTableModel.NUMCOL+1));
+
+        
+        t.dispose();
+        
+        
     }
 
     // create a standard test roster
     static int NENTRIES = 3;
-    // static int NKEYS = 4;
+    static int NKEYS = 4;
 
     @BeforeEach
     public void setUp() {
-        jmri.util.JUnitUtil.setUp();
+        JUnitUtil.setUp();
 
-        jmri.util.JUnitUtil.resetProfileManager();
+        JUnitUtil.resetProfileManager();
         JUnitUtil.initRosterConfigManager();
 
         // first entry
-        Element e;
-        RosterEntry r;
-
-        e = new org.jdom2.Element("locomotive")
-                .setAttribute("id", "id 1")
-                .setAttribute("fileName", "file here")
-                .setAttribute("roadNumber", "431")
-                .setAttribute("roadName", "SP")
-                .setAttribute("mfg", "Athearn")
-                .setAttribute("dccAddress", "1234")
-                .addContent(new org.jdom2.Element("decoder")
-                        .setAttribute("family", "91")
-                        .setAttribute("model", "33")
-                )
-                .addContent(new org.jdom2.Element("locoaddress")
-                        .addContent(new org.jdom2.Element("dcclocoaddress")
-                                .setAttribute("number", "12")
-                                .setAttribute("longaddress", "yes")
-                        )
-                ); // end create element
-
-        r = new RosterEntry(e) {
-            @Override
-            protected void warnShortLong(String s) {
-            }
-        };
+        RosterEntry r = RosterEntryImplementations.id1();
         Roster.getDefault().addEntry(r);
         r.putAttribute("key a", "value 1");
 
-        e = new org.jdom2.Element("locomotive")
-                .setAttribute("id", "id 2")
-                .setAttribute("fileName", "file here")
-                .setAttribute("roadNumber", "431")
-                .setAttribute("roadName", "SP")
-                .setAttribute("mfg", "Athearn")
-                .addContent(new org.jdom2.Element("decoder")
-                        .setAttribute("family", "91")
-                        .setAttribute("model", "34")
-                )
-                .addContent(new org.jdom2.Element("locoaddress")
-                        .addContent(new org.jdom2.Element("dcclocoaddress")
-                                .setAttribute("number", "13")
-                                .setAttribute("longaddress", "yes")
-                        )
-                ); // end create element
-
-        r = new RosterEntry(e) {
-            @Override
-            protected void warnShortLong(String s) {
-            }
-        };
+        r = RosterEntryImplementations.id2();
         Roster.getDefault().addEntry(r);
         r.putAttribute("key a", "value 11");
         r.putAttribute("key b", "value 12");
         r.putAttribute("key c", "value 13");
         r.putAttribute("key d", "value 14");
 
-        e = new org.jdom2.Element("locomotive")
-                .setAttribute("id", "id 3")
-                .setAttribute("fileName", "file here")
-                .setAttribute("roadNumber", "431")
-                .setAttribute("roadName", "SP")
-                .setAttribute("mfg", "Athearn")
-                .addContent(new org.jdom2.Element("decoder")
-                        .setAttribute("family", "91")
-                        .setAttribute("model", "35")
-                )
-                .addContent(new org.jdom2.Element("locoaddress")
-                        .addContent(new org.jdom2.Element("dcclocoaddress")
-                                .setAttribute("number", "14")
-                                .setAttribute("longaddress", "yes")
-                        )
-                ); // end create element
-
-        r = new RosterEntry(e) {
-            @Override
-            protected void warnShortLong(String s) {
-            }
-        };
+        r = RosterEntryImplementations.id3();
         Roster.getDefault().addEntry(r);
 
     }

--- a/java/test/jmri/jmrit/roster/swing/RosterTableModelTest.java
+++ b/java/test/jmri/jmrit/roster/swing/RosterTableModelTest.java
@@ -177,8 +177,8 @@ public class RosterTableModelTest {
         // hard-coded value is number of columns expected
         // 11 normal columns + 2 attribute columns
         Assert.assertEquals(13, t.getColumnCount());
-        Assert.assertEquals(java.util.Date.class,(Class)t.getColumnClass(RosterTableModel.NUMCOL));
-        
+        Assert.assertTrue(java.util.Date.class == t.getColumnClass(RosterTableModel.NUMCOL));
+
         Assert.assertNotNull(t.getValueAt(0, RosterTableModel.NUMCOL));
         Assert.assertNull(t.getValueAt(1, RosterTableModel.NUMCOL));
         Assert.assertNull(t.getValueAt(2, RosterTableModel.NUMCOL));


### PR DESCRIPTION
RosterTable.java -
use same Date format for all Dates passed.
get roster attributes from table model
add DateTimeCellEditor for easier editing of Date Time values

RosterTableModel.java -
constructor - add prop change listeners to Roster Entries
standardise access to RosterEntry attribute columns
no need for RosterTable to add attribute Columns
Enable OperatingDuration & LastOperated to be in Bundle
remove listeners in dispose

RosterEntry.java -
add OperatingDuration / LastOperated constants

Tests -
Adds RosterEntryImplementations.java 