### PR TITLE
Improve JUnitUtil waitFor condition Exception Reporting

### DIFF
--- a/java/test/jmri/util/JUnitUtil.java
+++ b/java/test/jmri/util/JUnitUtil.java
@@ -1,5 +1,7 @@
 package jmri.util;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import java.awt.*;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -458,6 +460,7 @@ public class JUnitUtil {
      * @param name      name of condition being waited for; will appear in
      *                  Assert.fail if condition not true fast enough
      */
+    @SuppressFBWarnings("REC_CATCH_EXCEPTION")
     static public void waitFor(ReleaseUntil condition, String name) {
         if (javax.swing.SwingUtilities.isEventDispatchThread()) {
             log.error("Cannot use waitFor on Swing thread", new Exception());
@@ -466,8 +469,12 @@ public class JUnitUtil {
         int delay = 0;
         try {
             while (delay < WAITFOR_MAX_DELAY) {
-                if (condition.ready()) {
-                    return;
+                try {
+                    if (condition.ready()) {
+                        return;
+                    }
+                } catch(Exception ex) {
+                    Assertions.fail("Exception while processing condition for \"" + name + "\" ", ex);
                 }
                 int priority = Thread.currentThread().getPriority();
                 try {
@@ -475,14 +482,14 @@ public class JUnitUtil {
                     Thread.sleep(WAITFOR_DELAY_STEP);
                     delay += WAITFOR_DELAY_STEP;
                 } catch (InterruptedException e) {
-                    Assert.fail("failed due to InterruptedException");
+                    Assertions.fail("failed due to InterruptedException", e);
                 } finally {
                     Thread.currentThread().setPriority(priority);
                 }
             }
-            Assert.fail("\"" + name + "\" did not occur in time");
+            Assertions.fail("\"" + name + "\" did not occur in time");
         } catch (Exception ex) {
-            Assert.fail("Exception while waiting for \"" + name + "\" " + ex);
+            Assertions.fail("Exception while waiting for \"" + name + "\" ", ex);
         }
     }
 
@@ -575,6 +582,7 @@ public class JUnitUtil {
      * @param name      name of condition being waited for; will appear in
      *                  Assert.fail if condition not true fast enough
      */
+    @SuppressFBWarnings("REC_CATCH_EXCEPTION")
     static public void fasterWaitFor(ReleaseUntil condition, String name) {
         if (javax.swing.SwingUtilities.isEventDispatchThread()) {
             log.error("Cannot use waitFor on Swing thread", new Exception());
@@ -583,8 +591,12 @@ public class JUnitUtil {
         int delay = 0;
         try {
             while (delay < 1000) {
-                if (condition.ready()) {
-                    return;
+                try {
+                    if (condition.ready()) {
+                        return;
+                    }
+                } catch(Exception ex) {
+                    Assertions.fail("Exception while processing condition for \"" + name + "\" ", ex);
                 }
                 int priority = Thread.currentThread().getPriority();
                 try {
@@ -592,14 +604,14 @@ public class JUnitUtil {
                     Thread.sleep(5);
                     delay += 5;
                 } catch (InterruptedException e) {
-                    Assert.fail("failed due to InterruptedException");
+                    Assertions.fail("failed due to InterruptedException", e);
                 } finally {
                     Thread.currentThread().setPriority(priority);
                 }
             }
-            Assert.fail("\"" + name + "\" did not occur in time");
+            Assertions.fail("\"" + name + "\" did not occur in time");
         } catch (Exception ex) {
-            Assert.fail("Exception while waiting for \"" + name + "\" " + ex);
+            Assertions.fail("Exception while waiting for \"" + name + "\" ", ex);
         }
     }
 


### PR DESCRIPTION
eg. Failure : 

```
     [java] Failures (1):
     [java]   JUnit Jupiter:WarrantTest:testWarrant():repetition 1060 of 2000
     [java]     MethodSource [className = 'jmri.jmrit.logix.WarrantTest', methodName = 'testWarrant', methodParameterTypes = '']
     [java]     => org.opentest4j.AssertionFailedError: Exception while processing condition for "warrant not done"
     [java]        org.junit.jupiter.api.AssertionUtils.fail(AssertionUtils.java:42)
     [java]        org.junit.jupiter.api.Assertions.fail(Assertions.java:147)
     [java]        jmri.util.JUnitUtil.waitFor(JUnitUtil.java:474)
     [java]        jmri.jmrit.logix.WarrantTest.testWarrant(WarrantTest.java:228)
     [java]        jdk.internal.reflect.GeneratedMethodAccessor4.invoke(Unknown Source)
     [java]        [...]
     [java]      Caused by: java.lang.NullPointerException
     [java]        jmri.jmrit.logix.Warrant.getRunningMessage(Warrant.java:639)
     [java]        jmri.jmrit.logix.WarrantTest.lambda$testWarrant$3(WarrantTest.java:230)
     [java]        jmri.util.JUnitUtil.waitFor(JUnitUtil.java:470)
     [java]        [...]
```