### PR TITLE
Zimo MS updates

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -368,6 +368,8 @@
         <h4>ZIMO</h4>
             <ul>
                 <li> Include CV's 190-191 for Decoder FW V.37+ </li>
+                <li>Added MS950 and MS990 model info</li>
+                <li>Updated CV64 in MS models to have a maximum of 15, was 9</li>
             </ul>
 
         <h4>Miscellaneous</h4>

--- a/xml/decoders/Zimo_MS_small_v4.xml
+++ b/xml/decoders/Zimo_MS_small_v4.xml
@@ -13,9 +13,9 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
-  
+
   <!--  Initial version, created from copy of Zimo Unified Software (version 40+) for the MX-series decoders -->
-  <!-- v1  Nigel Cliffe. 29th July 2022, initial version to get most panes functioning   -->  
+  <!-- v1  Nigel Cliffe. 29th July 2022, initial version to get most panes functioning   -->
   <!--             noted in Zimo manual on Page 3 for differences to the MX series, Motor Control largely done -->
   <!-- v1.1  24 Nov 2022.  Nigel Cliffe   Rationalisation of sub-component files, now grouped in blocks of CVs, rather than fairly random groupings -->
 
@@ -111,6 +111,110 @@
         <size length="30" width="15" height="4" units="mm"/>
       </model>
 
+      <model model="MS950 version 4+" lowVersionID="4" highVersionID="42" maxInputVolts="35V" maxMotorCurrent="1.2A, peak=2.5A" maxTotalCurrent="1.2A" formFactor="HO" numOuts="12" numFns="14" productID="9">
+        <output name="1" label="Front Light">
+          <label xml:lang="de">Lvor</label>
+          <label xml:lang="cs">Přední světla</label>
+        </output>
+        <output name="2" label="Rear Light">
+          <label xml:lang="de">Lrück</label>
+          <label xml:lang="cs">Zadní světla</label>
+        </output>
+        <output name="3" label="FO 1">
+          <label xml:lang="de">FA1</label>
+          <label xml:lang="cs">FV 1</label>
+        </output>
+        <output name="4" label="FO 2">
+          <label xml:lang="de">FA2</label>
+          <label xml:lang="cs">FV 2</label>
+        </output>
+        <output name="5" label="FO 3">
+          <label xml:lang="de">FA3</label>
+          <label xml:lang="cs">FV 3</label>
+        </output>
+        <output name="6" label="FO 4">
+          <label xml:lang="de">FA4</label>
+          <label xml:lang="cs">FV 4</label>
+        </output>
+        <output name="7" label="FO 5">
+          <label xml:lang="de">FA5</label>
+          <label xml:lang="cs">FV 5</label>
+        </output>
+        <output name="8" label="FO 6">
+          <label xml:lang="de">FA6</label>
+          <label xml:lang="cs">FV 6</label>
+        </output>
+        <output name="9" label="FO 7">
+          <label xml:lang="de">FA7</label>
+          <label xml:lang="cs">FV 7</label>
+        </output>
+        <output name="10" label="FO 8">
+          <label xml:lang="de">FA8</label>
+          <label xml:lang="cs">FV 8</label>
+        </output>
+        <output name="11" label="FO 9 (+5V)">
+          <label xml:lang="de">FA9 (+5V)</label>
+          <label xml:lang="cs">FV 9 (+5V)</label>
+        </output>
+        <output name="12" label="FO 10 (+5V)">
+          <label xml:lang="de">FA10 (+5V)</label>
+          <label xml:lang="cs">FV 10 (+5V)</label>
+        </output>
+        <size length="30" width="15" height="4" units="mm"/>
+      </model>
+
+      <model model="MS990 version 4+" lowVersionID="4" highVersionID="42" maxInputVolts="35V" maxMotorCurrent="1.2A, peak=2.5A" maxTotalCurrent="1.2A" formFactor="HO" numOuts="12" numFns="14" productID="7">
+        <output name="1" label="Front Light">
+          <label xml:lang="de">Lvor</label>
+          <label xml:lang="cs">Přední světla</label>
+        </output>
+        <output name="2" label="Rear Light">
+          <label xml:lang="de">Lrück</label>
+          <label xml:lang="cs">Zadní světla</label>
+        </output>
+        <output name="3" label="FO 1">
+          <label xml:lang="de">FA1</label>
+          <label xml:lang="cs">FV 1</label>
+        </output>
+        <output name="4" label="FO 2">
+          <label xml:lang="de">FA2</label>
+          <label xml:lang="cs">FV 2</label>
+        </output>
+        <output name="5" label="FO 3">
+          <label xml:lang="de">FA3</label>
+          <label xml:lang="cs">FV 3</label>
+        </output>
+        <output name="6" label="FO 4">
+          <label xml:lang="de">FA4</label>
+          <label xml:lang="cs">FV 4</label>
+        </output>
+        <output name="7" label="FO 5">
+          <label xml:lang="de">FA5</label>
+          <label xml:lang="cs">FV 5</label>
+        </output>
+        <output name="8" label="FO 6">
+          <label xml:lang="de">FA6</label>
+          <label xml:lang="cs">FV 6</label>
+        </output>
+        <output name="9" label="FO 7">
+          <label xml:lang="de">FA7</label>
+          <label xml:lang="cs">FV 7</label>
+        </output>
+        <output name="10" label="FO 8">
+          <label xml:lang="de">FA8</label>
+          <label xml:lang="cs">FV 8</label>
+        </output>
+        <output name="11" label="FO 9 (+5V)">
+          <label xml:lang="de">FA9 (+5V)</label>
+          <label xml:lang="cs">FV 9 (+5V)</label>
+        </output>
+        <output name="12" label="FO 10 (+5V)">
+          <label xml:lang="de">FA10 (+5V)</label>
+          <label xml:lang="cs">FV 10 (+5V)</label>
+        </output>
+        <size length="30" width="15" height="4" units="mm"/>
+      </model>
+
       <model model="MS480 version 4+" lowVersionID="4" highVersionID="41" maxInputVolts="30V" maxMotorCurrent="0.8A, peak=1.5A" maxTotalCurrent="1.2A" formFactor="N" numOuts="8" numFns="14" productID="2">
         <output name="1" label="Front Light"/>
         <output name="2" label="Rear Light"/>
