### PR TITLE
Update signal system speed and speed2 to valid values

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -501,7 +501,12 @@
         </ul>
         <h4>Signal Systems</h4>
             <ul>
-                <li></li>
+                <li>Updated several definitions to replace invalid <i>speed</i> and
+                    <i>speed2</i> values with proper speed indications.
+                    The invalid values had been previously interpreted as zero.</li>
+                <li>Updated the <i>xml/schema/aspecttable.xsd</i> schema to ensure that
+                    only valid <i>speed</i> and <i>speed2</i> values will occur in
+                    signal system definitions.</li>
             </ul>
 
         <h4>Signal Heads</h4>

--- a/xml/schema/aspecttable.xsd
+++ b/xml/schema/aspecttable.xsd
@@ -104,8 +104,46 @@
                     <xs:element name="reference" type="xs:string" minOccurs="0" maxOccurs="unbounded"></xs:element>
                     <xs:element name="comment" type="xs:string" minOccurs="0" maxOccurs="unbounded"></xs:element>
                     <xs:element name="imagelink" type="xs:string" minOccurs="0" maxOccurs="unbounded"></xs:element>
-                    <xs:element name="speed" type="xs:string" minOccurs="1" maxOccurs="1"></xs:element>
-                    <xs:element name="speed2" type="xs:string" minOccurs="1" maxOccurs="1"></xs:element>
+                    <xs:element name="speed" minOccurs="1" maxOccurs="1">
+                     <xs:simpleType>
+                        <xs:restriction base="xs:string">
+                          <xs:annotation><xs:documentation>
+                            These come from xml/signals/signalSpeeds.xml and must be kept consistent
+                          </xs:documentation></xs:annotation>
+                          <xs:enumeration value="Cab"/>
+                          <xs:enumeration value="Maximum"/>
+                          <xs:enumeration value="Normal"/>
+                          <xs:enumeration value="Sixty"/>
+                          <xs:enumeration value="Fifty"/>
+                          <xs:enumeration value="Limited"/>
+                          <xs:enumeration value="Medium"/>
+                          <xs:enumeration value="Slow"/>
+                          <xs:enumeration value="Restricted"/>
+                          <xs:enumeration value="RestrictedSlow"/>
+                          <xs:enumeration value="Stop"/>
+                        </xs:restriction>
+                      </xs:simpleType>
+                    </xs:element>
+                    <xs:element name="speed2" minOccurs="1" maxOccurs="1">
+                     <xs:simpleType>
+                        <xs:restriction base="xs:string">
+                          <xs:annotation><xs:documentation>
+                            These come from xml/signals/signalSpeeds.xml and must be kept consistent
+                          </xs:documentation></xs:annotation>
+                          <xs:enumeration value="Cab"/>
+                          <xs:enumeration value="Maximum"/>
+                          <xs:enumeration value="Normal"/>
+                          <xs:enumeration value="Sixty"/>
+                          <xs:enumeration value="Fifty"/>
+                          <xs:enumeration value="Limited"/>
+                          <xs:enumeration value="Medium"/>
+                          <xs:enumeration value="Slow"/>
+                          <xs:enumeration value="Restricted"/>
+                          <xs:enumeration value="RestrictedSlow"/>
+                          <xs:enumeration value="Stop"/>
+                        </xs:restriction>
+                      </xs:simpleType>
+                    </xs:element>
                     <xs:element name="route" minOccurs="0" maxOccurs="1">
                      <xs:simpleType>
                         <xs:restriction base="xs:string">

--- a/xml/signals/BNSF-1996/aspects.xml
+++ b/xml/signals/BNSF-1996/aspects.xml
@@ -75,7 +75,7 @@
       <rule>Rule 9.1.7</rule>
       <indication>Proceed prepared to pass next signal at restricted speed.</indication>
       <speed>Normal</speed>
-      <speed2>Restricting</speed2>
+      <speed2>Restricted</speed2>
       <route>Normal</route>
       <dccAspect>16</dccAspect>
     </aspect>

--- a/xml/signals/CFL-2014/aspects.xml
+++ b/xml/signals/CFL-2014/aspects.xml
@@ -37,7 +37,7 @@
     <aspect>
       <name>Diverging Clear</name>
       <indication>Proceed through divergance at indicated speed</indication>
-      <speed>Diverging</speed>
+      <speed>Medium</speed>
       <speed2>Normal</speed2>
       <route>Diverging</route>
       <dccAspect>6</dccAspect>
@@ -53,7 +53,7 @@
     <aspect>
       <name>Diverging Approach</name>
       <indication>Proceed through divergance at indicated speed preparing to stop at next signal</indication>
-      <speed>Diverging</speed>
+      <speed>Medium</speed>
       <speed2>Stop</speed2>
       <route>Diverging</route>
       <dccAspect>2</dccAspect>
@@ -62,23 +62,23 @@
       <name>Approach Diverging</name>
       <indication>Proceed preparing to diverge at next signal</indication>
       <speed>Normal</speed>
-      <speed2>Diverging</speed2>
+      <speed2>Medium</speed2>
       <route>Normal</route>
       <dccAspect>5</dccAspect>
     </aspect>
     <aspect>
       <name>Diverging Approach Diverging</name>
       <indication>Proceed through divergance at indicated speed preparing to diverge at next signal</indication>
-      <speed>Diverging</speed>
-      <speed2>Diverging</speed2>
+      <speed>Medium</speed>
+      <speed2>Medium</speed2>
       <route>Diverging</route>
       <dccAspect>4</dccAspect>
     </aspect>
     <aspect>
       <name>Restricting</name>
       <indication>Proceed with caution for shunting within shunt limits</indication>
-      <speed>Restricting</speed>
-      <speed2>Restricting</speed2>
+      <speed>Restricted</speed>
+      <speed2>Restricted</speed2>
       <route>Either</route>
       <dccAspect>1</dccAspect>
     </aspect>

--- a/xml/signals/CROR-2008/aspects.xml
+++ b/xml/signals/CROR-2008/aspects.xml
@@ -58,7 +58,7 @@
       <rule>Rule 408</rule>
       <indication>Proceed, approaching the next signal at DIVERGING speed.</indication>
       <speed>Normal</speed>
-      <speed2>Diverging</speed2>
+      <speed2>Medium</speed2>
       <route>Normal</route>
       <dccAspect>26</dccAspect>
     </aspect>
@@ -166,7 +166,7 @@
       <rule>Rule 420</rule>
       <indication>Proceed, LIMITED speed passing signal and through turnouts, next signal is displaying restricted signal.</indication>
       <speed>Limited</speed>
-      <speed2>Restricting</speed2>
+      <speed2>Restricted</speed2>
       <route>Diverging</route>
       <dccAspect>15</dccAspect>
     </aspect>
@@ -220,7 +220,7 @@
       <rule>Rule 426</rule>
       <indication>Proceed, MEDIUM speed passing signal and through turnouts, next signal is displaying restricted signal.</indication>
       <speed>Medium</speed>
