### PR TITLE
settingsdir discovery reorder

### DIFF
--- a/scripts/AppScriptTemplate
+++ b/scripts/AppScriptTemplate
@@ -230,21 +230,6 @@ if [ -z "${OS}" ] ; then
 fi
 ARCH=${ARCH:-}
 
-# set OS-specific settings
-case "${OS}" in
-    macosx|Darwin*)
-        settingsdir="${HOME}/Library/Preferences/JMRI"
-        OS="macosx"
-        ;;
-    Linux*)
-        settingsdir="${HOME}/.jmri"
-        OS="linux"
-        ;;
-    *)
-        settingsdir="${HOME}/.jmri"
-        ;;
-esac
-
 # get the settings directory if set on command line
 found_settingsdir=""
 for opt in "$@"; do
@@ -263,6 +248,23 @@ for opt in "$@"; do
         break;
     fi
 done
+
+if [ -z $settingsdir ]; then
+   # set OS-specific settings
+   case "${OS}" in
+     macosx|Darwin*)
+        settingsdir="${HOME}/Library/Preferences/JMRI"
+        OS="macosx"
+        ;;
+     Linux*)
+        settingsdir="${HOME}/.jmri"
+        OS="linux"
+        ;;
+     *)
+        settingsdir="${HOME}/.jmri"
+        ;;
+   esac
+fi
 
 # log to $settingsdir/log/launcher.log for debugging purposes
 launcher_log=${settingsdir}/log/launcher.log

--- a/scripts/AppScriptTemplate
+++ b/scripts/AppScriptTemplate
@@ -228,6 +228,15 @@ OS=${OS:-}
 if [ -z "${OS}" ] ; then
   OS=$( uname -s )
 fi
+# sanitize os names
+case "${OS}" in
+  macosx|Darwin*)
+     OS="macosx"
+     ;;
+  Linux*)
+     OS="linux"
+     ;;
+esac
 ARCH=${ARCH:-}
 
 # get the settings directory if set on command line
@@ -250,17 +259,12 @@ for opt in "$@"; do
 done
 
 if [ -z $settingsdir ]; then
-   # set OS-specific settings
+   # set OS-specific settingsdir if not on cmd line
    case "${OS}" in
      macosx|Darwin*)
         settingsdir="${HOME}/Library/Preferences/JMRI"
-        OS="macosx"
         ;;
-     Linux*)
-        settingsdir="${HOME}/.jmri"
-        OS="linux"
-        ;;
-     *)
+     Linux*|*)
         settingsdir="${HOME}/.jmri"
         ;;
    esac


### PR DESCRIPTION
In Linux I start up Faceless via systemd service, but there is no HOME variable, so it end up with error regardless that settingsdir was passed as argument. By this simple reordering it gets it from arg and then it doesn't need HOME variable.