### PR TITLE
GrandReset.py jython script with release note and scripting reference

### DIFF
--- a/help/en/html/tools/scripting/Examples.shtml
+++ b/help/en/html/tools/scripting/Examples.shtml
@@ -130,6 +130,12 @@
       <p>Sample script to navigate through the GUI and disable the Ops Mode button on the main
       DecoderPro window.</p>
 
+      <p><a href="../../../../../jython/GrandReset.py">GrandReset.py</a>
+      </p>
+
+      <p>A script to remove <strong>All</strong> Transits, Sections, SignalMastLogics and
+      remove all saved paths from the Block Table. Requires confirmation when you run it.</p>
+
       <p><a href="../../../../../jython/InitTurnouts.py">InitTurnouts.py</a>
       </p>
 

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -503,7 +503,7 @@
     <h3>Scripting</h3>
         <a id="Scripting" name="Scripting"></a>
         <ul>
-            <li>A new script <a href="../../../../../jython/GrandReset.py">GrandReset.py</a> has been added. The
+            <li>A new script GrandReset.py</a> has been added. The
             script deletes all Transits, Sections and SignalMastLogics.</li>
         </ul>
 

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -503,7 +503,8 @@
     <h3>Scripting</h3>
         <a id="Scripting" name="Scripting"></a>
         <ul>
-            <li></li>
+            <li>A new script <a href="../../../../../jython/GrandReset.py">GrandReset.py</a> has been added. The
+            script deletes all Transits, Sections and SignalMastLogics.</li>
         </ul>
 
     <h3>Signals</h3>

--- a/jython/GrandReset.py
+++ b/jython/GrandReset.py
@@ -37,11 +37,11 @@ if response == 0 :
 
     #   make a copy of transit list (you can't modify the list itself when looping through it
     #   attempting to use the original list results in ConcurrentModificationException
-    transitList = []
+    newList = []
     for trans in transits.getNamedBeanSet() :
-        transitList.append(trans)
+        newList.append(trans)
     # remove all transits
-    for trans in transitList :
+    for trans in newList :
         transits.deleteTransit(trans)
 
     sectionList = sections.getNamedBeanSet()

--- a/jython/GrandReset.py
+++ b/jython/GrandReset.py
@@ -71,5 +71,7 @@ if response == 0 :
 
     # remove all saved paths from the Block menu (not effective until a Save and Quit)
     jmri.InstanceManager.getDefault(jmri.BlockManager).setSavedPathInfo(False)
+    msg = 'Grand reset done\nDo a Store and Quit'
+    JOptionPane.showMessageDialog(None, msg, 'Grand Reset', JOptionPane.INFORMATION_MESSAGE)
 else :
     print "Script aborted"

--- a/jython/GrandReset.py
+++ b/jython/GrandReset.py
@@ -6,7 +6,7 @@
 
 #  Caution:
 #      Only use this script if you have built a valid representation
-#      of your railroad with Layout Edit.
+#      of your railroad with Layout Editor.
 
 #
 #  This script (if you respond "OK" to the confirmation dialog) removes

--- a/jython/GrandReset.py
+++ b/jython/GrandReset.py
@@ -1,0 +1,75 @@
+#  Grand Reset
+#     Delete all transits
+#     Delete all sections
+#     Delete all Signal Mast Logics
+#     Remove all saved paths
+
+#  Caution:
+#      Only use this script if you have built a valid representation
+#      of your railroad with Layout Edit.
+
+#
+#  This script (if you respond "OK" to the confirmation dialog) removes
+#     all transits, sections and SignalMastLogics.
+#     To be effective, you must do a "Store" operation, quit the application
+#     and restart it.
+#  You can then go to the Signal Mast Logic table
+#     and select Tools "Auto Generate Signaling Pairs".
+#     If you know all the pairs are already correct, you can select the
+#     option to "Generate Sections from Mast Pairs".
+#  Finally you can rebuild Transits right click signals on your
+#     Layout Editor panel and using "Create Transit from here".
+#     Follow that by right clicking the next signal and selecting "Add to Transit".
+#     Continue and end with "Add to Transit and Complete"
+#
+
+import jmri
+import java
+from javax.swing import JOptionPane
+
+#  verify that we REALLY want to do this:
+msg = 'Are you SURE that you want do this?\n- Deletes Transits\n- Deletes Sections\n- Deletes SML\n- Deletes Block Paths'
+msg = msg + '\nNote: Do Store and Quit when done.'
+
+response = JOptionPane.showConfirmDialog(None, msg, 'Grand Reset', JOptionPane.OK_CANCEL_OPTION)
+if response == 0 :
+    # if the user doesn't click "OK", we want to leave the script
+    print response
+
+    #  get the transitManger and the sectionManager
+    #     these are two Objects that are not automatically
+    #     created by JMRI scripting as "turnouts" and "sensors" are
+    #
+    transitManager = jmri.InstanceManager.getDefault(jmri.TransitManager)
+    sectionManager = jmri.InstanceManager.getDefault(jmri.SectionManager)
+
+    #   make a copy of section list (you can't modify the list itself when looping through it
+    #   attempting to use the original list results in ConcurrentModificationException
+    transitList = []
+    for trans in transits.getNamedBeanSet() :
+        transitList.append(trans)
+    # remove all transits
+    for trans in transitList :
+        transitManager.deleteTransit(trans)
+
+    sectionList = sections.getNamedBeanSet()
+    #   make a copy of section list (you can't modify the list itself when looping through it
+    #   attempting to use the original list results in ConcurrentModificationException
+    newList = []
+    for section in sectionList:
+        newList.append(section)
+    # remove all sections
+    for section in newList:
+        sectionManager.deleteSection(section)
+
+    mastManager = jmri.InstanceManager.getDefault(jmri.SignalMastLogicManager)
+    mastList = mastManager.getSignalMastLogicList()
+    # remove all Signal Mast Logics
+    # this call removes all logics from the specified mast, regardless of destination mast
+    for mast in mastList:
+        mastManager.removeSignalMastLogic(mast)
+
+    # remove all saved paths from the Block menu (not effective until a Save and Quit)
+    jmri.InstanceManager.getDefault(jmri.BlockManager).setSavedPathInfo(False)
+else :
+    print "Script aborted"

