### PR TITLE
Suppress nashorn deprecation warning

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -819,6 +819,7 @@
             <sysproperty key="wdm.forceCache" value="true"/>
 
             <sysproperty key="java.security.policy" value="${libdir}/security.policy"/>
+            <sysproperty key="nashorn.args" value="--no-deprecation-warning"/>
             <!-- <sysproperty key="apple.laf.useScreenMenuBar" value="false"/> causes problems with Jemmy access to menus on Mac -->
             <sysproperty key="log4j.ignoreTCL" path="true/"/>
             <sysproperty key="java.library.path" path=".:${libdir}:${arch.lib.path}"/>
@@ -856,6 +857,7 @@
             <sysproperty key="wdm.forceCache" value="true"/>
 
             <sysproperty key="java.security.policy" value="${libdir}/security.policy"/>
+            <sysproperty key="nashorn.args" value="--no-deprecation-warning"/>
             <!-- <sysproperty key="apple.laf.useScreenMenuBar" value="false"/> causes problems with Jemmy access to menus on Mac -->
             <sysproperty key="log4j.ignoreTCL" path="true/"/>
             <sysproperty key="java.library.path" path=".:${libdir}:${arch.lib.path}"/>
@@ -1105,6 +1107,7 @@
             <classpath refid="project.class.path"/>
             <sysproperty key="java.security.policy"
                          value="${libdir}/security.policy"/>
+            <sysproperty key="nashorn.args" value="--no-deprecation-warning"/>
             <sysproperty key="apple.laf.useScreenMenuBar" value="true"/>
             <sysproperty key="apple.awt.graphics.UseQuartz" value="true"/>
             <sysproperty key="apple.awt.graphics.EnableQ2DX" value="true"/>
@@ -1140,6 +1143,7 @@
             <classpath refid="project.class.path"/>
             <sysproperty key="java.security.policy"
                          value="${libdir}/security.policy"/>
+            <sysproperty key="nashorn.args" value="--no-deprecation-warning"/>
             <sysproperty key="apple.laf.useScreenMenuBar" value="true"/>
             <sysproperty key="log4j.ignoreTCL" path="true/"/>
             <sysproperty key="java.library.path"
@@ -1263,6 +1267,7 @@
             <classpath refid="project.class.path"/>
             <sysproperty key="java.security.policy"
                          value="${libdir}/security.policy"/>
+            <sysproperty key="nashorn.args" value="--no-deprecation-warning"/>
             <sysproperty key="apple.laf.useScreenMenuBar" value="true"/>
             <sysproperty key="apple.awt.graphics.UseQuartz" value="true"/>
             <sysproperty key="apple.awt.graphics.EnableQ2DX" value="true"/>
@@ -1299,6 +1304,7 @@
           fork="yes" >
             <classpath refid="test.class.path"/>
             <sysproperty key="java.security.policy" value="${libdir}/security.policy"/>
+            <sysproperty key="nashorn.args" value="--no-deprecation-warning"/>
             <sysproperty key="apple.laf.useScreenMenuBar" value="true"/>
             <sysproperty key="log4j.ignoreTCL" path="true/"/>
             <sysproperty key="java.library.path" path=".:${libdir}:${arch.lib.path}"/>
@@ -1414,6 +1420,7 @@
             fork="yes" >
 
               <sysproperty key="java.security.policy" value="${libdir}/security.policy"/>
+              <sysproperty key="nashorn.args" value="--no-deprecation-warning"/>
               <sysproperty key="apple.laf.useScreenMenuBar" value="true"/>
               <sysproperty key="log4j.ignoreTCL" path="true/"/>
               <sysproperty key="java.library.path" path=".:${libdir}:${arch.lib.path}"/>
@@ -1440,6 +1447,7 @@
             fork="yes" >
 
               <sysproperty key="java.security.policy" value="${libdir}/security.policy"/>
+              <sysproperty key="nashorn.args" value="--no-deprecation-warning"/>
               <sysproperty key="apple.laf.useScreenMenuBar" value="true"/>
               <sysproperty key="log4j.ignoreTCL" path="true/"/>
               <sysproperty key="java.library.path" path=".:${libdir}:${arch.lib.path}"/>
@@ -1470,6 +1478,7 @@
           fork="yes" >
 
             <sysproperty key="java.security.policy" value="${libdir}/security.policy"/>
+            <sysproperty key="nashorn.args" value="--no-deprecation-warning"/>
             <!-- <sysproperty key="apple.laf.useScreenMenuBar" value="false"/> causes problems with Jemmy access to menus on Mac -->
             <sysproperty key="log4j.ignoreTCL" path="true/"/>
             <sysproperty key="java.library.path" path=".:${libdir}:${arch.lib.path}"/>
