### PR TITLE
Fix cut&paste error in SetUnknownTurnoutsToClosed script

### DIFF
--- a/jython/SetUnknownTurnoutsClosed.py
+++ b/jython/SetUnknownTurnoutsClosed.py
@@ -24,7 +24,7 @@ class SetUnknownTurnoutsClosed(jmri.jmrit.automat.AbstractAutomaton) :
               if (cs == UNKNOWN) :
                 chgCnt += 1
                 to.setState(CLOSED)
-                sleep(0.1) #pause for 1/10 second between commands
+                self.waitMsec(100) # pause for 1/10 second between commands
             print str(toCnt) + " turnouts checked, " + str(chgCnt) + " found in UNKNOWN state and changed to CLOSED"
             return False
 


### PR DESCRIPTION
Fix a cut and paste error introduced in PR #11757 

This was noticed overnight by a user, so I'd like to get it merged early so a fix can go in tonight's overnight build.  The change is entirely stand-alone to this script.