### PR TITLE
DecoderPro First Time Startup Wizard - fix Default Font Size set to 0

### DIFF
--- a/java/src/apps/gui3/FirstTimeStartUpWizard.java
+++ b/java/src/apps/gui3/FirstTimeStartUpWizard.java
@@ -313,6 +313,9 @@ public class FirstTimeStartUpWizard implements Thread.UncaughtExceptionHandler {
             Profile project = ProfileManager.getDefault().getActiveProfile();
             InstanceManager.getDefault(RosterConfigManager.class).setDefaultOwner(project, owner.getText());
             InstanceManager.getDefault(GuiLafPreferencesManager.class).setLocale(Locale.getDefault());
+            InstanceManager.getDefault(GuiLafPreferencesManager.class).setDefaultFontSize();
+            InstanceManager.getDefault(GuiLafPreferencesManager.class).setFontSize(
+                InstanceManager.getDefault(GuiLafPreferencesManager.class).getDefaultFontSize());
             InstanceManager.getDefault(RosterConfigManager.class).savePreferences(project);
             InstanceManager.getDefault(GuiLafPreferencesManager.class).savePreferences(project);
             connectionConfigPane.savePreferences();

--- a/java/test/apps/gui3/FirstTimeStartUpWizardTest.java
+++ b/java/test/apps/gui3/FirstTimeStartUpWizardTest.java
@@ -10,6 +10,7 @@ import jmri.util.JUnitAppender;
 import apps.gui3.dp3.DecoderPro3;
 
 import jmri.util.JUnitUtil;
+import jmri.util.gui.GuiLafPreferencesManager;
 
 import org.netbeans.jemmy.operators.*;
 import org.junit.jupiter.api.*;
@@ -112,6 +113,9 @@ public class FirstTimeStartUpWizardTest {
         JUnitUtil.waitFor(() -> {
             return JUnitAppender.checkForMessageStartingWith("No pre-existing config file found, searched for ") != null;
         }, "no existing config Info line seen");
+
+        Assertions.assertNotEquals(0, InstanceManager.getDefault(GuiLafPreferencesManager.class).getFontSize(),
+            "Font size should not be 0");
 
     }
 


### PR DESCRIPTION
Currently the font size is not set when the profile is saved, so when the profile is then loaded the font size is set to 0.
This PR sets the default font size for a profile before saving.
The new unit test which checks the profile font size currently fails in HOM.