### PR TITLE
Update Conditional Logix Action

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -434,7 +434,8 @@
     <h3>Logix</h3>
         <a id="Logix" name="Logix"></a>
         <ul>
-          <li></li>
+          <li>Recognize Logix user name changes for Conditional Logix Actions.  This is an action
+          that can be used to enable or disable a different Logix.</li>
         </ul>
 
     <h3>LogixNG</h3>

--- a/java/src/jmri/implementation/DefaultConditionalAction.java
+++ b/java/src/jmri/implementation/DefaultConditionalAction.java
@@ -223,6 +223,14 @@ public class DefaultConditionalAction implements ConditionalAction {
                         log.error("invalid NX name= \"{}\" in conditional action", devName);
                     }
                     break;
+                case LOGIX:
+                    try {
+                        bean = jmri.InstanceManager.getDefault(jmri.LogixManager.class).getLogix(devName);
+                    } catch (IllegalArgumentException e) {
+                        bean = null;
+                        log.error("invalid Logix name= \"{}\" in conditional action", devName);
+                    }
+                    break;
                 default:
                     if (getType() == Conditional.Action.TRIGGER_ROUTE) {
                         try {


### PR DESCRIPTION
A Conditional Action that changes the status of a different Logix did not recognize user name changes.  The reference was not using a named bean handle.