### PR TITLE
Enable delayed bean setup for EntryExit action and expression loading

### DIFF
--- a/java/src/jmri/jmrit/logixng/actions/ActionEntryExit.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionEntryExit.java
@@ -123,7 +123,7 @@ public class ActionEntryExit extends AbstractDigitalAction
     /** {@inheritDoc} */
     @Override
     public void setup() {
-        // Do nothing
+        getSelectNamedBean().setup();
     }
 
     /** {@inheritDoc} */

--- a/java/src/jmri/jmrit/logixng/actions/configurexml/ActionEntryExitXml.java
+++ b/java/src/jmri/jmrit/logixng/actions/configurexml/ActionEntryExitXml.java
@@ -61,6 +61,7 @@ public class ActionEntryExitXml extends jmri.managers.configurexml.AbstractNamed
 
         var selectNamedBeanXml = new LogixNG_SelectNamedBeanXml<DestinationPoints>();
         selectNamedBeanXml.load(shared.getChild("namedBean"), h.getSelectNamedBean(), true);
+        selectNamedBeanXml.loadLegacy(shared, h.getSelectNamedBean(), "destinationPoints");
 
         selectEnumXml.load(shared.getChild("operation"), h.getSelectEnum());
         selectEnumXml.loadLegacy(

--- a/java/src/jmri/jmrit/logixng/actions/configurexml/ActionEntryExitXml.java
+++ b/java/src/jmri/jmrit/logixng/actions/configurexml/ActionEntryExitXml.java
@@ -60,8 +60,7 @@ public class ActionEntryExitXml extends jmri.managers.configurexml.AbstractNamed
         var selectEnumXml = new LogixNG_SelectEnumXml<ActionEntryExit.Operation>();
 
         var selectNamedBeanXml = new LogixNG_SelectNamedBeanXml<DestinationPoints>();
-        selectNamedBeanXml.load(shared.getChild("namedBean"), h.getSelectNamedBean());
-        selectNamedBeanXml.loadLegacy(shared, h.getSelectNamedBean(), "destinationPoints");
+        selectNamedBeanXml.load(shared.getChild("namedBean"), h.getSelectNamedBean(), true);
 
         selectEnumXml.load(shared.getChild("operation"), h.getSelectEnum());
         selectEnumXml.loadLegacy(

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionEntryExit.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionEntryExit.java
@@ -226,7 +226,7 @@ public class ExpressionEntryExit extends AbstractDigitalExpression
     /** {@inheritDoc} */
     @Override
     public void setup() {
-        // Do nothing
+        getSelectNamedBean().setup();
     }
 
     /** {@inheritDoc} */

--- a/java/src/jmri/jmrit/logixng/expressions/configurexml/ExpressionEntryExitXml.java
+++ b/java/src/jmri/jmrit/logixng/expressions/configurexml/ExpressionEntryExitXml.java
@@ -60,8 +60,7 @@ public class ExpressionEntryExitXml extends jmri.managers.configurexml.AbstractN
         loadCommon(h, shared);
 
         var selectNamedBeanXml = new LogixNG_SelectNamedBeanXml<DestinationPoints>();
-        selectNamedBeanXml.load(shared.getChild("namedBean"), h.getSelectNamedBean());
-        selectNamedBeanXml.loadLegacy(shared, h.getSelectNamedBean(), "destinationPoints");
+        selectNamedBeanXml.load(shared.getChild("namedBean"), h.getSelectNamedBean(), true);
 
         Element is_IsNot = shared.getChild("is_isNot");
         if (is_IsNot != null) {

--- a/java/src/jmri/jmrit/logixng/expressions/configurexml/ExpressionEntryExitXml.java
+++ b/java/src/jmri/jmrit/logixng/expressions/configurexml/ExpressionEntryExitXml.java
@@ -61,6 +61,7 @@ public class ExpressionEntryExitXml extends jmri.managers.configurexml.AbstractN
 
         var selectNamedBeanXml = new LogixNG_SelectNamedBeanXml<DestinationPoints>();
         selectNamedBeanXml.load(shared.getChild("namedBean"), h.getSelectNamedBean(), true);
+        selectNamedBeanXml.loadLegacy(shared, h.getSelectNamedBean(), "destinationPoints");
 
         Element is_IsNot = shared.getChild("is_isNot");
         if (is_IsNot != null) {


### PR DESCRIPTION
The Entry/Exit beans are not available until after LogixNG has been loaded.