### PR TITLE
Use BoxLayout to ensure text fields are visible

### DIFF
--- a/java/src/jmri/jmrit/display/IconAdder.java
+++ b/java/src/jmri/jmrit/display/IconAdder.java
@@ -518,8 +518,11 @@ public class IconAdder extends JPanel implements ListSelectionListener {
         _buttonPanel = new JPanel();
         _buttonPanel.setLayout(new BoxLayout(_buttonPanel, BoxLayout.Y_AXIS));
         JPanel p = new JPanel();
-        p.setLayout(new BoxLayout(p, BoxLayout.X_AXIS));
+        p.setLayout(new FlowLayout());
         if (addToTable) {
+            JPanel pInner = new JPanel();
+            pInner.setLayout(new BoxLayout(pInner, BoxLayout.X_AXIS));
+            p.add(pInner);
             _sysNameText = new JTextField();
             _sysNameText.setPreferredSize(
                     new Dimension(150, _sysNameText.getPreferredSize().height + 2));
@@ -547,7 +550,7 @@ public class IconAdder extends JPanel implements ListSelectionListener {
             _addTableButton.addActionListener((ActionEvent a) -> addToTable());
             _addTableButton.setEnabled(false);
             _addTableButton.setToolTipText(Bundle.getMessage("ToolTipWillActivate"));
-            p.add(_sysNameText);
+            pInner.add(_sysNameText);
             _sysNameText.addKeyListener(new KeyAdapter() {
                 @Override
                 public void keyReleased(KeyEvent a) {
@@ -559,7 +562,7 @@ public class IconAdder extends JPanel implements ListSelectionListener {
                 }
             });
 
-            p.add(_addTableButton);
+            pInner.add(_addTableButton);
             _buttonPanel.add(p);
             p = new JPanel();
             p.setLayout(new FlowLayout());  //new BoxLayout(p, BoxLayout.Y_AXIS)

--- a/java/src/jmri/jmrit/display/IconAdder.java
+++ b/java/src/jmri/jmrit/display/IconAdder.java
@@ -522,7 +522,6 @@ public class IconAdder extends JPanel implements ListSelectionListener {
         if (addToTable) {
             JPanel pInner = new JPanel();
             pInner.setLayout(new BoxLayout(pInner, BoxLayout.X_AXIS));
-            p.add(pInner);
             _sysNameText = new JTextField();
             _sysNameText.setPreferredSize(
                     new Dimension(150, _sysNameText.getPreferredSize().height + 2));
@@ -563,6 +562,7 @@ public class IconAdder extends JPanel implements ListSelectionListener {
             });
 
             pInner.add(_addTableButton);
+            p.add(pInner);
             _buttonPanel.add(p);
             p = new JPanel();
             p.setLayout(new FlowLayout());  //new BoxLayout(p, BoxLayout.Y_AXIS)

--- a/java/src/jmri/jmrit/display/IconAdder.java
+++ b/java/src/jmri/jmrit/display/IconAdder.java
@@ -518,7 +518,7 @@ public class IconAdder extends JPanel implements ListSelectionListener {
         _buttonPanel = new JPanel();
         _buttonPanel.setLayout(new BoxLayout(_buttonPanel, BoxLayout.Y_AXIS));
         JPanel p = new JPanel();
-        p.setLayout(new FlowLayout());
+        p.setLayout(new BoxLayout(p, BoxLayout.X_AXIS));
         if (addToTable) {
             _sysNameText = new JTextField();
             _sysNameText.setPreferredSize(

--- a/java/src/jmri/jmrit/display/MemoryComboIcon.java
+++ b/java/src/jmri/jmrit/display/MemoryComboIcon.java
@@ -4,6 +4,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 
 import javax.swing.AbstractButton;
+import javax.swing.BoxLayout;
 import javax.swing.DefaultComboBoxModel;
 import javax.swing.DefaultListModel;
 import javax.swing.JButton;
@@ -260,8 +261,8 @@ public class MemoryComboIcon extends PositionableJPanel
                 p.add(p1);
                 p.add(scrollPane);
                 p1 = new JPanel();
+                p1.setLayout(new BoxLayout(p1, BoxLayout.X_AXIS));
                 p1.add(new JLabel(Bundle.getMessage("newItem"), SwingConstants.RIGHT));
-                textfield.setMaximumSize(textfield.getPreferredSize());
                 p1.add(textfield);
                 p.add(p1);
                 JPanel p2 = new JPanel();

--- a/java/src/jmri/jmrit/display/MemoryComboIcon.java
+++ b/java/src/jmri/jmrit/display/MemoryComboIcon.java
@@ -263,9 +263,9 @@ public class MemoryComboIcon extends PositionableJPanel
                 p1 = new JPanel();
                 JPanel pInner1 = new JPanel();
                 pInner1.setLayout(new BoxLayout(pInner1, BoxLayout.X_AXIS));
-                p1.add(pInner1);
                 pInner1.add(new JLabel(Bundle.getMessage("newItem"), SwingConstants.RIGHT));
                 pInner1.add(textfield);
+                p1.add(pInner1);
                 p.add(p1);
                 JPanel p2 = new JPanel();
                 //p2.setLayout(new BoxLayout(p2, BoxLayout.Y_AXIS));

--- a/java/src/jmri/jmrit/display/MemoryComboIcon.java
+++ b/java/src/jmri/jmrit/display/MemoryComboIcon.java
@@ -256,14 +256,16 @@ public class MemoryComboIcon extends PositionableJPanel
                 }
                 list = new JList<>(_listModel);
                 JScrollPane scrollPane = new JScrollPane(list);
-                JPanel p1 = new JPanel();
-                p1.add(new JLabel(Bundle.getMessage("comboList")));
-                p.add(p1);
+                JPanel pInner1 = new JPanel();
+                pInner1.add(new JLabel(Bundle.getMessage("comboList")));
+                p.add(pInner1);
                 p.add(scrollPane);
-                p1 = new JPanel();
-                p1.setLayout(new BoxLayout(p1, BoxLayout.X_AXIS));
-                p1.add(new JLabel(Bundle.getMessage("newItem"), SwingConstants.RIGHT));
-                p1.add(textfield);
+                JPanel p1 = new JPanel();
+                pInner1 = new JPanel();
+                pInner1.setLayout(new BoxLayout(pInner1, BoxLayout.X_AXIS));
+                p1.add(pInner1);
+                pInner1.add(new JLabel(Bundle.getMessage("newItem"), SwingConstants.RIGHT));
+                pInner1.add(textfield);
                 p.add(p1);
                 JPanel p2 = new JPanel();
                 //p2.setLayout(new BoxLayout(p2, BoxLayout.Y_AXIS));

--- a/java/src/jmri/jmrit/display/MemoryComboIcon.java
+++ b/java/src/jmri/jmrit/display/MemoryComboIcon.java
@@ -256,12 +256,12 @@ public class MemoryComboIcon extends PositionableJPanel
                 }
                 list = new JList<>(_listModel);
                 JScrollPane scrollPane = new JScrollPane(list);
-                JPanel pInner1 = new JPanel();
-                pInner1.add(new JLabel(Bundle.getMessage("comboList")));
-                p.add(pInner1);
-                p.add(scrollPane);
                 JPanel p1 = new JPanel();
-                pInner1 = new JPanel();
+                p1.add(new JLabel(Bundle.getMessage("comboList")));
+                p.add(p1);
+                p.add(scrollPane);
+                p1 = new JPanel();
+                JPanel pInner1 = new JPanel();
                 pInner1.setLayout(new BoxLayout(pInner1, BoxLayout.X_AXIS));
                 p1.add(pInner1);
                 pInner1.add(new JLabel(Bundle.getMessage("newItem"), SwingConstants.RIGHT));


### PR DESCRIPTION
This PR ensures that the two text fields are visible when the dialog is narrow.

See:
https://jmri-developers.groups.io/g/jmri/message/7993
https://jmri-developers.groups.io/g/jmri/message/8000

![MemoryComboBox2](https://user-images.githubusercontent.com/20255317/205438820-c9537191-5362-45a7-9328-073aff634e28.png)