### PR TITLE
Add LogixNG expression Linux Line Power

### DIFF
--- a/java/src/jmri/jmrit/logixng/Category.java
+++ b/java/src/jmri/jmrit/logixng/Category.java
@@ -38,6 +38,11 @@ public abstract class Category implements Comparable<Category> {
      */
     public static final Other OTHER = new Other();
 
+    /**
+     * Linux specific things.
+     */
+    public static final Linux LINUX = new Linux();
+
     static {
         // It's not often any item is added to this list so we use CopyOnWriteArrayList
         _categories = new CopyOnWriteArrayList<>();
@@ -45,6 +50,9 @@ public abstract class Category implements Comparable<Category> {
         registerCategory(COMMON);
         registerCategory(FLOW_CONTROL);
         registerCategory(OTHER);
+        if (jmri.util.SystemType.isLinux()) {
+            registerCategory(LINUX);
+        }
     }
 
     /**
@@ -140,6 +148,14 @@ public abstract class Category implements Comparable<Category> {
 
         public Other() {
             super("OTHER", Bundle.getMessage("CategoryOther"), 900);
+        }
+    }
+
+
+    public static final class Linux extends Category {
+
+        public Linux() {
+            super("LINUX", Bundle.getMessage("CategoryLinux"), 2000);
         }
     }
 

--- a/java/src/jmri/jmrit/logixng/LogixNGBundle.properties
+++ b/java/src/jmri/jmrit/logixng/LogixNGBundle.properties
@@ -42,6 +42,7 @@ CategoryItem            = Item
 CategoryCommon          = Common
 CategoryFlowControl     = Flow Control
 CategoryOther           = Other
+CategoryLinux           = Linux
 
 FemaleSocketOperation_Remove        = Remove socket
 FemaleSocketOperation_InsertBefore  = Insert new socket before

--- a/java/src/jmri/jmrit/logixng/expressions/DigitalFactory.java
+++ b/java/src/jmri/jmrit/logixng/expressions/DigitalFactory.java
@@ -1,6 +1,7 @@
 package jmri.jmrit.logixng.expressions;
 
 import java.util.AbstractMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import jmri.jmrit.logixng.Category;
@@ -17,40 +18,45 @@ public class DigitalFactory implements DigitalExpressionFactory {
     @Override
     public Set<Map.Entry<Category, Class<? extends DigitalExpressionBean>>> getExpressionClasses() {
         Set<Map.Entry<Category, Class<? extends DigitalExpressionBean>>> expressionClasses =
-                Set.of(
-                        new AbstractMap.SimpleEntry<>(Category.COMMON, And.class),
-                        new AbstractMap.SimpleEntry<>(Category.COMMON, Antecedent.class),
-                        new AbstractMap.SimpleEntry<>(Category.FLOW_CONTROL, DigitalCallModule.class),
-                        new AbstractMap.SimpleEntry<>(Category.OTHER, ConnectionName.class),
-                        new AbstractMap.SimpleEntry<>(Category.ITEM, ExpressionBlock.class),
-                        new AbstractMap.SimpleEntry<>(Category.ITEM, ExpressionClock.class),
-                        new AbstractMap.SimpleEntry<>(Category.ITEM, ExpressionConditional.class),
-                        new AbstractMap.SimpleEntry<>(Category.ITEM, ExpressionDispatcher.class),
-                        new AbstractMap.SimpleEntry<>(Category.ITEM, ExpressionEntryExit.class),
-                        new AbstractMap.SimpleEntry<>(Category.ITEM, ExpressionLight.class),
-                        new AbstractMap.SimpleEntry<>(Category.ITEM, ExpressionLocalVariable.class),
-                        new AbstractMap.SimpleEntry<>(Category.ITEM, ExpressionMemory.class),
-                        new AbstractMap.SimpleEntry<>(Category.ITEM, ExpressionOBlock.class),
-                        new AbstractMap.SimpleEntry<>(Category.ITEM, ExpressionPower.class),
-                        new AbstractMap.SimpleEntry<>(Category.ITEM, ExpressionReference.class),
-                        new AbstractMap.SimpleEntry<>(Category.ITEM, ExpressionReporter.class),
-                        new AbstractMap.SimpleEntry<>(Category.ITEM, ExpressionScript.class),
-                        new AbstractMap.SimpleEntry<>(Category.ITEM, ExpressionSensor.class),
-                        new AbstractMap.SimpleEntry<>(Category.ITEM, ExpressionSensorEdge.class),
-                        new AbstractMap.SimpleEntry<>(Category.ITEM, ExpressionSignalHead.class),
-                        new AbstractMap.SimpleEntry<>(Category.ITEM, ExpressionSignalMast.class),
-                        new AbstractMap.SimpleEntry<>(Category.ITEM, ExpressionTurnout.class),
-                        new AbstractMap.SimpleEntry<>(Category.ITEM, ExpressionWarrant.class),
-                        new AbstractMap.SimpleEntry<>(Category.OTHER, False.class),
-                        new AbstractMap.SimpleEntry<>(Category.COMMON, DigitalFormula.class),
-                        new AbstractMap.SimpleEntry<>(Category.OTHER, Hold.class),
-                        new AbstractMap.SimpleEntry<>(Category.OTHER, LastResultOfDigitalExpression.class),
-                        new AbstractMap.SimpleEntry<>(Category.OTHER, LogData.class),
-                        new AbstractMap.SimpleEntry<>(Category.COMMON, Not.class),
-                        new AbstractMap.SimpleEntry<>(Category.COMMON, Or.class),
-                        new AbstractMap.SimpleEntry<>(Category.OTHER, TriggerOnce.class),
-                        new AbstractMap.SimpleEntry<>(Category.OTHER, True.class)
-                );
+                new HashSet(        // Set.of() returns an immutable set
+                        Set.of(
+                                new AbstractMap.SimpleEntry<>(Category.COMMON, And.class),
+                                new AbstractMap.SimpleEntry<>(Category.COMMON, Antecedent.class),
+                                new AbstractMap.SimpleEntry<>(Category.FLOW_CONTROL, DigitalCallModule.class),
+                                new AbstractMap.SimpleEntry<>(Category.OTHER, ConnectionName.class),
+                                new AbstractMap.SimpleEntry<>(Category.ITEM, ExpressionBlock.class),
+                                new AbstractMap.SimpleEntry<>(Category.ITEM, ExpressionClock.class),
+                                new AbstractMap.SimpleEntry<>(Category.ITEM, ExpressionConditional.class),
+                                new AbstractMap.SimpleEntry<>(Category.ITEM, ExpressionDispatcher.class),
+                                new AbstractMap.SimpleEntry<>(Category.ITEM, ExpressionEntryExit.class),
+                                new AbstractMap.SimpleEntry<>(Category.ITEM, ExpressionLight.class),
+                                new AbstractMap.SimpleEntry<>(Category.ITEM, ExpressionLocalVariable.class),
+                                new AbstractMap.SimpleEntry<>(Category.ITEM, ExpressionMemory.class),
+                                new AbstractMap.SimpleEntry<>(Category.ITEM, ExpressionOBlock.class),
+                                new AbstractMap.SimpleEntry<>(Category.ITEM, ExpressionPower.class),
+                                new AbstractMap.SimpleEntry<>(Category.ITEM, ExpressionReference.class),
+                                new AbstractMap.SimpleEntry<>(Category.ITEM, ExpressionReporter.class),
+                                new AbstractMap.SimpleEntry<>(Category.ITEM, ExpressionScript.class),
+                                new AbstractMap.SimpleEntry<>(Category.ITEM, ExpressionSensor.class),
+                                new AbstractMap.SimpleEntry<>(Category.ITEM, ExpressionSensorEdge.class),
+                                new AbstractMap.SimpleEntry<>(Category.ITEM, ExpressionSignalHead.class),
+                                new AbstractMap.SimpleEntry<>(Category.ITEM, ExpressionSignalMast.class),
+                                new AbstractMap.SimpleEntry<>(Category.ITEM, ExpressionTurnout.class),
+                                new AbstractMap.SimpleEntry<>(Category.ITEM, ExpressionWarrant.class),
+                                new AbstractMap.SimpleEntry<>(Category.OTHER, False.class),
+                                new AbstractMap.SimpleEntry<>(Category.COMMON, DigitalFormula.class),
+                                new AbstractMap.SimpleEntry<>(Category.OTHER, Hold.class),
+                                new AbstractMap.SimpleEntry<>(Category.OTHER, LastResultOfDigitalExpression.class),
+                                new AbstractMap.SimpleEntry<>(Category.OTHER, LogData.class),
+                                new AbstractMap.SimpleEntry<>(Category.COMMON, Not.class),
+                                new AbstractMap.SimpleEntry<>(Category.COMMON, Or.class),
+                                new AbstractMap.SimpleEntry<>(Category.OTHER, TriggerOnce.class),
+                                new AbstractMap.SimpleEntry<>(Category.OTHER, True.class)
+                        ));
+
+        if (jmri.util.SystemType.isLinux()) {
+            expressionClasses.add(new AbstractMap.SimpleEntry<>(Category.LINUX, ExpressionLinuxLinePower.class));
+        }
 
         return expressionClasses;
     }

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionBundle.properties
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionBundle.properties
@@ -29,6 +29,10 @@ Antecedent_Short      = Antecedent
 Antecedent_Long       = Antecedent: {0}
 Antecedent_Long_Empty = Antecedent: empty
 
+LinuxLinePower_Short           = Linux Line Power
+LinuxLinePower_Long            = Linux Line Power {0} connected
+LinuxLinePower_NoPowerSuppliesException = No power supplies are found
+
 Block_Short            = Block
 Block_Long             = Block "{0}" {1} {2}
 Block_Long_Value       = Block "{0}" value {1} to "{2}"

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionLinuxLinePower.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionLinuxLinePower.java
@@ -1,0 +1,236 @@
+package jmri.jmrit.logixng.expressions;
+
+import java.beans.*;
+import java.io.*;
+import java.util.*;
+
+import jmri.*;
+import jmri.jmrit.logixng.*;
+import jmri.jmrit.logixng.util.*;
+import jmri.jmrit.logixng.util.parser.*;
+import jmri.util.TimerUtil;
+
+/**
+ * Check the status of battery and power supply.
+ *
+ * @author Daniel Bergqvist Copyright (C) 2023
+ */
+public class ExpressionLinuxLinePower extends AbstractDigitalExpression
+        implements PropertyChangeListener {
+
+    private Is_IsNot_Enum _is_IsNot = Is_IsNot_Enum.Is;
+    private ProtectedTimerTask _timerTask;
+    private final int _delay = 5;
+    private boolean _lastResult;
+    private JmriException _thrownException;
+
+    public ExpressionLinuxLinePower(String sys, String user)
+            throws BadUserNameException, BadSystemNameException {
+        super(sys, user);
+
+        try {
+            _lastResult = internalEvaluate();
+        } catch (JmriException e) {
+            _thrownException = e;
+        }
+    }
+
+    @Override
+    public Base getDeepCopy(Map<String, String> systemNames, Map<String, String> userNames) throws ParserException {
+        DigitalExpressionManager manager = InstanceManager.getDefault(DigitalExpressionManager.class);
+        String sysName = systemNames.get(getSystemName());
+        String userName = userNames.get(getSystemName());
+        if (sysName == null) sysName = manager.getAutoSystemName();
+        ExpressionLinuxLinePower copy = new ExpressionLinuxLinePower(sysName, userName);
+        copy.setComment(getComment());
+        copy.set_Is_IsNot(_is_IsNot);
+        return manager.registerExpression(copy);
+    }
+
+    public void set_Is_IsNot(Is_IsNot_Enum is_IsNot) {
+        _is_IsNot = is_IsNot;
+    }
+
+    public Is_IsNot_Enum get_Is_IsNot() {
+        return _is_IsNot;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Category getCategory() {
+        return Category.LINUX;
+    }
+
+    private List<String> getLinuxPowerSupplies() throws IOException, NoPowerSuppliesException {
+        List<String> powerSupplies = new ArrayList<>();
+
+        Process process = Runtime.getRuntime().exec("upower -e");
+        try (BufferedReader buffer = new BufferedReader(new InputStreamReader(process.getInputStream())))  {
+            String line;
+            while ((line = buffer.readLine()) != null) {
+                powerSupplies.add(line);
+            }
+        }
+
+//        powerSupplies.clear();  // For testing only
+
+        if (powerSupplies.isEmpty()) throw new NoPowerSuppliesException();
+
+        return powerSupplies;
+    }
+
+    public boolean isLinePowerOnline() throws IOException, JmriException {
+        boolean isPowerOnline = false;
+
+        for (String powerSupply : getLinuxPowerSupplies()) {
+            Process process = Runtime.getRuntime().exec("upower -i " + powerSupply);
+            try (BufferedReader buffer = new BufferedReader(new InputStreamReader(process.getInputStream())))  {
+                String line;
+                boolean linePowerFound = false;
+                while ((line = buffer.readLine()) != null) {
+                    if (line.isBlank()) continue;
+
+                    if (line.startsWith("  ")) {
+                        line = line.substring(2);
+                    } else {
+                        throw new JmriException("Unknown string. It doesn't start with two spaces.");
+                    }
+
+//                    System.out.format("'%s'%n", line);
+
+                    if ("line-power".equals(line)) {
+//                        System.out.format("Line power found%n");
+                        linePowerFound = true;
+                    } else if (line.startsWith("  ")) {
+//                        System.out.format("Spaces found%n");
+                        line = line.substring(2);
+                        if (linePowerFound && line.startsWith("online:")) {
+//                            System.out.format("Online found%n");
+                            String[] parts = line.split("\\s+");
+//                            System.out.format("Line: '%s', part0: '%s', part1: '%s'%n", line, parts[0], parts[1]);
+                            if ("yes".equals(parts[1])) {
+                                isPowerOnline = true;
+                            }
+                        }
+                    } else {
+//                        System.out.format("Other: %s%n", line);
+                        linePowerFound = false;
+                    }
+                }
+            }
+        }
+
+        return isPowerOnline;
+    }
+
+    private boolean internalEvaluate() throws JmriException {
+
+        try {
+            if (_is_IsNot == Is_IsNot_Enum.Is) {
+                return isLinePowerOnline();
+            } else {
+                return !isLinePowerOnline();
+            }
+        } catch (java.io.IOException e) {
+            throw new JmriException("IO Exception: " + e.getMessage(), e);
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean evaluate() throws JmriException {
+
+        if (_thrownException != null) {
+            JmriException e = _thrownException;
+            _thrownException = null;
+            throw e;
+        }
+
+        // Check this every ?? seconds
+        return internalEvaluate();
+    }
+
+    @Override
+    public FemaleSocket getChild(int index) throws IllegalArgumentException, UnsupportedOperationException {
+        throw new UnsupportedOperationException("Not supported.");
+    }
+
+    @Override
+    public int getChildCount() {
+        return 0;
+    }
+
+    @Override
+    public String getShortDescription(Locale locale) {
+        return Bundle.getMessage(locale, "LinuxLinePower_Short");
+    }
+
+    @Override
+    public String getLongDescription(Locale locale) {
+        return Bundle.getMessage(locale, "LinuxLinePower_Long", _is_IsNot.toString());
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void setup() {
+        // Do nothing
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void registerListenersForThisClass() {
+        if (!_listenersAreRegistered) {
+            _timerTask = new ProtectedTimerTask() {
+                @Override
+                public void execute() {
+                    try {
+                        boolean _lastLastResult = _lastResult;
+                        _lastResult = internalEvaluate();
+                        if (_lastResult != _lastLastResult) {
+                            getConditionalNG().execute();
+                        }
+                    } catch (JmriException e) {
+                        _thrownException = e;
+                    }
+                }
+            };
+
+            TimerUtil.schedule(_timerTask, _delay*1000, _delay*1000);
+            _listenersAreRegistered = true;
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void unregisterListenersForThisClass() {
+        if (_listenersAreRegistered) {
+            _timerTask.cancel();
+            _listenersAreRegistered = false;
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void propertyChange(PropertyChangeEvent evt) {
+        getConditionalNG().execute();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void disposeMe() {
+    }
+
+
+    public static class NoPowerSuppliesException extends JmriException {
+
+        /**
+         * Creates a new instance of <code>NoPowerSuppliesException</code>.
+         */
+        public NoPowerSuppliesException() {
+            super(Bundle.getMessage("LinuxLinePower_NoPowerSuppliesException"));
+        }
+    }
+
+//    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ExpressionLinuxLinePower.class);
+
+}

--- a/java/src/jmri/jmrit/logixng/expressions/configurexml/ExpressionLinuxLinePowerXml.java
+++ b/java/src/jmri/jmrit/logixng/expressions/configurexml/ExpressionLinuxLinePowerXml.java
@@ -1,0 +1,60 @@
+package jmri.jmrit.logixng.expressions.configurexml;
+
+import jmri.*;
+import jmri.configurexml.JmriConfigureXmlException;
+import jmri.jmrit.logixng.*;
+import jmri.jmrit.logixng.expressions.ExpressionLinuxLinePower;
+
+import org.jdom2.Element;
+
+/**
+ * Handle XML configuration for ExpressionLinuxLinePowerXml objects.
+ *
+ * @author Bob Jacobsen Copyright: Copyright (c) 2004, 2008, 2010
+ * @author Daniel Bergqvist Copyright (C) 2023
+ */
+public class ExpressionLinuxLinePowerXml extends jmri.managers.configurexml.AbstractNamedBeanManagerConfigXML {
+
+    public ExpressionLinuxLinePowerXml() {
+    }
+
+    /**
+     * Default implementation for storing the contents of a ExpressionLinuxLinePower
+     *
+     * @param o Object to store, of type ExpressionLinuxLinePower
+     * @return Element containing the complete info
+     */
+    @Override
+    public Element store(Object o) {
+        ExpressionLinuxLinePower p = (ExpressionLinuxLinePower) o;
+
+        Element element = new Element("ExpressionLinuxLinePower");
+        element.setAttribute("class", this.getClass().getName());
+        element.addContent(new Element("systemName").addContent(p.getSystemName()));
+
+        storeCommon(p, element);
+
+        element.addContent(new Element("is_isNot").addContent(p.get_Is_IsNot().name()));
+
+        return element;
+    }
+
+    @Override
+    public boolean load(Element shared, Element perNode) throws JmriConfigureXmlException {
+        String sys = getSystemName(shared);
+        String uname = getUserName(shared);
+        ExpressionLinuxLinePower h = new ExpressionLinuxLinePower(sys, uname);
+
+        loadCommon(h, shared);
+
+        Element is_IsNot = shared.getChild("is_isNot");
+        if (is_IsNot != null) {
+            h.set_Is_IsNot(Is_IsNot_Enum.valueOf(is_IsNot.getTextTrim()));
+        }
+
+        InstanceManager.getDefault(DigitalExpressionManager.class).registerExpression(h);
+        return true;
+    }
+
+//    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ExpressionLinuxLinePowerXml.class);
+}

--- a/java/src/jmri/jmrit/logixng/expressions/swing/DigitalExpressionSwingBundle.properties
+++ b/java/src/jmri/jmrit/logixng/expressions/swing/DigitalExpressionSwingBundle.properties
@@ -50,6 +50,22 @@ ExpressionConditional_Components        = Conditional {0} {1} {2}
 DigitalFormula_Formula                  = Formula
 DigitalFormula_InvalidFormula           = Formula is invalid: "{0}"
 
+ExpressionLinuxLinePower_Components     = Linux Line Power {0} connected
+ExpressionLinuxLinePower_NoPowerSuppliesFound   =                           \
+<html>                                                                      \
+<b>Warning</b><br>                                                          \
+No power supplies are found.<br>                                            \
+The Linux command line tool <i>upower</> needs<br>                          \
+to be installed for this expression to work.                                \
+</html>
+ExpressionLinuxLinePower_Error          =                                   \
+<html>                                                                      \
+<b>Warning</b><br>                                                          \
+This expression failed to try to read if power is connected.<br>            \
+The Linux command line tool <i>upower</> needs to be installed<br>          \
+for this expression to work.                                                \
+</html>
+
 ExpressionBlock_Components              = Block {0} {1} {2} {3}
 
 ExpressionClock_Components              = {0} time {1} between {2} and {3}

--- a/java/src/jmri/jmrit/logixng/expressions/swing/ExpressionLinuxLinePowerSwing.java
+++ b/java/src/jmri/jmrit/logixng/expressions/swing/ExpressionLinuxLinePowerSwing.java
@@ -1,0 +1,115 @@
+package jmri.jmrit.logixng.expressions.swing;
+
+import java.io.IOException;
+import java.util.List;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import javax.swing.*;
+
+import jmri.*;
+import jmri.jmrit.logixng.*;
+import jmri.jmrit.logixng.expressions.ExpressionLinuxLinePower;
+import jmri.jmrit.logixng.expressions.ExpressionLinuxLinePower.NoPowerSuppliesException;
+import jmri.jmrit.logixng.swing.SwingConfiguratorInterface;
+import jmri.util.swing.JComboBoxUtil;
+
+/**
+ * Configures an ExpressionLinuxLinePower object with a Swing JPanel.
+ *
+ * @author Daniel Bergqvist Copyright (C) 2023
+ */
+public class ExpressionLinuxLinePowerSwing extends AbstractDigitalExpressionSwing {
+
+    private JComboBox<Is_IsNot_Enum> _is_IsNot_ComboBox;
+
+
+    public ExpressionLinuxLinePowerSwing() {
+    }
+
+    public ExpressionLinuxLinePowerSwing(JDialog dialog) {
+        super.setJDialog(dialog);
+    }
+
+    @Override
+    protected void createPanel(@CheckForNull Base object, @Nonnull JPanel buttonPanel) {
+        ExpressionLinuxLinePower expression = (ExpressionLinuxLinePower)object;
+
+        panel = new JPanel();
+        panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
+
+        _is_IsNot_ComboBox = new JComboBox<>();
+        for (Is_IsNot_Enum e : Is_IsNot_Enum.values()) {
+            _is_IsNot_ComboBox.addItem(e);
+        }
+        JComboBoxUtil.setupComboBoxMaxRows(_is_IsNot_ComboBox);
+
+        if (expression != null) {
+            _is_IsNot_ComboBox.setSelectedItem(expression.get_Is_IsNot());
+        }
+
+        JComponent[] components = new JComponent[]{
+            _is_IsNot_ComboBox
+        };
+
+        JPanel innerPanel = new JPanel();
+        List<JComponent> componentList = SwingConfiguratorInterface.parseMessage(
+                Bundle.getMessage("ExpressionLinuxLinePower_Components"), components);
+
+        for (JComponent c : componentList) innerPanel.add(c);
+
+        panel.add(innerPanel);
+
+        try {
+            ExpressionLinuxLinePower tempExpression = new ExpressionLinuxLinePower("IQDE1", null);
+            tempExpression.isLinePowerOnline();
+        } catch (NoPowerSuppliesException e) {
+            JPanel p = new JPanel();
+            p.add(new JLabel(Bundle.getMessage("ExpressionLinuxLinePower_NoPowerSuppliesFound")));
+            panel.add(p);
+        } catch (IOException | JmriException e) {
+            JPanel p = new JPanel();
+            p.add(new JLabel(Bundle.getMessage("ExpressionLinuxLinePower_Error")));
+            panel.add(p);
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean validate(@Nonnull List<String> errorMessages) {
+        return true;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public MaleSocket createNewObject(@Nonnull String systemName, @CheckForNull String userName) {
+        ExpressionLinuxLinePower expression = new ExpressionLinuxLinePower(systemName, userName);
+        updateObject(expression);
+        return InstanceManager.getDefault(DigitalExpressionManager.class).registerExpression(expression);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void updateObject(@Nonnull Base object) {
+        if (! (object instanceof ExpressionLinuxLinePower)) {
+            throw new IllegalArgumentException("object must be an ExpressionLinuxLinePower but is a: "+object.getClass().getName());
+        }
+        ExpressionLinuxLinePower expression = (ExpressionLinuxLinePower)object;
+
+        expression.set_Is_IsNot((Is_IsNot_Enum)_is_IsNot_ComboBox.getSelectedItem());
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String toString() {
+        return Bundle.getMessage("LinuxLinePower_Short");
+    }
+
+    @Override
+    public void dispose() {
+    }
+
+
+//    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ExpressionLinuxLinePowerSwing.class);
+
+}

--- a/java/test/jmri/jmrit/logixng/ActionsAndExpressionsTest.java
+++ b/java/test/jmri/jmrit/logixng/ActionsAndExpressionsTest.java
@@ -298,7 +298,8 @@ public class ActionsAndExpressionsTest {
                     "Bundle",
                     "AbstractAnalogExpression","AnalogFactory",     // Analog
                     "AbstractDigitalExpression","AbstractScriptDigitalExpression","DigitalFactory",     // Digital
-                    "AbstractStringExpression","StringFactory"      // String
+                    "AbstractStringExpression","StringFactory",     // String
+                    "ExpressionLinuxLinePower"     // Only exists on Linux
                 });
 
         Assert.assertFalse("No errors found", errorsFound);

--- a/java/test/jmri/jmrit/logixng/CreateLogixNGTreeScaffold.java
+++ b/java/test/jmri/jmrit/logixng/CreateLogixNGTreeScaffold.java
@@ -3135,6 +3135,27 @@ public class CreateLogixNGTreeScaffold {
         and.getChild(indexExpr++).connect(maleSocket);
 
 
+        ExpressionLinuxLinePower expressionLinuxLinePower =
+                new ExpressionLinuxLinePower(digitalExpressionManager.getAutoSystemName(), null);
+        maleSocket = digitalExpressionManager.registerExpression(expressionLinuxLinePower);
+        maleSocket.setEnabled(false);
+        and.getChild(indexExpr++).connect(maleSocket);
+
+        expressionLinuxLinePower =
+                new ExpressionLinuxLinePower(digitalExpressionManager.getAutoSystemName(), null);
+        expressionLinuxLinePower.set_Is_IsNot(Is_IsNot_Enum.Is);
+        maleSocket = digitalExpressionManager.registerExpression(expressionLinuxLinePower);
+        maleSocket.setEnabled(false);
+        and.getChild(indexExpr++).connect(maleSocket);
+
+        expressionLinuxLinePower =
+                new ExpressionLinuxLinePower(digitalExpressionManager.getAutoSystemName(), null);
+        expressionLinuxLinePower.set_Is_IsNot(Is_IsNot_Enum.IsNot);
+        maleSocket = digitalExpressionManager.registerExpression(expressionLinuxLinePower);
+        maleSocket.setEnabled(false);
+        and.getChild(indexExpr++).connect(maleSocket);
+
+
         ExpressionBlock expressionBlock = new ExpressionBlock(digitalExpressionManager.getAutoSystemName(), null);
         maleSocket = digitalExpressionManager.registerExpression(expressionBlock);
         maleSocket.setEnabled(false);

--- a/java/test/jmri/jmrit/logixng/implementation/DefaultFemaleDigitalExpressionSocketTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/DefaultFemaleDigitalExpressionSocketTest.java
@@ -132,6 +132,12 @@ public class DefaultFemaleDigitalExpressionSocketTest extends FemaleSocketTestBa
         classes.add(jmri.jmrit.logixng.expressions.True.class);
         map.put(Category.OTHER, classes);
 
+        if (jmri.util.SystemType.isLinux()) {
+            classes = new ArrayList<>();
+            classes.add(jmri.jmrit.logixng.expressions.ExpressionLinuxLinePower.class);
+            map.put(Category.LINUX, classes);
+        }
+
         Assert.assertTrue("maps are equal",
                 isConnectionClassesEquals(map, _femaleSocket.getConnectableClasses()));
     }

--- a/xml/schema/logixng/digital-expressions/digital-expressions-4.23.1.xsd
+++ b/xml/schema/logixng/digital-expressions/digital-expressions-4.23.1.xsd
@@ -35,6 +35,7 @@
   <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/digital-expressions/expression-dispatcher-4.23.1.xsd"/>
   <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/digital-expressions/expression-entryexit-4.23.1.xsd"/>
   <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/digital-expressions/expression-light-4.23.1.xsd"/>
+  <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/digital-expressions/expression-linux-line-power-5.3.4.xsd"/>
   <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/digital-expressions/expression-local-variable-4.23.1.xsd"/>
   <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/digital-expressions/expression-loconet-slot-usage-4.23.1.xsd"/>
   <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/digital-expressions/expression-memory-4.23.1.xsd"/>
@@ -79,12 +80,13 @@
             <xs:element name="Antecedent"         type="LogixNG_DigitalExpression_AntecedentType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="CallDigitalExpressionModule"  type="LogixNG_DigitalExpression_CallModuleType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="ConnectionName"     type="LogixNG_DigitalExpression_ConnectionNameType" minOccurs="0" maxOccurs="unbounded" />
-            <xs:element name="ExpressionBlock"    type="LogixNG_DigitalExpression_ExpressionBlock" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="ExpressionBlock"    type="LogixNG_DigitalExpression_ExpressionBlockType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="ExpressionClock"    type="LogixNG_DigitalExpression_ExpressionClockType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="ExpressionConditional"  type="LogixNG_DigitalExpression_ExpressionConditionalType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="ExpressionDispatcher"  type="LogixNG_DigitalExpression_ExpressionDispatcherType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="ExpressionEntryExit"    type="LogixNG_DigitalExpression_ExpressionEntryExit" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="ExpressionLight"    type="LogixNG_DigitalExpression_ExpressionLightType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="ExpressionLinuxLinePower"  type="LogixNG_DigitalExpression_ExpressionLinuxLinePowerType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="ExpressionLocalVariable"  type="LogixNG_DigitalExpression_ExpressionLocalVariableType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="ExpressionLoconetSlotUsage" type="LogixNG_DigitalExpression_ExpressionLocoNetSlotUsageType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="ExpressionMemory"   type="LogixNG_DigitalExpression_ExpressionMemoryType" minOccurs="0" maxOccurs="unbounded" />

--- a/xml/schema/logixng/digital-expressions/expression-block-4.23.1.xsd
+++ b/xml/schema/logixng/digital-expressions/expression-block-4.23.1.xsd
@@ -25,7 +25,7 @@
             "
         >
 
-    <xs:complexType name="LogixNG_DigitalExpression_ExpressionBlock">
+    <xs:complexType name="LogixNG_DigitalExpression_ExpressionBlockType">
       <xs:annotation>
         <xs:documentation>
           Define the XML stucture for storing the contents of a ExpressionBlock class.

--- a/xml/schema/logixng/digital-expressions/expression-linux-line-power-5.3.4.xsd
+++ b/xml/schema/logixng/digital-expressions/expression-linux-line-power-5.3.4.xsd
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="../schema2xhtml.xsl" type="text/xsl"?>
+
+<!-- This schema is part of JMRI. Copyright 2018.                           -->
+<!--                                                                        -->
+<!-- JMRI is free software; you can redistribute it and/or modify it under  -->
+<!-- the terms of version 2 of the GNU General Public License as published  -->
+<!-- by the Free Software Foundation. See the "COPYING" file for a copy     -->
+<!-- of this license.                                                       -->
+<!--                                                                        -->
+<!-- JMRI is distributed in the hope that it will be useful, but WITHOUT    -->
+<!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
+<!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
+<!-- for more details.                                                      -->
+
+<!-- This file contains definitions for LogixNG                             -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:xsi ="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:docbook="http://docbook.org/ns/docbook"
+           xmlns:jmri="http://jmri.org/xml/schema/JMRIschema"
+           xsi:schemaLocation="
+                http://jmri.org/xml/schema/JMRIschema http://jmri.org/xml/schema/JMRIschema.xsd
+                http://docbook.org/ns/docbook http://jmri.org/xml/schema/docbook/docbook.xsd
+            "
+        >
+
+    <xs:complexType name="LogixNG_DigitalExpression_ExpressionLinuxLinePowerType">
+      <xs:annotation>
+        <xs:documentation>
+          Define the XML stucture for storing the contents of a ExpressionLinuxLinePower class.
+        </xs:documentation>
+        <xs:appinfo>
+            <jmri:usingclass configurexml="true">jmri.jmrit.logixng.digital.expressions.configurexml.ExpressionLinuxLinePowerXml</jmri:usingclass>
+        </xs:appinfo>
+      </xs:annotation>
+
+            <xs:sequence>
+
+              <xs:element name="systemName" type="systemNameType" minOccurs="1" maxOccurs="1"/>
+              <xs:element name="userName" type="userNameType" minOccurs="0" maxOccurs="1"/>
+              <xs:element name="comment" type="commentType" minOccurs="0" maxOccurs="unbounded"/>
+
+              <xs:element name="is_isNot" type="LogixNG_Is_IsNot_Type" minOccurs="0" maxOccurs="1"/>
+
+<!--              <xs:element name="enabled" type="yesNoType" /> -->
+
+              <xs:element name="MaleSocket" type="LogixNG_MaleSocket_Type" minOccurs="0" maxOccurs="1"/>
+
+            </xs:sequence>
+<!--            <xs:attribute name="enabled" type="yesNoType" /> -->
+            <xs:attribute name="class" type="classType" use="required"/>
+
+    </xs:complexType>
+
+</xs:schema>


### PR DESCRIPTION
This PR adds the LogixNG expression `Linux Line Power`. It runs the `upower` command line tool to check if the computer has external power connected and doesn't run on battery. The main usage for this expression is to have JMRI and the computer shut down when external power is disconnected.

Linux has a builtin feature to shutdown power when battery is below a threashold, but this threashold cannot be higher than 20%. For old laptops with a bad battery, that might be too late. If the battery is bad, the computer needs to be shutdown immediately to not loose data.

This expression has a timer that runs the `upower` command line tool every five second and if it detects a change, it triggers the execution of the ConditionalNG.

The swing class has two security features.
- If the `upower` command isn't found or doesn't work as expected, a warning message is added to the configuration dialog.
- If the `upower` command reports none power interfaces, another warning message is added to the configuration dialog.

Since this expression only works on Linux, as far as I know, I have added a new category `Linux`. That category only exists when JMRI is run on Linux.