### PR TITLE
Prevent CBUS NV index 0 being passed as negative property

### DIFF
--- a/java/src/jmri/jmrix/can/cbus/node/CbusNodeNVManager.java
+++ b/java/src/jmri/jmrix/can/cbus/node/CbusNodeNVManager.java
@@ -96,7 +96,10 @@ public class CbusNodeNVManager {
             return;
         }
         _nvArray[index]=newnv;
-        _node.notifyPropertyChangeListener("SINGLENVUPDATE",null,( index -1));
+        if (index > 0) {
+            // Ignore index 0 (number of NVs) as this would pass a negative value in the property change
+            _node.notifyPropertyChangeListener("SINGLENVUPDATE",null,( index -1));
+        }
         
     }
     


### PR DESCRIPTION
Issue created by PR #11732. Fix prevents NV index 0 (internally used as count of NVs) being converted to a negative property change value.