### PR TITLE
Implement CdB CC-Schnitte 2.1 via USB as a command station

### DIFF
--- a/java/src/jmri/jmrix/marklin/MarklinSystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/marklin/MarklinSystemConnectionMemo.java
@@ -19,6 +19,10 @@ import jmri.util.NamedBeanComparator;
  */
 public class MarklinSystemConnectionMemo extends jmri.jmrix.DefaultSystemConnectionMemo implements ConfiguringSystemConnectionMemo {
 
+    // Allow is-a relation between sub types, i.e. CdB and Marklin
+    protected MarklinSystemConnectionMemo(String prefix, String userName) {
+        super(prefix, userName);
+    }
     public MarklinSystemConnectionMemo(MarklinTrafficController et) {
         super("M", "Marklin-CS2");
         this.et = et;

--- a/java/src/jmri/jmrix/marklin/cdb/CdBConnectionTypeList.java
+++ b/java/src/jmri/jmrix/marklin/cdb/CdBConnectionTypeList.java
@@ -1,0 +1,34 @@
+package jmri.jmrix.marklin.cdb;
+
+import javax.annotation.Nonnull;
+import jmri.jmrix.ConnectionTypeList;
+import org.openide.util.lookup.ServiceProvider;
+
+/**
+ * Provide a list of valid Uhlenbrock Connection Types.
+ *
+ * @author Bob Jacobsen Copyright (C) 2010, 2014
+ * @author Kevin Dickerson Copyright (C) 2010
+ *
+ */
+@ServiceProvider(service = ConnectionTypeList.class)
+public class CdBConnectionTypeList implements jmri.jmrix.ConnectionTypeList {
+
+    public static final String CDB = "CAN-digital-Bahn"; // NOI18N
+
+    @Override
+    @Nonnull
+    public String[] getAvailableProtocolClasses() {
+        // replace existing LocoNet protocol list with just our three
+        String[] tempList = new String[]{
+            "jmri.jmrix.marklin.cdb.serialdriver.ConnectionConfig"}; // NOI18N
+        return tempList;
+    }
+
+    @Override
+    @Nonnull
+    public String[] getManufacturers() {
+        return new String[]{CDB};
+    }
+
+}

--- a/java/src/jmri/jmrix/marklin/cdb/CdBPortController.java
+++ b/java/src/jmri/jmrix/marklin/cdb/CdBPortController.java
@@ -1,7 +1,7 @@
 package jmri.jmrix.marklin.cdb;
 
 /**
- * Identifying class representing a Tams communications port Based on work by
+ * Identifying class representing a Marklin CDB communications port Based on work by
  * Bob Jacobsen
  *
  * @author Kevin Dickerson Copyright (C) 2012

--- a/java/src/jmri/jmrix/marklin/cdb/CdBPortController.java
+++ b/java/src/jmri/jmrix/marklin/cdb/CdBPortController.java
@@ -1,0 +1,24 @@
+package jmri.jmrix.marklin.cdb;
+
+/**
+ * Identifying class representing a Tams communications port Based on work by
+ * Bob Jacobsen
+ *
+ * @author Kevin Dickerson Copyright (C) 2012
+ */
+public abstract class CdBPortController extends jmri.jmrix.AbstractSerialPortController {
+
+    // base class. Implementations will provide InputStream and OutputStream
+    // objects to CdBTrafficController classes, who in turn will deal in messages.
+    protected CdBPortController(CdBSystemConnectionMemo connectionMemo) {
+        super(connectionMemo);
+    }
+
+    @Override
+    public CdBSystemConnectionMemo getSystemConnectionMemo() {
+        return (CdBSystemConnectionMemo) super.getSystemConnectionMemo();
+    }
+}
+
+
+

--- a/java/src/jmri/jmrix/marklin/cdb/CdBSystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/marklin/cdb/CdBSystemConnectionMemo.java
@@ -31,7 +31,7 @@ import jmri.jmrix.marklin.MarklinSystemConnectionMemo;
 public class CdBSystemConnectionMemo extends MarklinSystemConnectionMemo {
 
     public CdBSystemConnectionMemo(MarklinTrafficController et) {
-        super("C", "CdB");
+        super("M", "CdB");
         this.et = et;
         et.setAdapterMemo(this);
         InstanceManager.store(this, CdBSystemConnectionMemo.class);
@@ -40,7 +40,7 @@ public class CdBSystemConnectionMemo extends MarklinSystemConnectionMemo {
     }
 
     public CdBSystemConnectionMemo() {
-        super("C", "CdB");
+        super("M", "CdB");
         InstanceManager.store(this, CdBSystemConnectionMemo.class);
         InstanceManager.store(cf = new jmri.jmrix.marklin.swing.MarklinComponentFactory(this),
                 jmri.jmrix.swing.ComponentFactory.class);

--- a/java/src/jmri/jmrix/marklin/cdb/CdBSystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/marklin/cdb/CdBSystemConnectionMemo.java
@@ -52,10 +52,12 @@ public class CdBSystemConnectionMemo extends MarklinSystemConnectionMemo {
      * Provides access to the TrafficController for this particular connection.
      * @return Marklin Traffic Controller.
      */
+    @Override
     public MarklinTrafficController getTrafficController() {
         return et;
     }
 
+    @Override
     public void setMarklinTrafficController(MarklinTrafficController et) {
         this.et = et;
         et.setAdapterMemo(this);
@@ -65,6 +67,7 @@ public class CdBSystemConnectionMemo extends MarklinSystemConnectionMemo {
     /**
      * This puts the common manager config in one place.
      */
+    @Override
     public void configureManagers() {
 
         MarklinPowerManager powerManager = new MarklinPowerManager(getTrafficController());
@@ -113,18 +116,22 @@ public class CdBSystemConnectionMemo extends MarklinSystemConnectionMemo {
         store(p,TamsProgrammerManager.class);
     }*/
 
+    @Override
     public MarklinTurnoutManager getTurnoutManager() {
         return (MarklinTurnoutManager) classObjectMap.computeIfAbsent(TurnoutManager.class, (Class<?> c) -> { return new MarklinTurnoutManager(this); });
     }
 
+    @Override
     public MarklinSensorManager getSensorManager() {
         return (MarklinSensorManager) classObjectMap.computeIfAbsent(SensorManager.class, (Class<?> c) -> { return new MarklinSensorManager(this); });
     }
 
+    @Override
     public MarklinThrottleManager getThrottleManager() {
         return (MarklinThrottleManager) classObjectMap.computeIfAbsent(ThrottleManager.class, (Class<?> c) -> { return new MarklinThrottleManager(this); });
     }
 
+    @Override
     public MarklinPowerManager getPowerManager() {
         return (MarklinPowerManager) classObjectMap.computeIfAbsent(PowerManager.class, (Class<?> c) -> { return new MarklinPowerManager(getTrafficController()); });
     }

--- a/java/src/jmri/jmrix/marklin/cdb/CdBSystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/marklin/cdb/CdBSystemConnectionMemo.java
@@ -1,0 +1,145 @@
+package jmri.jmrix.marklin.cdb;
+
+import java.util.Comparator;
+import java.util.ResourceBundle;
+
+import jmri.*;
+import jmri.jmrix.ConfiguringSystemConnectionMemo;
+import jmri.jmrix.DefaultSystemConnectionMemo;
+import jmri.util.NamedBeanComparator;
+
+import jmri.jmrix.marklin.MarklinTrafficController;
+//import jmri.jmrix.marklin.MarklinProgrammer;
+//import jmri.jmrix.marklin.MarklinProgrammerManager;
+import jmri.jmrix.marklin.MarklinSensorManager;
+import jmri.jmrix.marklin.MarklinThrottleManager;
+import jmri.jmrix.marklin.MarklinTurnoutManager;
+import jmri.jmrix.marklin.MarklinPowerManager;
+import jmri.jmrix.marklin.MarklinSystemConnectionMemo;
+
+/**
+ * Lightweight class to denote that a system is active, and provide general
+ * information.
+ * <p>
+ * Objects of specific subtypes are registered in the instance manager to
+ * activate their particular system.
+ *
+ * Based on work by Bob Jacobsen
+ *
+ * @author Kevin Dickerson Copyright (C) 2012
+ */
+public class CdBSystemConnectionMemo extends MarklinSystemConnectionMemo {
+
+    public CdBSystemConnectionMemo(MarklinTrafficController et) {
+        super("C", "CdB");
+        this.et = et;
+        et.setAdapterMemo(this);
+        InstanceManager.store(this, CdBSystemConnectionMemo.class);
+        InstanceManager.store(cf = new jmri.jmrix.marklin.swing.MarklinComponentFactory(this),
+                jmri.jmrix.swing.ComponentFactory.class);
+    }
+
+    public CdBSystemConnectionMemo() {
+        super("C", "CdB");
+        InstanceManager.store(this, CdBSystemConnectionMemo.class);
+        InstanceManager.store(cf = new jmri.jmrix.marklin.swing.MarklinComponentFactory(this),
+                jmri.jmrix.swing.ComponentFactory.class);
+    }
+
+    jmri.jmrix.swing.ComponentFactory cf = null;
+
+    /**
+     * Provides access to the TrafficController for this particular connection.
+     * @return Marklin Traffic Controller.
+     */
+    public MarklinTrafficController getTrafficController() {
+        return et;
+    }
+
+    public void setMarklinTrafficController(MarklinTrafficController et) {
+        this.et = et;
+        et.setAdapterMemo(this);
+    }
+    private MarklinTrafficController et;
+
+    /**
+     * This puts the common manager config in one place.
+     */
+    public void configureManagers() {
+
+        MarklinPowerManager powerManager = new MarklinPowerManager(getTrafficController());
+        InstanceManager.store(powerManager, jmri.PowerManager.class);
+        store(powerManager, jmri.PowerManager.class);
+
+/*        MarklinProgrammerManager programmerManager = getProgrammerManager();
+        InstanceManager.store(programmerManager, GlobalProgrammerManager.class);
+        InstanceManager.store(programmerManager, AddressedProgrammerManager.class);*/
+
+        TurnoutManager turnoutManager = new MarklinTurnoutManager(this);
+        InstanceManager.setTurnoutManager(turnoutManager);
+        store(turnoutManager,TurnoutManager.class);
+
+        ThrottleManager throttleManager = new MarklinThrottleManager(this);
+        InstanceManager.setThrottleManager(throttleManager);
+        store(throttleManager,ThrottleManager.class);
+
+        SensorManager sensorManager = new MarklinSensorManager(this);
+        InstanceManager.setSensorManager(sensorManager);
+        store(throttleManager,ThrottleManager.class);
+
+        register();
+    }
+
+    @Override
+    protected ResourceBundle getActionModelResourceBundle() {
+        return ResourceBundle.getBundle("jmri.jmrix.marklin.MarklinActionListBundle");
+    }
+
+    @Override
+    public <B extends NamedBean> Comparator<B> getNamedBeanComparator(Class<B> type) {
+        return new NamedBeanComparator<>();
+    }
+
+    /**
+     * Provides access to the Programmer for this particular connection.
+     * NOTE: Programmer defaults to null
+     * @return programmer manager.
+     */
+    /*  public MarklinProgrammerManager getProgrammerManager() {
+        return (MarklinProgrammerManager) classObjectMap.computeIfAbsent(MarklinProgrammerManager.class, (Class<?> c) -> new MarklinProgrammerManager(new MarklinProgrammer(getTrafficController()),this));
+    }
+
+    public void setProgrammerManager(MarklinProgrammerManager p) {
+        store(p,TamsProgrammerManager.class);
+    }*/
+
+    public MarklinTurnoutManager getTurnoutManager() {
+        return (MarklinTurnoutManager) classObjectMap.computeIfAbsent(TurnoutManager.class, (Class<?> c) -> { return new MarklinTurnoutManager(this); });
+    }
+
+    public MarklinSensorManager getSensorManager() {
+        return (MarklinSensorManager) classObjectMap.computeIfAbsent(SensorManager.class, (Class<?> c) -> { return new MarklinSensorManager(this); });
+    }
+
+    public MarklinThrottleManager getThrottleManager() {
+        return (MarklinThrottleManager) classObjectMap.computeIfAbsent(ThrottleManager.class, (Class<?> c) -> { return new MarklinThrottleManager(this); });
+    }
+
+    public MarklinPowerManager getPowerManager() {
+        return (MarklinPowerManager) classObjectMap.computeIfAbsent(PowerManager.class, (Class<?> c) -> { return new MarklinPowerManager(getTrafficController()); });
+    }
+
+    @Override
+    public void dispose() {
+        et = null;
+        InstanceManager.deregister(this, CdBSystemConnectionMemo.class);
+        if (cf != null) {
+            InstanceManager.deregister(cf, jmri.jmrix.swing.ComponentFactory.class);
+        }
+
+        super.dispose();
+    }
+}
+
+
+

--- a/java/src/jmri/jmrix/marklin/cdb/serialdriver/Bundle.java
+++ b/java/src/jmri/jmrix/marklin/cdb/serialdriver/Bundle.java
@@ -21,9 +21,9 @@ import javax.annotation.ParametersAreNonnullByDefault;
  * @author      Bob Jacobsen  Copyright (C) 2012
  * @since       3.7.2
  */
-public class Bundle extends jmri.jmrix.tams.Bundle {
+public class Bundle extends jmri.jmrix.marklin.Bundle {
 
-    @CheckForNull private static final String name = null; // No local resources
+    @CheckForNull private static final String name = "jmri.jmrix.marklin.cdb.serialdriver.Bundle"; // No local resources
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/jmri/jmrix/marklin/cdb/serialdriver/Bundle.java
+++ b/java/src/jmri/jmrix/marklin/cdb/serialdriver/Bundle.java
@@ -1,0 +1,93 @@
+package jmri.jmrix.marklin.cdb.serialdriver;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.Locale;
+import javax.annotation.CheckReturnValue;
+import javax.annotation.CheckForNull;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
+@CheckReturnValue
+@SuppressFBWarnings(value = "NM_SAME_SIMPLE_NAME_AS_SUPERCLASS",justification="Desired pattern is repeated class names with package-level access to members")
+
+@javax.annotation.concurrent.Immutable
+
+/**
+ * Provides standard access for resource bundles in a package.
+ * 
+ * Convention is to provide a subclass of this name
+ * in each package, working off the local resource bundle name.
+ *
+ * @author      Bob Jacobsen  Copyright (C) 2012
+ * @since       3.7.2
+ */
+public class Bundle extends jmri.jmrix.tams.Bundle {
+
+    @CheckForNull private static final String name = null; // No local resources
+
+    //
+    // below here is boilerplate to be copied exactly
+    //
+    
+    /**
+     * Provides a translated string for a given 
+     * key from the package resource bundle or 
+     * parent.
+     * <p>
+     * Note that this is intentionally package-local
+     * access.
+     * 
+     * @param key Bundle key to be translated
+     * @return Internationalized text
+     */
+    static String getMessage(String key) {
+        return getBundle().handleGetMessage(key);
+    }
+    /**
+     * Merges user data with a translated string for a given 
+     * key from the package resource bundle or 
+     * parent.
+     * <p>
+     * Uses the transformation conventions of 
+     * the Java MessageFormat utility.
+     * <p>
+     * Note that this is intentionally package-local
+     * access.
+     *
+     * @see java.text.MessageFormat
+     * @param key Bundle key to be translated
+     * @param subs One or more objects to be inserted into the message
+     * @return Internationalized text
+     */
+    static String getMessage(String key, Object ... subs) {
+        return getBundle().handleGetMessage(key, subs);
+    }
+
+    /**
+     * Merges user data with a translated string for a given key in a given
+     * locale from the package resource bundle or parent.
+     * <p>
+     * Uses the transformation conventions of the Java MessageFormat utility.
+     * <p>
+     * Note that this is intentionally package-local access.
+     *
+     * @see java.text.MessageFormat
+     * @param locale The locale to be used
+     * @param key    Bundle key to be translated
+     * @param subs   One or more objects to be inserted into the message
+     * @return Internationalized text
+     */
+    static String getMessage(Locale locale, String key, Object... subs) {
+        return getBundle().handleGetMessage(locale, key, subs);
+    }
+   
+    private final static Bundle b = new Bundle();
+    @Override @CheckForNull protected String bundleName() {return name; }
+    protected static jmri.Bundle getBundle() { return b; }
+
+    @Override 
+    protected String retry(Locale locale,String key) { 
+        return super.getBundle().handleGetMessage(locale,key); 
+    }
+
+}

--- a/java/src/jmri/jmrix/marklin/cdb/serialdriver/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/marklin/cdb/serialdriver/ConnectionConfig.java
@@ -1,7 +1,7 @@
 package jmri.jmrix.marklin.cdb.serialdriver;
 
 /**
- * Definition of objects to handle configuring a layout connection via an TAMS
+ * Definition of objects to handle configuring a layout connection via an Marklin CDB
  * SerialDriverAdapter object.
  *
  * @author Kevin Dickerson Copyright (C) 2012

--- a/java/src/jmri/jmrix/marklin/cdb/serialdriver/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/marklin/cdb/serialdriver/ConnectionConfig.java
@@ -1,0 +1,47 @@
+package jmri.jmrix.marklin.cdb.serialdriver;
+
+/**
+ * Definition of objects to handle configuring a layout connection via an TAMS
+ * SerialDriverAdapter object.
+ *
+ * @author Kevin Dickerson Copyright (C) 2012
+ */
+public class ConnectionConfig extends jmri.jmrix.AbstractSerialConnectionConfig {
+
+    public final static String NAME = "CC-Schnitte 2.1"; // NOI18N
+
+    /**
+     * Create a connection configuration with a preexisting adapter. This is
+     * used principally when loading a configuration that defines this
+     * connection.
+     *
+     * @param p the adapter to create a connection configuration for
+     */
+    public ConnectionConfig(jmri.jmrix.SerialPortAdapter p) {
+        super(p);
+    }
+
+    /**
+     * Ctor for a connection configuration with no preexisting adapter.
+     * {@link #setInstance()} will fill the adapter member.
+     */
+    public ConnectionConfig() {
+        super();
+    }
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void setInstance() {
+        if (adapter == null) {
+            adapter = new SerialDriverAdapter();
+        }
+    }
+
+}

--- a/java/src/jmri/jmrix/marklin/cdb/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/marklin/cdb/serialdriver/SerialDriverAdapter.java
@@ -17,7 +17,7 @@ import purejavacomm.SerialPort;
 import purejavacomm.UnsupportedCommOperationException;
 
 /**
- * Implements SerialPortAdapter for the TAMS system.
+ * Implements SerialPortAdapter for the Marklin CDB system.
  * <p>
  * This connects a CC-Schnitte command station via a serial usb port.
  * <p>

--- a/java/src/jmri/jmrix/marklin/cdb/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/marklin/cdb/serialdriver/SerialDriverAdapter.java
@@ -1,0 +1,173 @@
+package jmri.jmrix.marklin.cdb.serialdriver;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import jmri.jmrix.marklin.cdb.CdBPortController;
+import jmri.jmrix.marklin.cdb.CdBSystemConnectionMemo;
+import jmri.jmrix.marklin.MarklinTrafficController;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import purejavacomm.CommPortIdentifier;
+import purejavacomm.NoSuchPortException;
+import purejavacomm.PortInUseException;
+import purejavacomm.SerialPort;
+import purejavacomm.UnsupportedCommOperationException;
+
+/**
+ * Implements SerialPortAdapter for the TAMS system.
+ * <p>
+ * This connects a CC-Schnitte command station via a serial usb port.
+ * <p>
+ * Based on work by Bob Jacobsen
+ *
+ * @author Ralf Lang Copyright (C) 2022
+ */
+public class SerialDriverAdapter extends CdBPortController {
+
+    SerialPort activeSerialPort = null;
+
+    public SerialDriverAdapter() {
+        super(new CdBSystemConnectionMemo());
+        setManufacturer(jmri.jmrix.marklin.cdb.CdBConnectionTypeList.CDB);
+    }
+
+    @Override
+    public String openPort(String portName, String appName) {
+        // open the port, check ability to set moderators
+        try {
+            // get and open the primary port
+            CommPortIdentifier portID = CommPortIdentifier.getPortIdentifier(portName);
+            try {
+                activeSerialPort = (SerialPort) portID.open(appName, 2000);  // name of program, msec to wait
+            } catch (PortInUseException p) {
+                return handlePortBusy(p, portName, log);
+            }
+
+            // try to set it for communication via SerialDriver
+            try {
+                // find the baud rate value, configure comm options
+                int baud = currentBaudNumber(mBaudRate);
+                activeSerialPort.setSerialPortParams(baud, SerialPort.DATABITS_8, SerialPort.STOPBITS_1, SerialPort.PARITY_NONE);
+            } catch (UnsupportedCommOperationException e) {
+                log.error("Cannot set serial parameters on port {}: {}", portName, e.getMessage());
+                return "Cannot set serial parameters on port " + portName + ": " + e.getMessage();
+            }
+
+            // Hardware flow control
+            // configureLeadsAndFlowControl(activeSerialPort, SerialPort.FLOWCONTROL_RTSCTS_IN | SerialPort.FLOWCONTROL_RTSCTS_OUT);
+
+            // Xon/Xoff flow control
+            configureLeadsAndFlowControl(activeSerialPort, 0);
+
+            // set timeout
+            try {
+                activeSerialPort.enableReceiveTimeout(50);  // Set to 50 was 10 mSec timeout before sending chars
+                log.debug("Serial timeout was observed as: {} {}", activeSerialPort.getReceiveTimeout(),
+                        activeSerialPort.isReceiveTimeoutEnabled());
+            } catch (Exception et) {
+                log.info("failed to set serial timeout: ", et);
+            }
+            // get and save stream
+            serialStream = activeSerialPort.getInputStream();
+
+            // purge contents, if any
+            purgeStream(serialStream);
+
+            if (log.isInfoEnabled()) {
+                log.info("{} port opened at {} baud, sees  DTR: {} RTS: {} DSR: {} CTS: {}  CD: {}", portName, activeSerialPort.getBaudRate(), activeSerialPort.isDTR(), activeSerialPort.isRTS(), activeSerialPort.isDSR(), activeSerialPort.isCTS(), activeSerialPort.isCD());
+            }
+
+            // report status
+            if (log.isInfoEnabled()) {
+                log.info("CC-Schnitte {} port opened at {} baud", portName,
+                        activeSerialPort.getBaudRate());
+            }
+            opened = true;
+
+        } catch (NoSuchPortException p) {
+            return handlePortNotFound(p, portName, log);
+        } catch (IOException ex) {
+            log.error("Unexpected exception while opening port {}", portName, ex);
+            return "Unexpected error while opening port " + portName + ": " + ex;
+        }
+
+        return null; // indicates OK return
+    }
+
+    /**
+     * set up all of the other objects to operate with an NCE command station
+     * connected to this port
+     */
+    @Override
+    public void configure() {
+        MarklinTrafficController tc = new MarklinTrafficController();
+        this.getSystemConnectionMemo().setMarklinTrafficController(tc);
+        tc.setAdapterMemo(this.getSystemConnectionMemo());
+
+        tc.connectPort(this);
+
+        this.getSystemConnectionMemo().configureManagers();
+    }
+
+    // base class methods for the MarklinPortController interface
+    @Override
+    public DataInputStream getInputStream() {
+        if (!opened) {
+            log.error("getInputStream called before load(), stream not available");
+            return null;
+        }
+        return new DataInputStream(serialStream);
+    }
+
+    @Override
+    public DataOutputStream getOutputStream() {
+        if (!opened) {
+            log.error("getOutputStream called before load(), stream not available");
+        }
+        try {
+            return new DataOutputStream(activeSerialPort.getOutputStream());
+        } catch (java.io.IOException e) {
+            log.error("getOutputStream exception: ", e);
+        }
+        return null;
+    }
+
+    @Override
+    public boolean status() {
+        return opened;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String[] validBaudRates() {
+        return Arrays.copyOf(validSpeeds, validSpeeds.length);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int[] validBaudNumbers() {
+        return Arrays.copyOf(validSpeedValues, validSpeedValues.length);
+    }
+
+    private final String[] validSpeeds = new String[]{Bundle.getMessage("Baud500000")};
+    private final int[] validSpeedValues = new int[]{500000};
+
+    @Override
+    public int defaultBaudIndex() {
+        return 0;
+    }
+
+    // private control members
+    private boolean opened = false;
+    InputStream serialStream = null;
+
+    private final static Logger log = LoggerFactory.getLogger(SerialDriverAdapter.class);
+
+}

--- a/java/src/jmri/jmrix/marklin/cdb/serialdriver/configurexml/COPYING
+++ b/java/src/jmri/jmrix/marklin/cdb/serialdriver/configurexml/COPYING
@@ -1,0 +1,372 @@
+JMRI is free software; you can redistribute it and/or modify it 
+under the terms of version 2 of the GNU General Public License as 
+published by the Free Software Foundation.
+
+JMRI is distributed in the hope that it will be useful, but 
+WITHOUT ANY WARRANTY; without even the implied warranty of 
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+GNU General Public License for more details.
+
+A copy of version 2 of the GNU General Public License is 
+appended below. For more information, see 
+<http://www.gnu.org/licenses/>.
+
+Linking JMRI or its parts statically or dynamically with other 
+modules is making a combined work based on this library. Thus, the 
+terms and conditions of the GNU General Public License 2.0 cover 
+the whole combination.
+
+As a special exception, the copyright holders of JMRI give you 
+permission to link JMRI with independent modules to produce an 
+executable, regardless of the license terms of these independent 
+modules, and to copy and distribute the resulting executable under 
+terms of your choice, provided that you also meet, for each linked 
+independent module, the terms and conditions of the license of that 
+module. An independent module is a module which is not derived from 
+or based on JMRI. If you modify JMRI, you may extend this exception 
+to your version of JMRI, but you are not obligated to do so. If you do 
+not wish to do so, delete this exception statement from your version.
+
+
+-------------------------------------------------------------------
+
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.
+

--- a/java/src/jmri/jmrix/marklin/cdb/serialdriver/configurexml/ConnectionConfigXml.java
+++ b/java/src/jmri/jmrix/marklin/cdb/serialdriver/configurexml/ConnectionConfigXml.java
@@ -1,0 +1,40 @@
+package jmri.jmrix.marklin.cdb.serialdriver.configurexml;
+
+import jmri.jmrix.configurexml.AbstractSerialConnectionConfigXml;
+import jmri.jmrix.marklin.cdb.serialdriver.ConnectionConfig;
+import jmri.jmrix.marklin.cdb.serialdriver.SerialDriverAdapter;
+
+/**
+ * Handle XML persistatams of layout connections by persistening the
+ * SerialDriverAdapter (and connections). Note this is named as the XML version
+ * of a ConnectionConfig object, but it's actually persisting the
+ * SerialDriverAdapter.
+ * <p>
+ * This class is invoked from jmrix.JmrixConfigPaneXml on write, as that class
+ * is the one actually registered. Reads are brought here directly via the class
+ * attribute in the XML.
+ *
+ * @author Bob Jacobsen Copyright: Copyright (c) 2003
+ */
+public class ConnectionConfigXml extends AbstractSerialConnectionConfigXml {
+
+    public ConnectionConfigXml() {
+        super();
+    }
+
+    @Override
+    protected void getInstance() {
+        adapter = new SerialDriverAdapter();
+    }
+
+    @Override
+    protected void getInstance(Object object) {
+        adapter = ((ConnectionConfig) object).getAdapter();
+    }
+
+    @Override
+    protected void register() {
+        this.register(new ConnectionConfig(adapter));
+    }
+
+}


### PR DESCRIPTION
Implement issue #11653 Feature: Support for CanDigitalBahn CC-Schnitte 2.1 Command Station.

- can connect to the Märklin CAN bus. 
- can see/log bus commands issued by other bus participants
- can send commands over the wire

Success of actual integration into JMRI features (i.e. sensors, turnouts, throttles) remains to be tested.

I can positively confirm this will NOT act as a programmer without much further work as the underlying CS2 driver also currently has no programmer implementation.