-      <speed2>Restricting</speed2>
+      <speed2>Restricted</speed2>
       <route>Diverging</route>
       <dccAspect>9</dccAspect>
     </aspect>
@@ -237,7 +237,7 @@
       <name>Diverging to Clear</name>
       <rule>Rule 428</rule>
       <indication>Proceed, DIVERGING speed passing signal and through turnouts.</indication>
-      <speed>Diverging</speed>
+      <speed>Medium</speed>
       <speed2>Normal</speed2>
       <route>Diverging</route>
       <dccAspect>7</dccAspect>
@@ -246,8 +246,8 @@
       <name>Diverging to Stop</name>
       <rule>Rule 429</rule>
       <indication>Proceed, DIVERGING speed passing signal and through turnouts, preparing to stop at the next signal.</indication>
-      <speed>Diverging</speed>
-      <speed2>Diverging</speed2>
+      <speed>Medium</speed>
+      <speed2>Medium</speed2>
       <route>Normal</route>
       <dccAspect>3</dccAspect>
     </aspect>
@@ -255,8 +255,8 @@
       <name>Diverging</name>
       <rule>Rule 430</rule>
       <indication>Proceed, REDUCED speed  not exceeding DIVERGING speedpassing signal and through turnouts.</indication>
-      <speed>Diverging</speed>
-      <speed2>Diverging</speed2>
+      <speed>Medium</speed>
+      <speed2>Medium</speed2>
       <route>Normal</route>
       <dccAspect>2</dccAspect>
     </aspect>

--- a/xml/signals/CSD-1962-cestova/aspects.xml
+++ b/xml/signals/CSD-1962-cestova/aspects.xml
@@ -18,7 +18,7 @@
     <author>
         <personname><firstname>Petr</firstname><surname>Šídlo</surname></personname>
         <email>sidlo64@hotmail.com</email>
-    </author>    
+    </author>
   </authorgroup>
 
   <revhistory xmlns="http://docbook.org/ns/docbook">
@@ -27,23 +27,23 @@
         <date>2016-11-21</date>
         <authorinitials>PŠ</authorinitials>
         <revremark>Initial version</revremark>
-    </revision>    
+    </revision>
     <revision>
         <revnumber>2</revnumber>
         <date>2018-09-21</date>
         <authorinitials>PŠ</authorinitials>
         <revremark>Panel indicators</revremark>
-    </revision>    
+    </revision>
     <revision>
         <revnumber>3</revnumber>
         <date>2020-08-25</date>
         <authorinitials>PŠ</authorinitials>
         <revremark>Panel indicators JOP, Speed names</revremark>
-    </revision>    
+    </revision>
   </revhistory>
 
   <aspects>
-  
+
     <aspect>
       <name>Stůj</name>
       <title>Stop</title>
@@ -160,7 +160,7 @@
       <route>Diverging</route>
       <dccAspect>8</dccAspect>
     </aspect>
- 
+
     <aspect>
       <name>Rychlost 80 a opakovaná volno</name>
       <title>Slowly 80 km/h proceed clear repeated</title>
@@ -173,7 +173,7 @@
       <route>Diverging</route>
       <dccAspect>9</dccAspect>
     </aspect>
-    
+
     <aspect>
       <name>Rychlost 40 a opakovaná výstraha</name>
       <title>Slowly 40 km/h proceed caution repeated</title>
@@ -441,7 +441,7 @@
       <description>One white flashing light with red light</description>
       <reference>Aspect 31</reference>
       <comment>Opatrně na přivolávací návěst</comment>
-      <speed>Slowly</speed>
+      <speed>Slow</speed>
       <speed2>Stop</speed2>
       <route>Either</route>
       <dccAspect>31</dccAspect>
@@ -451,21 +451,21 @@
 
   <imagetypes>
 	<imagetype type="prototype"/>
-	
+
 	<imagetype type="AŽD zb"/>
 	<imagetype type="AŽD zbz"/>
 	<imagetype type="AŽD žzb"/>
 	<imagetype type="AŽD žzbz"/>
 	<imagetype type="AŽD žb"/>
 	<imagetype type="AŽD žbz"/>
-	
+
 	<imagetype type="ESP zb"/>
 	<imagetype type="ESP zbz"/>
 	<imagetype type="ESP žzb"/>
 	<imagetype type="ESP žzbz"/>
 	<imagetype type="ESP žb"/>
 	<imagetype type="ESP žbz"/>
-		
+
 	<imagetype type="JOP hlavní"/>
 	<imagetype type="JOP seřaďovací"/>
 

--- a/xml/signals/CSD-1962-mechaniky/aspects.xml
+++ b/xml/signals/CSD-1962-mechaniky/aspects.xml
@@ -18,7 +18,7 @@
     <author>
         <personname><firstname>Petr</firstname><surname>Šídlo</surname></personname>
         <email>sidlo64@hotmail.com</email>
-    </author>    
+    </author>
   </authorgroup>
 
   <revhistory xmlns="http://docbook.org/ns/docbook">
@@ -27,29 +27,29 @@
         <date>2016-12-28</date>
         <authorinitials>PŠ</authorinitials>
         <revremark>Initial version</revremark>
-    </revision>    
+    </revision>
     <revision>
         <revnumber>2</revnumber>
         <date>2018-09-22</date>
         <authorinitials>PŠ</authorinitials>
         <revremark>Panel indicators</revremark>
-    </revision>    
+    </revision>
     <revision>
         <revnumber>3</revnumber>
         <date>2019-02-21</date>
         <authorinitials>PŠ</authorinitials>
         <revremark>Test set</revremark>
-    </revision>    
+    </revision>
     <revision>
         <revnumber>4</revnumber>
         <date>2020-07-15</date>
         <authorinitials>PŠ</authorinitials>
         <revremark>Image types</revremark>
-    </revision>    
+    </revision>
   </revhistory>
 
   <aspects>
-  
+
     <aspect>
       <name>Stůj</name>
       <title>Stop</title>
@@ -103,7 +103,7 @@
       <reference>Aspect 7</reference>
       <comment>Pomalu, u hlavního návěstidla rychlost 40 km/h</comment>
       <speed>Normal</speed>
-      <speed2>40 km/h</speed2>
+      <speed2>Slow</speed2>
       <route>Normal</route>
       <dccAspect>3</dccAspect>
     </aspect>
@@ -131,7 +131,7 @@
       <description>Two green lights</description>
       <reference>Aspect 23</reference>
       <comment>Vjezd odbočkou, rychlost 40 km/h</comment>
-      <speed>40 km/h</speed>
+      <speed>Slow</speed>
       <speed2>Stop</speed2>
       <route>Diverging</route>
       <dccAspect>7</dccAspect>
@@ -198,7 +198,7 @@
       <description>Three white light arranged to triangl</description>
       <reference>Aspect 203</reference>
       <comment>Opatrně na přivolávací návěst</comment>
-      <speed>Slowly</speed>
+      <speed>Slow</speed>
       <speed2>Stop</speed2>
       <route>Either</route>
       <dccAspect>31</dccAspect>
