### PR TITLE
Disable LogixNG on load if F9 is pressed

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -412,7 +412,7 @@
     <h3>LogixNG</h3>
         <a id="LogixNG" name="LogixNG"></a>
         <ul>
-          <li></li>
+          <li>Pressing the F9 key when the spash screen is visible prevents LogixNGs to be started.</li>
         </ul>
 
     <h3>Meters and MeterFrames</h3>

--- a/java/src/apps/Apps.java
+++ b/java/src/apps/Apps.java
@@ -1,5 +1,10 @@
 package apps;
 
+import apps.gui3.tabbedpreferences.TabbedPreferences;
+import apps.gui3.tabbedpreferences.TabbedPreferencesAction;
+import apps.plaf.macosx.Application;
+import apps.util.Log4JUtil;
+
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.awt.*;
@@ -10,23 +15,18 @@ import java.io.*;
 import java.lang.reflect.InvocationTargetException;
 import java.net.*;
 import java.util.*;
-
 import javax.swing.*;
 import javax.swing.text.DefaultEditorKit;
 import javax.swing.text.JTextComponent;
 
-import jmri.jmrit.logixng.LogixNGPreferences;
-
 import jmri.*;
-
 import jmri.jmrit.decoderdefn.DecoderIndexFile;
 import jmri.jmrit.jython.*;
+import jmri.jmrit.logixng.LogixNG_Manager;
+import jmri.jmrit.logixng.LogixNGPreferences;
 import jmri.jmrit.revhistory.FileHistory;
 import jmri.jmrit.throttle.ThrottleFrame;
 import jmri.jmrix.*;
-
-import apps.plaf.macosx.Application;
-
 import jmri.profile.*;
 import jmri.script.JmriScriptEngineManager;
 import jmri.util.*;
@@ -35,10 +35,6 @@ import jmri.util.prefs.JmriPreferencesActionFactory;
 import jmri.util.swing.JFrameInterface;
 import jmri.util.swing.JmriMouseEvent;
 import jmri.util.swing.WindowInterface;
-
-import apps.gui3.tabbedpreferences.TabbedPreferences;
-import apps.gui3.tabbedpreferences.TabbedPreferencesAction;
-import apps.util.Log4JUtil;
 
 /**
  * Base class for JMRI applications.
@@ -358,10 +354,10 @@ public class Apps extends JPanel implements PropertyChangeListener, WindowListen
         InstanceManager.getDefault(jmri.LogixManager.class).activateAllLogixs();
         InstanceManager.getDefault(jmri.jmrit.display.layoutEditor.LayoutBlockManager.class).initializeLayoutBlockPaths();
 
-        jmri.jmrit.logixng.LogixNG_Manager logixNG_Manager =
-                InstanceManager.getDefault(jmri.jmrit.logixng.LogixNG_Manager.class);
+        LogixNG_Manager logixNG_Manager = InstanceManager.getDefault(LogixNG_Manager.class);
         logixNG_Manager.setupAllLogixNGs();
-        if (InstanceManager.getDefault(LogixNGPreferences.class).getStartLogixNGOnStartup()) {
+        if (InstanceManager.getDefault(LogixNGPreferences.class).getStartLogixNGOnStartup()
+                && InstanceManager.getDefault(jmri.jmrit.logixng.LogixNG_Manager.class).isStartLogixNGsOnLoad()) {
             logixNG_Manager.activateAllLogixNGs();
         }
 
@@ -708,8 +704,10 @@ public class Apps extends JPanel implements PropertyChangeListener, WindowListen
                             and the if the debugFired hasn't been set, this allows us to ensure that we don't
                             miss the user pressing F8, while we are checking*/
                             debugmsg = true;
