### PR TITLE
Additional change to PR #11711

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -283,7 +283,7 @@
             <ul>
                 <li></li>
             </ul>
-	    
+
         <h4>Piko</h4>
             <ul>
                 <li>Piko Smart Decoder 4.1 and XP5.1</li>
@@ -367,7 +367,8 @@
     <h3>DecoderPro</h3>
         <a id="DecoderPro" name="DecoderPro"></a>
         <ul>
-            <li></li>
+            <li>Some internal state constants have been changed from integer values
+                to an enum.  This should not have any external effect.</li>
         </ul>
 
     <h3>CTC Tool</h3>

--- a/java/src/apps/gui3/dp3/PaneProgDp3Action.java
+++ b/java/src/apps/gui3/dp3/PaneProgDp3Action.java
@@ -725,14 +725,14 @@ public class PaneProgDp3Action extends JmriAbstractAction implements ProgListene
         public void setCVValue(String cv, int value) {
             if (_cvModel.getCvByNumber(cv) != null) {
                 (_cvModel.getCvByNumber(cv)).setValue(value);
-                (_cvModel.getCvByNumber(cv)).setState(AbstractValue.READ);
+                (_cvModel.getCvByNumber(cv)).setState(AbstractValue.ValueState.READ);
             }
         }
 
         public void setVariableValue(String variable, int value) {
             if (_varModel.findVar(variable) != null) {
                 _varModel.findVar(variable).setIntValue(value);
-                _varModel.findVar(variable).setState(AbstractValue.READ);
+                _varModel.findVar(variable).setState(AbstractValue.ValueState.READ);
             }
         }
 

--- a/java/src/jmri/jmrit/roster/LocoFile.java
+++ b/java/src/jmri/jmrit/roster/LocoFile.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import jmri.jmrit.XmlFile;
+import jmri.jmrit.symbolicprog.AbstractValue;
 import jmri.jmrit.symbolicprog.CvTableModel;
 import jmri.jmrit.symbolicprog.CvValue;
 import jmri.jmrit.symbolicprog.VariableTableModel;
