### PR TITLE
Call JUnitUtil.deregisterBlockManagerShutdownTask() in tests

### DIFF
--- a/java/test/jmri/jmrit/logixng/ConditionalNGTest.java
+++ b/java/test/jmri/jmrit/logixng/ConditionalNGTest.java
@@ -213,6 +213,7 @@ public class ConditionalNGTest {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/Is_IsNot_EnumTest.java
+++ b/java/test/jmri/jmrit/logixng/Is_IsNot_EnumTest.java
@@ -9,7 +9,7 @@ import org.junit.Test;
 
 /**
  * Test SwingToolsTest
- * 
+ *
  * @author Daniel Bergqvist 2019
  */
 public class Is_IsNot_EnumTest {
@@ -25,7 +25,7 @@ public class Is_IsNot_EnumTest {
         Assert.assertTrue("Enum is correct",
                 Is_IsNot_Enum.IsNot == Is_IsNot_Enum.valueOf("IsNot"));
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() {
@@ -39,7 +39,8 @@ public class Is_IsNot_EnumTest {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/LogixNGCategoryTest.java
+++ b/java/test/jmri/jmrit/logixng/LogixNGCategoryTest.java
@@ -8,7 +8,7 @@ import org.junit.Test;
 
 /**
  * Test Category
- * 
+ *
  * @author Daniel Bergqvist 2018
  */
 public class LogixNGCategoryTest {
@@ -19,7 +19,7 @@ public class LogixNGCategoryTest {
         Assert.assertTrue("COMMON".equals(Category.COMMON.name()));
         Assert.assertTrue("OTHER".equals(Category.OTHER.name()));
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() {
@@ -35,7 +35,8 @@ public class LogixNGCategoryTest {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/LogixNGTest.java
+++ b/java/test/jmri/jmrit/logixng/LogixNGTest.java
@@ -483,6 +483,7 @@ public class LogixNGTest {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/LogixNG_InitializationManagerTest.java
+++ b/java/test/jmri/jmrit/logixng/LogixNG_InitializationManagerTest.java
@@ -19,19 +19,19 @@ import org.junit.Test;
 
 /**
  * Test LogixNG_InitializationManager
- * 
+ *
  * @author Daniel Bergqvist 2021
  */
 public class LogixNG_InitializationManagerTest {
 
     List<AtomicBoolean> abList = new ArrayList<>();
-    
+
     private AtomicBoolean getAB() {
         AtomicBoolean ab = new AtomicBoolean();
         abList.add(ab);
         return ab;
     }
-    
+
     private boolean checkAB() {
         for (AtomicBoolean ab : abList) {
             if (!ab.get()) {
@@ -40,16 +40,16 @@ public class LogixNG_InitializationManagerTest {
         }
         return true;
     }
-    
+
     @Test
     public void testInitialization() throws SocketAlreadyConnectedException {
         StringWriter stringWriter = new StringWriter();
         PrintWriter printWriter = new PrintWriter(stringWriter);
-        
+
         LogixNG_Thread threadL2 = LogixNG_Thread.createNewThread("Another thread");
         LogixNG_Thread threadL7 = LogixNG_Thread.createNewThread("Some other thread");
         LogixNG_Thread threadL5 = LogixNG_Thread.createNewThread("A different thread");
-        
+
         MyAction.getLogixNG("IQ4", "LogixNG 4", getAB(), printWriter, 0, LogixNG_Thread.DEFAULT_LOGIXNG_THREAD);
         MyAction.getLogixNG("IQ5", "LogixNG 5", getAB(), printWriter, 100, threadL5.getThreadId());   // Long delay on separate thread
         MyAction.getLogixNG("IQ2", "LogixNG 2", getAB(), printWriter, 500, threadL2.getThreadId());   // Long delay on separate thread
@@ -59,27 +59,27 @@ public class LogixNG_InitializationManagerTest {
         MyAction.getLogixNG("IQ9", "LogixNG 9", getAB(), printWriter, 100, LogixNG_Thread.DEFAULT_LOGIXNG_THREAD);
         MyAction.getLogixNG("IQ8", "LogixNG 8", getAB(), printWriter, 0, LogixNG_Thread.DEFAULT_LOGIXNG_THREAD);
         MyAction.getLogixNG("IQ3", "LogixNG 3", getAB(), printWriter, 0, LogixNG_Thread.DEFAULT_LOGIXNG_THREAD);
-        
+
         LogixNG l2 = InstanceManager.getDefault(LogixNG_Manager.class).getBySystemName("IQ2");
         LogixNG l7 = InstanceManager.getDefault(LogixNG_Manager.class).getBySystemName("IQ7");
         LogixNG l8 = InstanceManager.getDefault(LogixNG_Manager.class).getBySystemName("IQ8");
-        
+
         LogixNG_InitializationManager initManager =
                 InstanceManager.getDefault(LogixNG_InitializationManager.class);
-        
+
         initManager.add(l7);
         initManager.add(l2);
         initManager.add(l8);
-        
+
         // No LogixNG has been executed yet.
         Assert.assertEquals("Strings are equal", "", stringWriter.toString());
-        
+
         InstanceManager.getDefault(LogixNG_Manager.class)
                 .activateAllLogixNGs(true, true);
-        
+
         boolean result = JUnitUtil.waitFor(() -> {return checkAB();});
         Assert.assertTrue(result);
-        
+
         String expectedResult =
                 // These are registered in the init manager
                 "LogixNG 7: start" + System.lineSeparator() +
@@ -90,7 +90,7 @@ public class LogixNG_InitializationManagerTest {
                 "LogixNG 8: end";
         Assert.assertTrue(stringWriter.toString().startsWith(expectedResult));
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() {
@@ -106,30 +106,31 @@ public class LogixNG_InitializationManagerTest {
     @After
     public void tearDown() {
         LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
-    
-    
-    
+
+
+
     private static final class MyAction extends ActionAtomicBoolean {
-        
+
         private final AtomicBoolean _ab;
         private final PrintWriter _printWriter;
         private final long _delay;
-        
+
         MyAction(
                 String userName,
                 AtomicBoolean ab,
                 PrintWriter printWriter,
                 long delay) {
-            
+
             super(ab, false);
             setUserName(userName);
             _ab = ab;
             _printWriter = printWriter;
             _delay = delay;
         }
-        
+
         @Override
         public void execute() {
 //            System.out.format("%s: start\n", getUserName());
@@ -144,7 +145,7 @@ public class LogixNG_InitializationManagerTest {
             _printWriter.flush();
             _ab.set(true);
         }
-        
+
         public static LogixNG getLogixNG(
                 String systemName,
                 String userName,
@@ -153,11 +154,11 @@ public class LogixNG_InitializationManagerTest {
                 long delay,
                 int threadID)
                 throws SocketAlreadyConnectedException {
-            
+
             LogixNG logixNG =
                     InstanceManager.getDefault(LogixNG_Manager.class)
                             .createLogixNG(systemName, null);
-            
+
             systemName =
                     InstanceManager.getDefault(ConditionalNG_Manager.class)
                             .getAutoSystemName();
@@ -166,16 +167,16 @@ public class LogixNG_InitializationManagerTest {
             InstanceManager.getDefault(ConditionalNG_Manager.class).register(conditionalNG);
             conditionalNG.setEnabled(true);
             logixNG.addConditionalNG(conditionalNG);
-            
+
             MyAction action = new MyAction(userName, ab, printWriter, delay);
             MaleSocket socket = InstanceManager.getDefault(DigitalActionManager.class).registerAction(action);
             conditionalNG.getChild(0).connect(socket);
-            
+
             logixNG.setEnabled(true);
-            
+
             return logixNG;
         }
-        
+
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/LogixNG_ManagerTest.java
+++ b/java/test/jmri/jmrit/logixng/LogixNG_ManagerTest.java
@@ -108,6 +108,7 @@ public class LogixNG_ManagerTest {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/SymbolTableTest.java
+++ b/java/test/jmri/jmrit/logixng/SymbolTableTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
 
 /**
  * Test SymbolTable
- * 
+ *
  * @author Daniel Bergqvist 2021
  */
 public class SymbolTableTest {
@@ -29,7 +29,7 @@ public class SymbolTableTest {
         Assert.assertTrue(SymbolTable.validateName("Abc___"));
         Assert.assertTrue(SymbolTable.validateName("Abc___fsdffs"));
         Assert.assertTrue(SymbolTable.validateName("Abc3123__2341fsdf"));
-        
+
         // Invalid names
         Assert.assertFalse(SymbolTable.validateName("12Abc"));  // Starts with a digit
         Assert.assertFalse(SymbolTable.validateName("_Abc"));   // Starts with an underscore
@@ -38,7 +38,7 @@ public class SymbolTableTest {
         Assert.assertFalse(SymbolTable.validateName("A{bc"));   // Has a character that's not letter, digit or underscore
         Assert.assertFalse(SymbolTable.validateName("A+bc"));   // Has a character that's not letter, digit or underscore
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() {
@@ -51,6 +51,7 @@ public class SymbolTableTest {
 
     @After
     public void tearDown() {
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/TableTest.java
+++ b/java/test/jmri/jmrit/logixng/TableTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
 
 /**
  * Test Category
- * 
+ *
  * @author Daniel Bergqvist 2018
  */
 public class TableTest {
@@ -30,47 +30,47 @@ public class TableTest {
         }
         Assert.assertTrue("Exception is thrown", exceptionThrown);
     }
-    
+
     @Test
     @SuppressWarnings("ResultOfMethodCallIgnored")  // This method test thrown exceptions
     public void testExceptions() {
         Table t = new MyTable();
-        
+
         expectException(() -> {
             t.getCell("Bad row", "Seventh column");
         }, Table.RowNotFoundException.class, "Row \"Bad row\" is not found");
-        
+
         expectException(() -> {
             t.getCell("Second row", "Bad column");
         }, Table.ColumnNotFoundException.class, "Column \"Bad column\" is not found");
-        
+
         expectException(() -> {
             t.setCell("Hello", "Bad row", "Seventh column");
         }, Table.RowNotFoundException.class, "Row \"Bad row\" is not found");
-        
+
         expectException(() -> {
             t.setCell("Hello", "Second row", "Bad column");
         }, Table.ColumnNotFoundException.class, "Column \"Bad column\" is not found");
     }
-    
+
     @Test
     public void testTable() {
         Table t = new MyTable();
-        
+
         Assert.assertTrue("Item is null", null == t.getCell("Second row", "Seventh column"));
-        
+
         t.setCell("Hello", "Third row");
         Assert.assertTrue("Item has correct value", "Hello" == t.getCell("Third row"));
         Assert.assertTrue("Item has correct value", "Hello" == t.getCell("Third row", "First column"));
-        
+
         t.setCell("Hello again", "Second row", "Seventh column");
         Assert.assertTrue("Item has correct value", "Hello again" == t.getCell("Second row", "Seventh column"));
-        
+
         Integer i = 15;
         t.setCell(i, "Second row", "Seventh column");
         Assert.assertTrue("Item has correct value", t.getCell("Second row", "Seventh column").equals(15));
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() {
@@ -84,10 +84,11 @@ public class TableTest {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
-    
-    
+
+
     private static class MyTable implements Table {
 
         private static final int NUM_ROWS = 3;
@@ -95,7 +96,7 @@ public class TableTest {
         private final Object[][] _data = new Object[NUM_ROWS+1][NUM_COLUMNS+1];
         private final Map<String, Integer> rowHeaders = new HashMap<>();
         private final Map<String, Integer> columnHeaders = new HashMap<>();
-        
+
         public MyTable() {
             _data[1][0] = "First row";
             _data[2][0] = "Second row";
@@ -111,7 +112,7 @@ public class TableTest {
             for (int i=1; i <= NUM_ROWS; i++) rowHeaders.put(_data[i][0].toString(), i);
             for (int i=1; i <= NUM_COLUMNS; i++) columnHeaders.put(_data[0][i].toString(), i);
         }
-        
+
         @Override
         public Object getCell(int row, int column) {
             return _data[row][column];
@@ -155,7 +156,7 @@ public class TableTest {
         public void storeTableAsCSV(File file, String systemName, String userName) throws FileNotFoundException {
             throw new UnsupportedOperationException("55Not supported.");
         }
-        
+
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/actions/AbstractDigitalActionTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/AbstractDigitalActionTest.java
@@ -52,10 +52,11 @@ public class AbstractDigitalActionTest {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
-    
-    
+
+
     // The purpose of this class is to test the method
     // AbstractDigitalAction.getNewSocketName(). We want
     // to test that the method throws an exception if no
@@ -68,11 +69,11 @@ public class AbstractDigitalActionTest {
     private static class MyAction extends AbstractDigitalAction implements FemaleSocketListener {
 
         private final MyFemaleSocket child = new MyFemaleSocket(this, this, "A1");
-        
+
         public MyAction() {
             super(InstanceManager.getDefault(DigitalActionManager.class).getAutoSystemName(), null);
         }
-        
+
         @Override
         protected void registerListenersForThisClass() {
             throw new UnsupportedOperationException("Not supported.");
@@ -154,16 +155,16 @@ public class AbstractDigitalActionTest {
         public Base deepCopyChildren(Base base, Map<String, String> map, Map<String, String> map1) throws JmriException {
             throw new UnsupportedOperationException("Not supported");
         }
-        
+
     }
-    
-    
+
+
     private static class MyFemaleSocket extends AbstractFemaleSocket {
-    
+
         public MyFemaleSocket(Base parent, FemaleSocketListener listener, String name) {
             super(parent, listener, name);
         }
-        
+
         @Override
         public void disposeMe() {
             throw new UnsupportedOperationException("Not supported.");
@@ -188,9 +189,9 @@ public class AbstractDigitalActionTest {
         public String getLongDescription(Locale locale) {
             throw new UnsupportedOperationException("Not supported.");
         }
-    
+
     }
-    
-    
-    
+
+
+
 }

--- a/java/test/jmri/jmrit/logixng/actions/AbstractDigitalBooleanActionTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/AbstractDigitalBooleanActionTest.java
@@ -19,7 +19,7 @@ import org.junit.Test;
 
 /**
  * Test AbstractDigitalBooleanAction
- * 
+ *
  * @author Daniel Bergqvist 2020
  */
 public class AbstractDigitalBooleanActionTest {
@@ -39,8 +39,8 @@ public class AbstractDigitalBooleanActionTest {
             hasThrown = true;
         }
         Assert.assertTrue("Exception is thrown", hasThrown);
-        
-        
+
+
         DigitalBooleanOnChange action2 = new DigitalBooleanOnChange("IQDB1", null, DigitalBooleanOnChange.Trigger.CHANGE);
         Assert.assertEquals("New socket name is correct", "A1", action2.getNewSocketName());
     }
@@ -58,10 +58,11 @@ public class AbstractDigitalBooleanActionTest {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
-    
-    
+
+
     // The purpose of this class is to test the method
     // AbstractDigitalAction.getNewSocketName(). We want
     // to test that the method throws an exception if no
@@ -74,11 +75,11 @@ public class AbstractDigitalBooleanActionTest {
     private static class MyAction extends AbstractDigitalBooleanAction implements FemaleSocketListener {
 
         private final MyFemaleSocket child = new MyFemaleSocket(this, this, "A1");
-        
+
         public MyAction() {
             super(InstanceManager.getDefault(DigitalBooleanActionManager.class).getAutoSystemName(), null);
         }
-        
+
         @Override
         protected void registerListenersForThisClass() {
             throw new UnsupportedOperationException("Not supported.");
@@ -160,16 +161,16 @@ public class AbstractDigitalBooleanActionTest {
         public Base deepCopyChildren(Base base, Map<String, String> map, Map<String, String> map1) throws JmriException {
             throw new UnsupportedOperationException("Not supported");
         }
-        
+
     }
-    
-    
+
+
     private static class MyFemaleSocket extends AbstractFemaleSocket {
-    
+
         public MyFemaleSocket(Base parent, FemaleSocketListener listener, String name) {
             super(parent, listener, name);
         }
-        
+
         @Override
         public void disposeMe() {
             throw new UnsupportedOperationException("Not supported.");
@@ -194,7 +195,7 @@ public class AbstractDigitalBooleanActionTest {
         public String getLongDescription(Locale locale) {
             throw new UnsupportedOperationException("Not supported.");
         }
-    
+
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/actions/ActionAtomicBooleanTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ActionAtomicBooleanTest.java
@@ -224,6 +224,7 @@ public class ActionAtomicBooleanTest extends AbstractDigitalActionTestBase {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/ActionListenOnBeansTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ActionListenOnBeansTest.java
@@ -136,6 +136,7 @@ public class ActionListenOnBeansTest extends AbstractDigitalActionTestBase {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/ActionMemoryTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ActionMemoryTest.java
@@ -339,6 +339,7 @@ public class ActionMemoryTest extends AbstractDigitalActionTestBase {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/ActionThrottleTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ActionThrottleTest.java
@@ -754,6 +754,7 @@ public class ActionThrottleTest extends AbstractDigitalActionTestBase {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/ActionTimerTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ActionTimerTest.java
@@ -322,6 +322,7 @@ public class ActionTimerTest extends AbstractDigitalActionTestBase {
     public void tearDown() {
         _logixNG.setEnabled(false);
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
         _category = null;
         _logixNG = null;

--- a/java/test/jmri/jmrit/logixng/actions/AnalogManyTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/AnalogManyTest.java
@@ -354,6 +354,7 @@ public class AnalogManyTest extends AbstractAnalogActionTestBase {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/DigitalBooleanOnChangeTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/DigitalBooleanOnChangeTest.java
@@ -344,6 +344,7 @@ public class DigitalBooleanOnChangeTest extends AbstractDigitalBooleanActionTest
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/DigitalManyTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/DigitalManyTest.java
@@ -342,6 +342,7 @@ public class DigitalManyTest extends AbstractDigitalActionTestBase {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/DoAnalogActionTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/DoAnalogActionTest.java
@@ -301,6 +301,7 @@ public class DoAnalogActionTest extends AbstractDigitalActionTestBase {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/DoStringActionTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/DoStringActionTest.java
@@ -301,6 +301,7 @@ public class DoStringActionTest extends AbstractDigitalActionTestBase {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/ExecuteDelayedTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ExecuteDelayedTest.java
@@ -243,6 +243,7 @@ public class ExecuteDelayedTest extends AbstractDigitalActionTestBase {
     public void tearDown() {
         _logixNG.setEnabled(false);
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
         _category = null;
         _logixNG = null;

--- a/java/test/jmri/jmrit/logixng/actions/IfThenElseTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/IfThenElseTest.java
@@ -395,6 +395,7 @@ public class IfThenElseTest extends AbstractDigitalActionTestBase {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/LogixTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/LogixTest.java
@@ -327,6 +327,7 @@ public class LogixTest extends AbstractDigitalActionTestBase {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/SocketTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/SocketTest.java
@@ -55,6 +55,7 @@ public class SocketTest {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/StringActionMemoryTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/StringActionMemoryTest.java
@@ -275,6 +275,7 @@ public class StringActionMemoryTest extends AbstractStringActionTestBase {
     public void tearDown() {
         _base.dispose();
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/StringManyTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/StringManyTest.java
@@ -351,6 +351,7 @@ public class StringManyTest extends AbstractStringActionTestBase {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/TableForEachTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/TableForEachTest.java
@@ -295,6 +295,7 @@ public class TableForEachTest extends AbstractDigitalActionTestBase {
         JUnitAppender.suppressErrorMessage("tableHandle is null");
         _logixNG.setEnabled(false);
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
         _category = null;
         _logixNG = null;

--- a/java/test/jmri/jmrit/logixng/actions/configurexml/ActionTurnoutXmlTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/configurexml/ActionTurnoutXmlTest.java
@@ -9,7 +9,7 @@ import org.junit.Test;
 
 /**
  * Test ActionTurnoutXml
- * 
+ *
  * @author Daniel Bergqvist 2019
  */
 public class ActionTurnoutXmlTest {
@@ -19,7 +19,7 @@ public class ActionTurnoutXmlTest {
         ActionTurnoutXml b = new ActionTurnoutXml();
         Assert.assertNotNull("exists", b);
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() {
@@ -35,7 +35,8 @@ public class ActionTurnoutXmlTest {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/actions/configurexml/AnalogActionsTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/configurexml/AnalogActionsTest.java
@@ -13,7 +13,7 @@ import org.junit.Test;
 
 /**
  * Test ActionTurnoutXml
- * 
+ *
  * @author Daniel Bergqvist 2019
  */
 public class AnalogActionsTest {
@@ -21,18 +21,18 @@ public class AnalogActionsTest {
     @Test
     public void testLoad() throws JmriConfigureXmlException {
         AbstractNamedBeanManagerConfigXML b;
-        
+
         b = new AnalogActionMemoryXml();
         Assert.assertNotNull("exists", b);
         b.load((Element) null, (Object) null);
         JUnitAppender.assertMessage("Invalid method called");
-        
+
         b = new AnalogManyXml();
         Assert.assertNotNull("exists", b);
         b.load((Element) null, (Object) null);
         JUnitAppender.assertMessage("Invalid method called");
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() {
@@ -48,7 +48,8 @@ public class AnalogActionsTest {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/actions/configurexml/DigitalActionsXmlTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/configurexml/DigitalActionsXmlTest.java
@@ -106,6 +106,7 @@ public class DigitalActionsXmlTest {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/configurexml/DigitalBooleanOnChangeXmlTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/configurexml/DigitalBooleanOnChangeXmlTest.java
@@ -13,7 +13,7 @@ import org.junit.Test;
 
 /**
  * Test ActionTurnoutXml
- * 
+ *
  * @author Daniel Bergqvist 2019
  */
 public class DigitalBooleanOnChangeXmlTest {
@@ -21,13 +21,13 @@ public class DigitalBooleanOnChangeXmlTest {
     @Test
     public void testLoad() throws JmriConfigureXmlException {
         AbstractNamedBeanManagerConfigXML b;
-        
+
         b = new DigitalBooleanOnChangeXml();
         Assert.assertNotNull("exists", b);
         b.load((Element) null, (Object) null);
         JUnitAppender.assertMessage("Invalid method called");
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() {
@@ -43,6 +43,7 @@ public class DigitalBooleanOnChangeXmlTest {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/configurexml/StringActionsTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/configurexml/StringActionsTest.java
@@ -13,7 +13,7 @@ import org.junit.Test;
 
 /**
  * Test ActionTurnoutXml
- * 
+ *
  * @author Daniel Bergqvist 2019
  */
 public class StringActionsTest {
@@ -21,18 +21,18 @@ public class StringActionsTest {
     @Test
     public void testLoad() throws JmriConfigureXmlException {
         AbstractNamedBeanManagerConfigXML b;
-        
+
         b = new StringActionMemoryXml();
         Assert.assertNotNull("exists", b);
         b.load((Element) null, (Object) null);
         JUnitAppender.assertMessage("Invalid method called");
-        
+
         b = new StringManyXml();
         Assert.assertNotNull("exists", b);
         b.load((Element) null, (Object) null);
         JUnitAppender.assertMessage("Invalid method called");
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() {
@@ -48,7 +48,8 @@ public class StringActionsTest {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/actions/swing/ActionLightSwingTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/swing/ActionLightSwingTest.java
@@ -102,6 +102,7 @@ public class ActionLightSwingTest extends SwingConfiguratorInterfaceTestBase {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/swing/ActionSensorSwingTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/swing/ActionSensorSwingTest.java
@@ -91,6 +91,7 @@ public class ActionSensorSwingTest extends SwingConfiguratorInterfaceTestBase {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/swing/ActionTurnoutSwingTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/swing/ActionTurnoutSwingTest.java
@@ -93,6 +93,7 @@ public class ActionTurnoutSwingTest extends SwingConfiguratorInterfaceTestBase {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/swing/DigitalBooleanOnChangeSwingTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/swing/DigitalBooleanOnChangeSwingTest.java
@@ -15,7 +15,7 @@ import org.junit.Test;
 
 /**
  * Test ActionLight
- * 
+ *
  * @author Daniel Bergqvist 2018
  */
 public class DigitalBooleanOnChangeSwingTest {
@@ -23,21 +23,21 @@ public class DigitalBooleanOnChangeSwingTest {
     @Test
     public void testCtor() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        
+
         DigitalBooleanOnChangeSwing t = new DigitalBooleanOnChangeSwing();
         Assert.assertNotNull("exists",t);
     }
-    
+
     @Test
     public void testCreatePanel() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        
+
         Assert.assertTrue("panel is not null",
             null != new DigitalBooleanOnChangeSwing().getConfigPanel(new JPanel()));
         Assert.assertTrue("panel is not null",
             null != new DigitalBooleanOnChangeSwing().getConfigPanel(new DigitalBooleanOnChange("IQDB1", null, DigitalBooleanOnChange.Trigger.CHANGE), new JPanel()));
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() {
@@ -53,7 +53,8 @@ public class DigitalBooleanOnChangeSwingTest {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/actions/swing/DigitalManySwingTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/swing/DigitalManySwingTest.java
@@ -15,7 +15,7 @@ import org.junit.Test;
 
 /**
  * Test ManySwing
- * 
+ *
  * @author Daniel Bergqvist 2018
  */
 public class DigitalManySwingTest {
@@ -23,21 +23,21 @@ public class DigitalManySwingTest {
     @Test
     public void testCtor() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        
+
         DigitalManySwing t = new DigitalManySwing();
         Assert.assertNotNull("exists",t);
     }
-    
+
     @Test
     public void testCreatePanel() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        
+
         Assert.assertTrue("panel is not null",
             null != new DigitalManySwing().getConfigPanel(new JPanel()));
         Assert.assertTrue("panel is not null",
             null != new DigitalManySwing().getConfigPanel(new DigitalMany("IQDA1", null), new JPanel()));
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() {
@@ -54,7 +54,8 @@ public class DigitalManySwingTest {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/actions/swing/DoAnalogActionSwingTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/swing/DoAnalogActionSwingTest.java
@@ -15,7 +15,7 @@ import org.junit.Test;
 
 /**
  * Test DoAnalogAction
- * 
+ *
  * @author Daniel Bergqvist 2018
  */
 public class DoAnalogActionSwingTest {
@@ -23,21 +23,21 @@ public class DoAnalogActionSwingTest {
     @Test
     public void testCtor() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        
+
         DoAnalogActionSwing t = new DoAnalogActionSwing();
         Assert.assertNotNull("exists",t);
     }
-    
+
     @Test
     public void testCreatePanel() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        
+
         Assert.assertTrue("panel is not null",
             null != new DoAnalogActionSwing().getConfigPanel(new JPanel()));
         Assert.assertTrue("panel is not null",
             null != new DoAnalogActionSwing().getConfigPanel(new DoAnalogAction("IQDA1", null), new JPanel()));
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() {
@@ -53,7 +53,8 @@ public class DoAnalogActionSwingTest {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/actions/swing/DoStringActionSwingTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/swing/DoStringActionSwingTest.java
@@ -15,7 +15,7 @@ import org.junit.Test;
 
 /**
  * Test DoStringAction
- * 
+ *
  * @author Daniel Bergqvist 2018
  */
 public class DoStringActionSwingTest {
@@ -23,21 +23,21 @@ public class DoStringActionSwingTest {
     @Test
     public void testCtor() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        
+
         DoStringActionSwing t = new DoStringActionSwing();
         Assert.assertNotNull("exists",t);
     }
-    
+
     @Test
     public void testCreatePanel() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        
+
         Assert.assertTrue("panel is not null",
             null != new DoStringActionSwing().getConfigPanel(new JPanel()));
         Assert.assertTrue("panel is not null",
             null != new DoStringActionSwing().getConfigPanel(new DoStringAction("IQDA1", null), new JPanel()));
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() {
@@ -53,7 +53,8 @@ public class DoStringActionSwingTest {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/actions/swing/IfThenElseSwingTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/swing/IfThenElseSwingTest.java
@@ -15,7 +15,7 @@ import org.junit.Test;
 
 /**
  * Test IfThenElseSwing
- * 
+ *
  * @author Daniel Bergqvist 2018
  */
 public class IfThenElseSwingTest {
@@ -23,21 +23,21 @@ public class IfThenElseSwingTest {
     @Test
     public void testCtor() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        
+
         IfThenElseSwing t = new IfThenElseSwing();
         Assert.assertNotNull("exists",t);
     }
-    
+
     @Test
     public void testCreatePanel() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        
+
         Assert.assertTrue("panel is not null",
             null != new IfThenElseSwing().getConfigPanel(new JPanel()));
         Assert.assertTrue("panel is not null",
             null != new IfThenElseSwing().getConfigPanel(new IfThenElse("IQDA1", null), new JPanel()));
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() {
@@ -53,7 +53,8 @@ public class IfThenElseSwingTest {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/actions/swing/ShutdownComputerSwingTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/swing/ShutdownComputerSwingTest.java
@@ -40,7 +40,7 @@ public class ShutdownComputerSwingTest {
         Assert.assertTrue("panel is not null",
             null != new ShutdownComputerSwing(dialog).getConfigPanel(new ShutdownComputer("IQDA1", null), new JPanel()));
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() {
@@ -56,6 +56,7 @@ public class ShutdownComputerSwingTest {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/AbstractDigitalExpressionTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/AbstractDigitalExpressionTest.java
@@ -51,10 +51,11 @@ public class AbstractDigitalExpressionTest {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
-    
-    
+
+
     // The purpose of this class is to test the method
     // AbstractDigitalAction.getNewSocketName(). We want
     // to test that the method throws an exception if no
@@ -67,11 +68,11 @@ public class AbstractDigitalExpressionTest {
     private static class MyExpression extends AbstractDigitalExpression implements FemaleSocketListener {
 
         private final MyFemaleSocket child = new MyFemaleSocket(this, this, "E1");
-        
+
         public MyExpression() {
             super(InstanceManager.getDefault(DigitalExpressionManager.class).getAutoSystemName(), null);
         }
-        
+
         @Override
         protected void registerListenersForThisClass() {
             throw new UnsupportedOperationException("Not supported.");
@@ -153,16 +154,16 @@ public class AbstractDigitalExpressionTest {
         public Base deepCopyChildren(Base base, Map<String, String> map, Map<String, String> map1) throws JmriException {
             throw new UnsupportedOperationException("Not supported");
         }
-        
+
     }
-    
-    
+
+
     private static class MyFemaleSocket extends AbstractFemaleSocket {
-    
+
         public MyFemaleSocket(Base parent, FemaleSocketListener listener, String name) {
             super(parent, listener, name);
         }
-        
+
         @Override
         public void disposeMe() {
             throw new UnsupportedOperationException("Not supported.");
@@ -187,7 +188,7 @@ public class AbstractDigitalExpressionTest {
         public String getLongDescription(Locale locale) {
             throw new UnsupportedOperationException("Not supported.");
         }
-    
+
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/expressions/AnalogExpressionConstantTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/AnalogExpressionConstantTest.java
@@ -259,6 +259,7 @@ public class AnalogExpressionConstantTest extends AbstractAnalogExpressionTestBa
 //        JUnitAppender.clearBacklog();
         _base.dispose();
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/AnalogExpressionMemoryTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/AnalogExpressionMemoryTest.java
@@ -385,6 +385,7 @@ public class AnalogExpressionMemoryTest extends AbstractAnalogExpressionTestBase
     public void tearDown() {
         _base.dispose();
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/AnalogFormulaTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/AnalogFormulaTest.java
@@ -734,6 +734,7 @@ public class AnalogFormulaTest extends AbstractAnalogExpressionTestBase {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/AndTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/AndTest.java
@@ -389,6 +389,7 @@ public class AndTest extends AbstractDigitalExpressionTestBase {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/AntecedentTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/AntecedentTest.java
@@ -710,6 +710,7 @@ public class AntecedentTest extends AbstractDigitalExpressionTestBase implements
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/DigitalFormulaTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/DigitalFormulaTest.java
@@ -734,6 +734,7 @@ public class DigitalFormulaTest extends AbstractDigitalExpressionTestBase {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/ExpressionLightTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/ExpressionLightTest.java
@@ -427,6 +427,7 @@ public class ExpressionLightTest extends AbstractDigitalExpressionTestBase {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/ExpressionLocalVariableTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/ExpressionLocalVariableTest.java
@@ -492,6 +492,7 @@ public class ExpressionLocalVariableTest extends AbstractDigitalExpressionTestBa
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/ExpressionMemoryTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/ExpressionMemoryTest.java
@@ -486,6 +486,7 @@ public class ExpressionMemoryTest extends AbstractDigitalExpressionTestBase {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/ExpressionPowerTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/ExpressionPowerTest.java
@@ -324,6 +324,7 @@ public class ExpressionPowerTest extends AbstractDigitalExpressionTestBase {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/ExpressionReporterTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/ExpressionReporterTest.java
@@ -700,6 +700,7 @@ public class ExpressionReporterTest extends AbstractDigitalExpressionTestBase {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/ExpressionSensorTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/ExpressionSensorTest.java
@@ -441,6 +441,7 @@ public class ExpressionSensorTest extends AbstractDigitalExpressionTestBase {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/ExpressionTurnoutTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/ExpressionTurnoutTest.java
@@ -441,6 +441,7 @@ public class ExpressionTurnoutTest extends AbstractDigitalExpressionTestBase {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/FalseTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/FalseTest.java
@@ -214,6 +214,7 @@ public class FalseTest extends AbstractDigitalExpressionTestBase {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/HoldTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/HoldTest.java
@@ -381,6 +381,7 @@ public class HoldTest extends AbstractDigitalExpressionTestBase {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/LastResultOfDigitalExpressionTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/LastResultOfDigitalExpressionTest.java
@@ -321,6 +321,7 @@ public class LastResultOfDigitalExpressionTest extends AbstractDigitalExpression
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/NotTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/NotTest.java
@@ -316,6 +316,7 @@ public class NotTest extends AbstractDigitalExpressionTestBase {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/OrTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/OrTest.java
@@ -390,6 +390,7 @@ public class OrTest extends AbstractDigitalExpressionTestBase {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/StringExpressionConstantTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/StringExpressionConstantTest.java
@@ -273,6 +273,7 @@ public class StringExpressionConstantTest extends AbstractStringExpressionTestBa
     public void tearDown() {
         _base.dispose();
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/StringExpressionMemoryTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/StringExpressionMemoryTest.java
@@ -384,6 +384,7 @@ public class StringExpressionMemoryTest extends AbstractStringExpressionTestBase
     public void tearDown() {
         _base.dispose();
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/StringFormulaTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/StringFormulaTest.java
@@ -740,6 +740,7 @@ public class StringFormulaTest extends AbstractStringExpressionTestBase {
     public void tearDown() {
         // JUnitAppender.clearBacklog();    REMOVE THIS!!!
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/TriggerOnceTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/TriggerOnceTest.java
@@ -325,6 +325,7 @@ public class TriggerOnceTest extends AbstractDigitalExpressionTestBase {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/TrueTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/TrueTest.java
@@ -196,6 +196,7 @@ public class TrueTest extends AbstractDigitalExpressionTestBase {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/configurexml/AnalogExpressionsTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/configurexml/AnalogExpressionsTest.java
@@ -13,7 +13,7 @@ import org.junit.Test;
 
 /**
  * Test ActionTurnoutXml
- * 
+ *
  * @author Daniel Bergqvist 2019
  */
 public class AnalogExpressionsTest {
@@ -21,18 +21,18 @@ public class AnalogExpressionsTest {
     @Test
     public void testLoad() throws JmriConfigureXmlException {
         AbstractNamedBeanManagerConfigXML b;
-        
+
         b = new AnalogExpressionConstantXml();
         Assert.assertNotNull("exists", b);
         b.load((Element) null, (Object) null);
         JUnitAppender.assertMessage("Invalid method called");
-        
+
         b = new AnalogExpressionMemoryXml();
         Assert.assertNotNull("exists", b);
         b.load((Element) null, (Object) null);
         JUnitAppender.assertMessage("Invalid method called");
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() {
@@ -48,7 +48,8 @@ public class AnalogExpressionsTest {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/expressions/configurexml/DigitalExpressionsTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/configurexml/DigitalExpressionsTest.java
@@ -13,7 +13,7 @@ import org.junit.Test;
 
 /**
  * Test DigitalExpressions
- * 
+ *
  * @author Daniel Bergqvist 2019
  */
 public class DigitalExpressionsTest {
@@ -21,58 +21,58 @@ public class DigitalExpressionsTest {
     @Test
     public void testLoad() throws JmriConfigureXmlException {
         AbstractNamedBeanManagerConfigXML b;
-        
+
         b = new AndXml();
         Assert.assertNotNull("exists", b);
         b.load((Element) null, (Object) null);
         JUnitAppender.assertMessage("Invalid method called");
-        
+
         b = new AntecedentXml();
         Assert.assertNotNull("exists", b);
         b.load((Element) null, (Object) null);
         JUnitAppender.assertMessage("Invalid method called");
-        
+
         b = new ExpressionLightXml();
         Assert.assertNotNull("exists", b);
         b.load((Element) null, (Object) null);
         JUnitAppender.assertMessage("Invalid method called");
-        
+
         b = new ExpressionSensorXml();
         Assert.assertNotNull("exists", b);
         b.load((Element) null, (Object) null);
         JUnitAppender.assertMessage("Invalid method called");
-        
+
         b = new ExpressionTurnoutXml();
         Assert.assertNotNull("exists", b);
         b.load((Element) null, (Object) null);
         JUnitAppender.assertMessage("Invalid method called");
-        
+
         b = new FalseXml();
         Assert.assertNotNull("exists", b);
         b.load((Element) null, (Object) null);
         JUnitAppender.assertMessage("Invalid method called");
-        
+
         b = new HoldXml();
         Assert.assertNotNull("exists", b);
         b.load((Element) null, (Object) null);
         JUnitAppender.assertMessage("Invalid method called");
-        
+
         b = new OrXml();
         Assert.assertNotNull("exists", b);
         b.load((Element) null, (Object) null);
         JUnitAppender.assertMessage("Invalid method called");
-        
+
         b = new TriggerOnceXml();
         Assert.assertNotNull("exists", b);
         b.load((Element) null, (Object) null);
         JUnitAppender.assertMessage("Invalid method called");
-        
+
         b = new TrueXml();
         Assert.assertNotNull("exists", b);
         b.load((Element) null, (Object) null);
         JUnitAppender.assertMessage("Invalid method called");
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() {
@@ -88,7 +88,8 @@ public class DigitalExpressionsTest {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/expressions/configurexml/StringExpressionsTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/configurexml/StringExpressionsTest.java
@@ -13,7 +13,7 @@ import org.junit.Test;
 
 /**
  * Test ActionTurnoutXml
- * 
+ *
  * @author Daniel Bergqvist 2019
  */
 public class StringExpressionsTest {
@@ -21,13 +21,13 @@ public class StringExpressionsTest {
     @Test
     public void testLoad() throws JmriConfigureXmlException {
         AbstractNamedBeanManagerConfigXML b;
-        
+
         b = new StringExpressionMemoryXml();
         Assert.assertNotNull("exists", b);
         b.load((Element) null, (Object) null);
         JUnitAppender.assertMessage("Invalid method called");
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() {
@@ -43,7 +43,8 @@ public class StringExpressionsTest {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/expressions/swing/AndSwingTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/swing/AndSwingTest.java
@@ -15,7 +15,7 @@ import org.junit.Test;
 
 /**
  * Test AndSwing
- * 
+ *
  * @author Daniel Bergqvist 2018
  */
 public class AndSwingTest {
@@ -23,30 +23,30 @@ public class AndSwingTest {
     @Test
     public void testCtor() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        
+
         AndSwing t = new AndSwing();
         Assert.assertNotNull("exists",t);
     }
-    
+
     @Test
     public void testPanel() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        
+
         AndSwing t = new AndSwing();
         JPanel panel = t.getConfigPanel(new JPanel());
         Assert.assertNotNull("exists",panel);
     }
-    
+
     @Test
     public void testCreatePanel() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        
+
         Assert.assertTrue("panel is not null",
             null != new AndSwing().getConfigPanel(new JPanel()));
         Assert.assertTrue("panel is not null",
             null != new AndSwing().getConfigPanel(new And("IQDE1", null), new JPanel()));
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() {
@@ -60,7 +60,8 @@ public class AndSwingTest {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/expressions/swing/AntecedentSwingTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/swing/AntecedentSwingTest.java
@@ -15,7 +15,7 @@ import org.junit.Test;
 
 /**
  * Test AntecedentSwing
- * 
+ *
  * @author Daniel Bergqvist 2018
  */
 public class AntecedentSwingTest {
@@ -23,30 +23,30 @@ public class AntecedentSwingTest {
     @Test
     public void testCtor() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        
+
         AntecedentSwing t = new AntecedentSwing();
         Assert.assertNotNull("exists",t);
     }
-    
+
     @Test
     public void testPanel() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        
+
         AntecedentSwing t = new AntecedentSwing();
         JPanel panel = t.getConfigPanel(new JPanel());
         Assert.assertNotNull("exists",panel);
     }
-    
+
     @Test
     public void testCreatePanel() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        
+
         Assert.assertTrue("panel is not null",
             null != new AntecedentSwing().getConfigPanel(new JPanel()));
         Assert.assertTrue("panel is not null",
             null != new AntecedentSwing().getConfigPanel(new Antecedent("IQDE1", null), new JPanel()));
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() {
@@ -60,7 +60,8 @@ public class AntecedentSwingTest {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/expressions/swing/ExpressionLightSwingTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/swing/ExpressionLightSwingTest.java
@@ -108,6 +108,7 @@ public class ExpressionLightSwingTest extends SwingConfiguratorInterfaceTestBase
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/swing/ExpressionSensorSwingTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/swing/ExpressionSensorSwingTest.java
@@ -107,6 +107,7 @@ public class ExpressionSensorSwingTest extends SwingConfiguratorInterfaceTestBas
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/swing/ExpressionTurnoutSwingTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/swing/ExpressionTurnoutSwingTest.java
@@ -120,6 +120,7 @@ public class ExpressionTurnoutSwingTest extends SwingConfiguratorInterfaceTestBa
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/swing/FalseSwingTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/swing/FalseSwingTest.java
@@ -15,7 +15,7 @@ import org.junit.Test;
 
 /**
  * Test FalseSwing
- * 
+ *
  * @author Daniel Bergqvist 2018
  */
 public class FalseSwingTest {
@@ -23,30 +23,30 @@ public class FalseSwingTest {
     @Test
     public void testCtor() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        
+
         FalseSwing t = new FalseSwing();
         Assert.assertNotNull("exists",t);
     }
-    
+
     @Test
     public void testPanel() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        
+
         FalseSwing t = new FalseSwing();
         JPanel panel = t.getConfigPanel(new JPanel());
         Assert.assertNotNull("exists",panel);
     }
-    
+
     @Test
     public void testCreatePanel() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        
+
         Assert.assertTrue("panel is not null",
             null != new FalseSwing().getConfigPanel(new JPanel()));
         Assert.assertTrue("panel is not null",
             null != new FalseSwing().getConfigPanel(new False("IQDE1", null), new JPanel()));
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() {
@@ -60,7 +60,8 @@ public class FalseSwingTest {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/expressions/swing/HoldSwingTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/swing/HoldSwingTest.java
@@ -15,7 +15,7 @@ import org.junit.Test;
 
 /**
  * Test HoldSwing
- * 
+ *
  * @author Daniel Bergqvist 2018
  */
 public class HoldSwingTest {
@@ -23,30 +23,30 @@ public class HoldSwingTest {
     @Test
     public void testCtor() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        
+
         HoldSwing t = new HoldSwing();
         Assert.assertNotNull("exists",t);
     }
-    
+
     @Test
     public void testPanel() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        
+
         HoldSwing t = new HoldSwing();
         JPanel panel = t.getConfigPanel(new JPanel());
         Assert.assertNotNull("exists",panel);
     }
-    
+
     @Test
     public void testCreatePanel() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        
+
         Assert.assertTrue("panel is not null",
             null != new HoldSwing().getConfigPanel(new JPanel()));
         Assert.assertTrue("panel is not null",
             null != new HoldSwing().getConfigPanel(new Hold("IQDE1", null), new JPanel()));
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() {
@@ -60,7 +60,8 @@ public class HoldSwingTest {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/expressions/swing/OrSwingTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/swing/OrSwingTest.java
@@ -15,7 +15,7 @@ import org.junit.Test;
 
 /**
  * Test OrSwing
- * 
+ *
  * @author Daniel Bergqvist 2018
  */
 public class OrSwingTest {
@@ -23,30 +23,30 @@ public class OrSwingTest {
     @Test
     public void testCtor() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        
+
         OrSwing t = new OrSwing();
         Assert.assertNotNull("exists",t);
     }
-    
+
     @Test
     public void testPanel() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        
+
         OrSwing t = new OrSwing();
         JPanel panel = t.getConfigPanel(new JPanel());
         Assert.assertNotNull("exists",panel);
     }
-    
+
     @Test
     public void testCreatePanel() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        
+
         Assert.assertTrue("panel is not null",
             null != new OrSwing().getConfigPanel(new JPanel()));
         Assert.assertTrue("panel is not null",
             null != new OrSwing().getConfigPanel(new Or("IQDE1", null), new JPanel()));
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() {
@@ -60,7 +60,8 @@ public class OrSwingTest {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/expressions/swing/TriggerOnceSwingTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/swing/TriggerOnceSwingTest.java
@@ -17,7 +17,7 @@ import org.junit.Test;
 
 /**
  * Test TriggerOnceSwing
- * 
+ *
  * @author Daniel Bergqvist 2018
  */
 public class TriggerOnceSwingTest {
@@ -25,30 +25,30 @@ public class TriggerOnceSwingTest {
     @Test
     public void testCtor() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        
+
         TriggerOnceSwing t = new TriggerOnceSwing();
         Assert.assertNotNull("exists",t);
     }
-    
+
     @Test
     public void testPanel() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        
+
         TriggerOnceSwing t = new TriggerOnceSwing();
         JPanel panel = t.getConfigPanel(new JPanel());
         Assert.assertNotNull("exists",panel);
     }
-    
+
     @Test
     public void testCreatePanel() throws NamedBean.BadUserNameException, NamedBean.BadSystemNameException, SocketAlreadyConnectedException {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        
+
         Assert.assertTrue("panel is not null",
             null != new TriggerOnceSwing().getConfigPanel(new JPanel()));
         Assert.assertTrue("panel is not null",
             null != new TriggerOnceSwing().getConfigPanel(new TriggerOnce("IQDE1", null), new JPanel()));
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() {
@@ -62,7 +62,8 @@ public class TriggerOnceSwingTest {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/expressions/swing/TrueSwingTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/swing/TrueSwingTest.java
@@ -15,7 +15,7 @@ import org.junit.Test;
 
 /**
  * Test TrueSwing
- * 
+ *
  * @author Daniel Bergqvist 2018
  */
 public class TrueSwingTest {
@@ -23,30 +23,30 @@ public class TrueSwingTest {
     @Test
     public void testCtor() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        
+
         TrueSwing t = new TrueSwing();
         Assert.assertNotNull("exists",t);
     }
-    
+
     @Test
     public void testPanel() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        
+
         TrueSwing t = new TrueSwing();
         JPanel panel = t.getConfigPanel(new JPanel());
         Assert.assertNotNull("exists",panel);
     }
-    
+
     @Test
     public void testCreatePanel() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        
+
         Assert.assertTrue("panel is not null",
             null != new TrueSwing().getConfigPanel(new JPanel()));
         Assert.assertTrue("panel is not null",
             null != new TrueSwing().getConfigPanel(new True("IQDE1", null), new JPanel()));
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() {
@@ -60,7 +60,8 @@ public class TrueSwingTest {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/implementation/AbstractFemaleSocketTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/AbstractFemaleSocketTest.java
@@ -216,6 +216,7 @@ public class AbstractFemaleSocketTest {
     public void tearDown() {
         _listener = null;
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/implementation/AnalogActionManagerTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/AnalogActionManagerTest.java
@@ -87,6 +87,7 @@ public class AnalogActionManagerTest extends AbstractManagerTestBase {
         _m = null;
         _manager = null;
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/implementation/AnalogExpressionManagerTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/AnalogExpressionManagerTest.java
@@ -97,6 +97,7 @@ public class AnalogExpressionManagerTest extends AbstractManagerTestBase {
         _m = null;
         _manager = null;
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/implementation/DefaultAnonymousTableTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/DefaultAnonymousTableTest.java
@@ -8,7 +8,7 @@ import org.junit.Test;
 
 /**
  * Test DefaultLogixNG
- * 
+ *
  * @author Daniel Bergqvist 2018
  */
 public class DefaultAnonymousTableTest {
@@ -18,7 +18,7 @@ public class DefaultAnonymousTableTest {
         Assert.assertNotNull("exists", new DefaultAnonymousTable(5,7));
         Assert.assertNotNull("exists", new DefaultAnonymousTable(new Object[10][15]));
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() {
@@ -34,7 +34,8 @@ public class DefaultAnonymousTableTest {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/implementation/DefaultConditionalNGTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/DefaultConditionalNGTest.java
@@ -95,6 +95,7 @@ public class DefaultConditionalNGTest {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/implementation/DefaultFemaleAnalogActionSocketTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/DefaultFemaleAnalogActionSocketTest.java
@@ -163,6 +163,7 @@ public class DefaultFemaleAnalogActionSocketTest extends FemaleSocketTestBase {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/implementation/DefaultFemaleAnalogExpressionSocketTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/DefaultFemaleAnalogExpressionSocketTest.java
@@ -145,6 +145,7 @@ public class DefaultFemaleAnalogExpressionSocketTest extends FemaleSocketTestBas
     public void tearDown() {
 //        JUnitAppender.clearBacklog();   // REMOVE THIS!!!!
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/implementation/DefaultFemaleDigitalBooleanActionSocketTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/DefaultFemaleDigitalBooleanActionSocketTest.java
@@ -141,6 +141,7 @@ public class DefaultFemaleDigitalBooleanActionSocketTest extends FemaleSocketTes
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/implementation/DefaultFemaleGenericExpressionSocket2_Test.java
+++ b/java/test/jmri/jmrit/logixng/implementation/DefaultFemaleGenericExpressionSocket2_Test.java
@@ -15,34 +15,34 @@ import org.junit.Test;
 
 /**
  * Test DefaultFemaleGenericExpressionSocket
- * 
+ *
  * @author Daniel Bergqvist 2018
  */
 public class DefaultFemaleGenericExpressionSocket2_Test {
 
     private ConditionalNG _conditionalNG;
     private FemaleSocketListener _listener;
-    
+
     @Test
     public void testEvaluateGeneric() throws JmriException {
         DefaultFemaleGenericExpressionSocket socket;
-        
+
         MyAnalogExpression analogExpression = new MyAnalogExpression("IQAE351", null);
         MaleSocket analogMaleSocket =
                 InstanceManager.getDefault(AnalogExpressionManager.class).registerExpression(analogExpression);
-        
+
         MyDigitalExpression digitalExpression = new MyDigitalExpression("IQDE351", null);
         MaleSocket digitalMaleSocket =
                 InstanceManager.getDefault(DigitalExpressionManager.class).registerExpression(digitalExpression);
-        
+
         MyStringExpression stringExpression = new MyStringExpression("IQSE351", null);
         MaleSocket stringMaleSocket =
                 InstanceManager.getDefault(StringExpressionManager.class).registerExpression(stringExpression);
-        
+
         socket = new DefaultFemaleGenericExpressionSocket(SocketType.GENERIC, _conditionalNG, _listener, "E");
-        
+
         Assert.assertEquals("evaluateGeneric() returns correct value", null, socket.evaluateGeneric());
-        
+
         socket.connect(analogMaleSocket);
         analogExpression._value = 0.0;
         Assert.assertTrue("evaluateGeneric() returns correct value", 0.0 == (Double)socket.evaluateGeneric());
@@ -51,24 +51,24 @@ public class DefaultFemaleGenericExpressionSocket2_Test {
         analogExpression._value = -1.0;
         Assert.assertTrue("evaluateGeneric() returns correct value", -1.0 == (Double)socket.evaluateGeneric());
         socket.disconnect();
-        
-        
+
+
         socket = new DefaultFemaleGenericExpressionSocket(SocketType.GENERIC, _conditionalNG, _listener, "E");
-        
+
         Assert.assertEquals("evaluateGeneric() returns correct value", null, socket.evaluateGeneric());
-        
+
         socket.connect(digitalMaleSocket);
         digitalExpression._value = false;
         Assert.assertFalse("evaluateGeneric() returns correct value", (Boolean)socket.evaluateGeneric());
         digitalExpression._value = true;
         Assert.assertTrue("evaluateGeneric() returns correct value", (Boolean)socket.evaluateGeneric());
         socket.disconnect();
-        
-        
+
+
         socket = new DefaultFemaleGenericExpressionSocket(SocketType.GENERIC, _conditionalNG, _listener, "E");
-        
+
         Assert.assertEquals("evaluateGeneric() returns correct value", null, socket.evaluateGeneric());
-        
+
         socket.connect(stringMaleSocket);
         stringExpression._value = "";
         Assert.assertEquals("evaluateGeneric() returns correct value", "", socket.evaluateGeneric());
@@ -78,7 +78,7 @@ public class DefaultFemaleGenericExpressionSocket2_Test {
         Assert.assertEquals("evaluateGeneric() returns correct value", "1.0", socket.evaluateGeneric());
         socket.disconnect();
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() {
@@ -89,9 +89,9 @@ public class DefaultFemaleGenericExpressionSocket2_Test {
         JUnitUtil.initInternalSensorManager();
         JUnitUtil.initInternalTurnoutManager();
         JUnitUtil.initLogixNGManager();
-        
+
         _conditionalNG = new DefaultConditionalNGScaffold("IQC1", "A conditionalNG");  // NOI18N;
-        
+
         _listener = new FemaleSocketListener(){
             @Override
             public void connected(FemaleSocket socket) {
@@ -108,59 +108,60 @@ public class DefaultFemaleGenericExpressionSocket2_Test {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
-    
-    
-    
+
+
+
     private static class MyAnalogExpression extends AnalogExpressionConstant {
-        
+
         private double _value;
-        
+
         public MyAnalogExpression(String sys, String user) {
             super(sys, user);
         }
-        
+
         /** {@inheritDoc} */
         @Override
         public double evaluate() {
             return _value;
         }
-        
+
     }
-    
-    
+
+
     private static class MyDigitalExpression extends ExpressionMemory {
-        
+
         private boolean _value;
-        
+
         public MyDigitalExpression(String sys, String user) {
             super(sys, user);
         }
-        
+
         /** {@inheritDoc} */
         @Override
         public boolean evaluate() {
             return _value;
         }
-        
+
     }
-    
-    
+
+
     private static class MyStringExpression extends StringExpressionConstant {
-        
+
         private String _value;
-        
+
         public MyStringExpression(String sys, String user) {
             super(sys, user);
         }
-        
+
         /** {@inheritDoc} */
         @Override
         public String evaluate() {
             return _value;
         }
-        
+
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/implementation/DefaultFemaleStringActionSocketTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/DefaultFemaleStringActionSocketTest.java
@@ -145,6 +145,7 @@ public class DefaultFemaleStringActionSocketTest extends FemaleSocketTestBase {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/implementation/DefaultFemaleStringExpressionSocketTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/DefaultFemaleStringExpressionSocketTest.java
@@ -140,6 +140,7 @@ public class DefaultFemaleStringExpressionSocketTest extends FemaleSocketTestBas
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/implementation/DefaultGlobalVariableTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/DefaultGlobalVariableTest.java
@@ -80,6 +80,7 @@ public class DefaultGlobalVariableTest {
     @AfterEach
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/implementation/DefaultLogixNGManagerTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/DefaultLogixNGManagerTest.java
@@ -676,6 +676,7 @@ public class DefaultLogixNGManagerTest {
     @AfterEach
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/implementation/DefaultMaleAnalogActionSocketTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/DefaultMaleAnalogActionSocketTest.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test DefaultMaleAnalogSocket
- * 
+ *
  * @author Daniel Bergqvist 2018
  */
 public class DefaultMaleAnalogActionSocketTest extends MaleSocketTestBase {
@@ -33,29 +33,29 @@ public class DefaultMaleAnalogActionSocketTest extends MaleSocketTestBase {
         return InstanceManager.getDefault(AnalogActionManager.class)
                 .getAutoSystemName();
     }
-    
+
     @Test
     public void testCtor() {
         AnalogActionBean action = new AnalogActionMemory("IQAA321", null);
         Assert.assertNotNull("object exists", new DefaultMaleAnalogActionSocket(manager, action));
     }
-    
+
     @Test
     public void testSetValue() throws JmriException {
         ConditionalNG conditionalNG = new DefaultConditionalNGScaffold("IQC1", "A conditionalNG");  // NOI18N;
 
-        double TOLERANCE = 0.0001; 
+        double TOLERANCE = 0.0001;
 
         MyAnalogAction action = new MyAnalogAction("IQAA321");
         action.setParent(conditionalNG);
-        
+
         DefaultMaleAnalogActionSocket socket = new DefaultMaleAnalogActionSocket(manager, action);
         Assert.assertNotNull("exists", socket);
-        
+
         socket.setParent(conditionalNG);
         socket.setEnabled(true);
         socket.setErrorHandlingType(MaleSocket.ErrorHandlingType.ThrowException);
-        
+
         action.je = null;
         action.re = null;
         socket.setValue(9.121);
@@ -64,7 +64,7 @@ public class DefaultMaleAnalogActionSocketTest extends MaleSocketTestBase {
         Assert.assertEquals(572.1, action._value, TOLERANCE);
         socket.setValue(0.0);
         Assert.assertEquals(0.0 , action._value, TOLERANCE);
-        
+
         action.je = new JmriException("Test JmriException");
         action.re = null;
         Throwable thrown = catchThrowable( () -> socket.setValue(9.121));
@@ -73,7 +73,7 @@ public class DefaultMaleAnalogActionSocketTest extends MaleSocketTestBase {
                 .isNotNull()
                 .isInstanceOf(JmriException.class)
                 .hasMessage("Test JmriException");
-        
+
         action.je = null;
         action.re = new RuntimeException("Test RuntimeException");
         thrown = catchThrowable( () -> socket.setValue(32.11));
@@ -82,7 +82,7 @@ public class DefaultMaleAnalogActionSocketTest extends MaleSocketTestBase {
                 .isNotNull()
                 .isInstanceOf(RuntimeException.class)
                 .hasMessage("Test RuntimeException");
-        
+
         // If the socket is not enabled, it shouldn't do anything
         socket.setEnabled(false);
         action.re = new RuntimeException("Test RuntimeException");
@@ -90,7 +90,7 @@ public class DefaultMaleAnalogActionSocketTest extends MaleSocketTestBase {
         assertThat(thrown)
                 .withFailMessage("Evaluate does nothing")
                 .isNull();
-        
+
         // Test debug config
         socket.setEnabled(true);
         DefaultMaleAnalogActionSocket.AnalogActionDebugConfig config = new DefaultMaleAnalogActionSocket.AnalogActionDebugConfig();
@@ -106,35 +106,35 @@ public class DefaultMaleAnalogActionSocketTest extends MaleSocketTestBase {
         socket.setValue(9.23);
         Assert.assertEquals(9.23, action._value, TOLERANCE);
     }
-    
+
     @Test
     public void testEvaluateErrors() {
         ConditionalNG conditionalNG = new DefaultConditionalNGScaffold("IQC1", "A conditionalNG");  // NOI18N;
-        
+
         MyAnalogAction action = new MyAnalogAction("IQAA321");
         action.setParent(conditionalNG);
-        
+
         DefaultMaleAnalogActionSocket socket = new DefaultMaleAnalogActionSocket(manager, action);
         Assert.assertNotNull("exists", socket);
-        
+
         socket.setParent(conditionalNG);
         socket.setEnabled(true);
         socket.setErrorHandlingType(MaleSocket.ErrorHandlingType.ThrowException);
-        
+
         Throwable thrown = catchThrowable( () -> socket.setValue(Double.NaN));
         assertThat(thrown)
                 .withFailMessage("Evaluate throws an exception")
                 .isNotNull()
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("The value is NaN");
-        
+
         thrown = catchThrowable( () -> socket.setValue(Double.NEGATIVE_INFINITY));
         assertThat(thrown)
                 .withFailMessage("Evaluate throws an exception")
                 .isNotNull()
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("The value is negative infinity");
-        
+
         thrown = catchThrowable( () -> socket.setValue(Double.POSITIVE_INFINITY));
         assertThat(thrown)
                 .withFailMessage("Evaluate throws an exception")
@@ -142,15 +142,15 @@ public class DefaultMaleAnalogActionSocketTest extends MaleSocketTestBase {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("The value is positive infinity");
     }
-    
+
     @Test
     public void testVetoableChange() {
         MyAnalogAction action = new MyAnalogAction("IQAA321");
         DefaultMaleAnalogActionSocket socket = new DefaultMaleAnalogActionSocket(manager, action);
         Assert.assertNotNull("exists", socket);
-        
+
         PropertyChangeEvent evt = new PropertyChangeEvent("Source", "Prop", null, null);
-        
+
         action._vetoChange = true;
         Throwable thrown = catchThrowable( () -> socket.vetoableChange(evt));
         assertThat(thrown)
@@ -158,22 +158,22 @@ public class DefaultMaleAnalogActionSocketTest extends MaleSocketTestBase {
                 .isNotNull()
                 .isInstanceOf(PropertyVetoException.class)
                 .hasMessage("Veto change");
-        
+
         action._vetoChange = false;
         thrown = catchThrowable( () -> socket.vetoableChange(evt));
         assertThat(thrown)
                 .withFailMessage("vetoableChange() does not throw")
                 .isNull();
     }
-    
+
     @Test
     public void testCompareSystemNameSuffix() {
         MyAnalogAction action1 = new MyAnalogAction("IQAA1");
         DefaultMaleAnalogActionSocket socket1 = new DefaultMaleAnalogActionSocket(manager, action1);
-        
+
         MyAnalogAction action2 = new MyAnalogAction("IQAA01");
         DefaultMaleAnalogActionSocket socket2 = new DefaultMaleAnalogActionSocket(manager, action2);
-        
+
         Assert.assertEquals("compareSystemNameSuffix returns correct value",
                 -1, socket1.compareSystemNameSuffix("01", "1", socket2));
         Assert.assertEquals("compareSystemNameSuffix returns correct value",
@@ -183,7 +183,7 @@ public class DefaultMaleAnalogActionSocketTest extends MaleSocketTestBase {
         Assert.assertEquals("compareSystemNameSuffix returns correct value",
                 +1, socket1.compareSystemNameSuffix("1", "01", socket2));
     }
-    
+
     // The minimal setup for log4J
     @BeforeEach
     @Override
@@ -195,19 +195,19 @@ public class DefaultMaleAnalogActionSocketTest extends MaleSocketTestBase {
         JUnitUtil.initInternalSensorManager();
         JUnitUtil.initInternalTurnoutManager();
         JUnitUtil.initLogixNGManager();
-        
+
         AnalogActionBean actionA = new AnalogActionMemory("IQAA321", null);
         Assert.assertNotNull("exists", actionA);
         AnalogActionBean actionB = new MyAnalogAction("IQAA322");
         Assert.assertNotNull("exists", actionA);
-        
+
         manager = InstanceManager.getDefault(AnalogActionManager.class);
-        
+
         maleSocketA =
                 InstanceManager.getDefault(AnalogActionManager.class)
                         .registerAction(actionA);
         Assert.assertNotNull("exists", maleSocketA);
-        
+
         maleSocketB =
                 InstanceManager.getDefault(AnalogActionManager.class)
                         .registerAction(actionB);
@@ -218,21 +218,22 @@ public class DefaultMaleAnalogActionSocketTest extends MaleSocketTestBase {
     @Override
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
-    
-    
+
+
     /**
      * This action is different from AnalogActionMemory and is used to test the
      * male socket.
      */
     private static class MyAnalogAction extends AbstractAnalogAction {
-        
+
         JmriException je = null;
         RuntimeException re = null;
         double _value = 0.0;
         boolean _vetoChange = false;
-        
+
         MyAnalogAction(String sysName) {
             super(sysName, null);
         }
@@ -288,7 +289,7 @@ public class DefaultMaleAnalogActionSocketTest extends MaleSocketTestBase {
             if (re != null) throw re;
             _value = value;
         }
-        
+
         @Override
         public void vetoableChange(PropertyChangeEvent evt) throws PropertyVetoException {
             if (_vetoChange) throw new java.beans.PropertyVetoException("Veto change", evt);
@@ -303,7 +304,7 @@ public class DefaultMaleAnalogActionSocketTest extends MaleSocketTestBase {
         public Base deepCopyChildren(Base base, Map<String, String> map, Map<String, String> map1) throws JmriException {
             throw new UnsupportedOperationException("Not supported");
         }
-        
+
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/implementation/DefaultMaleAnalogExpressionSocketTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/DefaultMaleAnalogExpressionSocketTest.java
@@ -24,7 +24,7 @@ import static org.assertj.core.api.Assertions.catchThrowable;
 
 /**
  * Test ExpressionTimer
- * 
+ *
  * @author Daniel Bergqvist 2018
  */
 public class DefaultMaleAnalogExpressionSocketTest extends MaleSocketTestBase {
@@ -34,28 +34,28 @@ public class DefaultMaleAnalogExpressionSocketTest extends MaleSocketTestBase {
         return InstanceManager.getDefault(AnalogExpressionManager.class)
                 .getAutoSystemName();
     }
-    
+
     @Test
     public void testCtor() {
         AnalogExpressionBean expression = new AnalogExpressionMemory("IQAE321", null);
         MaleSocket maleSocket = ((AnalogExpressionManager)manager).registerExpression(expression);
         Assert.assertNotNull("object exists", maleSocket);
     }
-    
+
     @Test
     public void testEvaluate() throws JmriException {
         ConditionalNG conditionalNG = new DefaultConditionalNGScaffold("IQC1", "A conditionalNG");  // NOI18N;
-        
+
         MyAnalogExpression expression = new MyAnalogExpression("IQAE321");
         expression.setParent(conditionalNG);
-        
+
         DefaultMaleAnalogExpressionSocket socket = new DefaultMaleAnalogExpressionSocket(manager, expression);
         Assert.assertNotNull("exists", socket);
-        
+
         socket.setParent(conditionalNG);
         socket.setEnabled(true);
         socket.setErrorHandlingType(MaleSocket.ErrorHandlingType.ThrowException);
-        
+
         expression.je = null;
         expression.re = null;
         expression.result = 94.27;
@@ -64,7 +64,7 @@ public class DefaultMaleAnalogExpressionSocketTest extends MaleSocketTestBase {
         Assert.assertTrue(12.92 == socket.evaluate());
         expression.result = 0.0;
         Assert.assertTrue(0.0 == socket.evaluate());
-        
+
         expression.je = new JmriException("Test JmriException");
         expression.re = null;
         Throwable thrown = catchThrowable( () -> socket.evaluate());
@@ -73,7 +73,7 @@ public class DefaultMaleAnalogExpressionSocketTest extends MaleSocketTestBase {
                 .isNotNull()
                 .isInstanceOf(JmriException.class)
                 .hasMessage("Test JmriException");
-        
+
         expression.je = null;
         expression.re = new RuntimeException("Test RuntimeException");
         thrown = catchThrowable( () -> socket.evaluate());
@@ -82,7 +82,7 @@ public class DefaultMaleAnalogExpressionSocketTest extends MaleSocketTestBase {
                 .isNotNull()
                 .isInstanceOf(RuntimeException.class)
                 .hasMessage("Test RuntimeException");
-        
+
         // If the socket is not enabled, it shouldn't do anything
         socket.setEnabled(false);
         expression.re = new RuntimeException("Test RuntimeException");
@@ -90,7 +90,7 @@ public class DefaultMaleAnalogExpressionSocketTest extends MaleSocketTestBase {
         assertThat(thrown)
                 .withFailMessage("Evaluate does nothing")
                 .isNull();
-        
+
         // Test debug config
         socket.setEnabled(true);
         AnalogExpressionDebugConfig config = new AnalogExpressionDebugConfig();
@@ -104,21 +104,21 @@ public class DefaultMaleAnalogExpressionSocketTest extends MaleSocketTestBase {
         config._forceResult = false;
         Assert.assertTrue(93.23 == socket.evaluate());
     }
-    
+
     @Test
     public void testEvaluateErrors() {
         ConditionalNG conditionalNG = new DefaultConditionalNGScaffold("IQC1", "A conditionalNG");  // NOI18N;
-        
+
         MyAnalogExpression expression = new MyAnalogExpression("IQAE321");
         expression.setParent(conditionalNG);
-        
+
         DefaultMaleAnalogExpressionSocket socket = new DefaultMaleAnalogExpressionSocket(manager, expression);
         Assert.assertNotNull("exists", socket);
-        
+
         socket.setParent(conditionalNG);
         socket.setEnabled(true);
         socket.setErrorHandlingType(MaleSocket.ErrorHandlingType.ThrowException);
-        
+
         expression.result = Double.NaN;
         Throwable thrown = catchThrowable( () -> socket.evaluate());
         assertThat(thrown)
@@ -126,7 +126,7 @@ public class DefaultMaleAnalogExpressionSocketTest extends MaleSocketTestBase {
                 .isNotNull()
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("The result is NaN");
-        
+
         expression.result = Double.NEGATIVE_INFINITY;
         thrown = catchThrowable( () -> socket.evaluate());
         assertThat(thrown)
@@ -134,7 +134,7 @@ public class DefaultMaleAnalogExpressionSocketTest extends MaleSocketTestBase {
                 .isNotNull()
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("The result is negative infinity");
-        
+
         expression.result = Double.POSITIVE_INFINITY;
         thrown = catchThrowable( () -> socket.evaluate());
         assertThat(thrown)
@@ -143,19 +143,19 @@ public class DefaultMaleAnalogExpressionSocketTest extends MaleSocketTestBase {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("The result is positive infinity");
     }
-    
+
     @Test
     public void testVetoableChange() {
         ConditionalNG conditionalNG = new DefaultConditionalNGScaffold("IQC1", "A conditionalNG");  // NOI18N;
-        
+
         MyAnalogExpression expression = new MyAnalogExpression("IQAE321");
         expression.setParent(conditionalNG);
-        
+
         MaleSocket socket = ((AnalogExpressionManager)manager).registerExpression(expression);
         Assert.assertNotNull("exists", socket);
-        
+
         PropertyChangeEvent evt = new PropertyChangeEvent("Source", "Prop", null, null);
-        
+
         expression._vetoChange = true;
         Throwable thrown = catchThrowable( () -> socket.vetoableChange(evt));
         assertThat(thrown)
@@ -163,22 +163,22 @@ public class DefaultMaleAnalogExpressionSocketTest extends MaleSocketTestBase {
                 .isNotNull()
                 .isInstanceOf(PropertyVetoException.class)
                 .hasMessage("Veto change");
-        
+
         expression._vetoChange = false;
         thrown = catchThrowable( () -> socket.vetoableChange(evt));
         assertThat(thrown)
                 .withFailMessage("vetoableChange() does not throw")
                 .isNull();
     }
-    
+
     @Test
     public void testCompareSystemNameSuffix() {
         MyAnalogExpression expression1 = new MyAnalogExpression("IQAE1");
         MaleAnalogExpressionSocket socket1 = ((AnalogExpressionManager)manager).registerExpression(expression1);
-        
+
         MyAnalogExpression expression2 = new MyAnalogExpression("IQAE01");
         MaleAnalogExpressionSocket socket2 = ((AnalogExpressionManager)manager).registerExpression(expression2);
-        
+
         Assert.assertEquals("compareSystemNameSuffix returns correct value",
                 -1, socket1.compareSystemNameSuffix("01", "1", socket2));
         Assert.assertEquals("compareSystemNameSuffix returns correct value",
@@ -188,7 +188,7 @@ public class DefaultMaleAnalogExpressionSocketTest extends MaleSocketTestBase {
         Assert.assertEquals("compareSystemNameSuffix returns correct value",
                 +1, socket1.compareSystemNameSuffix("1", "01", socket2));
     }
-    
+
     // The minimal setup for log4J
     @BeforeEach
     @Override
@@ -200,19 +200,19 @@ public class DefaultMaleAnalogExpressionSocketTest extends MaleSocketTestBase {
         JUnitUtil.initInternalSensorManager();
         JUnitUtil.initInternalTurnoutManager();
         JUnitUtil.initLogixNGManager();
-        
+
         AnalogExpressionBean expressionA = new AnalogExpressionMemory("IQAE999", null);
         Assert.assertNotNull("exists", expressionA);
         AnalogExpressionBean expressionB = new MyAnalogExpression("IQAE322");
         Assert.assertNotNull("exists", expressionA);
-        
+
         manager = InstanceManager.getDefault(AnalogExpressionManager.class);
-        
+
         maleSocketA =
                 InstanceManager.getDefault(AnalogExpressionManager.class)
                         .registerExpression(expressionA);
         Assert.assertNotNull("exists", maleSocketA);
-        
+
         maleSocketB =
                 InstanceManager.getDefault(AnalogExpressionManager.class)
                         .registerExpression(expressionB);
@@ -223,21 +223,22 @@ public class DefaultMaleAnalogExpressionSocketTest extends MaleSocketTestBase {
     @Override
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
-    
-    
+
+
     /**
      * This action is different from AnalogExpressionMemory and is used to test the
      * male socket.
      */
     private class MyAnalogExpression extends AbstractAnalogExpression {
-        
+
         JmriException je = null;
         RuntimeException re = null;
         double result = 0.0;
         boolean _vetoChange = false;
-        
+
         MyAnalogExpression(String sysName) {
             super(sysName, null);
         }
@@ -293,7 +294,7 @@ public class DefaultMaleAnalogExpressionSocketTest extends MaleSocketTestBase {
             if (re != null) throw re;
             return result;
         }
-        
+
         @Override
         public void vetoableChange(PropertyChangeEvent evt) throws PropertyVetoException {
             if (_vetoChange) throw new java.beans.PropertyVetoException("Veto change", evt);
@@ -308,7 +309,7 @@ public class DefaultMaleAnalogExpressionSocketTest extends MaleSocketTestBase {
         public Base deepCopyChildren(Base base, Map<String, String> map, Map<String, String> map1) throws JmriException {
             throw new UnsupportedOperationException("Not supported");
         }
-        
+
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/implementation/DefaultMaleDigitalActionSocketTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/DefaultMaleDigitalActionSocketTest.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test ExpressionTimer
- * 
+ *
  * @author Daniel Bergqvist 2018
  */
 public class DefaultMaleDigitalActionSocketTest extends MaleSocketTestBase{
@@ -35,33 +35,33 @@ public class DefaultMaleDigitalActionSocketTest extends MaleSocketTestBase{
         return InstanceManager.getDefault(DigitalActionManager.class)
                 .getAutoSystemName();
     }
-    
+
     @Test
     public void testCtor() {
         DigitalActionBean action = new DigitalMany("IQDA321", null);
         Assert.assertNotNull("exists", new DefaultMaleDigitalActionSocket(manager, action));
     }
-    
+
     @Test
     public void testExecute() throws JmriException {
         ConditionalNG conditionalNG = new DefaultConditionalNGScaffold("IQC1", "A conditionalNG");  // NOI18N;
-        
+
         MyDigitalAction action = new MyDigitalAction("IQDA321");
         action.setParent(conditionalNG);
-        
+
         DefaultMaleDigitalActionSocket socket = new DefaultMaleDigitalActionSocket(manager, action);
         Assert.assertNotNull("exists", socket);
-        
+
         socket.setParent(conditionalNG);
         socket.setEnabled(true);
         socket.setErrorHandlingType(MaleSocket.ErrorHandlingType.ThrowException);
-        
+
         action.je = null;
         action.re = null;
         action._hasExecuted = false;
         socket.execute();
         Assert.assertTrue(action._hasExecuted);
-        
+
         action.je = new JmriException("Test JmriException");
         action.re = null;
         Throwable thrown = catchThrowable( () -> socket.execute());
@@ -70,7 +70,7 @@ public class DefaultMaleDigitalActionSocketTest extends MaleSocketTestBase{
                 .isNotNull()
                 .isInstanceOf(JmriException.class)
                 .hasMessage("Test JmriException");
-        
+
         action.je = null;
         action.re = new RuntimeException("Test RuntimeException");
         thrown = catchThrowable( () -> socket.execute());
@@ -79,7 +79,7 @@ public class DefaultMaleDigitalActionSocketTest extends MaleSocketTestBase{
                 .isNotNull()
                 .isInstanceOf(RuntimeException.class)
                 .hasMessage("Test RuntimeException");
-        
+
         // If the socket is not enabled, it shouldn't do anything
         socket.setEnabled(false);
         action.re = new RuntimeException("Test RuntimeException");
@@ -87,7 +87,7 @@ public class DefaultMaleDigitalActionSocketTest extends MaleSocketTestBase{
         assertThat(thrown)
                 .withFailMessage("Evaluate does nothing")
                 .isNull();
-        
+
         // Test debug config
         socket.setEnabled(true);
         DigitalActionDebugConfig config = new DigitalActionDebugConfig();
@@ -103,15 +103,15 @@ public class DefaultMaleDigitalActionSocketTest extends MaleSocketTestBase{
         socket.execute();
         Assert.assertTrue(action._hasExecuted);
     }
-    
+
     @Test
     public void testVetoableChange() {
         MyDigitalAction action = new MyDigitalAction("IQDA321");
         DefaultMaleDigitalActionSocket socket = new DefaultMaleDigitalActionSocket(manager, action);
         Assert.assertNotNull("exists", socket);
-        
+
         PropertyChangeEvent evt = new PropertyChangeEvent("Source", "Prop", null, null);
-        
+
         action._vetoChange = true;
         Throwable thrown = catchThrowable( () -> socket.vetoableChange(evt));
         assertThat(thrown)
@@ -119,22 +119,22 @@ public class DefaultMaleDigitalActionSocketTest extends MaleSocketTestBase{
                 .isNotNull()
                 .isInstanceOf(PropertyVetoException.class)
                 .hasMessage("Veto change");
-        
+
         action._vetoChange = false;
         thrown = catchThrowable( () -> socket.vetoableChange(evt));
         assertThat(thrown)
                 .withFailMessage("vetoableChange() does not throw")
                 .isNull();
     }
-    
+
     @Test
     public void testCompareSystemNameSuffix() {
         MyDigitalAction action1 = new MyDigitalAction("IQDA1");
         DefaultMaleDigitalActionSocket socket1 = new DefaultMaleDigitalActionSocket(manager, action1);
-        
+
         MyDigitalAction action2 = new MyDigitalAction("IQDA01");
         DefaultMaleDigitalActionSocket socket2 = new DefaultMaleDigitalActionSocket(manager, action2);
-        
+
         Assert.assertEquals("compareSystemNameSuffix returns correct value",
                 -1, socket1.compareSystemNameSuffix("01", "1", socket2));
         Assert.assertEquals("compareSystemNameSuffix returns correct value",
@@ -144,7 +144,7 @@ public class DefaultMaleDigitalActionSocketTest extends MaleSocketTestBase{
         Assert.assertEquals("compareSystemNameSuffix returns correct value",
                 +1, socket1.compareSystemNameSuffix("1", "01", socket2));
     }
-    
+
     // The minimal setup for log4J
     @BeforeEach
     @Override
@@ -156,19 +156,19 @@ public class DefaultMaleDigitalActionSocketTest extends MaleSocketTestBase{
         JUnitUtil.initInternalSensorManager();
         JUnitUtil.initInternalTurnoutManager();
         JUnitUtil.initLogixNGManager();
-        
+
         DigitalActionBean actionA = new ActionTurnout("IQDA321", null);
         Assert.assertNotNull("exists", actionA);
         DigitalActionBean actionB = new MyDigitalAction("IQDA322");
         Assert.assertNotNull("exists", actionA);
-        
+
         manager = InstanceManager.getDefault(DigitalActionManager.class);
-        
+
         maleSocketA =
                 InstanceManager.getDefault(DigitalActionManager.class)
                         .registerAction(actionA);
         Assert.assertNotNull("exists", maleSocketA);
-        
+
         maleSocketB =
                 InstanceManager.getDefault(DigitalActionManager.class)
                         .registerAction(actionB);
@@ -179,21 +179,22 @@ public class DefaultMaleDigitalActionSocketTest extends MaleSocketTestBase{
     @Override
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
-    
-    
+
+
     /**
      * This action is different from MyStringAction and is used to test the
      * male socket.
      */
     private class MyDigitalAction extends AbstractDigitalAction {
-        
+
         JmriException je = null;
         RuntimeException re = null;
         boolean _hasExecuted = false;
         boolean _vetoChange = false;
-        
+
         MyDigitalAction(String sysName) {
             super(sysName, null);
         }
@@ -249,7 +250,7 @@ public class DefaultMaleDigitalActionSocketTest extends MaleSocketTestBase{
             if (re != null) throw re;
             _hasExecuted = true;
         }
-        
+
         @Override
         public void vetoableChange(PropertyChangeEvent evt) throws PropertyVetoException {
             if (_vetoChange) throw new java.beans.PropertyVetoException("Veto change", evt);
@@ -264,7 +265,7 @@ public class DefaultMaleDigitalActionSocketTest extends MaleSocketTestBase{
         public Base deepCopyChildren(Base base, Map<String, String> map, Map<String, String> map1) throws JmriException {
             throw new UnsupportedOperationException("Not supported");
         }
-        
+
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/implementation/DefaultMaleDigitalBooleanActionSocketTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/DefaultMaleDigitalBooleanActionSocketTest.java
@@ -25,7 +25,7 @@ import static org.assertj.core.api.Assertions.catchThrowable;
 
 /**
  * Test ExpressionTimer
- * 
+ *
  * @author Daniel Bergqvist 2018
  */
 public class DefaultMaleDigitalBooleanActionSocketTest extends MaleSocketTestBase{
@@ -35,27 +35,27 @@ public class DefaultMaleDigitalBooleanActionSocketTest extends MaleSocketTestBas
         return InstanceManager.getDefault(DigitalBooleanActionManager.class)
                 .getAutoSystemName();
     }
-    
+
     @Test
     public void testCtor() {
         DigitalBooleanActionBean action = new DigitalBooleanOnChange("IQDB321", null, DigitalBooleanOnChange.Trigger.CHANGE);
         Assert.assertNotNull("exists", new DefaultMaleDigitalBooleanActionSocket(manager, action));
     }
-    
+
     @Test
     public void testEvaluate() throws JmriException {
         ConditionalNG conditionalNG = new DefaultConditionalNGScaffold("IQC1", "A conditionalNG");  // NOI18N;
-        
+
         MyDigitalBooleanAction action = new MyDigitalBooleanAction("IQDB321");
         action.setParent(conditionalNG);
-        
+
         DefaultMaleDigitalBooleanActionSocket socket = new DefaultMaleDigitalBooleanActionSocket(manager, action);
         Assert.assertNotNull("exists", socket);
-        
+
         socket.setParent(conditionalNG);
         socket.setEnabled(true);
         socket.setErrorHandlingType(MaleSocket.ErrorHandlingType.ThrowException);
-        
+
         action.je = null;
         action.re = null;
         socket.execute(false, false);
@@ -67,7 +67,7 @@ public class DefaultMaleDigitalBooleanActionSocketTest extends MaleSocketTestBas
         socket.execute(false, true);
         Assert.assertFalse(action._hasChangedToTrue);
         Assert.assertTrue(action._hasChangedToFalse);
-        
+
         action.je = new JmriException("Test JmriException");
         action.re = null;
         Throwable thrown = catchThrowable( () -> socket.execute(false, false));
@@ -76,7 +76,7 @@ public class DefaultMaleDigitalBooleanActionSocketTest extends MaleSocketTestBas
                 .isNotNull()
                 .isInstanceOf(JmriException.class)
                 .hasMessage("Test JmriException");
-        
+
         action.je = null;
         action.re = new RuntimeException("Test RuntimeException");
         thrown = catchThrowable( () -> socket.execute(false, false));
@@ -85,7 +85,7 @@ public class DefaultMaleDigitalBooleanActionSocketTest extends MaleSocketTestBas
                 .isNotNull()
                 .isInstanceOf(RuntimeException.class)
                 .hasMessage("Test RuntimeException");
-        
+
         // If the socket is not enabled, it shouldn't do anything
         socket.setEnabled(false);
         action.re = new RuntimeException("Test RuntimeException");
@@ -93,7 +93,7 @@ public class DefaultMaleDigitalBooleanActionSocketTest extends MaleSocketTestBas
         assertThat(thrown)
                 .withFailMessage("Evaluate does nothing")
                 .isNull();
-        
+
         // Test debug config
         socket.setEnabled(true);
         DigitalBooleanActionDebugConfig config = new DigitalBooleanActionDebugConfig();
@@ -123,15 +123,15 @@ public class DefaultMaleDigitalBooleanActionSocketTest extends MaleSocketTestBas
         Assert.assertFalse(action._hasChangedToTrue);
         Assert.assertTrue(action._hasChangedToFalse);
     }
-    
+
     @Test
     public void testVetoableChange() {
         MyDigitalBooleanAction action = new MyDigitalBooleanAction("IQDB321");
         DefaultMaleDigitalBooleanActionSocket socket = new DefaultMaleDigitalBooleanActionSocket(manager, action);
         Assert.assertNotNull("exists", socket);
-        
+
         PropertyChangeEvent evt = new PropertyChangeEvent("Source", "Prop", null, null);
-        
+
         action._vetoChange = true;
         Throwable thrown = catchThrowable( () -> socket.vetoableChange(evt));
         assertThat(thrown)
@@ -139,22 +139,22 @@ public class DefaultMaleDigitalBooleanActionSocketTest extends MaleSocketTestBas
                 .isNotNull()
                 .isInstanceOf(PropertyVetoException.class)
                 .hasMessage("Veto change");
-        
+
         action._vetoChange = false;
         thrown = catchThrowable( () -> socket.vetoableChange(evt));
         assertThat(thrown)
                 .withFailMessage("vetoableChange() does not throw")
                 .isNull();
     }
-    
+
     @Test
     public void testCompareSystemNameSuffix() {
         MyDigitalBooleanAction action1 = new MyDigitalBooleanAction("IQDB1");
         DefaultMaleDigitalBooleanActionSocket socket1 = new DefaultMaleDigitalBooleanActionSocket(manager, action1);
-        
+
         MyDigitalBooleanAction action2 = new MyDigitalBooleanAction("IQDB01");
         DefaultMaleDigitalBooleanActionSocket socket2 = new DefaultMaleDigitalBooleanActionSocket(manager, action2);
-        
+
         Assert.assertEquals("compareSystemNameSuffix returns correct value",
                 -1, socket1.compareSystemNameSuffix("01", "1", socket2));
         Assert.assertEquals("compareSystemNameSuffix returns correct value",
@@ -164,7 +164,7 @@ public class DefaultMaleDigitalBooleanActionSocketTest extends MaleSocketTestBas
         Assert.assertEquals("compareSystemNameSuffix returns correct value",
                 +1, socket1.compareSystemNameSuffix("1", "01", socket2));
     }
-    
+
     // The minimal setup for log4J
     @BeforeEach
     @Override
@@ -176,19 +176,19 @@ public class DefaultMaleDigitalBooleanActionSocketTest extends MaleSocketTestBas
         JUnitUtil.initInternalSensorManager();
         JUnitUtil.initInternalTurnoutManager();
         JUnitUtil.initLogixNGManager();
-        
+
         DigitalBooleanActionBean actionA = new DigitalBooleanOnChange("IQDB321", null, DigitalBooleanOnChange.Trigger.CHANGE);
         Assert.assertNotNull("exists", actionA);
         DigitalBooleanActionBean actionB = new MyDigitalBooleanAction("IQDB322");
         Assert.assertNotNull("exists", actionA);
-        
+
         manager = InstanceManager.getDefault(DigitalBooleanActionManager.class);
-        
+
         maleSocketA =
                 InstanceManager.getDefault(DigitalBooleanActionManager.class)
                         .registerAction(actionA);
         Assert.assertNotNull("exists", maleSocketA);
-        
+
         maleSocketB =
                 InstanceManager.getDefault(DigitalBooleanActionManager.class)
                         .registerAction(actionB);
@@ -199,22 +199,23 @@ public class DefaultMaleDigitalBooleanActionSocketTest extends MaleSocketTestBas
     @Override
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
-    
-    
+
+
     /**
      * This action is different from MyStringAction and is used to test the
      * male socket.
      */
     private class MyDigitalBooleanAction extends AbstractDigitalBooleanAction {
-        
+
         JmriException je = null;
         RuntimeException re = null;
         boolean _hasChangedToTrue = false;
         boolean _hasChangedToFalse = false;
         boolean _vetoChange = false;
-        
+
         MyDigitalBooleanAction(String sysName) {
             super(sysName, null);
         }
@@ -271,7 +272,7 @@ public class DefaultMaleDigitalBooleanActionSocketTest extends MaleSocketTestBas
            _hasChangedToTrue = hasChangedToTrue;
            _hasChangedToFalse = hasChangedToFalse;
         }
-        
+
         @Override
         public void vetoableChange(PropertyChangeEvent evt) throws PropertyVetoException {
             if (_vetoChange) throw new java.beans.PropertyVetoException("Veto change", evt);
@@ -286,7 +287,7 @@ public class DefaultMaleDigitalBooleanActionSocketTest extends MaleSocketTestBas
         public Base deepCopyChildren(Base base, Map<String, String> map, Map<String, String> map1) throws JmriException {
             throw new UnsupportedOperationException("Not supported");
         }
-        
+
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/implementation/DefaultMaleDigitalExpressionSocketTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/DefaultMaleDigitalExpressionSocketTest.java
@@ -25,7 +25,7 @@ import static org.assertj.core.api.Assertions.catchThrowable;
 
 /**
  * Test ExpressionTimer
- * 
+ *
  * @author Daniel Bergqvist 2018
  */
 public class DefaultMaleDigitalExpressionSocketTest extends MaleSocketTestBase {
@@ -35,34 +35,34 @@ public class DefaultMaleDigitalExpressionSocketTest extends MaleSocketTestBase {
         return InstanceManager.getDefault(DigitalExpressionManager.class)
                 .getAutoSystemName();
     }
-    
+
     @Test
     public void testCtor() {
         DigitalExpressionBean expression = new And("IQDE321", null);
         Assert.assertNotNull("exists", new DefaultMaleDigitalExpressionSocket(manager, expression));
     }
-    
+
     @Test
     public void testEvaluate() throws JmriException {
         ConditionalNG conditionalNG = new DefaultConditionalNGScaffold("IQC1", "A conditionalNG");  // NOI18N;
-        
+
         MyDigitalExpression expression = new MyDigitalExpression("IQDE321");
         expression.setParent(conditionalNG);
-        
+
         DefaultMaleDigitalExpressionSocket socket = new DefaultMaleDigitalExpressionSocket(manager, expression);
         Assert.assertNotNull("exists", socket);
-        
+
         socket.setParent(conditionalNG);
         socket.setEnabled(true);
         socket.setErrorHandlingType(MaleSocket.ErrorHandlingType.ThrowException);
-        
+
         expression.je = null;
         expression.re = null;
         expression.result = true;
         Assert.assertTrue(socket.evaluate());
         expression.result = false;
         Assert.assertFalse(socket.evaluate());
-        
+
         expression.je = new JmriException("Test JmriException");
         expression.re = null;
         Throwable thrown = catchThrowable( () -> socket.evaluate());
@@ -71,7 +71,7 @@ public class DefaultMaleDigitalExpressionSocketTest extends MaleSocketTestBase {
                 .isNotNull()
                 .isInstanceOf(JmriException.class)
                 .hasMessage("Test JmriException");
-        
+
         expression.je = null;
         expression.re = new RuntimeException("Test RuntimeException");
         thrown = catchThrowable( () -> socket.evaluate());
@@ -80,7 +80,7 @@ public class DefaultMaleDigitalExpressionSocketTest extends MaleSocketTestBase {
                 .isNotNull()
                 .isInstanceOf(RuntimeException.class)
                 .hasMessage("Test RuntimeException");
-        
+
         // If the socket is not enabled, it shouldn't do anything
         socket.setEnabled(false);
         expression.re = new RuntimeException("Test RuntimeException");
@@ -88,7 +88,7 @@ public class DefaultMaleDigitalExpressionSocketTest extends MaleSocketTestBase {
         assertThat(thrown)
                 .withFailMessage("Evaluate does nothing")
                 .isNull();
-        
+
         // Test debug config
         socket.setEnabled(true);
         DigitalExpressionDebugConfig config = new DigitalExpressionDebugConfig();
@@ -102,15 +102,15 @@ public class DefaultMaleDigitalExpressionSocketTest extends MaleSocketTestBase {
         config._forceResult = false;
         Assert.assertFalse(socket.evaluate());
     }
-    
+
     @Test
     public void testVetoableChange() {
         MyDigitalExpression action = new MyDigitalExpression("IQDE321");
         DefaultMaleDigitalExpressionSocket socket = new DefaultMaleDigitalExpressionSocket(manager, action);
         Assert.assertNotNull("exists", socket);
-        
+
         PropertyChangeEvent evt = new PropertyChangeEvent("Source", "Prop", null, null);
-        
+
         action._vetoChange = true;
         Throwable thrown = catchThrowable( () -> socket.vetoableChange(evt));
         assertThat(thrown)
@@ -118,22 +118,22 @@ public class DefaultMaleDigitalExpressionSocketTest extends MaleSocketTestBase {
                 .isNotNull()
                 .isInstanceOf(PropertyVetoException.class)
                 .hasMessage("Veto change");
-        
+
         action._vetoChange = false;
         thrown = catchThrowable( () -> socket.vetoableChange(evt));
         assertThat(thrown)
                 .withFailMessage("vetoableChange() does not throw")
                 .isNull();
     }
-    
+
     @Test
     public void testCompareSystemNameSuffix() {
         MyDigitalExpression expression1 = new MyDigitalExpression("IQDE1");
         DefaultMaleDigitalExpressionSocket socket1 = new DefaultMaleDigitalExpressionSocket(manager, expression1);
-        
+
         MyDigitalExpression expression2 = new MyDigitalExpression("IQDE01");
         DefaultMaleDigitalExpressionSocket socket2 = new DefaultMaleDigitalExpressionSocket(manager, expression2);
-        
+
         Assert.assertEquals("compareSystemNameSuffix returns correct value",
                 -1, socket1.compareSystemNameSuffix("01", "1", socket2));
         Assert.assertEquals("compareSystemNameSuffix returns correct value",
@@ -143,7 +143,7 @@ public class DefaultMaleDigitalExpressionSocketTest extends MaleSocketTestBase {
         Assert.assertEquals("compareSystemNameSuffix returns correct value",
                 +1, socket1.compareSystemNameSuffix("1", "01", socket2));
     }
-    
+
     // The minimal setup for log4J
     @BeforeEach
     @Override
@@ -155,19 +155,19 @@ public class DefaultMaleDigitalExpressionSocketTest extends MaleSocketTestBase {
         JUnitUtil.initInternalSensorManager();
         JUnitUtil.initInternalTurnoutManager();
         JUnitUtil.initLogixNGManager();
-        
+
         DigitalExpressionBean expressionA = new ExpressionTurnout("IQDE321", null);
         Assert.assertNotNull("exists", expressionA);
         DigitalExpressionBean expressionB = new MyDigitalExpression("IQDE322");
         Assert.assertNotNull("exists", expressionA);
-        
+
         manager = InstanceManager.getDefault(DigitalExpressionManager.class);
-        
+
         maleSocketA =
                 InstanceManager.getDefault(DigitalExpressionManager.class)
                         .registerExpression(expressionA);
         Assert.assertNotNull("exists", maleSocketA);
-        
+
         maleSocketB =
                 InstanceManager.getDefault(DigitalExpressionManager.class)
                         .registerExpression(expressionB);
@@ -178,21 +178,22 @@ public class DefaultMaleDigitalExpressionSocketTest extends MaleSocketTestBase {
     @Override
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
-    
-    
+
+
     /**
      * This action is different from action And and is used to test the
      * male socket.
      */
     private class MyDigitalExpression extends AbstractDigitalExpression {
-        
+
         JmriException je = null;
         RuntimeException re = null;
         boolean result = false;
         boolean _vetoChange = false;
-        
+
         MyDigitalExpression(String sysName) {
             super(sysName, null);
         }
@@ -248,7 +249,7 @@ public class DefaultMaleDigitalExpressionSocketTest extends MaleSocketTestBase {
             if (re != null) throw re;
             return result;
         }
-        
+
         @Override
         public void vetoableChange(PropertyChangeEvent evt) throws PropertyVetoException {
             if (_vetoChange) throw new java.beans.PropertyVetoException("Veto change", evt);
@@ -263,7 +264,7 @@ public class DefaultMaleDigitalExpressionSocketTest extends MaleSocketTestBase {
         public Base deepCopyChildren(Base base, Map<String, String> map, Map<String, String> map1) throws JmriException {
             throw new UnsupportedOperationException("Not supported");
         }
-        
+
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/implementation/DefaultMaleStringActionSocketTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/DefaultMaleStringActionSocketTest.java
@@ -24,7 +24,7 @@ import static org.assertj.core.api.Assertions.catchThrowable;
 
 /**
  * Test ExpressionTimer
- * 
+ *
  * @author Daniel Bergqvist 2018
  */
 public class DefaultMaleStringActionSocketTest extends MaleSocketTestBase {
@@ -34,27 +34,27 @@ public class DefaultMaleStringActionSocketTest extends MaleSocketTestBase {
         return InstanceManager.getDefault(StringActionManager.class)
                 .getAutoSystemName();
     }
-    
+
     @Test
     public void testCtor() {
         StringActionBean action = new StringActionMemory("IQSA321", null);
         Assert.assertNotNull("exists", new DefaultMaleStringActionSocket(manager, action));
     }
-    
+
     @Test
     public void testEvaluate() throws JmriException {
         ConditionalNG conditionalNG = new DefaultConditionalNGScaffold("IQC1", "A conditionalNG");  // NOI18N;
-        
+
         MyStringAction action = new MyStringAction("IQSA321");
         action.setParent(conditionalNG);
-        
+
         DefaultMaleStringActionSocket socket = new DefaultMaleStringActionSocket(manager, action);
         Assert.assertNotNull("exists", socket);
-        
+
         socket.setParent(conditionalNG);
         socket.setEnabled(true);
         socket.setErrorHandlingType(MaleSocket.ErrorHandlingType.ThrowException);
-        
+
         action.je = null;
         action.re = null;
         socket.setValue("Something");
@@ -65,7 +65,7 @@ public class DefaultMaleStringActionSocketTest extends MaleSocketTestBase {
         Assert.assertEquals("", action._value);
         socket.setValue(null);
         Assert.assertNull(action._value);
-        
+
         action.je = new JmriException("Test JmriException");
         action.re = null;
         Throwable thrown = catchThrowable( () -> socket.setValue("Something"));
@@ -74,7 +74,7 @@ public class DefaultMaleStringActionSocketTest extends MaleSocketTestBase {
                 .isNotNull()
                 .isInstanceOf(JmriException.class)
                 .hasMessage("Test JmriException");
-        
+
         action.je = null;
         action.re = new RuntimeException("Test RuntimeException");
         thrown = catchThrowable( () -> socket.setValue("Something"));
@@ -83,7 +83,7 @@ public class DefaultMaleStringActionSocketTest extends MaleSocketTestBase {
                 .isNotNull()
                 .isInstanceOf(RuntimeException.class)
                 .hasMessage("Test RuntimeException");
-        
+
         // If the socket is not enabled, it shouldn't do anything
         socket.setEnabled(false);
         action.re = new RuntimeException("Test RuntimeException");
@@ -91,7 +91,7 @@ public class DefaultMaleStringActionSocketTest extends MaleSocketTestBase {
         assertThat(thrown)
                 .withFailMessage("Evaluate does nothing")
                 .isNull();
-        
+
         // Test debug config
         socket.setEnabled(true);
         StringActionDebugConfig config = new StringActionDebugConfig();
@@ -107,15 +107,15 @@ public class DefaultMaleStringActionSocketTest extends MaleSocketTestBase {
         socket.setValue("Something else");
         Assert.assertEquals("Something else", action._value);
     }
-    
+
     @Test
     public void testVetoableChange() {
         MyStringAction action = new MyStringAction("IQSA321");
         DefaultMaleStringActionSocket socket = new DefaultMaleStringActionSocket(manager, action);
         Assert.assertNotNull("exists", socket);
-        
+
         PropertyChangeEvent evt = new PropertyChangeEvent("Source", "Prop", null, null);
-        
+
         action._vetoChange = true;
         Throwable thrown = catchThrowable( () -> socket.vetoableChange(evt));
         assertThat(thrown)
@@ -123,22 +123,22 @@ public class DefaultMaleStringActionSocketTest extends MaleSocketTestBase {
                 .isNotNull()
                 .isInstanceOf(PropertyVetoException.class)
                 .hasMessage("Veto change");
-        
+
         action._vetoChange = false;
         thrown = catchThrowable( () -> socket.vetoableChange(evt));
         assertThat(thrown)
                 .withFailMessage("vetoableChange() does not throw")
                 .isNull();
     }
-    
+
     @Test
     public void testCompareSystemNameSuffix() {
         MyStringAction action1 = new MyStringAction("IQSA1");
         DefaultMaleStringActionSocket socket1 = new DefaultMaleStringActionSocket(manager, action1);
-        
+
         MyStringAction action2 = new MyStringAction("IQSA01");
         DefaultMaleStringActionSocket socket2 = new DefaultMaleStringActionSocket(manager, action2);
-        
+
         Assert.assertEquals("compareSystemNameSuffix returns correct value",
                 -1, socket1.compareSystemNameSuffix("01", "1", socket2));
         Assert.assertEquals("compareSystemNameSuffix returns correct value",
@@ -148,7 +148,7 @@ public class DefaultMaleStringActionSocketTest extends MaleSocketTestBase {
         Assert.assertEquals("compareSystemNameSuffix returns correct value",
                 +1, socket1.compareSystemNameSuffix("1", "01", socket2));
     }
-    
+
     // The minimal setup for log4J
     @BeforeEach
     @Override
@@ -160,19 +160,19 @@ public class DefaultMaleStringActionSocketTest extends MaleSocketTestBase {
         JUnitUtil.initInternalSensorManager();
         JUnitUtil.initInternalTurnoutManager();
         JUnitUtil.initLogixNGManager();
-        
+
         StringActionBean actionA = new StringActionMemory("IQSA321", null);
         Assert.assertNotNull("exists", actionA);
         StringActionBean actionB = new MyStringAction("IQSA322");
         Assert.assertNotNull("exists", actionA);
-        
+
         manager = InstanceManager.getDefault(StringActionManager.class);
-        
+
         maleSocketA =
                 InstanceManager.getDefault(StringActionManager.class)
                         .registerAction(actionA);
         Assert.assertNotNull("exists", maleSocketA);
-        
+
         maleSocketB =
                 InstanceManager.getDefault(StringActionManager.class)
                         .registerAction(actionB);
@@ -183,20 +183,21 @@ public class DefaultMaleStringActionSocketTest extends MaleSocketTestBase {
     @Override
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
-    
-    
+
+
     /**
      * This action is different from MyAnalogAction and is used to test the male socket.
      */
     private class MyStringAction extends AbstractStringAction {
-        
+
         JmriException je = null;
         RuntimeException re = null;
         String _value = "";
         boolean _vetoChange = false;
-        
+
         MyStringAction(String sysName) {
             super(sysName, null);
         }
@@ -252,7 +253,7 @@ public class DefaultMaleStringActionSocketTest extends MaleSocketTestBase {
             if (re != null) throw re;
             _value = value;
         }
-        
+
         @Override
         public void vetoableChange(PropertyChangeEvent evt) throws PropertyVetoException {
             if (_vetoChange) throw new java.beans.PropertyVetoException("Veto change", evt);
@@ -267,7 +268,7 @@ public class DefaultMaleStringActionSocketTest extends MaleSocketTestBase {
         public Base deepCopyChildren(Base base, Map<String, String> map, Map<String, String> map1) throws JmriException {
             throw new UnsupportedOperationException("Not supported");
         }
-        
+
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/implementation/DefaultMaleStringExpressionSocketTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/DefaultMaleStringExpressionSocketTest.java
@@ -23,7 +23,7 @@ import static org.assertj.core.api.Assertions.catchThrowable;
 
 /**
  * Test ExpressionTimer
- * 
+ *
  * @author Daniel Bergqvist 2018
  */
 public class DefaultMaleStringExpressionSocketTest extends MaleSocketTestBase {
@@ -33,27 +33,27 @@ public class DefaultMaleStringExpressionSocketTest extends MaleSocketTestBase {
         return InstanceManager.getDefault(StringExpressionManager.class)
                 .getAutoSystemName();
     }
-    
+
     @Test
     public void testCtor() {
         StringExpressionBean expression = new StringExpressionMemory("IQSE321", null);
         Assert.assertNotNull("exists", new DefaultMaleStringExpressionSocket(manager, expression));
     }
-    
+
     @Test
     public void testEvaluate() throws JmriException {
         ConditionalNG conditionalNG = new DefaultConditionalNGScaffold("IQC1", "A conditionalNG");  // NOI18N;
-        
+
         MyStringExpression expression = new MyStringExpression("IQSE321");
         expression.setParent(conditionalNG);
-        
+
         DefaultMaleStringExpressionSocket socket = new DefaultMaleStringExpressionSocket(manager, expression);
         Assert.assertNotNull("exists", socket);
-        
+
         socket.setParent(conditionalNG);
         socket.setEnabled(true);
         socket.setErrorHandlingType(MaleSocket.ErrorHandlingType.ThrowException);
-        
+
         expression.je = null;
         expression.re = null;
         expression.result = "Something";
@@ -64,7 +64,7 @@ public class DefaultMaleStringExpressionSocketTest extends MaleSocketTestBase {
         Assert.assertEquals("", socket.evaluate());
         expression.result = null;
         Assert.assertNull(socket.evaluate());
-        
+
         expression.je = new JmriException("Test JmriException");
         expression.re = null;
         Throwable thrown = catchThrowable( () -> socket.evaluate());
@@ -73,7 +73,7 @@ public class DefaultMaleStringExpressionSocketTest extends MaleSocketTestBase {
                 .isNotNull()
                 .isInstanceOf(JmriException.class)
                 .hasMessage("Test JmriException");
-        
+
         expression.je = null;
         expression.re = new RuntimeException("Test RuntimeException");
         thrown = catchThrowable( () -> socket.evaluate());
@@ -82,7 +82,7 @@ public class DefaultMaleStringExpressionSocketTest extends MaleSocketTestBase {
                 .isNotNull()
                 .isInstanceOf(RuntimeException.class)
                 .hasMessage("Test RuntimeException");
-        
+
         // If the socket is not enabled, it shouldn't do anything
         socket.setEnabled(false);
         expression.re = new RuntimeException("Test RuntimeException");
@@ -90,7 +90,7 @@ public class DefaultMaleStringExpressionSocketTest extends MaleSocketTestBase {
         assertThat(thrown)
                 .withFailMessage("Evaluate does nothing")
                 .isNull();
-        
+
         // Test debug config
         socket.setEnabled(true);
         StringExpressionDebugConfig config = new StringExpressionDebugConfig();
@@ -104,15 +104,15 @@ public class DefaultMaleStringExpressionSocketTest extends MaleSocketTestBase {
         config._forceResult = false;
         Assert.assertEquals("Something", socket.evaluate());
     }
-    
+
     @Test
     public void testVetoableChange() {
         MyStringExpression action = new MyStringExpression("IQSE321");
         DefaultMaleStringExpressionSocket socket = new DefaultMaleStringExpressionSocket(manager, action);
         Assert.assertNotNull("exists", socket);
-        
+
         PropertyChangeEvent evt = new PropertyChangeEvent("Source", "Prop", null, null);
-        
+
         action._vetoChange = true;
         Throwable thrown = catchThrowable( () -> socket.vetoableChange(evt));
         assertThat(thrown)
@@ -120,22 +120,22 @@ public class DefaultMaleStringExpressionSocketTest extends MaleSocketTestBase {
                 .isNotNull()
                 .isInstanceOf(PropertyVetoException.class)
                 .hasMessage("Veto change");
-        
+
         action._vetoChange = false;
         thrown = catchThrowable( () -> socket.vetoableChange(evt));
         assertThat(thrown)
                 .withFailMessage("vetoableChange() does not throw")
                 .isNull();
     }
-    
+
     @Test
     public void testCompareSystemNameSuffix() {
         MyStringExpression expression1 = new MyStringExpression("IQSE1");
         DefaultMaleStringExpressionSocket socket1 = new DefaultMaleStringExpressionSocket(manager, expression1);
-        
+
         MyStringExpression expression2 = new MyStringExpression("IQSE01");
         DefaultMaleStringExpressionSocket socket2 = new DefaultMaleStringExpressionSocket(manager, expression2);
-        
+
         Assert.assertEquals("compareSystemNameSuffix returns correct value",
                 -1, socket1.compareSystemNameSuffix("01", "1", socket2));
         Assert.assertEquals("compareSystemNameSuffix returns correct value",
@@ -145,7 +145,7 @@ public class DefaultMaleStringExpressionSocketTest extends MaleSocketTestBase {
         Assert.assertEquals("compareSystemNameSuffix returns correct value",
                 +1, socket1.compareSystemNameSuffix("1", "01", socket2));
     }
-    
+
     // The minimal setup for log4J
     @BeforeEach
     @Override
@@ -157,19 +157,19 @@ public class DefaultMaleStringExpressionSocketTest extends MaleSocketTestBase {
         JUnitUtil.initInternalSensorManager();
         JUnitUtil.initInternalTurnoutManager();
         JUnitUtil.initLogixNGManager();
-        
+
         StringExpressionBean actionA = new StringExpressionMemory("IQSE321", null);
         Assert.assertNotNull("exists", actionA);
         StringExpressionBean actionB = new MyStringExpression("IQSE322");
         Assert.assertNotNull("exists", actionA);
-        
+
         manager = InstanceManager.getDefault(StringExpressionManager.class);
-        
+
         maleSocketA =
                 InstanceManager.getDefault(StringExpressionManager.class)
                         .registerExpression(actionA);
         Assert.assertNotNull("exists", maleSocketA);
-        
+
         maleSocketB =
                 InstanceManager.getDefault(StringExpressionManager.class)
                         .registerExpression(actionB);
@@ -180,21 +180,22 @@ public class DefaultMaleStringExpressionSocketTest extends MaleSocketTestBase {
     @Override
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
-    
-    
+
+
     /**
      * This expression is different from StringExpressionMemory and is used to test the
      * male socket.
      */
     private class MyStringExpression extends AbstractStringExpression {
-        
+
         JmriException je = null;
         RuntimeException re = null;
         String result = "";
         boolean _vetoChange = false;
-        
+
         MyStringExpression(String sysName) {
             super(sysName, null);
         }
@@ -250,7 +251,7 @@ public class DefaultMaleStringExpressionSocketTest extends MaleSocketTestBase {
             if (re != null) throw re;
             return result;
         }
-        
+
         @Override
         public void vetoableChange(PropertyChangeEvent evt) throws PropertyVetoException {
             if (_vetoChange) throw new java.beans.PropertyVetoException("Veto change", evt);
@@ -265,7 +266,7 @@ public class DefaultMaleStringExpressionSocketTest extends MaleSocketTestBase {
         public Base deepCopyChildren(Base base, Map<String, String> map, Map<String, String> map1) throws JmriException {
             throw new UnsupportedOperationException("Not supported");
         }
-        
+
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/implementation/DefaultNamedTableTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/DefaultNamedTableTest.java
@@ -12,7 +12,7 @@ import org.junit.Test;
 
 /**
  * Test DefaultLogixNG
- * 
+ *
  * @author Daniel Bergqvist 2018
  */
 public class DefaultNamedTableTest {
@@ -21,7 +21,7 @@ public class DefaultNamedTableTest {
     public void testCtor() {
         Assert.assertNotNull("exists", new DefaultInternalNamedTable("IQT10", "A table", 10, 15));
     }
-    
+
     @Test
     public void testCSVFile() throws IOException {
         NamedTable table = AbstractNamedTable.loadTableFromCSV_File(
@@ -29,14 +29,14 @@ public class DefaultNamedTableTest {
                 new File("java/test/jmri/jmrit/logixng/panel_and_data_files/turnout_and_signals.csv"),
                 true,
                 DefaultCsvNamedTable.CsvType.TABBED);
-        
+
         FileUtil.createDirectory(FileUtil.getUserFilesPath() + "temp");
         File file = new File(FileUtil.getUserFilesPath() + "temp/" + "turnout_and_signals.csv");
 //        System.out.format("Temporary file: %s%n", file.getAbsoluteFile());
         table.storeTableAsCSV(file);
         Assert.assertNotNull("exists", table);
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() {
@@ -52,7 +52,8 @@ public class DefaultNamedTableTest {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/implementation/DigitalActionManagerTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/DigitalActionManagerTest.java
@@ -87,6 +87,7 @@ public class DigitalActionManagerTest extends AbstractManagerTestBase {
         _m = null;
         _manager = null;
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/implementation/DigitalBooleanActionManagerTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/DigitalBooleanActionManagerTest.java
@@ -87,6 +87,7 @@ public class DigitalBooleanActionManagerTest extends AbstractManagerTestBase {
         _m = null;
         _manager = null;
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/implementation/DigitalExpressionManagerTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/DigitalExpressionManagerTest.java
@@ -97,6 +97,7 @@ public class DigitalExpressionManagerTest extends AbstractManagerTestBase {
         _m = null;
         _manager = null;
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/implementation/LogixNGPreferencesTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/LogixNGPreferencesTest.java
@@ -8,7 +8,7 @@ import org.junit.*;
 
 /**
  * Test LogixNGPreferences
- * 
+ *
  * @author Daniel Bergqvist 2020
  */
 public class LogixNGPreferencesTest {
@@ -22,63 +22,63 @@ public class LogixNGPreferencesTest {
         DefaultLogixNGPreferences prefsB = new DefaultLogixNGPreferences();
         Assert.assertFalse("prefs are equal", prefsA.compareValuesDifferent(prefsB));
         Assert.assertFalse("prefs are equal", prefsB.compareValuesDifferent(prefsA));
-        
+
         prefsA.setInstallDebugger(false);
         prefsB.setInstallDebugger(true);
         Assert.assertTrue("prefs are not equal", prefsA.compareValuesDifferent(prefsB));
         Assert.assertTrue("prefs are not equal", prefsB.compareValuesDifferent(prefsA));
         prefsB.setInstallDebugger(false);
-        
+
         prefsA.setStartLogixNGOnStartup(false);
         prefsB.setStartLogixNGOnStartup(true);
         Assert.assertTrue("prefs are not equal", prefsA.compareValuesDifferent(prefsB));
         Assert.assertTrue("prefs are not equal", prefsB.compareValuesDifferent(prefsA));
         prefsB.setStartLogixNGOnStartup(false);
     }
-    
+
     @Test
     public void testSetAndGet() {
         DefaultLogixNGPreferences prefs = new DefaultLogixNGPreferences();
-        
+
         prefs.setStartLogixNGOnStartup(true);
         Assert.assertTrue(prefs.getStartLogixNGOnStartup());
-        
+
         prefs.setStartLogixNGOnStartup(false);
         Assert.assertFalse(prefs.getStartLogixNGOnStartup());
-        
+
         prefs.setInstallDebugger(true);
         Assert.assertTrue(prefs.getInstallDebugger());
-        
+
         prefs.setInstallDebugger(false);
         Assert.assertFalse(prefs.getInstallDebugger());
     }
-    
+
     @Test
     public void testApply() {
         DefaultLogixNGPreferences prefsA = new DefaultLogixNGPreferences();
         DefaultLogixNGPreferences prefsB = new DefaultLogixNGPreferences();
-        
+
         prefsA.setStartLogixNGOnStartup(false);
         prefsB.setStartLogixNGOnStartup(true);
         Assert.assertFalse(prefsA.getStartLogixNGOnStartup());
         Assert.assertTrue(prefsB.getStartLogixNGOnStartup());
         prefsA.apply(prefsB);
         Assert.assertTrue(prefsA.getStartLogixNGOnStartup());
-        
+
         prefsA.setStartLogixNGOnStartup(true);
         prefsB.setStartLogixNGOnStartup(false);
         Assert.assertTrue(prefsA.getStartLogixNGOnStartup());
         Assert.assertFalse(prefsB.getStartLogixNGOnStartup());
         prefsA.apply(prefsB);
         Assert.assertFalse(prefsA.getStartLogixNGOnStartup());
-        
+
         prefsA.setInstallDebugger(false);
         prefsB.setInstallDebugger(true);
         Assert.assertFalse(prefsA.getInstallDebugger());
         Assert.assertTrue(prefsB.getInstallDebugger());
         prefsA.apply(prefsB);
         Assert.assertTrue(prefsA.getInstallDebugger());
-        
+
         prefsA.setInstallDebugger(true);
         prefsB.setInstallDebugger(false);
         Assert.assertTrue(prefsA.getInstallDebugger());
@@ -86,33 +86,33 @@ public class LogixNGPreferencesTest {
         prefsA.apply(prefsB);
         Assert.assertFalse(prefsA.getInstallDebugger());
     }
-    
+
     @Test
     public void testSave() {
         DefaultLogixNGPreferences prefsA = new DefaultLogixNGPreferences();
         DefaultLogixNGPreferences prefsB;
-        
+
         prefsA.setStartLogixNGOnStartup(false);
         prefsA.save();
         prefsB = new DefaultLogixNGPreferences();
         Assert.assertFalse(prefsB.getStartLogixNGOnStartup());
-        
+
         prefsA.setStartLogixNGOnStartup(true);
         prefsA.save();
         prefsB = new DefaultLogixNGPreferences();
         Assert.assertTrue(prefsB.getStartLogixNGOnStartup());
-        
+
         prefsA.setInstallDebugger(false);
         prefsA.save();
         prefsB = new DefaultLogixNGPreferences();
         Assert.assertFalse(prefsB.getInstallDebugger());
-        
+
         prefsA.setInstallDebugger(true);
         prefsA.save();
         prefsB = new DefaultLogixNGPreferences();
         Assert.assertTrue(prefsB.getInstallDebugger());
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() throws IOException {
@@ -128,7 +128,8 @@ public class LogixNGPreferencesTest {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/implementation/StringActionManagerTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/StringActionManagerTest.java
@@ -87,6 +87,7 @@ public class StringActionManagerTest extends AbstractManagerTestBase {
         _m = null;
         _manager = null;
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/implementation/StringExpressionManagerTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/StringExpressionManagerTest.java
@@ -97,6 +97,7 @@ public class StringExpressionManagerTest extends AbstractManagerTestBase {
         _m = null;
         _manager = null;
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/implementation/configurexml/DefaultAnalogActionManagerXmlTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/configurexml/DefaultAnalogActionManagerXmlTest.java
@@ -32,14 +32,14 @@ public class DefaultAnalogActionManagerXmlTest {
     @Test
     public void testLoad() {
         DefaultAnalogActionManagerXml b = new DefaultAnalogActionManagerXml();
-        
+
         Element e = new Element("logixngAnalogExpressions");
         Element e2 = new Element("missing_class");
         e2.setAttribute("class", "jmri.jmrit.logixng.this.class.does.not.exist.TestClassXml");
         e.addContent(e2);
         b.loadActions(e);
         JUnitAppender.assertErrorMessage("cannot load class jmri.jmrit.logixng.this.class.does.not.exist.TestClassXml");
-/*        
+/*
         // Test loading the same class twice, in order to check field "xmlClasses"
         e = new Element("logixngAnalogExpressions");
         e2 = new Element("existing_class");
@@ -48,7 +48,7 @@ public class DefaultAnalogActionManagerXmlTest {
         e2.addContent(new Element("systemName").addContent("IQAA1"));
         e2.addContent(new Element("maleSocket"));
         b.loadActions(e);
-        
+
         e = new Element("logixngAnalogExpressions");
         e2 = new Element("existing_class");
         e2.setAttribute("class", "jmri.jmrit.logixng.actions.configurexml.AnalogActionMemoryXml");
@@ -56,7 +56,7 @@ public class DefaultAnalogActionManagerXmlTest {
         e2.addContent(new Element("systemName").addContent("IQAA2"));
         e2.addContent(new Element("maleSocket"));
         b.loadActions(e);
-        
+
         // Test trying to load a class with private constructor
         e = new Element("logixngAnalogExpressions");
         e2 = new Element("existing_class");
@@ -65,7 +65,7 @@ public class DefaultAnalogActionManagerXmlTest {
         e.addContent(e2);
         b.loadActions(e);
         JUnitAppender.assertErrorMessage("cannot create constructor");
-        
+
         // Test trying to load a class which throws an exception
         e = new Element("logixngAnalogExpressions");
         e2 = new Element("existing_class");
@@ -74,7 +74,7 @@ public class DefaultAnalogActionManagerXmlTest {
         e.addContent(e2);
         b.loadActions(e);
         JUnitAppender.assertErrorMessage("cannot create constructor");
-*/        
+*/
 //        System.out.format("Class name: %s%n", PrivateConstructorXml.class.getName());
     }
 
@@ -82,10 +82,10 @@ public class DefaultAnalogActionManagerXmlTest {
     @Test
     public void testStore() {
         DefaultAnalogActionManagerXml b = new DefaultAnalogActionManagerXml();
-        
+
         // If parameter is null, nothing should happen
         b.store(null);
-        
+
         // Test store a named bean that has no configurexml class
         AnalogActionManager manager = InstanceManager.getDefault(AnalogActionManager.class);
         manager.registerAction(new MyAnalogAction());
@@ -93,10 +93,10 @@ public class DefaultAnalogActionManagerXmlTest {
         JUnitAppender.assertErrorMessage("Cannot load configuration adapter for jmri.jmrit.logixng.implementation.configurexml.DefaultAnalogActionManagerXmlTest$MyAnalogAction");
         JUnitAppender.assertErrorMessage("Cannot store configuration for jmri.jmrit.logixng.implementation.configurexml.DefaultAnalogActionManagerXmlTest$MyAnalogAction");
     }
-    
+
     @Test
     public void testReplaceActionManagerWithoutConfigManager() {
-        
+
         // if old manager exists, remove it from configuration process
         if (InstanceManager.getNullableDefault(jmri.jmrit.logixng.AnalogActionManager.class) != null) {
             ConfigureManager cmOD = InstanceManager.getNullableDefault(jmri.ConfigureManager.class);
@@ -114,26 +114,26 @@ public class DefaultAnalogActionManagerXmlTest {
         if (cmOD != null) {
             cmOD.registerConfig(pManager, jmri.Manager.LOGIXNG_ANALOG_ACTIONS);
         }
-        
+
         Assert.assertTrue("manager is a MyManager",
                 InstanceManager.getDefault(AnalogActionManager.class)
                         instanceof MyManager);
-        
+
         // Test replacing the manager
         DefaultAnalogActionManagerXml b = new DefaultAnalogActionManagerXml();
         b.replaceActionManager();
-        
+
         Assert.assertFalse("manager is not a MyManager",
                 InstanceManager.getDefault(AnalogActionManager.class)
                         instanceof MyManager);
     }
-    
+
 //    @Ignore("When debug is enabled, jmri.configurexml.ConfigXmlManager.registerConfig checks if the manager has a XML class, which our fake manager doesn't have")
     @Test
     public void testReplaceActionManagerWithConfigManager() {
-        
+
         JUnitUtil.initConfigureManager();
-        
+
         // if old manager exists, remove it from configuration process
         if (InstanceManager.getNullableDefault(jmri.jmrit.logixng.AnalogActionManager.class) != null) {
             ConfigureManager cmOD = InstanceManager.getNullableDefault(jmri.ConfigureManager.class);
@@ -151,15 +151,15 @@ public class DefaultAnalogActionManagerXmlTest {
         if (cmOD != null) {
             cmOD.registerConfig(pManager, jmri.Manager.LOGIXNG_ANALOG_ACTIONS);
         }
-        
+
         Assert.assertTrue("manager is a MyManager",
                 InstanceManager.getDefault(AnalogActionManager.class)
                         instanceof MyManager);
-        
+
         // Test replacing the manager
         DefaultAnalogActionManagerXml b = new DefaultAnalogActionManagerXml();
         b.replaceActionManager();
-        
+
         Assert.assertFalse("manager is not a MyManager",
                 InstanceManager.getDefault(AnalogActionManager.class)
                         instanceof MyManager);
@@ -178,27 +178,28 @@ public class DefaultAnalogActionManagerXmlTest {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
-    
-    
-    
+
+
+
     private class MyAnalogAction extends AnalogActionMemory {
-        
+
         MyAnalogAction() {
             super("IQAA9999", null);
         }
-        
+
     }
-    
-    
+
+
     // This class is loaded by reflection. The class cannot be private since
     // Spotbugs will in that case flag it as "is never used locally"
     class PrivateConstructorXml extends AnalogActionMemoryXml {
         private PrivateConstructorXml() {
         }
     }
-    
+
     // This class is loaded by reflection. The class cannot be private since
     // Spotbugs will in that case flag it as "is never used locally"
     class ThrowExceptionXml extends AnalogActionMemoryXml {
@@ -207,17 +208,17 @@ public class DefaultAnalogActionManagerXmlTest {
             throw new JmriConfigureXmlException();
         }
     }
-    
-    
+
+
     class MyManager extends DefaultAnalogActionManager {
-        
+
         @edu.umd.cs.findbugs.annotations.SuppressFBWarnings( value = "OVERRIDING_METHODS_MUST_INVOKE_SUPER",
             justification = "We don't want to save config for this class")
         @Override
         protected void registerSelf() {
             // We don't want to save config for this class
         }
-        
+
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/implementation/configurexml/DefaultAnalogExpressionManagerXmlTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/configurexml/DefaultAnalogExpressionManagerXmlTest.java
@@ -179,6 +179,7 @@ public class DefaultAnalogExpressionManagerXmlTest {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/implementation/configurexml/DefaultConditionalNGManagerXmlTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/configurexml/DefaultConditionalNGManagerXmlTest.java
@@ -29,16 +29,16 @@ public class DefaultConditionalNGManagerXmlTest {
     public void testLoad() {
         DefaultConditionalNGManagerXml b = new DefaultConditionalNGManagerXml();
         Assert.assertNotNull("exists", b);
-        
+
         // Test loading a conditionalng without system name
         Element e = new Element("ConditionalNGs");
         Element e2 = new Element("ConditionalNG");
         e.addContent(e2);
         b.loadConditionalNGs(e);
         JUnitAppender.assertWarnMessage("unexpected null in systemName [Element: <ConditionalNG/>]");
-        
+
         // Fix this later!!!
-/***************************        
+/***************************
         // Test load ConditionalNG without attribute "enable"
         e = new Element("ConditionalNGs");
         e2 = new Element("ConditionalNG");
@@ -47,7 +47,7 @@ public class DefaultConditionalNGManagerXmlTest {
         e2.addContent(eConditionals);
         e.addContent(e2);
         b.loadConditionalNGs(e);
-        
+
         // Test load ConditionalNG with bad conditionalng (no systemName in the conditionalNG)
         e = new Element("ConditionalNGs");
         e2 = new Element("ConditionalNG");
@@ -60,7 +60,7 @@ public class DefaultConditionalNGManagerXmlTest {
         b.loadConditionalNGs(e);
 //        JUnitAppender.assertWarnMessage("unexpected null in systemName [Element: <ConditionalNG/>]");
 //        JUnitAppender.assertErrorMessage("exception thrown");
-        
+
         // Test loading a ConditionalNG that already exists
         e = new Element("ConditionalNGs");
         e2 = new Element("ConditionalNG");
@@ -70,7 +70,7 @@ public class DefaultConditionalNGManagerXmlTest {
         e2.addContent(new Element("systemName").addContent(systemName));
         e.addContent(e2);
         b.loadConditionalNGs(e);
-        
+
         // Test load ConditionalNG with attribute "enable" as empty string
         e = new Element("ConditionalNGs");
         e2 = new Element("ConditionalNG");
@@ -83,7 +83,7 @@ public class DefaultConditionalNGManagerXmlTest {
         ConditionalNG conditionalNG = InstanceManager.getDefault(ConditionalNG_Manager.class).getBySystemName("IQC1003");
         Assert.assertNotNull("bean is not null", conditionalNG);
         Assert.assertFalse("bean is not enabled", conditionalNG.isEnabled());
-        
+
         // Test load ConditionalNG with attribute "enable" as invalid value
         e = new Element("ConditionalNGs");
         e2 = new Element("ConditionalNG");
@@ -96,7 +96,7 @@ public class DefaultConditionalNGManagerXmlTest {
         conditionalNG = InstanceManager.getDefault(ConditionalNG_Manager.class).getBySystemName("IQC1004");
         Assert.assertNotNull("bean is not null", conditionalNG);
         Assert.assertFalse("bean is not enabled", conditionalNG.isEnabled());
-        
+
         // Test load ConditionalNG with attribute "enable" as yes
         e = new Element("ConditionalNGs");
         e2 = new Element("ConditionalNG");
@@ -109,8 +109,8 @@ public class DefaultConditionalNGManagerXmlTest {
         conditionalNG = InstanceManager.getDefault(ConditionalNG_Manager.class).getBySystemName("IQC1005");
         Assert.assertNotNull("bean is not null", conditionalNG);
         Assert.assertTrue("bean is enabled", conditionalNG.isEnabled());
-        
-/*        
+
+/*
         // Test loading the same class twice, in order to check field "xmlClasses"
         e = new Element("ConditionalNGs");
         e2 = new Element("existing_class");
@@ -118,14 +118,14 @@ public class DefaultConditionalNGManagerXmlTest {
         e.addContent(e2);
         e2.addContent(new Element("systemName").addContent("IQAA1"));
         b.loadConditionalNGs(e);
-        
+
         e = new Element("ConditionalNGs");
         e2 = new Element("existing_class");
         e2.setAttribute("class", "jmri.jmrit.logixng.actions.configurexml.AnalogActionMemoryXml");
         e.addContent(e2);
         e2.addContent(new Element("systemName").addContent("IQAA2"));
         b.loadConditionalNGs(e);
-/*        
+/*
         // Test trying to load a class with private constructor
         e = new Element("ConditionalNGs");
         e2 = new Element("existing_class");
@@ -133,7 +133,7 @@ public class DefaultConditionalNGManagerXmlTest {
         e.addContent(e2);
         b.loadConditionalNGs(e);
         JUnitAppender.assertErrorMessage("cannot create constructor");
-        
+
         // Test trying to load a class which throws an exception
         e = new Element("ConditionalNGs");
         e2 = new Element("existing_class");
@@ -154,7 +154,7 @@ public class DefaultConditionalNGManagerXmlTest {
 
     @Test
     public void testReplaceActionManagerWithoutConfigManager() {
-/*        
+/*
         // if old manager exists, remove it from configuration process
         if (InstanceManager.getNullableDefault(jmri.jmrit.logixng.AnalogActionManager.class) != null) {
             ConfigureManager cmOD = InstanceManager.getNullableDefault(jmri.ConfigureManager.class);
@@ -172,34 +172,34 @@ public class DefaultConditionalNGManagerXmlTest {
         if (cmOD != null) {
             cmOD.registerConfig(pManager, jmri.Manager.LOGIXNG_CONDITIONALNGS);
         }
-        
+
         Assert.assertTrue("manager is a MyManager",
                 InstanceManager.getDefault(ConditionalNG_Manager.class)
                         instanceof MyManager);
-        
+
         // Test replacing the manager
         DefaultConditionalNGManagerXml b = new DefaultConditionalNGManagerXml();
         b.replaceConditionalNGManager();
-        
+
         Assert.assertFalse("manager is not a MyManager",
                 InstanceManager.getDefault(ConditionalNG_Manager.class)
                         instanceof MyManager);
-        
+
         // Test replace the manager when where is no manager registered yet
         InstanceManager.deregister(
                 InstanceManager.getDefault(ConditionalNG_Manager.class),
                 ConditionalNG_Manager.class);
-        
+
         Assert.assertNotNull("manager is not null",
                 InstanceManager.getDefault(ConditionalNG_Manager.class));
     }
-    
+
 //    @Ignore("When debug is enabled, jmri.configurexml.ConfigXmlManager.registerConfig checks if the manager has a XML class, which our fake manager doesn't have")
     @Test
     public void testReplaceActionManagerWithConfigManager() {
-        
+
         JUnitUtil.initConfigureManager();
-/*        
+/*
         // if old manager exists, remove it from configuration process
         if (InstanceManager.getNullableDefault(jmri.jmrit.logixng.AnalogActionManager.class) != null) {
             ConfigureManager cmOD = InstanceManager.getNullableDefault(jmri.ConfigureManager.class);
@@ -217,20 +217,20 @@ public class DefaultConditionalNGManagerXmlTest {
         if (cmOD != null) {
             cmOD.registerConfig(pManager, jmri.Manager.LOGIXNG_CONDITIONALNGS);
         }
-        
+
         Assert.assertTrue("manager is a MyManager",
                 InstanceManager.getDefault(ConditionalNG_Manager.class)
                         instanceof MyManager);
-        
+
         // Test replacing the manager
         DefaultConditionalNGManagerXml b = new DefaultConditionalNGManagerXml();
         b.replaceConditionalNGManager();
-        
+
         Assert.assertFalse("manager is not a MyManager",
                 InstanceManager.getDefault(ConditionalNG_Manager.class)
                         instanceof MyManager);
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() {
@@ -244,26 +244,27 @@ public class DefaultConditionalNGManagerXmlTest {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
-    
-/*    
+
+/*
     private class MyConditionalNG extends jmri.jmrit.logixng.implementation.DefaultConditionalNG {
-        
+
         MyConditionalNG() {
             super("IQ9999");
         }
-        
+
     }
-    
-/*    
+
+/*
     // This class is loaded by reflection. The class cannot be private since
     // Spotbugs will in that case flag it as "is never used locally"
     class PrivateConstructorXml extends DefaultConditionalNGXml {
         private PrivateConstructorXml() {
         }
     }
-    
+
     // This class is loaded by reflection. The class cannot be private since
     // Spotbugs will in that case flag it as "is never used locally"
     class ThrowExceptionXml extends DefaultConditionalNGXml {
@@ -272,8 +273,8 @@ public class DefaultConditionalNGManagerXmlTest {
             throw new JmriConfigureXmlException();
         }
     }
-*/    
+*/
     class MyManager extends DefaultConditionalNGManager {
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/implementation/configurexml/DefaultDigitalActionManagerXmlTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/configurexml/DefaultDigitalActionManagerXmlTest.java
@@ -32,7 +32,7 @@ public class DefaultDigitalActionManagerXmlTest {
     @Test
     public void testLoad() {
         DefaultDigitalActionManagerXml b = new DefaultDigitalActionManagerXml();
-        
+
         Element e = new Element("logixngDigitalExpressions");
         Element e2 = new Element("missing_class");
         e2.setAttribute("class", "jmri.jmrit.logixng.this.class.does.not.exist.TestClassXml");
@@ -40,7 +40,7 @@ public class DefaultDigitalActionManagerXmlTest {
         e.addContent(e2);
         b.loadActions(e);
         JUnitAppender.assertErrorMessage("cannot load class jmri.jmrit.logixng.this.class.does.not.exist.TestClassXml");
-/*        
+/*
         // Test loading the same class twice, in order to check field "xmlClasses"
         e = new Element("logixngDigitalExpressions");
         e2 = new Element("existing_class");
@@ -52,7 +52,7 @@ public class DefaultDigitalActionManagerXmlTest {
         e2.addContent(new Element("localVariable"));
         e2.addContent(new Element("formula"));
         b.loadActions(e);
-        
+
         e = new Element("logixngDigitalExpressions");
         e2 = new Element("existing_class");
         e2.setAttribute("class", "jmri.jmrit.logixng.actions.configurexml.ActionTurnoutXml");
@@ -63,7 +63,7 @@ public class DefaultDigitalActionManagerXmlTest {
         e2.addContent(new Element("localVariable"));
         e2.addContent(new Element("formula"));
         b.loadActions(e);
-        
+
         // Test trying to load a class with private constructor
         e = new Element("logixngDigitalExpressions");
         e2 = new Element("existing_class");
@@ -72,7 +72,7 @@ public class DefaultDigitalActionManagerXmlTest {
         e.addContent(e2);
         b.loadActions(e);
         JUnitAppender.assertErrorMessage("cannot create constructor");
-        
+
         // Test trying to load a class which throws an exception
         e = new Element("logixngDigitalExpressions");
         e2 = new Element("existing_class");
@@ -81,7 +81,7 @@ public class DefaultDigitalActionManagerXmlTest {
         e.addContent(e2);
         b.loadActions(e);
         JUnitAppender.assertErrorMessage("cannot create constructor");
-*/        
+*/
 //        System.out.format("Class name: %s%n", PrivateConstructorXml.class.getName());
     }
 
@@ -89,10 +89,10 @@ public class DefaultDigitalActionManagerXmlTest {
     @Test
     public void testStore() {
         DefaultDigitalActionManagerXml b = new DefaultDigitalActionManagerXml();
-        
+
         // If parameter is null, nothing should happen
         b.store(null);
-        
+
         // Test store a named bean that has no configurexml class
         DigitalActionManager manager = InstanceManager.getDefault(DigitalActionManager.class);
         manager.registerAction(new DefaultDigitalActionManagerXmlTest.MyDigitalAction());
@@ -100,10 +100,10 @@ public class DefaultDigitalActionManagerXmlTest {
         JUnitAppender.assertErrorMessage("Cannot load configuration adapter for jmri.jmrit.logixng.implementation.configurexml.DefaultDigitalActionManagerXmlTest$MyDigitalAction");
         JUnitAppender.assertErrorMessage("Cannot store configuration for jmri.jmrit.logixng.implementation.configurexml.DefaultDigitalActionManagerXmlTest$MyDigitalAction");
     }
-    
+
     @Test
     public void testReplaceActionManagerWithoutConfigManager() {
-        
+
         // if old manager exists, remove it from configuration process
         if (InstanceManager.getNullableDefault(jmri.jmrit.logixng.DigitalActionManager.class) != null) {
             ConfigureManager cmOD = InstanceManager.getNullableDefault(jmri.ConfigureManager.class);
@@ -121,26 +121,26 @@ public class DefaultDigitalActionManagerXmlTest {
         if (cmOD != null) {
             cmOD.registerConfig(pManager, jmri.Manager.LOGIXNG_DIGITAL_ACTIONS);
         }
-        
+
         Assert.assertTrue("manager is a MyManager",
                 InstanceManager.getDefault(DigitalActionManager.class)
                         instanceof DefaultDigitalActionManagerXmlTest.MyManager);
-        
+
         // Test replacing the manager
         DefaultDigitalActionManagerXml b = new DefaultDigitalActionManagerXml();
         b.replaceActionManager();
-        
+
         Assert.assertFalse("manager is not a MyManager",
                 InstanceManager.getDefault(DigitalActionManager.class)
                         instanceof DefaultDigitalActionManagerXmlTest.MyManager);
     }
-    
+
 //    @Ignore("When debug is enabled, jmri.configurexml.ConfigXmlManager.registerConfig checks if the manager has a XML class, which our fake manager doesn't have")
     @Test
     public void testReplaceActionManagerWithConfigManager() {
-        
+
         JUnitUtil.initConfigureManager();
-        
+
         // if old manager exists, remove it from configuration process
         if (InstanceManager.getNullableDefault(jmri.jmrit.logixng.DigitalActionManager.class) != null) {
             ConfigureManager cmOD = InstanceManager.getNullableDefault(jmri.ConfigureManager.class);
@@ -158,20 +158,20 @@ public class DefaultDigitalActionManagerXmlTest {
         if (cmOD != null) {
             cmOD.registerConfig(pManager, jmri.Manager.LOGIXNG_DIGITAL_ACTIONS);
         }
-        
+
         Assert.assertTrue("manager is a MyManager",
                 InstanceManager.getDefault(DigitalActionManager.class)
                         instanceof DefaultDigitalActionManagerXmlTest.MyManager);
-        
+
         // Test replacing the manager
         DefaultDigitalActionManagerXml b = new DefaultDigitalActionManagerXml();
         b.replaceActionManager();
-        
+
         Assert.assertFalse("manager is not a MyManager",
                 InstanceManager.getDefault(DigitalActionManager.class)
                         instanceof DefaultDigitalActionManagerXmlTest.MyManager);
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() {
@@ -185,27 +185,28 @@ public class DefaultDigitalActionManagerXmlTest {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
-    
-    
-    
+
+
+
     private class MyDigitalAction extends ActionTurnout {
-        
+
         MyDigitalAction() {
             super("IQDA9999", null);
         }
-        
+
     }
-    
-    
+
+
     // This class is loaded by reflection. The class cannot be private since
     // Spotbugs will in that case flag it as "is never used locally"
     class PrivateConstructorXml extends ActionTurnoutXml {
         private PrivateConstructorXml() {
         }
     }
-    
+
     // This class is loaded by reflection. The class cannot be private since
     // Spotbugs will in that case flag it as "is never used locally"
     class ThrowExceptionXml extends ActionTurnoutXml {
@@ -214,9 +215,9 @@ public class DefaultDigitalActionManagerXmlTest {
             throw new JmriConfigureXmlException();
         }
     }
-    
-    
+
+
     class MyManager extends DefaultDigitalActionManager {
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/implementation/configurexml/DefaultDigitalBooleanActionManagerXmlTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/configurexml/DefaultDigitalBooleanActionManagerXmlTest.java
@@ -30,9 +30,9 @@ public class DefaultDigitalBooleanActionManagerXmlTest {
 
     @Test
     public void testLoad() {
-        
+
         DefaultDigitalBooleanActionManagerXml b = new DefaultDigitalBooleanActionManagerXml();
-        
+
         Element e = new Element("logixngDigitalExpressions");
         Element e2 = new Element("missing_class");
         e2.setAttribute("class", "jmri.jmrit.logixng.this.class.does.not.exist.TestClassXml");
@@ -40,7 +40,7 @@ public class DefaultDigitalBooleanActionManagerXmlTest {
         e.addContent(e2);
         b.loadActions(e);
         JUnitAppender.assertErrorMessage("cannot load class jmri.jmrit.logixng.this.class.does.not.exist.TestClassXml");
-/*        
+/*
         // Test loading the same class twice, in order to check field "xmlClasses"
         e = new Element("logixngDigitalExpressions");
         e2 = new Element("existing_class");
@@ -54,7 +54,7 @@ public class DefaultDigitalBooleanActionManagerXmlTest {
         socketElement.addContent(new Element("systemName").addContent("IQDA2"));
         e2.setAttribute("trigger", "CHANGE_TO_TRUE");
         b.loadActions(e);
-        
+
         e = new Element("logixngDigitalExpressions");
         e2 = new Element("existing_class");
         e2.setAttribute("class", "jmri.jmrit.logixng.actions.configurexml.DigitalBooleanOnChangeXml");
@@ -67,7 +67,7 @@ public class DefaultDigitalBooleanActionManagerXmlTest {
         e2.setAttribute("trigger", "CHANGE_TO_TRUE");
         e2.addContent(new Element("maleSocket"));
         b.loadActions(e);
-        
+
         // Test trying to load a class with private constructor
         e = new Element("logixngDigitalExpressions");
         e2 = new Element("existing_class");
@@ -76,7 +76,7 @@ public class DefaultDigitalBooleanActionManagerXmlTest {
         e.addContent(e2);
         b.loadActions(e);
         JUnitAppender.assertErrorMessage("cannot create constructor");
-        
+
         // Test trying to load a class which throws an exception
         e = new Element("logixngDigitalExpressions");
         e2 = new Element("existing_class");
@@ -84,19 +84,19 @@ public class DefaultDigitalBooleanActionManagerXmlTest {
         e.addContent(e2);
         b.loadActions(e);
         JUnitAppender.assertErrorMessage("cannot create constructor");
-*/        
+*/
 //        System.out.format("Class name: %s%n", PrivateConstructorXml.class.getName());
     }
 
     @Ignore("Cannot load xml configurator")
     @Test
     public void testStore() {
-        
+
         DefaultDigitalBooleanActionManagerXml b = new DefaultDigitalBooleanActionManagerXml();
-        
+
         // If parameter is null, nothing should happen
         b.store(null);
-        
+
         // Test store a named bean that has no configurexml class
         DigitalBooleanActionManager manager = InstanceManager.getDefault(DigitalBooleanActionManager.class);
         manager.registerAction(new MyDigitalBooleanAction());
@@ -104,10 +104,10 @@ public class DefaultDigitalBooleanActionManagerXmlTest {
         JUnitAppender.assertErrorMessage("Cannot load configuration adapter for jmri.jmrit.logixng.implementation.configurexml.DefaultDigitalBooleanActionManagerXmlTest$MyDigitalBooleanAction");
         JUnitAppender.assertErrorMessage("Cannot store configuration for jmri.jmrit.logixng.implementation.configurexml.DefaultDigitalBooleanActionManagerXmlTest$MyDigitalBooleanAction");
     }
-    
+
     @Test
     public void testReplaceActionManagerWithoutConfigManager() {
-        
+
         // if old manager exists, remove it from configuration process
         if (InstanceManager.getNullableDefault(jmri.jmrit.logixng.DigitalBooleanActionManager.class) != null) {
             ConfigureManager cmOD = InstanceManager.getNullableDefault(jmri.ConfigureManager.class);
@@ -125,26 +125,26 @@ public class DefaultDigitalBooleanActionManagerXmlTest {
         if (cmOD != null) {
             cmOD.registerConfig(pManager, jmri.Manager.LOGIXNG_DIGITAL_BOOLEAN_ACTIONS);
         }
-        
+
         Assert.assertTrue("manager is a MyManager",
                 InstanceManager.getDefault(DigitalBooleanActionManager.class)
                         instanceof DefaultDigitalBooleanActionManagerXmlTest.MyManager);
-        
+
         // Test replacing the manager
         DefaultDigitalBooleanActionManagerXml b = new DefaultDigitalBooleanActionManagerXml();
         b.replaceActionManager();
-        
+
         Assert.assertFalse("manager is not a MyManager",
                 InstanceManager.getDefault(DigitalBooleanActionManager.class)
                         instanceof DefaultDigitalBooleanActionManagerXmlTest.MyManager);
     }
-    
+
 //    @Ignore("When debug is enabled, jmri.configurexml.ConfigXmlManager.registerConfig checks if the manager has a XML class, which our fake manager doesn't have")
     @Test
     public void testReplaceActionManagerWithConfigManager() {
-        
+
         JUnitUtil.initConfigureManager();
-        
+
         // if old manager exists, remove it from configuration process
         if (InstanceManager.getNullableDefault(jmri.jmrit.logixng.DigitalBooleanActionManager.class) != null) {
             ConfigureManager cmOD = InstanceManager.getNullableDefault(jmri.ConfigureManager.class);
@@ -162,20 +162,20 @@ public class DefaultDigitalBooleanActionManagerXmlTest {
         if (cmOD != null) {
             cmOD.registerConfig(pManager, jmri.Manager.LOGIXNG_DIGITAL_BOOLEAN_ACTIONS);
         }
-        
+
         Assert.assertTrue("manager is a MyManager",
                 InstanceManager.getDefault(DigitalBooleanActionManager.class)
                         instanceof DefaultDigitalBooleanActionManagerXmlTest.MyManager);
-        
+
         // Test replacing the manager
         DefaultDigitalBooleanActionManagerXml b = new DefaultDigitalBooleanActionManagerXml();
         b.replaceActionManager();
-        
+
         Assert.assertFalse("manager is not a MyManager",
                 InstanceManager.getDefault(DigitalBooleanActionManager.class)
                         instanceof DefaultDigitalBooleanActionManagerXmlTest.MyManager);
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() {
@@ -189,27 +189,28 @@ public class DefaultDigitalBooleanActionManagerXmlTest {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
-    
-    
-    
+
+
+
     private class MyDigitalBooleanAction extends DigitalBooleanOnChange {
-        
+
         MyDigitalBooleanAction() {
             super("IQDB9999", null, DigitalBooleanOnChange.Trigger.CHANGE);
         }
-        
+
     }
-    
-    
+
+
     // This class is loaded by reflection. The class cannot be private since
     // Spotbugs will in that case flag it as "is never used locally"
     class PrivateConstructorXml extends DigitalBooleanOnChangeXml {
         private PrivateConstructorXml() {
         }
     }
-/*    
+/*
     // This class is loaded by reflection. The class cannot be private since
     // Spotbugs will in that case flag it as "is never used locally"
     class ThrowExceptionXml extends OnChangeActionXml {
@@ -218,9 +219,9 @@ public class DefaultDigitalBooleanActionManagerXmlTest {
             throw new JmriConfigureXmlException();
         }
     }
-*/    
-    
+*/
+
     class MyManager extends DefaultDigitalBooleanActionManager {
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/implementation/configurexml/DefaultDigitalExpressionManagerXmlTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/configurexml/DefaultDigitalExpressionManagerXmlTest.java
@@ -32,7 +32,7 @@ public class DefaultDigitalExpressionManagerXmlTest {
     @Test
     public void testLoad() {
         DefaultDigitalExpressionManagerXml b = new DefaultDigitalExpressionManagerXml();
-        
+
         Element e = new Element("logixngAnalogExpressions");
         Element e2 = new Element("missing_class");
         e2.setAttribute("class", "jmri.jmrit.logixng.this.class.does.not.exist.TestClassXml");
@@ -40,7 +40,7 @@ public class DefaultDigitalExpressionManagerXmlTest {
         e.addContent(e2);
         b.loadExpressions(e);
         JUnitAppender.assertErrorMessage("cannot load class jmri.jmrit.logixng.this.class.does.not.exist.TestClassXml");
-/*        
+/*
         // Test loading the same class twice, in order to check field "xmlClasses"
         e = new Element("logixngAnalogExpressions");
         e2 = new Element("existing_class");
@@ -49,7 +49,7 @@ public class DefaultDigitalExpressionManagerXmlTest {
         e2.addContent(new Element("systemName").addContent("IQDE1"));
         e2.addContent(new Element("maleSocket"));
         b.loadExpressions(e);
-        
+
         e = new Element("logixngAnalogExpressions");
         e2 = new Element("existing_class");
         e2.setAttribute("class", "jmri.jmrit.logixng.expressions.configurexml.ExpressionTurnoutXml");
@@ -57,7 +57,7 @@ public class DefaultDigitalExpressionManagerXmlTest {
         e2.addContent(new Element("systemName").addContent("IQDE2"));
         e2.addContent(new Element("maleSocket"));
         b.loadExpressions(e);
-        
+
         // Test trying to load a class with private constructor
         e = new Element("logixngAnalogExpressions");
         e2 = new Element("existing_class");
@@ -66,7 +66,7 @@ public class DefaultDigitalExpressionManagerXmlTest {
         e.addContent(e2);
         b.loadExpressions(e);
         JUnitAppender.assertErrorMessage("cannot create constructor");
-        
+
         // Test trying to load a class which throws an exception
         e = new Element("logixngAnalogExpressions");
         e2 = new Element("existing_class");
@@ -75,7 +75,7 @@ public class DefaultDigitalExpressionManagerXmlTest {
         e.addContent(e2);
         b.loadExpressions(e);
         JUnitAppender.assertErrorMessage("cannot create constructor");
-*/        
+*/
 //        System.out.format("Class name: %s%n", PrivateConstructorXml.class.getName());
     }
 
@@ -83,10 +83,10 @@ public class DefaultDigitalExpressionManagerXmlTest {
     @Test
     public void testStore() {
         DefaultDigitalExpressionManagerXml b = new DefaultDigitalExpressionManagerXml();
-        
+
         // If parameter is null, nothing should happen
         b.store(null);
-        
+
         // Test store a named bean that has no configurexml class
         DigitalExpressionManager manager = InstanceManager.getDefault(DigitalExpressionManager.class);
         manager.registerExpression(new DefaultDigitalExpressionManagerXmlTest.MyDigitalExpression());
@@ -94,10 +94,10 @@ public class DefaultDigitalExpressionManagerXmlTest {
         JUnitAppender.assertErrorMessage("Cannot load configuration adapter for jmri.jmrit.logixng.implementation.configurexml.DefaultDigitalExpressionManagerXmlTest$MyDigitalExpression");
         JUnitAppender.assertErrorMessage("Cannot store configuration for jmri.jmrit.logixng.implementation.configurexml.DefaultDigitalExpressionManagerXmlTest$MyDigitalExpression");
     }
-    
+
     @Test
     public void testReplaceActionManagerWithoutConfigManager() {
-        
+
         // if old manager exists, remove it from configuration process
         if (InstanceManager.getNullableDefault(jmri.jmrit.logixng.DigitalExpressionManager.class) != null) {
             ConfigureManager cmOD = InstanceManager.getNullableDefault(jmri.ConfigureManager.class);
@@ -115,26 +115,26 @@ public class DefaultDigitalExpressionManagerXmlTest {
         if (cmOD != null) {
             cmOD.registerConfig(pManager, jmri.Manager.LOGIXNG_DIGITAL_EXPRESSIONS);
         }
-        
+
         Assert.assertTrue("manager is a MyManager",
                 InstanceManager.getDefault(DigitalExpressionManager.class)
                         instanceof DefaultDigitalExpressionManagerXmlTest.MyManager);
-        
+
         // Test replacing the manager
         DefaultDigitalExpressionManagerXml b = new DefaultDigitalExpressionManagerXml();
         b.replaceExpressionManager();
-        
+
         Assert.assertFalse("manager is not a MyManager",
                 InstanceManager.getDefault(DigitalExpressionManager.class)
                         instanceof DefaultDigitalExpressionManagerXmlTest.MyManager);
     }
-    
+
 //    @Ignore("When debug is enabled, jmri.configurexml.ConfigXmlManager.registerConfig checks if the manager has a XML class, which our fake manager doesn't have")
     @Test
     public void testReplaceActionManagerWithConfigManager() {
-        
+
         JUnitUtil.initConfigureManager();
-        
+
         // if old manager exists, remove it from configuration process
         if (InstanceManager.getNullableDefault(jmri.jmrit.logixng.DigitalExpressionManager.class) != null) {
             ConfigureManager cmOD = InstanceManager.getNullableDefault(jmri.ConfigureManager.class);
@@ -152,20 +152,20 @@ public class DefaultDigitalExpressionManagerXmlTest {
         if (cmOD != null) {
             cmOD.registerConfig(pManager, jmri.Manager.LOGIXNG_DIGITAL_EXPRESSIONS);
         }
-        
+
         Assert.assertTrue("manager is a MyManager",
                 InstanceManager.getDefault(DigitalExpressionManager.class)
                         instanceof DefaultDigitalExpressionManagerXmlTest.MyManager);
-        
+
         // Test replacing the manager
         DefaultDigitalExpressionManagerXml b = new DefaultDigitalExpressionManagerXml();
         b.replaceExpressionManager();
-        
+
         Assert.assertFalse("manager is not a MyManager",
                 InstanceManager.getDefault(DigitalExpressionManager.class)
                         instanceof DefaultDigitalExpressionManagerXmlTest.MyManager);
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() {
@@ -179,27 +179,28 @@ public class DefaultDigitalExpressionManagerXmlTest {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
-    
-    
-    
+
+
+
     private class MyDigitalExpression extends ExpressionTurnout {
-        
+
         MyDigitalExpression() {
             super("IQDE9999", null);
         }
-        
+
     }
-    
-    
+
+
     // This class is loaded by reflection. The class cannot be private since
     // Spotbugs will in that case flag it as "is never used locally"
     class PrivateConstructorXml extends ExpressionTurnoutXml {
         private PrivateConstructorXml() {
         }
     }
-    
+
     // This class is loaded by reflection. The class cannot be private since
     // Spotbugs will in that case flag it as "is never used locally"
     class ThrowExceptionXml extends ExpressionTurnoutXml {
@@ -208,9 +209,9 @@ public class DefaultDigitalExpressionManagerXmlTest {
             throw new JmriConfigureXmlException();
         }
     }
-    
-    
+
+
     class MyManager extends DefaultDigitalExpressionManager {
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/implementation/configurexml/DefaultLogixNGManagerXmlTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/configurexml/DefaultLogixNGManagerXmlTest.java
@@ -31,15 +31,15 @@ public class DefaultLogixNGManagerXmlTest {
     public void testLoad() {
         DefaultLogixNGManagerXml b = new DefaultLogixNGManagerXml();
         Assert.assertNotNull("exists", b);
-        
+
         // Test loading a logixng without system name
         Element e = new Element("LogixNGs");
         Element e2 = new Element("LogixNG");
         e.addContent(e2);
         b.loadLogixNGs(e);
         JUnitAppender.assertWarnMessage("unexpected null in systemName [Element: <LogixNG/>]");
-        
-        
+
+
         // Test load LogixNG without attribute "enable"
         e = new Element("LogixNGs");
         e2 = new Element("LogixNG");
@@ -48,7 +48,7 @@ public class DefaultLogixNGManagerXmlTest {
         e2.addContent(eConditionals);
         e.addContent(e2);
         b.loadLogixNGs(e);
-        
+
         // Test load LogixNG with bad conditionalng (no systemName in the conditionalNG)
         e = new Element("LogixNGs");
         e2 = new Element("LogixNG");
@@ -61,7 +61,7 @@ public class DefaultLogixNGManagerXmlTest {
         b.loadLogixNGs(e);
 //        JUnitAppender.assertWarnMessage("unexpected null in systemName [Element: <conditionalng/>]");
 //        JUnitAppender.assertErrorMessage("exception thrown");
-        
+
         // Test loading a LogixNG that already exists
         e = new Element("LogixNGs");
         e2 = new Element("LogixNG");
@@ -71,7 +71,7 @@ public class DefaultLogixNGManagerXmlTest {
         e2.addContent(new Element("systemName").addContent(systemName));
         e.addContent(e2);
         b.loadLogixNGs(e);
-        
+
         // Test load LogixNG with attribute "enable" as empty string
         e = new Element("LogixNGs");
         e2 = new Element("LogixNG");
@@ -84,7 +84,7 @@ public class DefaultLogixNGManagerXmlTest {
         LogixNG logixNG = InstanceManager.getDefault(LogixNG_Manager.class).getBySystemName("IQ1003");
         Assert.assertNotNull("bean is not null", logixNG);
         Assert.assertFalse("bean is not enabled", logixNG.isEnabled());
-        
+
         // Test load LogixNG with attribute "enable" as invalid value
         e = new Element("LogixNGs");
         e2 = new Element("LogixNG");
@@ -97,7 +97,7 @@ public class DefaultLogixNGManagerXmlTest {
         logixNG = InstanceManager.getDefault(LogixNG_Manager.class).getBySystemName("IQ1004");
         Assert.assertNotNull("bean is not null", logixNG);
         Assert.assertFalse("bean is not enabled", logixNG.isEnabled());
-        
+
         // Test load LogixNG with attribute "enable" as yes
         e = new Element("LogixNGs");
         e2 = new Element("LogixNG");
@@ -110,8 +110,8 @@ public class DefaultLogixNGManagerXmlTest {
         logixNG = InstanceManager.getDefault(LogixNG_Manager.class).getBySystemName("IQ1005");
         Assert.assertNotNull("bean is not null", logixNG);
         Assert.assertTrue("bean is enabled", logixNG.isEnabled());
-        
-/*        
+
+/*
         // Test loading the same class twice, in order to check field "xmlClasses"
         e = new Element("LogixNGs");
         e2 = new Element("existing_class");
@@ -119,14 +119,14 @@ public class DefaultLogixNGManagerXmlTest {
         e.addContent(e2);
         e2.addContent(new Element("systemName").addContent("IQAA1"));
         b.loadLogixNGs(e);
-        
+
         e = new Element("LogixNGs");
         e2 = new Element("existing_class");
         e2.setAttribute("class", "jmri.jmrit.logixng.actions.configurexml.AnalogActionMemoryXml");
         e.addContent(e2);
         e2.addContent(new Element("systemName").addContent("IQAA2"));
         b.loadLogixNGs(e);
-/*        
+/*
         // Test trying to load a class with private constructor
         e = new Element("LogixNGs");
         e2 = new Element("existing_class");
@@ -134,7 +134,7 @@ public class DefaultLogixNGManagerXmlTest {
         e.addContent(e2);
         b.loadLogixNGs(e);
         JUnitAppender.assertErrorMessage("cannot create constructor");
-        
+
         // Test trying to load a class which throws an exception
         e = new Element("LogixNGs");
         e2 = new Element("existing_class");
@@ -156,7 +156,7 @@ public class DefaultLogixNGManagerXmlTest {
     @Ignore("LogixNG thread is already started so this test fails")
     @Test
     public void testReplaceActionManagerWithoutConfigManager() {
-/*        
+/*
         // if old manager exists, remove it from configuration process
         if (InstanceManager.getNullableDefault(jmri.jmrit.logixng.AnalogActionManager.class) != null) {
             ConfigureManager cmOD = InstanceManager.getNullableDefault(jmri.ConfigureManager.class);
@@ -174,35 +174,35 @@ public class DefaultLogixNGManagerXmlTest {
         if (cmOD != null) {
             cmOD.registerConfig(pManager, jmri.Manager.LOGIXNGS);
         }
-        
+
         Assert.assertTrue("manager is a MyManager",
                 InstanceManager.getDefault(LogixNG_Manager.class)
                         instanceof MyManager);
-        
+
         // Test replacing the manager
         DefaultLogixNGManagerXml b = new DefaultLogixNGManagerXml();
         b.replaceLogixNGManager();
-        
+
         Assert.assertFalse("manager is not a MyManager",
                 InstanceManager.getDefault(LogixNG_Manager.class)
                         instanceof MyManager);
-        
+
         // Test replace the manager when where is no manager registered yet
         InstanceManager.deregister(
                 InstanceManager.getDefault(LogixNG_Manager.class),
                 LogixNG_Manager.class);
-        
+
         Assert.assertNotNull("manager is not null",
                 InstanceManager.getDefault(LogixNG_Manager.class));
     }
-    
+
     @Ignore("LogixNG thread is already started so this test fails")
 //    @Ignore("When debug is enabled, jmri.configurexml.ConfigXmlManager.registerConfig checks if the manager has a XML class, which our fake manager doesn't have")
     @Test
     public void testReplaceActionManagerWithConfigManager() {
-        
+
         JUnitUtil.initConfigureManager();
-/*        
+/*
         // if old manager exists, remove it from configuration process
         if (InstanceManager.getNullableDefault(jmri.jmrit.logixng.AnalogActionManager.class) != null) {
             ConfigureManager cmOD = InstanceManager.getNullableDefault(jmri.ConfigureManager.class);
@@ -220,20 +220,20 @@ public class DefaultLogixNGManagerXmlTest {
         if (cmOD != null) {
             cmOD.registerConfig(pManager, jmri.Manager.LOGIXNGS);
         }
-        
+
         Assert.assertTrue("manager is a MyManager",
                 InstanceManager.getDefault(LogixNG_Manager.class)
                         instanceof MyManager);
-        
+
         // Test replacing the manager
         DefaultLogixNGManagerXml b = new DefaultLogixNGManagerXml();
         b.replaceLogixNGManager();
-        
+
         Assert.assertFalse("manager is not a MyManager",
                 InstanceManager.getDefault(LogixNG_Manager.class)
                         instanceof MyManager);
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() {
@@ -247,26 +247,27 @@ public class DefaultLogixNGManagerXmlTest {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
-    
-/*    
+
+/*
     private class MyLogixNG extends jmri.jmrit.logixng.implementation.DefaultLogixNG {
-        
+
         MyLogixNG() {
             super("IQ9999");
         }
-        
+
     }
-    
-/*    
+
+/*
     // This class is loaded by reflection. The class cannot be private since
     // Spotbugs will in that case flag it as "is never used locally"
     class PrivateConstructorXml extends DefaultLogixNGXml {
         private PrivateConstructorXml() {
         }
     }
-    
+
     // This class is loaded by reflection. The class cannot be private since
     // Spotbugs will in that case flag it as "is never used locally"
     class ThrowExceptionXml extends DefaultLogixNGXml {
@@ -275,8 +276,8 @@ public class DefaultLogixNGManagerXmlTest {
             throw new JmriConfigureXmlException();
         }
     }
-*/    
+*/
     class MyManager extends DefaultLogixNGManager {
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/implementation/configurexml/DefaultStringActionManagerXmlTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/configurexml/DefaultStringActionManagerXmlTest.java
@@ -32,7 +32,7 @@ public class DefaultStringActionManagerXmlTest {
     @Test
     public void testLoad() {
         DefaultStringActionManagerXml b = new DefaultStringActionManagerXml();
-        
+
         Element e = new Element("logixngStringExpressions");
         Element e2 = new Element("missing_class");
         e2.setAttribute("class", "jmri.jmrit.logixng.this.class.does.not.exist.TestClassXml");
@@ -40,7 +40,7 @@ public class DefaultStringActionManagerXmlTest {
         e.addContent(e2);
         b.loadActions(e);
         JUnitAppender.assertErrorMessage("cannot load class jmri.jmrit.logixng.this.class.does.not.exist.TestClassXml");
-/*        
+/*
         // Test loading the same class twice, in order to check field "xmlClasses"
         e = new Element("logixngStringExpressions");
         e2 = new Element("existing_class");
@@ -49,7 +49,7 @@ public class DefaultStringActionManagerXmlTest {
         e2.addContent(new Element("systemName").addContent("IQSA1"));
         e2.addContent(new Element("maleSocket"));
         b.loadActions(e);
-        
+
         e = new Element("logixngStringExpressions");
         e2 = new Element("existing_class");
         e2.setAttribute("class", "jmri.jmrit.logixng.actions.configurexml.StringActionMemoryXml");
@@ -57,7 +57,7 @@ public class DefaultStringActionManagerXmlTest {
         e2.addContent(new Element("systemName").addContent("IQSA2"));
         e2.addContent(new Element("maleSocket"));
         b.loadActions(e);
-        
+
         // Test trying to load a class with private constructor
         e = new Element("logixngStringExpressions");
         e2 = new Element("existing_class");
@@ -66,7 +66,7 @@ public class DefaultStringActionManagerXmlTest {
         e.addContent(e2);
         b.loadActions(e);
         JUnitAppender.assertErrorMessage("cannot create constructor");
-        
+
         // Test trying to load a class which throws an exception
         e = new Element("logixngStringExpressions");
         e2 = new Element("existing_class");
@@ -75,7 +75,7 @@ public class DefaultStringActionManagerXmlTest {
         e.addContent(e2);
         b.loadActions(e);
         JUnitAppender.assertErrorMessage("cannot create constructor");
-*/        
+*/
 //        System.out.format("Class name: %s%n", PrivateConstructorXml.class.getName());
     }
 
@@ -83,10 +83,10 @@ public class DefaultStringActionManagerXmlTest {
     @Test
     public void testStore() {
         DefaultStringActionManagerXml b = new DefaultStringActionManagerXml();
-        
+
         // If parameter is null, nothing should happen
         b.store(null);
-        
+
         // Test store a named bean that has no configurexml class
         StringActionManager manager = InstanceManager.getDefault(StringActionManager.class);
         manager.registerAction(new DefaultStringActionManagerXmlTest.MyStringAction());
@@ -94,10 +94,10 @@ public class DefaultStringActionManagerXmlTest {
         JUnitAppender.assertErrorMessage("Cannot load configuration adapter for jmri.jmrit.logixng.implementation.configurexml.DefaultStringActionManagerXmlTest$MyStringAction");
         JUnitAppender.assertErrorMessage("Cannot store configuration for jmri.jmrit.logixng.implementation.configurexml.DefaultStringActionManagerXmlTest$MyStringAction");
     }
-    
+
     @Test
     public void testReplaceActionManagerWithoutConfigManager() {
-        
+
         // if old manager exists, remove it from configuration process
         if (InstanceManager.getNullableDefault(jmri.jmrit.logixng.StringActionManager.class) != null) {
             ConfigureManager cmOD = InstanceManager.getNullableDefault(jmri.ConfigureManager.class);
@@ -115,26 +115,26 @@ public class DefaultStringActionManagerXmlTest {
         if (cmOD != null) {
             cmOD.registerConfig(pManager, jmri.Manager.LOGIXNG_STRING_ACTIONS);
         }
-        
+
         Assert.assertTrue("manager is a MyManager",
                 InstanceManager.getDefault(StringActionManager.class)
                         instanceof DefaultStringActionManagerXmlTest.MyManager);
-        
+
         // Test replacing the manager
         DefaultStringActionManagerXml b = new DefaultStringActionManagerXml();
         b.replaceActionManager();
-        
+
         Assert.assertFalse("manager is not a MyManager",
                 InstanceManager.getDefault(StringActionManager.class)
                         instanceof DefaultStringActionManagerXmlTest.MyManager);
     }
-    
+
 //    @Ignore("When debug is enabled, jmri.configurexml.ConfigXmlManager.registerConfig checks if the manager has a XML class, which our fake manager doesn't have")
     @Test
     public void testReplaceActionManagerWithConfigManager() {
-        
+
         JUnitUtil.initConfigureManager();
-        
+
         // if old manager exists, remove it from configuration process
         if (InstanceManager.getNullableDefault(jmri.jmrit.logixng.StringActionManager.class) != null) {
             ConfigureManager cmOD = InstanceManager.getNullableDefault(jmri.ConfigureManager.class);
@@ -152,20 +152,20 @@ public class DefaultStringActionManagerXmlTest {
         if (cmOD != null) {
             cmOD.registerConfig(pManager, jmri.Manager.LOGIXNG_STRING_ACTIONS);
         }
-        
+
         Assert.assertTrue("manager is a MyManager",
                 InstanceManager.getDefault(StringActionManager.class)
                         instanceof DefaultStringActionManagerXmlTest.MyManager);
-        
+
         // Test replacing the manager
         DefaultStringActionManagerXml b = new DefaultStringActionManagerXml();
         b.replaceActionManager();
-        
+
         Assert.assertFalse("manager is not a MyManager",
                 InstanceManager.getDefault(StringActionManager.class)
                         instanceof DefaultStringActionManagerXmlTest.MyManager);
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() {
@@ -179,27 +179,28 @@ public class DefaultStringActionManagerXmlTest {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
-    
-    
-    
+
+
+
     private class MyStringAction extends StringActionMemory {
-        
+
         MyStringAction() {
             super("IQSA9999", null);
         }
-        
+
     }
-    
-    
+
+
     // This class is loaded by reflection. The class cannot be private since
     // Spotbugs will in that case flag it as "is never used locally"
     class PrivateConstructorXml extends StringActionMemoryXml {
         private PrivateConstructorXml() {
         }
     }
-    
+
     // This class is loaded by reflection. The class cannot be private since
     // Spotbugs will in that case flag it as "is never used locally"
     class ThrowExceptionXml extends StringActionMemoryXml {
@@ -208,9 +209,9 @@ public class DefaultStringActionManagerXmlTest {
             throw new JmriConfigureXmlException();
         }
     }
-    
-    
+
+
     class MyManager extends DefaultStringActionManager {
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/implementation/configurexml/DefaultStringExpressionManagerXmlTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/configurexml/DefaultStringExpressionManagerXmlTest.java
@@ -32,7 +32,7 @@ public class DefaultStringExpressionManagerXmlTest {
     @Test
     public void testLoad() {
         DefaultStringExpressionManagerXml b = new DefaultStringExpressionManagerXml();
-        
+
         Element e = new Element("logixngAnalogExpressions");
         Element e2 = new Element("missing_class");
         e2.setAttribute("class", "jmri.jmrit.logixng.this.class.does.not.exist.TestClassXml");
@@ -40,7 +40,7 @@ public class DefaultStringExpressionManagerXmlTest {
         e.addContent(e2);
         b.loadExpressions(e);
         JUnitAppender.assertErrorMessage("cannot load class jmri.jmrit.logixng.this.class.does.not.exist.TestClassXml");
-/*        
+/*
         // Test loading the same class twice, in order to check field "xmlClasses"
         e = new Element("logixngAnalogExpressions");
         e2 = new Element("existing_class");
@@ -49,7 +49,7 @@ public class DefaultStringExpressionManagerXmlTest {
         e2.addContent(new Element("systemName").addContent("IQSE1"));
         e2.addContent(new Element("maleSocket"));
         b.loadExpressions(e);
-        
+
         e = new Element("logixngAnalogExpressions");
         e2 = new Element("existing_class");
         e2.setAttribute("class", "jmri.jmrit.logixng.expressions.configurexml.StringExpressionMemoryXml");
@@ -57,7 +57,7 @@ public class DefaultStringExpressionManagerXmlTest {
         e2.addContent(new Element("systemName").addContent("IQSE2"));
         e2.addContent(new Element("maleSocket"));
         b.loadExpressions(e);
-        
+
         // Test trying to load a class with private constructor
         e = new Element("logixngAnalogExpressions");
         e2 = new Element("existing_class");
@@ -66,7 +66,7 @@ public class DefaultStringExpressionManagerXmlTest {
         e.addContent(e2);
         b.loadExpressions(e);
         JUnitAppender.assertErrorMessage("cannot create constructor");
-        
+
         // Test trying to load a class which throws an exception
         e = new Element("logixngAnalogExpressions");
         e2 = new Element("existing_class");
@@ -75,7 +75,7 @@ public class DefaultStringExpressionManagerXmlTest {
         e.addContent(e2);
         b.loadExpressions(e);
         JUnitAppender.assertErrorMessage("cannot create constructor");
-*/        
+*/
 //        System.out.format("Class name: %s%n", PrivateConstructorXml.class.getName());
     }
 
@@ -83,10 +83,10 @@ public class DefaultStringExpressionManagerXmlTest {
     @Test
     public void testStore() {
         DefaultStringExpressionManagerXml b = new DefaultStringExpressionManagerXml();
-        
+
         // If parameter is null, nothing should happen
         b.store(null);
-        
+
         // Test store a named bean that has no configurexml class
         StringExpressionManager manager = InstanceManager.getDefault(StringExpressionManager.class);
         manager.registerExpression(new DefaultStringExpressionManagerXmlTest.MyStringExpression());
@@ -94,10 +94,10 @@ public class DefaultStringExpressionManagerXmlTest {
         JUnitAppender.assertErrorMessage("Cannot load configuration adapter for jmri.jmrit.logixng.implementation.configurexml.DefaultStringExpressionManagerXmlTest$MyStringExpression");
         JUnitAppender.assertErrorMessage("Cannot store configuration for jmri.jmrit.logixng.implementation.configurexml.DefaultStringExpressionManagerXmlTest$MyStringExpression");
     }
-    
+
     @Test
     public void testReplaceActionManagerWithoutConfigManager() {
-        
+
         // if old manager exists, remove it from configuration process
         if (InstanceManager.getNullableDefault(jmri.jmrit.logixng.StringExpressionManager.class) != null) {
             ConfigureManager cmOD = InstanceManager.getNullableDefault(jmri.ConfigureManager.class);
@@ -115,26 +115,26 @@ public class DefaultStringExpressionManagerXmlTest {
         if (cmOD != null) {
             cmOD.registerConfig(pManager, jmri.Manager.LOGIXNG_STRING_EXPRESSIONS);
         }
-        
+
         Assert.assertTrue("manager is a MyManager",
                 InstanceManager.getDefault(StringExpressionManager.class)
                         instanceof DefaultStringExpressionManagerXmlTest.MyManager);
-        
+
         // Test replacing the manager
         DefaultStringExpressionManagerXml b = new DefaultStringExpressionManagerXml();
         b.replaceExpressionManager();
-        
+
         Assert.assertFalse("manager is not a MyManager",
                 InstanceManager.getDefault(StringExpressionManager.class)
                         instanceof DefaultStringExpressionManagerXmlTest.MyManager);
     }
-    
+
 //    @Ignore("When debug is enabled, jmri.configurexml.ConfigXmlManager.registerConfig checks if the manager has a XML class, which our fake manager doesn't have")
     @Test
     public void testReplaceActionManagerWithConfigManager() {
-        
+
         JUnitUtil.initConfigureManager();
-        
+
         // if old manager exists, remove it from configuration process
         if (InstanceManager.getNullableDefault(jmri.jmrit.logixng.StringExpressionManager.class) != null) {
             ConfigureManager cmOD = InstanceManager.getNullableDefault(jmri.ConfigureManager.class);
@@ -152,20 +152,20 @@ public class DefaultStringExpressionManagerXmlTest {
         if (cmOD != null) {
             cmOD.registerConfig(pManager, jmri.Manager.LOGIXNG_STRING_EXPRESSIONS);
         }
-        
+
         Assert.assertTrue("manager is a MyManager",
                 InstanceManager.getDefault(StringExpressionManager.class)
                         instanceof DefaultStringExpressionManagerXmlTest.MyManager);
-        
+
         // Test replacing the manager
         DefaultStringExpressionManagerXml b = new DefaultStringExpressionManagerXml();
         b.replaceExpressionManager();
-        
+
         Assert.assertFalse("manager is not a MyManager",
                 InstanceManager.getDefault(StringExpressionManager.class)
                         instanceof DefaultStringExpressionManagerXmlTest.MyManager);
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() {
@@ -179,27 +179,28 @@ public class DefaultStringExpressionManagerXmlTest {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
-    
-    
-    
+
+
+
     private class MyStringExpression extends StringExpressionMemory {
-        
+
         MyStringExpression() {
             super("IQSE9999", null);
         }
-        
+
     }
-    
-    
+
+
     // This class is loaded by reflection. The class cannot be private since
     // Spotbugs will in that case flag it as "is never used locally"
     class PrivateConstructorXml extends StringExpressionMemoryXml {
         private PrivateConstructorXml() {
         }
     }
-    
+
     // This class is loaded by reflection. The class cannot be private since
     // Spotbugs will in that case flag it as "is never used locally"
     class ThrowExceptionXml extends StringExpressionMemoryXml {
@@ -208,9 +209,9 @@ public class DefaultStringExpressionManagerXmlTest {
             throw new JmriConfigureXmlException();
         }
     }
-    
-    
+
+
     class MyManager extends DefaultStringExpressionManager {
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/implementation/swing/DefaultMaleAnalogActionSocketSwingTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/swing/DefaultMaleAnalogActionSocketSwingTest.java
@@ -8,7 +8,7 @@ import org.junit.*;
 
 /**
  * Test LogixNGPreferences
- * 
+ *
  * @author Daniel Bergqvist 2020
  */
 public class DefaultMaleAnalogActionSocketSwingTest {
@@ -18,7 +18,7 @@ public class DefaultMaleAnalogActionSocketSwingTest {
         DefaultMaleAnalogActionSocketSwing obj = new DefaultMaleAnalogActionSocketSwing();
         Assert.assertNotNull(obj);
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() throws IOException {
@@ -33,7 +33,8 @@ public class DefaultMaleAnalogActionSocketSwingTest {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/implementation/swing/DefaultMaleAnalogExpressionSocketSwingTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/swing/DefaultMaleAnalogExpressionSocketSwingTest.java
@@ -8,7 +8,7 @@ import org.junit.*;
 
 /**
  * Test LogixNGPreferences
- * 
+ *
  * @author Daniel Bergqvist 2020
  */
 public class DefaultMaleAnalogExpressionSocketSwingTest {
@@ -18,7 +18,7 @@ public class DefaultMaleAnalogExpressionSocketSwingTest {
         DefaultMaleAnalogExpressionSocketSwing obj = new DefaultMaleAnalogExpressionSocketSwing();
         Assert.assertNotNull(obj);
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() throws IOException {
@@ -33,7 +33,8 @@ public class DefaultMaleAnalogExpressionSocketSwingTest {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/implementation/swing/DefaultMaleDigitalBooleanActionSocketSwingTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/swing/DefaultMaleDigitalBooleanActionSocketSwingTest.java
@@ -8,7 +8,7 @@ import org.junit.*;
 
 /**
  * Test LogixNGPreferences
- * 
+ *
  * @author Daniel Bergqvist 2020
  */
 public class DefaultMaleDigitalBooleanActionSocketSwingTest {
@@ -18,7 +18,7 @@ public class DefaultMaleDigitalBooleanActionSocketSwingTest {
         DefaultMaleDigitalBooleanActionSocketSwing obj = new DefaultMaleDigitalBooleanActionSocketSwing();
         Assert.assertNotNull(obj);
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() throws IOException {
@@ -33,7 +33,8 @@ public class DefaultMaleDigitalBooleanActionSocketSwingTest {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/implementation/swing/DefaultMaleStringActionSocketSwingTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/swing/DefaultMaleStringActionSocketSwingTest.java
@@ -8,7 +8,7 @@ import org.junit.*;
 
 /**
  * Test LogixNGPreferences
- * 
+ *
  * @author Daniel Bergqvist 2020
  */
 public class DefaultMaleStringActionSocketSwingTest {
@@ -18,7 +18,7 @@ public class DefaultMaleStringActionSocketSwingTest {
         DefaultMaleStringActionSocketSwing obj = new DefaultMaleStringActionSocketSwing();
         Assert.assertNotNull(obj);
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() throws IOException {
@@ -33,7 +33,8 @@ public class DefaultMaleStringActionSocketSwingTest {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/implementation/swing/DefaultMaleStringExpressionSocketSwingTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/swing/DefaultMaleStringExpressionSocketSwingTest.java
@@ -8,7 +8,7 @@ import org.junit.*;
 
 /**
  * Test LogixNGPreferences
- * 
+ *
  * @author Daniel Bergqvist 2020
  */
 public class DefaultMaleStringExpressionSocketSwingTest {
@@ -18,7 +18,7 @@ public class DefaultMaleStringExpressionSocketSwingTest {
         DefaultMaleStringExpressionSocketSwing obj = new DefaultMaleStringExpressionSocketSwing();
         Assert.assertNotNull(obj);
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() throws IOException {
@@ -33,7 +33,8 @@ public class DefaultMaleStringExpressionSocketSwingTest {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/implementation/swing/ErrorHandlingDialogTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/swing/ErrorHandlingDialogTest.java
@@ -8,7 +8,7 @@ import org.junit.*;
 
 /**
  * Test ErrorHandlingDialog
- * 
+ *
  * @author Daniel Bergqvist 2020
  */
 public class ErrorHandlingDialogTest {
@@ -18,7 +18,7 @@ public class ErrorHandlingDialogTest {
         ErrorHandlingDialog obj = new ErrorHandlingDialog();
         Assert.assertNotNull(obj);
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() throws IOException {
@@ -33,7 +33,8 @@ public class ErrorHandlingDialogTest {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/implementation/swing/ErrorHandlingDialog_MultiLineTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/swing/ErrorHandlingDialog_MultiLineTest.java
@@ -8,7 +8,7 @@ import org.junit.*;
 
 /**
  * Test ErrorHandlingDialog_MultiLine
- * 
+ *
  * @author Daniel Bergqvist 2021
  */
 public class ErrorHandlingDialog_MultiLineTest {
@@ -18,7 +18,7 @@ public class ErrorHandlingDialog_MultiLineTest {
         ErrorHandlingDialog_MultiLine obj = new ErrorHandlingDialog_MultiLine();
         Assert.assertNotNull(obj);
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() throws IOException {
@@ -33,7 +33,8 @@ public class ErrorHandlingDialog_MultiLineTest {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/implementation/swing/VariableTableModelTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/swing/VariableTableModelTest.java
@@ -10,7 +10,7 @@ import org.junit.*;
 
 /**
  * Test VariableTableModel
- * 
+ *
  * @author Daniel Bergqvist 2020
  */
 public class VariableTableModelTest {
@@ -20,7 +20,7 @@ public class VariableTableModelTest {
         LocalVariableTableModel obj = new LocalVariableTableModel(null);
         Assert.assertNotNull(obj);
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() throws IOException {
@@ -35,7 +35,8 @@ public class VariableTableModelTest {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/swing/SwingConfiguratorInterfaceTest.java
+++ b/java/test/jmri/jmrit/logixng/swing/SwingConfiguratorInterfaceTest.java
@@ -16,18 +16,18 @@ import org.junit.Test;
 
 /**
  * Test SwingConfiguratorInterface
- * 
+ *
  * @author Daniel Bergqvist (C) 2020
  */
 public class SwingConfiguratorInterfaceTest {
-    
+
     @Test
     public void testSwingTools() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        
+
         // This test tests that the components can be in a different order than
         // expected, since different languages may order words in a different way.
-        
+
         // If turnout 'IT2' 'is' 'thrown' then check if sensor 'IS34' is 'active' now
         String message = "If turnout {2} {1} {4} then check if sensor {0} is {3} now";
         JTextField component2_Turnout = new JTextField();
@@ -35,45 +35,45 @@ public class SwingConfiguratorInterfaceTest {
         JTextField component4_thrownClosed = new JTextField();
         JTextField component0_sensor = new JTextField();
         JTextField component3_activeInactive = new JTextField();
-        
+
         JComponent[] components = new JComponent[]{
             component0_sensor,
             component1_Is_IsNot,
             component2_Turnout,
             component3_activeInactive,
             component4_thrownClosed};
-        
+
         List<JComponent> list = SwingConfiguratorInterface.parseMessage(message, components);
-        
+
         Assert.assertTrue(list.get(0) instanceof JLabel);
         Assert.assertEquals("If turnout ", ((JLabel)list.get(0)).getText());
-        
+
         Assert.assertEquals(component2_Turnout, list.get(1));
-        
+
         Assert.assertTrue(list.get(2) instanceof JLabel);
         Assert.assertEquals(" ", ((JLabel)list.get(2)).getText());
-        
+
         Assert.assertEquals(component1_Is_IsNot, list.get(3));
-        
+
         Assert.assertTrue(list.get(4) instanceof JLabel);
         Assert.assertEquals(" ", ((JLabel)list.get(4)).getText());
-        
+
         Assert.assertEquals(component4_thrownClosed, list.get(5));
-        
+
         Assert.assertTrue(list.get(6) instanceof JLabel);
         Assert.assertEquals(" then check if sensor ", ((JLabel)list.get(6)).getText());
-        
+
         Assert.assertEquals(component0_sensor, list.get(7));
-        
+
         Assert.assertTrue(list.get(8) instanceof JLabel);
         Assert.assertEquals(" is ", ((JLabel)list.get(8)).getText());
-        
+
         Assert.assertEquals(component3_activeInactive, list.get(9));
-        
+
         Assert.assertTrue(list.get(10) instanceof JLabel);
         Assert.assertEquals(" now", ((JLabel)list.get(10)).getText());
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() {
@@ -89,7 +89,8 @@ public class SwingConfiguratorInterfaceTest {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/swing/SwingToolsTest.java
+++ b/java/test/jmri/jmrit/logixng/swing/SwingToolsTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
 
 /**
  * Test SwingToolsTest
- * 
+ *
  * @author Daniel Bergqvist 2018
  */
 public class SwingToolsTest {
@@ -22,39 +22,39 @@ public class SwingToolsTest {
     @Test
     public void testSwingTools() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        
+
         DigitalActionBean action = new ActionTurnout("IQDA1", null);
         Class actionClass = ActionTurnout.class;
-        
+
         Assert.assertTrue("Class name is correct",
                 "jmri.jmrit.logixng.actions.swing.ActionTurnoutSwing"
                         .equals(SwingTools.adapterNameForObject(action)));
-        
+
         Assert.assertTrue("Class name is correct",
                 "jmri.jmrit.logixng.actions.swing.ActionTurnoutSwing"
                         .equals(SwingTools.adapterNameForClass(actionClass)));
-        
+
         Assert.assertTrue("Class is correct",
                 "jmri.jmrit.logixng.actions.swing.ActionTurnoutSwing"
                         .equals(SwingTools.getSwingConfiguratorForObject(action).getClass().getName()));
-        
+
         Assert.assertTrue("Class is correct",
                 "jmri.jmrit.logixng.actions.swing.ActionTurnoutSwing"
                         .equals(SwingTools.getSwingConfiguratorForClass(actionClass).getClass().getName()));
-        
+
         // The class SwingToolsTest does not have a swing configurator
         SwingConfiguratorInterface iface = SwingTools.getSwingConfiguratorForObject(this);
         Assert.assertNull("interface is null", iface);
         jmri.util.JUnitAppender.assertErrorMessage("Cannot load SwingConfiguratorInterface adapter for jmri.jmrit.logixng.swing.SwingToolsTest");
         jmri.util.JUnitAppender.assertErrorMessage("Cannot load SwingConfiguratorInterface for jmri.jmrit.logixng.swing.SwingToolsTest");
-        
+
         // The class SwingToolsTest does not have a swing configurator
         iface = SwingTools.getSwingConfiguratorForClass(this.getClass());
         Assert.assertNull("interface is null", iface);
         jmri.util.JUnitAppender.assertErrorMessage("Cannot load SwingConfiguratorInterface adapter for jmri.jmrit.logixng.swing.SwingToolsTest");
         jmri.util.JUnitAppender.assertErrorMessage("Cannot load SwingConfiguratorInterface for jmri.jmrit.logixng.swing.SwingToolsTest");
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() {
@@ -70,7 +70,8 @@ public class SwingToolsTest {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/tools/swing/ClipboardEditorTest.java
+++ b/java/test/jmri/jmrit/logixng/tools/swing/ClipboardEditorTest.java
@@ -12,7 +12,7 @@ import org.junit.Test;
 
 /**
  * Test ClipboardEditor
- * 
+ *
  * @author Daniel Bergqvist 2020
  */
 public class ClipboardEditorTest {
@@ -20,11 +20,11 @@ public class ClipboardEditorTest {
     @Test
     public void testCtor() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        
+
         ClipboardEditor editor = new ClipboardEditor();
         Assert.assertNotNull("object not null", editor);
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() {
@@ -40,7 +40,8 @@ public class ClipboardEditorTest {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/tools/swing/ConditionalNGEditorTest.java
+++ b/java/test/jmri/jmrit/logixng/tools/swing/ConditionalNGEditorTest.java
@@ -46,6 +46,7 @@ public class ConditionalNGEditorTest {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/tools/swing/EditCommentDialogTest.java
+++ b/java/test/jmri/jmrit/logixng/tools/swing/EditCommentDialogTest.java
@@ -10,7 +10,7 @@ import org.junit.Test;
 
 /**
  * Test EditCommentDialog
- * 
+ *
  * @author Daniel Bergqvist 2021
  */
 public class EditCommentDialogTest {
@@ -20,7 +20,7 @@ public class EditCommentDialogTest {
         EditCommentDialog d = new EditCommentDialog();
         Assert.assertNotNull(d);
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() {
@@ -34,7 +34,8 @@ public class EditCommentDialogTest {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/tools/swing/LogixNGInitializationTableTest.java
+++ b/java/test/jmri/jmrit/logixng/tools/swing/LogixNGInitializationTableTest.java
@@ -10,7 +10,7 @@ import org.junit.Test;
 
 /**
  * Test TimeDiagram
- * 
+ *
  * @author Daniel Bergqvist Copyright (C) 2018
  */
 public class LogixNGInitializationTableTest {
@@ -18,7 +18,7 @@ public class LogixNGInitializationTableTest {
     @Test
     public void testCTor() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        
+
         LogixNGInitializationTable b = new LogixNGInitializationTable();
         Assert.assertNotNull("exists", b);
     }
@@ -36,6 +36,7 @@ public class LogixNGInitializationTableTest {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/util/DispatcherActiveTrainManagerTest.java
+++ b/java/test/jmri/jmrit/logixng/util/DispatcherActiveTrainManagerTest.java
@@ -39,6 +39,7 @@ public class DispatcherActiveTrainManagerTest {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/util/ReferenceUtilTest.java
+++ b/java/test/jmri/jmrit/logixng/util/ReferenceUtilTest.java
@@ -17,7 +17,7 @@ import java.io.IOException;
 
 /**
  * Test ReferenceUtil
- * 
+ *
  * @author Daniel Bergqvist 2019
  */
 public class ReferenceUtilTest {
@@ -25,16 +25,16 @@ public class ReferenceUtilTest {
     private MemoryManager _memoryManager;
     private NamedTableManager _tableManager;
     private NamedTable yardTable;
-    
+
     // The system appropriate newline separator.
     private static final String _nl = System.getProperty("line.separator"); // NOI18N
-    
+
     @Test
     public void testCtor() {
         ReferenceUtil t = new ReferenceUtil();
         Assert.assertNotNull("not null", t);
     }
-    
+
     private void expectException(Runnable r, Class<? extends Exception> exceptionClass, String errorMessage) {
         boolean exceptionThrown = false;
         try {
@@ -50,7 +50,7 @@ public class ReferenceUtilTest {
         }
         Assert.assertTrue("Exception is thrown", exceptionThrown);
     }
-    
+
     @Test
     public void testIsReference() {
         Assert.assertFalse("Is reference", ReferenceUtil.isReference(null));
@@ -63,16 +63,16 @@ public class ReferenceUtilTest {
         Assert.assertFalse("Is reference", ReferenceUtil.isReference("Abc}"));
         Assert.assertFalse("Is reference", ReferenceUtil.isReference("Abc"));
     }
-    
+
     @Test
     public void testGetReference() {
-        
+
         Memory m1 = _memoryManager.newMemory("IM1", "Memory 1");
         Memory m2 = _memoryManager.newMemory("IM2", "Memory 2");
         Memory m3 = _memoryManager.newMemory("IM3", "Memory 3");
-        
+
         SymbolTable symbolTable = new DefaultSymbolTable(new DefaultConditionalNG("IQC1", null));
-        
+
         // Test references
         m1.setValue("Turnout 1");
         Assert.assertEquals("Reference is correct",
@@ -81,7 +81,7 @@ public class ReferenceUtilTest {
         Assert.assertEquals("Reference is correct",
                 "Turnout 1",
                 ReferenceUtil.getReference(symbolTable, "{  IM1  }"));
-        
+
         m2.setValue("IM1");
         Assert.assertEquals("Reference is correct",
                 "IM1",
@@ -98,7 +98,7 @@ public class ReferenceUtilTest {
         Assert.assertEquals("Reference is correct",
                 "Turnout 1",
                 ReferenceUtil.getReference(symbolTable, "{ {   IM2 } }"));
-        
+
         m3.setValue("IM2");
         Assert.assertEquals("Reference is correct",
                 "IM2",
@@ -107,18 +107,18 @@ public class ReferenceUtilTest {
                 "Turnout 1",
                 ReferenceUtil.getReference(symbolTable, "{{{IM3}}}"));
     }
-    
+
     @Test
     public void testTables() {
-        
+
         Memory m1 = _memoryManager.newMemory("IM1", "Memory 1");
         Memory m15 = _memoryManager.newMemory("IM15", "Memory 15");
         Memory m333 = _memoryManager.newMemory("IM333", "Memory 333");
-        
+
         SymbolTable symbolTable = new DefaultSymbolTable(new DefaultConditionalNG("IQC1", null));
-        
+
         yardTable.setCell(null, "Other turnout");
-        
+
         Assert.assertNull("Reference is correct",
                 ReferenceUtil.getReference(symbolTable, "{Yard table[Other turnout]}"));
         Assert.assertNull("Reference is correct",
@@ -135,17 +135,17 @@ public class ReferenceUtilTest {
                 ReferenceUtil.getReference(symbolTable, "{Yard table[  Other turnout  ]}"));
         Assert.assertNull("Reference is correct",
                 ReferenceUtil.getReference(symbolTable, "{Yard table[Other turnout,North yard]}"));
-        
+
         Assert.assertNull("Reference is correct",
                 ReferenceUtil.getReference(symbolTable, "{  Yard table[Other turnout,North yard]  }"));
-        
+
         Assert.assertNull("Reference is correct",
                 ReferenceUtil.getReference(symbolTable, "{Yard table[  Other turnout , North yard  ]}"));
         Assert.assertNull("Reference is correct",
                 ReferenceUtil.getReference(symbolTable, "{  Yard table[  Other turnout   ,   North yard   ]  }"));
         Assert.assertNull("Reference is correct",
                 ReferenceUtil.getReference(symbolTable, "{  Yard table  [  Other turnout   ,   North yard   ]  }"));
-        
+
         m1.setValue("Turnout 1");
         Assert.assertEquals("Reference is correct",
                 "Turnout 111",
@@ -165,7 +165,7 @@ public class ReferenceUtilTest {
         Assert.assertEquals("Reference is correct",
                 "Turnout 222",
                 ReferenceUtil.getReference(symbolTable, "{Yard table[ Rightmost turnout  , North yard ]}"));
-        
+
         // The line below reads 'Yard table[Rightmost turnout,East yard]' which
         // has the value IM15. And then reads the memory IM15 which has the value
         // 'Chicago north east'.
@@ -179,7 +179,7 @@ public class ReferenceUtilTest {
         Assert.assertEquals("Reference is correct",
                 "Chicago north east",
                 ReferenceUtil.getReference(symbolTable, "{{  Yard table   [ Rightmost turnout  ,  East yard ]}}"));
-        
+
         // The line below reads the reference '{Turnout table[Yellow turnout]}'
         // which has the value 'Right turnout'. It then reads the reference
         // '{Other yard table[Turnouts,Green yard]}' which has the value
@@ -190,131 +190,131 @@ public class ReferenceUtilTest {
         m333.setValue("Blue turnout");
         Assert.assertEquals("Reference is correct",
                 "Blue turnout",
-                ReferenceUtil.getReference(symbolTable, 
+                ReferenceUtil.getReference(symbolTable,
                         "{{Yard table[{Turnout table[Yellow turnout]},{Other yard table[Turnouts,Green yard]}]}}"));
         Assert.assertEquals("Reference is correct",
                 "Blue turnout",
-                ReferenceUtil.getReference(symbolTable, 
+                ReferenceUtil.getReference(symbolTable,
                         "{{Yard table[{Turnout table[ Yellow turnout ]},{Other yard table[  Turnouts , Green yard  ]}]}}"));
-        
+
         Assert.assertEquals("Reference is correct",
                 "Blue turnout",
-                ReferenceUtil.getReference(symbolTable, 
+                ReferenceUtil.getReference(symbolTable,
                         "{{Yard table[{Turnout table[ Yellow turnout ]},  {Other yard table[  Turnouts , Green yard  ]}]}}"));
         Assert.assertEquals("Reference is correct",
                 "Blue turnout",
-                ReferenceUtil.getReference(symbolTable, 
+                ReferenceUtil.getReference(symbolTable,
                         "{{Yard table[{Turnout table[ Yellow turnout ]}  ,{Other yard table[  Turnouts , Green yard  ]}]}}"));
         Assert.assertEquals("Reference is correct",
                 "Blue turnout",
-                ReferenceUtil.getReference(symbolTable, 
+                ReferenceUtil.getReference(symbolTable,
                         "{{Yard table[{Turnout table[ Yellow turnout ]}  ,  {Other yard table[  Turnouts , Green yard  ]}]}}"));
         Assert.assertEquals("Reference is correct",
                 "Blue turnout",
-                ReferenceUtil.getReference(symbolTable, 
+                ReferenceUtil.getReference(symbolTable,
                         "{{  Yard table [{Turnout table[ Yellow turnout ]}  ,  {Other yard table[  Turnouts , Green yard  ]}]}}"));
         Assert.assertEquals("Reference is correct",
                 "Blue turnout",
-                ReferenceUtil.getReference(symbolTable, 
+                ReferenceUtil.getReference(symbolTable,
                         "{  {  Yard table [{Turnout table[ Yellow turnout ]}  ,  {Other yard table[  Turnouts , Green yard  ]}]}}"));
         Assert.assertEquals("Reference is correct",
                 "Blue turnout",
-                ReferenceUtil.getReference(symbolTable, 
+                ReferenceUtil.getReference(symbolTable,
                         "{  {  Yard table [ {  Turnout table  [ Yellow turnout ]}  ,  {Other yard table[  Turnouts , Green yard  ]}]}}"));
         Assert.assertEquals("Reference is correct",
                 "Blue turnout",
-                ReferenceUtil.getReference(symbolTable, 
+                ReferenceUtil.getReference(symbolTable,
                         "{  {  Yard table [ {  Turnout table  [ Yellow turnout ]  }  ,  {Other yard table[  Turnouts , Green yard  ]}]}}"));
         Assert.assertEquals("Reference is correct",
                 "Blue turnout",
-                ReferenceUtil.getReference(symbolTable, 
+                ReferenceUtil.getReference(symbolTable,
                         "{  {  Yard table [ {  Turnout table  [ Yellow turnout ]  }  ,  {  Other yard table  [  Turnouts , Green yard  ]}]}}"));
-        
+
         Assert.assertEquals("Reference is correct",
                 "Blue turnout",
-                ReferenceUtil.getReference(symbolTable, 
+                ReferenceUtil.getReference(symbolTable,
                         "{  {  Yard table [ {  Turnout table  [ Yellow turnout ]  }  ,  {  Other yard table  [  Turnouts , Green yard  ]}]}}"));
         Assert.assertEquals("Reference is correct",
                 "Blue turnout",
-                ReferenceUtil.getReference(symbolTable, 
+                ReferenceUtil.getReference(symbolTable,
                         "{  {  Yard table [ {  Turnout table  [ Yellow turnout ]  }  ,  {  Other yard table  [  Turnouts , Green yard  ]  }  ]  }  }"));
-        
+
     }
-    
+
     @Test
     @SuppressWarnings("ResultOfMethodCallIgnored")  // This method test thrown exceptions
     public void testExceptions() {
-        
+
         SymbolTable symbolTable = new DefaultSymbolTable(new DefaultConditionalNG("IQC1", null));
-        
+
         // Test exceptions
         expectException(() -> {
             ReferenceUtil.getReference(symbolTable, "abc");
         }, IllegalArgumentException.class, "Reference 'abc' is not a valid reference");
-        
+
         // Test exceptions
         expectException(() -> {
             ReferenceUtil.getReference(symbolTable, "{}");
         }, IllegalArgumentException.class, "Reference '{}' is not a valid reference");
-        
+
         expectException(() -> {
             ReferenceUtil.getReference(symbolTable, "{IM999}");
         }, IllegalArgumentException.class, "Memory 'IM999' is not found");
-        
+
         Memory m999 = _memoryManager.newMemory("IM999", "Memory 999");
         expectException(() -> {
             ReferenceUtil.getReference(symbolTable, "{IM999}");
         }, IllegalArgumentException.class, "Memory 'IM999' has no value");
-        
+
         m999.setValue("Turnout 1");
         Assert.assertEquals("Reference is correct",
                 "Turnout 1",
                 ReferenceUtil.getReference(symbolTable, "{IM999}"));
     }
-    
+
     @Test
     @SuppressWarnings("ResultOfMethodCallIgnored")  // This method test thrown exceptions
     public void testExceptions2() {
-        
+
         ReferenceUtil.IntRef endRef = new ReferenceUtil.IntRef();
-        
+
         SymbolTable symbolTable = new DefaultSymbolTable(new DefaultConditionalNG("IQC1", null));
-        
+
         // Test exceptions
         expectException(() -> {
             ReferenceUtil.getValue("", 0, endRef);
         }, IllegalArgumentException.class, "Reference '' is not a valid reference");
-        
+
         // Test exceptions
         expectException(() -> {
             ReferenceUtil.getReference(symbolTable, "abc", 0, endRef);
         }, IllegalArgumentException.class, "Reference 'abc' is not a valid reference");
-        
+
         // Test exceptions
         expectException(() -> {
             ReferenceUtil.getReference(symbolTable, "{aaa", 0, endRef);
         }, IllegalArgumentException.class, "Reference '{aaa' is not a valid reference");
-        
+
         // Test exceptions
         expectException(() -> {
             ReferenceUtil.getReference(symbolTable, "{abc[1]1", 0, endRef);
         }, IllegalArgumentException.class, "Reference '{abc[1]1' is not a valid reference");
-        
+
         // Test exceptions
         expectException(() -> {
             ReferenceUtil.getReference(symbolTable, "{Some other table[1]}", 0, endRef);
         }, IllegalArgumentException.class, "Table 'Some other table' is not found");
-        
+
         // Test exceptions
         expectException(() -> {
             ReferenceUtil.getReference(symbolTable, "{Some other table[1,2]}", 0, endRef);
         }, IllegalArgumentException.class, "Table 'Some other table' is not found");
     }
-    
+
     @Test
     @SuppressWarnings("ResultOfMethodCallIgnored")  // This method test thrown exceptions
     public void testSpecialCharacters() {
-        
+
         Memory m91 = _memoryManager.newMemory("IM91", "Memory , abc");
         m91.setValue("Turnout 91");
         Memory m92 = _memoryManager.newMemory("IM92", "Memory [ abc");
@@ -329,9 +329,9 @@ public class ReferenceUtilTest {
         m96.setValue("Turnout 96");
         Memory m97 = _memoryManager.newMemory("IM97", "Memory ");
         m97.setValue("Turnout 97");
-        
+
         SymbolTable symbolTable = new DefaultSymbolTable(new DefaultConditionalNG("IQC1", null));
-        
+
         // Test special characters. Special characters must be escaped.
         Assert.assertEquals("Reference is correct",
                 "Turnout 91",
@@ -339,28 +339,28 @@ public class ReferenceUtilTest {
         expectException(() -> {
             ReferenceUtil.getReference(symbolTable, "{Memory , abc}");
         }, IllegalArgumentException.class, "Reference '{Memory , abc}' is not a valid reference");
-        
+
         Assert.assertEquals("Reference is correct",
                 "Turnout 92",
                 ReferenceUtil.getReference(symbolTable, "{Memory \\[ abc}"));
         expectException(() -> {
             ReferenceUtil.getReference(symbolTable, "{Memory [ abc}");
         }, IllegalArgumentException.class, "Reference '{Memory [ abc}' is not a valid reference");
-        
+
         Assert.assertEquals("Reference is correct",
                 "Turnout 93",
                 ReferenceUtil.getReference(symbolTable, "{Memory \\] abc}"));
         expectException(() -> {
             ReferenceUtil.getReference(symbolTable, "{Memory ] abc}");
         }, IllegalArgumentException.class, "Reference '{Memory ] abc}' is not a valid reference");
-        
+
         Assert.assertEquals("Reference is correct",
                 "Turnout 94",
                 ReferenceUtil.getReference(symbolTable, "{Memory \\{ abc}"));
         expectException(() -> {
             ReferenceUtil.getReference(symbolTable, "{Memory { abc}");
         }, IllegalArgumentException.class, "Reference '{Memory { abc}' is not a valid reference");
-        
+
         // This will try to find the "Memory ", which exists.
         Assert.assertEquals("Reference is correct",
                 "Turnout 95",
@@ -368,7 +368,7 @@ public class ReferenceUtilTest {
         expectException(() -> {
             ReferenceUtil.getReference(symbolTable, "{Memory } abc}");
         }, IllegalArgumentException.class, "Reference '{Memory } abc}' is not a valid reference");
-        
+
         Assert.assertEquals("Reference is correct",
                 "Turnout 96",
                 ReferenceUtil.getReference(symbolTable, "{Memory \\\\ abc}"));
@@ -377,7 +377,7 @@ public class ReferenceUtilTest {
             ReferenceUtil.getReference(symbolTable, "{Memory \\ abc}");
         }, IllegalArgumentException.class, "Memory 'Memory  abc' is not found");
     }
-    
+
     private void setupTables()
         throws IOException
     {
@@ -385,7 +385,7 @@ public class ReferenceUtilTest {
         // when pressing the <Tab> key, which may be a problem when editing the
         // CSV table data below, since the separator between columns must be a
         // tab character.
-        
+
         String yardTableData =
                 "\tNorth yard\tEast yard\tSouth yard\tWest yard" + _nl +
                 "Leftmost turnout\tIT101\tIT201\tIT301\tIT401" + _nl +
@@ -393,25 +393,25 @@ public class ReferenceUtilTest {
                 "Right turnout\tIT104\tMemory 333\tIT304\tIT404" + _nl +
                 "Rightmost turnout\tTurnout 222\tIM15\tIT302\tIT402" + _nl +
                 "Other turnout\tIT1\tIT2\tIT3\tIT4" + _nl;
-        
+
         String turnoutTableData =
                 "\tColumn" + _nl +
                 "Green turnout\tIT101" + _nl +
                 "Red turnout\tTurnout" + _nl +
                 "Yellow turnout\tRight turnout" + _nl +
                 "Blue turnout\tTurnout 222" + _nl;
-        
+
         String otherYardTableData =
                 "\tYellow yard\tGreen yard\tBlue yard\tRed yard" + _nl +
                 "Turnouts\tWest yard\tEast yard\tIT301\tIT401" + _nl +
                 "Sensors\tTurnout 111\tIT203\tIT303\tIT403" + _nl +
                 "Lights\tIT104\tIT204\tIT304\tIT404" + _nl;
-        
+
         yardTable = _tableManager.loadTableFromCSVData("IQT1", "Yard table", yardTableData);
         _tableManager.loadTableFromCSVData("IQT2", "Turnout table", turnoutTableData);
         _tableManager.loadTableFromCSVData("IQT3", "Other yard table", otherYardTableData);
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() throws IOException {
@@ -422,7 +422,7 @@ public class ReferenceUtilTest {
         JUnitUtil.initInternalSensorManager();
         JUnitUtil.initInternalTurnoutManager();
         JUnitUtil.initLogixNGManager();
-        
+
         _memoryManager = InstanceManager.getDefault(MemoryManager.class);
         _tableManager = InstanceManager.getDefault(NamedTableManager.class);
         setupTables();
@@ -431,8 +431,9 @@ public class ReferenceUtilTest {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
-    
+
     private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ReferenceUtilTest.class);
 }

--- a/java/test/jmri/jmrit/logixng/util/parser/functions/ClockFunctionsTest.java
+++ b/java/test/jmri/jmrit/logixng/util/parser/functions/ClockFunctionsTest.java
@@ -100,6 +100,7 @@ public class ClockFunctionsTest {
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 


### PR DESCRIPTION
Due to a change in #11913, most LogixNG tests accesses the BlockManager and therefore a BlockManagerShutdownTask is created. This PR deregisters that shutdown task. This reduces the output to the log.

This PR only changes the tests so it doesn't matter if it's merged before or after the next test release.