### PR TITLE
Transit action windows and follow on train delay

### DIFF
--- a/java/src/jmri/jmrit/beantable/TransitTableAction.java
+++ b/java/src/jmri/jmrit/beantable/TransitTableAction.java
@@ -1370,7 +1370,6 @@ public class TransitTableAction extends AbstractTableAction<Transit> {
             actionTableFrame = new JmriJFrame(rbx.getString("TitleViewActions"));
             actionTableFrame.addHelpMenu(
                     "package.jmri.jmrit.beantable.ViewSpecialActions", true);
-            actionTableFrame.setLocation(50, 60);
             Container contentPane = actionTableFrame.getContentPane();
             contentPane.setLayout(new BoxLayout(contentPane, BoxLayout.Y_AXIS));
             JPanel panel1 = new JPanel();
@@ -1514,7 +1513,6 @@ public class TransitTableAction extends AbstractTableAction<Transit> {
             addEditActionFrame = new JmriJFrame(rbx.getString("TitleAddAction"));
             addEditActionFrame.addHelpMenu(
                     "package.jmri.jmrit.beantable.TransitSectionAddEditAction", true);
-            addEditActionFrame.setLocation(120, 80);
             Container contentPane = addEditActionFrame.getContentPane();
             contentPane.setLayout(new BoxLayout(contentPane, BoxLayout.Y_AXIS));
             // to set When to start the action

--- a/java/src/jmri/jmrit/dispatcher/DispatcherFrame.java
+++ b/java/src/jmri/jmrit/dispatcher/DispatcherFrame.java
@@ -1567,10 +1567,13 @@ public class DispatcherFrame extends jmri.util.JmriJFrame implements InstanceMan
             at.terminate();
             if (runNextTrain && !at.getNextTrain().isEmpty() && !at.getNextTrain().equals("None")) {
                 log.debug("Loading Next Train[{}]", at.getNextTrain());
+                // must wait at least 2 secs to allow dispose to fully complete.
                 if (at.getRosterEntry() != null) {
-                    loadTrainFromTrainInfo(at.getNextTrain(),"ROSTER",at.getRosterEntry().getId());
+                    jmri.util.ThreadingUtil.runOnLayoutDelayed(()-> {
+                        loadTrainFromTrainInfo(at.getNextTrain(),"ROSTER",at.getRosterEntry().getId());},2000);
                 } else {
-                    loadTrainFromTrainInfo(at.getNextTrain(),"USER",at.getDccAddress());
+                    jmri.util.ThreadingUtil.runOnLayoutDelayed(()-> {
+                        loadTrainFromTrainInfo(at.getNextTrain(),"USER",at.getDccAddress());},2000);
                 }
             }
             at.dispose();

--- a/java/test/jmri/jmrit/dispatcher/LoadAtStartUpTest.java
+++ b/java/test/jmri/jmrit/dispatcher/LoadAtStartUpTest.java
@@ -185,7 +185,7 @@ public class LoadAtStartUpTest {
             return (Math.abs(aat.getTargetSpeed() ) < TOLERANCE );
         }, "Signal Just passed east end throat now stop");
 
-        JUnitUtil.waitFor(200);
+        JUnitUtil.waitFor(2200);
         // check for next train note dcc name is original transit name has changed
         Assert.assertEquals("Next Train Load","1000 / SouthPlatFormReturnToSouthCC", d.getActiveTrainsList().get(0).getActiveTrainName());
         JUnitUtil.waitFor(2000);


### PR DESCRIPTION
Open Transit Action windows where they were closed.
Add a 2sec delay on the follow traininfo at termination.