### PR TITLE
Fix typo in MQTT sensor default path name

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -96,7 +96,7 @@
 
         <h4>MQTT</h4>
             <ul>
-                <li></li>
+                <li>Fix typo in Sensor default name; should not have visible effect.</li>
             </ul>
 
         <h4>MRC</h4>

--- a/java/src/jmri/jmrix/mqtt/MqttSensorManager.java
+++ b/java/src/jmri/jmrix/mqtt/MqttSensorManager.java
@@ -34,10 +34,10 @@ public class MqttSensorManager extends jmri.managers.AbstractSensorManager {
     }
 
     @Nonnull
-    public String sendTopicPrefix = "track/turnout/"; // for constructing topic; public for script access
+    public String sendTopicPrefix = "track/sensor/"; // for constructing topic; public for script access
     @Nonnull
-    public String rcvTopicPrefix = "track/turnout/"; // for constructing topic; public for script access
-    
+    public String rcvTopicPrefix = "track/sensor/"; // for constructing topic; public for script access
+
     /** {@inheritDoc} */
     @Override
     public boolean allowMultipleAdditions(String systemName) {
@@ -54,7 +54,7 @@ public class MqttSensorManager extends jmri.managers.AbstractSensorManager {
     public String createSystemName(@Nonnull String topicSuffix, @Nonnull String prefix) throws JmriException {
         return prefix + typeLetter() + topicSuffix;
     }
-    
+
     /**
      * Create an new sensor object.
      * {@inheritDoc}


### PR DESCRIPTION
This should have no user impact because the configuration process will override it, but better to get this cleaned up in any case.