@@ -209,7 +209,7 @@
   <imagetypes>
 	<imagetype type="prototype"/>
 	<imagetype type="prototype-night"/>
-        
+
 	<imagetype type="hlavní-1R"/>
 	<imagetype type="hlavní-2R"/>
 	<imagetype type="hlavní-2RP"/>
@@ -219,35 +219,35 @@
 	<imagetype type="vložená"/>
 	<imagetype type="uzávěry"/>
 	<imagetype type="vyčkávací"/>
-	
+
         <imagetype type="AŽD b"/>
-	
+
         <imagetype type="ESP b"/>
-	
+
   </imagetypes>
 
   <appearancefiles>
 
     <appearancefile href="appearance-entry_auxiliary.xml"/>
     <appearancefile href="appearance-entry_distant_auxiliary.xml"/>
-    
+
     <appearancefile href="appearance-entry.xml"/>
     <appearancefile href="appearance-entry_distant.xml"/>
-    
+
 
     <appearancefile href="appearance-exit.xml"/>
-        
+
     <appearancefile href="appearance-block.xml"/>
     <appearancefile href="appearance-block_distant.xml"/>
-    
+
     <appearancefile href="appearance-shunting.xml"/>
-        
+
     <appearancefile href="appearance-waiting.xml"/>
-        
+
     <appearancefile href="appearance-embedded.xml"/>
-    
+
     <appearancefile href="appearance-protection.xml"/>
-      
+
     <appearancefile href="appearance-test.xml"/>
 
   </appearancefiles>

--- a/xml/signals/CSD-1962-vlozena/aspects.xml
+++ b/xml/signals/CSD-1962-vlozena/aspects.xml
@@ -18,7 +18,7 @@
     <author>
         <personname><firstname>Petr</firstname><surname>Šídlo</surname></personname>
         <email>sidlo64@hotmail.com</email>
-    </author>    
+    </author>
   </authorgroup>
 
   <revhistory xmlns="http://docbook.org/ns/docbook">
@@ -27,23 +27,23 @@
         <date>2016-11-27</date>
         <authorinitials>PŠ</authorinitials>
         <revremark>Initial version</revremark>
-    </revision>    
+    </revision>
     <revision>
         <revnumber>2</revnumber>
         <date>2018-09-22</date>
         <authorinitials>PŠ</authorinitials>
         <revremark>Panel indicators</revremark>
-    </revision>    
+    </revision>
     <revision>
         <revnumber>3</revnumber>
         <date>2019-02-20</date>
         <authorinitials>PŠ</authorinitials>
         <revremark>Test set</revremark>
-    </revision>    
+    </revision>
   </revhistory>
 
   <aspects>
-  
+
     <aspect>
       <name>Stůj</name>
       <title>Stop</title>
@@ -91,7 +91,7 @@
       <reference>Aspect 16</reference>
       <comment>Očekávejte rychlost 40 km/h</comment>
       <speed>Normal</speed>
-      <speed2>40 km/h</speed2>
+      <speed2>Slow</speed2>
       <route>Normal</route>
       <dccAspect>3</dccAspect>
     </aspect>
@@ -129,7 +129,7 @@
       <description>Lower light yellow, upper light yellow</description>
       <reference>Aspect 23</reference>
       <comment>Rychlost 40 km/h a výstraha</comment>
-      <speed>40 km/h</speed>
+      <speed>Slow</speed>
       <speed2>Stop</speed2>
       <route>Diverging</route>
       <dccAspect>7</dccAspect>
@@ -168,8 +168,8 @@
       <description>Lower light white, upper light white</description>
       <reference>Aspect 110</reference>
       <comment>Sunout pomalu</comment>
-      <speed>Push slowly</speed>
-      <speed2>Push slowly</speed2>
+      <speed>RestrictedSlow</speed>
+      <speed2>RestrictedSlow</speed2>
       <route>Either</route>
       <dccAspect>17</dccAspect>
     </aspect>
@@ -181,8 +181,8 @@
       <description>Upper light white</description>
       <reference>Aspect 111</reference>
       <comment>Sunout rychleji</comment>
-      <speed>Push speedily</speed>
-      <speed2>Push speedily</speed2>
+      <speed>Restricted</speed>
+      <speed2>Restricted</speed2>
       <route>Either</route>
       <dccAspect>18</dccAspect>
     </aspect>
@@ -194,8 +194,8 @@
       <description>Red light with white letter Z</description>
       <reference>Aspect 112</reference>
       <comment>Zpět</comment>
-      <speed>Reverse</speed>
-      <speed2>Reverse</speed2>
+      <speed>Restricted</speed>
+      <speed2>Restricted</speed2>
       <route>Either</route>
       <dccAspect>19</dccAspect>
     </aspect>
@@ -207,8 +207,8 @@
       <description>Blue light with white letter Z</description>
       <reference>Aspect 112</reference>
       <comment>Zpět opakovaná</comment>
-      <speed>Reverse</speed>
-      <speed2>Reverse</speed2>
+      <speed>Restricted</speed>
+      <speed2>Restricted</speed2>
       <route>Either</route>
       <dccAspect>20</dccAspect>
     </aspect>
@@ -247,7 +247,7 @@
       <reference>Aspect 27</reference>
       <comment>Opakovaná očekávejte rychlost 40 km/h</comment>
       <speed>Normal</speed>
-      <speed2>40 km/h</speed2>
+      <speed2>Slow</speed2>
       <route>Normal</route>
       <dccAspect>23</dccAspect>
     </aspect>
@@ -324,7 +324,7 @@
       <description>One white light</description>
       <reference>Aspect 203</reference>
       <comment>Opatrně na přivolávací návěst</comment>
-      <speed>Slowly</speed>
+      <speed>Slow</speed>
       <speed2>Stop</speed2>
       <route>Either</route>
       <dccAspect>31</dccAspect>
@@ -334,15 +334,15 @@
 
   <imagetypes>
 	<imagetype type="prototype"/>
-	
+
 	<imagetype type="AŽD žzčb"/>
         <imagetype type="AŽD z"/>
         <imagetype type="AŽD b"/>
-	
+
 	<imagetype type="ESP žzčb"/>
         <imagetype type="ESP z"/>
         <imagetype type="ESP b"/>
-	
+
   </imagetypes>
 
   <appearancefiles>
@@ -350,9 +350,9 @@
     <appearancefile href="appearance-entry.xml"/>
     <appearancefile href="appearance-entry_distant.xml"/>
     <appearancefile href="appearance-entry_distant_repeater.xml"/>
-    
+
     <appearancefile href="appearance-embedded.xml"/>
-    
+
     <appearancefile href="appearance-exit.xml"/>
 
     <appearancefile href="appearance-shunting.xml"/>

--- a/xml/signals/CSD-1962-zakladni/aspects.xml
+++ b/xml/signals/CSD-1962-zakladni/aspects.xml
@@ -18,7 +18,7 @@
     <author>
         <personname><firstname>Petr</firstname><surname>Šídlo</surname></personname>
         <email>sidlo64@hotmail.com</email>
