### PR TITLE
Update of the Lenz_Plus_2010.xml decoders definition, adding the Plux22 model (8 outputs) to the existing list

### DIFF
--- a/xml/decoders/Lenz_Plus_2010.xml
+++ b/xml/decoders/Lenz_Plus_2010.xml
@@ -12,6 +12,7 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
+  <version author="Alain Carasso (Alain355) acarasso_fr@yahoo.fr" version="5.2" lastUpdated="20230410"/>
   <version author="Alain Carasso (Alain355) acarasso_fr@yahoo.fr" version="5.1" lastUpdated="20160429"/>
   <version author="Alain Carasso (Alain355) acarasso_fr@yahoo.fr" version="5" lastUpdated="20160414"/>
   <version author="Bernd Wisotzki (Ba), wsb56" version="4" lastUpdated="20140730"/>
@@ -57,6 +58,10 @@ Silver direct+ Silent-Back EMF DCC Decoder
 	1) Added the Lenz standard plus V2 decoder (RailCom, 4 outputs with F1(f) and F1(r))
 	2) Added versionID check for those Plus Serie decoder when known
 
+Comments for version 5.2
+
+	I added the Lenz Silver Plus Plux22 decoder (8 outputs like the Gold Maxi 10440)
+	
 	-->
   <!--
 nmraWarrant="yes" nmraWarrantStart="200604"
@@ -109,6 +114,17 @@ nmraWarrant="yes" nmraWarrantStart="200604"
     		<output name="3" label="C" maxcurrent="0.5A"/>
     		<output name="4" label="D" maxcurrent="0.5A"/>
     		<output name="5" label="E" maxcurrent="0.5A"/>
+    	</model>
+     	<model model="Silver+ PluX22 10322-01" numOuts="8" numFns="31" maxMotorCurrent="0.75A" formFactor="TT" maxTotalCurrent="0.75A">
+      		<versionCV highVersionID="97" lowVersionID="97"/>
+    		<output name="1" label="A" maxcurrent="0.5A"/>
+    		<output name="2" label="B" maxcurrent="0.5A"/>
+    		<output name="3" label="C" maxcurrent="0.5A"/>
+    		<output name="4" label="D" maxcurrent="0.5A"/>
+    		<output name="5" label="E" maxcurrent="0.5A"/>
+    		<output name="6" label="F" maxcurrent="0.5A"/>
+    		<output name="7" label="G" maxcurrent="0.5A"/>
+    		<output name="8" label="H" maxcurrent="0.5A"/>
     	</model>
     	<model model="Silver+ Next18 10312-01" numOuts="5" numFns="31" maxMotorCurrent="0.75A" formFactor="TT" maxTotalCurrent="0.75A" comment="New in 2014">
     		<versionCV highVersionID="94" lowVersionID="94"/>


### PR DESCRIPTION
I updated the existing Lenz Plus decoders list, adding the 8 outputs Plux22 10322-01 decoder (8 outputs instead of 5 on the Plux12 model). Tested OK using JMRI latest test version 5.3.5

Thanks to merge once checked OK.

Alain