### PR TITLE
Cleanup LogixNG controlled Dispatcher train when terminated externally

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -414,7 +414,7 @@
     <h3>LogixNG</h3>
         <a id="LogixNG" name="LogixNG"></a>
         <ul>
-          <li></li>
+          <li>Cleanup LogixNG controlled Dispatcher train when the train has been terminated by an external action.</li>
         </ul>
 
     <h3>Meters and MeterFrames</h3>

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionDispatcher.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionDispatcher.java
@@ -431,8 +431,18 @@ public class ExpressionDispatcher extends AbstractDigitalExpression
                 manageActiveTrain(evt);
                 break;
 
-            case "status":
             case "mode":
+                if ((int) evt.getNewValue() == ActiveTrain.TERMINATED) {
+                    // The Dispatcher active train was terminated by an external process.
+                    // Force the manager to update the LogixNG active train map.
+                    _atManager.getActiveTrain(_trainInfoFileName);
+                    return;
+                }
+
+                getConditionalNG().execute();
+                break;
+
+            case "status":
                 getConditionalNG().execute();
                 break;
 


### PR DESCRIPTION
When an active train is terminated using the Dispatcher window, the active train object remains since LogixNG still has a reference.  This results in unexpected status check results.