-    </author>    
+    </author>
   </authorgroup>
 
   <revhistory xmlns="http://docbook.org/ns/docbook">
@@ -27,29 +27,29 @@
         <date>2016-07-02</date>
         <authorinitials>PŠ</authorinitials>
         <revremark>Initial version</revremark>
-    </revision>    
+    </revision>
     <revision>
         <revnumber>2</revnumber>
         <date>2018-09-19</date>
         <authorinitials>PŠ</authorinitials>
         <revremark>Panel indicators</revremark>
-    </revision>    
+    </revision>
     <revision>
         <revnumber>3</revnumber>
         <date>2019-02-19</date>
         <authorinitials>PŠ</authorinitials>
         <revremark>Aspect 26 Unlit</revremark>
-    </revision>    
+    </revision>
     <revision>
         <revnumber>4</revnumber>
         <date>2020-08-25</date>
         <authorinitials>PŠ</authorinitials>
         <revremark>Panel indicators JOP, Speed names</revremark>
-    </revision>    
+    </revision>
   </revhistory>
 
   <aspects>
-  
+
     <aspect>
       <name>Stůj</name>
       <title>Stop</title>
@@ -446,7 +446,7 @@
       <description>One white flashing light</description>
       <reference>Aspect 31</reference>
       <comment>Opatrně na přivolávací návěst</comment>
-      <speed>Slowly</speed>
+      <speed>Slow</speed>
       <speed2>Stop</speed2>
       <route>Either</route>
       <dccAspect>30</dccAspect>
@@ -459,7 +459,7 @@
       <description>One white flashing light with red light</description>
       <reference>Aspect 31</reference>
       <comment>Opatrně na přivolávací návěst</comment>
-      <speed>Slowly</speed>
+      <speed>Slow</speed>
       <speed2>Stop</speed2>
       <route>Either</route>
       <dccAspect>31</dccAspect>
@@ -468,9 +468,9 @@
   </aspects>
 
   <imagetypes>
-      
+
 	<imagetype type="prototype"/>
-	
+
         <imagetype type="AŽD z"/>
 	<imagetype type="AŽD zč"/>
 	<imagetype type="AŽD zb"/>
@@ -481,7 +481,7 @@
 	<imagetype type="AŽD žzb"/>
 	<imagetype type="AŽD žzbz"/>
 	<imagetype type="AŽD žčb"/>
-	
+
         <imagetype type="ESP z"/>
 	<imagetype type="ESP zč"/>
 	<imagetype type="ESP zb"/>
@@ -492,10 +492,10 @@
 	<imagetype type="ESP žzb"/>
 	<imagetype type="ESP žzbz"/>
 	<imagetype type="ESP žčb"/>
-	
+
 	<imagetype type="JOP hlavní"/>
 	<imagetype type="JOP seřaďovací"/>
-	
+
   </imagetypes>
 
   <appearancefiles>
@@ -508,10 +508,10 @@
 
     <appearancefile href="appearance-block.xml"/>
     <appearancefile href="appearance-block_distant.xml"/>
-    
+
     <appearancefile href="appearance-abs.xml"/>
     <appearancefile href="appearance-abs4.xml"/>
-    
+
     <appearancefile href="appearance-shunting.xml"/>
 
     <appearancefile href="appearance-test.xml"/>

--- a/xml/signals/FS-1987/aspects.xml
+++ b/xml/signals/FS-1987/aspects.xml
@@ -101,7 +101,7 @@
 	  <description>Red-Yellow</description>
 	  <comment>da usare per 1. e 2. vela</comment>
       <speed>Restricted</speed>
-      <speed2 />
+      <speed2>Restricted</speed2>
     </aspect>
 
     <aspect>
@@ -110,7 +110,7 @@
 	  <description>Red-Blinking Yellow</description>
 	  <comment>da usare per 1. e 2. vela</comment>
       <speed>Slow</speed>
-      <speed2 />
+      <speed2>Slow</speed2>
     </aspect>
 
     <aspect>
@@ -119,7 +119,7 @@
 	  <description>Red-Green</description>
 	  <comment>da usare per 1. e 2. vela</comment>
       <speed>Restricted</speed>
-      <speed2 />
+      <speed2>Restricted</speed2>
     </aspect>
 
     <aspect>
@@ -128,7 +128,7 @@
 	  <description>Yellow-Yellow</description>
 	  <comment>da usare per 1. e 2. vela</comment>
       <speed>Restricted</speed>
-      <speed2 />
+      <speed2>Restricted</speed2>
     </aspect>
 
     <aspect>
@@ -137,7 +137,7 @@
 	  <description>Yellow-Green</description>
 	  <comment>next main signal is set to diverging route max. 30 Km/h</comment>
       <speed>Slow</speed>
-      <speed2 />
+      <speed2>Slow</speed2>
     </aspect>
 
     <aspect>
@@ -146,7 +146,7 @@
 	  <description>Blinking Yellow-Green</description>
 	  <comment>next main signal is set to diverging route max. 60 Km/h</comment>
       <speed>Medium</speed>
-      <speed2 />
+      <speed2>Medium</speed2>
     </aspect>
 
     <aspect>
@@ -155,7 +155,7 @@
 	  <description>Alternate Blinking Yellow-Green</description>
 	  <comment>next main signal is set to diverging route max. 100 Km/h</comment>
       <speed>Limited</speed>
-      <speed2 />
+      <speed2>Limited</speed2>
     </aspect>
 
     <aspect>
@@ -164,7 +164,7 @@
 	  <description>Alternate Blinking Yellow-Green</description>
 	  <comment>Diverging clear and next main signal is set to diverging route max. 30 Km/h</comment>
       <speed>Slow</speed>
-      <speed2 />
+      <speed2>Slow</speed2>
     </aspect>
 
     <aspect>
@@ -190,8 +190,8 @@
       <indication>Diverging Approach</indication>
 	  <description>Alternate Blinking Yellow-Green</description>
 	  <comment>Diverging approach</comment>
-      <speed>Restricted Slow</speed>
-      <speed2>Diverging Clear</speed2>
+      <speed>RestrictedSlow</speed>
+      <speed2>Normal</speed2>
     </aspect>
 
     <aspect>
@@ -208,7 +208,7 @@
 	  <description>Real: 2 horizontal white lamps - Panel: dark</description>
 	  <comment>Stop</comment>
       <speed>Stop</speed>
-      <speed2 />
+      <speed2>Stop</speed2>
     </aspect>
 
     <aspect>
@@ -216,8 +216,8 @@
       <indication>Shunting-Clear</indication>
 	  <description>Real: 2 vertical white lamps - Panel: white lamp</description>
 	  <comment>Diverging approach</comment>
-      <speed>Restricted Slow</speed>
-      <speed2 />
+      <speed>RestrictedSlow</speed>
+      <speed2>RestrictedSlow</speed2>
     </aspect>
 
   </aspects>

--- a/xml/signals/InfraBel-2013/aspects.xml
+++ b/xml/signals/InfraBel-2013/aspects.xml
@@ -47,8 +47,8 @@
     <aspect>
       <name>Restricting</name>
       <indication>Proceed with caution</indication>
