### PR TITLE
Improved turnout scripts

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -475,6 +475,8 @@
         <a id="Scripting" name="Scripting"></a>
         <ul>
             <li>Cliff Anderson contributed a new TurnoutsMasterSlave.py script.
+            <li>Fixed the SetAllTurnoutsClosed so it would properly delay on polled systems such as C/MRI
+            <li>Added a new SetAllTurnoutsThrown script
             </li>
         </ul>
 

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -475,8 +475,9 @@
         <a id="Scripting" name="Scripting"></a>
         <ul>
             <li>Cliff Anderson contributed a new TurnoutsMasterSlave.py script.
-            <li>Fixed the SetAllTurnoutsClosed so it would properly delay on polled systems such as C/MRI
-            <li>Added a new SetAllTurnoutsThrown script
+            <li>Fixed the SetAllTurnoutsClosed and SetUnknownTurnoutsClosed so they would properly
+                delay on polled systems such as C/MRI
+            <li>Added a new SetAllTurnoutsThrown script and tests
             </li>
         </ul>
 

--- a/jython/SetAllTurnoutsClosed.py
+++ b/jython/SetAllTurnoutsClosed.py
@@ -1,11 +1,11 @@
-# Sample script to set all un-closed turnouts to Closed
+# Sample script to set all un-CLOSED turnouts to CLOSED
 #
 # After this script is turn, all the Turnouts defined in JMRI
 # should be in the CLOSED state.
 #
 # Note that some "Turnouts" may actually drive other things on the layout,
 # such as signal heads. This script should be run _before_ anything that
-# sets those.  
+# sets those.
 #
 # Part of the JMRI distribution
 
@@ -13,18 +13,23 @@ import jmri
 
 from time import sleep
 
-toCnt = 0
-chgCnt = 0
+class TurnoutSetClosed(jmri.jmrit.automat.AbstractAutomaton) :
+        # handle() is called just one when it returns false.
+        def handle(self):
+            # loop thru all defined turnouts
+            toCnt = 0
+            chgCnt = 0
+            for to in turnouts.getNamedBeanSet():
+              toCnt += 1
+              cs = to.getState()
+              if (cs != CLOSED) :
+                chgCnt += 1
+                to.setState(CLOSED)
+                self.waitMsec(100) # pause for 1/10 second between commands
+            print str(toCnt) + " turnouts found, " + str(chgCnt) + " changed to CLOSED"
+            return FALSE
 
-# loop thru all defined turnouts
-for to in turnouts.getNamedBeanSet():
-  toCnt += 1
-  cs = to.getState()
-  if (cs != CLOSED) :
-    chgCnt += 1
-    to.setState(CLOSED)
-    sleep(0.1) #pause for 1/10 second between commands
-print str(toCnt) + " turnouts found, " + str(chgCnt) + " changed to CLOSED"
+TurnoutSetClosed().start()
 
 
 

--- a/jython/SetAllTurnoutsClosed.py
+++ b/jython/SetAllTurnoutsClosed.py
@@ -11,9 +11,7 @@
 
 import jmri
 
-from time import sleep
-
-class TurnoutSetClosed(jmri.jmrit.automat.AbstractAutomaton) :
+class SetAllTurnoutsClosed(jmri.jmrit.automat.AbstractAutomaton) :
         # handle() is called just one when it returns false.
         def handle(self):
             # loop thru all defined turnouts
@@ -27,9 +25,9 @@ class TurnoutSetClosed(jmri.jmrit.automat.AbstractAutomaton) :
                 to.setState(CLOSED)
                 self.waitMsec(100) # pause for 1/10 second between commands
             print str(toCnt) + " turnouts found, " + str(chgCnt) + " changed to CLOSED"
-            return FALSE
+            return False
 
-TurnoutSetClosed().start()
+SetAllTurnoutsClosed().start()
 
 
 

--- a/jython/SetAllTurnoutsClosed.py
+++ b/jython/SetAllTurnoutsClosed.py
@@ -12,7 +12,7 @@
 import jmri
 
 class SetAllTurnoutsClosed(jmri.jmrit.automat.AbstractAutomaton) :