@@ -119,7 +120,7 @@ public class LocoFile extends XmlFile {
                 }
                 if (cvObject != null) {
                     cvObject.setValue(Integer.parseInt(value));
-                    cvObject.setState(CvValue.FROMFILE);
+                    cvObject.setState(AbstractValue.ValueState.FROMFILE);
                 }
             }
         } else {
@@ -131,7 +132,7 @@ public class LocoFile extends XmlFile {
         // CV17 to Edited.  This needs to be understood & fixed.
         cvObject = cvModel.allCvMap().get("17");
         if (cvObject != null) {
-            cvObject.setState(CvValue.FROMFILE);
+            cvObject.setState(AbstractValue.ValueState.FROMFILE);
         }
     }
 

--- a/java/src/jmri/jmrit/symbolicprog/AbstractValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/AbstractValue.java
@@ -33,46 +33,49 @@ public abstract class AbstractValue {
      */
     abstract void setColor(Color c);
 
-    /**
-     * Defines state when nothing is known about the real value.
-     */
-    public static final int UNKNOWN = 0;
+    public enum ValueState {
+        /**
+         * Defines state when nothing is known about the real value.
+         */
+        UNKNOWN,
 
-    /**
-     * Defines state where value has been edited, no longer same as in decoder
-     * or file.
-     */
-    public static final int EDITED = 4;
+        /**
+         * Defines state where value has been edited, no longer same as in decoder
+         * or file.
+         */
+        EDITED,
 
-    /**
-     * Defines state where value has been read from (hence same as) decoder, but
-     * perhaps not same as in file.
-     */
-    public static final int READ = 16;
+        /**
+         * Defines state where value has been read from (hence same as) decoder, but
+         * perhaps not same as in file.
+         */
+        READ,
 
-    /**
-     * Defines state where value has been written to (hence same as) decoder,
-     * but perhaps not same as in file.
-     */
-    public static final int STORED = 64;
+        /**
+         * Defines state where value has been written to (hence same as) decoder,
+         * but perhaps not same as in file.
+         */
+        STORED,
 
-    /**
-     * Defines state where value was read from a config file, but might not be
-     * the same as the decoder.
-     */
-    public static final int FROMFILE = 256;
+        /**
+         * Defines state where value was read from a config file, but might not be
+         * the same as the decoder.
+         */
+        FROMFILE,
 
-    /**
-     * Defines state where value was read from a config file, and is the same as
-     * the decoder.
-     */
-    public static final int SAME = 512;
+        /**
+         * Defines state where value was read from a config file, and is the same as
+         * the decoder.
+         */
+        SAME,
 
-    /**
-     * Defines state where value was read from a config file, and is the not the
-     * same as the decoder.
-     */
-    public static final int DIFF = 1024;
+        /**
+         * Defines state where value was read from a config file, and is the not the
+         * same as the decoder.
+         */
+        DIFF
+
+    }
 
     /**
      * Define color to denote UNKNOWN state. null means to use default for the
@@ -164,7 +167,7 @@ public abstract class AbstractValue {
      * @param val a state value
      * @return the color assigned to the specified state value
      */
-    public static Color stateColorFromValue(int val) {
+    public static Color stateColorFromValue(ValueState val) {
         switch (val) {
             case UNKNOWN:
                 return COLOR_UNKNOWN;
@@ -191,7 +194,7 @@ public abstract class AbstractValue {
      * @param val a state value
      * @return the name assigned to the specified state value
      */
-    public static String stateNameFromValue(int val) {
+    public static String stateNameFromValue(ValueState val) {
         switch (val) {
             case UNKNOWN:
                 return "Unknown";

--- a/java/src/jmri/jmrit/symbolicprog/AbstractValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/AbstractValue.java
@@ -37,43 +37,43 @@ public abstract class AbstractValue {
         /**
          * Defines state when nothing is known about the real value.
          */
-        UNKNOWN(COLOR_UNKNOWN, "Unknown"),
+        UNKNOWN(Color.red.brighter(), "Unknown"),
 
         /**
          * Defines state where value has been edited, no longer same as in decoder
          * or file.
          */
-        EDITED(COLOR_EDITED, "Edited"),
+        EDITED(Color.orange, "Edited"),
 
         /**
          * Defines state where value has been read from (hence same as) decoder, but
          * perhaps not same as in file.
          */
-        READ(COLOR_READ, "Read"),
+        READ(null, "Read"),
 
         /**
          * Defines state where value has been written to (hence same as) decoder,
          * but perhaps not same as in file.
          */
-        STORED(COLOR_STORED, "Stored"),
+        STORED(null, "Stored"),
 
         /**
          * Defines state where value was read from a config file, but might not be
          * the same as the decoder.
          */
-        FROMFILE(COLOR_FROMFILE, "FromFile"),
+        FROMFILE(Color.yellow, "FromFile"),
 
         /**
          * Defines state where value was read from a config file, and is the same as
          * the decoder.
          */
-        SAME(COLOR_SAME, "Same"),
+        SAME(null, "Same"),
 
         /**
          * Defines state where value was read from a config file, and is the not the
          * same as the decoder.
          */
-        DIFF(COLOR_DIFF, "Different");
+        DIFF(Color.red.brighter(), "Different");
 
 
         private final Color _color;
@@ -86,7 +86,8 @@ public abstract class AbstractValue {
 
         /**
          * Gets the color associated with this state value.
-         * @return the color assigned to this state value
+         * @return the color assigned to this state value or null if
+         *         use default for the component
          */
         public Color getColor() {
             return _color;
@@ -100,48 +101,6 @@ public abstract class AbstractValue {
             return _name;
         }
     }
-
-    /**
-     * Define color to denote UNKNOWN state. null means to use default for the
-     * component.
-     */
-    static final Color COLOR_UNKNOWN = Color.red.brighter();
-
-    /**
-     * Define color to denote EDITED state. null means to use default for the
-     * component.
-     */
-    static final Color COLOR_EDITED = Color.orange;
-
-    /**
-     * Define color to denote READ state. null means to use default for the
-     * component.
-     */
-    static final Color COLOR_READ = null;
-
-    /**
-     * Define color to denote STORED state. null means to use default for the
-     * component.
-     */
-    static final Color COLOR_STORED = null;
-
-    /**
-     * Define color to denote FROMFILE state. null means to use default for the
-     * component.
-     */
-    static final Color COLOR_FROMFILE = Color.yellow;
-
-    /**
-     * Define color to denote SAME state. null means to use default for the
-     * component.
-     */
-    static final Color COLOR_SAME = null;
-
-    /**
-     * Define color to denote DIFF state. null means to use default for the
-     * component.
-     */
-    static final Color COLOR_DIFF = Color.red.brighter();
 
     /**
      * Mark whether this object needs to be read.

--- a/java/src/jmri/jmrit/symbolicprog/AbstractValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/AbstractValue.java
@@ -87,7 +87,7 @@ public abstract class AbstractValue {
         /**
          * Gets the color associated with this state value.
          * @return the color assigned to this state value or null if
-         *         use default for the component
+         *         to use default for the component
          */
         public Color getColor() {
             return _color;

--- a/java/src/jmri/jmrit/symbolicprog/AbstractValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/AbstractValue.java
@@ -73,7 +73,7 @@ public abstract class AbstractValue {
          * Defines state where value was read from a config file, and is the not the
          * same as the decoder.
          */
-        DIFF(Color.red.brighter(), "Different");
+        DIFFERENT(Color.red.brighter(), "Different");
 
 
         private final Color _color;

--- a/java/src/jmri/jmrit/symbolicprog/AbstractValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/AbstractValue.java
@@ -37,44 +37,68 @@ public abstract class AbstractValue {
         /**
          * Defines state when nothing is known about the real value.
          */
-        UNKNOWN,
+        UNKNOWN(COLOR_UNKNOWN, "Unknown"),
 
         /**
          * Defines state where value has been edited, no longer same as in decoder
          * or file.
          */
-        EDITED,
+        EDITED(COLOR_EDITED, "Edited"),
 
         /**
          * Defines state where value has been read from (hence same as) decoder, but
          * perhaps not same as in file.
          */
-        READ,
+        READ(COLOR_READ, "Read"),
 
         /**
          * Defines state where value has been written to (hence same as) decoder,
          * but perhaps not same as in file.
          */
-        STORED,
+        STORED(COLOR_STORED, "Stored"),
 
         /**
          * Defines state where value was read from a config file, but might not be
          * the same as the decoder.
          */
-        FROMFILE,
+        FROMFILE(COLOR_FROMFILE, "FromFile"),
 
         /**
          * Defines state where value was read from a config file, and is the same as
          * the decoder.
          */
-        SAME,
+        SAME(COLOR_SAME, "Same"),
 
         /**
          * Defines state where value was read from a config file, and is the not the
          * same as the decoder.
          */
-        DIFF
+        DIFF(COLOR_DIFF, "Different");
 
+
+        private final Color _color;
+        private final String _name;
+
+        private ValueState(Color color, String name) {
+            this._color = color;
+            this._name = name;
+        }
+
+        /**
+         * Gets the color associated with this state value.
+         * @return the color assigned to this state value
+         */
+        public Color getColor() {
+            return _color;
+        }
+
+        /**
+         * Gets the name associated with this state value.
+         * @return the name assigned to this state value
+         */
+        public String getName() {
+            return _name;
+        }
     }
 
     /**
@@ -160,60 +184,6 @@ public abstract class AbstractValue {
         return _toWrite;
     }
     private boolean _toWrite = false;
-
-    /**
-     * Gets the color associated with a particular state value.
-     *
-     * @param val a state value
-     * @return the color assigned to the specified state value
-     */
-    public static Color stateColorFromValue(ValueState val) {
-        switch (val) {
-            case UNKNOWN:
-                return COLOR_UNKNOWN;
-            case EDITED:
-                return COLOR_EDITED;
-            case READ:
-                return COLOR_READ;
-            case STORED:
-                return COLOR_STORED;
-            case FROMFILE:
-                return COLOR_FROMFILE;
-            case SAME:
-                return COLOR_SAME;
-            case DIFF:
-                return COLOR_DIFF;
-            default:
-                return null;
-        }
-    }
-
-    /**
-     * Gets the name associated with a particular state value.
-     *
-     * @param val a state value
-     * @return the name assigned to the specified state value
-     */
-    public static String stateNameFromValue(ValueState val) {
-        switch (val) {
-            case UNKNOWN:
-                return "Unknown";
-            case EDITED:
-                return "Edited";
-            case READ:
-                return "Read";
-            case STORED:
-                return "Stored";
-            case FROMFILE:
-                return "FromFile";
-            case SAME:
-                return "Same";
-            case DIFF:
-                return "Different";
-            default:
-                return "<unexpected value: " + val + ">";
-        }
-    }
 
     /**
      * Sets the availability status of the object.

--- a/java/src/jmri/jmrit/symbolicprog/CompositeVariableValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/CompositeVariableValue.java
@@ -221,7 +221,7 @@ public class CompositeVariableValue extends EnumVariableValue {
     public void lastItem() {
         // configure the representation object
         _defaultColor = _value.getBackground();
-        super.setState(READ);
+        super.setState(ValueState.READ);
 
         // note that we don't set this to COLOR_UNKNOWN!  Rather,
         // we check the current value
@@ -274,7 +274,7 @@ public class CompositeVariableValue extends EnumVariableValue {
      * This variable doesn't change state, hence doesn't change color.
      */
     @Override
-    public void setState(int state) {
+    public void setState(ValueState state) {
         log.debug("Ignore setState({})", state);
     }
 
@@ -313,7 +313,7 @@ public class CompositeVariableValue extends EnumVariableValue {
         int oldVal = getIntValue();
         selectValue(value);
 
-        if (oldVal != value || getState() == VariableValue.UNKNOWN) {
+        if (oldVal != value || getState() == ValueState.UNKNOWN) {
             prop.firePropertyChange("Value", null, value);
         }
     }
@@ -323,7 +323,7 @@ public class CompositeVariableValue extends EnumVariableValue {
      * variables (e.g. not direct to CVs).
      */
     @Override
-    public void setCvState(int state) {
+    public void setCvState(ValueState state) {
         Iterator<VariableValue> i = variables.iterator();
         while (i.hasNext()) {
             VariableValue v = i.next();
@@ -448,7 +448,7 @@ public class CompositeVariableValue extends EnumVariableValue {
         }
         // found nothing, ensure cleaned up
         amReading = false;
-        super.setState(READ);
+        super.setState(ValueState.READ);
         setBusy(false);
         log.debug("End continueRead, nothing to do");
     }
@@ -491,7 +491,7 @@ public class CompositeVariableValue extends EnumVariableValue {
         }
         // found nothing, ensure cleaned up
         amWriting = false;
-        super.setState(STORED);
+        super.setState(ValueState.STORED);
         setBusy(false);
         log.debug("End continueWrite, nothing to do");
     }

--- a/java/src/jmri/jmrit/symbolicprog/ConstantValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/ConstantValue.java
@@ -106,7 +106,7 @@ public class ConstantValue extends VariableValue {
     public void setValue(int value) {
         int oldVal = _value.getSelectedIndex();
         _value.setSelectedIndex(value);
-        if (oldVal != value || getState() == VariableValue.UNKNOWN) {
+        if (oldVal != value || getState() == ValueState.UNKNOWN) {
             prop.firePropertyChange("Value", null, value);
         }
     }
@@ -156,7 +156,7 @@ public class ConstantValue extends VariableValue {
      *
      */
     @Override
-    public void setCvState(int state) {
+    public void setCvState(ValueState state) {
     }
 
     @Override
@@ -208,7 +208,7 @@ public class ConstantValue extends VariableValue {
     public void readAll() {
         log.debug("read invoked");
         setToRead(false);
-        setState(READ);
+        setState(ValueState.READ);
         setBusy(true);
         setBusy(false);
     }
@@ -225,7 +225,7 @@ public class ConstantValue extends VariableValue {
     public void writeAll() {
         log.debug("write invoked");
         setToWrite(false);
-        setState(STORED);
+        setState(ValueState.STORED);
         setBusy(true);
         setBusy(false);
     }

--- a/java/src/jmri/jmrit/symbolicprog/CsvExportModifiedAction.java
+++ b/java/src/jmri/jmrit/symbolicprog/CsvExportModifiedAction.java
@@ -17,7 +17,7 @@ public class CsvExportModifiedAction extends CsvExportAction {
 
     @Override
     protected boolean isWritable(CvValue cv) {
-        return cv.getState() == AbstractValue.EDITED;
+        return cv.getState() == AbstractValue.ValueState.EDITED;
     }
 
     // private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(CsvExportModifiedAction.class);

--- a/java/src/jmri/jmrit/symbolicprog/CvTableModel.java
+++ b/java/src/jmri/jmrit/symbolicprog/CvTableModel.java
@@ -212,7 +212,7 @@ public class CvTableModel extends javax.swing.table.AbstractTableModel implement
                         return Bundle.getMessage("CvStateFromFile");
                     case SAME:
                         return Bundle.getMessage("CvStateSame");
-                    case DIFF:
+                    case DIFFERENT:
                         return Bundle.getMessage("CvStateDiff") + " "
                                 + _cvDisplayVector.elementAt(row).getDecoderValue();
                     default:

--- a/java/src/jmri/jmrit/symbolicprog/CvTableModel.java
+++ b/java/src/jmri/jmrit/symbolicprog/CvTableModel.java
@@ -64,7 +64,7 @@ public class CvTableModel extends javax.swing.table.AbstractTableModel implement
         _status = status;
 
         // define just address CV at start, pending some variables
-        // boudreau: not sure why we need the statement below, 
+        // boudreau: not sure why we need the statement below,
         // messes up building CV table for CV #1 when in ops mode.
         //addCV("1", false, false, false);
     }
@@ -198,21 +198,21 @@ public class CvTableModel extends javax.swing.table.AbstractTableModel implement
             case VALCOLUMN:
                 return _cvDisplayVector.elementAt(row).getTableEntry();
             case STATECOLUMN:
-                int state = _cvDisplayVector.elementAt(row).getState();
+                AbstractValue.ValueState state = _cvDisplayVector.elementAt(row).getState();
                 switch (state) {
-                    case CvValue.UNKNOWN:
+                    case UNKNOWN:
                         return Bundle.getMessage("CvStateUnknown");
-                    case CvValue.READ:
+                    case READ:
                         return Bundle.getMessage("CvStateRead");
-                    case CvValue.EDITED:
+                    case EDITED:
                         return Bundle.getMessage("CvStateEdited");
-                    case CvValue.STORED:
+                    case STORED:
                         return Bundle.getMessage("CvStateStored");
-                    case CvValue.FROMFILE:
+                    case FROMFILE:
                         return Bundle.getMessage("CvStateFromFile");
-                    case CvValue.SAME:
+                    case SAME:
                         return Bundle.getMessage("CvStateSame");
-                    case CvValue.DIFF:
+                    case DIFF:
                         return Bundle.getMessage("CvStateDiff") + " "
                                 + _cvDisplayVector.elementAt(row).getDecoderValue();
                     default:
@@ -343,7 +343,7 @@ public class CvTableModel extends javax.swing.table.AbstractTableModel implement
     public boolean decoderDirty() {
         int len = _cvDisplayVector.size();
         for (int i = 0; i < len; i++) {
-            if (_cvDisplayVector.elementAt(i).getState() == CvValue.EDITED) {
+            if (_cvDisplayVector.elementAt(i).getState() == AbstractValue.ValueState.EDITED) {
                 if (log.isDebugEnabled()) {
                     log.debug("CV decoder dirty due to {}", _cvDisplayVector.elementAt(i).number());
                 }
@@ -389,9 +389,9 @@ public class CvTableModel extends javax.swing.table.AbstractTableModel implement
 
         _cvAllMap.clear();
         _cvAllMap = null;
-        
+
         _status = null;
-        
+
     }
 
     private final static Logger log = LoggerFactory.getLogger(CvTableModel.class);

--- a/java/src/jmri/jmrit/symbolicprog/CvValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/CvValue.java
@@ -32,7 +32,7 @@ public class CvValue extends AbstractValue implements ProgListener {
         mProgrammer = pProgrammer;
         _tableEntry = new JTextField("0", 3);
         _defaultColor = _tableEntry.getBackground();
-        _tableEntry.setBackground(COLOR_UNKNOWN);
+        _tableEntry.setBackground(ValueState.UNKNOWN.getColor());
     }
 
     public CvValue(String num, String cvName, Programmer pProgrammer) {
@@ -44,7 +44,7 @@ public class CvValue extends AbstractValue implements ProgListener {
         mProgrammer = pProgrammer;
         _tableEntry = new JTextField("0", 3);
         _defaultColor = _tableEntry.getBackground();
-        _tableEntry.setBackground(COLOR_UNKNOWN);
+        _tableEntry.setBackground(ValueState.UNKNOWN.getColor());
     }
 
     @Override
@@ -130,31 +130,7 @@ public class CvValue extends AbstractValue implements ProgListener {
         }
         ValueState oldstate = _state;
         _state = state;
-        switch (state) {
-            case UNKNOWN:
-                setColor(COLOR_UNKNOWN);
-                break;
-            case EDITED:
-                setColor(COLOR_EDITED);
-                break;
-            case READ:
-                setColor(COLOR_READ);
-                break;
-            case STORED:
-                setColor(COLOR_STORED);
-                break;
-            case FROMFILE:
-                setColor(COLOR_FROMFILE);
-                break;
-            case SAME:
-                setColor(COLOR_SAME);
-                break;
-            case DIFF:
-                setColor(COLOR_DIFF);
-                break;
-            default:
-                log.error("Inconsistent state: {}", _state); // NOI18N
-        }
+        setColor(state.getColor());
         if (oldstate != state) {
             prop.firePropertyChange("State", oldstate, state);
         }

--- a/java/src/jmri/jmrit/symbolicprog/CvValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/CvValue.java
@@ -96,7 +96,7 @@ public class CvValue extends AbstractValue implements ProgListener {
     public void setValue(int value) {
         log.debug("CV {} value changed from {} to {}", number(), _value, value); // NOI18N
 
-        setState(EDITED);
+        setState(ValueState.EDITED);
         if (_value != value) {
             _value = value;
             _tableEntry.setText("" + value);
@@ -116,7 +116,7 @@ public class CvValue extends AbstractValue implements ProgListener {
 
     private int _decoderValue = 0;
 
-    public int getState() {
+    public ValueState getState() {
         return _state;
     }
 
@@ -124,11 +124,11 @@ public class CvValue extends AbstractValue implements ProgListener {
      * Set state value and send notification.Also sets GUI color as needed.
      * @param state new state, e.g READ, UNKNOWN, SAME.
      */
-    public void setState(int state) {
+    public void setState(ValueState state) {
         if (log.isDebugEnabled()) {  // stateToString overhead
             log.debug("cv {} set state from {} to {}", number(), stateToString(_state), stateToString(state)); // NOI18N
         }
-        int oldstate = _state;
+        ValueState oldstate = _state;
         _state = state;
         switch (state) {
             case UNKNOWN:
@@ -156,7 +156,7 @@ public class CvValue extends AbstractValue implements ProgListener {
                 log.error("Inconsistent state: {}", _state); // NOI18N
         }
         if (oldstate != state) {
-            prop.firePropertyChange("State", Integer.valueOf(oldstate), Integer.valueOf(state));
+            prop.firePropertyChange("State", oldstate, state);
         }
     }
 
@@ -165,7 +165,7 @@ public class CvValue extends AbstractValue implements ProgListener {
      * @param state State to translate to text
      * @return Text (human readable) representation of state
      */
-    String stateToString(int state) {
+    String stateToString(ValueState state) {
         switch (state) {
             case UNKNOWN:
                 return "UNKNOWN";
@@ -187,7 +187,7 @@ public class CvValue extends AbstractValue implements ProgListener {
         }
     }
 
-    private int _state = 0;
+    private ValueState _state = ValueState.UNKNOWN;
 
     // read, write operations
     public boolean isBusy() {
@@ -430,10 +430,10 @@ public class CvValue extends AbstractValue implements ProgListener {
             _reading = false;
             _confirm = false;
             try {
-                setState(UNKNOWN);
+                setState(ValueState.UNKNOWN);
                 mProgrammer.writeCV(_num, _value, this);
             } catch (Exception e) {
-                setState(UNKNOWN);
+                setState(ValueState.UNKNOWN);
                 if (status != null) {
                     status.setText(
                             java.text.MessageFormat.format(
@@ -469,7 +469,7 @@ public class CvValue extends AbstractValue implements ProgListener {
                 _value = value;
                 _tableEntry.setText(Integer.toString(value));
                 notifyValueChange(value);
-                setState(READ);
+                setState(ValueState.READ);
                 log.debug("CV setting not busy on end read"); // NOI18N
                 _busy = false;
                 notifyBusyChange(oldBusy, _busy);
@@ -478,14 +478,14 @@ public class CvValue extends AbstractValue implements ProgListener {
                 _decoderValue = value;
                 // does the decoder value match the file value
                 if (value == _value) {
-                    setState(SAME);
+                    setState(ValueState.SAME);
                 } else {
-                    setState(DIFF);
+                    setState(ValueState.DIFF);
                 }
                 _busy = false;
                 notifyBusyChange(oldBusy, _busy);
             } else {  // writing
-                setState(STORED);
+                setState(ValueState.STORED);
                 _busy = false;
                 notifyBusyChange(oldBusy, _busy);
             }
@@ -513,7 +513,7 @@ public class CvValue extends AbstractValue implements ProgListener {
     }
 
     void errorTimeout() {
-        setState(UNKNOWN);
+        setState(ValueState.UNKNOWN);
         log.debug("CV setting not busy on error reply"); // NOI18N
         _busy = false;
         notifyBusyChange(true, _busy);

--- a/java/src/jmri/jmrit/symbolicprog/CvValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/CvValue.java
@@ -126,40 +126,13 @@ public class CvValue extends AbstractValue implements ProgListener {
      */
     public void setState(ValueState state) {
         if (log.isDebugEnabled()) {  // stateToString overhead
-            log.debug("cv {} set state from {} to {}", number(), stateToString(_state), stateToString(state)); // NOI18N
+            log.debug("cv {} set state from {} to {}", number(), _state.name(), state.name()); // NOI18N
         }
         ValueState oldstate = _state;
         _state = state;
         setColor(state.getColor());
         if (oldstate != state) {
             prop.firePropertyChange("State", oldstate, state);
-        }
-    }
-
-    /**
-     * Intended for debugging only, don't translate.
-     * @param state State to translate to text
-     * @return Text (human readable) representation of state
-     */
-    String stateToString(ValueState state) {
-        switch (state) {
-            case UNKNOWN:
-                return "UNKNOWN";
-            case EDITED:
-                return "EDITED";
-            case READ:
-                return "READ";
-            case STORED:
-                return "STORED";
-            case FROMFILE:
-                return "FROMFILE";
-            case SAME:
-                return "SAME";
-            case DIFF:
-                return "DIFF";
-            default:
-                log.error("Inconsistent state: {}", _state); // NOI18N
-                return "ERROR!!";
         }
     }
 
@@ -456,7 +429,7 @@ public class CvValue extends AbstractValue implements ProgListener {
                 if (value == _value) {
                     setState(ValueState.SAME);
                 } else {
-                    setState(ValueState.DIFF);
+                    setState(ValueState.DIFFERENT);
                 }
                 _busy = false;
                 notifyBusyChange(oldBusy, _busy);

--- a/java/src/jmri/jmrit/symbolicprog/DecVarSlider.java
+++ b/java/src/jmri/jmrit/symbolicprog/DecVarSlider.java
@@ -50,7 +50,7 @@ public class DecVarSlider extends JSlider implements ChangeListener {
         BoundedRangeModel r = j.getModel();
 
         _var.setIntValue(r.getValue());
-        _var.setState(AbstractValue.EDITED);
+        _var.setState(AbstractValue.ValueState.EDITED);
     }
 
     DecVariableValue _var;

--- a/java/src/jmri/jmrit/symbolicprog/DecVariableValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/DecVariableValue.java
@@ -53,7 +53,7 @@ public class DecVariableValue extends VariableValue
         _value = new JTextField("0", fieldLength());
         _value.getAccessibleContext().setAccessibleName(label());
         _defaultColor = _value.getBackground();
-        _value.setBackground(COLOR_UNKNOWN);
+        _value.setBackground(ValueState.UNKNOWN.getColor());
         // connect to the JTextField value, cv
         _value.addActionListener(this);
         _value.addFocusListener(this);

--- a/java/src/jmri/jmrit/symbolicprog/DecVariableValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/DecVariableValue.java
@@ -59,7 +59,7 @@ public class DecVariableValue extends VariableValue
         _value.addFocusListener(this);
         CvValue cv = _cvMap.get(getCvNum());
         cv.addPropertyChangeListener(this);
-        cv.setState(CvValue.FROMFILE);
+        cv.setState(ValueState.FROMFILE);
         simplifyMask();
     }
 
@@ -359,7 +359,7 @@ public class DecVariableValue extends VariableValue
      *
      */
     @Override
-    public void setCvState(int state) {
+    public void setCvState(ValueState state) {
         _cvMap.get(getCvNum()).setState(state);
     }
 
@@ -417,10 +417,10 @@ public class DecVariableValue extends VariableValue
             }
         } else if (e.getPropertyName().equals("State")) {
             CvValue cv = _cvMap.get(getCvNum());
-            if (cv.getState() == STORED) {
+            if (cv.getState() == ValueState.STORED) {
                 setToWrite(false);
             }
-            if (cv.getState() == READ) {
+            if (cv.getState() == ValueState.READ) {
                 setToRead(false);
             }
             setState(cv.getState());

--- a/java/src/jmri/jmrit/symbolicprog/EnumVariableValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/EnumVariableValue.java
@@ -107,7 +107,7 @@ public class EnumVariableValue extends VariableValue implements ActionListener {
         // finish initialization
         _value.setActionCommand("");
         _defaultColor = _value.getBackground();
-        _value.setBackground(COLOR_UNKNOWN);
+        _value.setBackground(ValueState.UNKNOWN.getColor());
         _value.setOpaque(true);
         // connect to the JComboBox model and the CV so we'll see changes.
         _value.addActionListener(this);

--- a/java/src/jmri/jmrit/symbolicprog/EnumVariableValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/EnumVariableValue.java
@@ -117,7 +117,7 @@ public class EnumVariableValue extends VariableValue implements ActionListener {
             return;
         }
         cv.addPropertyChangeListener(this);
-        cv.setState(CvValue.FROMFILE);
+        cv.setState(ValueState.FROMFILE);
     }
 
     @Override
@@ -317,7 +317,7 @@ public class EnumVariableValue extends VariableValue implements ActionListener {
         log.debug("setValue in EnumVariableValue to {}", value);
         selectValue(value);
 
-        if (oldVal != value || getState() == VariableValue.UNKNOWN) {
+        if (oldVal != value || getState() == ValueState.UNKNOWN) {
             prop.firePropertyChange("Value", null, value);
         }
     }
@@ -440,7 +440,7 @@ public class EnumVariableValue extends VariableValue implements ActionListener {
      * Notify the connected CVs of a state change from above
      */
     @Override
-    public void setCvState(int state) {
+    public void setCvState(ValueState state) {
         _cvMap.get(getCvNum()).setState(state);
     }
 
@@ -501,10 +501,10 @@ public class EnumVariableValue extends VariableValue implements ActionListener {
                 break;
             case "State": {
                 CvValue cv = _cvMap.get(getCvNum());
-                if (cv.getState() == STORED) {
+                if (cv.getState() == ValueState.STORED) {
                     setToWrite(false);
                 }
-                if (cv.getState() == READ) {
+                if (cv.getState() == ValueState.READ) {
                     setToRead(false);
                 }
                 setState(cv.getState());

--- a/java/src/jmri/jmrit/symbolicprog/ExtraMenuTableModel.java
+++ b/java/src/jmri/jmrit/symbolicprog/ExtraMenuTableModel.java
@@ -114,17 +114,17 @@ public class ExtraMenuTableModel extends AbstractTableModel implements ActionLis
             case "Write":
                 return _writeButtons.get(row);
             case "State":
-                int state = cv.getState();
+                AbstractValue.ValueState state = cv.getState();
                 switch (state) {
-                    case CvValue.UNKNOWN:
+                    case UNKNOWN:
                         return "Unknown";
-                    case CvValue.READ:
+                    case READ:
                         return "Read";
-                    case CvValue.EDITED:
+                    case EDITED:
                         return "Edited";
-                    case CvValue.STORED:
+                    case STORED:
                         return "Stored";
-                    case CvValue.FROMFILE:
+                    case FROMFILE:
                         return "From file";
                     default:
                         return "inconsistent";
@@ -147,7 +147,7 @@ public class ExtraMenuTableModel extends AbstractTableModel implements ActionLis
         resetCV.addPropertyChangeListener(this);
         resetCV.setValue(cvVal);
         resetCV.setWriteOnly(true);
-        resetCV.setState(VariableValue.STORED);
+        resetCV.setState(AbstractValue.ValueState.STORED);
         rowVector.add(resetCV);
         labelVector.add(label);
         modeVector.add(getResetModeList(e, p));

--- a/java/src/jmri/jmrit/symbolicprog/FnMapPanelESU.java
+++ b/java/src/jmri/jmrit/symbolicprog/FnMapPanelESU.java
@@ -744,7 +744,7 @@ public final class FnMapPanelESU extends JPanel {
             retString.deleteCharAt(0);
         }
 
-        summaryLine[row][block].setBackground(AbstractValue.stateColorFromValue(retState));
+        summaryLine[row][block].setBackground(retState.getColor());
         summaryLine[row][block].setText(retString.toString());
         summaryLine[row][block].setToolTipText(retString.toString());
     }

--- a/java/src/jmri/jmrit/symbolicprog/FnMapPanelESU.java
+++ b/java/src/jmri/jmrit/symbolicprog/FnMapPanelESU.java
@@ -705,12 +705,12 @@ public final class FnMapPanelESU extends JPanel {
      */
     void updateSummaryLine(int row, int block) {
         StringBuilder retString = new StringBuilder("");
-        int retState = AbstractValue.SAME;
+        AbstractValue.ValueState retState = AbstractValue.ValueState.SAME;
 
         for (int item = outBlockStartCol[block]; item < (outBlockStartCol[block] + outBlockLength[block]); item++) {
             if (itemIsUsed[item]) {
                 int value = Integer.parseInt(varModel.getValString(iVarIndex[item][row]));
-                int state = varModel.getState(iVarIndex[item][row]);
+                var state = varModel.getState(iVarIndex[item][row]);
                 if ((item == outBlockStartCol[block]) || (priorityValue(state) > priorityValue(retState))) {
                     retState = state;
                 }
@@ -756,19 +756,19 @@ public final class FnMapPanelESU extends JPanel {
      * @return the assigned priority value
      */
     @SuppressFBWarnings({"SF_SWITCH_NO_DEFAULT", "SF_SWITCH_FALLTHROUGH"})
-    int priorityValue(int state) {
+    int priorityValue(AbstractValue.ValueState state) {
         int value = 0;
         switch (state) {
-            case AbstractValue.UNKNOWN:
+            case UNKNOWN:
                 value++;
             //$FALL-THROUGH$
-            case AbstractValue.DIFF:
+            case DIFF:
                 value++;
             //$FALL-THROUGH$
-            case AbstractValue.EDITED:
+            case EDITED:
                 value++;
             //$FALL-THROUGH$
-            case AbstractValue.FROMFILE:
+            case FROMFILE:
                 value++;
             //$FALL-THROUGH$
             default:

--- a/java/src/jmri/jmrit/symbolicprog/FnMapPanelESU.java
+++ b/java/src/jmri/jmrit/symbolicprog/FnMapPanelESU.java
@@ -762,7 +762,7 @@ public final class FnMapPanelESU extends JPanel {
             case UNKNOWN:
                 value++;
             //$FALL-THROUGH$
-            case DIFF:
+            case DIFFERENT:
                 value++;
             //$FALL-THROUGH$
             case EDITED:

--- a/java/src/jmri/jmrit/symbolicprog/LongAddrVariableValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/LongAddrVariableValue.java
@@ -42,11 +42,11 @@ public class LongAddrVariableValue extends VariableValue
         // connect for notification
         CvValue cv = (_cvMap.get(getCvNum()));
         cv.addPropertyChangeListener(this);
-        cv.setState(CvValue.FROMFILE);
+        cv.setState(ValueState.FROMFILE);
 
         highCV = mHighCV;
         highCV.addPropertyChangeListener(this);
-        highCV.setState(CvValue.FROMFILE);
+        highCV.setState(ValueState.FROMFILE);
         // simplifyMask(); // not required as mask is ignored
     }
 
@@ -194,7 +194,7 @@ public class LongAddrVariableValue extends VariableValue
         }
         log.debug("setValue with new value {} old value {}", value, oldVal);
         _value.setText("" + value);
-        if (oldVal != value || getState() == VariableValue.UNKNOWN) {
+        if (oldVal != value || getState() == ValueState.UNKNOWN) {
             actionPerformed(null);
         }
         prop.firePropertyChange("Value", Integer.valueOf(oldVal), Integer.valueOf(value));
@@ -231,7 +231,7 @@ public class LongAddrVariableValue extends VariableValue
      *
      */
     @Override
-    public void setCvState(int state) {
+    public void setCvState(ValueState state) {
         (_cvMap.get(getCvNum())).setState(state);
     }
 
@@ -328,8 +328,8 @@ public class LongAddrVariableValue extends VariableValue
                 case READING_SECOND:  // finally done, set not busy
                     log.debug("Busy goes false with state READING_SECOND");
                     _progState = IDLE;
-                    (_cvMap.get(getCvNum())).setState(READ);
-                    highCV.setState(READ);
+                    (_cvMap.get(getCvNum())).setState(ValueState.READ);
+                    highCV.setState(ValueState.READ);
                     //super.setState(READ);
                     setBusy(false);
                     return;
@@ -341,7 +341,7 @@ public class LongAddrVariableValue extends VariableValue
                 case WRITING_SECOND:  // now done with complete request
                     log.debug("Busy goes false with state WRITING_SECOND");
                     _progState = IDLE;
-                    super.setState(STORED);
+                    super.setState(ValueState.STORED);
                     setBusy(false);
                     return;
                 default:  // unexpected!

--- a/java/src/jmri/jmrit/symbolicprog/LongAddrVariableValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/LongAddrVariableValue.java
@@ -35,7 +35,7 @@ public class LongAddrVariableValue extends VariableValue
         _value.getAccessibleContext().setAccessibleName(label());
 
         _defaultColor = _value.getBackground();
-        _value.setBackground(COLOR_UNKNOWN);
+        _value.setBackground(ValueState.UNKNOWN.getColor());
         // connect to the JTextField value, cv
         _value.addActionListener(this);
         _value.addFocusListener(this);

--- a/java/src/jmri/jmrit/symbolicprog/ShortAddrVariableValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/ShortAddrVariableValue.java
@@ -64,7 +64,7 @@ public class ShortAddrVariableValue extends DecVariableValue {
                 log.error("CV numbers don't match: {} {}", cvNumbers[i], cv.number());
             }
             cv.setToWrite(true);
-            cv.setState(EDITED);
+            cv.setState(ValueState.EDITED);
             if (log.isDebugEnabled()) {
                 log.debug("Mark to write {}", cv.number());
             }

--- a/java/src/jmri/jmrit/symbolicprog/SpeedTableVarValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/SpeedTableVarValue.java
@@ -143,7 +143,7 @@ public class SpeedTableVarValue extends VariableValue implements ChangeListener 
             CvValue c = _cvMap.get(cvList[i]);
             c.setValue(_range * i / (nValues - 1) + _min);
             c.addPropertyChangeListener(this);
-            c.setState(CvValue.FROMFILE);
+            c.setState(ValueState.FROMFILE);
         }
 
         _defaultColor = (new JSlider()).getBackground();
@@ -320,35 +320,35 @@ public class SpeedTableVarValue extends VariableValue implements ChangeListener 
     }
 
     @Override
-    public int getState() {
+    public ValueState getState() {
         int i;
         for (i = 0; i < numCvs; i++) {
-            if (_cvMap.get(cvList[i]).getState() == UNKNOWN) {
-                return UNKNOWN;
+            if (_cvMap.get(cvList[i]).getState() == ValueState.UNKNOWN) {
+                return ValueState.UNKNOWN;
             }
         }
         for (i = 0; i < numCvs; i++) {
-            if (_cvMap.get(cvList[i]).getState() == EDITED) {
-                return EDITED;
+            if (_cvMap.get(cvList[i]).getState() == ValueState.EDITED) {
+                return ValueState.EDITED;
             }
         }
         for (i = 0; i < numCvs; i++) {
-            if (_cvMap.get(cvList[i]).getState() == FROMFILE) {
-                return FROMFILE;
+            if (_cvMap.get(cvList[i]).getState() == ValueState.FROMFILE) {
+                return ValueState.FROMFILE;
             }
         }
         for (i = 0; i < numCvs; i++) {
-            if (_cvMap.get(cvList[i]).getState() == READ) {
-                return READ;
+            if (_cvMap.get(cvList[i]).getState() == ValueState.READ) {
+                return ValueState.READ;
             }
         }
         for (i = 0; i < numCvs; i++) {
-            if (_cvMap.get(cvList[i]).getState() == STORED) {
-                return STORED;
+            if (_cvMap.get(cvList[i]).getState() == ValueState.STORED) {
+                return ValueState.STORED;
             }
         }
         log.error("getState did not decode a possible state");
-        return UNKNOWN;
+        return ValueState.UNKNOWN;
     }
 
     // to complete this class, fill in the routines to handle "Value" parameter
@@ -430,7 +430,7 @@ public class SpeedTableVarValue extends VariableValue implements ChangeListener 
             s.setOrientation(JSlider.VERTICAL);
             s.addChangeListener(this);
 
-            int currentState = cv.getState();
+            ValueState currentState = cv.getState();
             int currentValue = cv.getValue();
 
             DecVariableValue decVal = new DecVariableValue("val" + i, "", "", false, false, false, false,
@@ -705,7 +705,7 @@ public class SpeedTableVarValue extends VariableValue implements ChangeListener 
      *
      */
     @Override
-    public void setCvState(int state) {
+    public void setCvState(ValueState state) {
         _cvMap.get(cvList[0]).setState(state);
     }
 
@@ -756,7 +756,7 @@ public class SpeedTableVarValue extends VariableValue implements ChangeListener 
             log.error("unexpected write operation when readOnly is set");
         }
         setBusy(true);  // will be reset when value changes
-        super.setState(STORED);
+        super.setState(ValueState.STORED);
         if (_progState != IDLE) {
             log.warn("Programming state {}, not IDLE, in write()", _progState);
         }
@@ -802,7 +802,7 @@ public class SpeedTableVarValue extends VariableValue implements ChangeListener 
         }
         setToWrite(false);
         setBusy(true);  // will be reset when value changes
-        super.setState(STORED);
+        super.setState(ValueState.STORED);
         if (_progState != IDLE) {
             log.warn("Programming state {}, not IDLE, in write()", _progState);
         }
@@ -820,7 +820,7 @@ public class SpeedTableVarValue extends VariableValue implements ChangeListener 
         // read operation start/continue
         // check for retry if needed
         if ((_progState >= 0) && (retries < RETRY_MAX)
-                && (_cvMap.get(cvList[_progState]).getState() != CvValue.READ)) {
+                && (_cvMap.get(cvList[_progState]).getState() != ValueState.READ)) {
             // need to retry an error; leave progState (CV number) as it was
             retries++;
         } else {
@@ -839,7 +839,7 @@ public class SpeedTableVarValue extends VariableValue implements ChangeListener 
         }
         // not done, proceed to do the next
         CvValue cv = _cvMap.get(cvList[_progState]);
-        int state = cv.getState();
+        ValueState state = cv.getState();
         if (log.isDebugEnabled()) {
             log.debug("invoke CV read index {} cv state {}", _progState, state);
         }
@@ -854,7 +854,7 @@ public class SpeedTableVarValue extends VariableValue implements ChangeListener 
         // write operation start/continue
         // check for retry if needed
         if ((_progState >= 0) && (retries < RETRY_MAX)
-                && (_cvMap.get(cvList[_progState]).getState() != CvValue.STORED)) {
+                && (_cvMap.get(cvList[_progState]).getState() != ValueState.STORED)) {
             // need to retry an error; leave progState (CV number) as it was
             retries++;
         } else {
@@ -871,7 +871,7 @@ public class SpeedTableVarValue extends VariableValue implements ChangeListener 
             return;
         }
         CvValue cv = _cvMap.get(cvList[_progState]);
-        int state = cv.getState();
+        ValueState state = cv.getState();
         if (log.isDebugEnabled()) {
             log.debug("invoke CV write index {} cv state {}", _progState, state);
         }

--- a/java/src/jmri/jmrit/symbolicprog/SplitEnumVariableValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/SplitEnumVariableValue.java
@@ -25,7 +25,6 @@ import javax.swing.event.TreeSelectionListener;
 import javax.swing.tree.DefaultTreeModel;
 import javax.swing.tree.DefaultTreeSelectionModel;
 
-import static jmri.jmrit.symbolicprog.AbstractValue.COLOR_UNKNOWN;
 import jmri.util.CvUtil;
 
 import org.slf4j.Logger;
@@ -247,7 +246,7 @@ public class SplitEnumVariableValue extends VariableValue
         // finish initialization
         _value.setActionCommand("");
         _defaultColor = _value.getBackground();
-        _value.setBackground(COLOR_UNKNOWN);
+        _value.setBackground(ValueState.UNKNOWN.getColor());
         _value.setOpaque(true);
         // connect to the JComboBox model and the CV so we'll see changes.
         _value.addActionListener(this);

--- a/java/src/jmri/jmrit/symbolicprog/SplitEnumVariableValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/SplitEnumVariableValue.java
@@ -1083,7 +1083,7 @@ public class SplitEnumVariableValue extends VariableValue
             case "State": {
                 log.info("Possible {} variable state change due to CV state change, so propagate that", _name);
                 ValueState varState = getState(); // AbstractValue.SAME;
-                log.info("{} variable state was {}", _name, stateNameFromValue(varState));
+                log.info("{} variable state was {}", _name, varState.getName());
                 for (int i = 0; i < cvCount; i++) {
                     ValueState state = cvList.get(i).thisCV.getState();
                     if (i == 0) {
@@ -1098,7 +1098,7 @@ public class SplitEnumVariableValue extends VariableValue
                     tree.setBackground(_value.getBackground());
                     //tree.setOpaque(true);
                 }
-                log.info("{} variable state set to {}", _name, stateNameFromValue(varState));
+                log.info("{} variable state set to {}", _name, varState.getName());
                 break;
             }
             case "Value": {

--- a/java/src/jmri/jmrit/symbolicprog/SplitEnumVariableValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/SplitEnumVariableValue.java
@@ -154,7 +154,7 @@ public class SplitEnumVariableValue extends VariableValue
         // have to do when list is complete
         for (int i = 0; i < cvCount; i++) {
             cvList.get(i).thisCV.addPropertyChangeListener(this);
-            cvList.get(i).thisCV.setState(CvValue.FROMFILE);
+            cvList.get(i).thisCV.setState(ValueState.FROMFILE);
         }
         treeNodes.addLast(new DefaultMutableTreeNode(""));
     }
@@ -258,9 +258,9 @@ public class SplitEnumVariableValue extends VariableValue
             return;
         }
         cv1.addPropertyChangeListener(this);
-        cv1.setState(CvValue.FROMFILE);
+        cv1.setState(ValueState.FROMFILE);
         cv2.addPropertyChangeListener(this);
-        cv2.setState(CvValue.FROMFILE);
+        cv2.setState(ValueState.FROMFILE);
     }
 
 
@@ -777,7 +777,7 @@ public class SplitEnumVariableValue extends VariableValue
           }
         }
         */
-        if (oldVal != value || getState() == VariableValue.UNKNOWN) {
+        if (oldVal != value || getState() == ValueState.UNKNOWN) {
             actionPerformed(null);
         }
         // TODO PENDING: the code used to fire value * mFactor + mOffset, which is a text representation;
@@ -902,7 +902,7 @@ public class SplitEnumVariableValue extends VariableValue
      * @param state The new state
      */
     @Override
-    public void setCvState(int state) {
+    public void setCvState(ValueState state) {
         for (int i = 0; i < cvCount; i++) {
             cvList.get(i).thisCV.setState(state);
         }
@@ -963,7 +963,7 @@ public class SplitEnumVariableValue extends VariableValue
         //super.setState(READ);
         //_value.setSelectedIndex(0); // start with a clean slate
         for (int i = 0; i < cvCount; i++) { // mark all Cvs as unknown otherwise problems occur
-            cvList.get(i).thisCV.setState(AbstractValue.UNKNOWN);
+            cvList.get(i).thisCV.setState(ValueState.UNKNOWN);
         }
         //super.setState(READING_FIRST);
         _progState = READING_FIRST;
@@ -997,19 +997,19 @@ public class SplitEnumVariableValue extends VariableValue
      * @return Priority value from state, with UNKNOWN numerically highest
      */
     @SuppressFBWarnings(value = {"SF_SWITCH_NO_DEFAULT", "SF_SWITCH_FALLTHROUGH"}, justification = "Intentional fallthrough to produce correct value")
-    int priorityValue(int state) {
+    int priorityValue(ValueState state) {
         int value = 0;
         switch (state) {
-            case AbstractValue.UNKNOWN:
+            case UNKNOWN:
                 value++;
             //$FALL-THROUGH$
-            case AbstractValue.DIFF:
+            case DIFF:
                 value++;
             //$FALL-THROUGH$
-            case AbstractValue.EDITED:
+            case EDITED:
                 value++;
             //$FALL-THROUGH$
-            case AbstractValue.FROMFILE:
+            case FROMFILE:
                 value++;
             //$FALL-THROUGH$
             default:
@@ -1031,8 +1031,8 @@ public class SplitEnumVariableValue extends VariableValue
                         setBusy(false);
                     }
                     if (_progState >= READING_FIRST){
-                        int curState = (cvList.get(Math.abs(_progState) - 1).thisCV).getState();
-                        if (curState == READ) {   // was the last read successful?
+                        ValueState curState = (cvList.get(Math.abs(_progState) - 1).thisCV).getState();
+                        if (curState == ValueState.READ) {   // was the last read successful?
                             retry = 0;
                             if (Math.abs(_progState) < cvCount) {   // read next CV
                                 _progState++;
@@ -1055,13 +1055,13 @@ public class SplitEnumVariableValue extends VariableValue
                                 setBusy(false);
                                 if (RETRY_COUNT > 0) {
                                     for (int i = 0; i < cvCount; i++) { // mark all CVs as unknown otherwise problems may occur
-                                        cvList.get(i).thisCV.setState(AbstractValue.UNKNOWN);
+                                        cvList.get(i).thisCV.setState(ValueState.UNKNOWN);
                                     }
                                 }
                             }
                         }
                     } else  if (_progState <= WRITING_FIRST) {  // writing CVs
-                        if ((cvList.get(Math.abs(_progState) - 1).thisCV).getState() == STORED) {   // was the last read successful?
+                        if ((cvList.get(Math.abs(_progState) - 1).thisCV).getState() == ValueState.STORED) {   // was the last read successful?
                             if (Math.abs(_progState) < cvCount) {   // write next CV
                                 _progState--;
                                 log.info("Writing CV={}", cvList.get(Math.abs(_progState) - 1).cvName);
@@ -1082,14 +1082,14 @@ public class SplitEnumVariableValue extends VariableValue
                 break;
             case "State": {
                 log.info("Possible {} variable state change due to CV state change, so propagate that", _name);
-                int varState = getState(); // AbstractValue.SAME;
+                ValueState varState = getState(); // AbstractValue.SAME;
                 log.info("{} variable state was {}", _name, stateNameFromValue(varState));
                 for (int i = 0; i < cvCount; i++) {
-                    int state = cvList.get(i).thisCV.getState();
+                    ValueState state = cvList.get(i).thisCV.getState();
                     if (i == 0) {
                         varState = state;
                     } else if (priorityValue(state) > priorityValue(varState)) {
-                        varState = AbstractValue.UNKNOWN; // or should it be = state ?
+                        varState = ValueState.UNKNOWN; // or should it be = state ?
 //                        varState = state; // or should it be = state ?
                     }
                 }
@@ -1116,9 +1116,9 @@ public class SplitEnumVariableValue extends VariableValue
                 updateVariableValue(intVals);
 
                 log.info("state change due to CV value change, so propagate that");
-                int varState = AbstractValue.SAME;
+                ValueState varState = ValueState.SAME;
                 for (int i = 0; i < cvCount; i++) {
-                    int state = cvList.get(i).thisCV.getState();
+                    ValueState state = cvList.get(i).thisCV.getState();
                     if (priorityValue(state) > priorityValue(varState)) {
                         varState = state;
                     }

--- a/java/src/jmri/jmrit/symbolicprog/SplitEnumVariableValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/SplitEnumVariableValue.java
@@ -1002,7 +1002,7 @@ public class SplitEnumVariableValue extends VariableValue
             case UNKNOWN:
                 value++;
             //$FALL-THROUGH$
-            case DIFF:
+            case DIFFERENT:
                 value++;
             //$FALL-THROUGH$
             case EDITED:

--- a/java/src/jmri/jmrit/symbolicprog/SplitVariableValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/SplitVariableValue.java
@@ -139,7 +139,7 @@ public class SplitVariableValue extends VariableValue
         // have to do when list is complete
         for (int i = 0; i < cvCount; i++) {
             cvList.get(i).thisCV.addPropertyChangeListener(this);
-            cvList.get(i).thisCV.setState(CvValue.FROMFILE);
+            cvList.get(i).thisCV.setState(ValueState.FROMFILE);
         }
     }
 
@@ -537,7 +537,7 @@ public class SplitVariableValue extends VariableValue
         }
         log.debug("Variable={}; setValue with new value {} old value {}", _name, value, oldVal);
         _textField.setText(getTextFromValue(value * mFactor + mOffset));
-        if (oldVal != value || getState() == VariableValue.UNKNOWN) {
+        if (oldVal != value || getState() == ValueState.UNKNOWN) {
             actionPerformed(null);
         }
         // TODO PENDING: the code used to fire value * mFactor + mOffset, which is a text representation;
@@ -601,7 +601,7 @@ public class SplitVariableValue extends VariableValue
      * @param state The new state
      */
     @Override
-    public void setCvState(int state) {
+    public void setCvState(ValueState state) {
         for (int i = 0; i < cvCount; i++) {
             cvList.get(i).thisCV.setState(state);
         }
@@ -665,7 +665,7 @@ public class SplitVariableValue extends VariableValue
         }
         _textField.setText(""); // start with a clean slate
         for (int i = 0; i < cvCount; i++) { // mark all Cvs as unknown otherwise problems occur
-            cvList.get(i).thisCV.setState(AbstractValue.UNKNOWN);
+            cvList.get(i).thisCV.setState(ValueState.UNKNOWN);
         }
         _progState = READING_FIRST;
         retry = 0;
@@ -698,19 +698,19 @@ public class SplitVariableValue extends VariableValue
      * @return Priority value from state, with UNKNOWN numerically highest
      */
     @SuppressFBWarnings(value = {"SF_SWITCH_NO_DEFAULT", "SF_SWITCH_FALLTHROUGH"}, justification = "Intentional fallthrough to produce correct value")
-    int priorityValue(int state) {
+    int priorityValue(ValueState state) {
         int value = 0;
         switch (state) {
-            case AbstractValue.UNKNOWN:
+            case UNKNOWN:
                 value++;
             //$FALL-THROUGH$
-            case AbstractValue.DIFF:
+            case DIFF:
                 value++;
             //$FALL-THROUGH$
-            case AbstractValue.EDITED:
+            case EDITED:
                 value++;
             //$FALL-THROUGH$
-            case AbstractValue.FROMFILE:
+            case FROMFILE:
                 value++;
             //$FALL-THROUGH$
             default:
@@ -735,7 +735,7 @@ public class SplitVariableValue extends VariableValue
                 // It is definitely not an error condition, but needs to be ignored by this variable's state machine.
                 log.debug("Variable={}; Busy goes false with _progState IDLE, so ignore by state machine", _name);
             } else if (_progState >= READING_FIRST) {   // reading CVs
-                if ((cvList.get(Math.abs(_progState) - 1).thisCV).getState() == READ) {   // was the last read successful?
+                if ((cvList.get(Math.abs(_progState) - 1).thisCV).getState() == ValueState.READ) {   // was the last read successful?
                     retry = 0;
                     if (Math.abs(_progState) < cvCount) {   // read next CV
                         _progState++;
@@ -756,13 +756,13 @@ public class SplitVariableValue extends VariableValue
                         setBusy(false);
                         if (RETRY_COUNT > 0) {
                             for (int i = 0; i < cvCount; i++) { // mark all CVs as unknown otherwise problems may occur
-                                cvList.get(i).thisCV.setState(AbstractValue.UNKNOWN);
+                                cvList.get(i).thisCV.setState(ValueState.UNKNOWN);
                             }
                         }
                     }
                 }
             } else {  // writing CVs
-                if ((cvList.get(Math.abs(_progState) - 1).thisCV).getState() == STORED) {   // was the last read successful?
+                if ((cvList.get(Math.abs(_progState) - 1).thisCV).getState() == ValueState.STORED) {   // was the last read successful?
                     if (Math.abs(_progState) < cvCount) {   // write next CV
                         _progState--;
                         log.debug("Writing CV={}", cvList.get(Math.abs(_progState) - 1).cvName);
@@ -780,10 +780,10 @@ public class SplitVariableValue extends VariableValue
             }
         } else if (e.getPropertyName().equals("State")) {
             log.debug("Possible {} variable state change due to CV state change, so propagate that", _name);
-            int varState = getState(); // AbstractValue.SAME;
+            ValueState varState = getState(); // AbstractValue.SAME;
             log.debug("{} variable state was {}", _name, stateNameFromValue(varState));
             for (int i = 0; i < cvCount; i++) {
-                int state = cvList.get(i).thisCV.getState();
+                var state = cvList.get(i).thisCV.getState();
                 if (i == 0) {
                     varState = state;
                 } else if (priorityValue(state) > priorityValue(varState)) {
@@ -806,9 +806,9 @@ public class SplitVariableValue extends VariableValue
             updateVariableValue(intVals);
 
             log.debug("state change due to CV value change, so propagate that");
-            int varState = AbstractValue.SAME;
+            ValueState varState = ValueState.SAME;
             for (int i = 0; i < cvCount; i++) {
-                int state = cvList.get(i).thisCV.getState();
+                ValueState state = cvList.get(i).thisCV.getState();
                 if (priorityValue(state) > priorityValue(varState)) {
                     varState = state;
                 }

--- a/java/src/jmri/jmrit/symbolicprog/SplitVariableValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/SplitVariableValue.java
@@ -781,7 +781,7 @@ public class SplitVariableValue extends VariableValue
         } else if (e.getPropertyName().equals("State")) {
             log.debug("Possible {} variable state change due to CV state change, so propagate that", _name);
             ValueState varState = getState(); // AbstractValue.SAME;
-            log.debug("{} variable state was {}", _name, stateNameFromValue(varState));
+            log.debug("{} variable state was {}", _name, varState.getName());
             for (int i = 0; i < cvCount; i++) {
                 var state = cvList.get(i).thisCV.getState();
                 if (i == 0) {
@@ -792,7 +792,7 @@ public class SplitVariableValue extends VariableValue
                 }
             }
             setState(varState);
-            log.debug("{} variable state set to {}", _name, stateNameFromValue(varState));
+            log.debug("{} variable state set to {}", _name, varState.getName());
         } else if (e.getPropertyName().equals("Value")) {
             // update value of Variable
             log.debug("update value of Variable {}", _name);

--- a/java/src/jmri/jmrit/symbolicprog/SplitVariableValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/SplitVariableValue.java
@@ -71,7 +71,7 @@ public class SplitVariableValue extends VariableValue
         _textField = new JTextField("0");
         _defaultColor = _textField.getBackground();
 
-        _textField.setBackground(COLOR_UNKNOWN);
+        _textField.setBackground(ValueState.UNKNOWN.getColor());
         _textField.getAccessibleContext().setAccessibleName(label());
 
         mFactor = pFactor;

--- a/java/src/jmri/jmrit/symbolicprog/SplitVariableValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/SplitVariableValue.java
@@ -704,7 +704,7 @@ public class SplitVariableValue extends VariableValue
             case UNKNOWN:
                 value++;
             //$FALL-THROUGH$
-            case DIFF:
+            case DIFFERENT:
                 value++;
             //$FALL-THROUGH$
             case EDITED:

--- a/java/src/jmri/jmrit/symbolicprog/VariableTableModel.java
+++ b/java/src/jmri/jmrit/symbolicprog/VariableTableModel.java
@@ -137,12 +137,12 @@ public class VariableTableModel extends AbstractTableModel implements ActionList
         (rowVector.elementAt(row)).setIntValue(val);
     }
 
-    public void setState(int row, int val) {
+    public void setState(int row, AbstractValue.ValueState val) {
         log.debug("setState row: {} val: {}", row, val);
         (rowVector.elementAt(row)).setState(val);
     }
 
-    public int getState(int row) {
+    public AbstractValue.ValueState getState(int row) {
         return (rowVector.elementAt(row)).getState();
     }
 
@@ -190,17 +190,17 @@ public class VariableTableModel extends AbstractTableModel implements ActionList
                 return v.getMask();
             case "State":
                 // NOI18N
-                int state = v.getState();
+                AbstractValue.ValueState state = v.getState();
                 switch (state) {
-                    case CvValue.UNKNOWN:
+                    case UNKNOWN:
                         return "Unknown";
-                    case CvValue.READ:
+                    case READ:
                         return "Read";
-                    case CvValue.EDITED:
+                    case EDITED:
                         return "Edited";
-                    case CvValue.STORED:
+                    case STORED:
                         return "Stored";
-                    case CvValue.FROMFILE:
+                    case FROMFILE:
                         return "From file";
                     default:
                         return "inconsistent";
@@ -366,7 +366,7 @@ public class VariableTableModel extends AbstractTableModel implements ActionList
 
         // record new variable, update state, hook up listeners
         rowVector.addElement(v);
-        v.setState(VariableValue.FROMFILE);
+        v.setState(AbstractValue.ValueState.FROMFILE);
         v.addPropertyChangeListener(this);
 
         // set to default value if specified (CV load may later override this)
@@ -377,8 +377,8 @@ public class VariableTableModel extends AbstractTableModel implements ActionList
                 cvList.add(CV);  // it's an ordinary CV so add it as such
             }
             for (String theCV : cvList) {
-                log.debug("Setting CV={} of '{}'to {}", theCV, CV, VariableValue.stateNameFromValue(VariableValue.FROMFILE));
-                _cvModel.getCvByNumber(theCV).setState(VariableValue.FROMFILE); // correct for transition to "edited"
+                log.debug("Setting CV={} of '{}'to {}", theCV, CV, VariableValue.stateNameFromValue(AbstractValue.ValueState.FROMFILE));
+                _cvModel.getCvByNumber(theCV).setState(AbstractValue.ValueState.FROMFILE); // correct for transition to "edited"
             }
         }
     }
@@ -560,7 +560,7 @@ public class VariableTableModel extends AbstractTableModel implements ActionList
         int minVal = 0;
         int maxVal = 255;
         String highCV = null;
-        
+
         int count = 0;
         IteratorIterable<Content> iterator = child.getDescendants();
         while (iterator.hasNext()) {
@@ -596,12 +596,12 @@ public class VariableTableModel extends AbstractTableModel implements ActionList
         if ((a = child.getAttribute("max")) != null) {
             extra4 = a.getValue();
         }
-        
+
         SplitEnumVariableValue v1 = new SplitEnumVariableValue(name, comment, "", readOnly, infoOnly, writeOnly, opsOnly, CV, mask, minVal, maxVal, _cvModel.allCvMap(), _status, item, highCV, factor, offset, uppermask, null, null, extra3, extra4);
         v = v1; // v1 is of EnunVariableValue type, so doesn't need casts
 
         v1.nItems(count);
-        
+
         handleSplitEnumValChildren(child, v1);
         v1.lastItem();
         return v;
@@ -1036,7 +1036,7 @@ public class VariableTableModel extends AbstractTableModel implements ActionList
 
         // record new variable, update state, hook up listeners
         rowVector.addElement(v);
-        v.setState(VariableValue.FROMFILE);
+        v.setState(AbstractValue.ValueState.FROMFILE);
         v.addPropertyChangeListener(this);
 
         // set to default value if specified (CV load will later override this)
@@ -1128,16 +1128,16 @@ public class VariableTableModel extends AbstractTableModel implements ActionList
     @Override
     public void propertyChange(PropertyChangeEvent e) {
         if (log.isDebugEnabled()) {
-            log.debug("prop changed {} new value: {}{} Source {}", e.getPropertyName(), e.getNewValue(), e.getPropertyName().equals("State") ? (" (" + VariableValue.stateNameFromValue(((Integer) e.getNewValue())) + ") ") : " ", e.getSource());
+            log.debug("prop changed {} new value: {}{} Source {}", e.getPropertyName(), e.getNewValue(), e.getPropertyName().equals("State") ? (" (" + VariableValue.stateNameFromValue(((AbstractValue.ValueState) e.getNewValue())) + ") ") : " ", e.getSource());
         }
         if (e.getNewValue() == null) {
             log.error("new value of {} should not be null!", e.getPropertyName(), new Exception());
         }
         // set dirty only if edited or read
         if (e.getPropertyName().equals("State")
-                && ((Integer) e.getNewValue()) == CvValue.READ
+                && ((AbstractValue.ValueState) e.getNewValue()) == AbstractValue.ValueState.READ
                 || e.getPropertyName().equals("State")
-                && ((Integer) e.getNewValue()) == CvValue.EDITED) {
+                && ((AbstractValue.ValueState) e.getNewValue()) == AbstractValue.ValueState.EDITED) {
             setFileDirty(true);
 
         }
@@ -1172,7 +1172,7 @@ public class VariableTableModel extends AbstractTableModel implements ActionList
     public boolean decoderDirty() {
         int len = rowVector.size();
         for (int i = 0; i < len; i++) {
-            if (((rowVector.elementAt(i))).getState() == CvValue.EDITED) {
+            if (((rowVector.elementAt(i))).getState() == AbstractValue.ValueState.EDITED) {
                 return true;
             }
         }
@@ -1208,7 +1208,7 @@ public class VariableTableModel extends AbstractTableModel implements ActionList
     /**
      * Returns the index of the first variable that matches a given name string.
      * <p>
-     * Checks the search string against every variable's "item", the true name, 
+     * Checks the search string against every variable's "item", the true name,
      * then against their "label" (default language only) and finally the
      * CV name before moving on to the next variable if none of those match.
      *
@@ -1218,11 +1218,11 @@ public class VariableTableModel extends AbstractTableModel implements ActionList
     public int findVarIndex(String name) {
         return findVarIndex(name, false);
     }
-    
+
     /**
      * Returns the index of a variable that matches a given name string.
      * <p>
-     * Checks the search string against every variable's "item", the true name, 
+     * Checks the search string against every variable's "item", the true name,
      * then against their "label" (default language only) and finally the
      * CV name before moving on to the next variable if none of those match.
      *

--- a/java/src/jmri/jmrit/symbolicprog/VariableTableModel.java
+++ b/java/src/jmri/jmrit/symbolicprog/VariableTableModel.java
@@ -377,7 +377,7 @@ public class VariableTableModel extends AbstractTableModel implements ActionList
                 cvList.add(CV);  // it's an ordinary CV so add it as such
             }
             for (String theCV : cvList) {
-                log.debug("Setting CV={} of '{}'to {}", theCV, CV, VariableValue.stateNameFromValue(AbstractValue.ValueState.FROMFILE));
+                log.debug("Setting CV={} of '{}'to {}", theCV, CV, AbstractValue.ValueState.FROMFILE.getName());
                 _cvModel.getCvByNumber(theCV).setState(AbstractValue.ValueState.FROMFILE); // correct for transition to "edited"
             }
         }
@@ -1128,7 +1128,7 @@ public class VariableTableModel extends AbstractTableModel implements ActionList
     @Override
     public void propertyChange(PropertyChangeEvent e) {
         if (log.isDebugEnabled()) {
-            log.debug("prop changed {} new value: {}{} Source {}", e.getPropertyName(), e.getNewValue(), e.getPropertyName().equals("State") ? (" (" + VariableValue.stateNameFromValue(((AbstractValue.ValueState) e.getNewValue())) + ") ") : " ", e.getSource());
+            log.debug("prop changed {} new value: {}{} Source {}", e.getPropertyName(), e.getNewValue(), e.getPropertyName().equals("State") ? (" (" + ((AbstractValue.ValueState) e.getNewValue()).getName() + ") ") : " ", e.getSource());
         }
         if (e.getNewValue() == null) {
             log.error("new value of {} should not be null!", e.getPropertyName(), new Exception());

--- a/java/src/jmri/jmrit/symbolicprog/VariableValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/VariableValue.java
@@ -452,31 +452,7 @@ public abstract class VariableValue extends AbstractValue implements java.beans.
      * @see AbstractValue
      */
     public void setState(ValueState state) {
-        switch (state) {
-            case UNKNOWN:
-                setColor(COLOR_UNKNOWN);
-                break;
-            case EDITED:
-                setColor(COLOR_EDITED);
-                break;
-            case READ:
-                setColor(COLOR_READ);
-                break;
-            case STORED:
-                setColor(COLOR_STORED);
-                break;
-            case FROMFILE:
-                setColor(COLOR_FROMFILE);
-                break;
-            case SAME:
-                setColor(COLOR_SAME);
-                break;
-            case DIFF:
-                setColor(COLOR_DIFF);
-                break;
-            default:
-                log.error("Inconsistent state: {}", _state);
-        }
+        setColor(state.getColor());
         if (_state != state || _state == ValueState.UNKNOWN) {
             prop.firePropertyChange("State", _state, state);
         }

--- a/java/src/jmri/jmrit/symbolicprog/VariableValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/VariableValue.java
@@ -244,8 +244,8 @@ public abstract class VariableValue extends AbstractValue implements java.beans.
         if (c == null) {
             return false; // if no CV was assigned to a decoder variable
         }
-        int state = c.getState();
-        return (state == CvValue.EDITED || state == CvValue.UNKNOWN);
+        ValueState state = c.getState();
+        return (state == ValueState.EDITED || state == ValueState.UNKNOWN);
     }
 
     // handle incoming parameter notification
@@ -441,7 +441,7 @@ public abstract class VariableValue extends AbstractValue implements java.beans.
      *
      * @return the current state of the Variable
      */
-    public int getState() {
+    public ValueState getState() {
         return _state;
     }
 
@@ -451,7 +451,7 @@ public abstract class VariableValue extends AbstractValue implements java.beans.
      * @param state the desired state as per definitions in AbstractValue
      * @see AbstractValue
      */
-    public void setState(int state) {
+    public void setState(ValueState state) {
         switch (state) {
             case UNKNOWN:
                 setColor(COLOR_UNKNOWN);
@@ -477,12 +477,12 @@ public abstract class VariableValue extends AbstractValue implements java.beans.
             default:
                 log.error("Inconsistent state: {}", _state);
         }
-        if (_state != state || _state == UNKNOWN) {
-            prop.firePropertyChange("State", Integer.valueOf(_state), Integer.valueOf(state));
+        if (_state != state || _state == ValueState.UNKNOWN) {
+            prop.firePropertyChange("State", _state, state);
         }
         _state = state;
     }
-    private int _state = UNKNOWN;
+    private ValueState _state = ValueState.UNKNOWN;
 
     /**
      * {@inheritDoc}
@@ -590,7 +590,7 @@ public abstract class VariableValue extends AbstractValue implements java.beans.
      *
      * @param state the new state to set
      */
-    public abstract void setCvState(int state);
+    public abstract void setCvState(ValueState state);
 
     /**
      * Check if a variable is busy (during read, write operations).

--- a/java/src/jmri/jmrit/symbolicprog/tabbedframe/PaneProgPane.java
+++ b/java/src/jmri/jmrit/symbolicprog/tabbedframe/PaneProgPane.java
@@ -813,7 +813,7 @@ public class PaneProgPane extends javax.swing.JPanel
             AbstractValue.ValueState vState = _varModel.getState(varNum);
             VariableValue var = _varModel.getVariable(varNum);
             if (log.isDebugEnabled()) {
-                log.debug("nextRead var index {} state {} isToRead: {} label: {}", varNum, VariableValue.stateNameFromValue(vState), var.isToRead(), var.label());
+                log.debug("nextRead var index {} state {} isToRead: {} label: {}", varNum, vState.getName(), var.isToRead(), var.label());
             }
             varListIndex++;
             if (var.isToRead()) {
@@ -975,7 +975,7 @@ public class PaneProgPane extends javax.swing.JPanel
             AbstractValue.ValueState vState = _varModel.getState(varNum);
             VariableValue var = _varModel.getVariable(varNum);
             if (log.isDebugEnabled()) {
-                log.debug("nextWrite var index {} state {} isToWrite: {} label:{}", varNum, VariableValue.stateNameFromValue(vState), var.isToWrite(), var.label());
+                log.debug("nextWrite var index {} state {} isToWrite: {} label:{}", varNum, vState.getName(), var.isToWrite(), var.label());
             }
             varListIndex++;
             if (var.isToWrite()) {

--- a/java/src/jmri/jmrit/symbolicprog/tabbedframe/PaneProgPane.java
+++ b/java/src/jmri/jmrit/symbolicprog/tabbedframe/PaneProgPane.java
@@ -32,6 +32,7 @@ import javax.swing.SwingConstants;
 import javax.swing.table.TableModel;
 import javax.swing.table.TableRowSorter;
 import jmri.jmrit.roster.RosterEntry;
+import jmri.jmrit.symbolicprog.AbstractValue;
 import jmri.jmrit.symbolicprog.CvTableModel;
 import jmri.jmrit.symbolicprog.CvValue;
 import jmri.jmrit.symbolicprog.DccAddressPanel;
@@ -809,7 +810,7 @@ public class PaneProgPane extends javax.swing.JPanel
         }
         while ((varList.size() > 0) && (varListIndex < varList.size())) {
             int varNum = varList.get(varListIndex);
-            int vState = _varModel.getState(varNum);
+            AbstractValue.ValueState vState = _varModel.getState(varNum);
             VariableValue var = _varModel.getVariable(varNum);
             if (log.isDebugEnabled()) {
                 log.debug("nextRead var index {} state {} isToRead: {} label: {}", varNum, VariableValue.stateNameFromValue(vState), var.isToRead(), var.label());
@@ -971,7 +972,7 @@ public class PaneProgPane extends javax.swing.JPanel
         // look for possible variables
         while ((varList.size() > 0) && (varListIndex < varList.size())) {
             int varNum = varList.get(varListIndex);
-            int vState = _varModel.getState(varNum);
+            AbstractValue.ValueState vState = _varModel.getState(varNum);
             VariableValue var = _varModel.getVariable(varNum);
             if (log.isDebugEnabled()) {
                 log.debug("nextWrite var index {} state {} isToWrite: {} label:{}", varNum, VariableValue.stateNameFromValue(vState), var.isToWrite(), var.label());
@@ -1141,7 +1142,7 @@ public class PaneProgPane extends javax.swing.JPanel
         if (e.getSource() == _programmingVar
                 && e.getPropertyName().equals("Busy")
                 && e.getNewValue().equals(Boolean.FALSE)) {
-            if (_programmingVar.getState() == VariableValue.UNKNOWN) {
+            if (_programmingVar.getState() == AbstractValue.ValueState.UNKNOWN) {
                 if (retry == 0) {
                     varListIndex--;
                     retry++;

--- a/java/test/jmri/jmrit/symbolicprog/AbstractVariableValueTestBase.java
+++ b/java/test/jmri/jmrit/symbolicprog/AbstractVariableValueTestBase.java
@@ -1,13 +1,17 @@
 package jmri.jmrit.symbolicprog;
 
+import java.awt.Color;
 import java.awt.Component;
 import java.util.HashMap;
+
 import javax.swing.JComboBox;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JTextField;
+
 import jmri.progdebugger.ProgDebugger;
 import jmri.util.JUnitUtil;
+
 import org.junit.Assert;
 import org.junit.jupiter.api.*;
 
@@ -35,6 +39,27 @@ public abstract class AbstractVariableValueTestBase {
     abstract void checkReadOnlyValue(VariableValue var, String comment, String value);
 
     // start of base tests
+
+    // Test the ValueState enum
+    @Test
+    public void testValueStateEnum() {
+        Assert.assertEquals(Color.red.brighter(), AbstractValue.ValueState.UNKNOWN.getColor());
+        Assert.assertEquals(Color.orange, AbstractValue.ValueState.EDITED.getColor());
+        Assert.assertNull(AbstractValue.ValueState.READ.getColor());
+        Assert.assertNull(AbstractValue.ValueState.STORED.getColor());
+        Assert.assertEquals(Color.yellow, AbstractValue.ValueState.FROMFILE.getColor());
+        Assert.assertNull(AbstractValue.ValueState.SAME.getColor());
+        Assert.assertEquals(Color.red.brighter(), AbstractValue.ValueState.DIFF.getColor());
+
+        Assert.assertEquals("Unknown", AbstractValue.ValueState.UNKNOWN.getName());
+        Assert.assertEquals("Edited", AbstractValue.ValueState.EDITED.getName());
+        Assert.assertEquals("Read", AbstractValue.ValueState.READ.getName());
+        Assert.assertEquals("Stored", AbstractValue.ValueState.STORED.getName());
+        Assert.assertEquals("FromFile", AbstractValue.ValueState.FROMFILE.getName());
+        Assert.assertEquals("Same", AbstractValue.ValueState.SAME.getName());
+        Assert.assertEquals("Different", AbstractValue.ValueState.DIFF.getName());
+    }
+
     // check label, item from ctor
     @Test
     public void testVariableNaming() {

--- a/java/test/jmri/jmrit/symbolicprog/AbstractVariableValueTestBase.java
+++ b/java/test/jmri/jmrit/symbolicprog/AbstractVariableValueTestBase.java
@@ -49,7 +49,7 @@ public abstract class AbstractVariableValueTestBase {
         Assert.assertNull(AbstractValue.ValueState.STORED.getColor());
         Assert.assertEquals(Color.yellow, AbstractValue.ValueState.FROMFILE.getColor());
         Assert.assertNull(AbstractValue.ValueState.SAME.getColor());
-        Assert.assertEquals(Color.red.brighter(), AbstractValue.ValueState.DIFF.getColor());
+        Assert.assertEquals(Color.red.brighter(), AbstractValue.ValueState.DIFFERENT.getColor());
 
         Assert.assertEquals("Unknown", AbstractValue.ValueState.UNKNOWN.getName());
         Assert.assertEquals("Edited", AbstractValue.ValueState.EDITED.getName());
@@ -57,7 +57,7 @@ public abstract class AbstractVariableValueTestBase {
         Assert.assertEquals("Stored", AbstractValue.ValueState.STORED.getName());
         Assert.assertEquals("FromFile", AbstractValue.ValueState.FROMFILE.getName());
         Assert.assertEquals("Same", AbstractValue.ValueState.SAME.getName());
-        Assert.assertEquals("Different", AbstractValue.ValueState.DIFF.getName());
+        Assert.assertEquals("Different", AbstractValue.ValueState.DIFFERENT.getName());
     }
 
     // check label, item from ctor

--- a/java/test/jmri/jmrit/symbolicprog/AbstractVariableValueTestBase.java
+++ b/java/test/jmri/jmrit/symbolicprog/AbstractVariableValueTestBase.java
@@ -320,10 +320,10 @@ public abstract class AbstractVariableValueTestBase {
         v.put("81", cv);
         // create a variable pointed at CV 81, loaded as 5, manually notified
         VariableValue variable = makeVar("label", "comment", "", false, false, false, false, "81", "XXVVVVXX", 0, 255, v, null, null);
-        Assertions.assertEquals(VariableValue.COLOR_FROMFILE, variable.getCommonRep().getBackground(), "FROM_FILE color");
+        Assertions.assertEquals(VariableValue.ValueState.FROMFILE.getColor(), variable.getCommonRep().getBackground(), "FROM_FILE color");
 
         cv.setState(AbstractValue.ValueState.UNKNOWN);
-        Assertions.assertEquals(VariableValue.COLOR_UNKNOWN, variable.getCommonRep().getBackground(), "UNKNOWN color");
+        Assertions.assertEquals(VariableValue.ValueState.UNKNOWN.getColor(), variable.getCommonRep().getBackground(), "UNKNOWN color");
     }
 
     // check the state <-> color connection for rep when var changes
@@ -339,18 +339,18 @@ public abstract class AbstractVariableValueTestBase {
         // get a representation
         JComponent rep = (JComponent) variable.getNewRep("");
 
-        Assertions.assertEquals(VariableValue.COLOR_FROMFILE, variable.getCommonRep().getBackground(), "FROMFILE color");
-        Assertions.assertEquals(VariableValue.COLOR_FROMFILE, rep.getBackground(), "FROMFILE color");
+        Assertions.assertEquals(VariableValue.ValueState.FROMFILE.getColor(), variable.getCommonRep().getBackground(), "FROMFILE color");
+        Assertions.assertEquals(VariableValue.ValueState.FROMFILE.getColor(), rep.getBackground(), "FROMFILE color");
 
         cv.setState(AbstractValue.ValueState.UNKNOWN);
 
-        Assertions.assertEquals(VariableValue.COLOR_UNKNOWN, variable.getCommonRep().getBackground(), "UNKNOWN color");
-        Assertions.assertEquals(VariableValue.COLOR_UNKNOWN, rep.getBackground(), "UNKNOWN color");
+        Assertions.assertEquals(VariableValue.ValueState.UNKNOWN.getColor(), variable.getCommonRep().getBackground(), "UNKNOWN color");
+        Assertions.assertEquals(VariableValue.ValueState.UNKNOWN.getColor(), rep.getBackground(), "UNKNOWN color");
 
         setValue(variable, "5");
 
-        Assertions.assertEquals(VariableValue.COLOR_EDITED, variable.getCommonRep().getBackground(), "EDITED color");
-        Assertions.assertEquals(VariableValue.COLOR_EDITED, rep.getBackground(), "EDITED color");
+        Assertions.assertEquals(VariableValue.ValueState.EDITED.getColor(), variable.getCommonRep().getBackground(), "EDITED color");
+        Assertions.assertEquals(VariableValue.ValueState.EDITED.getColor(), rep.getBackground(), "EDITED color");
     }
 
     // check the state <-> color connection for var when rep changes
@@ -367,20 +367,20 @@ public abstract class AbstractVariableValueTestBase {
         // get a representation
         JComponent rep = (JComponent) variable.getNewRep("");
 
-        Assertions.assertEquals(VariableValue.COLOR_FROMFILE, variable.getCommonRep().getBackground(), "FROMFILE color");
-        Assertions.assertEquals(VariableValue.COLOR_FROMFILE, rep.getBackground(), "FROMFILE color");
+        Assertions.assertEquals(VariableValue.ValueState.FROMFILE.getColor(), variable.getCommonRep().getBackground(), "FROMFILE color");
+        Assertions.assertEquals(VariableValue.ValueState.FROMFILE.getColor(), rep.getBackground(), "FROMFILE color");
 
         cv.setState(AbstractValue.ValueState.UNKNOWN);
-        Assertions.assertEquals(VariableValue.COLOR_UNKNOWN, variable.getCommonRep().getBackground(), "UNKNOWN color");
-        Assertions.assertEquals(VariableValue.COLOR_UNKNOWN, rep.getBackground(), "UNKNOWN color");
+        Assertions.assertEquals(VariableValue.ValueState.UNKNOWN.getColor(), variable.getCommonRep().getBackground(), "UNKNOWN color");
+        Assertions.assertEquals(VariableValue.ValueState.UNKNOWN.getColor(), rep.getBackground(), "UNKNOWN color");
 
         try {   // might be either of two reps?
             ((JComboBox<String>) rep).setSelectedItem("9");
         } catch (java.lang.ClassCastException e) {
             ((JTextField) rep).setText("9");
             ((JTextField) rep).postActionEvent();
-            Assertions.assertEquals(VariableValue.COLOR_EDITED, variable.getCommonRep().getBackground(), "EDITED color");
-            Assertions.assertEquals(VariableValue.COLOR_EDITED, rep.getBackground(), "EDITED color");
+            Assertions.assertEquals(VariableValue.ValueState.EDITED.getColor(), variable.getCommonRep().getBackground(), "EDITED color");
+            Assertions.assertEquals(VariableValue.ValueState.EDITED.getColor(), rep.getBackground(), "EDITED color");
         }
     }
 

--- a/java/test/jmri/jmrit/symbolicprog/AbstractVariableValueTestBase.java
+++ b/java/test/jmri/jmrit/symbolicprog/AbstractVariableValueTestBase.java
@@ -216,11 +216,11 @@ public abstract class AbstractVariableValueTestBase {
         variable.readAll();
         // wait for reply (normally, done by callback; will check that later)
         JUnitUtil.waitFor(()-> !variable.isBusy(), "variable.isBusy");
-        
+
         checkValue(variable, "text var value ", "14");
-        Assertions.assertEquals(AbstractValue.READ, variable.getState(), "var state ");
+        Assertions.assertEquals(AbstractValue.ValueState.READ, variable.getState(), "var state ");
         Assertions.assertEquals(123, cv.getValue(), "cv value");
-        Assertions.assertEquals(AbstractValue.READ, cv.getState(), "CV state ");
+        Assertions.assertEquals(AbstractValue.ValueState.READ, cv.getState(), "CV state ");
     }
 
     // check a write operation to the variable
@@ -238,10 +238,10 @@ public abstract class AbstractVariableValueTestBase {
         variable.writeAll();
         // wait for reply (normally, done by callback; will check that later)
         JUnitUtil.waitFor(()-> !variable.isBusy(), "variable.isBusy");
-        
+
         checkValue(variable, "value ", "5");
-        Assertions.assertEquals(AbstractValue.STORED, variable.getState(), "var state ");
-        Assertions.assertEquals(AbstractValue.STORED, cv.getState(), "cv state ");
+        Assertions.assertEquals(AbstractValue.ValueState.STORED, variable.getState(), "var state ");
+        Assertions.assertEquals(AbstractValue.ValueState.STORED, cv.getState(), "cv state ");
         Assertions.assertEquals(5 * 4 + 128 + 1, p.lastWrite(), "last program write "); // include checking original bits
     }
 
@@ -260,10 +260,10 @@ public abstract class AbstractVariableValueTestBase {
         cv.write(statusLabel);  // JLabel is for reporting status, ignored here
         // wait for reply (normally, done by callback; will check that later)
         JUnitUtil.waitFor(()-> !cv.isBusy(), "cv.isBusy");
-        
+
         checkValue(variable, "value ", "5");
-        Assertions.assertEquals(AbstractValue.STORED, variable.getState(), "variable state ");
-        Assertions.assertEquals(AbstractValue.STORED, cv.getState(), "cv state ");
+        Assertions.assertEquals(AbstractValue.ValueState.STORED, variable.getState(), "variable state ");
+        Assertions.assertEquals(AbstractValue.ValueState.STORED, cv.getState(), "cv state ");
         Assertions.assertEquals(5 * 4 + 3, p.lastWrite(), "value written "); // includes initial value bits
         Assertions.assertEquals("OK", statusLabel.getText(), "status label ");
     }
@@ -278,11 +278,11 @@ public abstract class AbstractVariableValueTestBase {
         v.put("81", cv);
         // create a variable pointed at CV 81, loaded as 5, manually notified
         VariableValue variable = makeVar("label", "comment", "", false, false, false, false, "81", "XXVVVVXX", 0, 255, v, null, null);
-        Assertions.assertEquals(VariableValue.FROMFILE, variable.getState(), "initial state");
-        cv.setState(CvValue.UNKNOWN);
-        Assertions.assertEquals(VariableValue.UNKNOWN, variable.getState(), "after CV set unknown");
+        Assertions.assertEquals(VariableValue.ValueState.FROMFILE, variable.getState(), "initial state");
+        cv.setState(AbstractValue.ValueState.UNKNOWN);
+        Assertions.assertEquals(VariableValue.ValueState.UNKNOWN, variable.getState(), "after CV set unknown");
         setValue(variable, "5");
-        Assertions.assertEquals(VariableValue.EDITED, variable.getState(), "state after setValue");
+        Assertions.assertEquals(VariableValue.ValueState.EDITED, variable.getState(), "state after setValue");
     }
 
     // check the state <-> color connection for value
@@ -297,7 +297,7 @@ public abstract class AbstractVariableValueTestBase {
         VariableValue variable = makeVar("label", "comment", "", false, false, false, false, "81", "XXVVVVXX", 0, 255, v, null, null);
         Assertions.assertEquals(VariableValue.COLOR_FROMFILE, variable.getCommonRep().getBackground(), "FROM_FILE color");
 
-        cv.setState(CvValue.UNKNOWN);
+        cv.setState(AbstractValue.ValueState.UNKNOWN);
         Assertions.assertEquals(VariableValue.COLOR_UNKNOWN, variable.getCommonRep().getBackground(), "UNKNOWN color");
     }
 
@@ -317,7 +317,7 @@ public abstract class AbstractVariableValueTestBase {
         Assertions.assertEquals(VariableValue.COLOR_FROMFILE, variable.getCommonRep().getBackground(), "FROMFILE color");
         Assertions.assertEquals(VariableValue.COLOR_FROMFILE, rep.getBackground(), "FROMFILE color");
 
-        cv.setState(CvValue.UNKNOWN);
+        cv.setState(AbstractValue.ValueState.UNKNOWN);
 
         Assertions.assertEquals(VariableValue.COLOR_UNKNOWN, variable.getCommonRep().getBackground(), "UNKNOWN color");
         Assertions.assertEquals(VariableValue.COLOR_UNKNOWN, rep.getBackground(), "UNKNOWN color");
@@ -345,7 +345,7 @@ public abstract class AbstractVariableValueTestBase {
         Assertions.assertEquals(VariableValue.COLOR_FROMFILE, variable.getCommonRep().getBackground(), "FROMFILE color");
         Assertions.assertEquals(VariableValue.COLOR_FROMFILE, rep.getBackground(), "FROMFILE color");
 
-        cv.setState(CvValue.UNKNOWN);
+        cv.setState(AbstractValue.ValueState.UNKNOWN);
         Assertions.assertEquals(VariableValue.COLOR_UNKNOWN, variable.getCommonRep().getBackground(), "UNKNOWN color");
         Assertions.assertEquals(VariableValue.COLOR_UNKNOWN, rep.getBackground(), "UNKNOWN color");
 
@@ -419,8 +419,8 @@ public abstract class AbstractVariableValueTestBase {
 
         checkValue(var1, "var 1 value", "5");
         checkValue(var2, "var 2 value", "5");
-        Assertions.assertEquals(AbstractValue.STORED, var1.getState(), "1st variable state ");
-        Assertions.assertEquals(AbstractValue.STORED, var2.getState(), "2nd variable state ");
+        Assertions.assertEquals(AbstractValue.ValueState.STORED, var1.getState(), "1st variable state ");
+        Assertions.assertEquals(AbstractValue.ValueState.STORED, var2.getState(), "2nd variable state ");
         Assertions.assertEquals(5 * 4 + 3, p.lastWrite(), "value written to programmer "); // includes initial value bits
     }
 

--- a/java/test/jmri/jmrit/symbolicprog/CompositeVariableValueTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/CompositeVariableValueTest.java
@@ -63,27 +63,27 @@ public class CompositeVariableValueTest extends AbstractVariableValueTestBase {
     @Override
     @Test
     public void testVariableValueCreate() {
-    }// mask is ignored 
+    }// mask is ignored
 
     @Override
     @Test
     public void testVariableValueCreateLargeValue() {
-    } // mask is ignored 
+    } // mask is ignored
 
     @Override
     @Test
     public void testVariableValueCreateLargeMaskValue() {
-    } // mask is ignored 
+    } // mask is ignored
 
     @Override
     @Test
     public void testVariableValueCreateLargeMaskValue256() {
-    } // mask is ignored 
+    } // mask is ignored
 
     @Override
     @Test
     public void testVariableValueCreateLargeMaskValue2up16() {
-    } // mask is ignored 
+    } // mask is ignored
 
     @Override
     @Test
@@ -229,7 +229,7 @@ public class CompositeVariableValueTest extends AbstractVariableValueTestBase {
         Assert.assertEquals("CV 18 value ", 123, cv18.getValue());
         Assert.assertEquals("CV 19 value ", 123, cv19.getValue());
         Assert.assertEquals("var value after read", 2, ((JComboBox<?>) testVar.getCommonRep()).getSelectedIndex());
-        Assert.assertEquals("Var state", AbstractValue.READ, testVar.getState());
+        Assert.assertEquals("Var state", AbstractValue.ValueState.READ, testVar.getState());
         log.debug("end testRead");
     }
 
@@ -269,7 +269,7 @@ public class CompositeVariableValueTest extends AbstractVariableValueTestBase {
         Assert.assertEquals("only one Busy -> false transition ", 1, nBusyFalse);
 
         Assert.assertEquals("value after write", 1, ((JComboBox<?>) testVar.getCommonRep()).getSelectedIndex());
-        Assert.assertEquals("Var state", AbstractValue.STORED, testVar.getState());
+        Assert.assertEquals("Var state", AbstractValue.ValueState.STORED, testVar.getState());
 
         Assert.assertEquals("CV 17 value ", 21, cv17.getValue());
         Assert.assertEquals("CV 18 value ", 22, cv18.getValue());

--- a/java/test/jmri/jmrit/symbolicprog/CvValueTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/CvValueTest.java
@@ -112,7 +112,7 @@ public class CvValueTest {
     @Test
     public void testInitialColor() {
         CvValue cv = new CvValue("21", p);
-        Assert.assertEquals("initial color", CvValue.COLOR_UNKNOWN, cv.getTableEntry().getBackground());
+        Assert.assertEquals("initial color", AbstractValue.ValueState.UNKNOWN.getColor(), cv.getTableEntry().getBackground());
     }
 
     // check color update for EDITED
@@ -120,7 +120,7 @@ public class CvValueTest {
     public void testEditedColor() {
         CvValue cv = new CvValue("21", p);
         cv.setValue(23);
-        Assert.assertEquals("edited color", CvValue.COLOR_EDITED, cv.getTableEntry().getBackground());
+        Assert.assertEquals("edited color", AbstractValue.ValueState.EDITED.getColor(), cv.getTableEntry().getBackground());
     }
 
     private final static Logger log = LoggerFactory.getLogger(CvValueTest.class);

--- a/java/test/jmri/jmrit/symbolicprog/CvValueTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/CvValueTest.java
@@ -41,9 +41,9 @@ public class CvValueTest {
         cv.read(null);
         // wait for reply (normally, done by callback; will check that later)
         JUnitUtil.waitFor(()->{return !cv.isBusy();}, "cv.isBusy");
-        
+
         Assert.assertTrue(cv.getValue() == 123);
-        Assert.assertTrue(cv.getState() == CvValue.READ);
+        Assert.assertTrue(cv.getState() == AbstractValue.ValueState.READ);
     }
 
     // check a confirm operation
@@ -59,7 +59,7 @@ public class CvValueTest {
         JUnitUtil.waitFor(()->{return !cv.isBusy();}, "cv.isBusy");
 
         Assert.assertEquals("CV value ", 91, cv.getValue());
-        Assert.assertEquals("CV state ", CvValue.UNKNOWN, cv.getState());
+        Assert.assertEquals("CV state ", AbstractValue.ValueState.UNKNOWN, cv.getState());
     }
 
     // check a confirm operation
@@ -78,7 +78,7 @@ public class CvValueTest {
         JUnitUtil.waitFor(()->{return !cv.isBusy();}, "cv.isBusy");
 
         Assert.assertEquals("CV value ", 123, cv.getValue());
-        Assert.assertEquals("CV state ", CvValue.SAME, cv.getState());
+        Assert.assertEquals("CV state ", AbstractValue.ValueState.SAME, cv.getState());
     }
 
     // check a write operation
@@ -95,7 +95,7 @@ public class CvValueTest {
         JUnitUtil.waitFor(()->{return !cv.isBusy();}, "cv.isBusy");
 
         Assert.assertEquals("cv value ", 12, cv.getValue());
-        Assert.assertEquals("cv state ", CvValue.STORED, cv.getState());
+        Assert.assertEquals("cv state ", AbstractValue.ValueState.STORED, cv.getState());
         Assert.assertEquals("last value written ", 12, p.lastWrite());
     }
 
@@ -103,9 +103,9 @@ public class CvValueTest {
     @Test
     public void testCvValStates() {
         CvValue cv = new CvValue("21", p);
-        Assert.assertTrue(cv.getState() == CvValue.UNKNOWN);
+        Assert.assertTrue(cv.getState() == AbstractValue.ValueState.UNKNOWN);
         cv.setValue(23);
-        Assert.assertTrue(cv.getState() == CvValue.EDITED);
+        Assert.assertTrue(cv.getState() == AbstractValue.ValueState.EDITED);
     }
 
     // check the initial color

--- a/java/test/jmri/jmrit/symbolicprog/LongAddrVariableValueTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/LongAddrVariableValueTest.java
@@ -69,22 +69,22 @@ public class LongAddrVariableValueTest extends AbstractVariableValueTestBase {
     @Override
     @Test
     public void testVariableValueCreateLargeValue() {
-    } // mask is ignored 
+    } // mask is ignored
 
     @Override
     @Test
     public void testVariableValueCreateLargeMaskValue() {
-    } // mask is ignored 
+    } // mask is ignored
 
     @Override
     @Test
     public void testVariableValueCreateLargeMaskValue256() {
-    } // mask is ignored 
+    } // mask is ignored
 
     @Override
     @Test
     public void testVariableValueCreateLargeMaskValue2up16() {
-    } // mask is ignored 
+    } // mask is ignored
 
     @Override
     @Test
@@ -208,7 +208,7 @@ public class LongAddrVariableValueTest extends AbstractVariableValueTestBase {
         Assert.assertEquals("only one Busy -> false transition ", 1, nBusyFalse);
 
         Assert.assertEquals("text value ", "15227", ((JTextField) var.getCommonRep()).getText());  // 15227 = (1230x3f)*256+123
-        Assert.assertEquals("Var state", AbstractValue.READ, var.getState());
+        Assert.assertEquals("Var state", AbstractValue.ValueState.READ, var.getState());
         Assert.assertEquals("CV 17 value ", 251, cv17.getValue());  // 123 with 128 bit set
         Assert.assertEquals("CV 18 value ", 123, cv18.getValue());
     }
@@ -235,20 +235,20 @@ public class LongAddrVariableValueTest extends AbstractVariableValueTestBase {
         Assert.assertEquals("CV 17 value ", 210, cv17.getValue());
         Assert.assertEquals("CV 18 value ", 189, cv18.getValue());
         Assert.assertEquals("4797", ((JTextField) var.getCommonRep()).getText());
-        Assert.assertEquals("Var state", AbstractValue.STORED, var.getState());
+        Assert.assertEquals("Var state", AbstractValue.ValueState.STORED, var.getState());
         Assert.assertEquals(189, p.lastWrite());
         // how do you check separation of the two writes?  State model?
     }
 
-    private JLabel jlabel; 
-    
+    private JLabel jlabel;
+
     @BeforeEach
     @Override
     public void setUp() {
         super.setUp();
         jlabel = new JLabel();
     }
-    
+
     @AfterEach
     @Override
     public void tearDown() {

--- a/java/test/jmri/jmrit/symbolicprog/SplitVariableValueTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/SplitVariableValueTest.java
@@ -325,7 +325,7 @@ public class SplitVariableValueTest extends AbstractVariableValueTestBase {
         Assertions.assertEquals(1, nBusyFalse, "only one Busy -> false transition ");
 
         Assertions.assertEquals("" + ((123 & 0x3f) + (123) * 64), ((JTextField) var.getCommonRep()).getText(), "text value ");  // 15227 = (1230x3f)*256+123
-        Assertions.assertEquals(AbstractValue.READ, var.getState(), "Var state");
+        Assertions.assertEquals(AbstractValue.ValueState.READ, var.getState(), "Var state");
         Assertions.assertEquals(123, cv1.getValue(), "CV 1 value ");  // 123 with 128 bit set
         Assertions.assertEquals(123, cv2.getValue(), "CV 2 value ");
     }
@@ -356,7 +356,7 @@ public class SplitVariableValueTest extends AbstractVariableValueTestBase {
         Assertions.assertEquals(61, cv1.getValue(), "CV 1 value ");
         Assertions.assertEquals(74, cv2.getValue(), "CV 2 value ");
         Assertions.assertEquals("4797", ((JTextField) var.getCommonRep()).getText(), "text ");
-        Assertions.assertEquals(AbstractValue.STORED, var.getState(), "Var state");
+        Assertions.assertEquals(AbstractValue.ValueState.STORED, var.getState(), "Var state");
         Assertions.assertEquals(74, p.lastWrite(), "last write");
         // how do you check separation of the two writes?  State model?
     }


### PR DESCRIPTION
This PR which is based on PR #11711 removes the methods `stateColorFromValue()` and `stateNameFromValue()` and moves them to the enum `AbstractValue.ValueState`.