### PR TITLE
Loconet Consist Tools Scan all loco slots not just low slots

### DIFF
--- a/java/src/jmri/jmrix/loconet/LocoNetConsistManager.java
+++ b/java/src/jmri/jmrix/loconet/LocoNetConsistManager.java
@@ -10,6 +10,8 @@ import jmri.Consist;
 import jmri.LocoAddress;
 import jmri.DccLocoAddress;
 import jmri.implementation.AbstractConsistManager;
+import jmri.jmrix.loconet.SlotMapEntry.SlotType;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -91,38 +93,42 @@ public class LocoNetConsistManager extends AbstractConsistManager {
 
         // in the first pass, check for consists top addresses in the
         // command station slots.
-        for (int i = 0; i < 128; i++) {
-            LocoNetSlot s = sm.slot(i);
-            DccLocoAddress address = new DccLocoAddress(s.locoAddr(), LnThrottleManager.isLongAddress(s.locoAddr()));
-            if (log.isDebugEnabled()) {
-                log.debug(" Slot {} Address {} consist status {}", i, address, LnConstants.CONSIST_STAT(s.consistStatus()));
-            }
-            if (s.consistStatus() == LnConstants.CONSIST_TOP || s.consistStatus() == LnConstants.CONSIST_MID) {
-                // this is a consist top, add it to the list, if it is not there
-                // already.
-                if (!consistTable.containsKey(address)) {
-                    if (log.isDebugEnabled()) {
-                        log.debug("Adding Consist with Address {} due to command station read", address);
+        for (int i = 0; i < sm.getNumSlots(); i++) {
+            if (sm.slot(i).getSlotType() == SlotType.LOCO) {
+                LocoNetSlot s = sm.slot(i);
+                DccLocoAddress address = new DccLocoAddress(s.locoAddr(), LnThrottleManager.isLongAddress(s.locoAddr()));
+                if (log.isDebugEnabled()) {
+                    log.debug(" Slot {} Address {} consist status {}", i, address, LnConstants.CONSIST_STAT(s.consistStatus()));
+                }
+                if (s.consistStatus() == LnConstants.CONSIST_TOP || s.consistStatus() == LnConstants.CONSIST_MID) {
+                    // this is a consist top, add it to the list, if it is not there
+                    // already.
+                    if (!consistTable.containsKey(address)) {
+                        if (log.isDebugEnabled()) {
+                            log.debug("Adding Consist with Address {} due to command station read", address);
+                        }
+                        addConsist(address);
+                        getConsist(address).add(address, true); // add the address to the consist.
                     }
-                    addConsist(address);
-                    getConsist(address).add(address, true); // add the address to the consist.
                 }
             }
         }
 
         // make a second pass, this time looking for locomotives in a consist.
-        for (int i = 0; i < 128; i++) {
-            LocoNetSlot s = sm.slot(i);
-            DccLocoAddress address = new DccLocoAddress(s.locoAddr(), LnThrottleManager.isLongAddress(s.locoAddr()));
-            if (log.isDebugEnabled()) {
-                log.debug(" Slot {} Address {} consist status {}", i, address, LnConstants.CONSIST_STAT(s.consistStatus()));
-            }
-            if (s.consistStatus() == LnConstants.CONSIST_SUB || s.consistStatus() == LnConstants.CONSIST_MID) {
-                // this is a consist member, add it to the consist in the
-                // slot which it has a pointer to (the slot pointer is stored in
-                // the slot's speed).
-                DccLocoAddress lead = new DccLocoAddress(sm.slot(s.speed()).locoAddr(), LnThrottleManager.isLongAddress(sm.slot(s.speed()).locoAddr()));
-                getConsist(lead).add(address, s.isForward() == sm.slot(s.speed()).isForward());
+        for (int i = 0; i < sm.getNumSlots(); i++) {
+            if (sm.slot(i).getSlotType() == SlotType.LOCO) {
+                LocoNetSlot s = sm.slot(i);
+                DccLocoAddress address = new DccLocoAddress(s.locoAddr(), LnThrottleManager.isLongAddress(s.locoAddr()));
+                if (log.isDebugEnabled()) {
+                    log.debug(" Slot {} Address {} consist status {}", i, address, LnConstants.CONSIST_STAT(s.consistStatus()));
+                }
+                if (s.consistStatus() == LnConstants.CONSIST_SUB || s.consistStatus() == LnConstants.CONSIST_MID) {
+                    // this is a consist member, add it to the consist in the
+                    // slot which it has a pointer to (the slot pointer is stored in
+                    // the slot's speed).
+                    DccLocoAddress lead = new DccLocoAddress(sm.slot(s.speed()).locoAddr(), LnThrottleManager.isLongAddress(sm.slot(s.speed()).locoAddr()));
+                    getConsist(lead).add(address, s.isForward() == sm.slot(s.speed()).isForward());
+                }
             }
         }
         requestingUpdate = false;


### PR DESCRIPTION
During the startup of the Loconet Consist tool it scans for existing command station consists.

This updates the scans to scan all loco type slots.