-                            if (e.getID() == KeyEvent.KEY_PRESSED && e instanceof KeyEvent && ((KeyEvent) e).getKeyCode() == 119) {
+                            if (e.getID() == KeyEvent.KEY_PRESSED && e instanceof KeyEvent && ((KeyEvent) e).getKeyCode() == 119) {     // F8
                                 startupDebug();
+                            } else if (e.getID() == KeyEvent.KEY_PRESSED && e instanceof KeyEvent && ((KeyEvent) e).getKeyCode() == 120) {  // F9
+                                InstanceManager.getDefault(LogixNG_Manager.class).startLogixNGsOnLoad(false);
                             } else {
                                 debugmsg = false;
                             }
@@ -736,10 +734,14 @@ public class Apps extends JPanel implements PropertyChangeListener, WindowListen
     }
 
     static protected JPanel splashDebugMsg() {
-        JLabel panelLabel = new JLabel(Bundle.getMessage("PressF8ToDebug"));
-        panelLabel.setFont(panelLabel.getFont().deriveFont(9f));
+        JLabel panelLabelDisableLogix = new JLabel(Bundle.getMessage("PressF8ToDebug"));
+        panelLabelDisableLogix.setFont(panelLabelDisableLogix.getFont().deriveFont(9f));
+        JLabel panelLabelDisableLogixNG = new JLabel(Bundle.getMessage("PressF9ToDisableLogixNG"));
+        panelLabelDisableLogixNG.setFont(panelLabelDisableLogix.getFont().deriveFont(9f));
         JPanel panel = new JPanel();
-        panel.add(panelLabel);
+        panel.setLayout(new BoxLayout(panel, BoxLayout.PAGE_AXIS));
+        panel.add(panelLabelDisableLogix);
+        panel.add(panelLabelDisableLogixNG);
         return panel;
     }
 

