### PR TITLE
IdTag Table Update

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -579,7 +579,7 @@
     <h3>Turnouts, Lights, Sensors and other elements</h3>
         <a id="TLae" name="TLae"></a>
         <ul>
-            <li></li>
+            <li>ID Tag Tables - Speed improvements when working with large numbers of Tags.</li>
         </ul>
 
    <h3>Warrants</h3>

--- a/java/src/jmri/implementation/DefaultIdTag.java
+++ b/java/src/jmri/implementation/DefaultIdTag.java
@@ -46,6 +46,9 @@ public class DefaultIdTag extends AbstractIdTag {
         setWhereLastSeen(null);
     }
 
+    public final static String PROPERTY_WHEN_LAST_SEEN = "whenLastSeen";
+    public final static String PROPERTY_WHERE_LAST_SEEN = "whereLastSeen";
+
     @Override
     public int compareTo(NamedBean n2) {
         Objects.requireNonNull(n2);
@@ -71,8 +74,8 @@ public class DefaultIdTag extends AbstractIdTag {
             this.whenLastSeen = null;
         }
         setCurrentState(r != null ? SEEN : UNSEEN);
-        firePropertyChange("whereLastSeen", oldWhere, this.whereLastSeen); // NOI18N
-        firePropertyChange("whenLastSeen", oldWhen, this.whenLastSeen);    // NOI18N
+        firePropertyChange(PROPERTY_WHERE_LAST_SEEN, oldWhere, this.whereLastSeen);
+        firePropertyChange(PROPERTY_WHEN_LAST_SEEN, oldWhen, this.whenLastSeen);
     }
 
     private Date getDateNow() {
@@ -113,10 +116,10 @@ public class DefaultIdTag extends AbstractIdTag {
         }
         Reporter whereLast = this.getWhereLastSeen();
         if (whereLast != null && storeState) {
-            e.addContent(new Element("whereLastSeen").addContent(whereLast.getSystemName())); // NOI18N
+            e.addContent(new Element(PROPERTY_WHERE_LAST_SEEN).addContent(whereLast.getSystemName()));
         }
         if (this.getWhenLastSeen() != null && storeState) {
-            e.addContent(new Element("whenLastSeen").addContent(new StdDateFormat().format(this.getWhenLastSeen())));
+            e.addContent(new Element(PROPERTY_WHEN_LAST_SEEN).addContent(new StdDateFormat().format(this.getWhenLastSeen())));
         }
         return e;
     }
