### PR TITLE
Add Prestart Actions, Remove warnings re miss tags, fix crash in speedprofile

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -383,7 +383,7 @@
    <h3>Dispatcher</h3>
         <a id="Dispatcher" name="Dispatcher"></a>
         <ul>
-             <li></li>
+             <li>Add ability to add PreStart delay and actions.</li>
         </ul>
 
     <h3>Dispatcher System</h3>

--- a/java/src/jmri/TransitSectionAction.java
+++ b/java/src/jmri/TransitSectionAction.java
@@ -1,5 +1,8 @@
 package jmri;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * This class holds information and options for a Action to be applied when an
  * automated train enters, exits, or is inside of a Section in a Transit.
@@ -28,7 +31,8 @@ public class TransitSectionAction {
      * 
      * TODO: Convert to ENUM
      */
-    public static final int NUM_WHENS = 8; // Must correspond to the number of entries below
+    public static final int NUM_WHENS = 10; // Must correspond to the number of entries below
+    public static final int SELECTWHEN = 0;
     public static final int ENTRY = 1;   // On entry to Section
     public static final int EXIT = 2;   // On exit from Section
     public static final int BLOCKENTRY = 3; // On entry to specified Block in the Section
@@ -37,6 +41,9 @@ public class TransitSectionAction {
     public static final int TRAINSTART = 6; // When train starts 
     public static final int SENSORACTIVE = 7; // When specified Sensor changes to Active
     public static final int SENSORINACTIVE = 8; // When specified Sensor changtes to Inactive
+    public static final int PRESTARTDELAY = 9; // delays the throttle going from 0
+    public static final int PRESTARTACTION = 10; // Actions timed of prestartdelay
+
     // other action 'whens" may be defined here
 
     /**
@@ -44,6 +51,7 @@ public class TransitSectionAction {
      * 
      * TODO: Convert to ENUM
      */
+    public static final int SELECTWHAT = 0;
     public static final int PAUSE = 1;    // pause for the number of fast minutes in mDataWhat (e.g. station stop)
     public static final int SETMAXSPEED = 2; // set maximum train speed to value entered
     public static final int SETCURRENTSPEED = 3; // set current speed to target speed immediately - no ramping
@@ -62,14 +70,15 @@ public class TransitSectionAction {
     public static final int HOLDSIGNAL = 14;    // set specified signalhead or signalmast to HELD
     public static final int RELEASESIGNAL = 15; // set specified signalhead or signalmast to NOT HELD
     public static final int ESTOP = 16;   // set ESTOP
-    public static final int NUM_WHATS = 16; // Must correspond to the number of entries above
-    // other action 'whats" may be defined here, increment NUM_WHATS to match
+    public static final int PRESTARTRESUME = 17; // Resume after prestart
+    public static final int NUM_WHATS = 17; // Must correspond to the number of entries above
+    // other action 'whats" may be defined above, increment NUM_WHATS to match
 
     /**
      * Create a TransitSectionAction.
      *
      * @param when one of
-     *             {@link #ENTRY}, {@link #EXIT}, {@link #BLOCKENTRY}, {@link #BLOCKEXIT}, {@link #TRAINSTOP}, {@link #TRAINSTART}, {@link #SENSORACTIVE}, {@link #SENSORINACTIVE}
+     *             {@link #ENTRY}, {@link #EXIT}, {@link #BLOCKENTRY}, {@link #BLOCKEXIT}, {@link #TRAINSTOP}, {@link #TRAINSTART}, {@link #SENSORACTIVE}, {@link #SENSORINACTIVE}, {@link #PRESTARTRESUME}
      * @param what one of
      *             {@link #PAUSE}, {@link #SETMAXSPEED}, {@link #SETCURRENTSPEED}, {@link #RAMPTRAINSPEED}, {@link #TOMANUALMODE}, {@link #SETLIGHT}, {@link #STARTBELL}, {@link #STOPBELL}, {@link #SOUNDHORN}, {@link #SOUNDHORNPATTERN}, {@link #LOCOFUNCTION}, {@link #SETSENSORACTIVE}, {@link #SETSENSORINACTIVE}, {@link #HOLDSIGNAL}, {@link #RELEASESIGNAL}
      */
@@ -102,18 +111,27 @@ public class TransitSectionAction {
         mStringWhat = sWhat;
     }
 
+
     // instance variables
     private int mWhen = 0;
     private int mWhat = 0;
     private int mDataWhen = -1; // negative number signified no data 
     private int mDataWhat1 = -1;    // negative number signified no data 
+    private float mDataWhat1Float = -1.0f;
     private int mDataWhat2 = -1;    // negative number signified no data 
     private String mStringWhen = "";
     private String mStringWhat = "";
+    private Object threadObject;
 
     /*
      * Access methods
      */
+    public void setThreadObject(Object threadObj) {
+        threadObject = threadObj;
+    }
+    public Object getThreadObject() {
+        return threadObject;
+    }
     public int getWhenCode() {
         return mWhen;
     }
@@ -136,6 +154,14 @@ public class TransitSectionAction {
 
     public void setDataWhen(int n) {
         mDataWhen = n;
+    }
+
+    public float getDataWhat1Float() {
+        return mDataWhat1Float;
+    }
+
+    public void setDataWhat1Float(float n) {
+        mDataWhat1Float = n;
     }
 
     public int getDataWhat1() {

--- a/java/src/jmri/implementation/DefaultTransit.java
+++ b/java/src/jmri/implementation/DefaultTransit.java
@@ -101,6 +101,7 @@ public class DefaultTransit extends AbstractNamedBean implements Transit {
      *
      * @param s the Section object to add
      */
+    @Override
     public void addTransitSection(TransitSection s) {
         mTransitSectionList.add(s);
         mMaxSequence = s.getSequenceNumber();
@@ -111,6 +112,7 @@ public class DefaultTransit extends AbstractNamedBean implements Transit {
      *
      * @return a copy of the internal list of TransitSections or an empty list
      */
+    @Override
     public ArrayList<TransitSection> getTransitSectionList() {
         return new ArrayList<>(mTransitSectionList);
     }
@@ -120,6 +122,7 @@ public class DefaultTransit extends AbstractNamedBean implements Transit {
      *
      * @return the maximum sequence
      */
+    @Override
     public int getMaxSequence() {
         return mMaxSequence;
     }
@@ -127,6 +130,7 @@ public class DefaultTransit extends AbstractNamedBean implements Transit {
     /**
      * Remove all TransitSections in this Transit.
      */
+    @Override
     public void removeAllSections() {
         mTransitSectionList.clear();
     }
@@ -137,6 +141,7 @@ public class DefaultTransit extends AbstractNamedBean implements Transit {
      * @param s the section to check for
      * @return true if the section is present; false otherwise
      */
+    @Override
     public boolean containsSection(Section s) {
         return mTransitSectionList.stream().anyMatch((ts) -> (ts.getSection() == s));
     }
@@ -147,6 +152,7 @@ public class DefaultTransit extends AbstractNamedBean implements Transit {
      * @param seq the sequence number
      * @return the list of of matching sections or an empty list if none
      */
+    @Override
     public ArrayList<Section> getSectionListBySeq(int seq) {
         ArrayList<Section> list = new ArrayList<>();
         for (TransitSection ts : mTransitSectionList) {
@@ -163,6 +169,7 @@ public class DefaultTransit extends AbstractNamedBean implements Transit {
      * @param seq the sequence number
      * @return the list of of matching sections or an empty list if none
      */
+    @Override
     public ArrayList<TransitSection> getTransitSectionListBySeq(int seq) {
         ArrayList<TransitSection> list = new ArrayList<>();
         for (TransitSection ts : mTransitSectionList) {
@@ -179,6 +186,7 @@ public class DefaultTransit extends AbstractNamedBean implements Transit {
      * @param s the section to match
      * @return the list of matching sequence numbers or an empty list if none
      */
+    @Override
     public ArrayList<Integer> getSeqListBySection(Section s) {
         ArrayList<Integer> list = new ArrayList<>();
         for (TransitSection ts : mTransitSectionList) {
@@ -195,6 +203,7 @@ public class DefaultTransit extends AbstractNamedBean implements Transit {
      * @param block the block to check for
      * @return true if block is present; false otherwise
      */
+    @Override
     public boolean containsBlock(Block block) {
         for (Block b : getInternalBlocksList()) {
             if (b == block) {
@@ -210,6 +219,7 @@ public class DefaultTransit extends AbstractNamedBean implements Transit {
      * @param block the block to check for
      * @return the number of times block is present; 0 if block is not present
      */
+    @Override
     public int getBlockCount(Block block) {
         int count = 0;
         for (Block b : getInternalBlocksList()) {
@@ -227,6 +237,7 @@ public class DefaultTransit extends AbstractNamedBean implements Transit {
      * @param seq the sequence number of the Section
      * @return the Section or null if no matching Section is present
      */
+    @Override
     public Section getSectionFromBlockAndSeq(Block b, int seq) {
         for (TransitSection ts : mTransitSectionList) {
             if (ts.getSequenceNumber() == seq) {
@@ -246,6 +257,7 @@ public class DefaultTransit extends AbstractNamedBean implements Transit {
      * @param seq the sequence number of the Section
      * @return the Section or null if no matching Section is present
      */
+    @Override
     public Section getSectionFromConnectedBlockAndSeq(Block b, int seq) {
         for (TransitSection ts : mTransitSectionList) {
             if (ts.getSequenceNumber() == seq) {
@@ -267,6 +279,7 @@ public class DefaultTransit extends AbstractNamedBean implements Transit {
      *         or {@link jmri.Section#REVERSE} or zero if s and seq are not in a
      *         TransitSection together
      */
+    @Override
     public int getDirectionFromSectionAndSeq(Section s, int seq) {
         for (TransitSection ts : mTransitSectionList) {
             if ((ts.getSection() == s) && (ts.getSequenceNumber() == seq)) {
@@ -283,6 +296,7 @@ public class DefaultTransit extends AbstractNamedBean implements Transit {
      * @param seq the sequence number of the Section
      * @return the transit section or null if not found
      */
+    @Override
     public TransitSection getTransitSectionFromSectionAndSeq(Section s, int seq) {
         for (TransitSection ts : mTransitSectionList) {
             if ((ts.getSection() == s) && (ts.getSequenceNumber() == seq)) {
@@ -301,6 +315,7 @@ public class DefaultTransit extends AbstractNamedBean implements Transit {
      *
      * @return the list of all Blocks or an empty list if none are present
      */
+    @Override
     public ArrayList<Block> getInternalBlocksList() {
         ArrayList<Block> list = new ArrayList<>();
         blockSecSeqList.clear();
@@ -321,6 +336,7 @@ public class DefaultTransit extends AbstractNamedBean implements Transit {
      * @return the list of all sequence numbers or an empty list if no Blocks
      *         are present
      */
+    @Override
     public ArrayList<Integer> getBlockSeqList() {
         return new ArrayList<>(blockSecSeqList);
     }
@@ -334,6 +350,7 @@ public class DefaultTransit extends AbstractNamedBean implements Transit {
      *
      * @return the list of all blocks or an empty list if none are present
      */
+    @Override
     public ArrayList<Block> getEntryBlocksList() {
         ArrayList<Block> list = new ArrayList<>();
         ArrayList<Block> internalBlocks = getInternalBlocksList();
@@ -380,6 +397,7 @@ public class DefaultTransit extends AbstractNamedBean implements Transit {
      *                       otherwise
      * @return a list of destination Blocks or an empty list if none exist
      */
+    @Override
     public ArrayList<Block> getDestinationBlocksList(Block startBlock, boolean startInTransit) {
         ArrayList<Block> list = new ArrayList<>();
         destBlocksSeqList.clear();
@@ -430,6 +448,7 @@ public class DefaultTransit extends AbstractNamedBean implements Transit {
      * @return the list of all destination Block sequence numbers or an empty
      *         list if no destination Blocks are present
      */
+    @Override
     public ArrayList<Integer> getDestBlocksSeqList() {
         ArrayList<Integer> list = new ArrayList<>();
         for (int i = 0; i < destBlocksSeqList.size(); i++) {
@@ -452,6 +471,7 @@ public class DefaultTransit extends AbstractNamedBean implements Transit {
      *
      * @return true if continuous running is possible; otherwise false
      */
+    @Override
     public boolean canBeResetWhenDone() {
         TransitSection firstTS = mTransitSectionList.get(0);
         int lastIndex = mTransitSectionList.size() - 1;
@@ -486,6 +506,7 @@ public class DefaultTransit extends AbstractNamedBean implements Transit {
      *
      * @return 0 if no errors, number of errors otherwise.
      */
+    @Override
     public int initializeBlockingSensors() {
         int numErrors = 0;
         for (int i = 0; i < mTransitSectionList.size(); i++) {
@@ -520,8 +541,9 @@ public class DefaultTransit extends AbstractNamedBean implements Transit {
         return numErrors;
     }
 
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(value = "UC_USELESS_OBJECT",
-            justification = "SpotBugs doesn't see that toBeRemoved is being read by the forEach clause")
+    //@edu.umd.cs.findbugs.annotations.SuppressFBWarnings(value = "UC_USELESS_OBJECT",
+    //         justification = "SpotBugs doesn't see that toBeRemoved is being read by the forEach clause")
+    @Override
     public void removeTemporarySections() {
         ArrayList<TransitSection> toBeRemoved = new ArrayList<>();
         for (TransitSection ts : mTransitSectionList) {
@@ -534,6 +556,7 @@ public class DefaultTransit extends AbstractNamedBean implements Transit {
         });
     }
 
+    @Override
     public boolean removeLastTemporarySection(Section s) {
         TransitSection last = mTransitSectionList.get(mTransitSectionList.size() - 1);
         if (last.getSection() != s) {

--- a/java/src/jmri/jmrit/Bundle.properties
+++ b/java/src/jmri/jmrit/Bundle.properties
@@ -158,6 +158,7 @@ Locked          = Locked
 Normal          = Normal
 ReminderSaveString=<html>Remember to save your {0} information in your Configuration.<br>(choose Store &gt; Store Configuration... from the File menu)</html>
 LabelMilliseconds = milliseconds
+LabelSeconds = seconds
 
 # system- and user name moved to NBBundle
 ColumnHeadEnabled = Enabled

--- a/java/src/jmri/jmrit/beantable/SectionTransitTableBundle.properties
+++ b/java/src/jmri/jmrit/beantable/SectionTransitTableBundle.properties
@@ -93,6 +93,7 @@ WhenBoxTip = Select when the action is to be initiated
 WhatText = What:
 WhatBoxTip = Select what action is requested
 OptionalDelay = Delay (optional)
+Delay = Delay
 #Milliseconds = milliseconds
 BlockStringTip = Select a Block within this Section
 # On/Off moved to jmri.NamedBeanBundle.properties key StateOff/StateOn
@@ -102,8 +103,9 @@ SelectASignal = Select one of
 DoneSensorLabel = Done Sensor (optional)
 HintDoneSensor = (Optional) Select a Sensor notifying the dispatcher when done working.
 
+SelectWhen = Select When
 OnEntry = On Section Entry
-HintDelayData = Enter time in milliseconds to wait before action is initiated (0 = no delay)
+HintDelayData = Enter time in milliseconds/seconds to wait before action is initiated (0 = no delay)
 OnExit = On Section Exit
 OnEntryFull = On Entry to this Section
 OnEntryDelayedFull = "{0}" mSec after entering this Section
@@ -130,7 +132,13 @@ OnSensorActiveDelayedFull = "{0}" mSec after Sensor "{1}" becomes ACTIVE
 OnSensorInactive = On Sensor INACTIVE
 OnSensorInactiveFull = When Sensor "{0}" becomes INACTIVE
 OnSensorInactiveDelayedFull = "{0}" mSec after Sensor "{1}" becomes INACTIVE
-
+PreStartDelay = Delay Start
+PreStartAction = Delay Start Action
+PreStartDelayFull = Pre-start
+PreStartActionFull = "{0}" mSec after Start of Delay
+PreStartResume = Pre-start Delay
+PreStartResumeFull = Delay Start for "{0}" mSec
+SelectWhat = Select What
 Pause = Pause Train
 PauseFull = Pause for "{0}" fast minutes
 HintPauseData = Enter the number of fast clock minutes to pause for.

--- a/java/src/jmri/jmrit/dispatcher/AutoActiveTrain.java
+++ b/java/src/jmri/jmrit/dispatcher/AutoActiveTrain.java
@@ -138,7 +138,16 @@ public class AutoActiveTrain implements ThrottleListener {
         return _autoEngineer.getTargetSpeed();
     }
 
+    public synchronized void setTargetSpeedByPass(float speed) {
+         _autoEngineer.setTargetSpeed(speed);
+    }
+
     public synchronized void setTargetSpeed(float speed) {
+        if (_autoEngineer.isStopped() && getTargetSpeed() == 0.0f && speed > 0.0f) {
+            if (_autoTrainAction.isDelayedStart(speed)) {
+                return;
+            }
+        }
         _autoEngineer.setTargetSpeed(speed);
     }
 
@@ -1811,7 +1820,7 @@ public class AutoActiveTrain implements ThrottleListener {
                         waitNow = false;
                     }
                 } catch (InterruptedException e) {
-                    log.error("InterruptedException while waiting to stop for pause", e);
+                    log.trace("InterruptedException while waiting to stop for pause-indicates action cancelled.", e);
                     waitNow = false;
                     keepGoing = false;
                 }
@@ -1833,7 +1842,7 @@ public class AutoActiveTrain implements ThrottleListener {
                             waitNow = false;
                         }
                     } catch (InterruptedException e) {
-                        log.error("InterruptedException while waiting when paused", e);
+                        log.trace("InterruptedException indicates action cancelled.", e);
                         keepGoing = false;
                     }
                 }

--- a/java/src/jmri/jmrit/roster/RosterSpeedProfile.java
+++ b/java/src/jmri/jmrit/roster/RosterSpeedProfile.java
@@ -829,7 +829,7 @@ public class RosterSpeedProfile {
                 log.warn("Throttle destroyed before zero length[{}] remaining.",calculatedDistance);
                 calculatedDistance = 0;
             }
-            if (calculatedDistance < 0 && !calculated) {
+            if (calculatedDistance <= 0 && !calculated) {
                 log.error("distance remaining is now 0, but we have not reached desired speed setting {} v {}", desiredSpeedStep, calculatingStep);
                 ss = new SpeedSetting(desiredSpeedStep, 10);
                 synchronized (this) {


### PR DESCRIPTION
Add Prestart Action that take place in a defined period ahead of a train moving.
    Clean up Actions executed thru iterator. Remove those that have executed,
    stop flagging cancelling of task errors and other stuff.
    Ensure actions that were not used in a section are removed and not stacked to occur
    next time the condition becomes true, even though its in the wrong section.
    eg every section has a sound horn on stop, after ten sections the train needs to stop.
    It now only executes the action for that section and does not repeat 9 more times.
    Allow Action pauses to be entered as second or milliseconds.
    Fix crash in stopping by profile. If the distance goes to zero there is no throttle.
    Add @override when overriding, so removing warning messages.