### PR TITLE
Fix the CPE and PE 'hide' attribute to use showHidden() for store

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -463,13 +463,15 @@
    <h3>Panel Editor</h3>
         <a id="PE" name="PE"></a>
         <ul>
-            <li></li>
+            <li>The show hidden items selection was not being stored properly.  The fix may cause
+            unexpected changes the first time a PE panel is loaded.</li>
         </ul>
 
     <h3>Control Panel Editor</h3>
         <a id="CPE" name="CPE"></a>
         <ul>
-            <li></li>
+            <li>The show hidden items selection was not being stored properly.  The fix may cause
+            unexpected changes the first time a CPE panel is loaded.</li>
         </ul>
         <h4>Circuit Builder</h4>
             <a id="CPE-CB" name="CPE-CB"></a>

--- a/java/src/jmri/jmrit/display/controlPanelEditor/configurexml/ControlPanelEditorXml.java
+++ b/java/src/jmri/jmrit/display/controlPanelEditor/configurexml/ControlPanelEditorXml.java
@@ -55,7 +55,7 @@ public class ControlPanelEditorXml extends AbstractXmlAdapter {
         //panel.setAttribute("showcoordinates", ""+(p.showCoordinates()?"yes":"no"));
         panel.setAttribute("showtooltips", "" + (p.showToolTip() ? "yes" : "no"));
         panel.setAttribute("controlling", "" + (p.allControlling() ? "yes" : "no"));
-        panel.setAttribute("hide", p.showHidden() ? "yes" : "no");  // 5.3.4 hide redefined as showHidden
+        panel.setAttribute("hide", p.showHidden() ? "no" : "yes");  // hide=no means showHidden enabled
         panel.setAttribute("panelmenu", p.isPanelMenuVisible() ? "yes" : "no");
         panel.setAttribute("scrollable", p.getScrollable());
         if (p.getBackgroundColor() != null) {
@@ -205,8 +205,7 @@ public class ControlPanelEditorXml extends AbstractXmlAdapter {
         panel.setAllControlling(value);
 
         value = true;
-        // 5.3.4 hide redefined as showHidden
-        if ((a = shared.getAttribute("hide")) != null && a.getValue().equals("no")) {
+        if ((a = shared.getAttribute("hide")) != null && a.getValue().equals("yes")) {
             value = false;
         }
         panel.setShowHidden(value);

--- a/java/src/jmri/jmrit/display/controlPanelEditor/configurexml/ControlPanelEditorXml.java
+++ b/java/src/jmri/jmrit/display/controlPanelEditor/configurexml/ControlPanelEditorXml.java
@@ -55,7 +55,7 @@ public class ControlPanelEditorXml extends AbstractXmlAdapter {
         //panel.setAttribute("showcoordinates", ""+(p.showCoordinates()?"yes":"no"));
         panel.setAttribute("showtooltips", "" + (p.showToolTip() ? "yes" : "no"));
         panel.setAttribute("controlling", "" + (p.allControlling() ? "yes" : "no"));
-        panel.setAttribute("hide", p.isVisible() ? "no" : "yes");
+        panel.setAttribute("hide", p.showHidden() ? "yes" : "no");  // 5.3.4 hide redefined as showHidden
         panel.setAttribute("panelmenu", p.isPanelMenuVisible() ? "yes" : "no");
         panel.setAttribute("scrollable", p.getScrollable());
         if (p.getBackgroundColor() != null) {
@@ -204,9 +204,10 @@ public class ControlPanelEditorXml extends AbstractXmlAdapter {
         }
         panel.setAllControlling(value);
 
-        value = false;
-        if ((a = shared.getAttribute("hide")) != null && a.getValue().equals("yes")) {
-            value = true;
+        value = true;
+        // 5.3.4 hide redefined as showHidden
+        if ((a = shared.getAttribute("hide")) != null && a.getValue().equals("no")) {
+            value = false;
         }
         panel.setShowHidden(value);
 

--- a/java/src/jmri/jmrit/display/panelEditor/configurexml/PanelEditorXml.java
+++ b/java/src/jmri/jmrit/display/panelEditor/configurexml/PanelEditorXml.java
@@ -56,7 +56,7 @@ public class PanelEditorXml extends AbstractXmlAdapter {
         //panel.setAttribute("showcoordinates", ""+(p.showCoordinates()?"yes":"no"));
         panel.setAttribute("showtooltips", "" + (p.showToolTip() ? "yes" : "no"));
         panel.setAttribute("controlling", "" + (p.allControlling() ? "yes" : "no"));
-        panel.setAttribute("hide", p.isVisible() ? "no" : "yes");
+        panel.setAttribute("hide", p.showHidden() ? "yes" : "no");  // 5.3.4 hide redefined as showHidden
         panel.setAttribute("panelmenu", p.isPanelMenuVisible() ? "yes" : "no");
         panel.setAttribute("scrollable", p.getScrollable());
         if (p.getBackgroundColor() != null) {
@@ -167,7 +167,7 @@ public class PanelEditorXml extends AbstractXmlAdapter {
         //panel.setShowCoordinates(shared.getAttributeValue("showcoordinates","no").equals("yes"));
         panel.setAllShowToolTip(!shared.getAttributeValue("showtooltips","yes").equals("no"));
         panel.setAllControlling(!shared.getAttributeValue("controlling", "yes").equals("no"));
-        panel.setShowHidden(shared.getAttributeValue("hide","no").equals("yes"));
+        panel.setShowHidden(!shared.getAttributeValue("hide","yes").equals("no"));  // 5.3.4 hide redefined as showHidden
         panel.setPanelMenuVisible(!shared.getAttributeValue("panelmenu","yes").equals("no"));
         panel.setScroll(shared.getAttributeValue("scrollable","both"));
 

--- a/java/src/jmri/jmrit/display/panelEditor/configurexml/PanelEditorXml.java
+++ b/java/src/jmri/jmrit/display/panelEditor/configurexml/PanelEditorXml.java
@@ -56,7 +56,7 @@ public class PanelEditorXml extends AbstractXmlAdapter {
         //panel.setAttribute("showcoordinates", ""+(p.showCoordinates()?"yes":"no"));
         panel.setAttribute("showtooltips", "" + (p.showToolTip() ? "yes" : "no"));
         panel.setAttribute("controlling", "" + (p.allControlling() ? "yes" : "no"));
-        panel.setAttribute("hide", p.showHidden() ? "yes" : "no");  // 5.3.4 hide redefined as showHidden
+        panel.setAttribute("hide", p.showHidden() ? "no" : "yes");  // hide=no means showHidden enabled
         panel.setAttribute("panelmenu", p.isPanelMenuVisible() ? "yes" : "no");
         panel.setAttribute("scrollable", p.getScrollable());
         if (p.getBackgroundColor() != null) {
@@ -167,7 +167,7 @@ public class PanelEditorXml extends AbstractXmlAdapter {
         //panel.setShowCoordinates(shared.getAttributeValue("showcoordinates","no").equals("yes"));
         panel.setAllShowToolTip(!shared.getAttributeValue("showtooltips","yes").equals("no"));
         panel.setAllControlling(!shared.getAttributeValue("controlling", "yes").equals("no"));
-        panel.setShowHidden(!shared.getAttributeValue("hide","yes").equals("no"));  // 5.3.4 hide redefined as showHidden
+        panel.setShowHidden(!shared.getAttributeValue("hide","no").equals("yes"));
         panel.setPanelMenuVisible(!shared.getAttributeValue("panelmenu","yes").equals("no"));
         panel.setScroll(shared.getAttributeValue("scrollable","both"));
 

--- a/java/test/jmri/jmrit/display/panelEditor/loadref/IconSample.xml
+++ b/java/test/jmri/jmrit/display/panelEditor/loadref/IconSample.xml
@@ -40,7 +40,7 @@
     <logicDelay>500</logicDelay>
   </signalmastlogics>
   <timebase class="jmri.jmrit.simpleclock.configurexml.SimpleTimebaseXml" time="Wed Jun 01 14:08:11 EDT 2022" rate="1.0" startrate="1.0" run="yes" master="yes" sync="no" correct="no" display="no" startstopped="no" startrunning="yes" startsettime="no" startclockoption="0" showbutton="no" startsetrate="yes" />
-  <paneleditor class="jmri.jmrit.display.panelEditor.configurexml.PanelEditorXml" name="Panel" x="561" y="325" height="363" width="565" editable="yes" positionable="yes" showtooltips="yes" controlling="yes" hide="yes" panelmenu="yes" scrollable="both" redBackground="255" greenBackground="255" blueBackground="255">
+  <paneleditor class="jmri.jmrit.display.panelEditor.configurexml.PanelEditorXml" name="Panel" x="561" y="325" height="363" width="565" editable="yes" positionable="yes" showtooltips="yes" controlling="yes" hide="no" panelmenu="yes" scrollable="both" redBackground="255" greenBackground="255" blueBackground="255">
     <sensoricon sensor="IS1" x="147" y="18" level="10" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" degrees="90" momentary="false" icon="yes" class="jmri.jmrit.display.configurexml.SensorIconXml">
       <active url="program:resources/icons/track/line/TrackSeg/block-green.gif" degrees="90" scale="1.0">
         <rotation>0</rotation>


### PR DESCRIPTION
The CPE and PE xml **store** processes were using the panel visibility state as the `hide` value, but the xml **load** processes were using the `hide` value to indicate whether the hidden items on a panel should be shown when the panel was not in edit mode.

Since the existing xml files have potentially inconsistent data, the decision was made to treat the existing `hide` values **_as if_** they were `showHidden` values.  The first load after upgrading may result in unexpected showHidden behavior.

The `hide` attribute is set to **No** when `showHidden()` is enabled.