### PR TITLE
Add "where used" tooltips to CV pane

### DIFF
--- a/help/en/Acknowledgements.shtml
+++ b/help/en/Acknowledgements.shtml
@@ -414,6 +414,9 @@
          who fixed the XML definition of the block contents icon, and helped fix the Transit
         implementation of comments.</li>
 
+        <li>Ulrich Gerlach</li> <!-- uli-2016 -->
+        who improved multiple decoder definitions.
+
         <li>Brian Gilhuly, who helped debug a programmer problem in JMRI 3.11.1</li>
 
         <li>Simon Ginsburg has helped with advanced consisting, provided some Digitrax definition

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -381,7 +381,8 @@
     <h3>DecoderPro</h3>
         <a id="DecoderPro" name="DecoderPro"></a>
         <ul>
-            <li></li>
+            <li>Added tooltips to the CV Pane that will show a brief summary of where the CV is
+                being used.</li>
         </ul>
 
     <h3>CTC Tool</h3>

--- a/java/src/jmri/jmrit/symbolicprog/CvTableModel.java
+++ b/java/src/jmri/jmrit/symbolicprog/CvTableModel.java
@@ -4,8 +4,11 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.Set;
 import java.util.Vector;
+
 import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JTextField;
@@ -353,6 +356,27 @@ public class CvTableModel extends javax.swing.table.AbstractTableModel implement
         return false;
     }
 
+    /**
+     * Register a VariableValue in a common store mapping CV numbers to
+     * variable names. This is for use by e.g. a CVTable to show tooltips
+     * efficiently.
+     * @param cv specific CV number that the variable references
+     * @param variableName from the variable being defined
+     */
+    public void registerCvToVariableMapping(String cv, String variableName) {
+        // is there already a Set for these?
+        if ( ! cvToVarMap.containsKey(cv)) {
+            // no, create one
+            cvToVarMap.put(cv, Collections.newSetFromMap(new HashMap<String, Boolean>()));
+        }
+        // add the String
+        cvToVarMap.get(cv).add(variableName);
+    }
+
+    public Set<String> getCvToVariableMapping(String cv) { return cvToVarMap.get(cv); }
+
+    private HashMap<String, Set<String>> cvToVarMap = new HashMap<>();
+
     public void dispose() {
         if (log.isDebugEnabled()) {
             log.debug("dispose");
@@ -375,6 +399,8 @@ public class CvTableModel extends javax.swing.table.AbstractTableModel implement
         }
 
         // null references, so that they can be gc'd even if this isn't.
+        cvToVarMap = null;
+
         _cvDisplayVector.removeAllElements();
         _cvDisplayVector = null;
 

--- a/java/src/jmri/jmrit/symbolicprog/CvValueRenderer.java
+++ b/java/src/jmri/jmrit/symbolicprog/CvValueRenderer.java
@@ -1,0 +1,56 @@
+package jmri.jmrit.symbolicprog;
+
+import java.awt.Component;
+import javax.swing.JComponent;
+import javax.swing.JLabel;
+import javax.swing.JTable;
+import javax.swing.table.TableCellRenderer;
+
+/**
+ * Specialization of ValueRenderer to add CV-usage tooltips and handle Integer values
+ *
+ * @author Bob Jacobsen Copyright (C) 2023
+ */
+public class CvValueRenderer extends ValueRenderer {
+
+    public CvValueRenderer() {
+        super();
+    }
+
+    @Override
+    public Component getTableCellRendererComponent(JTable table, Object value,
+            boolean isSelected, boolean hasFocus,
+            int row, int column) {
+        // if (log.isDebugEnabled()) log.debug("getTableCellRendererComponent "
+        //       +" "+row+" "+column
+        //       +" "+isSelected+" "+hasFocus
+        //       +" "+value);
+
+        JComponent retval;
+
+        if (value instanceof Integer) {
+            retval = new JLabel(value.toString());
+        } else {
+            retval = (JComponent) super.getTableCellRendererComponent(table, value,
+                                                                      isSelected, hasFocus,
+                                                                      row, column);
+        }
+
+        // get the CV number
+        var model = (CvTableModel)table.getModel();
+        int modelRow = table.convertRowIndexToModel(row);
+        var cvNum = model.getValueAt(modelRow, CvTableModel.NUMCOLUMN).toString();
+        var nameSet = model.getCvToVariableMapping(cvNum);
+        if (nameSet != null ) {
+            var building = new StringBuilder();
+            boolean first = true;
+            for(String item : nameSet){
+                if (! first) building.append("; ");
+                first = false;
+                building.append(item);
+            }
+            retval.setToolTipText(building.toString());
+        }
+        return retval;
+    }
+}

--- a/java/src/jmri/jmrit/symbolicprog/VariableTableModel.java
+++ b/java/src/jmri/jmrit/symbolicprog/VariableTableModel.java
@@ -519,6 +519,7 @@ public class VariableTableModel extends AbstractTableModel implements ActionList
         }
         v = new DecVariableValue(name, comment, "", readOnly, infoOnly, writeOnly, opsOnly,
                 CV, mask, minVal, maxVal, _cvModel.allCvMap(), _status, item, offset, factor);
