### PR TITLE
Change module IDs to get around a MERG FCU issue

### DIFF
--- a/java/src/jmri/jmrix/can/cbus/node/CbusNodeConstants.java
+++ b/java/src/jmri/jmrix/can/cbus/node/CbusNodeConstants.java
@@ -346,10 +346,12 @@ public class CbusNodeConstants {
         result.put(3, "CANSPROG"); // NOI18N
         result.put(4, "SBOOST"); // NOI18N
         result.put(5, "Unsupported"); // NOI18N
-        result.put(6, "CANISB"); // NOI18N
-        result.put(7, "CANCBUSIO"); // NOI18N
-        result.put(8, "CANSERVOIO"); // NOI18N
-        result.put(9, "CANSOLIO"); // NOI18N
+
+        result.put(8, "CANSOLNOID"); // NOI18N matches MERG CANSOL
+        result.put(50, "CANSERVOIO"); // NOI18N matches MERG canmio-svo
+        
+        result.put(100, "CANISB"); // NOI18N
+        result.put(101, "CANSOLIO"); // NOI18N
         return Collections.unmodifiableMap(result);
     }
     
@@ -503,14 +505,22 @@ public class CbusNodeConstants {
         result.put(2, "SPROG 3 Plus programmer/command station.");
         result.put(3, "CAN SPROG programmer/command station.");
         result.put(4, "System booster");
-        result.put(5, "Unsuppoerted module type");
-        result.put(6, "Isolated USB to CAN interface with CBUS node.");
-        result.put(7, "CBUS I/O module.");
-        result.put(8, "8-channel servo I/O.");
-        result.put(9, "8-channel twin-coil solenoid I/O.");
+        result.put(5, "Unsupported module type");
+        
+        result.put(8, "8-channel twin-coil solenoid, like MERG CANACC4_2.");
+        result.put(50, "8-channel servo I/O, like MERG CANMIO_SVO.");
+        
+        result.put(100, "Isolated USB to CAN interface with CBUS node.");
+        result.put(101, "8-channel twin-coil solenoid I/O.");
         return Collections.unmodifiableMap(result);
     }   
 
+//        result.put(8, "CANSOLNOID"); // NOI18N matches MERG CANSOL
+//        result.put(50, "CANSVO"); // NOI18N matches MERG canmio-svo
+//        
+//        result.put(100, "CANISB"); // NOI18N
+//        result.put(101, "CANSERVOIO"); // NOI18N
+//        result.put(102, "CANSOLIO"); // NOI18N
     
     /**
      * Return a string representation of Module Support Link
@@ -646,10 +656,10 @@ public class CbusNodeConstants {
         result.put(3, "https://www.sprog-dcc.co.uk/download-page"); // NOI18N
         result.put(4, "https://www.sprog-dcc.co.uk/download-page"); // NOI18N
         result.put(5, "https://www.sprog-dcc.co.uk/download-page"); // NOI18N
-        result.put(6, "https://www.sprog-dcc.co.uk/download-page"); // NOI18N
-        result.put(7, "https://www.sprog-dcc.co.uk/download-page"); // NOI18N
         result.put(8, "https://www.sprog-dcc.co.uk/download-page"); // NOI18N
-        result.put(9, "https://www.sprog-dcc.co.uk/download-page"); // NOI18N
+        result.put(50, "https://www.sprog-dcc.co.uk/download-page"); // NOI18N
+        result.put(100, "https://www.sprog-dcc.co.uk/download-page"); // NOI18N
+        result.put(101, "https://www.sprog-dcc.co.uk/download-page"); // NOI18N
         return Collections.unmodifiableMap(result);
     }
     

--- a/java/src/jmri/jmrix/can/cbus/node/CbusNodeConstants.java
+++ b/java/src/jmri/jmrix/can/cbus/node/CbusNodeConstants.java
@@ -347,8 +347,8 @@ public class CbusNodeConstants {
         result.put(4, "SBOOST"); // NOI18N
         result.put(5, "Unsupported"); // NOI18N
 
-        result.put(8, "CANSOLNOID"); // NOI18N matches MERG CANSOL
-        result.put(50, "CANSERVOIO"); // NOI18N matches MERG canmio-svo
+        result.put(8, "CANSOLNOID"); // NOI18N. Matches MERG CANSOL
+        result.put(50, "CANSERVOIO"); // NOI18N. Matches MERG canmio-svo
         
         result.put(100, "CANISB"); // NOI18N
         result.put(101, "CANSOLIO"); // NOI18N
@@ -515,13 +515,7 @@ public class CbusNodeConstants {
         return Collections.unmodifiableMap(result);
     }   
 
-//        result.put(8, "CANSOLNOID"); // NOI18N matches MERG CANSOL
-//        result.put(50, "CANSVO"); // NOI18N matches MERG canmio-svo
-//        
-//        result.put(100, "CANISB"); // NOI18N
-//        result.put(101, "CANSERVOIO"); // NOI18N
-//        result.put(102, "CANSOLIO"); // NOI18N
-    
+  
     /**
      * Return a string representation of Module Support Link
      * @param man int manufacturer ID


### PR DESCRIPTION
MERG FCU tool ignores the module manufacturer ID and/or default to MERG. This change allows some SPROG DCC modules to mimic existing MERG modules by changing module IDs to match.