### PR TITLE
Add "duplicate" actions to the Timetable tool

### DIFF
--- a/help/en/html/tools/TimeTable.shtml
+++ b/help/en/html/tools/TimeTable.shtml
@@ -170,6 +170,7 @@
             <th>Layout</th>
             <td>1</td>
             <td>New Layout</td>
+            <td>Duplicate Layout</td>
             <td>Delete Layout</td>
           </tr>
 
@@ -182,6 +183,7 @@
           <tr>
             <th>Train Type</th>
             <td>3</td>
+            <td>Duplicate Train Type</td>
             <td>Delete Train Type</td>
           </tr>
 
@@ -195,6 +197,7 @@
             <th>Segment</th>
             <td>3</td>
             <td>Add Station</td>
+            <td>Duplicate Segment</td>
             <td>Delete Segment</td>
             <td>Graph: Display | Print</td>
           </tr>
@@ -202,6 +205,7 @@
           <tr>
             <th>Station</th>
             <td>4</td>
+            <td>Duplicate Station</td>
             <td>Delete Station</td>
           </tr>
 
@@ -215,6 +219,7 @@
             <th>Schedule</th>
             <td>3</td>
             <td>Add Train</td>
+            <td>Duplicate Schedule</td>
             <td>Delete Schedule</td>
           </tr>
 
@@ -222,6 +227,7 @@
             <th>Train</th>
             <td>4</td>
             <td>Add Stop</td>
+            <td>Duplicate Train</td>
             <td>Copy Stops</td>
             <td>Delete Train</td>
           </tr>
@@ -229,6 +235,7 @@
           <tr>
             <th>Stop</th>
             <td>5</td>
+            <td>Duplicate Stop</td>
             <td>Delete Stop</td>
             <td>Up</td>
             <td>Down</td>
@@ -399,23 +406,23 @@
       data.</p>
 
       <ul>
-        <li>Train name &mdash; This is usually a short name, or symbol, for the train.</li>
+        <li>Train Name &mdash; This is usually a short name, or symbol, for the train.</li>
 
         <li>Description &mdash; This is a more descriptive name for the train.</li>
 
         <li>Type &mdash; The train type is selected from the train type list defined earlier.</li>
 
-        <li>Default speed &mdash; The default speed is used when the next speed for a stop is set to
+        <li>Default Speed &mdash; The default speed is used when the next speed for a stop is set to
         zero.</li>
 
-        <li>Start time &mdash; The start time using hh:mm.</li>
+        <li>Start Time &mdash; The start time using hh:mm.</li>
 
         <li>Throttle &mdash; The assigned throttle if using the throttles feature.</li>
 
         <li>Notes &mdash; Additional information about the train, such as special handling.</li>
       </ul>
 
-      <p>The calculated duration for the train is also displayed.</p>
+      <p>The calculated duration for the train is also displayed as hh:mm.</p>
 
       <p><span class="since">since 4.99.4</span>When a new train is added and before any stops have
       been added, the <strong>Copy Stops</strong> action button can be used to copy the stops from

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -544,7 +544,8 @@
     <h3>Timetable</h3>
         <a id="Timetable" name="Timetable"></a>
         <ul>
-            <li></li>
+            <li>Add action buttons to <strong>duplicate</strong> the Timetable data items.</li>
+            <li>Add the logic to calculate the train route durations.</li>
         </ul>
 
    <h3>Tracker</h3>