@@ -151,7 +255,7 @@
         <size length="19" width="8.6" height="2.9" units="mm"/>
       </model>
 
-      
+
       <model model="MS500 version 4+" lowVersionID="4" highVersionID="41" maxInputVolts="35V" maxMotorCurrent="0.8A, peak=1.5A" maxTotalCurrent="0.8A" formFactor="N" numOuts="6" numFns="14" productID="1">
         <output name="1" label="Front Light">
           <label xml:lang="de">Lvor</label>
@@ -179,7 +283,7 @@
         </output>
         <size length="14" width="10" height="2.6" units="mm"/>
       </model>
-      
+
       <model model="MS580N18 version 4+" lowVersionID="4" highVersionID="41" maxInputVolts="35V" maxMotorCurrent="0.8A, peak=1.5A" maxTotalCurrent="0.8A" formFactor="N" connector="Next18" numOuts="6" numFns="14" productID="8">
         <output name="1" label="Front Light">
           <label xml:lang="de">Lvor</label>
@@ -235,7 +339,7 @@
         </output>
         <size length="15" width="9.5" height="3.3" units="mm"/>
       </model>
-      
+
 
 
 
@@ -245,8 +349,8 @@
       <xi:include href="http://jmri.org/xml/decoders/zimo/CV1-CV99_MS_series.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/zimo/CV100-CV199_MS_series.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/zimo/CV200-CV249_MS_series.xml"/>
- 
-     
+
+
       <variable CV="7" item="Decoder Version" readOnly="yes" default="4">
         <decVal/>
         <label>Manufacturer Version No: </label>

--- a/xml/decoders/zimo/CV1-CV99_MS_series.xml
+++ b/xml/decoders/zimo/CV1-CV99_MS_series.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet type="text/xsl" href="../XSLT/decoder.xsl"?>
 
-<!-- version 1.0 24 Nov 2022  Nigel Cliffe - Merging various MX-series and MS-series files covering CVs 1-99 into single file.   --> 
+<!-- version 1.0 24 Nov 2022  Nigel Cliffe - Merging various MX-series and MS-series files covering CVs 1-99 into single file.   -->
 <!--            Removed CV10, (not in MS series manuals),  -->
 <variables xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
   <xi:include href="http://jmri.org/xml/decoders/nmra/shortAndLongAddress.xml"/>
@@ -48,7 +48,7 @@
   <variable item="Operating Mode AC Analogue" CV="12" mask="XXXVXXXX" default="1">
       <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
       <label>Decoder Operating Mode AC Analogue</label>
-  </variable>  
+  </variable>
     <variable item="Operating Mode MM" CV="12" mask="XXVXXXXX" default="1">
       <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
       <label>Decoder Operating Mode MM</label>
@@ -57,7 +57,7 @@
       <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
       <label>Decoder Operating Mode MFX</label>
   </variable>
-  
+
   <variable item="Analog Mode Function Status - F1" CV="13" mask="XXXXXXXV">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
       <label>Analog Mode Function Status - F1</label>
