### PR TITLE
fix testing for Assert Warn Message when Error Message

### DIFF
--- a/java/test/jmri/implementation/DefaultConditionalActionTest.java
+++ b/java/test/jmri/implementation/DefaultConditionalActionTest.java
@@ -440,7 +440,7 @@ public class DefaultConditionalActionTest {
         // Test invalid data
         Assert.assertTrue("getActionDataString() returns correct value",
                 "".equals(DefaultConditionalAction.getActionDataString(Conditional.Action.CONTROL_AUDIO, 0)));
-        jmri.util.JUnitAppender.assertWarnMessage("Unhandled Audio operation command: 0");
+        jmri.util.JUnitAppender.assertErrorMessage("Unhandled Audio operation command: 0");
         
         Assert.assertTrue("getActionDataString() returns correct value",
                 "Slow to Halt".equals(DefaultConditionalAction.getActionDataString(Conditional.Action.CONTROL_TRAIN, Warrant.HALT)));

--- a/java/test/jmri/jmrit/logixng/actions/ActionLightTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ActionLightTest.java
@@ -180,7 +180,7 @@ public class ActionLightTest extends AbstractDigitalActionTestBase {
 
         actionLight.getSelectNamedBean().setNamedBean("A non existent light");
         Assert.assertNull("light handle is null", actionLight.getSelectNamedBean().getNamedBean());
-        JUnitAppender.assertWarnMessage("Light \"A non existent light\" is not found");
+        JUnitAppender.assertErrorMessage("Light \"A non existent light\" is not found");
 
         actionLight.getSelectNamedBean().setNamedBean(light13.getSystemName());
         Assert.assertTrue("light is correct", light13 == actionLight.getSelectNamedBean().getNamedBean().getBean());

--- a/java/test/jmri/jmrit/logixng/actions/ActionMemoryTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ActionMemoryTest.java
@@ -167,7 +167,7 @@ public class ActionMemoryTest extends AbstractDigitalActionTestBase {
 
         actionMemory.getSelectNamedBean().setNamedBean("A non existent memory");
         Assert.assertNull("memory handle is null", actionMemory.getSelectNamedBean().getNamedBean());
-        JUnitAppender.assertWarnMessage("Memory \"A non existent memory\" is not found");
+        JUnitAppender.assertErrorMessage("Memory \"A non existent memory\" is not found");
 
         actionMemory.getSelectNamedBean().setNamedBean(memory13.getSystemName());
         Assert.assertTrue("memory is correct", memory13 == actionMemory.getSelectNamedBean().getNamedBean().getBean());

--- a/java/test/jmri/jmrit/logixng/actions/ActionSensorTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ActionSensorTest.java
@@ -180,7 +180,7 @@ public class ActionSensorTest extends AbstractDigitalActionTestBase {
 
         actionSensor.getSelectNamedBean().setNamedBean("A non existent sensor");
         Assert.assertNull("sensor handle is null", actionSensor.getSelectNamedBean().getNamedBean());
-        JUnitAppender.assertWarnMessage("Sensor \"A non existent sensor\" is not found");
+        JUnitAppender.assertErrorMessage("Sensor \"A non existent sensor\" is not found");
 
         actionSensor.getSelectNamedBean().setNamedBean(sensor13.getSystemName());
         Assert.assertTrue("sensor is correct", sensor13 == actionSensor.getSelectNamedBean().getNamedBean().getBean());

--- a/java/test/jmri/jmrit/logixng/expressions/ExpressionMemoryTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/ExpressionMemoryTest.java
@@ -352,7 +352,7 @@ public class ExpressionMemoryTest extends AbstractDigitalExpressionTestBase {
 
         expressionMemory.getSelectNamedBean().setNamedBean("A non existent memory");
         Assert.assertNull("memory handle is null", expressionMemory.getSelectNamedBean().getNamedBean());
-        JUnitAppender.assertWarnMessage("Memory \"A non existent memory\" is not found");
+        JUnitAppender.assertErrorMessage("Memory \"A non existent memory\" is not found");
 
         expressionMemory.getSelectNamedBean().setNamedBean(memory13.getSystemName());
         Assert.assertTrue("memory is correct", memory13 == expressionMemory.getSelectNamedBean().getNamedBean().getBean());

--- a/java/test/jmri/jmrit/logixng/expressions/ExpressionReporterTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/ExpressionReporterTest.java
@@ -564,7 +564,7 @@ public class ExpressionReporterTest extends AbstractDigitalExpressionTestBase {
 
         expressionReporter.getSelectNamedBean().setNamedBean("A non existent reporter");
         Assert.assertNull("reporter handle is null", expressionReporter.getSelectNamedBean().getNamedBean());
-        JUnitAppender.assertWarnMessage("Reporter \"A non existent reporter\" is not found");
+        JUnitAppender.assertErrorMessage("Reporter \"A non existent reporter\" is not found");
 
         expressionReporter.getSelectNamedBean().setNamedBean(reporter13.getSystemName());
         Assert.assertTrue("reporter is correct", reporter13 == expressionReporter.getSelectNamedBean().getNamedBean().getBean());

--- a/java/test/jmri/jmrix/lenz/XNetInitializationManagerTest.java
+++ b/java/test/jmri/jmrix/lenz/XNetInitializationManagerTest.java
@@ -61,7 +61,7 @@ public class XNetInitializationManagerTest {
         softly.assertThat(memo.getLightManager()).isNull();
         softly.assertThat(memo.getConsistManager()).isNull();
         softly.assertAll();
-        jmri.util.JUnitAppender.assertWarnMessage("Command Station does not support XpressNet Version 3 Command Set");
+        jmri.util.JUnitAppender.assertErrorMessage("Command Station does not support XpressNet Version 3 Command Set");
     }
 
     @Test

--- a/java/test/jmri/jmrix/lenz/li100/XNetInitializationManagerTest.java
+++ b/java/test/jmri/jmrix/lenz/li100/XNetInitializationManagerTest.java
@@ -59,7 +59,7 @@ public class XNetInitializationManagerTest {
         softly.assertThat(memo.getLightManager()).isNull();
         softly.assertThat(memo.getConsistManager()).isNull();
         softly.assertAll();
-        jmri.util.JUnitAppender.assertWarnMessage("Command Station does not support XpressNet Version 3 Command Set");
+        jmri.util.JUnitAppender.assertErrorMessage("Command Station does not support XpressNet Version 3 Command Set");
     }
 
     @Test


### PR DESCRIPTION
assertWarnMessage currently passes Error Messages. 
This PR fixes the tests to check for Error, not Warn log messages.

Discovered while developing #11977