--- a/java/src/jmri/jmrit/timetable/Layout.java
+++ b/java/src/jmri/jmrit/timetable/Layout.java
@@ -53,6 +53,20 @@ public class Layout implements VetoableChangeListener {
     private double _scaleMK;          // Scale mile (real feet) or km (real meter)
 
     /**
+     * Make a copy of the layout.
+     * @return a new layout instance.
+     */
+    public Layout getCopy() {
+        Layout copy = new Layout();
+        copy.setLayoutName(Bundle.getMessage("DuplicateCopyName", _layoutName));
+        copy.setScale(_scale);
+        copy.setFastClock(_fastClock);
+        copy.setThrottles(_throttles);
+        copy.setMetric(_metric);
+        return copy;
+    }
+
+    /**
      * Calculate the length of a scale mile or scale kilometer.
      * The values are adjusted for scale and fast clock ratio.
      * The resulting value is the real feet or meters.

--- a/java/src/jmri/jmrit/timetable/Schedule.java
+++ b/java/src/jmri/jmrit/timetable/Schedule.java
@@ -39,6 +39,21 @@ public class Schedule {
     private int _startHour = 0;
     private int _duration = 24;
 
+    /**
+     * Make a copy of the schedule.
+     * @param layoutId The new layoutId, if zero use the current layout id.
+     * @return a new schedule instance.
+     */
+    public Schedule getCopy(int layoutId) {
+        if (layoutId == 0) layoutId = getLayoutId();
+        Schedule copy = new Schedule(layoutId);
+        copy.setScheduleName(Bundle.getMessage("DuplicateCopyName", _scheduleName));
+        copy.setEffDate(_effDate);
+        copy.setStartHour(_startHour);
+        copy.setDuration(_duration);
+        return copy;
+    }
+
     public int getScheduleId() {
         return _scheduleId;
     }

--- a/java/src/jmri/jmrit/timetable/Segment.java
+++ b/java/src/jmri/jmrit/timetable/Segment.java
@@ -33,6 +33,18 @@ public class Segment {
     private final int _layoutId;
     private String _segmentName = Bundle.getMessage("NewSegmentName");  // NOI18N
 
+    /**
+     * Make a copy of the segment.
+     * @param layoutId The new layoutId, if zero use the current layout id.
+     * @return a new segment instance.
+     */
+    public Segment getCopy(int layoutId) {
+        if (layoutId == 0) layoutId = getLayoutId();
+        Segment copy = new Segment(layoutId);
+        copy.setSegmentName(Bundle.getMessage("DuplicateCopyName", _segmentName));
+        return copy;
+    }
+
     public int getSegmentId() {
         return _segmentId;
     }

--- a/java/src/jmri/jmrit/timetable/Station.java
+++ b/java/src/jmri/jmrit/timetable/Station.java
@@ -41,6 +41,22 @@ public class Station {
     private int _sidings = 0;
     private int _staging = 0;
 
+    /**
+     * Make a copy of the station.
+     * @param segmentId The new segmentId, if zero use the current segment id.
+     * @return a new station instance.
+     */
+    public Station getCopy(int segmentId) {
+        if (segmentId == 0) segmentId = getSegmentId();
+        Station copy = new Station(segmentId);
+        copy.setStationName(Bundle.getMessage("DuplicateCopyName", _stationName));
+        copy.setDistance(_distance);
+        copy.setDoubleTrack(_doubleTrack);
+        copy.setSidings(_sidings);
+        copy.setStaging(_staging);
+        return copy;
+    }
+
     public int getStationId() {
         return _stationId;
     }

--- a/java/src/jmri/jmrit/timetable/Stop.java
+++ b/java/src/jmri/jmrit/timetable/Stop.java
@@ -50,6 +50,28 @@ public class Stop {
     private int _stagingTrack = 0;
     private String _stopNotes = "";
 
+    /**
+     * Make a copy of the stop.
+     * @param trainId The new train id, if zero use the current train id.
+     * @param stationId The new station id.  If zero use the current station id.
+     * @param seq The sequence for the new stop.
+     * @return a new Stop instance.
+     */
+    public Stop getCopy(int trainId, int stationId, int seq) {
+        if (trainId == 0) trainId = getTrainId();
+        if (stationId == 0) stationId = getStationId();
+
+        Stop copy = new Stop(trainId, seq);
+        copy.setStationId(stationId);
+        copy.setDuration(_duration);
+        copy.setNextSpeed(_nextSpeed);
+        copy.setArriveTime(_arriveTime);
+        copy.setDepartTime(_departTime);
+        copy.setStagingTrack(_stagingTrack);
+        copy.setStopNotes(_stopNotes);
+        return copy;
+    }
+
     public int getStopId() {
         return _stopId;
     }

--- a/java/src/jmri/jmrit/timetable/TimeTableBundle.properties
+++ b/java/src/jmri/jmrit/timetable/TimeTableBundle.properties
@@ -119,6 +119,14 @@ CopyStopsButton = Copy Stops
 TitleCopyStops  = Select Train
 LabelCopyStops  = Select the train to provide the list of stops.
 
+DuplicateLayoutButtonText = Duplicate Layout
+DuplicateTrainTypeButtonText = Duplicate Train Type
+DuplicateSegmentButtonText = Duplicate Segment
+DuplicateStationButtonText = Duplicate Station
+DuplicateScheduleButtonText = Duplicate Schedule
+DuplicateTrainButtonText = Duplicate Train
+DuplicateStopButtonText = Duplicate Stop
+
 DeleteLayoutButtonText = Delete Layout
 DeleteTrainTypeButtonText = Delete Train Type
 DeleteSegmentButtonText = Delete Segment
@@ -130,6 +138,7 @@ DeleteStopButtonText = Delete Stop
 # Hints
 HintAddButton = Add a new item
 HintEditButton = Edit the selected item
+HintDuplicateButton = Duplicate the selected item
 HintDeleteButton = Delete the selected item
 HintSaveButton = Save the timetables
 HintDoneButton = Close the timetables window

--- a/java/src/jmri/jmrit/timetable/TimeTableBundle.properties
+++ b/java/src/jmri/jmrit/timetable/TimeTableBundle.properties
@@ -239,4 +239,5 @@ NewScheduleName = New Schedule
 NewScheduleDate = Today
 NewTrainName    = NT
 NewTrainDesc    = New Train
+DuplicateCopyName = {0} copy
 

--- a/java/src/jmri/jmrit/timetable/TimeTableDataManager.java
+++ b/java/src/jmri/jmrit/timetable/TimeTableDataManager.java
@@ -520,6 +520,9 @@ public class TimeTableDataManager {
         int elapseTime = 0;
         boolean firstStop = true;
 
+        int routeStart = currentTime;
+        int routeEnd = 0;
+
         for (Stop stop : stops) {
             Station station = getStation(stop.getStationId());
             Segment segment = getSegment(station.getSegmentId());
@@ -576,6 +579,7 @@ public class TimeTableDataManager {
             if (currentTime > 1439)
                 currentTime -= 1440;
             newDepart = currentTime;
+            routeEnd = currentTime;
 
             currentDistance = station.getDistance();
             currentSpeed = (stop.getNextSpeed() > 0) ? stop.getNextSpeed() : defaultSpeed;
@@ -590,6 +594,15 @@ public class TimeTableDataManager {
             } else {
                 throw new IllegalArgumentException(String.format("%s~%d~%s", TIME_OUT_OF_RANGE, stop.getSeq(), train.getTrainName()));  // NOI18N
             }
+        }
+        if (updateStops) {
+//             log.info("train {} route start {}, end {}", train.getTrainName(), routeStart, routeEnd);
+            var routeDuration = routeEnd - routeStart;
+            // Adjust for day wrap
+            if (routeEnd < routeStart) {
+                routeDuration = (1440 - routeStart) + routeEnd;
+            }
+            train.setRouteDuration(routeDuration);
         }
     }
 

--- a/java/src/jmri/jmrit/timetable/Train.java
+++ b/java/src/jmri/jmrit/timetable/Train.java
@@ -48,6 +48,28 @@ public class Train {
     private int _routeDuration = 0;
     private String _trainNotes = "";
 
+    /**
+     * Make a copy of the train.
+     * @param schedId The new schedule id, if zero use the current schedule id.
+     * @param typeId The new train type id.  If zero use the current train type id.
+     * @return a new Train instance.
+     */
+    public Train getCopy(int schedId, int typeId) {
+        if (schedId == 0) schedId = getScheduleId();
+        if (typeId == 0) typeId = getTypeId();
+
+        Train copy = new Train(schedId);
+        copy.setTypeId(typeId);
+        copy.setTrainName(Bundle.getMessage("DuplicateCopyName", _trainName));
+        copy.setTrainDesc(Bundle.getMessage("DuplicateCopyName", _trainDesc));
+        copy.setDefaultSpeed(_defaultSpeed);
+        copy.setStartTime(_startTime);
+        copy.setThrottle(_throttle);
+        copy.setRouteDuration(_routeDuration);
+        copy.setTrainNotes(_trainNotes);
+        return copy;
+    }
+
     public int getTrainId() {
         return _trainId;
     }

--- a/java/src/jmri/jmrit/timetable/TrainType.java
+++ b/java/src/jmri/jmrit/timetable/TrainType.java
@@ -37,6 +37,19 @@ public class TrainType {
     private String _typeName = Bundle.getMessage("NewTypeName");  // NOI18N
     private String _typeColor = "#000000";  // NOI18N
 
+    /**
+     * Make a copy of the train type.
+     * @param layoutId The new layoutId, if zero use the current layout id.
+     * @return a new train type instance.
+     */
+    public TrainType getCopy(int layoutId) {
+        if (layoutId == 0) layoutId = getLayoutId();
+        TrainType copy = new TrainType(layoutId);
+        copy.setTypeName(Bundle.getMessage("DuplicateCopyName", _typeName));
+        copy.setTypeColor(_typeColor);
+        return copy;
+    }
+
     public int getTypeId() {
         return _typeId;
     }

--- a/java/src/jmri/jmrit/timetable/swing/TimeTableFrame.java
+++ b/java/src/jmri/jmrit/timetable/swing/TimeTableFrame.java
@@ -155,11 +155,13 @@ public class TimeTableFrame extends jmri.util.JmriJFrame {
     // ------------ Button bar components ------------
     JPanel _leftButtonBar;
     JPanel _addButtonPanel;
+    JPanel _duplicateButtonPanel;
     JPanel _copyButtonPanel;
     JPanel _deleteButtonPanel;
     JPanel _moveButtonPanel;
     JPanel _graphButtonPanel;
     JButton _addButton = new JButton();
+    JButton _duplicateButton = new JButton();
     JButton _copyButton = new JButton();
     JButton _deleteButton = new JButton();
     JButton _displayButton = new JButton();
@@ -231,6 +233,19 @@ public class TimeTableFrame extends jmri.util.JmriJFrame {
         _addButtonPanel = new JPanel();
         _addButtonPanel.add(_addButton);
         _leftButtonBar.add(_addButtonPanel);
+
+        // ------------ Duplicate Button ------------
+        _duplicateButton = new JButton(Bundle.getMessage("DuplicateLayoutButtonText"));    // NOI18N
+        _duplicateButton.setToolTipText(Bundle.getMessage("HintDuplicateButton"));       // NOI18N
+        _duplicateButton.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                duplicatePressed();
+            }
+        });
+        _duplicateButtonPanel = new JPanel();
+        _duplicateButtonPanel.add(_duplicateButton);
+        _leftButtonBar.add(_duplicateButtonPanel);
 
         // ------------ Copy Button ------------
         _copyButton = new JButton(Bundle.getMessage("CopyStopsButton"));    // NOI18N
@@ -363,6 +378,7 @@ public class TimeTableFrame extends jmri.util.JmriJFrame {
 
         pack();
         _addButtonPanel.setVisible(false);
+        _duplicateButtonPanel.setVisible(false);
         _copyButtonPanel.setVisible(false);
         _deleteButtonPanel.setVisible(false);
         _graphButtonPanel.setVisible(false);
@@ -1012,6 +1028,45 @@ public class TimeTableFrame extends jmri.util.JmriJFrame {
 
         // Switch to new node
         _timetableTree.setSelectionPath(new TreePath(_leafNode.getPath()));
+    }
+
+    /**
+     * Duplicate selected item.
+     */
+    void duplicatePressed() {
+        log.info("duplicatePressed: node = {}", _curNodeType);
+//         switch (_curNodeType) {
+//             case "Layout":     // NOI18N
+//                 addLayout();
+//                 break;
+//
+//             case "TrainTypes": // NOI18N
+//                 addTrainType();
+//                 break;
+//
+//             case "Segments":   // NOI18N
+//                 addSegment();
+//                 break;
+//
+//             case "Segment":    // NOI18N
+//                 addStation();
+//                 break;
+//
+//             case "Schedules":  // NOI18N
+//                 addSchedule();
+//                 break;
+//
+//             case "Schedule":   // NOI18N
+//                 addTrain();
+//                 break;
+//
+//             case "Train":      // NOI18N
+//                 addStop();
+//                 break;
+//
+//             default:
+//                 log.error("Add called for unsupported node type: '{}'", _curNodeType);  // NOI18N
+//         }
     }
 
     /**
@@ -2661,6 +2716,7 @@ public class TimeTableFrame extends jmri.util.JmriJFrame {
 
         // Reset button bar
         _addButtonPanel.setVisible(false);
+        _duplicateButtonPanel.setVisible(false);
         _copyButtonPanel.setVisible(false);
         _deleteButtonPanel.setVisible(false);
         _moveButtonPanel.setVisible(false);
@@ -2670,6 +2726,8 @@ public class TimeTableFrame extends jmri.util.JmriJFrame {
             case "Layout":     // NOI18N
                 _addButton.setText(Bundle.getMessage("AddLayoutButtonText"));  // NOI18N
                 _addButtonPanel.setVisible(true);
+                _duplicateButton.setText(Bundle.getMessage("DuplicateLayoutButtonText"));  // NOI18N
+                _duplicateButtonPanel.setVisible(true);
                 _deleteButton.setText(Bundle.getMessage("DeleteLayoutButtonText"));  // NOI18N
                 _deleteButtonPanel.setVisible(true);
                 editPressed();
@@ -2682,6 +2740,8 @@ public class TimeTableFrame extends jmri.util.JmriJFrame {
                 break;
 
             case "TrainType":     // NOI18N
+                _duplicateButton.setText(Bundle.getMessage("DuplicateTrainTypeButtonText"));  // NOI18N
+                _duplicateButtonPanel.setVisible(true);
                 _deleteButton.setText(Bundle.getMessage("DeleteTrainTypeButtonText"));  // NOI18N
                 _deleteButtonPanel.setVisible(true);
                 editPressed();
@@ -2696,6 +2756,8 @@ public class TimeTableFrame extends jmri.util.JmriJFrame {
             case "Segment":     // NOI18N
                 _addButton.setText(Bundle.getMessage("AddStationButtonText"));  // NOI18N
                 _addButtonPanel.setVisible(true);
+                _duplicateButton.setText(Bundle.getMessage("DuplicateSegmentButtonText"));  // NOI18N
+                _duplicateButtonPanel.setVisible(true);
                 _deleteButton.setText(Bundle.getMessage("DeleteSegmentButtonText"));  // NOI18N
                 _deleteButtonPanel.setVisible(true);
                 _graphButtonPanel.setVisible(true);
@@ -2703,6 +2765,8 @@ public class TimeTableFrame extends jmri.util.JmriJFrame {
                 break;
 
             case "Station":     // NOI18N
+                _duplicateButton.setText(Bundle.getMessage("DuplicateStationButtonText"));  // NOI18N
+                _duplicateButtonPanel.setVisible(true);
                 _deleteButton.setText(Bundle.getMessage("DeleteStationButtonText"));  // NOI18N
                 _deleteButtonPanel.setVisible(true);
                 editPressed();
@@ -2717,6 +2781,8 @@ public class TimeTableFrame extends jmri.util.JmriJFrame {
             case "Schedule":     // NOI18N
                 _addButton.setText(Bundle.getMessage("AddTrainButtonText"));  // NOI18N
                 _addButtonPanel.setVisible(true);
+                _duplicateButton.setText(Bundle.getMessage("DuplicateScheduleButtonText"));  // NOI18N
+                _duplicateButtonPanel.setVisible(true);
                 _deleteButton.setText(Bundle.getMessage("DeleteScheduleButtonText"));  // NOI18N
                 _deleteButtonPanel.setVisible(true);
                 editPressed();
@@ -2731,12 +2797,16 @@ public class TimeTableFrame extends jmri.util.JmriJFrame {
                     _copyButtonPanel.setVisible(true);
                 }
 
+                _duplicateButton.setText(Bundle.getMessage("DuplicateTrainButtonText"));  // NOI18N
+                _duplicateButtonPanel.setVisible(true);
                 _deleteButton.setText(Bundle.getMessage("DeleteTrainButtonText"));  // NOI18N
                 _deleteButtonPanel.setVisible(true);
                 editPressed();
                 break;
 
             case "Stop":     // NOI18N
+                _duplicateButton.setText(Bundle.getMessage("DuplicateStopButtonText"));  // NOI18N
+                _duplicateButtonPanel.setVisible(true);
                 _deleteButton.setText(Bundle.getMessage("DeleteStopButtonText"));  // NOI18N
                 _deleteButtonPanel.setVisible(true);
                 editPressed();

--- a/java/src/jmri/jmrit/timetable/swing/TimeTableFrame.java
+++ b/java/src/jmri/jmrit/timetable/swing/TimeTableFrame.java
@@ -1111,18 +1111,18 @@ public class TimeTableFrame extends jmri.util.JmriJFrame {
         // Copy train types
         typeMap.clear();
         for (var type : _dataMgr.getTrainTypes(layoutId, true)) {
-            duplicateTrainType(newLayout.getLayoutId(), type.getTypeId(), (TimeTableTreeNode) typesNode);
+            duplicateTrainType(newLayout.getLayoutId(), type.getTypeId(), typesNode);
         }
 
         // Copy segments
         stationMap.clear();
         for (var segment : _dataMgr.getSegments(layoutId, true)) {
-            duplicateSegment(newLayout.getLayoutId(), segment.getSegmentId(), (TimeTableTreeNode) segmentsNode);
+            duplicateSegment(newLayout.getLayoutId(), segment.getSegmentId(), segmentsNode);
         }
 
         // schedules
         for (var schedule : _dataMgr.getSchedules(layoutId, true)) {
-            duplicateSchedule(newLayout.getLayoutId(), schedule.getScheduleId(), (TimeTableTreeNode) schedlulesNode);
+            duplicateSchedule(newLayout.getLayoutId(), schedule.getScheduleId(), schedlulesNode);
         }
 
         // Switch to new node
@@ -1134,7 +1134,7 @@ public class TimeTableFrame extends jmri.util.JmriJFrame {
     /**
      * Create a copy of a train type.
      * @param layoutId The id for the parent layout.  Zero if within the same layout.
-     * @param trainTypeId The id of the train type to be duplicated.
+     * @param typeId The id of the train type to be duplicated.
      * @param typesNode The types node which will be parent for the new train type.
      */
     void duplicateTrainType(int layoutId, int typeId, TimeTableTreeNode typesNode) {

--- a/java/src/jmri/jmrit/timetable/swing/TimeTableFrame.java
+++ b/java/src/jmri/jmrit/timetable/swing/TimeTableFrame.java
@@ -1035,7 +1035,6 @@ public class TimeTableFrame extends jmri.util.JmriJFrame {
      * Duplicate selected item.
      */
     void duplicatePressed() {
-        log.info("duplicatePressed: node = {}", _curNodeType);
         _dataMgr.setLockCalculate(true);
         switch (_curNodeType) {
             case "Layout":     // NOI18N

--- a/java/src/jmri/jmrit/timetable/swing/TimeTableFrame.java
+++ b/java/src/jmri/jmrit/timetable/swing/TimeTableFrame.java
@@ -1035,38 +1035,121 @@ public class TimeTableFrame extends jmri.util.JmriJFrame {
      */
     void duplicatePressed() {
         log.info("duplicatePressed: node = {}", _curNodeType);
-//         switch (_curNodeType) {
-//             case "Layout":     // NOI18N
-//                 addLayout();
-//                 break;
-//
-//             case "TrainTypes": // NOI18N
-//                 addTrainType();
-//                 break;
-//
-//             case "Segments":   // NOI18N
-//                 addSegment();
-//                 break;
-//
-//             case "Segment":    // NOI18N
-//                 addStation();
-//                 break;
-//
-//             case "Schedules":  // NOI18N
-//                 addSchedule();
-//                 break;
-//
-//             case "Schedule":   // NOI18N
-//                 addTrain();
-//                 break;
-//
-//             case "Train":      // NOI18N
-//                 addStop();
-//                 break;
-//
-//             default:
-//                 log.error("Add called for unsupported node type: '{}'", _curNodeType);  // NOI18N
-//         }
+        switch (_curNodeType) {
+            case "Layout":     // NOI18N
+                duplicateLayout();
+                break;
+
+            case "TrainType": // NOI18N
+                duplicateTrainType(0, _curNodeId, (TimeTableTreeNode) _curNode.getParent());
+                break;
+
+            case "Segment":    // NOI18N
+                duplicateSegment(0, _curNodeId,  (TimeTableTreeNode) _curNode.getParent());
+                break;
+
+            case "Station":    // NOI18N
+                duplicateStation(0, _curNodeId, (TimeTableTreeNode) _curNode.getParent());
+                break;
+
+            case "Schedule":  // NOI18N
+                duplicateSchedule();
+                break;
+
+            case "Train":   // NOI18N
+                duplicateTrain();
+                break;
+
+            case "Stop":      // NOI18N
+                duplicateStop();
+                break;
+
+            default:
+                log.error("Duplicate called for unsupported node type: '{}'", _curNodeType);  // NOI18N
+        }
+    }
+
+    void duplicateLayout() {
+        log.info("Duplicate Layout");
+    }
+
+    /**
+     * Create a copy of a train type.
+     * @param layoutId The id for the parent layout.  Zero if within the same layout.
+     * @param trainTypeId The id of the train type to be duplicated.
+     * @param typesNode The types node which will be parent for the new train type.
+     */
+    void duplicateTrainType(int layoutId, int typeId, TimeTableTreeNode typesNode) {
+        TrainType type = _dataMgr.getTrainType(typeId);
+        TrainType newType = type.getCopy(layoutId);
+        setShowReminder(true);
+
+        // Build tree components
+        _leafNode = new TimeTableTreeNode(newType.getTypeName(), "TrainType", newType.getTypeId(), 0);    // NOI18N
+        typesNode.add(_leafNode);
+        _timetableModel.nodeStructureChanged(typesNode);
+
+        // Switch to new node
+        _timetableTree.setSelectionPath(new TreePath(_leafNode.getPath()));
+    }
+
+    /**
+     * Create a copy of a segment.
+     * @param layoutId The id for the parent layout.  Zero if within the same layout.
+     * @param segmentId The id of the segment to be duplicated.
+     * @param segmentsNode The segments node which will be parent for the new segment.
+     */
+    void duplicateSegment(int layoutId, int segmentId, TimeTableTreeNode segmentsNode) {
+        Segment segment = _dataMgr.getSegment(segmentId);
+        Segment newSegment = segment.getCopy(layoutId);
+        setShowReminder(true);
+
+        // Build tree components
+        _leafNode = new TimeTableTreeNode(newSegment.getSegmentName(), "Segment", newSegment.getSegmentId(), 0);    // NOI18N
+        segmentsNode.add(_leafNode);
+        _timetableModel.nodeStructureChanged(segmentsNode);
+
+        // Duplicate the stations using the stations from the orignal segment
+        List<Station> stationList = new ArrayList<>(_dataMgr.getStations(segmentId, true));
+        TimeTableTreeNode segmentNode = _leafNode;
+        for (Station station : stationList) {
+            duplicateStation(newSegment.getSegmentId(), station.getStationId(), segmentNode);
+        }
+
+        // Switch to new node
+        _timetableTree.setSelectionPath(new TreePath(_leafNode.getPath()));
+    }
+
+    /**
+     * Create a copy of a station.
+     * @param segmentId The id for the parent segment.  Zero if within the same segment.
+     * @param stationId The id of the station to be duplicated.
+     * @param segmentNode The segment node which will be parent for the new station.
+     */
+    void duplicateStation(int segmentId, int stationId, TimeTableTreeNode segmentNode) {
+        Station station = _dataMgr.getStation(stationId);
+        Station newStation = station.getCopy(segmentId);
+        setShowReminder(true);
+
+        // Build tree components
+        _leafNode = new TimeTableTreeNode(newStation.getStationName(), "Station", newStation.getStationId(), 0);    // NOI18N
+        segmentNode.add(_leafNode);
+        _timetableModel.nodeStructureChanged(segmentNode);
+
+        // Switch to new node
+        _timetableTree.setSelectionPath(new TreePath(_leafNode.getPath()));
+    }
+
+    void duplicateSchedule() {
+        log.info("Duplicate schedule");
+    }
+
+    void duplicateTrain() {
+        log.info("Duplicate train");
+    }
+
+    void duplicateStop() {
+        log.info("Duplicate stop");
     }
 
     /**

--- a/java/test/jmri/jmrit/timetable/swing/TimeTableFrameTest.java
+++ b/java/test/jmri/jmrit/timetable/swing/TimeTableFrameTest.java
@@ -46,6 +46,7 @@ public class TimeTableFrameTest {
 
         menuTests();
         addTests();
+        duplicateTests();
         deleteTests();
         addTests();
         deleteLayout();
@@ -311,6 +312,11 @@ public class TimeTableFrameTest {
             jmri.ScaleManager.getScale("UK-N").setScaleRatio(150.0);
         } catch (PropertyVetoException ex) {
         }
+    }
+
+    void duplicateTests() {
+        _jto.clickOnPath(_jto.findPath(new String[]{"Test"}));  // NOI18N
+        new JButtonOperator(_jfo, Bundle.getMessage("DuplicateLayoutButtonText")).doClick();  // NOI18N
     }
 
     void timeRangeTests() {


### PR DESCRIPTION
The ability to duplicate a data type has been added, including the ability to duplicate an entire layout.

The calculation of the train route direction has been added.  This was missed in the orignal release.