### PR TITLE
On Loconet, handle LACK 0x7 f properly

### DIFF
--- a/help/en/Acknowledgements.shtml
+++ b/help/en/Acknowledgements.shtml
@@ -373,6 +373,9 @@
         made it work with TCS decoders. He's helped with networking and various Macintosh issues,
         including the XML IO system.</li>
 
+        <li>Frank Fezzie, who helped test a fix to an obscure LocoNet bug.
+        </li>
+
         <li>Don Fiehmann provided MRC decoders for testing</li>
 
         <li>Bill Fitch, <!-- bill-fitch14; not it's his JMRI-1 repo -->
@@ -445,7 +448,7 @@
         implementation to do a background refresh of the function values.</li>
 
         <li>Jerry Grochow, <!-- jerryg2003 -->
-         who helped with the scripting documentation</li>
+         who helped with the scripting documentation and the XSLT panel viewer.</li>
 
         <li>Mark Gurries, who provided loaner equipment and great ideas. He's currently working on
         decoder definitions for DecoderPro <a id="H"></a>
@@ -723,6 +726,9 @@
 
         <li>Jeff Moonmaw, who provided the <a href=
         "http:jmri.org/xml/signals/WPRR-1971">WPRR 1971 </a> signal system definition.
+        </li>
+
+        <li>Bob Morningstar, who helped test a fix to an obscure LocoNet bug.
         </li>
 
         <li>Michael Mosher, who helped identify the way Digitrax decoder models are organized, has

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -76,7 +76,9 @@
 
         <h4>LocoNet</h4>
             <ul>
-                <li></li>
+                <li>Changed handling of LACK messages during programming to
+                    avoid a recently-uncovered conflict with attached DT602D
+                    throttles.</li>
             </ul>
 
         <h4>Maple</h4>

--- a/help/en/releasenotes/current-draft-warnings.shtml
+++ b/help/en/releasenotes/current-draft-warnings.shtml
@@ -1,7 +1,9 @@
 
     <!-- contains new warnings for the release under development -->
     <li>
-        None yet
+        The code for LocoNet programming operations was significantly changed in this release.
+        If you encounter any (new) troubles programming via LocoNet, please get in touch on the
+        <a href="https://groups.io/g/jmriusers">JMRIusers list</a>.
     </li>
     <li>
     </li>

--- a/java/src/jmri/jmrix/loconet/SlotManager.java
+++ b/java/src/jmri/jmrix/loconet/SlotManager.java
@@ -710,12 +710,12 @@ public class SlotManager extends AbstractProgrammer implements LocoNetListener, 
      * It is divided into numerous small methods so that each bit can be
      * overridden for special parsing for individual command station types.
      *
-     * @param Byte1 from the LocoNet message
-     * @return true if Byte1 encodes a response to a OPC_SL_WRITE or an
+     * @param byte1 from the LocoNet message
+     * @return true if byte1 encodes a response to a OPC_SL_WRITE or an
      *          Expanded Slot Write
      */
