### PR TITLE
Make sure IdTagManager has loaded before access

### DIFF
--- a/java/src/jmri/managers/DefaultIdTagManager.java
+++ b/java/src/jmri/managers/DefaultIdTagManager.java
@@ -1,12 +1,11 @@
 package jmri.managers;
 
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
+
 import javax.annotation.CheckForNull;
+import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
+
 import jmri.*;
 import jmri.implementation.AbstractInstanceInitializer;
 import jmri.implementation.DefaultIdTag;
@@ -102,6 +101,29 @@ public class DefaultIdTagManager extends AbstractManager<IdTag> implements IdTag
     @Nonnull
     public IdTag provide(@Nonnull String name) throws IllegalArgumentException {
         return provideIdTag(name);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    @CheckReturnValue
+    @Nonnull
+    public SortedSet<IdTag> getNamedBeanSet() {
+        // need to ensure that load has taken place before returning
+        if (!initialised && !loading) {
+            init();
+        }
+        return super.getNamedBeanSet();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    @CheckReturnValue
+    public int getObjectCount() {
+        // need to ensure that load has taken place before returning
+        if (!initialised && !loading) {
+            init();
+        }
+        return super.getObjectCount();
     }
 
     /** {@inheritDoc} */

--- a/java/src/jmri/managers/ProxyIdTagManager.java
+++ b/java/src/jmri/managers/ProxyIdTagManager.java
@@ -37,7 +37,7 @@ public class ProxyIdTagManager extends AbstractProvidingProxyManager<IdTag>
     @Override
     public void init() {
         if (!isInitialised()) {
-            getDefaultManager();
+            getDefaultManager().init();
         }
     }
 
@@ -49,14 +49,16 @@ public class ProxyIdTagManager extends AbstractProvidingProxyManager<IdTag>
 
     /**
      * {@inheritDoc}
+     *
+     * This returns the specific IdTagManager type.
      */
     @Override
     @Nonnull
-    public Manager<IdTag> getDefaultManager() {
+    public IdTagManager getDefaultManager() {
         if(defaultManager != getInternalManager()){
            defaultManager = getInternalManager();
         }
-        return defaultManager;
+        return (IdTagManager) defaultManager;
     }
 
     @Override


### PR DESCRIPTION
This fixes an oversight where some inherited methods were not properly initializing.