-      <speed>Restricting</speed>
-      <speed2>Restricting</speed2>
+      <speed>Restricted</speed>
+      <speed2>Restricted</speed2>
       <route>Normal</route>
       <dccAspect>3</dccAspect>
     </aspect>

--- a/xml/signals/LMS-1932/aspects.xml
+++ b/xml/signals/LMS-1932/aspects.xml
@@ -151,16 +151,16 @@
     <aspect>
       <name>Permissive</name>
       <indication>Proceed with caution</indication>
-      <speed>Restricting</speed>
-      <speed2>Restricting</speed2>
+      <speed>Restricted</speed>
+      <speed2>Restricted</speed2>
       <route>Either</route>
       <dccAspect>2</dccAspect>
     </aspect>
     <aspect>
       <name>Take Siding</name>
       <indication>Proceed with caution</indication>
-      <speed>Restricting</speed>
-      <speed2>Restricting</speed2>
+      <speed>Restricted</speed>
+      <speed2>Restricted</speed2>
       <route>Diverging</route>
       <dccAspect>1</dccAspect>
     </aspect>

--- a/xml/signals/NYC-1956/aspects.xml
+++ b/xml/signals/NYC-1956/aspects.xml
@@ -16,7 +16,7 @@
   <authorgroup xmlns="http://docbook.org/ns/docbook">
     <author>
         <personname><firstname>John</firstname><surname>Lang</surname></personname>
-    </author>    
+    </author>
   </authorgroup>
 
   <revhistory xmlns="http://docbook.org/ns/docbook">
@@ -27,20 +27,20 @@
         <revremark>Initial version</revremark>
     </revision>
     <revision>
-    
+
         <revnumber>2</revnumber>
         <date>2013-07-07</date>
         <authorinitials>JDL</authorinitials>
         <revremark>aspect mapping revisions</revremark>
     </revision>
-    
+
     <revision>
         <revnumber>2.1</revnumber>
         <date>2013-12-30</date>
         <authorinitials>JDL</authorinitials>
         <revremark>fixed aspect name reference in appearence files. tweaked aspect mappings</revremark>
     </revision>
-    
+
   </revhistory>
 
   <aspects>
@@ -54,7 +54,7 @@
       <speed2>Normal</speed2>
       <route>Normal</route>
     </aspect>
-    
+
     <aspect>
       <name>Advance Approach Medium</name>
       <rule>Rule 281A</rule>
@@ -64,7 +64,7 @@
       <speed2>Limited</speed2>
       <route>Normal</route>
     </aspect>
- 
+
     <aspect>
       <name>Approach Limited</name>
       <rule>Rule 281B</rule>
@@ -114,7 +114,7 @@
       <speed2>Medium</speed2>
       <route>Either</route>
     </aspect>
-    
+
     <aspect>
       <name>Medium Clear</name>
       <rule>Rule 283</rule>
@@ -123,7 +123,7 @@
       <speed>Medium</speed>
       <speed2>Normal</speed2>
       <route>Diverging</route>
-    </aspect>   
+    </aspect>
 
     <aspect>
       <name>Medium-Advance Approach</name>
@@ -143,15 +143,15 @@
       <speed>Medium</speed>
       <speed2>Slow</speed2>
       <route>Either</route>
-    </aspect>   
-    
+    </aspect>
+
     <aspect>
       <name>Approach Slow</name>
       <rule>Rule 284</rule>
       <indication>Proceed approaching next signal at slow speed Train exceeding medium speed must at once reduce to that speed</indication>
       <reference>Page 94</reference>
       <speed>Medium</speed>
-      <speed2>slow</speed2>
+      <speed2>Slow</speed2>
       <route>Normal</route>
     </aspect>
 
@@ -164,7 +164,7 @@
       <speed2>Stop</speed2>
       <route>Normal</route>
     </aspect>
- 
+
     <aspect>
       <name>Medium-Approach</name>
       <rule>Rule 286</rule>
@@ -173,8 +173,8 @@
       <speed>Medium</speed>
       <speed2>Stop</speed2>
       <route>Diverging</route>
-    </aspect>  
-  
+    </aspect>
+
     <aspect>
       <name>Slow-Clear</name>
       <rule>Rule 287</rule>
@@ -184,7 +184,7 @@
       <speed2>Normal</speed2>
       <route>Diverging</route>
     </aspect>
- 
+
     <aspect>
       <name>Slow-Approach</name>
       <rule>Rule 288</rule>
@@ -224,7 +224,7 @@
       <route>Either</route>
     </aspect>
 
-    <aspect>  
+    <aspect>
       <name>Held</name>
       <rule>Rule 292</rule>
       <indication>Stop.</indication>
@@ -232,8 +232,8 @@
       <speed>Stop</speed>
       <speed2>Stop</speed2>
       <route>Either</route>
-    </aspect>  
-    
+    </aspect>
+
   </aspects>
 
   <appearancefiles>
@@ -243,6 +243,6 @@
     <appearancefile href="appearance-SL-2-high-per.xml"/>
     <appearancefile href="appearance-SL-3-high.xml"/>
   </appearancefiles>
-  
+
 </aspecttable>
-  
+

--- a/xml/signals/NYCS-1937/aspects.xml
+++ b/xml/signals/NYCS-1937/aspects.xml
@@ -16,7 +16,7 @@
   <authorgroup xmlns="http://docbook.org/ns/docbook">
     <author>
         <personname><firstname>Dick</firstname><surname>Bronson</surname></personname>
-    </author>    
+    </author>
   </authorgroup>
 
   <revhistory xmlns="http://docbook.org/ns/docbook">
@@ -31,13 +31,13 @@
         <date>2010-01-11</date>
         <authorinitials>DB</authorinitials>
         <revremark>Typo Correction</revremark>
-    </revision>    
+    </revision>
     <revision>
         <revnumber>3</revnumber>
         <date>2020-01-03</date>
         <authorinitials>BJ</authorinitials>
         <revremark>Duplicate Stop aspect corrected</revremark>
-    </revision>    
+    </revision>
   </revhistory>
 
   <aspects>
@@ -103,7 +103,7 @@
       <indication>Proceed preparing to stop at second signal</indication>
       <reference>Page 95</reference>
       <speed>Medium</speed>
-      <speed2>Approach</speed2>
+      <speed2>Medium</speed2>
     </aspect>
 
     <aspect>
@@ -112,7 +112,7 @@
       <indication>Proceed; medium speed within interlocking limits</indication>
       <reference>Page 45</reference>
       <speed>Medium</speed>
-      <speed2>Clear</speed2>
+      <speed2>Normal</speed2>
     </aspect>
 
     <aspect>
@@ -121,7 +121,7 @@
       <indication>Proceed preparing to stop at second signal; medium speed within interlocking limits</indication>
       <reference>Page 96</reference>
       <speed>Medium</speed>
-      <speed2>Approach</speed2>
+      <speed2>Medium</speed2>
     </aspect>
 
     <aspect>