+        _cvModel.registerCvToVariableMapping(CV, name);
         return v;
     }
 
@@ -547,6 +548,7 @@ public class VariableTableModel extends AbstractTableModel implements ActionList
         EnumVariableValue v1 = new EnumVariableValue(name, comment, "", readOnly, infoOnly, writeOnly, opsOnly,
                 CV, mask, 0, maxVal, _cvModel.allCvMap(), _status, item);
         v = v1; // v1 is of EnumVariableValue type, so doesn't need casts
+        _cvModel.registerCvToVariableMapping(CV, name);
 
         v1.nItems(count);
         handleEnumValChildren(child, v1);
@@ -575,6 +577,7 @@ public class VariableTableModel extends AbstractTableModel implements ActionList
         if ((a = child.getAttribute("highCV")) != null) {
             highCV = a.getValue();
             _cvModel.addCV("" + (highCV), readOnly, infoOnly, writeOnly); // ensure 2nd CV exists
+            _cvModel.registerCvToVariableMapping(highCV, name);
         }
         int factor = 1;
         if ((a = child.getAttribute("factor")) != null) {
@@ -599,6 +602,7 @@ public class VariableTableModel extends AbstractTableModel implements ActionList
 
         SplitEnumVariableValue v1 = new SplitEnumVariableValue(name, comment, "", readOnly, infoOnly, writeOnly, opsOnly, CV, mask, minVal, maxVal, _cvModel.allCvMap(), _status, item, highCV, factor, offset, uppermask, null, null, extra3, extra4);
         v = v1; // v1 is of EnunVariableValue type, so doesn't need casts
+        _cvModel.registerCvToVariableMapping(CV, name);
 
         v1.nItems(count);
 
@@ -688,6 +692,7 @@ public class VariableTableModel extends AbstractTableModel implements ActionList
             log.debug("Created mask {} for Hex CV {}", mask, name);
         }
         v = new HexVariableValue(name, comment, "", readOnly, infoOnly, writeOnly, opsOnly, CV, mask, minVal, maxVal, _cvModel.allCvMap(), _status, item);
+        _cvModel.registerCvToVariableMapping(CV, name);
         return v;
     }
 
@@ -697,6 +702,8 @@ public class VariableTableModel extends AbstractTableModel implements ActionList
         int maxVal = 255;
         _cvModel.addCV("18", readOnly, infoOnly, writeOnly); // ensure 2nd CV exists
         v = new LongAddrVariableValue(name, comment, "", readOnly, infoOnly, writeOnly, opsOnly, CV, mask, minVal, maxVal, _cvModel.allCvMap(), _status, item, _cvModel.allCvMap().get("18"));
+        _cvModel.registerCvToVariableMapping(CV, name);
+        _cvModel.registerCvToVariableMapping("18", name); // see fixed value two lines up
         return v;
     }
 
@@ -709,6 +716,7 @@ public class VariableTableModel extends AbstractTableModel implements ActionList
         for (Element element : l) {
             v1.setModifiedCV(element.getAttribute("cv").getValue());
         }
+        _cvModel.registerCvToVariableMapping(CV, name);
         return v;
     }
 
@@ -742,10 +750,16 @@ public class VariableTableModel extends AbstractTableModel implements ActionList
         // ensure all CVs exist
         for (int i = 0; i < entries; i++) {
             _cvModel.addCV(Integer.toString(Integer.parseInt(CV) + i), readOnly, infoOnly, writeOnly);
+            _cvModel.registerCvToVariableMapping(Integer.toString(Integer.parseInt(CV) + i), name);
+
         }
         if (mfxFlag) {
             _cvModel.addCV("2", readOnly, infoOnly, writeOnly);
+            _cvModel.registerCvToVariableMapping("2", name);
+
             _cvModel.addCV("5", readOnly, infoOnly, writeOnly);
+            _cvModel.registerCvToVariableMapping("5", name);
+
         }
         v = new SpeedTableVarValue(name, comment, "", readOnly, infoOnly, writeOnly, opsOnly, CV, mask, minVal, maxVal, _cvModel.allCvMap(), _status, item, entries, mfxFlag);
         return v;
@@ -761,6 +775,8 @@ public class VariableTableModel extends AbstractTableModel implements ActionList
         if ((a = child.getAttribute("highCV")) != null) {
             highCV = a.getValue();
             _cvModel.addCV("" + (highCV), readOnly, infoOnly, writeOnly); // ensure 2nd CV exists
+            _cvModel.registerCvToVariableMapping("" + (highCV), name);
+
         }
         int factor = 1;
         if ((a = child.getAttribute("factor")) != null) {
@@ -783,6 +799,7 @@ public class VariableTableModel extends AbstractTableModel implements ActionList
             extra4 = a.getValue();
         }
         v = new SplitVariableValue(name, comment, "", readOnly, infoOnly, writeOnly, opsOnly, CV, mask, minVal, maxVal, _cvModel.allCvMap(), _status, item, highCV, factor, offset, uppermask, null, null, extra3, extra4);
