### PR TITLE
Fix missing write to upper CVs in SplitEnumVariableValue

### DIFF
--- a/help/en/html/apps/DecoderPro/CreateDecoderAdvanced.shtml
+++ b/help/en/html/apps/DecoderPro/CreateDecoderAdvanced.shtml
@@ -828,14 +828,39 @@ delay is 500 milliseconds.
             </li>
           </ul>
         </li>
+
+
+        <li>A <a href="/JavaDoc/doc/jmri/jmrit/symbolicprog/SplitEnumVariableValue.html" target=
+        "_blank">splitEnumVal</a> type. This is like <a href=
+        "/JavaDoc/doc/jmri/jmrit/symbolicprog/SplitVariableValue.html" target="_blank">splitVal</a>
+        but uses the selection of one object from a specified list.
+          <ul>
+            <li>For examples, see this <a href=
+            "https://github.com/JMRI/JMRI/blob/master/xml/decoders/TCS_BachmannFT.xml"
+              target="_blank">decoder file</a>.
+            </li>
+            <li>For details of required/optional attributes and advanced features, see this
+              <a href="/JavaDoc/doc/jmri/jmrit/symbolicprog/SplitEnumVariableValue.html" target=
+              "_blank">JavaDoc page</a>.
+            </li>
+          </ul>
+        </li>
+
       </ul>
       <p>The CVs to be used are specified in the <code>CV</code> attribute and masks (if required)
-        in the <code>mask</code> attribute. For example:</p>
+        in the <code>mask</code> attribute.
+        Both CVs and masks are specified lowest-value first order:
+        The least
+        significant bit of the value will be in the first CV and mask specified, and the most
+        significant bit of the value will be in the last CV and mask specified.
+        For example:</p>
 <pre style="font-family: monospace;">
   &lt;variable CV="1,27,13" mask="XXVVVVVV XXXXXVVV XXXXXVVV" item="Sample Item"&gt;
       &lt;splitVal/&gt;
   &lt;/variable&gt;
 </pre>
+      puts the least significant 6 bits of the value in CV1, and the most significant
+      three bits in CV 13.
       <p>In cases where a number of complex or contiguous CVs are used, there are a number of
       alternative more concise methods of specifying in the <code>CV</code> variable parameter:</p>
       <ul>

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -313,7 +313,9 @@
 
         <h4>TCS</h4>
             <ul>
-                <li></li>
+                <li>Fixed problems in the sound CV definitions for
+                    Bachmann FT, Bachmann GP35, Bachmann RS3 and
+                    WOW Diesel V5-121 decoders.</li>
             </ul>
 
 	    <h4>Team Digital</h4>
@@ -366,6 +368,7 @@
         <ul>
             <li>Improve how filename extensions are handled when exporting the complete roster.</li>
             <li>Updated list of NMRA-registered manufacturer IDs</li>
+            <li>Improved how split enum-style variables are handled.</li>
         </ul>
 
     <h3>CTC Tool</h3>

--- a/java/src/jmri/jmrit/symbolicprog/CvValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/CvValue.java
@@ -88,23 +88,6 @@ public class CvValue extends AbstractValue implements ProgListener {
 
 
     /**
-     * Edit a new value into the CV without firing property listeners
-     * <p>
-     * Only use this for external edits, e.g. set from a GUI.
-     * Not for internal uses, as it sets the state to EDITED.
-     * @param value new CV value.
-     */
-    public void setValueWithoutUpdate(int value) {
-        log.debug("CV {} value changed Without Update from {} to {}", number(), _value, value); // NOI18N
-
-        setState(ValueState.EDITED);
-        if (_value != value) {
-            _value = value;
-            _tableEntry.setText("" + value);
-        }
-    }
-
-    /**
      * Edit a new value into the CV. Fires listeners
      * <p>
      * Only use this for external edits, e.g. set from a GUI.

--- a/java/src/jmri/jmrit/symbolicprog/CvValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/CvValue.java
@@ -86,8 +86,26 @@ public class CvValue extends AbstractValue implements ProgListener {
         prop.firePropertyChange("Value", null, value);
     }
 
+
     /**
-     * Edit a new value into the CV.
+     * Edit a new value into the CV without firing property listeners
+     * <p>
+     * Only use this for external edits, e.g. set from a GUI.
+     * Not for internal uses, as it sets the state to EDITED.
+     * @param value new CV value.
+     */
+    public void setValueWithoutUpdate(int value) {
+        log.debug("CV {} value changed from {} to {}", number(), _value, value); // NOI18N
+
+        setState(ValueState.EDITED);
+        if (_value != value) {
+            _value = value;
+            _tableEntry.setText("" + value);
+        }
+    }
+
+    /**
+     * Edit a new value into the CV. Fires listeners
      * <p>
      * Only use this for external edits, e.g. set from a GUI.
      * Not for internal uses, as it sets the state to EDITED.

--- a/java/src/jmri/jmrit/symbolicprog/CvValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/CvValue.java
@@ -95,7 +95,7 @@ public class CvValue extends AbstractValue implements ProgListener {
      * @param value new CV value.
      */
     public void setValueWithoutUpdate(int value) {
-        log.debug("CV {} value changed from {} to {}", number(), _value, value); // NOI18N
+        log.debug("CV {} value changed Without Update from {} to {}", number(), _value, value); // NOI18N
 
         setState(ValueState.EDITED);
         if (_value != value) {

--- a/java/src/jmri/jmrit/symbolicprog/SplitEnumVariableValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/SplitEnumVariableValue.java
@@ -580,7 +580,7 @@ public class SplitEnumVariableValue extends VariableValue
             // cv updates here trigger updated property changes, which means
             // we're going to get notified sooner or later.
             if (newCvVal != oldCvVal) {
-                thisCV.setValueWithoutUpdate(newCvVal);
+                thisCV.setValue(newCvVal);
             }
         }
         log.debug("Variable={}; exit updatedDropDown", _name);

--- a/java/src/jmri/jmrit/symbolicprog/SplitEnumVariableValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/SplitEnumVariableValue.java
@@ -1128,10 +1128,8 @@ public class SplitEnumVariableValue extends VariableValue
                 }
                 setState(varState);
 
-                int intMax = (int)_maxVal;
-                CvValue cv = _cvMap.get(getCvNum());
-                int newVal = getValueInCV(cv.getValue(), getMask(), intMax-1); // _maxVal value is count of possibles, i.e. radix
-                setValue(newVal);
+                updatedDropDown();
+
                 break;
             }
             default:

--- a/java/src/jmri/jmrit/symbolicprog/SplitEnumVariableValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/SplitEnumVariableValue.java
@@ -641,8 +641,6 @@ public class SplitEnumVariableValue extends VariableValue
                 }
             }
 
-            int oldVal = getIntValue();
-
             // called for new values - set the CV as needed
             CvValue cv = _cvMap.get(getCvNum());
             if (cv == null) {
@@ -650,23 +648,8 @@ public class SplitEnumVariableValue extends VariableValue
                 return;
             }
 
-            updatedDropDown(); //+
+            updatedDropDown();
 
-//+             int oldCv = cv.getValue();
-//             int newVal = getIntValue();
-//
-//             log.debug("  cv={} oldCv value={} newVal={}", getCvNum(), oldCv, newVal);
-//             int max = (int)_maxVal;
-//             int newCv = setValueInCV(oldCv, newVal, getMask(), max-1);
-//             if (newCv != oldCv) {
-//                 cv.setValue(newCv);  // to prevent CV going EDITED during loading of decoder file
-//
-//                 // notify  (this used to be before setting the values)
-//                 log.debug("{} about to firePropertyChange", label());
-//                 prop.firePropertyChange("Value", null, oldVal);
-//                 log.debug("{} returned to from firePropertyChange", label());
-//             }
-//+             log.debug("{} end action event saw oldCv={} newVal={} newCv={}", label(), oldCv, newVal, newCv);
         }
         exitField();
     }

--- a/java/src/jmri/jmrit/symbolicprog/SplitEnumVariableValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/SplitEnumVariableValue.java
@@ -480,7 +480,8 @@ public class SplitEnumVariableValue extends VariableValue
             long newVal = 0;
             for (int i = 0; i < intVals.length; i++) {
                 newVal = newVal | (((long) intVals[i]) << cvList.get(i).startOffset);
-                log.debug("Variable={}; i={}; newVal={}", _name, i, getTextFromValue(newVal));
+                log.debug("Variable={}; i={}; intVals={}; startOffset={}; newVal={}",
+                    _name, i, intVals[i], cvList.get(i).startOffset, getTextFromValue(newVal));
             }
             log.debug("Variable={}; set value to {}", _name, newVal);
             setLongValue(newVal);  // check for duplicate is done inside setLongValue
@@ -579,7 +580,7 @@ public class SplitEnumVariableValue extends VariableValue
             // cv updates here trigger updated property changes, which means
             // we're going to get notified sooner or later.
             if (newCvVal != oldCvVal) {
-                thisCV.setValue(newCvVal);
+                thisCV.setValueWithoutUpdate(newCvVal);
             }
         }
         log.debug("Variable={}; exit updatedDropDown", _name);
