### PR TITLE
Named icon searches location all

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -603,6 +603,17 @@
     <h3>Miscellaneous</h3>
         <a id="Misc" name="Misc"></a>
         <ul>
-            <li></li>
+            <li>The NamedIcon class will now search Locations.ALL for files. This means
+                <ul>
+                <li>Files and filepaths will be found in the user area first for all
+                    subclasses of
+                    <a href="https://www.jmri.org/JavaDoc/doc/jmri/jmrit/catalog/NamedIcon.html">NamedIcon</a>.
+                <li>This change might result in different graphics in some cases,
+                    where it hadn't been
+                    searching before and a file was not being found (even though it
+                    really should have been). Please check your graphics carefully to
+                    see if there are any issues.
+                </ul>
+            </li>
         </ul>
 

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -603,7 +603,7 @@
     <h3>Miscellaneous</h3>
         <a id="Misc" name="Misc"></a>
         <ul>
-            <li>The NamedIcon class will now search Locations.ALL for files. This means
+            <li>The NamedIcon class will now search <i>Locations.ALL</i> for files. This means
                 <ul>
                 <li>Files and filepaths will be found in the user area first for all
                     subclasses of

--- a/java/src/jmri/jmrit/catalog/NamedIcon.java
+++ b/java/src/jmri/jmrit/catalog/NamedIcon.java
@@ -163,7 +163,7 @@ public class NamedIcon extends ImageIcon {
 
     static private final String DEFAULTURL = "resources/icons/misc/X-red.gif";
     static private URL substituteDefaultUrl(String pUrl) {
-        URL url = FileUtil.findURL(pUrl);
+        URL url = FileUtil.findURL(pUrl, FileUtil.Location.ALL);
         if (url == null) {
             url = FileUtil.findURL(DEFAULTURL);
             log.error("Did not find \"{}\" for NamedIcon, substitute {}", pUrl, url);


### PR DESCRIPTION
See Issue #11880 

The NamedIcon class constructor wasn't doing any searching when given a raw pathname. It would just look in the program: location.  This PR changes it to search Locations.ALL, which first searches the user directory, then the program directory.  

This fixes the problem in #11880 with LocoIcons (markers).  it may also add searching to other kinds of icons.  In theory, if somebody 1) wants the system icon but 2) has put a different, replacement file in their user directory, that could cause their display to change.  I think that's a pretty unlikely case.