### PR TITLE
Update LogixNG help

### DIFF
--- a/help/en/html/tools/logixng/reference/chapter5.shtml
+++ b/help/en/html/tools/logixng/reference/chapter5.shtml
@@ -1679,7 +1679,8 @@
         <dt>LogixNG_WebRequest_Test.php</dt>
         <dd>
           <p>This is a <strong>PHP</strong> program that acts as a web based application.  This needs
-          to be installed in a web server that has been configured to run PHP programs.</p>
+          to be installed in a web server that has been configured to run PHP programs. The source code
+          can be downloaded from <a href="https://github.com/JMRI/JMRI/blob/master/help/en/html/tools/logixng/reference/WebRequestExample/LogixNG_WebRequest_Test.php">GitHub</a>.</p>
         </dd>
       </dl>
 

--- a/help/en/html/tools/logixng/reference/chapter5.shtml
+++ b/help/en/html/tools/logixng/reference/chapter5.shtml
@@ -1667,8 +1667,8 @@
 
       <h5>Examples</h5>
 
-      <p>There are two example files included in the JMRI distribution.  They are located at
-      help/en/html/tools/logixng/reference/WebRequestExample</p>
+      <p>There are two example files included in the JMRI distribution. They are located at
+      <a href="https://www.jmri.org/help/en/html/tools/logixng/reference/WebRequestExample/">help/en/html/tools/logixng/reference/WebRequestExample</a></p>
 
       <dl>
         <dt>WebRequest.xml</dt>


### PR DESCRIPTION
@dsand47 
This PR makes the reference to `help/en/html/tools/logixng/reference/WebRequestExample` as a clickable link so that people can easily access it directly from the web page.