-        # handle() is called just one when it returns false.
+        # handle() is called just once when it returns false.
         def handle(self):
             # loop thru all defined turnouts
             toCnt = 0

--- a/jython/SetAllTurnoutsThrown.py
+++ b/jython/SetAllTurnoutsThrown.py
@@ -11,9 +11,7 @@
 
 import jmri
 
-from time import sleep
-
-class TurnoutSetThrown(jmri.jmrit.automat.AbstractAutomaton) :
+class SetAllTurnoutsThrown(jmri.jmrit.automat.AbstractAutomaton) :
         # handle() is called just one when it returns false.
         def handle(self):
             # loop thru all defined turnouts
@@ -27,9 +25,9 @@ class TurnoutSetThrown(jmri.jmrit.automat.AbstractAutomaton) :
                 to.setState(THROWN)
                 self.waitMsec(100) # pause for 1/10 second between commands
             print str(toCnt) + " turnouts found, " + str(chgCnt) + " changed to THROWN"
-            return FALSE
+            return False
 
-TurnoutSetThrown().start()
+SetAllTurnoutsThrown().start()
 
 
 

--- a/jython/SetAllTurnoutsThrown.py
+++ b/jython/SetAllTurnoutsThrown.py
@@ -1,0 +1,35 @@
+# Sample script to set all un-THROWN turnouts to THROWN
+#
+# After this script is turn, all the Turnouts defined in JMRI
+# should be in the THROWN state.
+#
+# Note that some "Turnouts" may actually drive other things on the layout,
+# such as signal heads. This script should be run _before_ anything that
+# sets those.
+#
+# Part of the JMRI distribution
+
+import jmri
+
+from time import sleep
+
+class TurnoutSetThrown(jmri.jmrit.automat.AbstractAutomaton) :
+        # handle() is called just one when it returns false.
+        def handle(self):
+            # loop thru all defined turnouts
+            toCnt = 0
+            chgCnt = 0
+            for to in turnouts.getNamedBeanSet():
+              toCnt += 1
+              cs = to.getState()
+              if (cs != THROWN) :
+                chgCnt += 1
+                to.setState(THROWN)
+                self.waitMsec(100) # pause for 1/10 second between commands
+            print str(toCnt) + " turnouts found, " + str(chgCnt) + " changed to THROWN"
+            return FALSE
+
+TurnoutSetThrown().start()
+
+
+

--- a/jython/SetAllTurnoutsThrown.py
+++ b/jython/SetAllTurnoutsThrown.py
@@ -12,7 +12,7 @@
 import jmri
 
 class SetAllTurnoutsThrown(jmri.jmrit.automat.AbstractAutomaton) :
-        # handle() is called just one when it returns false.
+        # handle() is called just once when it returns false.
         def handle(self):
             # loop thru all defined turnouts
             toCnt = 0

--- a/jython/SetUnknownTurnoutsClosed.py
+++ b/jython/SetUnknownTurnoutsClosed.py
@@ -4,27 +4,28 @@
 # UNKNOWN state; any that were at the start should have been set to CLOSED.
 #
 # By skipping over Turnouts that have already been set, this minimizes
-# the chance of disturbing e.g. Turnouts driving signals that have already been set 
+# the chance of disturbing e.g. Turnouts driving signals that have already been set
 # by signal logic.
 #
 # Part of the JMRI distribution
 
 import jmri
 
-from time import sleep
+class SetUnknownTurnoutsClosed(jmri.jmrit.automat.AbstractAutomaton) :
+        # handle() is called just one when it returns false.
+        def handle(self):
+            toCnt = 0
+            chgCnt = 0
+            # loop thru all defined turnouts
+            print "Starting to set turnouts in UNKNOWN state to CLOSED"
+            for to in turnouts.getNamedBeanSet():
+              toCnt += 1
+              cs = to.getState()
+              if (cs == UNKNOWN) :
+                chgCnt += 1
+                to.setState(CLOSED)
+                sleep(0.1) #pause for 1/10 second between commands
+            print str(toCnt) + " turnouts checked, " + str(chgCnt) + " found in UNKNOWN state and changed to CLOSED"
+            return False
 