--- a/java/src/apps/AppsBase.java
+++ b/java/src/apps/AppsBase.java
@@ -119,7 +119,8 @@ public abstract class AppsBase {
         jmri.jmrit.logixng.LogixNG_Manager logixNG_Manager =
                 InstanceManager.getDefault(jmri.jmrit.logixng.LogixNG_Manager.class);
         logixNG_Manager.setupAllLogixNGs();
-        if (InstanceManager.getDefault(LogixNGPreferences.class).getStartLogixNGOnStartup()) {
+        if (InstanceManager.getDefault(LogixNGPreferences.class).getStartLogixNGOnStartup()
+                && InstanceManager.getDefault(jmri.jmrit.logixng.LogixNG_Manager.class).isStartLogixNGsOnLoad()) {
             logixNG_Manager.activateAllLogixNGs();
         }
     }

--- a/java/src/apps/AppsBundle.properties
+++ b/java/src/apps/AppsBundle.properties
@@ -88,6 +88,7 @@ The new storage format will be used next time this profile is used.
 
 # Splash screen
 PressF8ToDebug = Press F8 to disable Logixs.
+PressF9ToDisableLogixNG = Press F9 to disable LogixNGs.
 #Multiple errors in Startup Actions
 StartupActionsMultipleErrors=There are multiple errors running Startup Actions.
 #Startup Actions unable to create class

--- a/java/src/apps/gui3/Apps3.java
+++ b/java/src/apps/gui3/Apps3.java
@@ -1,7 +1,8 @@
 package apps.gui3;
 
-import apps.gui3.tabbedpreferences.TabbedPreferencesAction;
 import apps.*;
+import apps.gui3.tabbedpreferences.TabbedPreferencesAction;
+import apps.swing.AboutDialog;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -13,10 +14,9 @@ import java.util.EventObject;
 
 import javax.swing.*;
 
+import jmri.InstanceManager;
+import jmri.jmrit.logixng.LogixNG_Manager;
 import jmri.profile.*;
-
-import apps.swing.AboutDialog;
-
 import jmri.util.*;
 
 import org.slf4j.Logger;
@@ -170,8 +170,10 @@ public abstract class Apps3 extends AppsBase {
                          and the if the debugFired hasn't been set, this allows us to ensure that we don't
                          miss the user pressing F8, while we are checking*/
                         debugmsg = true;
-                        if (e.getID() == KeyEvent.KEY_PRESSED && e instanceof KeyEvent && ((KeyEvent) e).getKeyCode() == 119) {
+                        if (e.getID() == KeyEvent.KEY_PRESSED && e instanceof KeyEvent && ((KeyEvent) e).getKeyCode() == 119) {     // F8
                             startupDebug();
+                        } else if (e.getID() == KeyEvent.KEY_PRESSED && e instanceof KeyEvent && ((KeyEvent) e).getKeyCode() == 120) {  // F9
+                                InstanceManager.getDefault(LogixNG_Manager.class).startLogixNGsOnLoad(false);
                         } else {
                             debugmsg = false;
                         }
@@ -196,10 +198,14 @@ public abstract class Apps3 extends AppsBase {
     }
 
     static protected JPanel splashDebugMsg() {
-        JLabel panelLabel = new JLabel(Bundle.getMessage("PressF8ToDebug"));
-        panelLabel.setFont(panelLabel.getFont().deriveFont(9f));
+        JLabel panelLabelDisableLogix = new JLabel(Bundle.getMessage("PressF8ToDebug"));
+        panelLabelDisableLogix.setFont(panelLabelDisableLogix.getFont().deriveFont(9f));
+        JLabel panelLabelDisableLogixNG = new JLabel(Bundle.getMessage("PressF9ToDisableLogixNG"));
+        panelLabelDisableLogixNG.setFont(panelLabelDisableLogix.getFont().deriveFont(9f));
         JPanel panel = new JPanel();
-        panel.add(panelLabel);
+        panel.setLayout(new BoxLayout(panel, BoxLayout.PAGE_AXIS));
+        panel.add(panelLabelDisableLogix);
+        panel.add(panelLabelDisableLogixNG);
         return panel;
     }
 

--- a/java/src/apps/gui3/Apps3.java
+++ b/java/src/apps/gui3/Apps3.java
@@ -173,7 +173,7 @@ public abstract class Apps3 extends AppsBase {
                         if (e.getID() == KeyEvent.KEY_PRESSED && e instanceof KeyEvent && ((KeyEvent) e).getKeyCode() == 119) {     // F8
                             startupDebug();
                         } else if (e.getID() == KeyEvent.KEY_PRESSED && e instanceof KeyEvent && ((KeyEvent) e).getKeyCode() == 120) {  // F9
-                                InstanceManager.getDefault(LogixNG_Manager.class).startLogixNGsOnLoad(false);
+                            InstanceManager.getDefault(LogixNG_Manager.class).startLogixNGsOnLoad(false);
                         } else {
                             debugmsg = false;
                         }

--- a/java/src/jmri/configurexml/LoadXmlConfigAction.java
+++ b/java/src/jmri/configurexml/LoadXmlConfigAction.java
@@ -78,7 +78,8 @@ public class LoadXmlConfigAction extends LoadStoreBaseAction {
                         jmri.jmrit.logixng.LogixNG_Manager logixNG_Manager =
                                 InstanceManager.getDefault(jmri.jmrit.logixng.LogixNG_Manager.class);
                         logixNG_Manager.setupAllLogixNGs();
-                        if (InstanceManager.getDefault(LogixNGPreferences.class).getStartLogixNGOnStartup()) {
+                        if (InstanceManager.getDefault(LogixNGPreferences.class).getStartLogixNGOnStartup()
+                                && InstanceManager.getDefault(jmri.jmrit.logixng.LogixNG_Manager.class).isStartLogixNGsOnLoad()) {
                             logixNG_Manager.activateAllLogixNGs();
                         }
                     }

--- a/java/src/jmri/jmrit/logixng/LogixNG_Manager.java
+++ b/java/src/jmri/jmrit/logixng/LogixNG_Manager.java
@@ -82,6 +82,18 @@ public interface LogixNG_Manager extends Manager<LogixNG> {
     public String getAutoSystemName();
 
     /**
+     * Should the LogixNGs be started when the configuration file is loaded?
+     * @param value true if they should be started, false otherwise.
+     */
+    public void startLogixNGsOnLoad(boolean value);
+
+    /**
+     * Should the LogixNGs not be started when the configuration file is loaded?
+     * @return true if they should be started, false otherwise.
+     */
+    public boolean isStartLogixNGsOnLoad();
+
+    /**
      * Setup all LogixNGs. This method is called after a configuration file is
      * loaded.
      */

--- a/java/src/jmri/jmrit/logixng/implementation/DefaultLogixNGManager.java
+++ b/java/src/jmri/jmrit/logixng/implementation/DefaultLogixNGManager.java
@@ -32,6 +32,7 @@ public class DefaultLogixNGManager extends AbstractManager<LogixNG>
     private final Map<String, Manager<? extends MaleSocket>> _managers = new HashMap<>();
     private final Clipboard _clipboard = new DefaultClipboard();
     private boolean _isActive = false;
+    private boolean _startLogixNGsOnLoad = true;
     private final List<Runnable> _setupTasks = new ArrayList<>();
 
 
@@ -153,6 +154,18 @@ public class DefaultLogixNGManager extends AbstractManager<LogixNG>
     @Override
     public String getBeanTypeHandled(boolean plural) {
         return Bundle.getMessage(plural ? "BeanNameLogixNGs" : "BeanNameLogixNG");
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void startLogixNGsOnLoad(boolean value) {
+        _startLogixNGsOnLoad = value;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean isStartLogixNGsOnLoad() {
+        return _startLogixNGsOnLoad;
     }
 
     /** {@inheritDoc} */


### PR DESCRIPTION
This adds "F9" key to the spash screen. If F9 is pressed, LogixNGs will not be activated. Use Tools -> LogixNG -> Start LogixNG to start LogixNGs if F9 is pressed.

This is useful if the user creates LogixNGs that breaks JMRI, for example creating endless loops.