### PR TITLE
minor update WarrantFrame Test

### DIFF
--- a/java/test/jmri/jmrit/logix/WarrantFrameTest.java
+++ b/java/test/jmri/jmrit/logix/WarrantFrameTest.java
@@ -3,7 +3,6 @@ package jmri.jmrit.logix;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
-import javax.swing.JFrame;
 
 import jmri.ConfigureManager;
 import jmri.InstanceManager;
@@ -93,19 +92,20 @@ public class WarrantFrameTest {
         Warrant startW = _warrantMgr.getWarrant("WestBoundStart");
         Warrant endW = _warrantMgr.getWarrant("WestBoundFinish");
 
-        new Thread(() -> {
-            JFrameOperator jfo = new JFrameOperator(WarrantTableFrame.getDefault());
-            JDialogOperator jdo = new JDialogOperator(jfo, Bundle.getMessage("QuestionTitle"));
-            JButtonOperator jbo = new JButtonOperator(jdo, Bundle.getMessage("ButtonNo"));
-            jbo.push();
-        }).start();
-        
+        Thread clickDialog = new Thread(() -> {
+            JemmyUtil.pressDialogButton(Bundle.getMessage("QuestionTitle"), Bundle.getMessage("ButtonNo"));
+        });
+        clickDialog.setName("WarrantFrameTest click Question No");
+        clickDialog.start();
+
         WarrantFrame warrantFrame= new WarrantFrame(startW, endW);
         assertThat(warrantFrame).withFailMessage("JoinWFrame exits").isNotNull();
 
         warrantFrame._userNameBox.setText("WestBound");
         JFrameOperator editFrame = new JFrameOperator(warrantFrame);
         JemmyUtil.pressButton(editFrame, Bundle.getMessage("ButtonSave"));
+
+        JUnitUtil.waitFor(() ->  { return !clickDialog.isAlive(); },"QuestionTitle ButtonNo clicked");
 
         Warrant w = _warrantMgr.getWarrant("WestBound");
         assertThat(w).withFailMessage("Concatenated Warrant exits").isNotNull();


### PR DESCRIPTION
ensure dialog thread closed / test fails in reasonable time

eg. timeout at https://github.com/icklesteve/JMRI/actions/runs/3855653903/jobs/6570932124

```
[INFO] Running jmri.jmrit.logix.TrackerTest
Warning:  Tests run: 3, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 0.141 s - in jmri.jmrit.logix.TrackerTest
[INFO] Running jmri.jmrit.logix.TrainOrderTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in jmri.jmrit.logix.TrainOrderTest
[INFO] Running jmri.jmrit.logix.WarrantFrameTest
Error: Exception in thread "Thread-3419" org.netbeans.jemmy.TimeoutExpiredException: Dialog with title "Question" (WindowWaiter.WaitWindowTimeout)
	at org.netbeans.jemmy.Waiter.waitAction(Waiter.java:213)
	at org.netbeans.jemmy.WindowWaiter.waitWindow(WindowWaiter.java:272)
	at org.netbeans.jemmy.DialogWaiter.waitDialog(DialogWaiter.java:439)
	at org.netbeans.jemmy.operators.JDialogOperator.waitJDialog(JDialogOperator.java:650)
	at org.netbeans.jemmy.operators.JDialogOperator.waitJDialog(JDialogOperator.java:629)
	at org.netbeans.jemmy.operators.JDialogOperator.<init>(JDialogOperator.java:152)
	at org.netbeans.jemmy.operators.JDialogOperator.<init>(JDialogOperator.java:169)
	at jmri.jmrit.logix.WarrantFrameTest.lambda$testJoinWarrantsNoStop$1(WarrantFrameTest.java:98)
	at java.base/java.lang.Thread.run(Thread.java:829)
Terminate batch job (Y/N)? 
Error: The operation was canceled.
```