### PR TITLE
Add empty constructor for JmriUserPreferencesManager

### DIFF
--- a/java/src/jmri/jmrit/beantable/routetable/RouteEditFrame.java
+++ b/java/src/jmri/jmrit/beantable/routetable/RouteEditFrame.java
@@ -25,6 +25,10 @@ public class RouteEditFrame extends AbstractRouteAddEditFrame {
 
     private final String systemName;
 
+    public RouteEditFrame() {
+        this(Bundle.getMessage("TitleEditRoute"));
+    }
+
     public RouteEditFrame(String systemName) {
         this(Bundle.getMessage("TitleEditRoute"), systemName);
     }


### PR DESCRIPTION
JmriUserPreferencesManager uses an empty constructor to get the class for classPreferences in user-interface.xml.