### PR TITLE
Fix bug in LogixNG

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -395,6 +395,9 @@
     <h3>Layout Editor</h3>
         <a id="LE" name="LE"></a>
         <ul>
+	        <li>Fixes a bug in the actions <i>Icon/Label on panel</i> and
+	        <i>Turnout on LayoutPanel</i> which caused that the actions
+	        wasn't loaded correctly.</li>
 	        <li>Add support for LogixNG Global Variable icons.  These work like memory icons.</li>
         </ul>
 

--- a/java/src/jmri/jmrit/display/logixng/ActionLayoutTurnout.java
+++ b/java/src/jmri/jmrit/display/logixng/ActionLayoutTurnout.java
@@ -28,8 +28,10 @@ import jmri.util.TypeConversionUtil;
 public class ActionLayoutTurnout extends AbstractDigitalAction
         implements PropertyChangeListener, VetoableChangeListener {
 
+    private String _layoutEditorName;
     private LayoutEditor _layoutEditor;
     private NamedBeanAddressing _addressing = NamedBeanAddressing.Direct;
+    private String _layoutTurnoutName;
     private LayoutTurnout _layoutTurnout;
     private String _reference = "";
     private String _localVariable = "";
@@ -76,6 +78,8 @@ public class ActionLayoutTurnout extends AbstractDigitalAction
 
         InstanceManager.getDefault(EditorManager.class)
                 .removePropertyChangeListener(EDITORS, this);
+
+        _layoutEditorName = layoutEditorName;
 
         if (layoutEditorName != null) {
             _layoutEditor = InstanceManager.getDefault(EditorManager.class)
@@ -128,6 +132,7 @@ public class ActionLayoutTurnout extends AbstractDigitalAction
 
     public void setLayoutTurnout(@CheckForNull String layoutTurnoutName) {
         assertListenersAreNotRegistered(log, "setLayoutTurnout");
+        _layoutTurnoutName = layoutTurnoutName;
         if ((layoutTurnoutName != null) && (_layoutEditor != null)) {
             this._layoutTurnout = findLayoutTurnout(layoutTurnoutName);
         } else {
@@ -468,15 +473,12 @@ public class ActionLayoutTurnout extends AbstractDigitalAction
     /** {@inheritDoc} */
     @Override
     public void setup() {
-        // Do nothing
-/*
         if ((_layoutEditorName != null) && (_layoutEditor == null)) {
-            setEditor(_layoutEditorName);
+            setLayoutEditor(_layoutEditorName);
         }
         if ((_layoutTurnoutName != null) && (_layoutTurnout == null)) {
             setLayoutTurnout(_layoutTurnoutName);
         }
-*/
     }
 
     /** {@inheritDoc} */

--- a/java/src/jmri/jmrit/display/logixng/ActionPositionable.java
+++ b/java/src/jmri/jmrit/display/logixng/ActionPositionable.java
@@ -22,7 +22,7 @@ import jmri.util.TypeConversionUtil;
 
 /**
  * This action controls various things of a Positionable on a panel.
- * 
+ *
  * @author Daniel Bergqvist Copyright 2021
  */
 public class ActionPositionable extends AbstractDigitalAction implements VetoableChangeListener {
@@ -43,12 +43,12 @@ public class ActionPositionable extends AbstractDigitalAction implements Vetoabl
     private String _stateLocalVariable = "";
     private String _stateFormula = "";
     private ExpressionNode _stateExpressionNode;
-    
+
     public ActionPositionable(String sys, String user)
             throws BadUserNameException, BadSystemNameException {
         super(sys, user);
     }
-    
+
     @Override
     public Base getDeepCopy(Map<String, String> systemNames, Map<String, String> userNames) throws ParserException {
         DigitalActionManager manager = InstanceManager.getDefault(DigitalActionManager.class);
@@ -70,7 +70,7 @@ public class ActionPositionable extends AbstractDigitalAction implements Vetoabl
         copy.setStateReference(_stateReference);
         return manager.registerAction(copy);
     }
-    
+
     public void setEditor(@CheckForNull String editorName) {
         assertListenersAreNotRegistered(log, "setEditor");
         _editorName = editorName;
@@ -81,11 +81,11 @@ public class ActionPositionable extends AbstractDigitalAction implements Vetoabl
         }
 //        InstanceManager.turnoutManagerInstance().addVetoableChangeListener(this);
     }
-    
+
     public String getEditorName() {
         return _editorName;
     }
-    
+
     public void setPositionable(@CheckForNull String positionableName) {
         assertListenersAreNotRegistered(log, "setPositionable");
         _positionableName = positionableName;
@@ -96,118 +96,118 @@ public class ActionPositionable extends AbstractDigitalAction implements Vetoabl
         }
 //        InstanceManager.turnoutManagerInstance().addVetoableChangeListener(this);
     }
-    
+
     public String getPositionableName() {
         return _positionableName;
     }
-    
+
     public void setAddressing(NamedBeanAddressing addressing) throws ParserException {
         _addressing = addressing;
         parseFormula();
     }
-    
+
     public NamedBeanAddressing getAddressing() {
         return _addressing;
     }
-    
+
     public void setReference(@Nonnull String reference) {
         if ((! reference.isEmpty()) && (! ReferenceUtil.isReference(reference))) {
             throw new IllegalArgumentException("The reference \"" + reference + "\" is not a valid reference");
         }
         _reference = reference;
     }
-    
+
     public String getReference() {
         return _reference;
     }
-    
+
     public void setLocalVariable(@Nonnull String localVariable) {
         _localVariable = localVariable;
     }
-    
+
     public String getLocalVariable() {
         return _localVariable;
     }
-    
+
     public void setFormula(@Nonnull String formula) throws ParserException {
         _formula = formula;
         parseFormula();
     }
-    
+
     public String getFormula() {
         return _formula;
     }
-    
+
     private void parseFormula() throws ParserException {
         if (_addressing == NamedBeanAddressing.Formula) {
             Map<String, Variable> variables = new HashMap<>();
-            
+
             RecursiveDescentParser parser = new RecursiveDescentParser(variables);
             _expressionNode = parser.parseExpression(_formula);
         } else {
             _expressionNode = null;
         }
     }
-    
+
     public void setStateAddressing(NamedBeanAddressing addressing) throws ParserException {
         _stateAddressing = addressing;
         parseStateFormula();
     }
-    
+
     public NamedBeanAddressing getStateAddressing() {
         return _stateAddressing;
     }
-    
+
     public void setOperation(Operation isControlling) {
         _operation = isControlling;
     }
-    
+
     public Operation getOperation() {
         return _operation;
     }
-    
+
     public void setStateReference(@Nonnull String reference) {
         if ((! reference.isEmpty()) && (! ReferenceUtil.isReference(reference))) {
             throw new IllegalArgumentException("The reference \"" + reference + "\" is not a valid reference");
         }
         _stateReference = reference;
     }
-    
+
     public String getStateReference() {
         return _stateReference;
     }
-    
+
     public void setStateLocalVariable(@Nonnull String localVariable) {
         _stateLocalVariable = localVariable;
     }
-    
+
     public String getStateLocalVariable() {
         return _stateLocalVariable;
     }
-    
+
     public void setStateFormula(@Nonnull String formula) throws ParserException {
         _stateFormula = formula;
         parseStateFormula();
     }
-    
+
     public String getStateFormula() {
         return _stateFormula;
     }
-    
+
     private void parseStateFormula() throws ParserException {
         if (_stateAddressing == NamedBeanAddressing.Formula) {
             Map<String, Variable> variables = new HashMap<>();
-            
+
             RecursiveDescentParser parser = new RecursiveDescentParser(variables);
             _stateExpressionNode = parser.parseExpression(_stateFormula);
         } else {
             _stateExpressionNode = null;
         }
     }
-    
+
     @Override
     public void vetoableChange(java.beans.PropertyChangeEvent evt) throws java.beans.PropertyVetoException {
-/*        
+/*
         if ("CanDelete".equals(evt.getPropertyName())) { // No I18N
             if (evt.getOldValue() instanceof Turnout) {
                 if (evt.getOldValue().equals(getTurnout().getBean())) {
@@ -222,9 +222,9 @@ public class ActionPositionable extends AbstractDigitalAction implements Vetoabl
                 }
             }
         }
-*/        
+*/
     }
-    
+
     /** {@inheritDoc} */
     @Override
     public Category getCategory() {
@@ -232,53 +232,53 @@ public class ActionPositionable extends AbstractDigitalAction implements Vetoabl
     }
 
     private String getNewState() throws JmriException {
-        
+
         switch (_stateAddressing) {
             case Reference:
                 return ReferenceUtil.getReference(
                         getConditionalNG().getSymbolTable(), _stateReference);
-                
+
             case LocalVariable:
                 SymbolTable symbolTable = getConditionalNG().getSymbolTable();
                 return TypeConversionUtil
                         .convertToString(symbolTable.getValue(_stateLocalVariable), false);
-                
+
             case Formula:
                 return _stateExpressionNode != null
                         ? TypeConversionUtil.convertToString(
                                 _stateExpressionNode.calculate(
                                         getConditionalNG().getSymbolTable()), false)
                         : null;
-                
+
             default:
                 throw new IllegalArgumentException("invalid _addressing state: " + _stateAddressing.name());
         }
     }
-    
+
     /** {@inheritDoc} */
     @Override
     public void execute() throws JmriException {
         Positionable positionable;
-        
+
 //        System.out.format("ActionPositionable.execute: %s%n", getLongDescription());
-        
+
         switch (_addressing) {
             case Direct:
                 positionable = this._positionable;
                 break;
-                
+
             case Reference:
                 String ref = ReferenceUtil.getReference(
                         getConditionalNG().getSymbolTable(), _reference);
                 positionable = _editor.getIdContents().get(ref);
                 break;
-                
+
             case LocalVariable:
                 SymbolTable symbolTable = getConditionalNG().getSymbolTable();
                 positionable = _editor.getIdContents().get(TypeConversionUtil
                                 .convertToString(symbolTable.getValue(_localVariable), false));
                 break;
-                
+
             case Formula:
                 positionable = _expressionNode != null ?
                         _editor.getIdContents().get(TypeConversionUtil
@@ -286,28 +286,28 @@ public class ActionPositionable extends AbstractDigitalAction implements Vetoabl
                                                 getConditionalNG().getSymbolTable()), false))
                         : null;
                 break;
-                
+
             default:
                 throw new IllegalArgumentException("invalid _addressing state: " + _addressing.name());
         }
-        
+
 //        System.out.format("ActionPositionable.execute: positionable: %s%n", positionable);
-        
+
         if (positionable == null) {
             log.error("positionable is null");
             return;
         }
-        
+
         String name = (_stateAddressing != NamedBeanAddressing.Direct)
                 ? getNewState() : null;
-        
+
         Operation operation;
         if ((_stateAddressing == NamedBeanAddressing.Direct)) {
             operation = _operation;
         } else {
             operation = Operation.valueOf(name);
         }
-        
+
         ThreadingUtil.runOnLayout(() -> {
             switch (operation) {
                 case Disable:
@@ -348,7 +348,7 @@ public class ActionPositionable extends AbstractDigitalAction implements Vetoabl
         String editorName = _editorName != null ? _editorName : Bundle.getMessage(locale, "BeanNotSelected");
         String positonableName;
         String state;
-        
+
         switch (_addressing) {
             case Direct:
                 String positionableName;
@@ -359,96 +359,93 @@ public class ActionPositionable extends AbstractDigitalAction implements Vetoabl
                 }
                 positonableName = Bundle.getMessage(locale, "AddressByDirect", positionableName);
                 break;
-                
+
             case Reference:
                 positonableName = Bundle.getMessage(locale, "AddressByReference", _reference);
                 break;
-                
+
             case LocalVariable:
                 positonableName = Bundle.getMessage(locale, "AddressByLocalVariable", _localVariable);
                 break;
-                
+
             case Formula:
                 positonableName = Bundle.getMessage(locale, "AddressByFormula", _formula);
                 break;
-                
+
             default:
                 throw new IllegalArgumentException("invalid _addressing state: " + _addressing.name());
         }
-        
+
         switch (_stateAddressing) {
             case Direct:
                 state = Bundle.getMessage(locale, "AddressByDirect", _operation._text);
                 break;
-                
+
             case Reference:
                 state = Bundle.getMessage(locale, "AddressByReference", _stateReference);
                 break;
-                
+
             case LocalVariable:
                 state = Bundle.getMessage(locale, "AddressByLocalVariable", _stateLocalVariable);
                 break;
-                
+
             case Formula:
                 state = Bundle.getMessage(locale, "AddressByFormula", _stateFormula);
                 break;
-                
+
             default:
                 throw new IllegalArgumentException("invalid _stateAddressing state: " + _stateAddressing.name());
         }
-        
+
         return Bundle.getMessage(locale, "ActionPositionable_Long", editorName, positonableName, state);
     }
-    
+
     /** {@inheritDoc} */
     @Override
     public void setup() {
-        // Do nothing
-/*        
         if ((_editorName != null) && (_editor == null)) {
             setEditor(_editorName);
         }
         if ((_positionableName != null) && (_positionable == null)) {
             setPositionable(_positionableName);
         }
-*/        
     }
-    
+
     /** {@inheritDoc} */
     @Override
     public void registerListenersForThisClass() {
     }
-    
+
     /** {@inheritDoc} */
     @Override
     public void unregisterListenersForThisClass() {
     }
-    
+
     /** {@inheritDoc} */
     @Override
     public void disposeMe() {
     }
 
-    
+
     public enum Operation {
         Disable(Bundle.getMessage("ActionPositionable_Disable")),
         Enable(Bundle.getMessage("ActionPositionable_Enable")),
         Hide(Bundle.getMessage("ActionPositionable_Hide")),
         Show(Bundle.getMessage("ActionPositionable_Show"));
-        
+
         private final String _text;
-        
+
         private Operation(String text) {
             this._text = text;
         }
-        
+
         @Override
         public String toString() {
             return _text;
         }
-        
+
     }
-    
+
     private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ActionPositionable.class);
-    
+
 }


### PR DESCRIPTION
When a ActionLayoutTurnout or ActionPositionable is loaded from a panel file, it didn't set the panel correctly. The bug was introduced in PR #11647 in the commit https://github.com/JMRI/JMRI/commit/055f39f3c2f9f9fc187168bc3861bd7d44411f13.

The cause is that the LogixNGs is now loaded before the panels. Therefore the panels don't exists when the ActionLayoutTurnout and ActionPositionable is load. This PR ensures that the `setup()` method sets the panel and the icon/turnout if it hasn't been set before. The setup() method is called after the panels are loaded.

The `StoreAndLoad` test isn't able to detect this bug since the StoreAndLoad doesn't load any panels.