-    protected boolean checkLackByte1(int Byte1) {
-        if ((Byte1 & 0xEF) == 0x6F) {
+    protected boolean checkLackByte1(int byte1) {
+        if ((byte1 & 0xEF) == 0x6F) {
             return true;
         } else {
             return false;
@@ -726,13 +726,14 @@ public class SlotManager extends AbstractProgrammer implements LocoNetListener, 
      * Checks the status byte of an OPC_LONG_ACK when performing CV programming
      * operations.
      *
-     * @param Byte2 status byte
+     * @param byte2 status byte
      * @return True if status byte indicates acceptance of the command, else false.
      */
-    protected boolean checkLackTaskAccepted(int Byte2) {
-        if (Byte2 == 1 // task accepted
-                || Byte2 == 0x23 || Byte2 == 0x2B || Byte2 == 0x6B// added as DCS51 fix
-                /* || Byte2 == 0x7F */) {
+    protected boolean checkLackTaskAccepted(int byte2) {
+        if (byte2 == 1 // task accepted
+                || byte2 == 0x23 || byte2 == 0x2B || byte2 == 0x6B // added as DCS51 fix
+                // deliberately ignoring 0x7F varient, see okToIgnoreLack
+            ) {
             return true;
         } else {
             return false;
@@ -743,11 +744,11 @@ public class SlotManager extends AbstractProgrammer implements LocoNetListener, 
      * Checks the OPC_LONG_ACK status byte response to a programming
      * operation.
      *
-     * @param Byte2 from the OPC_LONG_ACK message
+     * @param byte2 from the OPC_LONG_ACK message
      * @return true if the programmer returned "busy" else false
      */
-    protected boolean checkLackProgrammerBusy(int Byte2) {
-        if (Byte2 == 0) {
+    protected boolean checkLackProgrammerBusy(int byte2) {
+        if (byte2 == 0) {
             return true;
         } else {
             return false;
@@ -758,11 +759,25 @@ public class SlotManager extends AbstractProgrammer implements LocoNetListener, 
      * Checks the OPC_LONG_ACK status byte response to a programming
      * operation to see if the programmer accepted the operation "blindly".
      *
-     * @param Byte2 from the OPC_LONG_ACK message
+     * @param byte2 from the OPC_LONG_ACK message
      * @return true if the programmer indicated a "blind operation", else false
      */
-    protected boolean checkLackAcceptedBlind(int Byte2) {
-        if (Byte2 == 0x40 || Byte2 == 0x7F ) {
+    protected boolean checkLackAcceptedBlind(int byte2) {
+        if (byte2 == 0x40) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * Some LACKs with specific OPC_LONG_ACK status byte values can just be ignored.
+     *
+     * @param byte2 from the OPC_LONG_ACK message
+     * @return true if this form of LACK can be ignored without a warning message
+     */
+    protected boolean okToIgnoreLack(int byte2) {
+        if (byte2 == 0x7F ) {
             return true;
         } else {
             return false;
@@ -790,7 +805,8 @@ public class SlotManager extends AbstractProgrammer implements LocoNetListener, 
         log.debug("LACK in state {} message: {}", progState, m.toString()); // NOI18N
         if (checkLackByte1(m.getElement(1)) && progState == 1) {
             // in programming state
-            if (acceptAnyLACK) {
+            if (acceptAnyLACK && !okToIgnoreLack(m.getElement(2))) {
+                log.debug("accepted LACK {} via acceptAnyLACK", m.getElement(2));
                 // Any form of LACK response from CS is accepted here.
                 // Loconet-attached decoders (LOCONETOPSBOARD) receive the program commands
                 // directly via loconet and respond as required without needing any CS action,
@@ -813,7 +829,7 @@ public class SlotManager extends AbstractProgrammer implements LocoNetListener, 
                 // 'not implemented' (op on main)
                 // but BDL16 and other devices can eventually reply, so
                 // move to commandExecuting state
-                log.debug("LACK accepted, next state 2"); // NOI18N
+                log.debug("checkLackTaskAccepted accepted, next state 2"); // NOI18N
                 if ((_progRead || _progConfirm) && mServiceMode) {
                     startLongTimer();
                 } else {
@@ -840,6 +856,9 @@ public class SlotManager extends AbstractProgrammer implements LocoNetListener, 
                     // allow command station time to execute then notify ProgListener
                     notifyProgListenerEndAfterDelay();
                 }
+            } else if (okToIgnoreLack(m.getElement(2))) {
+                // this form of LACK can be silently ignored
+                log.debug("Ignoring LACK with {}", m.getElement(2));
             } else { // not sure how to cope, so complain
                 log.warn("unexpected LACK reply code {}", m.getElement(2)); // NOI18N
                 // move to not programming state

--- a/java/src/jmri/jmrix/loconet/SlotManager.java
+++ b/java/src/jmri/jmrix/loconet/SlotManager.java
@@ -732,7 +732,7 @@ public class SlotManager extends AbstractProgrammer implements LocoNetListener, 
     protected boolean checkLackTaskAccepted(int Byte2) {
         if (Byte2 == 1 // task accepted
                 || Byte2 == 0x23 || Byte2 == 0x2B || Byte2 == 0x6B// added as DCS51 fix
-                || Byte2 == 0x7F) {
+                /* || Byte2 == 0x7F */) {
             return true;
         } else {
             return false;
@@ -762,7 +762,7 @@ public class SlotManager extends AbstractProgrammer implements LocoNetListener, 
      * @return true if the programmer indicated a "blind operation", else false
      */
     protected boolean checkLackAcceptedBlind(int Byte2) {
-        if (Byte2 == 0x40) {
+        if (Byte2 == 0x40 || Byte2 == 0x7F ) {
             return true;
         } else {
             return false;

--- a/java/test/jmri/jmrix/loconet/LnOpsModeProgrammerTest.java
+++ b/java/test/jmri/jmrix/loconet/LnOpsModeProgrammerTest.java
@@ -20,7 +20,7 @@ public class LnOpsModeProgrammerTest extends jmri.AddressedProgrammerTestBase{
     @Test
     public void testGetCanWriteAddress() {
         Assert.assertFalse("can write address", programmer.getCanWrite("1234"));
-    }    
+    }
 
     @Test
     public void testSetMode() {
@@ -42,7 +42,7 @@ public class LnOpsModeProgrammerTest extends jmri.AddressedProgrammerTestBase{
     public void testGetCanReadWithTransponding() {
         // allow transponding
         sm.setTranspondingAvailable(true);
-        
+
         lnopsmodeprogrammer = new LnOpsModeProgrammer(memo, 1, true);
 
         Assert.assertEquals("ops mode can read with transponding", true,
@@ -503,7 +503,7 @@ public class LnOpsModeProgrammerTest extends jmri.AddressedProgrammerTestBase{
      }
 
      @Test
-     public void testOpsReadLocoNetModeLACKNotImplemented() throws ProgrammerException {
+     public void testOpsReadLocoNetModeLACKAcceptedBlind() throws ProgrammerException {
         // allow transponding
         sm.setTranspondingAvailable(false);
 
@@ -524,8 +524,8 @@ public class LnOpsModeProgrammerTest extends jmri.AddressedProgrammerTestBase{
         Assert.assertEquals("still one message sent", 1, lnis.outbound.size());
         Assert.assertEquals("No programming reply", 0, pl.getRcvdInvoked());
 
-        // LACK "function not implemented" followed by Known-good message in reply
-        m = new LocoNetMessage(new int[]{0xB4, 0x6F, 0x7F, 0x5B});
+        // LACK "accepted blind" followed by Known-good message in reply
+        m = new LocoNetMessage(new int[]{0xB4, 0x6F, 0x40, 0x64});
         lnopsmodeprogrammer.message(m);
         sm.message(m);
 

--- a/java/test/jmri/jmrix/loconet/SlotManagerTest.java
+++ b/java/test/jmri/jmrix/loconet/SlotManagerTest.java
@@ -282,6 +282,47 @@ public class SlotManagerTest {
     }
 
     @Test
+    public void testReadCVDirectWithDT6() throws jmri.ProgrammerException {
+        // test with extra 0x7F reply
+        log.debug(".... start testReadCVDirectWDT6 ...");
+        String CV1 = "29";
+        slotmanager.setMode(ProgrammingMode.DIRECTBYTEMODE);
+        slotmanager.readCV(CV1, lstn);
+        Assert.assertEquals("read message",
+                "EF 0E 7C 2B 00 00 00 00 00 1C 00 7F 7F 00",
+                lnis.outbound.elementAt(lnis.outbound.size() - 1).toString());
+        Assert.assertEquals("one message sent", 1, lnis.outbound.size());
+        Assert.assertEquals("initial status", -999, status);
+
+        // LACKs received back (DCS240 + DT6 sequence)
+        startedShortTimer = false;
+        startedLongTimer = false;
+
+        log.debug("send 1st LACK back");
+        slotmanager.message(new LocoNetMessage(new int[]{0xB4, 0x6F, 0x7F, 0x5B}));
+        Assert.assertTrue("long timer not started yet", !startedLongTimer);
+
+        log.debug("send 2nd LACK back");
+        slotmanager.message(new LocoNetMessage(new int[]{0xB4, 0x6F, 0x01, 0x25}));
+        JUnitUtil.waitFor(()->{return startedLongTimer;},"startedLongTimer not set");
+
+        Assert.assertEquals("post-LACK status", -999, status);
+        Assert.assertTrue("started long timer", startedLongTimer);
+        Assert.assertFalse("didn't start short timer", startedShortTimer);
+
+        // read received back (DCS240 sequence)
+        value = 0;
+        log.debug("send E7 reply back");
+        slotmanager.message(new LocoNetMessage(new int[]{0xE7, 0x0E, 0x7C, 0x2B, 0x00, 0x00, 0x02, 0x47, 0x00, 0x1C, 0x23, 0x7F, 0x7F, 0x3B}));
+        JUnitUtil.waitFor(()->{return value == 35;},"value == 35 not set");
+        log.debug("checking..");
+        Assert.assertEquals("reply status", 0, status);
+        Assert.assertEquals("reply value", 35, value);
+
+        log.debug(".... end testReadCVDirectWithDT6 ...");
+    }
+
+    @Test
     public void testReadCVOpsModeLong() throws jmri.ProgrammerException {
         String CV1 = "12";
         ProgListener p2 = null;
@@ -373,6 +414,49 @@ public class SlotManagerTest {
         Assert.assertEquals("reply value", -1, value);
 
         log.debug(".... end testWriteCVDirectStringDCS240 ...");
+    }
+
+    @Test
+    public void testWriteCVDirectStringDCS240WithDT6() throws jmri.ProgrammerException {
+        log.debug(".... start testWriteCVDirectStringDCS240WithDT6 ...");
+        String CV1 = "31";
+        int val2 = 16;
+        slotmanager.setMode(ProgrammingMode.DIRECTBYTEMODE);
+        slotmanager.writeCV(CV1, val2, lstn);
+        Assert.assertEquals("one message sent", 1, lnis.outbound.size());
+        Assert.assertEquals("initial status", -999, status);
+        Assert.assertEquals("write message",
+                "EF 0E 7C 6B 00 00 00 00 00 1E 10 7F 7F 00",
+                lnis.outbound.elementAt(lnis.outbound.size() - 1).toString());
+        Assert.assertEquals("one message sent", 1, lnis.outbound.size());
+        Assert.assertEquals("initial status", -999, status);
+
+        // LACK received back (DT6 plus DCS240 sequence)
+        startedShortTimer = false;
+        startedLongTimer = false;
+
+        log.debug("send 1st LACK back");
+        slotmanager.message(new LocoNetMessage(new int[]{0xB4, 0x6F, 0x7F, 0x5B}));
+        Assert.assertTrue("short timer not started yet", !startedShortTimer);
+
+        log.debug("send 2nd LACK back");
+        slotmanager.message(new LocoNetMessage(new int[]{0xB4, 0x6F, 0x01, 0x25}));
+        JUnitUtil.waitFor(()->{return startedShortTimer;},"startedShortTimer not set");
+        Assert.assertEquals("post-LACK status", -999, status);
+        Assert.assertTrue("started short timer", startedShortTimer);
+        Assert.assertFalse("didn't start long timer", startedLongTimer);
+
+        // read received back (DCS240 sequence)
+        value = -15;
+        log.debug("send E7 reply back");
+        slotmanager.message(new LocoNetMessage(new int[]{0xE7, 0x0E, 0x7C, 0x6B, 0x00, 0x00, 0x02, 0x47, 0x00, 0x1E, 0x10, 0x7F, 0x7F, 0x4A}));
+        Assert.assertEquals("no immediate reply", -999, status);
+        JUnitUtil.waitFor(()->{return value == -1;},"value == -1 not set");
+        log.debug("checking..");
+        Assert.assertEquals("reply status", 0, status);
+        Assert.assertEquals("reply value", -1, value);
+
+        log.debug(".... end testWriteCVDirectStringDCS240WithDT6 ...");
     }
 
     @Test


### PR DESCRIPTION
JMRI has been handling a LocoNet LACK with reason code 0x7F improperly.  Until recently, this didn't matter, as no hardware was emitting it.  The DT6 and DT602 emit LACK 0x7F when they see a programming operation from _another_ device, so JMRI now needs to handle this by ignoring LACK 0x7F (and only LACK 0x7F).

Thanks to Bob Morningstar, Heiko Rosemann, Robin Becker, Bob M and Frank Fezzie for help with this change.