-toCnt = 0
-chgCnt = 0
-
-# loop thru all defined turnouts
-print "Starting to set turnouts in UNKNOWN state to CLOSED"
-for to in turnouts.getNamedBeanSet():
-  toCnt += 1
-  cs = to.getState()
-  if (cs == UNKNOWN) :
-    chgCnt += 1
-    to.setState(CLOSED)
-    sleep(0.1) #pause for 1/10 second between commands
-print str(toCnt) + " turnouts checked, " + str(chgCnt) + " found in UNKNOWN state and changed to CLOSED"
-
-
+SetUnknownTurnoutsClosed().start()

--- a/jython/SetUnknownTurnoutsClosed.py
+++ b/jython/SetUnknownTurnoutsClosed.py
@@ -12,7 +12,7 @@
 import jmri
 
 class SetUnknownTurnoutsClosed(jmri.jmrit.automat.AbstractAutomaton) :
-        # handle() is called just one when it returns false.
+        # handle() is called just once when it returns false.
         def handle(self):
             toCnt = 0
             chgCnt = 0

--- a/jython/test/SetAllTurnoutsClosedTest.py
+++ b/jython/test/SetAllTurnoutsClosedTest.py
@@ -1,6 +1,7 @@
 
 # Test SetAllTurnoutsClosed.py script
 import jmri
+from time import sleep
 
 # test structure setup
 turnouts.provideTurnout("IS1").setState(UNKNOWN)
@@ -10,6 +11,8 @@ turnouts.provideTurnout("IS4").setState(INCONSISTENT)
 
 # run script
 execfile("jython/SetAllTurnoutsClosed.py")
+
+sleep(1.5)
 
 # test resuts
 if (turnouts.provideTurnout("IS1").getState() != CLOSED) : raise AssertionError('UNKNOWN not set to CLOSED')

--- a/jython/test/SetAllTurnoutsThrownTest.py
+++ b/jython/test/SetAllTurnoutsThrownTest.py
@@ -1,0 +1,19 @@
+# Test SetAllTurnoutsThrown.py script
+import jmri
+from time import sleep
+
+# test structure setup
+turnouts.provideTurnout("IS1").setState(UNKNOWN)
+turnouts.provideTurnout("IS2").setState(CLOSED)
+turnouts.provideTurnout("IS3").setState(THROWN)
+turnouts.provideTurnout("IS4").setState(INCONSISTENT)
+
+# run script
+execfile("jython/SetAllTurnoutsThrown.py")
+
+sleep(1.5)
+# test resuts
+if (turnouts.provideTurnout("IS1").getState() != THROWN) : raise AssertionError('UNKNOWN not set to THROWN')
+if (turnouts.provideTurnout("IS2").getState() != THROWN) : raise AssertionError('CLOSED not set to THROWN')
+if (turnouts.provideTurnout("IS3").getState() != THROWN) : raise AssertionError('THROWN not left at THROWN')
+if (turnouts.provideTurnout("IS4").getState() != THROWN) : raise AssertionError('INCONSISTENT not set to tHROWN')

--- a/jython/test/SetUnknownTurnoutsClosedTest.py
+++ b/jython/test/SetUnknownTurnoutsClosedTest.py
@@ -1,5 +1,6 @@
 # Test SetUnknownTurnoutsClosed.py script
 import jmri
+from time import sleep
 
 # test structure setup
 turnouts.provideTurnout("IS1").setState(UNKNOWN)
@@ -9,6 +10,8 @@ turnouts.provideTurnout("IS4").setState(INCONSISTENT)
 
 # run script
 execfile("jython/SetUnknownTurnoutsClosed.py")
+
+sleep(1.5)
 
 # test resuts
 if (turnouts.provideTurnout("IS1").getState() != CLOSED) : raise AssertionError('UNKNOWN not set to CLOSED')


### PR DESCRIPTION
 - SetAllTurnoutsClosed:  Updated so that it will properly delay on polled systems such as C/MRI
 - SetAllTurnoutsThrown: New script, counterpart of SetAllTurnoutsClosed