@@ -140,18 +143,18 @@ public class DefaultIdTag extends AbstractIdTag {
             if (e.getChild("comment") != null) { // NOI18N
                 this.setComment(e.getChild("comment").getText()); // NOI18N
             }
-            if (e.getChild("whereLastSeen") != null) { // NOI18N
+            if (e.getChild(PROPERTY_WHERE_LAST_SEEN) != null) {
                 try {
                     Reporter r = InstanceManager.getDefault(ReporterManager.class)
-                                    .provideReporter(e.getChild("whereLastSeen").getText()); // NOI18N
+                                    .provideReporter(e.getChild(PROPERTY_WHERE_LAST_SEEN).getText());
                     this.setWhereLastSeen(r);
                     this.whenLastSeen = null;
                 } catch (IllegalArgumentException ex) {
-                    log.warn("Failed to provide Reporter \"{}\" in load of \"{}\"", e.getChild("whereLastSeen").getText(), getDisplayName());
+                    log.warn("Failed to provide Reporter \"{}\" in load of \"{}\"", e.getChild(PROPERTY_WHERE_LAST_SEEN).getText(), getDisplayName());
                 }
             }
-            if (e.getChild("whenLastSeen") != null) { // NOI18N
-                String lastSeenText = e.getChildText("whenLastSeen");
+            if (e.getChild(PROPERTY_WHEN_LAST_SEEN) != null) {
+                String lastSeenText = e.getChildText(PROPERTY_WHEN_LAST_SEEN);
                 log.debug("Loading {} When Last Seen: {}", getDisplayName(), lastSeenText);
                 try { // parse using ISO 8601 date format
                     this.whenLastSeen = new StdDateFormat().parse(lastSeenText);

--- a/java/src/jmri/jmrit/beantable/BeanTableDataModel.java
+++ b/java/src/jmri/jmrit/beantable/BeanTableDataModel.java
@@ -1490,14 +1490,14 @@ abstract public class BeanTableDataModel<T extends NamedBean> extends AbstractTa
 
     static class DateRenderer extends DefaultTableCellRenderer {
 
-        private static final DateFormat DATE_FORMAT = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.MEDIUM);
+        private final DateFormat dateFormat = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.MEDIUM);
 
         @Override
         public Component getTableCellRendererComponent( JTable table, Object value,
             boolean isSelected, boolean hasFocus, int row, int column) {
             JLabel c = (JLabel) super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
             if ( value instanceof Date) {
-                c.setText(DATE_FORMAT.format(value));
+                c.setText(dateFormat.format(value));
             }
             return c;
         }

--- a/java/src/jmri/jmrit/beantable/BeanTableDataModel.java
+++ b/java/src/jmri/jmrit/beantable/BeanTableDataModel.java
@@ -1489,12 +1489,15 @@ abstract public class BeanTableDataModel<T extends NamedBean> extends AbstractTa
     }
 
     static class DateRenderer extends DefaultTableCellRenderer {
+
+        private static final DateFormat DATE_FORMAT = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.MEDIUM);
+
         @Override
         public Component getTableCellRendererComponent( JTable table, Object value,
             boolean isSelected, boolean hasFocus, int row, int column) {
             JLabel c = (JLabel) super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
             if ( value instanceof Date) {
-                c.setText(DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.MEDIUM).format(value));
+                c.setText(DATE_FORMAT.format(value));
             }
             return c;
         }

--- a/java/src/jmri/jmrit/beantable/BeanTableDataModel.java
+++ b/java/src/jmri/jmrit/beantable/BeanTableDataModel.java
@@ -10,8 +10,10 @@ import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyVetoException;
 import java.io.IOException;
+import java.text.DateFormat;
 import java.text.MessageFormat;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.Enumeration;
 import java.util.EventObject;
 import java.util.List;
@@ -486,6 +488,7 @@ abstract public class BeanTableDataModel<T extends NamedBean> extends AbstractTa
         table.setDefaultRenderer(JComboBox.class, new BtValueRenderer());
         table.setDefaultEditor(JComboBox.class, new BtComboboxEditor());
         table.setDefaultRenderer(Boolean.class, new EnablingCheckboxRenderer());
+        table.setDefaultRenderer(Date.class, new DateRenderer());
 
         // allow reordering of the columns
         table.getTableHeader().setReorderingAllowed(true);
@@ -1483,6 +1486,18 @@ abstract public class BeanTableDataModel<T extends NamedBean> extends AbstractTa
      */
     public Predicate<? super T> getFilter() {
         return filter;
+    }
+
+    static class DateRenderer extends DefaultTableCellRenderer {
+        @Override
+        public Component getTableCellRendererComponent( JTable table, Object value,
+            boolean isSelected, boolean hasFocus, int row, int column) {
+            JLabel c = (JLabel) super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
+            if ( value instanceof Date) {
+                c.setText(DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.MEDIUM).format(value));
+            }
+            return c;
+        }
     }
 
     private final static Logger log = LoggerFactory.getLogger(BeanTableDataModel.class);

--- a/java/src/jmri/jmrit/beantable/IdTagTableDataModel.java
+++ b/java/src/jmri/jmrit/beantable/IdTagTableDataModel.java
@@ -1,9 +1,11 @@
 package jmri.jmrit.beantable;
 
-import java.text.DateFormat;
+import java.beans.PropertyChangeEvent;
 import java.util.Date;
+import java.util.stream.Stream;
 
 import jmri.*;
+import jmri.implementation.DefaultIdTag;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -112,10 +114,11 @@ public class IdTagTableDataModel extends BeanTableDataModel<IdTag> {
         switch (col) {
             case VALUECOL:
             case WHERECOL:
-            case WHENCOL:
                 return String.class;
             case CLEARCOL:
                 return JButton.class;
+            case WHENCOL:
+                return Date.class;
             default:
                 return super.getColumnClass(col);
         }
@@ -150,10 +153,8 @@ public class IdTagTableDataModel extends BeanTableDataModel<IdTag> {
                 }
                 return null;
             case WHENCOL:
-                Date d;
                 t = getBySystemName(sysNameList.get(row));
-                return (t != null) ? (((d = t.getWhenLastSeen()) != null)
-                        ? DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.MEDIUM).format(d) : null) : null;
+                return (t != null ?  t.getWhenLastSeen() : null);
             case CLEARCOL:
                 return Bundle.getMessage("ButtonClear");
             default:
@@ -183,9 +184,39 @@ public class IdTagTableDataModel extends BeanTableDataModel<IdTag> {
     }
 
     @Override
+    public void propertyChange(PropertyChangeEvent e) {
+        if (!(((IdTagManager)getManager()).isInitialised())) {
+            return;
+        }
+        switch (e.getPropertyName()) {
+            case DefaultIdTag.PROPERTY_WHEN_LAST_SEEN: // fire whole table update to ensure sorted view is updated
+                fireTableDataChanged();
+                break;
+            case jmri.managers.DefaultIdTagManager.PROPERTY_INITIALISED: // fire whole table update
+                updateNameList();
+                fireTableDataChanged();
+                break;
+            default:
+                super.propertyChange(e);
+                break;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     * Do not update row on whereLastSeen as these are always followed
+     * by a whenLastSeen where we'll do a full data changed.
+     */
+    @Override
     protected boolean matchPropertyName(java.beans.PropertyChangeEvent e) {
-        return true;
-        // return (e.getPropertyName().indexOf("alue")>=0);
+        // log.debug("IdTag / Mgr matchPropertyName {} {}", e.getPropertyName(), e.getNewValue());
+        switch (e.getPropertyName()) {
+            case DefaultIdTag.PROPERTY_WHERE_LAST_SEEN:
+            case "beans":
+                return false;
+            default:
+                return true;
+        }
     }
 
     @Override
@@ -198,7 +229,14 @@ public class IdTagTableDataModel extends BeanTableDataModel<IdTag> {
     protected String getMasterClassName() {
         return IdTagTableAction.class.getName();
     }
-    
+
+    // TODO - further investigate why the TableRowSorter does not update on this
+    // @Override
+    // public void configureTable(JTable table) {
+       // super.configureTable(table);
+       // ((javax.swing.table.TableRowSorter)table.getRowSorter()).setSortsOnUpdates(true);
+    // }
+
     private static final Logger log = LoggerFactory.getLogger(IdTagTableDataModel.class);
 
 }

--- a/java/src/jmri/managers/DefaultIdTagManager.java
+++ b/java/src/jmri/managers/DefaultIdTagManager.java
@@ -32,6 +32,8 @@ public class DefaultIdTagManager extends AbstractManager<IdTag> implements IdTag
     private boolean useFastClock = false;
     private Runnable shutDownTask = null;
 
+    public final static String PROPERTY_INITIALISED = "initialised";
+
     public DefaultIdTagManager(SystemConnectionMemo memo) {
         super(memo);
     }
@@ -61,6 +63,7 @@ public class DefaultIdTagManager extends AbstractManager<IdTag> implements IdTag
             dirty = false;
             initShutdownTask();
             initialised = true;
+            propertyChangeSupport.firePropertyChange("PROPERTY_INITLIASED", false, true);
         }
     }
 

--- a/java/src/jmri/managers/DefaultIdTagManager.java
+++ b/java/src/jmri/managers/DefaultIdTagManager.java
@@ -63,7 +63,7 @@ public class DefaultIdTagManager extends AbstractManager<IdTag> implements IdTag
             dirty = false;
             initShutdownTask();
             initialised = true;
-            propertyChangeSupport.firePropertyChange("PROPERTY_INITLIASED", false, true);
+            propertyChangeSupport.firePropertyChange(PROPERTY_INITIALISED, false, true);
         }
     }
 