@@ -620,10 +621,9 @@ public class SplitEnumVariableValue extends VariableValue
             }
             if (!(e.getActionCommand().equals(""))) {
                 // is from alternate rep
+                log.debug("{} action event {} was from alternate rep <<<<<<<<<<<<<<<<", label(), e.getActionCommand());
                 _value.setSelectedItem(e.getActionCommand());
-                if (log.isDebugEnabled()) {
-                    log.debug("{} action event was from alternate rep", label());
-                }
+
                 // match and select in tree
                 if (_nstored > 0) {
                     for (int i = 0; i < _nstored; i++) {
@@ -745,6 +745,7 @@ public class SplitEnumVariableValue extends VariableValue
 
     public void setLongValue(long value) {
         log.debug("Variable={}; enter setLongValue {}", _name, value);
+        new Exception("traceback").printStackTrace();
         long oldVal;
         try {
             oldVal = (Long.parseLong((String)_value.getSelectedItem()) - mOffset) / mFactor;
@@ -756,7 +757,8 @@ public class SplitEnumVariableValue extends VariableValue
         int lengthOfArray = this._valueArray.length;
 
         for (int i = 0; i < lengthOfArray; i++) {
-          if(this._valueArray[i] == value){
+          if (this._valueArray[i] == value){
+              log.trace("{} setLongValue setSelectedIndex to {}    <<<<<<<<<<<<<<<<", _name, i);
               _value.setSelectedIndex(i);
           }
         }
@@ -862,6 +864,7 @@ public class SplitEnumVariableValue extends VariableValue
             for (int i = 0; i < _nstored; i++) {
                 if (_valueArray[i] == value) {
                     //found it, select it
+                    log.debug("{}: selectValue sets to {}   <<<<<<<<<<<<<<<<", _name, i);
                     _value.setSelectedIndex(i);
 
                     // now select in the tree

--- a/java/src/jmri/jmrit/symbolicprog/SplitEnumVariableValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/SplitEnumVariableValue.java
@@ -1032,7 +1032,7 @@ public class SplitEnumVariableValue extends VariableValue
                         log.trace("propertyChange Busy _progState={} curState={}", _progState, curState);
                         if (curState == ValueState.READ) {   // was the last read successful?
                             retry = 0;
-                            log.debug("   Variable={}; Busy finds ValueState.READ cvCount={}", cvCount);
+                            log.debug("   Variable={}; Busy finds ValueState.READ cvCount={}", _name, cvCount);
                             if (Math.abs(_progState) < cvCount) {   // read next CV
                                 _progState++;
                                 log.debug("Reading CV={}", cvList.get(Math.abs(_progState) - 1).cvName);

--- a/java/src/jmri/jmrit/symbolicprog/SplitEnumVariableValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/SplitEnumVariableValue.java
@@ -616,7 +616,7 @@ public class SplitEnumVariableValue extends VariableValue
         // if from an alternate rep, it will contain the value to select
         if (e != null){
             if (log.isDebugEnabled()) {
-                log.debug("Variable = {} start action event cmd=", label(), e.getActionCommand());
+                log.debug("Variable = {} start action event cmd={}", label(), e.getActionCommand());
             }
             if (!(e.getActionCommand().equals(""))) {
                 // is from alternate rep

--- a/java/src/jmri/jmrit/symbolicprog/SplitEnumVariableValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/SplitEnumVariableValue.java
@@ -503,6 +503,7 @@ public class SplitEnumVariableValue extends VariableValue
      */
     void exitField(){
         // there may be a lost focus event left in the queue when disposed so protect
+        log.trace("exitField starts ****");
         if (_value != null && !oldContents.equals(_value.getSelectedItem())) {
             long newFieldVal = 0;
             try {
@@ -520,6 +521,7 @@ public class SplitEnumVariableValue extends VariableValue
                 prop.firePropertyChange("Value", oldVal, newVal);
             }
         }
+        log.trace("exitField ends  ****");
     }
 
     boolean _fieldShrink = false;
@@ -586,20 +588,23 @@ public class SplitEnumVariableValue extends VariableValue
     int[] getCvValsFromSingleInt(long newEntry) {
         // calculate resulting number
         long newVal = (newEntry - mOffset) / mFactor;
-        log.debug("Variable={};newEntry={};newVal={} with Offset={} + Factor={} applied", _name, newEntry, newVal, mOffset, mFactor);
+        log.debug("getCvValsFromSingleInt Variable={};newEntry={};newVal={} with Offset={} + Factor={} applied", _name, newEntry, newVal, mOffset, mFactor);
 
         int[] retVals = new int[cvCount];
 
         // extract individual values via masks
         for (int i = 0; i < cvCount; i++) {
+            log.trace("      Starting with newVal={} startOffset={} mask={} offsetVal={}",
+                        newVal, cvList.get(i).startOffset, maskValAsInt(cvList.get(i).cvMask), offsetVal(cvList.get(i).cvMask));
             retVals[i] = (((int) (newVal >>> cvList.get(i).startOffset))
                     & (maskValAsInt(cvList.get(i).cvMask) >>> offsetVal(cvList.get(i).cvMask)));
+            log.trace("      Calculated {} entry is {}", i, retVals[i]);
         }
         return retVals;
     }
 
     /**
-     * ActionListener implementation.
+     * ActionListener implementation. Called by new selection in the JComboBox representation.
      * <p>
      * Invokes {@link #exitField exitField()}
      *
@@ -611,7 +616,7 @@ public class SplitEnumVariableValue extends VariableValue
         // if from an alternate rep, it will contain the value to select
         if (e != null){
             if (log.isDebugEnabled()) {
-                log.debug("{} start action event: {}", label(), e);
+                log.debug("Variable = {} start action event cmd=", label(), e.getActionCommand());
             }
             if (!(e.getActionCommand().equals(""))) {
                 // is from alternate rep
@@ -645,19 +650,23 @@ public class SplitEnumVariableValue extends VariableValue
                 return;
             }
 
-            int oldCv = cv.getValue();
-            int newVal = getIntValue();
-            int max = (int)_maxVal;
-            int newCv = setValueInCV(oldCv, newVal, getMask(), max-1);
-            if (newCv != oldCv) {
-                cv.setValue(newCv);  // to prevent CV going EDITED during loading of decoder file
+            updatedDropDown(); //+
 
-                // notify  (this used to be before setting the values)
-                log.debug("{} about to firePropertyChange", label());
-                prop.firePropertyChange("Value", null, oldVal);
-                log.debug("{} returned to from firePropertyChange", label());
-            }
-            log.debug("{} end action event saw oldCv={} newVal={} newCv={}", label(), oldCv, newVal, newCv);
+//+             int oldCv = cv.getValue();
+//             int newVal = getIntValue();
+//
+//             log.debug("  cv={} oldCv value={} newVal={}", getCvNum(), oldCv, newVal);
+//             int max = (int)_maxVal;
+//             int newCv = setValueInCV(oldCv, newVal, getMask(), max-1);
+//             if (newCv != oldCv) {
+//                 cv.setValue(newCv);  // to prevent CV going EDITED during loading of decoder file
+//
+//                 // notify  (this used to be before setting the values)
+//                 log.debug("{} about to firePropertyChange", label());
+//                 prop.firePropertyChange("Value", null, oldVal);
+//                 log.debug("{} returned to from firePropertyChange", label());
+//             }
+//+             log.debug("{} end action event saw oldCv={} newVal={} newCv={}", label(), oldCv, newVal, newCv);
         }
         exitField();
     }
@@ -712,7 +721,7 @@ public class SplitEnumVariableValue extends VariableValue
         if (_value.getSelectedIndex() >= _valueArray.length || _value.getSelectedIndex() < 0) {
             log.error("trying to get value {} too large for array length {} in var {}", _value.getSelectedIndex(), _valueArray.length, label());
         }
-        log.debug("SelectedIndex={}", _value.getSelectedIndex());
+        log.debug("SelectedIndex={} value={}", _value.getSelectedIndex(), _valueArray[_value.getSelectedIndex()]);
         return _valueArray[_value.getSelectedIndex()];
     }
 
@@ -1104,12 +1113,13 @@ public class SplitEnumVariableValue extends VariableValue
                 // update value of Variable
 
                 //setLongValue(Long.parseLong((String)_value.getSelectedItem()));  // check for duplicate done inside setValue
-                log.info("update value of Variable {}", _name);
+                log.info("update value of Variable {} cvCount={}", _name, cvCount);
 
                 int[] intVals = new int[cvCount];
 
                 for (int i = 0; i < cvCount; i++) {
                     intVals[i] = (cvList.get(i).thisCV.getValue() & maskValAsInt(cvList.get(i).cvMask)) >>> offsetVal(cvList.get(i).cvMask);
+                    log.trace("   with intVal[{}] = {}", i, intVals[i]);
                 }
 
                 updateVariableValue(intVals);

--- a/xml/decoders/TCS_BachmannFT.xml
+++ b/xml/decoders/TCS_BachmannFT.xml
@@ -78,7 +78,7 @@
         </enumVal>
         <label>Select Prime Mover: </label>
       </variable>
-      <variable default="-1" item="Sound Option 4" mask="VVVVVVVV XVVVVVVV" CV="16.4.(258,257)">
+      <variable default="-1" item="Sound Option 4" mask="XVVVVVVV VVVVVVVV" CV="16.4.(258,257)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - EMD645 non turbo SW1500 #1567 Phillipsburg Air Compressor" value="0"/>
@@ -142,7 +142,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F0</label>
       </variable>
-      <variable default="3" item="Sound Option 5" mask="VVVVVVVV XVVVVVVV" CV="16.4.(260,259)">
+      <variable default="3" item="Sound Option 5" mask="XVVVVVVV VVVVVVVV" CV="16.4.(260,259)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - EMD645 non turbo SW1500 #1567 Phillipsburg Air Compressor" value="0"/>
@@ -206,7 +206,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F1</label>
       </variable>
-      <variable default="54" item="Sound Option 6" mask="VVVVVVVV XVVVVVVV" CV="16.4.(262,261)">
+      <variable default="54" item="Sound Option 6" mask="XVVVVVVV VVVVVVVV" CV="16.4.(262,261)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - EMD645 non turbo SW1500 #1567 Phillipsburg Air Compressor" value="0"/>
@@ -270,7 +270,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F2</label>
       </variable>
-      <variable default="70" item="Sound Option 7" mask="VVVVVVVV XVVVVVVV" CV="16.4.(264,263)">
+      <variable default="70" item="Sound Option 7" mask="XVVVVVVV VVVVVVVV" CV="16.4.(264,263)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - EMD645 non turbo SW1500 #1567 Phillipsburg Air Compressor" value="0"/>
@@ -334,7 +334,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F3</label>
       </variable>
-      <variable default="62" item="Sound Option 8" mask="VVVVVVVV XVVVVVVV" CV="16.4.(266,265)">
+      <variable default="62" item="Sound Option 8" mask="XVVVVVVV VVVVVVVV" CV="16.4.(266,265)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - EMD645 non turbo SW1500 #1567 Phillipsburg Air Compressor" value="0"/>
@@ -398,7 +398,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F4</label>
       </variable>
-      <variable default="9" item="Sound Option 9" mask="VVVVVVVV XVVVVVVV" CV="16.4.(268,267)">
+      <variable default="9" item="Sound Option 9" mask="XVVVVVVV VVVVVVVV" CV="16.4.(268,267)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - EMD645 non turbo SW1500 #1567 Phillipsburg Air Compressor" value="0"/>
@@ -462,7 +462,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F5</label>
       </variable>
-      <variable default="159" item="Sound Option 10" mask="VVVVVVVV XVVVVVVV" CV="16.4.(270,269)">
+      <variable default="159" item="Sound Option 10" mask="XVVVVVVV VVVVVVVV" CV="16.4.(270,269)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - EMD645 non turbo SW1500 #1567 Phillipsburg Air Compressor" value="0"/>
@@ -526,7 +526,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F6</label>
       </variable>
-      <variable default="-1" item="Sound Option 11" mask="VVVVVVVV XVVVVVVV" CV="16.4.(272,271)">
+      <variable default="-1" item="Sound Option 11" mask="XVVVVVVV VVVVVVVV" CV="16.4.(272,271)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - EMD645 non turbo SW1500 #1567 Phillipsburg Air Compressor" value="0"/>
@@ -590,7 +590,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F7</label>
       </variable>
-      <variable default="82" item="Sound Option 12" mask="VVVVVVVV XVVVVVVV" CV="16.4.(274,273)">
+      <variable default="82" item="Sound Option 12" mask="XVVVVVVV VVVVVVVV" CV="16.4.(274,273)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - EMD645 non turbo SW1500 #1567 Phillipsburg Air Compressor" value="0"/>
@@ -654,7 +654,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F8</label>
       </variable>
-      <variable default="-1" item="Sound Option 13" mask="VVVVVVVV XVVVVVVV" CV="16.4.(276,275)">
+      <variable default="-1" item="Sound Option 13" mask="XVVVVVVV VVVVVVVV" CV="16.4.(276,275)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - EMD645 non turbo SW1500 #1567 Phillipsburg Air Compressor" value="0"/>
@@ -718,7 +718,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F9</label>
       </variable>
-      <variable default="79" item="Sound Option 14" mask="VVVVVVVV XVVVVVVV" CV="16.4.(278,277)">
+      <variable default="79" item="Sound Option 14" mask="XVVVVVVV VVVVVVVV" CV="16.4.(278,277)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - EMD645 non turbo SW1500 #1567 Phillipsburg Air Compressor" value="0"/>
@@ -782,7 +782,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F10</label>
       </variable>
-      <variable default="78" item="Sound Option 15" mask="VVVVVVVV XVVVVVVV" CV="16.4.(280,279)">
+      <variable default="78" item="Sound Option 15" mask="XVVVVVVV VVVVVVVV" CV="16.4.(280,279)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - EMD645 non turbo SW1500 #1567 Phillipsburg Air Compressor" value="0"/>
@@ -846,7 +846,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F11</label>
       </variable>
-      <variable default="39" item="Sound Option 16" mask="VVVVVVVV XVVVVVVV" CV="16.4.(282,281)">
+      <variable default="39" item="Sound Option 16" mask="XVVVVVVV VVVVVVVV" CV="16.4.(282,281)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - EMD645 non turbo SW1500 #1567 Phillipsburg Air Compressor" value="0"/>
@@ -910,7 +910,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F12</label>
       </variable>
-      <variable default="40" item="Sound Option 17" mask="VVVVVVVV XVVVVVVV" CV="16.4.(284,283)">
+      <variable default="40" item="Sound Option 17" mask="XVVVVVVV VVVVVVVV" CV="16.4.(284,283)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - EMD645 non turbo SW1500 #1567 Phillipsburg Air Compressor" value="0"/>
@@ -974,7 +974,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F13</label>
       </variable>
-      <variable default="8" item="Sound Option 18" mask="VVVVVVVV XVVVVVVV" CV="16.4.(286,285)">
+      <variable default="8" item="Sound Option 18" mask="XVVVVVVV VVVVVVVV" CV="16.4.(286,285)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - EMD645 non turbo SW1500 #1567 Phillipsburg Air Compressor" value="0"/>
@@ -1038,7 +1038,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F14</label>
       </variable>
-      <variable default="42" item="Sound Option 19" mask="VVVVVVVV XVVVVVVV" CV="16.4.(288,287)">
+      <variable default="42" item="Sound Option 19" mask="XVVVVVVV VVVVVVVV" CV="16.4.(288,287)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - EMD645 non turbo SW1500 #1567 Phillipsburg Air Compressor" value="0"/>
@@ -1102,7 +1102,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F15</label>
       </variable>
-      <variable default="80" item="Sound Option 20" mask="VVVVVVVV XVVVVVVV" CV="16.4.(290,289)">
+      <variable default="80" item="Sound Option 20" mask="XVVVVVVV VVVVVVVV" CV="16.4.(290,289)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - EMD645 non turbo SW1500 #1567 Phillipsburg Air Compressor" value="0"/>
@@ -1166,7 +1166,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F16</label>
       </variable>
-      <variable default="41" item="Sound Option 21" mask="VVVVVVVV XVVVVVVV" CV="16.4.(292,291)">
+      <variable default="41" item="Sound Option 21" mask="XVVVVVVV VVVVVVVV" CV="16.4.(292,291)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - EMD645 non turbo SW1500 #1567 Phillipsburg Air Compressor" value="0"/>
@@ -1230,7 +1230,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F17</label>
       </variable>
-      <variable default="83" item="Sound Option 22" mask="VVVVVVVV XVVVVVVV" CV="16.4.(294,293)">
+      <variable default="83" item="Sound Option 22" mask="XVVVVVVV VVVVVVVV" CV="16.4.(294,293)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - EMD645 non turbo SW1500 #1567 Phillipsburg Air Compressor" value="0"/>
@@ -1294,7 +1294,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F18</label>
       </variable>
-      <variable default="-1" item="Sound Option 23" mask="VVVVVVVV XVVVVVVV" CV="16.4.(296,295)">
+      <variable default="-1" item="Sound Option 23" mask="XVVVVVVV VVVVVVVV" CV="16.4.(296,295)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - EMD645 non turbo SW1500 #1567 Phillipsburg Air Compressor" value="0"/>
@@ -1358,7 +1358,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F19</label>
       </variable>
-      <variable default="2" item="Sound Option 24" mask="VVVVVVVV XVVVVVVV" CV="16.4.(298,297)">
+      <variable default="2" item="Sound Option 24" mask="XVVVVVVV VVVVVVVV" CV="16.4.(298,297)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - EMD645 non turbo SW1500 #1567 Phillipsburg Air Compressor" value="0"/>
@@ -1422,7 +1422,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F20</label>
       </variable>
-      <variable default="46" item="Sound Option 25" mask="VVVVVVVV XVVVVVVV" CV="16.4.(300,299)">
+      <variable default="46" item="Sound Option 25" mask="XVVVVVVV VVVVVVVV" CV="16.4.(300,299)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - EMD645 non turbo SW1500 #1567 Phillipsburg Air Compressor" value="0"/>
@@ -1486,7 +1486,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F21</label>
       </variable>
-      <variable default="161" item="Sound Option 26" mask="VVVVVVVV XVVVVVVV" CV="16.4.(302,301)">
+      <variable default="161" item="Sound Option 26" mask="XVVVVVVV VVVVVVVV" CV="16.4.(302,301)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - EMD645 non turbo SW1500 #1567 Phillipsburg Air Compressor" value="0"/>
@@ -1550,7 +1550,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F22</label>
       </variable>
-      <variable default="177" item="Sound Option 27" mask="VVVVVVVV XVVVVVVV" CV="16.4.(304,303)">
+      <variable default="177" item="Sound Option 27" mask="XVVVVVVV VVVVVVVV" CV="16.4.(304,303)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - EMD645 non turbo SW1500 #1567 Phillipsburg Air Compressor" value="0"/>
@@ -1614,7 +1614,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F23</label>
       </variable>
-      <variable default="169" item="Sound Option 28" mask="VVVVVVVV XVVVVVVV" CV="16.4.(306,305)">
+      <variable default="169" item="Sound Option 28" mask="XVVVVVVV VVVVVVVV" CV="16.4.(306,305)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - EMD645 non turbo SW1500 #1567 Phillipsburg Air Compressor" value="0"/>
@@ -1678,7 +1678,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F24</label>
       </variable>
-      <variable default="185" item="Sound Option 29" mask="VVVVVVVV XVVVVVVV" CV="16.4.(308,307)">
+      <variable default="185" item="Sound Option 29" mask="XVVVVVVV VVVVVVVV" CV="16.4.(308,307)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - EMD645 non turbo SW1500 #1567 Phillipsburg Air Compressor" value="0"/>
@@ -1742,7 +1742,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F25</label>
       </variable>
-      <variable default="45" item="Sound Option 30" mask="VVVVVVVV XVVVVVVV" CV="16.4.(310,309)">
+      <variable default="45" item="Sound Option 30" mask="XVVVVVVV VVVVVVVV" CV="16.4.(310,309)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - EMD645 non turbo SW1500 #1567 Phillipsburg Air Compressor" value="0"/>
@@ -1806,7 +1806,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F26</label>
       </variable>
-      <variable default="-1" item="Sound Option 31" mask="VVVVVVVV XVVVVVVV" CV="16.4.(312,311)">
+      <variable default="-1" item="Sound Option 31" mask="XVVVVVVV VVVVVVVV" CV="16.4.(312,311)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - EMD645 non turbo SW1500 #1567 Phillipsburg Air Compressor" value="0"/>
@@ -1870,7 +1870,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F27</label>
       </variable>
-      <variable default="84" item="Sound Option 32" mask="VVVVVVVV XVVVVVVV" CV="16.4.(314,313)">
+      <variable default="84" item="Sound Option 32" mask="XVVVVVVV VVVVVVVV" CV="16.4.(314,313)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - EMD645 non turbo SW1500 #1567 Phillipsburg Air Compressor" value="0"/>
@@ -1934,7 +1934,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F28</label>
       </variable>
-      <variable default="0" item="Sound Option 33" mask="VVVVVVVV XVVVVVVV" CV="16.4.(316,315)">
+      <variable default="0" item="Sound Option 33" mask="XVVVVVVV VVVVVVVV" CV="16.4.(316,315)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - EMD645 non turbo SW1500 #1567 Phillipsburg Air Compressor" value="0"/>
@@ -1998,7 +1998,7 @@
         </splitEnumVal>
         <label>Sound Mapping for R1</label>
       </variable>
-      <variable default="1" item="Sound Option 34" mask="VVVVVVVV XVVVVVVV" CV="16.4.(318,317)">
+      <variable default="1" item="Sound Option 34" mask="XVVVVVVV VVVVVVVV" CV="16.4.(318,317)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - EMD645 non turbo SW1500 #1567 Phillipsburg Air Compressor" value="0"/>
@@ -2062,7 +2062,7 @@
         </splitEnumVal>
         <label>Sound Mapping for R2</label>
       </variable>
-      <variable default="-1" item="Sound Option 35" mask="VVVVVVVV XVVVVVVV" CV="16.4.(320,319)">
+      <variable default="-1" item="Sound Option 35" mask="XVVVVVVV VVVVVVVV" CV="16.4.(320,319)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - EMD645 non turbo SW1500 #1567 Phillipsburg Air Compressor" value="0"/>
@@ -2126,7 +2126,7 @@
         </splitEnumVal>
         <label>Sound Mapping for R3</label>
       </variable>
-      <variable default="-1" item="Sound Option 36" mask="VVVVVVVV XVVVVVVV" CV="16.4.(322,321)">
+      <variable default="-1" item="Sound Option 36" mask="XVVVVVVV VVVVVVVV" CV="16.4.(322,321)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - EMD645 non turbo SW1500 #1567 Phillipsburg Air Compressor" value="0"/>
@@ -2190,7 +2190,7 @@
         </splitEnumVal>
         <label>Sound Mapping for R4</label>
       </variable>
-      <variable default="-1" item="Sound Option 37" mask="VVVVVVVV XVVVVVVV" CV="16.4.(324,323)">
+      <variable default="-1" item="Sound Option 37" mask="XVVVVVVV VVVVVVVV" CV="16.4.(324,323)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - EMD645 non turbo SW1500 #1567 Phillipsburg Air Compressor" value="0"/>
@@ -8235,11 +8235,11 @@
               </label><separator/><label>
                 <text> </text>
               </label>
-              
-              
+
+
   <row>
         <column>
-            <row> 
+            <row>
                   <display item="Function F0F effect generated"/><separator/>
                   <display item="Function F0R effect generated"/>
             </row>
@@ -8362,7 +8362,7 @@
               <label>
                  <text>Lighting Preset: 'Auto Mars'</text>
               </label>
-              
+
            </griditem>
            <griditem gridx="1" gridy="0">
               <display item="Lighting Preset 0 - Step 0 - Start Brightness">
@@ -8568,7 +8568,7 @@
               <label>
                  <text>Lighting Preset: 'Brake Lights'</text>
               </label>
-              
+
            </griditem>
            <griditem gridx="1" gridy="4">
               <display item="Lighting Preset 1 - Step 0 - Start Brightness">
@@ -8774,7 +8774,7 @@
               <label>
                  <text>Lighting Preset: 'Rotary Beacon (New Style)'</text>
               </label>
-              
+
            </griditem>
            <griditem gridx="1" gridy="8">
               <display item="Lighting Preset 2 - Step 0 - Start Brightness">
@@ -8980,7 +8980,7 @@
               <label>
                  <text>Lighting Preset: 'Constant Bright'</text>
               </label>
-              
+
            </griditem>
            <griditem gridx="1" gridy="12">
               <display item="Lighting Preset 3 - Step 0 - Start Brightness">
@@ -9186,7 +9186,7 @@
               <label>
                  <text>Lighting Preset: 'Flashing F.R.E.D.'</text>
               </label>
-              
+
            </griditem>
            <griditem gridx="1" gridy="16">
               <display item="Lighting Preset 4 - Step 0 - Start Brightness">
@@ -9392,7 +9392,7 @@
               <label>
                  <text>Lighting Preset: 'Constant Dim'</text>
               </label>
-              
+
            </griditem>
            <griditem gridx="1" gridy="20">
               <display item="Lighting Preset 5 - Step 0 - Start Brightness">
@@ -9598,7 +9598,7 @@
               <label>
                  <text>Lighting Preset: 'Ditch Light Side 2'</text>
               </label>
-              
+
            </griditem>
            <griditem gridx="1" gridy="24">
               <display item="Lighting Preset 6 - Step 0 - Start Brightness">
@@ -9804,7 +9804,7 @@
               <label>
                  <text>Lighting Preset: 'Ditch Light Side 1'</text>
               </label>
-              
+
            </griditem>
            <griditem gridx="1" gridy="28">
               <display item="Lighting Preset 7 - Step 0 - Start Brightness">
@@ -10010,7 +10010,7 @@
               <label>
                  <text>Lighting Preset: 'Single Pulse Strobe'</text>
               </label>
-              
+
            </griditem>
            <griditem gridx="1" gridy="32">
               <display item="Lighting Preset 8 - Step 0 - Start Brightness">
@@ -10216,7 +10216,7 @@
               <label>
                  <text>Lighting Preset: 'Firebox Flicker'</text>
               </label>
-              
+
            </griditem>
            <griditem gridx="1" gridy="36">
               <display item="Lighting Preset 9 - Step 0 - Start Brightness">
@@ -10422,7 +10422,7 @@
               <label>
                  <text>Lighting Preset: 'Custom Light 1'</text>
               </label>
-              
+
            </griditem>
            <griditem gridx="1" gridy="40">
               <display item="Lighting Preset 10 - Step 0 - Start Brightness">
@@ -10628,7 +10628,7 @@
               <label>
                  <text>Lighting Preset: 'Rotary Beacon (Old style)'</text>
               </label>
-              
+
            </griditem>
            <griditem gridx="1" gridy="44">
               <display item="Lighting Preset 11 - Step 0 - Start Brightness">
@@ -10834,7 +10834,7 @@
               <label>
                  <text>Lighting Preset: 'Gyra Light'</text>
               </label>
-              
+
            </griditem>
            <griditem gridx="1" gridy="48">
               <display item="Lighting Preset 12 - Step 0 - Start Brightness">
@@ -11040,7 +11040,7 @@
               <label>
                  <text>Lighting Preset: 'Double Pulse Strobe'</text>
               </label>
-              
+
            </griditem>
            <griditem gridx="1" gridy="52">
               <display item="Lighting Preset 13 - Step 0 - Start Brightness">
@@ -11246,7 +11246,7 @@
               <label>
                  <text>Lighting Preset: 'Mars Light'</text>
               </label>
-              
+
            </griditem>
            <griditem gridx="1" gridy="56">
               <display item="Lighting Preset 14 - Step 0 - Start Brightness">
@@ -11452,7 +11452,7 @@
               <label>
                  <text>Lighting Preset: 'Rule 17'</text>
               </label>
-              
+
            </griditem>
            <griditem gridx="1" gridy="60">
               <display item="Lighting Preset 15 - Step 0 - Start Brightness">
@@ -11658,7 +11658,7 @@
               <label>
                  <text>Lighting Preset: 'Custom Light 2'</text>
               </label>
-              
+
            </griditem>
            <griditem gridx="1" gridy="64">
               <display item="Lighting Preset 16 - Step 0 - Start Brightness">

--- a/xml/decoders/TCS_BachmannGP35.xml
+++ b/xml/decoders/TCS_BachmannGP35.xml
@@ -78,7 +78,7 @@
         </enumVal>
         <label>Select Prime Mover: </label>
       </variable>
-      <variable default="-1" item="Sound Option 4" mask="VVVVVVVV XVVVVVVV" CV="16.4.(258,257)">
+      <variable default="-1" item="Sound Option 4" mask="XVVVVVVV VVVVVVVV" CV="16.4.(258,257)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - EMD645 non turbo SW1500 #1567 Phillipsburg Air Compressor" value="0"/>
@@ -142,7 +142,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F0</label>
       </variable>
-      <variable default="3" item="Sound Option 5" mask="VVVVVVVV XVVVVVVV" CV="16.4.(260,259)">
+      <variable default="3" item="Sound Option 5" mask="XVVVVVVV VVVVVVVV" CV="16.4.(260,259)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - EMD645 non turbo SW1500 #1567 Phillipsburg Air Compressor" value="0"/>
@@ -206,7 +206,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F1</label>
       </variable>
-      <variable default="54" item="Sound Option 6" mask="VVVVVVVV XVVVVVVV" CV="16.4.(262,261)">
+      <variable default="54" item="Sound Option 6" mask="XVVVVVVV VVVVVVVV" CV="16.4.(262,261)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - EMD645 non turbo SW1500 #1567 Phillipsburg Air Compressor" value="0"/>
@@ -270,7 +270,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F2</label>
       </variable>
-      <variable default="70" item="Sound Option 7" mask="VVVVVVVV XVVVVVVV" CV="16.4.(264,263)">
+      <variable default="70" item="Sound Option 7" mask="XVVVVVVV VVVVVVVV" CV="16.4.(264,263)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - EMD645 non turbo SW1500 #1567 Phillipsburg Air Compressor" value="0"/>
@@ -334,7 +334,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F3</label>
       </variable>
-      <variable default="62" item="Sound Option 8" mask="VVVVVVVV XVVVVVVV" CV="16.4.(266,265)">
+      <variable default="62" item="Sound Option 8" mask="XVVVVVVV VVVVVVVV" CV="16.4.(266,265)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - EMD645 non turbo SW1500 #1567 Phillipsburg Air Compressor" value="0"/>
@@ -398,7 +398,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F4</label>
       </variable>
-      <variable default="9" item="Sound Option 9" mask="VVVVVVVV XVVVVVVV" CV="16.4.(268,267)">
+      <variable default="9" item="Sound Option 9" mask="XVVVVVVV VVVVVVVV" CV="16.4.(268,267)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - EMD645 non turbo SW1500 #1567 Phillipsburg Air Compressor" value="0"/>
@@ -462,7 +462,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F5</label>
       </variable>
-      <variable default="159" item="Sound Option 10" mask="VVVVVVVV XVVVVVVV" CV="16.4.(270,269)">
+      <variable default="159" item="Sound Option 10" mask="XVVVVVVV VVVVVVVV" CV="16.4.(270,269)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - EMD645 non turbo SW1500 #1567 Phillipsburg Air Compressor" value="0"/>
@@ -526,7 +526,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F6</label>
       </variable>
-      <variable default="-1" item="Sound Option 11" mask="VVVVVVVV XVVVVVVV" CV="16.4.(272,271)">
+      <variable default="-1" item="Sound Option 11" mask="XVVVVVVV VVVVVVVV" CV="16.4.(272,271)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - EMD645 non turbo SW1500 #1567 Phillipsburg Air Compressor" value="0"/>
@@ -590,7 +590,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F7</label>
       </variable>
-      <variable default="82" item="Sound Option 12" mask="VVVVVVVV XVVVVVVV" CV="16.4.(274,273)">
+      <variable default="82" item="Sound Option 12" mask="XVVVVVVV VVVVVVVV" CV="16.4.(274,273)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - EMD645 non turbo SW1500 #1567 Phillipsburg Air Compressor" value="0"/>
@@ -654,7 +654,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F8</label>
       </variable>
-      <variable default="-1" item="Sound Option 13" mask="VVVVVVVV XVVVVVVV" CV="16.4.(276,275)">
+      <variable default="-1" item="Sound Option 13" mask="XVVVVVVV VVVVVVVV" CV="16.4.(276,275)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - EMD645 non turbo SW1500 #1567 Phillipsburg Air Compressor" value="0"/>
@@ -718,7 +718,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F9</label>
       </variable>
-      <variable default="79" item="Sound Option 14" mask="VVVVVVVV XVVVVVVV" CV="16.4.(278,277)">
+      <variable default="79" item="Sound Option 14" mask="XVVVVVVV VVVVVVVV" CV="16.4.(278,277)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - EMD645 non turbo SW1500 #1567 Phillipsburg Air Compressor" value="0"/>
@@ -782,7 +782,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F10</label>
       </variable>
-      <variable default="78" item="Sound Option 15" mask="VVVVVVVV XVVVVVVV" CV="16.4.(280,279)">
+      <variable default="78" item="Sound Option 15" mask="XVVVVVVV VVVVVVVV" CV="16.4.(280,279)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - EMD645 non turbo SW1500 #1567 Phillipsburg Air Compressor" value="0"/>
@@ -846,7 +846,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F11</label>
       </variable>
-      <variable default="39" item="Sound Option 16" mask="VVVVVVVV XVVVVVVV" CV="16.4.(282,281)">
+      <variable default="39" item="Sound Option 16" mask="XVVVVVVV VVVVVVVV" CV="16.4.(282,281)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - EMD645 non turbo SW1500 #1567 Phillipsburg Air Compressor" value="0"/>
@@ -910,7 +910,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F12</label>
       </variable>
-      <variable default="40" item="Sound Option 17" mask="VVVVVVVV XVVVVVVV" CV="16.4.(284,283)">
+      <variable default="40" item="Sound Option 17" mask="XVVVVVVV VVVVVVVV" CV="16.4.(284,283)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - EMD645 non turbo SW1500 #1567 Phillipsburg Air Compressor" value="0"/>
@@ -974,7 +974,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F13</label>
       </variable>
-      <variable default="8" item="Sound Option 18" mask="VVVVVVVV XVVVVVVV" CV="16.4.(286,285)">
+      <variable default="8" item="Sound Option 18" mask="XVVVVVVV VVVVVVVV" CV="16.4.(286,285)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - EMD645 non turbo SW1500 #1567 Phillipsburg Air Compressor" value="0"/>
@@ -1038,7 +1038,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F14</label>
       </variable>
-      <variable default="42" item="Sound Option 19" mask="VVVVVVVV XVVVVVVV" CV="16.4.(288,287)">
+      <variable default="42" item="Sound Option 19" mask="XVVVVVVV VVVVVVVV" CV="16.4.(288,287)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - EMD645 non turbo SW1500 #1567 Phillipsburg Air Compressor" value="0"/>
@@ -1102,7 +1102,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F15</label>
       </variable>
-      <variable default="80" item="Sound Option 20" mask="VVVVVVVV XVVVVVVV" CV="16.4.(290,289)">
+      <variable default="80" item="Sound Option 20" mask="XVVVVVVV VVVVVVVV" CV="16.4.(290,289)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - EMD645 non turbo SW1500 #1567 Phillipsburg Air Compressor" value="0"/>
@@ -1166,7 +1166,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F16</label>
       </variable>
-      <variable default="41" item="Sound Option 21" mask="VVVVVVVV XVVVVVVV" CV="16.4.(292,291)">
+      <variable default="41" item="Sound Option 21" mask="XVVVVVVV VVVVVVVV" CV="16.4.(292,291)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - EMD645 non turbo SW1500 #1567 Phillipsburg Air Compressor" value="0"/>
@@ -1230,7 +1230,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F17</label>
       </variable>
-      <variable default="83" item="Sound Option 22" mask="VVVVVVVV XVVVVVVV" CV="16.4.(294,293)">
+      <variable default="83" item="Sound Option 22" mask="XVVVVVVV VVVVVVVV" CV="16.4.(294,293)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - EMD645 non turbo SW1500 #1567 Phillipsburg Air Compressor" value="0"/>
@@ -1294,7 +1294,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F18</label>
       </variable>
-      <variable default="-1" item="Sound Option 23" mask="VVVVVVVV XVVVVVVV" CV="16.4.(296,295)">
+      <variable default="-1" item="Sound Option 23" mask="XVVVVVVV VVVVVVVV" CV="16.4.(296,295)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - EMD645 non turbo SW1500 #1567 Phillipsburg Air Compressor" value="0"/>
@@ -1358,7 +1358,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F19</label>
       </variable>
-      <variable default="1" item="Sound Option 24" mask="VVVVVVVV XVVVVVVV" CV="16.4.(298,297)">
+      <variable default="1" item="Sound Option 24" mask="XVVVVVVV VVVVVVVV" CV="16.4.(298,297)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - EMD645 non turbo SW1500 #1567 Phillipsburg Air Compressor" value="0"/>
@@ -1422,7 +1422,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F20</label>
       </variable>
-      <variable default="46" item="Sound Option 25" mask="VVVVVVVV XVVVVVVV" CV="16.4.(300,299)">
+      <variable default="46" item="Sound Option 25" mask="XVVVVVVV VVVVVVVV" CV="16.4.(300,299)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - EMD645 non turbo SW1500 #1567 Phillipsburg Air Compressor" value="0"/>
@@ -1486,7 +1486,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F21</label>
       </variable>
-      <variable default="161" item="Sound Option 26" mask="VVVVVVVV XVVVVVVV" CV="16.4.(302,301)">
+      <variable default="161" item="Sound Option 26" mask="XVVVVVVV VVVVVVVV" CV="16.4.(302,301)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - EMD645 non turbo SW1500 #1567 Phillipsburg Air Compressor" value="0"/>
@@ -1550,7 +1550,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F22</label>
       </variable>
-      <variable default="177" item="Sound Option 27" mask="VVVVVVVV XVVVVVVV" CV="16.4.(304,303)">
+      <variable default="177" item="Sound Option 27" mask="XVVVVVVV VVVVVVVV" CV="16.4.(304,303)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - EMD645 non turbo SW1500 #1567 Phillipsburg Air Compressor" value="0"/>
@@ -1614,7 +1614,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F23</label>
       </variable>
-      <variable default="169" item="Sound Option 28" mask="VVVVVVVV XVVVVVVV" CV="16.4.(306,305)">
+      <variable default="169" item="Sound Option 28" mask="XVVVVVVV VVVVVVVV" CV="16.4.(306,305)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - EMD645 non turbo SW1500 #1567 Phillipsburg Air Compressor" value="0"/>
@@ -1678,7 +1678,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F24</label>
       </variable>
-      <variable default="185" item="Sound Option 29" mask="VVVVVVVV XVVVVVVV" CV="16.4.(308,307)">
+      <variable default="185" item="Sound Option 29" mask="XVVVVVVV VVVVVVVV" CV="16.4.(308,307)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - EMD645 non turbo SW1500 #1567 Phillipsburg Air Compressor" value="0"/>
@@ -1742,7 +1742,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F25</label>
       </variable>
-      <variable default="45" item="Sound Option 30" mask="VVVVVVVV XVVVVVVV" CV="16.4.(310,309)">
+      <variable default="45" item="Sound Option 30" mask="XVVVVVVV VVVVVVVV" CV="16.4.(310,309)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - EMD645 non turbo SW1500 #1567 Phillipsburg Air Compressor" value="0"/>
@@ -1806,7 +1806,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F26</label>
       </variable>
-      <variable default="-1" item="Sound Option 31" mask="VVVVVVVV XVVVVVVV" CV="16.4.(312,311)">
+      <variable default="-1" item="Sound Option 31" mask="XVVVVVVV VVVVVVVV" CV="16.4.(312,311)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - EMD645 non turbo SW1500 #1567 Phillipsburg Air Compressor" value="0"/>
@@ -1870,7 +1870,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F27</label>
       </variable>
-      <variable default="84" item="Sound Option 32" mask="VVVVVVVV XVVVVVVV" CV="16.4.(314,313)">
+      <variable default="84" item="Sound Option 32" mask="XVVVVVVV VVVVVVVV" CV="16.4.(314,313)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - EMD645 non turbo SW1500 #1567 Phillipsburg Air Compressor" value="0"/>
@@ -1934,7 +1934,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F28</label>
       </variable>
-      <variable default="0" item="Sound Option 33" mask="VVVVVVVV XVVVVVVV" CV="16.4.(316,315)">
+      <variable default="0" item="Sound Option 33" mask="XVVVVVVV VVVVVVVV" CV="16.4.(316,315)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - EMD645 non turbo SW1500 #1567 Phillipsburg Air Compressor" value="0"/>
@@ -1998,7 +1998,7 @@
         </splitEnumVal>
         <label>Sound Mapping for R1</label>
       </variable>
-      <variable default="2" item="Sound Option 34" mask="VVVVVVVV XVVVVVVV" CV="16.4.(318,317)">
+      <variable default="2" item="Sound Option 34" mask="XVVVVVVV VVVVVVVV" CV="16.4.(318,317)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - EMD645 non turbo SW1500 #1567 Phillipsburg Air Compressor" value="0"/>
@@ -2062,7 +2062,7 @@
         </splitEnumVal>
         <label>Sound Mapping for R2</label>
       </variable>
-      <variable default="-1" item="Sound Option 35" mask="VVVVVVVV XVVVVVVV" CV="16.4.(320,319)">
+      <variable default="-1" item="Sound Option 35" mask="XVVVVVVV VVVVVVVV" CV="16.4.(320,319)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - EMD645 non turbo SW1500 #1567 Phillipsburg Air Compressor" value="0"/>
@@ -2126,7 +2126,7 @@
         </splitEnumVal>
         <label>Sound Mapping for R3</label>
       </variable>
-      <variable default="-1" item="Sound Option 36" mask="VVVVVVVV XVVVVVVV" CV="16.4.(322,321)">
+      <variable default="-1" item="Sound Option 36" mask="XVVVVVVV VVVVVVVV" CV="16.4.(322,321)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - EMD645 non turbo SW1500 #1567 Phillipsburg Air Compressor" value="0"/>
@@ -2190,7 +2190,7 @@
         </splitEnumVal>
         <label>Sound Mapping for R4</label>
       </variable>
-      <variable default="-1" item="Sound Option 37" mask="VVVVVVVV XVVVVVVV" CV="16.4.(324,323)">
+      <variable default="-1" item="Sound Option 37" mask="XVVVVVVV VVVVVVVV" CV="16.4.(324,323)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - EMD645 non turbo SW1500 #1567 Phillipsburg Air Compressor" value="0"/>
@@ -8235,11 +8235,11 @@
               </label><separator/><label>
                 <text> </text>
               </label>
-              
-              
+
+
   <row>
         <column>
-            <row> 
+            <row>
                   <display item="Function F0F effect generated"/><separator/>
                   <display item="Function F0R effect generated"/>
             </row>
@@ -8362,7 +8362,7 @@
               <label>
                  <text>Lighting Preset: 'Auto Mars'</text>
               </label>
-              
+
            </griditem>
            <griditem gridx="1" gridy="0">
               <display item="Lighting Preset 0 - Step 0 - Start Brightness">
@@ -8568,7 +8568,7 @@
               <label>
                  <text>Lighting Preset: 'Brake Lights'</text>
               </label>
-              
+
            </griditem>
            <griditem gridx="1" gridy="4">
               <display item="Lighting Preset 1 - Step 0 - Start Brightness">
@@ -8774,7 +8774,7 @@
               <label>
                  <text>Lighting Preset: 'Rotary Beacon (New Style)'</text>
               </label>
-              
+
            </griditem>
            <griditem gridx="1" gridy="8">
               <display item="Lighting Preset 2 - Step 0 - Start Brightness">
@@ -8980,7 +8980,7 @@
               <label>
                  <text>Lighting Preset: 'Constant Bright'</text>
               </label>
-              
+
            </griditem>
            <griditem gridx="1" gridy="12">
               <display item="Lighting Preset 3 - Step 0 - Start Brightness">
@@ -9186,7 +9186,7 @@
               <label>
                  <text>Lighting Preset: 'Flashing F.R.E.D.'</text>
               </label>
-              
+
            </griditem>
            <griditem gridx="1" gridy="16">
               <display item="Lighting Preset 4 - Step 0 - Start Brightness">
@@ -9392,7 +9392,7 @@
               <label>
                  <text>Lighting Preset: 'Constant Dim'</text>
               </label>
-              
+
            </griditem>
            <griditem gridx="1" gridy="20">
               <display item="Lighting Preset 5 - Step 0 - Start Brightness">
@@ -9598,7 +9598,7 @@
               <label>
                  <text>Lighting Preset: 'Ditch Light Side 2'</text>
               </label>
-              
+
            </griditem>
            <griditem gridx="1" gridy="24">
               <display item="Lighting Preset 6 - Step 0 - Start Brightness">
@@ -9804,7 +9804,7 @@
               <label>
                  <text>Lighting Preset: 'Ditch Light Side 1'</text>
               </label>
-              
+
            </griditem>
            <griditem gridx="1" gridy="28">
               <display item="Lighting Preset 7 - Step 0 - Start Brightness">
@@ -10010,7 +10010,7 @@
               <label>
                  <text>Lighting Preset: 'Single Pulse Strobe'</text>
               </label>
-              
+
            </griditem>
            <griditem gridx="1" gridy="32">
               <display item="Lighting Preset 8 - Step 0 - Start Brightness">
@@ -10216,7 +10216,7 @@
               <label>
                  <text>Lighting Preset: 'Firebox Flicker'</text>
               </label>
-              
+
            </griditem>
            <griditem gridx="1" gridy="36">
               <display item="Lighting Preset 9 - Step 0 - Start Brightness">
@@ -10422,7 +10422,7 @@
               <label>
                  <text>Lighting Preset: 'Custom Light 1'</text>
               </label>
-              
+
            </griditem>
            <griditem gridx="1" gridy="40">
               <display item="Lighting Preset 10 - Step 0 - Start Brightness">
@@ -10628,7 +10628,7 @@
               <label>
                  <text>Lighting Preset: 'Rotary Beacon (Old style)'</text>
               </label>
-              
+
            </griditem>
            <griditem gridx="1" gridy="44">
               <display item="Lighting Preset 11 - Step 0 - Start Brightness">
@@ -10834,7 +10834,7 @@
               <label>
                  <text>Lighting Preset: 'Gyra Light'</text>
               </label>
-              
+
            </griditem>
            <griditem gridx="1" gridy="48">
               <display item="Lighting Preset 12 - Step 0 - Start Brightness">
@@ -11040,7 +11040,7 @@
               <label>
                  <text>Lighting Preset: 'Double Pulse Strobe'</text>
               </label>
-              
+
            </griditem>
            <griditem gridx="1" gridy="52">
               <display item="Lighting Preset 13 - Step 0 - Start Brightness">
@@ -11246,7 +11246,7 @@
               <label>
                  <text>Lighting Preset: 'Mars Light'</text>
               </label>
-              
+
            </griditem>
            <griditem gridx="1" gridy="56">
               <display item="Lighting Preset 14 - Step 0 - Start Brightness">
@@ -11452,7 +11452,7 @@
               <label>
                  <text>Lighting Preset: 'Rule 17'</text>
               </label>
-              
+
            </griditem>
            <griditem gridx="1" gridy="60">
               <display item="Lighting Preset 15 - Step 0 - Start Brightness">
@@ -11658,7 +11658,7 @@
               <label>
                  <text>Lighting Preset: 'Custom Light 2'</text>
               </label>
-              
+
            </griditem>
            <griditem gridx="1" gridy="64">
               <display item="Lighting Preset 16 - Step 0 - Start Brightness">

--- a/xml/decoders/TCS_BachmannRS3.xml
+++ b/xml/decoders/TCS_BachmannRS3.xml
@@ -78,7 +78,7 @@
         </enumVal>
         <label>Select Prime Mover: </label>
       </variable>
-      <variable default="-1" item="Sound Option 4" mask="VVVVVVVV XVVVVVVV" CV="16.4.(258,257)">
+      <variable default="-1" item="Sound Option 4" mask="XVVVVVVV VVVVVVVV" CV="16.4.(258,257)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - ALCO 251 compressor #503" value="0"/>
@@ -143,7 +143,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F0</label>
       </variable>
-      <variable default="4" item="Sound Option 5" mask="VVVVVVVV XVVVVVVV" CV="16.4.(260,259)">
+      <variable default="4" item="Sound Option 5" mask="XVVVVVVV VVVVVVVV" CV="16.4.(260,259)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - ALCO 251 compressor #503" value="0"/>
@@ -208,7 +208,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F1</label>
       </variable>
-      <variable default="55" item="Sound Option 6" mask="VVVVVVVV XVVVVVVV" CV="16.4.(262,261)">
+      <variable default="55" item="Sound Option 6" mask="XVVVVVVV VVVVVVVV" CV="16.4.(262,261)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - ALCO 251 compressor #503" value="0"/>
@@ -273,7 +273,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F2</label>
       </variable>
-      <variable default="71" item="Sound Option 7" mask="VVVVVVVV XVVVVVVV" CV="16.4.(264,263)">
+      <variable default="71" item="Sound Option 7" mask="XVVVVVVV VVVVVVVV" CV="16.4.(264,263)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - ALCO 251 compressor #503" value="0"/>
@@ -338,7 +338,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F3</label>
       </variable>
-      <variable default="63" item="Sound Option 8" mask="VVVVVVVV XVVVVVVV" CV="16.4.(266,265)">
+      <variable default="63" item="Sound Option 8" mask="XVVVVVVV VVVVVVVV" CV="16.4.(266,265)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - ALCO 251 compressor #503" value="0"/>
@@ -403,7 +403,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F4</label>
       </variable>
-      <variable default="10" item="Sound Option 9" mask="VVVVVVVV XVVVVVVV" CV="16.4.(268,267)">
+      <variable default="10" item="Sound Option 9" mask="XVVVVVVV VVVVVVVV" CV="16.4.(268,267)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - ALCO 251 compressor #503" value="0"/>
@@ -468,7 +468,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F5</label>
       </variable>
-      <variable default="160" item="Sound Option 10" mask="VVVVVVVV XVVVVVVV" CV="16.4.(270,269)">
+      <variable default="160" item="Sound Option 10" mask="XVVVVVVV VVVVVVVV" CV="16.4.(270,269)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - ALCO 251 compressor #503" value="0"/>
@@ -533,7 +533,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F6</label>
       </variable>
-      <variable default="-1" item="Sound Option 11" mask="VVVVVVVV XVVVVVVV" CV="16.4.(272,271)">
+      <variable default="-1" item="Sound Option 11" mask="XVVVVVVV VVVVVVVV" CV="16.4.(272,271)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - ALCO 251 compressor #503" value="0"/>
@@ -598,7 +598,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F7</label>
       </variable>
-      <variable default="83" item="Sound Option 12" mask="VVVVVVVV XVVVVVVV" CV="16.4.(274,273)">
+      <variable default="83" item="Sound Option 12" mask="XVVVVVVV VVVVVVVV" CV="16.4.(274,273)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - ALCO 251 compressor #503" value="0"/>
@@ -663,7 +663,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F8</label>
       </variable>
-      <variable default="-1" item="Sound Option 13" mask="VVVVVVVV XVVVVVVV" CV="16.4.(276,275)">
+      <variable default="-1" item="Sound Option 13" mask="XVVVVVVV VVVVVVVV" CV="16.4.(276,275)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - ALCO 251 compressor #503" value="0"/>
@@ -728,7 +728,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F9</label>
       </variable>
-      <variable default="80" item="Sound Option 14" mask="VVVVVVVV XVVVVVVV" CV="16.4.(278,277)">
+      <variable default="80" item="Sound Option 14" mask="XVVVVVVV VVVVVVVV" CV="16.4.(278,277)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - ALCO 251 compressor #503" value="0"/>
@@ -793,7 +793,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F10</label>
       </variable>
-      <variable default="79" item="Sound Option 15" mask="VVVVVVVV XVVVVVVV" CV="16.4.(280,279)">
+      <variable default="79" item="Sound Option 15" mask="XVVVVVVV VVVVVVVV" CV="16.4.(280,279)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - ALCO 251 compressor #503" value="0"/>
@@ -858,7 +858,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F11</label>
       </variable>
-      <variable default="40" item="Sound Option 16" mask="VVVVVVVV XVVVVVVV" CV="16.4.(282,281)">
+      <variable default="40" item="Sound Option 16" mask="XVVVVVVV VVVVVVVV" CV="16.4.(282,281)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - ALCO 251 compressor #503" value="0"/>
@@ -923,7 +923,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F12</label>
       </variable>
-      <variable default="41" item="Sound Option 17" mask="VVVVVVVV XVVVVVVV" CV="16.4.(284,283)">
+      <variable default="41" item="Sound Option 17" mask="XVVVVVVV VVVVVVVV" CV="16.4.(284,283)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - ALCO 251 compressor #503" value="0"/>
@@ -988,7 +988,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F13</label>
       </variable>
-      <variable default="9" item="Sound Option 18" mask="VVVVVVVV XVVVVVVV" CV="16.4.(286,285)">
+      <variable default="9" item="Sound Option 18" mask="XVVVVVVV VVVVVVVV" CV="16.4.(286,285)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - ALCO 251 compressor #503" value="0"/>
@@ -1053,7 +1053,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F14</label>
       </variable>
-      <variable default="43" item="Sound Option 19" mask="VVVVVVVV XVVVVVVV" CV="16.4.(288,287)">
+      <variable default="43" item="Sound Option 19" mask="XVVVVVVV VVVVVVVV" CV="16.4.(288,287)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - ALCO 251 compressor #503" value="0"/>
@@ -1118,7 +1118,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F15</label>
       </variable>
-      <variable default="81" item="Sound Option 20" mask="VVVVVVVV XVVVVVVV" CV="16.4.(290,289)">
+      <variable default="81" item="Sound Option 20" mask="XVVVVVVV VVVVVVVV" CV="16.4.(290,289)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - ALCO 251 compressor #503" value="0"/>
@@ -1183,7 +1183,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F16</label>
       </variable>
-      <variable default="42" item="Sound Option 21" mask="VVVVVVVV XVVVVVVV" CV="16.4.(292,291)">
+      <variable default="42" item="Sound Option 21" mask="XVVVVVVV VVVVVVVV" CV="16.4.(292,291)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - ALCO 251 compressor #503" value="0"/>
@@ -1248,7 +1248,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F17</label>
       </variable>
-      <variable default="84" item="Sound Option 22" mask="VVVVVVVV XVVVVVVV" CV="16.4.(294,293)">
+      <variable default="84" item="Sound Option 22" mask="XVVVVVVV VVVVVVVV" CV="16.4.(294,293)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - ALCO 251 compressor #503" value="0"/>
@@ -1313,7 +1313,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F18</label>
       </variable>
-      <variable default="-1" item="Sound Option 23" mask="VVVVVVVV XVVVVVVV" CV="16.4.(296,295)">
+      <variable default="-1" item="Sound Option 23" mask="XVVVVVVV VVVVVVVV" CV="16.4.(296,295)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - ALCO 251 compressor #503" value="0"/>
@@ -1378,7 +1378,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F19</label>
       </variable>
-      <variable default="3" item="Sound Option 24" mask="VVVVVVVV XVVVVVVV" CV="16.4.(298,297)">
+      <variable default="3" item="Sound Option 24" mask="XVVVVVVV VVVVVVVV" CV="16.4.(298,297)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - ALCO 251 compressor #503" value="0"/>
@@ -1443,7 +1443,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F20</label>
       </variable>
-      <variable default="47" item="Sound Option 25" mask="VVVVVVVV XVVVVVVV" CV="16.4.(300,299)">
+      <variable default="47" item="Sound Option 25" mask="XVVVVVVV VVVVVVVV" CV="16.4.(300,299)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - ALCO 251 compressor #503" value="0"/>
@@ -1508,7 +1508,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F21</label>
       </variable>
-      <variable default="162" item="Sound Option 26" mask="VVVVVVVV XVVVVVVV" CV="16.4.(302,301)">
+      <variable default="162" item="Sound Option 26" mask="XVVVVVVV VVVVVVVV" CV="16.4.(302,301)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - ALCO 251 compressor #503" value="0"/>
@@ -1573,7 +1573,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F22</label>
       </variable>
-      <variable default="178" item="Sound Option 27" mask="VVVVVVVV XVVVVVVV" CV="16.4.(304,303)">
+      <variable default="178" item="Sound Option 27" mask="XVVVVVVV VVVVVVVV" CV="16.4.(304,303)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - ALCO 251 compressor #503" value="0"/>
@@ -1638,7 +1638,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F23</label>
       </variable>
-      <variable default="170" item="Sound Option 28" mask="VVVVVVVV XVVVVVVV" CV="16.4.(306,305)">
+      <variable default="170" item="Sound Option 28" mask="XVVVVVVV VVVVVVVV" CV="16.4.(306,305)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - ALCO 251 compressor #503" value="0"/>
@@ -1703,7 +1703,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F24</label>
       </variable>
-      <variable default="186" item="Sound Option 29" mask="VVVVVVVV XVVVVVVV" CV="16.4.(308,307)">
+      <variable default="186" item="Sound Option 29" mask="XVVVVVVV VVVVVVVV" CV="16.4.(308,307)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - ALCO 251 compressor #503" value="0"/>
@@ -1768,7 +1768,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F25</label>
       </variable>
-      <variable default="46" item="Sound Option 30" mask="VVVVVVVV XVVVVVVV" CV="16.4.(310,309)">
+      <variable default="46" item="Sound Option 30" mask="XVVVVVVV VVVVVVVV" CV="16.4.(310,309)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - ALCO 251 compressor #503" value="0"/>
@@ -1833,7 +1833,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F26</label>
       </variable>
-      <variable default="-1" item="Sound Option 31" mask="VVVVVVVV XVVVVVVV" CV="16.4.(312,311)">
+      <variable default="-1" item="Sound Option 31" mask="XVVVVVVV VVVVVVVV" CV="16.4.(312,311)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - ALCO 251 compressor #503" value="0"/>
@@ -1898,7 +1898,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F27</label>
       </variable>
-      <variable default="85" item="Sound Option 32" mask="VVVVVVVV XVVVVVVV" CV="16.4.(314,313)">
+      <variable default="85" item="Sound Option 32" mask="XVVVVVVV VVVVVVVV" CV="16.4.(314,313)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - ALCO 251 compressor #503" value="0"/>
@@ -1963,7 +1963,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F28</label>
       </variable>
-      <variable default="0" item="Sound Option 33" mask="VVVVVVVV XVVVVVVV" CV="16.4.(316,315)">
+      <variable default="0" item="Sound Option 33" mask="XVVVVVVV VVVVVVVV" CV="16.4.(316,315)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - ALCO 251 compressor #503" value="0"/>
@@ -2028,7 +2028,7 @@
         </splitEnumVal>
         <label>Sound Mapping for R1</label>
       </variable>
-      <variable default="2" item="Sound Option 34" mask="VVVVVVVV XVVVVVVV" CV="16.4.(318,317)">
+      <variable default="2" item="Sound Option 34" mask="XVVVVVVV VVVVVVVV" CV="16.4.(318,317)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - ALCO 251 compressor #503" value="0"/>
@@ -2093,7 +2093,7 @@
         </splitEnumVal>
         <label>Sound Mapping for R2</label>
       </variable>
-      <variable default="-1" item="Sound Option 35" mask="VVVVVVVV XVVVVVVV" CV="16.4.(320,319)">
+      <variable default="-1" item="Sound Option 35" mask="XVVVVVVV VVVVVVVV" CV="16.4.(320,319)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - ALCO 251 compressor #503" value="0"/>
@@ -2158,7 +2158,7 @@
         </splitEnumVal>
         <label>Sound Mapping for R3</label>
       </variable>
-      <variable default="-1" item="Sound Option 36" mask="VVVVVVVV XVVVVVVV" CV="16.4.(322,321)">
+      <variable default="-1" item="Sound Option 36" mask="XVVVVVVV VVVVVVVV" CV="16.4.(322,321)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - ALCO 251 compressor #503" value="0"/>
@@ -2223,7 +2223,7 @@
         </splitEnumVal>
         <label>Sound Mapping for R4</label>
       </variable>
-      <variable default="-1" item="Sound Option 37" mask="VVVVVVVV XVVVVVVV" CV="16.4.(324,323)">
+      <variable default="-1" item="Sound Option 37" mask="XVVVVVVV VVVVVVVV" CV="16.4.(324,323)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - ALCO 251 compressor #503" value="0"/>
@@ -8269,11 +8269,11 @@
               </label><separator/><label>
                 <text> </text>
               </label>
-              
-              
+
+
   <row>
         <column>
-            <row> 
+            <row>
                   <display item="Function F0F effect generated"/><separator/>
                   <display item="Function F0R effect generated"/>
             </row>
@@ -8396,7 +8396,7 @@
               <label>
                  <text>Lighting Preset: 'Auto Mars'</text>
               </label>
-              
+
            </griditem>
            <griditem gridx="1" gridy="0">
               <display item="Lighting Preset 0 - Step 0 - Start Brightness">
@@ -8602,7 +8602,7 @@
               <label>
                  <text>Lighting Preset: 'Brake Lights'</text>
               </label>
-              
+
            </griditem>
            <griditem gridx="1" gridy="4">
               <display item="Lighting Preset 1 - Step 0 - Start Brightness">
@@ -8808,7 +8808,7 @@
               <label>
                  <text>Lighting Preset: 'Rotary Beacon (New Style)'</text>
               </label>
-              
+
            </griditem>
            <griditem gridx="1" gridy="8">
               <display item="Lighting Preset 2 - Step 0 - Start Brightness">
@@ -9014,7 +9014,7 @@
               <label>
                  <text>Lighting Preset: 'Constant Bright'</text>
               </label>
-              
+
            </griditem>
            <griditem gridx="1" gridy="12">
               <display item="Lighting Preset 3 - Step 0 - Start Brightness">
@@ -9220,7 +9220,7 @@
               <label>
                  <text>Lighting Preset: 'Flashing F.R.E.D.'</text>
               </label>
-              
+
            </griditem>
            <griditem gridx="1" gridy="16">
               <display item="Lighting Preset 4 - Step 0 - Start Brightness">
@@ -9426,7 +9426,7 @@
               <label>
                  <text>Lighting Preset: 'Constant Dim'</text>
               </label>
-              
+
            </griditem>
            <griditem gridx="1" gridy="20">
               <display item="Lighting Preset 5 - Step 0 - Start Brightness">
@@ -9632,7 +9632,7 @@
               <label>
                  <text>Lighting Preset: 'Ditch Light Side 2'</text>
               </label>
-              
+
            </griditem>
            <griditem gridx="1" gridy="24">
               <display item="Lighting Preset 6 - Step 0 - Start Brightness">
@@ -9838,7 +9838,7 @@
               <label>
                  <text>Lighting Preset: 'Ditch Light Side 1'</text>
               </label>
-              
+
            </griditem>
            <griditem gridx="1" gridy="28">
               <display item="Lighting Preset 7 - Step 0 - Start Brightness">
@@ -10044,7 +10044,7 @@
               <label>
                  <text>Lighting Preset: 'Single Pulse Strobe'</text>
               </label>
-              
+
            </griditem>
            <griditem gridx="1" gridy="32">
               <display item="Lighting Preset 8 - Step 0 - Start Brightness">
@@ -10250,7 +10250,7 @@
               <label>
                  <text>Lighting Preset: 'Firebox Flicker'</text>
               </label>
-              
+
            </griditem>
            <griditem gridx="1" gridy="36">
               <display item="Lighting Preset 9 - Step 0 - Start Brightness">
@@ -10456,7 +10456,7 @@
               <label>
                  <text>Lighting Preset: 'Custom Light 1'</text>
               </label>
-              
+
            </griditem>
            <griditem gridx="1" gridy="40">
               <display item="Lighting Preset 10 - Step 0 - Start Brightness">
@@ -10662,7 +10662,7 @@
               <label>
                  <text>Lighting Preset: 'Rotary Beacon (Old style)'</text>
               </label>
-              
+
            </griditem>
            <griditem gridx="1" gridy="44">
               <display item="Lighting Preset 11 - Step 0 - Start Brightness">
@@ -10868,7 +10868,7 @@
               <label>
                  <text>Lighting Preset: 'Gyra Light'</text>
               </label>
-              
+
            </griditem>
            <griditem gridx="1" gridy="48">
               <display item="Lighting Preset 12 - Step 0 - Start Brightness">
@@ -11074,7 +11074,7 @@
               <label>
                  <text>Lighting Preset: 'Double Pulse Strobe'</text>
               </label>
-              
+
            </griditem>
            <griditem gridx="1" gridy="52">
               <display item="Lighting Preset 13 - Step 0 - Start Brightness">
@@ -11280,7 +11280,7 @@
               <label>
                  <text>Lighting Preset: 'Mars Light'</text>
               </label>
-              
+
            </griditem>
            <griditem gridx="1" gridy="56">
               <display item="Lighting Preset 14 - Step 0 - Start Brightness">
@@ -11486,7 +11486,7 @@
               <label>
                  <text>Lighting Preset: 'Rule 17'</text>
               </label>
-              
+
            </griditem>
            <griditem gridx="1" gridy="60">
               <display item="Lighting Preset 15 - Step 0 - Start Brightness">
@@ -11692,7 +11692,7 @@
               <label>
                  <text>Lighting Preset: 'Custom Light 2'</text>
               </label>
-              
+
            </griditem>
            <griditem gridx="1" gridy="64">
               <display item="Lighting Preset 16 - Step 0 - Start Brightness">

--- a/xml/decoders/TCS_WOWDieselV5-121.xml
+++ b/xml/decoders/TCS_WOWDieselV5-121.xml
@@ -205,7 +205,7 @@
         </enumVal>
         <label>Select Prime Mover: </label>
       </variable>
-      <variable default="-1" item="Sound Option 4" mask="VVVVVVVV XVVVVVVV" CV="16.4.(258,257)">
+      <variable default="-1" item="Sound Option 4" mask="XVVVVVVV VVVVVVVV" CV="16.4.(258,257)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - ALCO 251 compressor #503" value="0"/>
@@ -284,7 +284,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F0</label>
       </variable>
-      <variable default="17" item="Sound Option 5" mask="VVVVVVVV XVVVVVVV" CV="16.4.(260,259)">
+      <variable default="17" item="Sound Option 5" mask="XVVVVVVV VVVVVVVV" CV="16.4.(260,259)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - ALCO 251 compressor #503" value="0"/>
@@ -363,7 +363,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F1</label>
       </variable>
-      <variable default="162" item="Sound Option 6" mask="VVVVVVVV XVVVVVVV" CV="16.4.(262,261)">
+      <variable default="162" item="Sound Option 6" mask="XVVVVVVV VVVVVVVV" CV="16.4.(262,261)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - ALCO 251 compressor #503" value="0"/>
@@ -442,7 +442,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F2</label>
       </variable>
-      <variable default="342" item="Sound Option 7" mask="VVVVVVVV XVVVVVVV" CV="16.4.(264,263)">
+      <variable default="342" item="Sound Option 7" mask="XVVVVVVV VVVVVVVV" CV="16.4.(264,263)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - ALCO 251 compressor #503" value="0"/>
@@ -521,7 +521,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F3</label>
       </variable>
-      <variable default="207" item="Sound Option 8" mask="VVVVVVVV XVVVVVVV" CV="16.4.(266,265)">
+      <variable default="207" item="Sound Option 8" mask="XVVVVVVV VVVVVVVV" CV="16.4.(266,265)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - ALCO 251 compressor #503" value="0"/>
@@ -600,7 +600,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F4</label>
       </variable>
-      <variable default="113" item="Sound Option 9" mask="VVVVVVVV XVVVVVVV" CV="16.4.(268,267)">
+      <variable default="113" item="Sound Option 9" mask="XVVVVVVV VVVVVVVV" CV="16.4.(268,267)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - ALCO 251 compressor #503" value="0"/>
@@ -679,7 +679,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F5</label>
       </variable>
-      <variable default="76" item="Sound Option 10" mask="VVVVVVVV XVVVVVVV" CV="16.4.(270,269)">
+      <variable default="76" item="Sound Option 10" mask="XVVVVVVV VVVVVVVV" CV="16.4.(270,269)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - ALCO 251 compressor #503" value="0"/>
@@ -758,7 +758,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F6</label>
       </variable>
-      <variable default="78" item="Sound Option 11" mask="VVVVVVVV XVVVVVVV" CV="16.4.(272,271)">
+      <variable default="78" item="Sound Option 11" mask="XVVVVVVV VVVVVVVV" CV="16.4.(272,271)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - ALCO 251 compressor #503" value="0"/>
@@ -837,7 +837,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F7</label>
       </variable>
-      <variable default="391" item="Sound Option 12" mask="VVVVVVVV XVVVVVVV" CV="16.4.(274,273)">
+      <variable default="391" item="Sound Option 12" mask="XVVVVVVV VVVVVVVV" CV="16.4.(274,273)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - ALCO 251 compressor #503" value="0"/>
@@ -916,7 +916,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F8</label>
       </variable>
-      <variable default="2945" item="Sound Option 13" mask="VVVVVVVV XVVVVVVV" CV="16.4.(276,275)">
+      <variable default="2945" item="Sound Option 13" mask="XVVVVVVV VVVVVVVV" CV="16.4.(276,275)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - ALCO 251 compressor #503" value="0"/>
@@ -995,7 +995,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F9</label>
       </variable>
-      <variable default="388" item="Sound Option 14" mask="VVVVVVVV XVVVVVVV" CV="16.4.(278,277)">
+      <variable default="388" item="Sound Option 14" mask="XVVVVVVV VVVVVVVV" CV="16.4.(278,277)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - ALCO 251 compressor #503" value="0"/>
@@ -1074,7 +1074,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F10</label>
       </variable>
-      <variable default="387" item="Sound Option 15" mask="VVVVVVVV XVVVVVVV" CV="16.4.(280,279)">
+      <variable default="387" item="Sound Option 15" mask="XVVVVVVV VVVVVVVV" CV="16.4.(280,279)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - ALCO 251 compressor #503" value="0"/>
@@ -1153,7 +1153,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F11</label>
       </variable>
-      <variable default="2834" item="Sound Option 16" mask="VVVVVVVV XVVVVVVV" CV="16.4.(282,281)">
+      <variable default="2834" item="Sound Option 16" mask="XVVVVVVV VVVVVVVV" CV="16.4.(282,281)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - ALCO 251 compressor #503" value="0"/>
@@ -1232,7 +1232,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F12</label>
       </variable>
-      <variable default="108" item="Sound Option 17" mask="VVVVVVVV XVVVVVVV" CV="16.4.(284,283)">
+      <variable default="108" item="Sound Option 17" mask="XVVVVVVV VVVVVVVV" CV="16.4.(284,283)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - ALCO 251 compressor #503" value="0"/>
@@ -1311,7 +1311,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F13</label>
       </variable>
-      <variable default="109" item="Sound Option 18" mask="VVVVVVVV XVVVVVVV" CV="16.4.(286,285)">
+      <variable default="109" item="Sound Option 18" mask="XVVVVVVV VVVVVVVV" CV="16.4.(286,285)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - ALCO 251 compressor #503" value="0"/>
@@ -1390,7 +1390,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F14</label>
       </variable>
-      <variable default="389" item="Sound Option 19" mask="VVVVVVVV XVVVVVVV" CV="16.4.(288,287)">
+      <variable default="389" item="Sound Option 19" mask="XVVVVVVV VVVVVVVV" CV="16.4.(288,287)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - ALCO 251 compressor #503" value="0"/>
@@ -1469,7 +1469,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F15</label>
       </variable>
-      <variable default="112" item="Sound Option 20" mask="VVVVVVVV XVVVVVVV" CV="16.4.(290,289)">
+      <variable default="112" item="Sound Option 20" mask="XVVVVVVV VVVVVVVV" CV="16.4.(290,289)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - ALCO 251 compressor #503" value="0"/>
@@ -1548,7 +1548,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F16</label>
       </variable>
-      <variable default="3035" item="Sound Option 21" mask="VVVVVVVV XVVVVVVV" CV="16.4.(292,291)">
+      <variable default="3035" item="Sound Option 21" mask="XVVVVVVV VVVVVVVV" CV="16.4.(292,291)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - ALCO 251 compressor #503" value="0"/>
@@ -1627,7 +1627,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F17</label>
       </variable>
-      <variable default="16" item="Sound Option 22" mask="VVVVVVVV XVVVVVVV" CV="16.4.(294,293)">
+      <variable default="16" item="Sound Option 22" mask="XVVVVVVV VVVVVVVV" CV="16.4.(294,293)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - ALCO 251 compressor #503" value="0"/>
@@ -1706,7 +1706,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F18</label>
       </variable>
-      <variable default="-1" item="Sound Option 23" mask="VVVVVVVV XVVVVVVV" CV="16.4.(296,295)">
+      <variable default="-1" item="Sound Option 23" mask="XVVVVVVV VVVVVVVV" CV="16.4.(296,295)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - ALCO 251 compressor #503" value="0"/>
@@ -1785,7 +1785,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F19</label>
       </variable>
-      <variable default="-1" item="Sound Option 24" mask="VVVVVVVV XVVVVVVV" CV="16.4.(298,297)">
+      <variable default="-1" item="Sound Option 24" mask="XVVVVVVV VVVVVVVV" CV="16.4.(298,297)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - ALCO 251 compressor #503" value="0"/>
@@ -1864,7 +1864,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F20</label>
       </variable>
-      <variable default="-1" item="Sound Option 25" mask="VVVVVVVV XVVVVVVV" CV="16.4.(300,299)">
+      <variable default="-1" item="Sound Option 25" mask="XVVVVVVV VVVVVVVV" CV="16.4.(300,299)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - ALCO 251 compressor #503" value="0"/>
@@ -1943,7 +1943,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F21</label>
       </variable>
-      <variable default="-1" item="Sound Option 26" mask="VVVVVVVV XVVVVVVV" CV="16.4.(302,301)">
+      <variable default="-1" item="Sound Option 26" mask="XVVVVVVV VVVVVVVV" CV="16.4.(302,301)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - ALCO 251 compressor #503" value="0"/>
@@ -2022,7 +2022,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F22</label>
       </variable>
-      <variable default="-1" item="Sound Option 27" mask="VVVVVVVV XVVVVVVV" CV="16.4.(304,303)">
+      <variable default="-1" item="Sound Option 27" mask="XVVVVVVV VVVVVVVV" CV="16.4.(304,303)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - ALCO 251 compressor #503" value="0"/>
@@ -2101,7 +2101,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F23</label>
       </variable>
-      <variable default="-1" item="Sound Option 28" mask="VVVVVVVV XVVVVVVV" CV="16.4.(306,305)">
+      <variable default="-1" item="Sound Option 28" mask="XVVVVVVV VVVVVVVV" CV="16.4.(306,305)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - ALCO 251 compressor #503" value="0"/>
@@ -2180,7 +2180,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F24</label>
       </variable>
-      <variable default="-1" item="Sound Option 29" mask="VVVVVVVV XVVVVVVV" CV="16.4.(308,307)">
+      <variable default="-1" item="Sound Option 29" mask="XVVVVVVV VVVVVVVV" CV="16.4.(308,307)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - ALCO 251 compressor #503" value="0"/>
@@ -2259,7 +2259,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F25</label>
       </variable>
-      <variable default="-1" item="Sound Option 30" mask="VVVVVVVV XVVVVVVV" CV="16.4.(310,309)">
+      <variable default="-1" item="Sound Option 30" mask="XVVVVVVV VVVVVVVV" CV="16.4.(310,309)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - ALCO 251 compressor #503" value="0"/>
@@ -2338,7 +2338,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F26</label>
       </variable>
-      <variable default="-1" item="Sound Option 31" mask="VVVVVVVV XVVVVVVV" CV="16.4.(312,311)">
+      <variable default="-1" item="Sound Option 31" mask="XVVVVVVV VVVVVVVV" CV="16.4.(312,311)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - ALCO 251 compressor #503" value="0"/>
@@ -2417,7 +2417,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F27</label>
       </variable>
-      <variable default="-1" item="Sound Option 32" mask="VVVVVVVV XVVVVVVV" CV="16.4.(314,313)">
+      <variable default="-1" item="Sound Option 32" mask="XVVVVVVV VVVVVVVV" CV="16.4.(314,313)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - ALCO 251 compressor #503" value="0"/>
@@ -2496,7 +2496,7 @@
         </splitEnumVal>
         <label>Sound Mapping for F28</label>
       </variable>
-      <variable default="8" item="Sound Option 33" mask="VVVVVVVV XVVVVVVV" CV="16.4.(316,315)">
+      <variable default="8" item="Sound Option 33" mask="XVVVVVVV VVVVVVVV" CV="16.4.(316,315)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - ALCO 251 compressor #503" value="0"/>
@@ -2575,7 +2575,7 @@
         </splitEnumVal>
         <label>Sound Mapping for R1</label>
       </variable>
-      <variable default="10" item="Sound Option 34" mask="VVVVVVVV XVVVVVVV" CV="16.4.(318,317)">
+      <variable default="10" item="Sound Option 34" mask="XVVVVVVV VVVVVVVV" CV="16.4.(318,317)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - ALCO 251 compressor #503" value="0"/>
@@ -2654,7 +2654,7 @@
         </splitEnumVal>
         <label>Sound Mapping for R2</label>
       </variable>
-      <variable default="-1" item="Sound Option 35" mask="VVVVVVVV XVVVVVVV" CV="16.4.(320,319)">
+      <variable default="-1" item="Sound Option 35" mask="XVVVVVVV VVVVVVVV" CV="16.4.(320,319)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - ALCO 251 compressor #503" value="0"/>
@@ -2733,7 +2733,7 @@
         </splitEnumVal>
         <label>Sound Mapping for R3</label>
       </variable>
-      <variable default="-1" item="Sound Option 36" mask="VVVVVVVV XVVVVVVV" CV="16.4.(322,321)">
+      <variable default="-1" item="Sound Option 36" mask="XVVVVVVV VVVVVVVV" CV="16.4.(322,321)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - ALCO 251 compressor #503" value="0"/>
@@ -2812,7 +2812,7 @@
         </splitEnumVal>
         <label>Sound Mapping for R4</label>
       </variable>
-      <variable default="208" item="Sound Option 37" mask="VVVVVVVV XVVVVVVV" CV="16.4.(324,323)">
+      <variable default="208" item="Sound Option 37" mask="XVVVVVVV VVVVVVVV" CV="16.4.(324,323)">
         <splitEnumVal xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <enumChoiceGroup>
             <enumChoice choice="Air Compressor - ALCO 251 compressor #503" value="0"/>
@@ -9168,11 +9168,11 @@
               </label><separator/><label>
                 <text> </text>
               </label>
-              
-              
+
+
   <row>
         <column>
-            <row> 
+            <row>
                   <display item="Function F0F effect generated"/><separator/>
                   <display item="Function F0R effect generated"/>
             </row>
@@ -9295,7 +9295,7 @@
               <label>
                  <text>Lighting Preset: 'Auto Mars'</text>
               </label>
-              
+
            </griditem>
            <griditem gridx="1" gridy="0">
               <display item="Lighting Preset 0 - Step 0 - Start Brightness">
@@ -9501,7 +9501,7 @@
               <label>
                  <text>Lighting Preset: 'Brake Lights'</text>
               </label>
-              
+
            </griditem>
            <griditem gridx="1" gridy="4">
               <display item="Lighting Preset 1 - Step 0 - Start Brightness">
@@ -9707,7 +9707,7 @@
               <label>
                  <text>Lighting Preset: 'Rotary Beacon (New Style)'</text>
               </label>
-              
+
            </griditem>
            <griditem gridx="1" gridy="8">
               <display item="Lighting Preset 2 - Step 0 - Start Brightness">
@@ -9913,7 +9913,7 @@
               <label>
                  <text>Lighting Preset: 'Constant Bright'</text>
               </label>
-              
+
            </griditem>
            <griditem gridx="1" gridy="12">
               <display item="Lighting Preset 3 - Step 0 - Start Brightness">
@@ -10119,7 +10119,7 @@
               <label>
                  <text>Lighting Preset: 'Flashing F.R.E.D.'</text>
               </label>
-              
+
            </griditem>
            <griditem gridx="1" gridy="16">
               <display item="Lighting Preset 4 - Step 0 - Start Brightness">
@@ -10325,7 +10325,7 @@
               <label>
                  <text>Lighting Preset: 'Constant Dim'</text>
               </label>
-              
+
            </griditem>
            <griditem gridx="1" gridy="20">
               <display item="Lighting Preset 5 - Step 0 - Start Brightness">
@@ -10531,7 +10531,7 @@
               <label>
                  <text>Lighting Preset: 'Ditch Light Side 2'</text>
               </label>
-              
+
            </griditem>
            <griditem gridx="1" gridy="24">
               <display item="Lighting Preset 6 - Step 0 - Start Brightness">
@@ -10737,7 +10737,7 @@
               <label>
                  <text>Lighting Preset: 'Ditch Light Side 1'</text>
               </label>
-              
+
            </griditem>
            <griditem gridx="1" gridy="28">
               <display item="Lighting Preset 7 - Step 0 - Start Brightness">
@@ -10943,7 +10943,7 @@
               <label>
                  <text>Lighting Preset: 'Single Pulse Strobe'</text>
               </label>
-              
+
            </griditem>
            <griditem gridx="1" gridy="32">
               <display item="Lighting Preset 8 - Step 0 - Start Brightness">
@@ -11149,7 +11149,7 @@
               <label>
                  <text>Lighting Preset: 'Firebox Flicker'</text>
               </label>
-              
+
            </griditem>
            <griditem gridx="1" gridy="36">
               <display item="Lighting Preset 9 - Step 0 - Start Brightness">
@@ -11355,7 +11355,7 @@
               <label>
                  <text>Lighting Preset: 'Custom Light 1'</text>
               </label>
-              
+
            </griditem>
            <griditem gridx="1" gridy="40">
               <display item="Lighting Preset 10 - Step 0 - Start Brightness">
@@ -11561,7 +11561,7 @@
               <label>
                  <text>Lighting Preset: 'Rotary Beacon (Old style)'</text>
               </label>
-              
+
            </griditem>
            <griditem gridx="1" gridy="44">
               <display item="Lighting Preset 11 - Step 0 - Start Brightness">
@@ -11767,7 +11767,7 @@
               <label>
                  <text>Lighting Preset: 'Gyra Light'</text>
               </label>
-              
+
            </griditem>
            <griditem gridx="1" gridy="48">
               <display item="Lighting Preset 12 - Step 0 - Start Brightness">
@@ -11973,7 +11973,7 @@
               <label>
                  <text>Lighting Preset: 'Double Pulse Strobe'</text>
               </label>
-              
+
            </griditem>
            <griditem gridx="1" gridy="52">
               <display item="Lighting Preset 13 - Step 0 - Start Brightness">
@@ -12179,7 +12179,7 @@
               <label>
                  <text>Lighting Preset: 'Mars Light'</text>
               </label>
-              
+
            </griditem>
            <griditem gridx="1" gridy="56">
               <display item="Lighting Preset 14 - Step 0 - Start Brightness">
@@ -12385,7 +12385,7 @@
               <label>
                  <text>Lighting Preset: 'Rule 17'</text>
               </label>
-              
+
            </griditem>
            <griditem gridx="1" gridy="60">
               <display item="Lighting Preset 15 - Step 0 - Start Brightness">
@@ -12591,7 +12591,7 @@
               <label>
                  <text>Lighting Preset: 'Custom Light 2'</text>
               </label>
-              
+
            </griditem>
            <griditem gridx="1" gridy="64">
               <display item="Lighting Preset 16 - Step 0 - Start Brightness">


### PR DESCRIPTION
Fixes missing write to upper CV(s) in SplitEnumVariableValue.

Also fixes issues with masks in TCS Bachman FT, RS3 and GP35 and Wow Diesel definitions.

Improves documentation of CV and mask order in split variables.