### PR TITLE
Persist firmware download path

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -600,6 +600,9 @@
         <a id="Misc" name="Misc"></a>
         <ul>
             <li>Updated the plantuml library to version 1.2023.1.  This is used to
-            create program documentation.</li>
+                create program documentation.</li>
+            <li>When downloading firmware to multiple boards, it can be a pain to have to select the file over and over.
+                This was changed to make the selected file (hence directory, etc) persistent from one download frame
+                to the next.
         </ul>
 

--- a/java/src/jmri/jmrix/AbstractLoaderPane.java
+++ b/java/src/jmri/jmrix/AbstractLoaderPane.java
@@ -89,7 +89,7 @@ public abstract class AbstractLoaderPane extends jmri.util.swing.JmriPanel
         setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
 
         {
-            /* Create panels for displaying a filename and for providing a file 
+            /* Create panels for displaying a filename and for providing a file
              * selection pushbutton
              */
             inputFileNamePanel = new JPanel();
@@ -201,7 +201,9 @@ public abstract class AbstractLoaderPane extends jmri.util.swing.JmriPanel
         }
     }
 
-    private JFileChooser chooser;
+    // static so that the selection will be retained from
+    // one open LoaderPane to the next
+    private static JFileChooser chooser;
 
     /**
      * Add filter(s) for possible types to the input file chooser.
@@ -502,7 +504,7 @@ public abstract class AbstractLoaderPane extends jmri.util.swing.JmriPanel
             disableDownloadVerifyButtons();
         }
     }
-    
+
     public void clearInputFileName() {
         inputFileName.setText("");
         inputFileName.setToolTipText("");

--- a/java/src/jmri/jmrix/openlcb/swing/downloader/LoaderPane.java
+++ b/java/src/jmri/jmrix/openlcb/swing/downloader/LoaderPane.java
@@ -97,6 +97,9 @@ public class LoaderPane extends jmri.jmrix.AbstractLoaderPane
 
     @Override
     public void doRead(JFileChooser chooser) {
+        // has a file been selected? Might not been if Chooser was cancelled
+        if (chooser == null || chooser.getSelectedFile() == null) return;
+
         String fn = chooser.getSelectedFile().getPath();
         readFile(fn);
         bar.setValue(0);


### PR DESCRIPTION
When downloading firmware to multiple boards, it can be a pain to have to select the file over and over.  This makes the selected file (hence directory, etc) persistent from one download frame to the next.