--- a/java/src/jmri/managers/ProxyIdTagManager.java
+++ b/java/src/jmri/managers/ProxyIdTagManager.java
@@ -41,10 +41,14 @@ public class ProxyIdTagManager extends AbstractProvidingProxyManager<IdTag>
         }
     }
 
+    /**
+     * {@inheritDoc}
+     * @return true if All IdTagManagers have initialised.
+     */
     @Override
     public boolean isInitialised() {
         return defaultManager!= null &&
-                getManagerList().stream().noneMatch(o->((IdTagManager)o).isInitialised());
+                getManagerList().stream().allMatch(o->((IdTagManager)o).isInitialised());
     }
 
     /**


### PR DESCRIPTION
This PR resolves some speed issues when there are large numbers of ID Tags.

Benchmarked with approx 15,500 tags,
CAN Frame process time for New ID Tag added via CBUS Reporter when ID Tag Table sorted by When Last Seen 1200ms >  175ms.
Load time When opening up the Tables before loading a panel file 310,000ms > 2,400ms.

IdTagTableDataModel -
return Date object for Last Seen column
only update table view when manager initialised
fire full Table Data Changed on IdTag When last seen as view was not always updating on this column sort.

ProxyIdTagManager- Correct reporting of actual IdTagManager(s) isInitialised()

DefaultIdTagManager- fire property change when initialised
DefaultIdTag- some property change Strings to constants
BeanTableDataModel- set a default Renderer for Date columns