@@ -212,7 +212,7 @@
   </variable>
 
   <xi:include href="http://jmri.org/xml/decoders/nmra/consistAddr.xml"/>
-  
+
   <variable CV="20" item="Extended Consist Address">
     <decVal max="102"/>
     <label>Extended Consist Address</label>
@@ -320,7 +320,7 @@
     <label xml:lang="cs">Adresa soupravy aktivní pro F12</label>
     <label xml:lang="de">im Verbundbetrieb aktiv F12</label>
   </variable>
-  
+
   <variable CV="22" item="Auto Consist" mask="XVXXXXXX">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
     <!--xi:include href="http://jmri.org/xml/decoders/parts/enum-LocoAddrConsistAddr.xml"/-->
@@ -367,7 +367,7 @@
     <label xml:lang="cs">Znaménko korekce zpomalení</label>
     <label xml:lang="de">Bremszeitvariation verwenden</label>
   </variable>
-  
+
 
   <variable item="Direction Dependent stops with asymmetrical DCC" CV="27" mask="XXXXVVVV">
     <enumVal>
@@ -445,7 +445,7 @@
     <label>Railcom voltage signal</label>
     <label xml:lang="de">Railcom-Spannungsmeldung</label>
     <label xml:lang="cs">RailCom signál napětí</label>
-  </variable> 
+  </variable>
   <xi:include href="http://jmri.org/xml/decoders/nmra/cv29table3-28.xml"/>
  <!--group exclude="253"-->
   <variable item="FL(f) controls output 1" CV="33" default="1" mask="XXXXXXXV" minOut="1">
@@ -1745,7 +1745,7 @@
     <tooltip xml:lang="de">Zykluszeit (Zehner-), Aus-Verlängerung (Einerstelle)</tooltip>
   </variable>
   <variable item="Global lighting option 4" CV="64" default="5" exclude="228,226,232,235,247,MX689_v30">
-    <decVal min="0" max="9"/>
+    <decVal min="0" max="15"/>
     <label>Ditch Light Off Time</label>
     <label xml:lang="it">Tempo di Off luci Ditch</label>
     <label xml:lang="cs">Čas zhasínání návěstních světel</label>
@@ -1771,7 +1771,7 @@
   </variable>
   <xi:include href="http://jmri.org/xml/decoders/nmra/fwdTrim.xml"/>
   <xi:include href="http://jmri.org/xml/decoders/nmra/revTrim.xml"/>
-  
+
   <variable CV="97" item="Consist Option 1" default="0">
    <xi:include href="http://jmri.org/xml/decoders/parts/enum-F1-F28.xml"/>
     <label>Consist-Key</label>
@@ -1781,5 +1781,5 @@
       <tooltip xml:lang="de">Taste zum Umschalten zwischen Hauptadresse und Consistadresse.</tooltip>
       <tooltip xml:lang="cs">Tlačítko které přepíná mezi výchozí adresou a adresou soupravy.</tooltip>
   </variable>
-  
+
 </variables>

--- a/xml/decoders/zimo/CV1-CV99_MS_series.xml
+++ b/xml/decoders/zimo/CV1-CV99_MS_series.xml
@@ -1744,7 +1744,7 @@
     <tooltip> </tooltip>
     <tooltip xml:lang="de">Zykluszeit (Zehner-), Aus-Verlängerung (Einerstelle)</tooltip>
   </variable>
-  <variable item="Global lighting option 4" CV="64" default="5" exclude="228,226,232,235,247,MX689_v30">
+  <variable item="Global lighting option 4" CV="64" default="5">
     <decVal min="0" max="15"/>
     <label>Ditch Light Off Time</label>
     <label xml:lang="it">Tempo di Off luci Ditch</label>

--- a/xml/decoders/zimo/Choice-Light8.xml
+++ b/xml/decoders/zimo/Choice-Light8.xml
@@ -17,8 +17,8 @@
         <choice xml:lang="de">Leuchtstoffröhren-Effekt</choice>
         <choice xml:lang="cs">Efekt zářivky</choice>
       </enumChoice>
-      <enumChoice choice="sparks with hevy braking">
-        <choice>Sparks with hevy braking</choice>
+      <enumChoice choice="sparks with heavy braking">
+        <choice>Sparks with heavy braking</choice>
         <choice xml:lang="de">Bremsfunken bei starkem Bremsen</choice>
         <choice xml:lang="cs">Jiskry při prudkém brždění</choice>
       </enumChoice>


### PR DESCRIPTION
 - Add MS950, MS990 model information
 - Correct MS model's CV64 (ditch light) to have a maximum possible value of 15, was 9.
 - Fixes a spelling error in an enum