@@ -1495,6 +1504,7 @@
           fork="yes" >
 
             <sysproperty key="java.security.policy" value="${libdir}/security.policy"/>
+            <sysproperty key="nashorn.args" value="--no-deprecation-warning"/>
             <!-- <sysproperty key="apple.laf.useScreenMenuBar" value="false"/> causes problems with Jemmy access to menus on Mac -->
             <sysproperty key="log4j.ignoreTCL" path="true/"/>
             <sysproperty key="java.library.path" path=".:${libdir}:${arch.lib.path}"/>
@@ -1526,6 +1536,7 @@
             <sysproperty key="wdm.forceCache" value="true"/>
 
             <sysproperty key="java.security.policy" value="${libdir}/security.policy"/>
+            <sysproperty key="nashorn.args" value="--no-deprecation-warning"/>
             <!-- <sysproperty key="apple.laf.useScreenMenuBar" value="false"/> causes problems with Jemmy access to menus on Mac -->
             <sysproperty key="log4j.ignoreTCL" path="true/"/>
             <sysproperty key="java.library.path" path=".:${libdir}:${arch.lib.path}"/>
@@ -1617,6 +1628,7 @@
                 <fileset refid="junitfileset"/>
                 <fork>
                     <sysproperty key="java.security.policy" value="${libdir}/security.policy"/>
+                    <sysproperty key="nashorn.args" value="--no-deprecation-warning"/>
                     <!-- <sysproperty key="apple.laf.useScreenMenuBar" value="false"/> causes problems with Jemmy access to menus on Mac -->
                     <sysproperty key="log4j.ignoreTCL" path="true/"/>
                     <sysproperty key="java.library.path" path=".:${libdir}:${arch.lib.path}"/>
@@ -1644,6 +1656,7 @@
           fork="yes" >
 
             <sysproperty key="java.security.policy" value="${libdir}/security.policy"/>
+            <sysproperty key="nashorn.args" value="--no-deprecation-warning"/>
             <!-- <sysproperty key="apple.laf.useScreenMenuBar" value="false"/> causes problems with Jemmy access to menus on Mac -->
             <sysproperty key="log4j.ignoreTCL" path="true/"/>
             <sysproperty key="java.library.path" path=".:${libdir}:${arch.lib.path}"/>
@@ -1672,6 +1685,7 @@
             <sysproperty key="wdm.forceCache" value="true"/>
 
             <sysproperty key="java.security.policy" value="${libdir}/security.policy"/>
+            <sysproperty key="nashorn.args" value="--no-deprecation-warning"/>
             <!-- <sysproperty key="apple.laf.useScreenMenuBar" value="false"/> causes problems with Jemmy access to menus on Mac -->
             <sysproperty key="log4j.ignoreTCL" path="true/"/>
             <sysproperty key="java.library.path" path=".:${libdir}:${arch.lib.path}"/>
@@ -1708,9 +1722,8 @@
                 </fileset>
                 <fork>
                     <sysproperty key="java.security.policy" value="${libdir}/security.policy"/>
-
-                   <sysproperty key="cucumber.options" value="--tags 'not @Ignore'"/>
-                    <sysproperty key="java.security.policy" value="${libdir}/security.policy"/>
+                    <sysproperty key="nashorn.args" value="--no-deprecation-warning"/>
+                    <sysproperty key="cucumber.options" value="--tags 'not @Ignore'"/>
                     <!-- <sysproperty key="apple.laf.useScreenMenuBar" value="false"/> causes problems with Jemmy access to menus on Mac -->
                     <sysproperty key="log4j.ignoreTCL" path="true/"/>
                     <sysproperty key="java.library.path" path=".:${libdir}:${arch.lib.path}"/>

--- a/scripts/AppScriptTemplate
+++ b/scripts/AppScriptTemplate
@@ -561,6 +561,7 @@ OPTIONS="${jmri_options} -noverify"
 OPTIONS="${OPTIONS} -Djava.security.policy=${LIBDIR}/security.policy"
 OPTIONS="${OPTIONS} -Djava.rmi.server.codebase=file:target/classes/"
 OPTIONS="${OPTIONS} -Djava.library.path=.:$SYSLIBPATH:${LIBDIR}"
+OPTIONS="${OPTIONS} -Dnashorn.args=--no-deprecation-warning"
 
 # memory start and max limits
 OPTIONS="${OPTIONS} ${OS_OPTIONS-} ${jmri_xms} ${jmri_xmx}"


### PR DESCRIPTION
This suppresses the Nashorn deprecation warning when running from a standard Mac/Linux startup script or via an Ant target.

Maven builds and the Windows startup are not affected.