### PR TITLE
Register PR2/3/4 connections for defaults

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -76,7 +76,13 @@
 
         <h4>LocoNet</h4>
             <ul>
-                <li></li>
+                <li>You can now select separate defaults (in the Preferences -> Defaults pane)
+                for PR2, PR3 and PR4 connections.
+                <p>
+                Note: Existing PR2, PR3 and PR4 connections might give a "The Defaults preferences are invalid"
+                warning when saving preferences.  In that case, click "yes" and then go set
+                all the default radio buttons on the "Defaults" pane to the LocoNet connection.  (You can also
+                click "no", but you'll get the message next time you store too)</li>
             </ul>
 
         <h4>Maple</h4>

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -77,9 +77,9 @@
         <h4>LocoNet</h4>
             <ul>
                 <li>You can now select separate defaults (in the Preferences -> Defaults pane)
-                for PR2, PR3 and PR4 connections.
+                for additional types of LocoNet connections.
                 <p>
-                Note: Existing PR2, PR3 and PR4 connections might give a "The Defaults preferences are invalid"
+                Note: Existing LocoNet connections might give a "The Defaults preferences are invalid"
                 warning when saving preferences.  In that case, click "yes" and then go set
                 all the default radio buttons on the "Defaults" pane to the LocoNet connection.  (You can also
                 click "no", but you'll get the message next time you store too)</li>

--- a/help/en/releasenotes/current-draft-warnings.shtml
+++ b/help/en/releasenotes/current-draft-warnings.shtml
@@ -1,8 +1,8 @@
 
     <!-- contains new warnings for the release under development -->
     <li>
-        The way defaults for Digitrax PR2, PR3 and PR4 connections are handled has changed.
-        Existing PR2, PR3 and PR4 connections might give a "The Defaults preferences are invalid"
+        The way defaults for some LocoNet connections are handled has changed.
+        Existing LocoNet connections might give a "The Defaults preferences are invalid"
         warning when saving preferences.  In that case, click "yes" and then go set
         all the default radio buttons on the "Defaults" pane to the LocoNet connection.  (You can also
         click "no", but you'll get the message next time you store too)

--- a/help/en/releasenotes/current-draft-warnings.shtml
+++ b/help/en/releasenotes/current-draft-warnings.shtml
@@ -1,7 +1,11 @@
 
     <!-- contains new warnings for the release under development -->
     <li>
-        None yet
+        The way defaults for Digitrax PR2, PR3 and PR4 connections are handled has changed.
+        Existing PR2, PR3 and PR4 connections might give a "The Defaults preferences are invalid"
+        warning when saving preferences.  In that case, click "yes" and then go set
+        all the default radio buttons on the "Defaults" pane to the LocoNet connection.  (You can also
+        click "no", but you'll get the message next time you store too)
     </li>
     <li>
     </li>

--- a/java/src/jmri/jmrix/loconet/pr3/PR3SystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/loconet/pr3/PR3SystemConnectionMemo.java
@@ -103,6 +103,8 @@ public class PR3SystemConnectionMemo extends LocoNetSystemConnectionMemo {
             };
             InstanceManager.getDefault(jmri.ShutDownManager.class).register(restoreToLocoNetInterfaceModeTask);
         }
+
+        register();
     }
 
     @Override


### PR DESCRIPTION
This fixes a problem where Digitrax PR2/3/4 device connections would not have entries in the Defaults preferences pane.