### PR TITLE
Changes to allow Roster System to be Used for CBUS NV Programming

### DIFF
--- a/java/src/jmri/jmrix/can/cbus/node/CbusBasicNodeTable.java
+++ b/java/src/jmri/jmrix/can/cbus/node/CbusBasicNodeTable.java
@@ -207,12 +207,23 @@ public class CbusBasicNodeTable extends javax.swing.table.AbstractTableModel {
                 // Try to load a local xml file
                 String title = _mainArray.get(row).getName() + " (CBUS)";
                 DecoderFile decoderFile = InstanceManager.getDefault(DecoderIndexFile.class).fileFromTitle(title);
+                String userName = _mainArray.get(row).getUserName();
+                String nodeNumber = "CBUS_Node_" + Integer.toString(_mainArray.get(row).getNodeNumber());
+                if (!userName.equals("")) {
+                    nodeNumber = nodeNumber.concat("_" + userName);
+                }
                 if ((decoderFile != null) && (progMan != null)) {
                     log.debug("decoder file: {}", decoderFile.getFileName()); // NOI18N
-                    RosterEntry re = new RosterEntry();
+                    RosterEntry blank = new RosterEntry();
+                    RosterEntry roster = new RosterEntry(blank, nodeNumber);
+                    roster.setDecoderFamily("CBUS");
+                    roster.setMfg(decoderFile.getMfg());
+                    roster.setDecoderModel(decoderFile.getModel());
+                    roster.setRoadNumber(Integer.toString(_mainArray.get(row).getNodeNumber()));
+                    roster.setRoadName(userName);
                     String progTitle = "CBUS NV Programmer";
                     String progFile = "programmers" + File.separator + "Cbus" + ".xml";
-                    JFrame p = new PaneServiceProgFrame(decoderFile, re, progTitle, progFile, progMan.getGlobalProgrammer());
+                    JFrame p = new PaneServiceProgFrame(decoderFile, roster, progTitle, progFile, progMan.getGlobalProgrammer());
                     p.pack();
                     p.setVisible(true);
                 } else {

--- a/java/src/jmri/jmrix/can/cbus/node/CbusBasicNodeTable.java
+++ b/java/src/jmri/jmrix/can/cbus/node/CbusBasicNodeTable.java
@@ -11,6 +11,7 @@ import jmri.InstanceManager;
 import jmri.jmrit.decoderdefn.DecoderFile;
 import jmri.jmrit.decoderdefn.DecoderIndexFile;
 import jmri.jmrit.roster.RosterEntry;
+import jmri.jmrit.roster.Roster;
 import jmri.jmrit.symbolicprog.tabbedframe.PaneServiceProgFrame;
 import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.jmrix.can.cbus.*;
@@ -214,16 +215,20 @@ public class CbusBasicNodeTable extends javax.swing.table.AbstractTableModel {
                 }
                 if ((decoderFile != null) && (progMan != null)) {
                     log.debug("decoder file: {}", decoderFile.getFileName()); // NOI18N
-                    RosterEntry blank = new RosterEntry();
-                    RosterEntry roster = new RosterEntry(blank, nodeNumber);
-                    roster.setDecoderFamily("CBUS");
-                    roster.setMfg(decoderFile.getMfg());
-                    roster.setDecoderModel(decoderFile.getModel());
-                    roster.setRoadNumber(Integer.toString(_mainArray.get(row).getNodeNumber()));
-                    roster.setRoadName(userName);
+                    // Look for an existing roster entry
+                    RosterEntry re = Roster.getDefault().getEntryForId(nodeNumber);
+                    if (re == null) {
+                        // Or create one
+                        re = new RosterEntry(new RosterEntry(), nodeNumber);
+                        re.setDecoderFamily("CBUS");
+                        re.setMfg(decoderFile.getMfg());
+                        re.setDecoderModel(decoderFile.getModel());
+                        re.setRoadNumber(Integer.toString(_mainArray.get(row).getNodeNumber()));
+                        re.setRoadName(userName);
+                    }
                     String progTitle = "CBUS NV Programmer";
                     String progFile = "programmers" + File.separator + "Cbus" + ".xml";
-                    JFrame p = new PaneServiceProgFrame(decoderFile, roster, progTitle, progFile, progMan.getGlobalProgrammer());
+                    JFrame p = new PaneServiceProgFrame(decoderFile, re, progTitle, progFile, progMan.getGlobalProgrammer());
                     p.pack();
                     p.setVisible(true);
                 } else {

--- a/xml/programmers/Cbus.xml
+++ b/xml/programmers/Cbus.xml
@@ -14,7 +14,7 @@
   <version author="Bob Jacobsen" version="1" lastUpdated="20020808"/>
   <!-- Programmer for wierd types that have all their info -->
   <!-- in the decoder files as panes -->
-  <programmer decoderFilePanes="yes" showRosterPane="no" showEmptyPanes="no" showFnLanelPane="no" showRosterMediaPane="no">
+  <programmer decoderFilePanes="yes" showRosterPane="yes" showEmptyPanes="no" showFnLanelPane="no" showRosterMediaPane="no">
     <!-- everything comes from the Roster and built in panes -->
   </programmer>
 </programmer-config>


### PR DESCRIPTION
ENable the roster pane in the Cbus programmer and create a new roster entry based on node number and username.