--- a/jython/GrandReset.py
+++ b/jython/GrandReset.py
@@ -34,23 +34,15 @@ msg = msg + '\nNote: Do a Store and Quit when done.'
 response = JOptionPane.showConfirmDialog(None, msg, 'Grand Reset', JOptionPane.OK_CANCEL_OPTION)
 if response == 0 :
     # if the user doesn't click "OK", we want to leave the script
-    print response
 
-    #  get the transitManger and the sectionManager
-    #     these are two Objects that are not automatically
-    #     created by JMRI scripting as "turnouts" and "sensors" are
-    #
-    transitManager = jmri.InstanceManager.getDefault(jmri.TransitManager)
-    sectionManager = jmri.InstanceManager.getDefault(jmri.SectionManager)
-
-    #   make a copy of section list (you can't modify the list itself when looping through it
+    #   make a copy of transit list (you can't modify the list itself when looping through it
     #   attempting to use the original list results in ConcurrentModificationException
     transitList = []
     for trans in transits.getNamedBeanSet() :
         transitList.append(trans)
     # remove all transits
     for trans in transitList :
-        transitManager.deleteTransit(trans)
+        transits.deleteTransit(trans)
 
     sectionList = sections.getNamedBeanSet()
     #   make a copy of section list (you can't modify the list itself when looping through it
@@ -60,7 +52,7 @@ if response == 0 :
         newList.append(section)
     # remove all sections
     for section in newList:
-        sectionManager.deleteSection(section)
+        sections.deleteSection(section)
 
     mastManager = jmri.InstanceManager.getDefault(jmri.SignalMastLogicManager)
     mastList = mastManager.getSignalMastLogicList()

--- a/jython/GrandReset.py
+++ b/jython/GrandReset.py
@@ -44,11 +44,10 @@ if response == 0 :
     for trans in newList :
         transits.deleteTransit(trans)
 
-    sectionList = sections.getNamedBeanSet()
     #   make a copy of section list (you can't modify the list itself when looping through it
     #   attempting to use the original list results in ConcurrentModificationException
     newList = []
-    for section in sectionList:
+    for section in sections.getNamedBeanSet():
         newList.append(section)
     # remove all sections
     for section in newList:

--- a/jython/GrandReset.py
+++ b/jython/GrandReset.py
@@ -29,7 +29,7 @@ from javax.swing import JOptionPane
 
 #  verify that we REALLY want to do this:
 msg = 'Are you SURE that you want do this?\n- Deletes Transits\n- Deletes Sections\n- Deletes SML\n- Deletes Block Paths'
-msg = msg + '\nNote: Do Store and Quit when done.'
+msg = msg + '\nNote: Do a Store and Quit when done.'
 
 response = JOptionPane.showConfirmDialog(None, msg, 'Grand Reset', JOptionPane.OK_CANCEL_OPTION)
 if response == 0 :


### PR DESCRIPTION
A new script "GrandReset.py" to remove ALL Transits, Sections and SignalMastLogics. Confirmation is required before acting. Added a reference line on the "Tools/Scripting/Examples(Links)" page. Added a line to the current -draft-note.shtml.