### PR TITLE
OpenLCB Hub - display LinkLocal addresses

### DIFF
--- a/java/src/jmri/jmrix/openlcb/swing/hub/Bundle.properties
+++ b/java/src/jmri/jmrix/openlcb/swing/hub/Bundle.properties
@@ -7,7 +7,7 @@ SendLineTermination     = Send Line Termination
 RequireLineTermination  = Require Line Termination
 
 HubStarted              = {0} {1} started
-IpAddressLine           = Hub ( {0}{1}{2} ) IP Address {3}
+IpAddressLine           = Hub ( {0}{1}{2} ) IP Address {3} {4}
 LineTermSettingDialog   = <html>                                                      \
 Please see the documentation for this setting at Hub Control > Help > Window Help .   \
 <br>You will likely require a Hub and JMRI restart following a change.                \

--- a/java/src/jmri/jmrix/openlcb/swing/hub/Bundle.properties
+++ b/java/src/jmri/jmrix/openlcb/swing/hub/Bundle.properties
@@ -7,7 +7,7 @@ SendLineTermination     = Send Line Termination
 RequireLineTermination  = Require Line Termination
 
 HubStarted              = {0} {1} started
-IpAddressLine           = Hub ( {0}{1}{2} ) IP Address {3} {4}
+IpAddressLine           = Hub ( {0}{1}{2} ) IP Address {3} port {4}
 LineTermSettingDialog   = <html>                                                      \
 Please see the documentation for this setting at Hub Control > Help > Window Help .   \
 <br>You will likely require a Hub and JMRI restart following a change.                \

--- a/java/src/jmri/jmrix/openlcb/swing/hub/HubPane.java
+++ b/java/src/jmri/jmrix/openlcb/swing/hub/HubPane.java
@@ -141,13 +141,13 @@ public class HubPane extends jmri.util.swing.JmriPanel implements CanListener, C
 
     private void addInetAddresses(){
         ZeroConfServiceManager manager = InstanceManager.getDefault(ZeroConfServiceManager.class);
-        Set<InetAddress> addresses = manager.getAddresses(ZeroConfServiceManager.Protocol.All, false, true);
+        Set<InetAddress> addresses = manager.getAddresses(ZeroConfServiceManager.Protocol.All, true, true);
         for (InetAddress ha : addresses) {
             textArea.append( System.lineSeparator() + Bundle.getMessage(("IpAddressLine"), // NOI18N
             !ha.getHostAddress().equals(ha.getHostName()) ? ha.getHostName() : "",
             ha.isLoopbackAddress() ? " Loopback" : "", // NOI18N
             ha.isLinkLocalAddress() ? " LinkLocal" : "", // NOI18N
-            ha.getHostAddress() + ":" + hub.getPort()));
+            ha.getHostAddress(), String.valueOf(hub.getPort())));
         }
     }
 


### PR DESCRIPTION
Adds LinkLocal connections to Hub list
Removes `:` character in UI spacing

![image](https://user-images.githubusercontent.com/39652002/229595986-beca113a-be8d-4809-a9cd-e00250471023.png)
