### PR TITLE
Update ControlPanel.py to show panel windows

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -486,7 +486,8 @@
     <h3>Scripting</h3>
         <a id="Scripting" name="Scripting"></a>
         <ul>
-            <li></li>
+            <li>Updated ControlPanel.py sample script to show the panel windows
+            instead of the panel editor windows.</li>
         </ul>
 
     <h3>Signals</h3>

--- a/jython/ControlPanel.py
+++ b/jython/ControlPanel.py
@@ -4,10 +4,10 @@
 # When this script is run, it finds all open panels
 # (for either PanelEditor or LayoutEditor)
 # and creates a small window with a button for each panel.
-# The buttons are labelled with the names of the panels, 
+# The buttons are labelled with the names of the panels,
 # and it's required that those names be unique.
 #
-# Author: Bob Jacobsen, copyright 2006,2008
+# Author: Bob Jacobsen, copyright 2006,2008, 2022
 # Part of the JMRI distribution
 
 import jmri
@@ -24,27 +24,29 @@ f.getContentPane().setLayout(java.awt.FlowLayout())
 def whenMyButtonClicked(event) :
         name  = event.getActionCommand()
         # find any PanelEditor panel(s) to show
-        for panel in jmri.InstanceManager.getDefault(jmri.jmrit.display.EditorManager).getAll() :
-            if (name == panel.getTitle()) : 
+        for editor in jmri.InstanceManager.getDefault(jmri.jmrit.display.EditorManager).getAll() :
+            panel = editor.getTargetFrame()
+            if (name == panel.getTitle()) :
                 panel.setVisible(not panel.isVisible())
-                return            
+                return
         return
-        
+
 # Now loop to create buttons.
 #
 # The "action" in each button is the name of the panel.
-# When clicked, it provides that name.  We 
-# then use a map between that name and the actual 
-# window produced from the file, so we can show/hide the 
+# When clicked, it provides that name.  We
+# then use a map between that name and the actual
+# window produced from the file, so we can show/hide the
 # proper panel window.
 
 # loop, creating a button for each panel
-for panel in jmri.InstanceManager.getDefault(jmri.jmrit.display.EditorManager).getAll() :
+for editor in jmri.InstanceManager.getDefault(jmri.jmrit.display.EditorManager).getAll() :
+    panel = editor.getTargetFrame()
     # create a button for this panel
     b = javax.swing.JButton(panel.getTitle())
     b.actionPerformed = whenMyButtonClicked
     f.contentPane.add(b)
-    
+
 
 # show the control panel frame
 f.pack()


### PR DESCRIPTION
ControlPanel.py used to show panel windows, but somewhere along the way the underlying code changed and it started showing the panel _editor_ windows instead.  This puts back the original behavior.