@@ -138,7 +138,7 @@
       <rule>Rule 284</rule>
       <indication>Proceed approaching next signal at slow speed. Train exceeding medium speed must at once reduce to that speed.</indication>
       <reference>Page 97</reference>
-      <speed>Approach</speed>
+      <speed>Medium</speed>
       <speed2>Slow</speed2>
     </aspect>
 
@@ -147,8 +147,8 @@
       <rule>Rule 285</rule>
       <indication>Proceed preparing to stop at next signal. Train exceeding medium speed must at once reduce to that speed.</indication>
       <reference>Page 98</reference>
-      <speed>Approach</speed>
-      <speed2>Approach</speed2>
+      <speed>Medium</speed>
+      <speed2>Medium</speed2>
     </aspect>
 
     <aspect>
@@ -157,7 +157,7 @@
       <indication>Proceed at medium speed preparing to stop at next signal</indication>
       <reference>Page 99</reference>
       <speed>Medium</speed>
-      <speed2>Approach</speed2>
+      <speed2>Medium</speed2>
     </aspect>
 
     <aspect>
@@ -166,7 +166,7 @@
       <indication>Proceed; slow speed within interlocking limits.</indication>
       <reference>Page 100</reference>
       <speed>Slow</speed>
-      <speed2>Clear</speed2>
+      <speed2>Normal</speed2>
     </aspect>
 
     <aspect>
@@ -175,7 +175,7 @@
       <indication>Proceed preparing to stop at next signal; slow speed within interlocking limits.</indication>
       <reference>Page 100</reference>
       <speed>Slow</speed>
-      <speed2>Approach</speed2>
+      <speed2>Medium</speed2>
     </aspect>
 
     <aspect>
@@ -183,8 +183,8 @@
       <rule>Rule 289</rule>
       <indication>Proceed; Manual Block</indication>
       <reference>Page 101</reference>
-      <speed>Clear</speed>
-      <speed2>Clear</speed2>
+      <speed>Normal</speed>
+      <speed2>Normal</speed2>
     </aspect>
 
     <aspect>
@@ -261,6 +261,6 @@
     <appearancefile href="appearance-SL-2-low.xml"/>
     <appearancefile href="appearance-SL-3-high.xml"/>
   </appearancefiles>
-  
+
 </aspecttable>
-  
+

--- a/xml/signals/PKP-PLK-2020/aspects.xml
+++ b/xml/signals/PKP-PLK-2020/aspects.xml
@@ -12,7 +12,7 @@
   <copyright xmlns="http://docbook.org/ns/docbook">
     <year>2020</year><holder>JMRI</holder>
   </copyright>
-  
+
   <authorgroup xmlns="http://docbook.org/ns/docbook">
     <author>
         <personname><firstname>Damian</firstname><surname>Dąbrowa</surname></personname>
@@ -142,16 +142,16 @@
       <name>Sygnał Ms 1</name>
       <indication>Pojedynczy ciągły sygnał niebieski</indication>
       <description>Jazda manewrowa zabroniona</description>
-      <speed />
-      <speed2 />
+      <speed>Restricted</speed>
+      <speed2>Restricted</speed2>
     </aspect>
 
     <aspect>
       <name>Sygnał Ms 2</name>
       <indication>Pojedynczy ciągły sygnał biały</indication>
       <description>Jazda manewrowa dozwolona</description>
-      <speed>Shunting</speed>
-      <speed2>Shunting</speed2>
+      <speed>Restricted</speed>
+      <speed2>Restricted</speed2>
     </aspect>
   </aspects>
 
@@ -160,7 +160,7 @@
     <imagetype type="default"/>
     <imagetype type="small"/>
   </imagetypes>
-  
+
   <appearancefiles>
     <appearancefile href="appearance-sbl2.xml"/>
     <appearancefile href="appearance-sbl3.xml"/>

--- a/xml/signals/SNCF-2015/aspects.xml
+++ b/xml/signals/SNCF-2015/aspects.xml
@@ -306,8 +306,8 @@
       <indication>Indicateur de Direction éteint</indication>
       <description>tableau fixe lumineux.</description>
       <comment>Indique la direction géographique.</comment>
-      <speed>Clear</speed>
-      <speed2>Clear</speed2>
+      <speed>Normal</speed>
+      <speed2>Normal</speed2>
       <route>Either</route>
       <dccAspect>15</dccAspect>
  </aspect>
@@ -317,8 +317,8 @@
       <indication>Indicateur de Direction</indication>
       <description>tableau fixe lumineux.</description>
       <comment>Indique la direction géographique.</comment>
-      <speed>Clear</speed>
-      <speed2>Clear</speed2>
+      <speed>Normal</speed>
+      <speed2>Normal</speed2>
       <route>Either</route>
       <dccAspect>16</dccAspect>
  </aspect>
@@ -328,8 +328,8 @@
       <indication>Indicateur de Direction</indication>
       <description>tableau fixe lumineux.</description>
       <comment>Indique la direction géographique.</comment>
-      <speed>Clear</speed>
-      <speed2>Clear</speed2>
+      <speed>Normal</speed>
+      <speed2>Normal</speed2>
       <route>Either</route>
       <dccAspect>17</dccAspect>
  </aspect>
@@ -339,8 +339,8 @@
       <indication>Indicateur de Direction</indication>
       <description>tableau fixe lumineux.</description>
       <comment>Indique la direction géographique.</comment>
-      <speed>Clear</speed>
-      <speed2>Clear</speed2>
+      <speed>Normal</speed>
+      <speed2>Normal</speed2>
       <route>Either</route>
       <dccAspect>18</dccAspect>
  </aspect>
@@ -350,8 +350,8 @@
       <indication>Indicateur de Direction éteint</indication>
       <description>tableau fixe lumineux.</description>
       <comment>Indique la direction géographique.</comment>
-      <speed>Clear</speed>
-      <speed2>Clear</speed2>
+      <speed>Normal</speed>
+      <speed2>Normal</speed2>
       <route>Either</route>
       <dccAspect>19</dccAspect>
  </aspect>
@@ -361,8 +361,8 @@
       <indication>Indicateur de Direction</indication>
       <description>tableau fixe lumineux.</description>
       <comment>Indique la direction géographique.</comment>
-      <speed>Clear</speed>
-      <speed2>Clear</speed2>
+      <speed>Normal</speed>
+      <speed2>Normal</speed2>
       <route>Either</route>
       <dccAspect>20</dccAspect>
  </aspect>
@@ -372,8 +372,8 @@
       <indication>Indicateur de Direction</indication>
       <description>tableau fixe lumineux.</description>
       <comment>Indique la direction géographique.</comment>
-      <speed>Clear</speed>
-      <speed2>Clear</speed2>
+      <speed>Normal</speed>
+      <speed2>Normal</speed2>
       <route>Either</route>
       <dccAspect>21</dccAspect>
  </aspect>
@@ -383,8 +383,8 @@
       <indication>Indicateur de Direction</indication>
       <description>tableau fixe lumineux.</description>
       <comment>Indique la direction géographique.</comment>