+        _cvModel.registerCvToVariableMapping(CV, name);
         return v;
     }
 
@@ -796,6 +813,7 @@ public class VariableTableModel extends AbstractTableModel implements ActionList
         if ((a = child.getAttribute("highCV")) != null) {
             highCV = a.getValue();
             _cvModel.addCV("" + (highCV), readOnly, infoOnly, writeOnly); // ensure 2nd CV exists
+            _cvModel.registerCvToVariableMapping("" + (highCV), name);
         }
         int factor = 1;
         if ((a = child.getAttribute("factor")) != null) {
@@ -822,6 +840,7 @@ public class VariableTableModel extends AbstractTableModel implements ActionList
             extra4 = a.getValue();
         }
         v = new SplitHexVariableValue(name, comment, "", readOnly, infoOnly, writeOnly, opsOnly, CV, mask, minVal, maxVal, _cvModel.allCvMap(), _status, item, highCV, factor, offset, uppermask, extra1, null, extra3, extra4);
+        _cvModel.registerCvToVariableMapping(CV, name);
         return v;
     }
 
@@ -843,6 +862,7 @@ public class VariableTableModel extends AbstractTableModel implements ActionList
         if ((a = child.getAttribute("highCV")) != null) {
             highCV = a.getValue();
             _cvModel.addCV("" + (highCV), readOnly, infoOnly, writeOnly); // ensure 2nd CV exists
+            _cvModel.registerCvToVariableMapping("" + (highCV), name);
         }
         int factor = 1;
         if ((a = child.getAttribute("factor")) != null) {
@@ -886,6 +906,7 @@ public class VariableTableModel extends AbstractTableModel implements ActionList
             log.error(Bundle.getMessage("UnsupportedCharset", charSet, name));
         }
         v = new SplitTextVariableValue(name, comment, "", readOnly, infoOnly, writeOnly, opsOnly, CV, mask, minVal, maxVal, _cvModel.allCvMap(), _status, item, highCV, factor, offset, uppermask, match, termByte, padByte, charSet);
+        _cvModel.registerCvToVariableMapping(CV, name);
         return v;
     }
 
@@ -906,6 +927,7 @@ public class VariableTableModel extends AbstractTableModel implements ActionList
         if ((a = child.getAttribute("highCV")) != null) {
             highCV = a.getValue();
             _cvModel.addCV("" + (highCV), readOnly, infoOnly, writeOnly); // ensure 2nd CV exists
+            _cvModel.registerCvToVariableMapping("" + (highCV), name);
         }
         int factor = 1;
         int offset = 0;
@@ -932,6 +954,7 @@ public class VariableTableModel extends AbstractTableModel implements ActionList
             extra4 = a.getValue();
         }
         v = new SplitDateTimeVariableValue(name, comment, "", varRreadOnly, infoOnly, writeOnly, opsOnly, CV, mask, minVal, maxVal, _cvModel.allCvMap(), _status, item, highCV, factor, offset, uppermask, extra1, extra2, extra3, extra4);
+        _cvModel.registerCvToVariableMapping(CV, name);
         return v;
     }
 

--- a/java/src/jmri/jmrit/symbolicprog/tabbedframe/PaneProgPane.java
+++ b/java/src/jmri/jmrit/symbolicprog/tabbedframe/PaneProgPane.java
@@ -43,7 +43,7 @@ import jmri.jmrit.symbolicprog.Qualifier;
 import jmri.jmrit.symbolicprog.QualifierAdder;
 import jmri.jmrit.symbolicprog.SymbolicProgBundle;
 import jmri.jmrit.symbolicprog.ValueEditor;
-import jmri.jmrit.symbolicprog.ValueRenderer;
+import jmri.jmrit.symbolicprog.CvValueRenderer;
 import jmri.jmrit.symbolicprog.VariableTableModel;
 import jmri.jmrit.symbolicprog.VariableValue;
 import jmri.util.CvUtil;
@@ -2093,8 +2093,10 @@ public class PaneProgPane extends javax.swing.JPanel
 
         cvTable.setRowSorter(sorter);
 
-        cvTable.setDefaultRenderer(JTextField.class, new ValueRenderer());
-        cvTable.setDefaultRenderer(JButton.class, new ValueRenderer());
+        cvTable.setDefaultRenderer(JTextField.class, new CvValueRenderer());
+        cvTable.setDefaultRenderer(JButton.class, new CvValueRenderer());
+        cvTable.setDefaultRenderer(String.class, new CvValueRenderer());
+        cvTable.setDefaultRenderer(Integer.class, new CvValueRenderer());
         cvTable.setDefaultEditor(JTextField.class, new ValueEditor());
         cvTable.setDefaultEditor(JButton.class, new ValueEditor());
         cvTable.setRowHeight(new JButton("X").getPreferredSize().height);


### PR DESCRIPTION
See Issue #11853 for background.

CVs that appear in multiple variables will show a semicolon separated list of the variables in no particular order.

Closes #11853