-      <speed>Clear</speed>
-      <speed2>Clear</speed2>
+      <speed>Normal</speed>
+      <speed2>Normal</speed2>
       <route>Either</route>
       <dccAspect>22</dccAspect>
  </aspect>
@@ -394,8 +394,8 @@
       <indication>Indicateur de Direction</indication>
       <description>tableau fixe lumineux.</description>
       <comment>Indique la direction géographique.</comment>
-      <speed>Clear</speed>
-      <speed2>Clear</speed2>
+      <speed>Normal</speed>
+      <speed2>Normal</speed2>
       <route>Either</route>
       <dccAspect>23</dccAspect>
  </aspect>
@@ -405,8 +405,8 @@
       <indication>Indicateur de Direction éteint</indication>
       <description>tableau fixe lumineux.</description>
       <comment>Indique la direction géographique.</comment>
-      <speed>Clear</speed>
-      <speed2>Clear</speed2>
+      <speed>Normal</speed>
+      <speed2>Normal</speed2>
       <route>Either</route>
       <dccAspect>32</dccAspect>
  </aspect>
@@ -416,8 +416,8 @@
       <indication>Indicateur de Direction</indication>
       <description>tableau fixe lumineux.</description>
       <comment>Indique la direction géographique.</comment>
-      <speed>Clear</speed>
-      <speed2>Clear</speed2>
+      <speed>Normal</speed>
+      <speed2>Normal</speed2>
       <route>Either</route>
       <dccAspect>25</dccAspect>
  </aspect>
@@ -427,8 +427,8 @@
       <indication>Indicateur de Direction</indication>
       <description>tableau fixe lumineux.</description>
       <comment>Indique la direction géographique.</comment>
-      <speed>Clear</speed>
-      <speed2>Clear</speed2>
+      <speed>Normal</speed>
+      <speed2>Normal</speed2>
       <route>Either</route>
       <dccAspect>26</dccAspect>
  </aspect>
@@ -438,8 +438,8 @@
       <indication>Indicateur de Direction</indication>
       <description>tableau fixe lumineux.</description>
       <comment>Indique la direction géographique.</comment>
-      <speed>Clear</speed>
-      <speed2>Clear</speed2>
+      <speed>Normal</speed>
+      <speed2>Normal</speed2>
       <route>Either</route>
       <dccAspect>27</dccAspect>
  </aspect>
@@ -449,8 +449,8 @@
       <indication>Indicateur de Direction</indication>
       <description>tableau fixe lumineux.</description>
       <comment>Indique la direction géographique.</comment>
-      <speed>Clear</speed>
-      <speed2>Clear</speed2>
+      <speed>Normal</speed>
+      <speed2>Normal</speed2>
       <route>Either</route>
       <dccAspect>28</dccAspect>
  </aspect>
@@ -460,8 +460,8 @@
       <indication>Indicateur de Direction</indication>
       <description>tableau fixe lumineux.</description>
       <comment>Indique la direction géographique.</comment>
-      <speed>Clear</speed>
-      <speed2>Clear</speed2>
+      <speed>Normal</speed>
+      <speed2>Normal</speed2>
       <route>Either</route>
       <dccAspect>29</dccAspect>
  </aspect>
@@ -582,8 +582,8 @@
       <indication>ouverture guidon d’arrêt-Clear</indication>
       <description>Le guidon d’arrêt ne présente aucune indication particulière en position d’ouverture.</description>
       <comment>celle-ci étant seulement caractérisée en signalisation lumineuse, par l’extinction de la bande rouge. </comment>
-      <speed>Clear</speed>
-      <speed2>Clear</speed2>
+      <speed>Normal</speed>
+      <speed2>Normal</speed2>
       <route>Either</route>
       <dccAspect>20</dccAspect>
  </aspect>
@@ -593,8 +593,8 @@
       <indication>ouverture guidon d’arrêt-Clear</indication>
       <description>Le guidon d’arrêt ne présente aucune indication particulière en position d’ouverture</description>
       <comment>en signalisation mécanique, par l’effacement de l’aile qui se trouve alors masquée, et l’extinction du feu rouge associé.</comment>
-      <speed>Clear</speed>
-      <speed2>Clear</speed2>
+      <speed>Normal</speed>
+      <speed2>Normal</speed2>
       <route>Either</route>
       <dccAspect>21</dccAspect>
  </aspect>

--- a/xml/signals/SZDC-2015-zakladni/aspects.xml
+++ b/xml/signals/SZDC-2015-zakladni/aspects.xml
@@ -7,7 +7,7 @@
 >
   <name>SŽDC 2015 základní návěstidla</name>
   <date>2015</date>
-  
+
   <reference>Správa železniční dopravní cesty; D1 Dopravní a návěstní předpis; SŽDC 2013, změna č. 3 2015</reference>
   <reference>The Railway Infrastructure Administration; D1 Traffic and Signal Aspects Rules; SŽDC 2013, amendment no. 3 2015</reference>
 
@@ -19,7 +19,7 @@
     <author>
         <personname><firstname>Petr</firstname><surname>Šídlo</surname></personname>
         <email>sidlo64@hotmail.com</email>
-    </author>    
+    </author>
   </authorgroup>
 
   <revhistory xmlns="http://docbook.org/ns/docbook">
@@ -28,29 +28,29 @@
         <date>2016-12-26</date>
         <authorinitials>PŠ</authorinitials>
         <revremark>Initial version</revremark>
-    </revision>    
+    </revision>
     <revision>
         <revnumber>2</revnumber>
         <date>2018-09-22</date>
         <authorinitials>PŠ</authorinitials>
         <revremark>Panel indicators</revremark>
-    </revision>    
+    </revision>
     <revision>
         <revnumber>3</revnumber>
         <date>2019-02-19</date>
         <authorinitials>PŠ</authorinitials>
         <revremark>Aspect 25 Unlit</revremark>
-    </revision>    
+    </revision>
     <revision>
         <revnumber>4</revnumber>
         <date>2020-05-12</date>
         <authorinitials>PŠ</authorinitials>
         <revremark>Speed names</revremark>
-    </revision>    
+    </revision>
   </revhistory>
 
   <aspects>
-  
+
     <aspect>
       <name>Stůj</name>
       <title>Stop</title>
@@ -358,7 +358,7 @@
       <reference>Aspect 841</reference>
       <comment>Jízda vlaku dovolena</comment>
       <speed>Normal</speed>
-      <speed2>Either</speed2>
+      <speed2>Normal</speed2>
       <route>Either</route>
       <dccAspect>26</dccAspect>
     </aspect>
@@ -409,7 +409,7 @@
       <description>One white flashing light</description>
       <reference>Aspect 971</reference>
       <comment>Přivolávací návěst</comment>
-      <speed>Slowly</speed>
+      <speed>Slow</speed>
       <speed2>Stop</speed2>
       <route>Either</route>
       <dccAspect>30</dccAspect>
@@ -422,7 +422,7 @@
       <description>One white flashing light with red light</description>
       <reference>Aspect 970</reference>
       <comment>Přivolávací návěst</comment>
-      <speed>Slowly</speed>
+      <speed>Slow</speed>
       <speed2>Stop</speed2>
       <route>Either</route>
       <dccAspect>31</dccAspect>
@@ -432,7 +432,7 @@
 
   <imagetypes>
 	<imagetype type="prototype"/>
-	
+
         <imagetype type="AŽD z"/>
 	<imagetype type="AŽD zč"/>
 	<imagetype type="AŽD zb"/>
@@ -445,7 +445,7 @@
 	<imagetype type="AŽD žčb"/>
 	<imagetype type="AŽD žb"/>
 	<imagetype type="AŽD žbz"/>
-	
+
         <imagetype type="ESP z"/>
 	<imagetype type="ESP zč"/>
 	<imagetype type="ESP zb"/>
@@ -458,10 +458,10 @@
 	<imagetype type="ESP žčb"/>
 	<imagetype type="ESP žb"/>
 	<imagetype type="ESP žbz"/>
-	
+
 	<imagetype type="JOP hlavní"/>
 	<imagetype type="JOP seřaďovací"/>
-        
+
   </imagetypes>
 
   <appearancefiles>
@@ -476,9 +476,9 @@
 
     <appearancefile href="appearance-block.xml"/>
     <appearancefile href="appearance-block_distant.xml"/>
-    
+
     <appearancefile href="appearance-abs.xml"/>
-    
+
     <appearancefile href="appearance-shunting.xml"/>
 
     <appearancefile href="appearance-test.xml"/>

--- a/xml/signals/UP-2008/aspects.xml
+++ b/xml/signals/UP-2008/aspects.xml
@@ -102,7 +102,7 @@
       <rule>Rule 9.2.7</rule>
       <indication>Proceed prepared to pass next signal at restricted speed.</indication>
       <speed>Normal</speed>
-      <speed2>Restricting</speed2>
+      <speed2>Restricted</speed2>
       <route>Normal</route>
       <dccAspect>16</dccAspect>
     </aspect>

--- a/xml/signals/sample-aspects.xml
+++ b/xml/signals/sample-aspects.xml
@@ -12,12 +12,12 @@
   <copyright xmlns="http://docbook.org/ns/docbook">
     <year>2009</year><year>2010</year><holder>JMRI</holder>
   </copyright>
-  
+
   <authorgroup xmlns="http://docbook.org/ns/docbook">
     <author>
         <personname><firstname>Sample</firstname><surname>Name</surname></personname>
         <email>name@com.domain</email>
-    </author>    
+    </author>
   </authorgroup>
 
   <revhistory xmlns="http://docbook.org/ns/docbook">
@@ -26,13 +26,13 @@
         <date>2009-12-28</date>
         <authorinitials>initials</authorinitials>
         <revremark>comment</revremark>
-    </revision>    
+    </revision>
     <revision>
         <revnumber>2</revnumber>
         <date>2009-12-29</date>
         <authorinitials>initials</authorinitials>
         <revremark>comment</revremark>
-    </revision>    
+    </revision>
   </revhistory>
 
   <aspects>
@@ -43,19 +43,19 @@
       <rule></rule>
       <indication></indication>
       <description></description>
-      <speed></speed>
-      <speed2></speed2>
+      <speed>Normal</speed>
+      <speed2>Normal</speed2>
     </aspect>
 
   </aspects>
-  
+
   <imagetypes>
     <imagetype type="large" />
     <imagetype type="small" />
   </imagetypes>
-  
+
   <appearancefiles>
     <appearancefile href="sample-appearance-file.xml"/>
   </appearancefiles>
 </aspecttable>
-  
+

--- a/xml/signals/signalSpeeds.xml
+++ b/xml/signals/signalSpeeds.xml
@@ -50,13 +50,13 @@
   <!-- developers will define it further here.                                            -->
   <!-- Please read the comment above the 'interpretation' element which explains that a   -->
   <!-- warrant can use the values of 'aspectSpeeds' element in different ways.  More      -->
-  <!-- details have been added.                                                           -->	
-  
+  <!-- details have been added.                                                           -->
+
   <!-- If you want to have your own version of this file not be overwritten with each new -->
   <!-- release of JMRI, put your custom version into your user preferences directory.     -->
   <!-- Note that the Warrants preferences pane can also write a file into the user        -->
   <!-- preferences directory.                                                             -->
-  
+
   <!-- The "aspectSpeeds" table below maps the speed names used in signal aspects.xml  -->
   <!-- files to a number. The number may be translated to a throttle setting.  The     -->
   <!-- meaning of the number may be given different interpretations:               -->
@@ -71,26 +71,27 @@
   <!--      motive roster is speed matched and one chooses values that has the trains  -->
   <!--      moving at scale speeds close to what the aspect requires.                  -->
   <interpretation>percentNormal</interpretation>
-  
+
   <!-- Speed changes are ramped from the current speed to the next in increments.      -->
   <!-- The msPerIncrement parameter is the delay in milliseconds between sending speed -->
   <!-- increments sent to the throttle.   -->
   <msPerIncrement>750</msPerIncrement>
-  
+
   <!-- stepsPerIncrement is the number of throttle speed increments to use per the -->
   <!-- above ms time. The time needed to ramp a speed change can be shortened      -->
   <!-- by increasing the number of throttle speed increments.                      -->
   <stepsPerIncrement>1</stepsPerIncrement>
-  
+
   <!-- Map speed names to ratios used in throttle settings                            -->
   <!-- Speed names may be put into aspect.xml files to indicate speed for the aspect. -->
   <!-- Each speed name is a "speed notch" and additional notch names can be added -   -->
   <!-- however the names must match those in the "appearanceSpeeds" table below for   -->
   <!-- signal Heads and those used in "aspects.xml" file for Signal Masts.            -->
+  <!-- If you change these, make the related changes in xml/schema/aspecttable.xsd    -->
   <!-- These speeds are enforced at the entrance to a block.  Any speed name used in  -->
   <!-- any signal aspect.xml file should appear in the aspect speeds table below.     -->
-  <!-- The order of these is enforced by the schema.  The values must be decreasing   -->
-  <!-- from one element to the next.                                                  -->
+  <!-- The order of these here is enforced by the schema.  The values must be         -->
+  <!-- decreasing from one element to the next.                                       -->
   <aspectSpeeds>
     <Cab>120</Cab>
     <Maximum>119</Maximum>
@@ -104,7 +105,7 @@
     <RestrictedSlow>10</RestrictedSlow>
     <Stop>0</Stop>
   </aspectSpeeds>
-  
+
   <!-- Speeds associated with SignalHead appearances for heads NOT used in SignalMasts. -->
   <!-- Appearance names are those listed in jmri.implementation.DefaultSignalHead       -->
   <!-- Speed names must agree with the names in the above "aspectSpeeds" element.       -->


### PR DESCRIPTION
See #11654 for background.

This PR sets all signal system speed and speed2 elements to valid values, and then updates the schema to require that the speed and speed2 values are valid.  

Because the previous invalid values parsed as "0", i.e. the last speed to be selected, this should have no affect on properly operating signal system installations.