### PR TITLE
LoggingUtil - emit a particular INFO-level message just once

### DIFF
--- a/java/src/jmri/jmrix/can/cbus/swing/modules/CbusConfigPaneProvider.java
+++ b/java/src/jmri/jmrix/can/cbus/swing/modules/CbusConfigPaneProvider.java
@@ -106,7 +106,7 @@ public abstract class CbusConfigPaneProvider extends jmri.jmrix.can.swing.CanPan
                 return p;
             }
         }
-        log.info("node gets unknown provider: {}", node);
+        jmri.util.LoggingUtil.infoOnce(log,"node gets unknown provider: {}", node);
         return new UnknownPaneProvider();
     }
 

--- a/java/src/jmri/util/LoggingUtil.java
+++ b/java/src/jmri/util/LoggingUtil.java
@@ -16,6 +16,7 @@ import org.slf4j.Logger;
 public class LoggingUtil {
 
     protected static Map<Logger, Set<String>> warnedOnce = new HashMap<>();
+    protected static Map<Logger, Set<String>> infodOnce = new HashMap<>();
     protected static boolean logDeprecations = true;
 
     /**
@@ -29,8 +30,8 @@ public class LoggingUtil {
      * @param args   message arguments
      * @return true if the log was emitted this time
      */
-    @SuppressFBWarnings({ "SLF4J_UNKNOWN_ARRAY","SLF4J_FORMAT_SHOULD_BE_CONST"})
-        // justification = "Passing varargs array through")
+    @SuppressFBWarnings( value = {"SLF4J_UNKNOWN_ARRAY", "SLF4J_FORMAT_SHOULD_BE_CONST"},
+        justification = "Passing arguments through")
     public static boolean warnOnce(@Nonnull Logger logger, @Nonnull String msg, Object... args) {
         Set<String> loggerSet = warnedOnce.computeIfAbsent(logger, l -> new HashSet<>());
         // if it exists, there was a prior warning given
@@ -39,6 +40,30 @@ public class LoggingUtil {
         }
         loggerSet.add(msg);
         logger.warn(msg, args);
+        return true;
+    }
+
+    /**
+     * Emit a particular INFO-level message just once.
+     * <p>
+     * Goal is to be lightweight and fast; this will only be used in a few
+     * places, and only those should appear in data structure.
+     *
+     * @param logger the source of the warning
+     * @param msg    info message
+     * @param args   message arguments
+     * @return true if the log was emitted this time
+     */
+    @SuppressFBWarnings( value = {"SLF4J_UNKNOWN_ARRAY","SLF4J_FORMAT_SHOULD_BE_CONST"},
+        justification = "Passing arguments through")
+    public static boolean infoOnce(@Nonnull Logger logger, @Nonnull String msg, Object... args) {
+        Set<String> loggerSet = infodOnce.computeIfAbsent(logger, l -> new HashSet<>());
+        // if it exists, there was a prior info given
+        if (loggerSet.contains(msg)) {
+            return false;
+        }
+        loggerSet.add(msg);
+        logger.info(msg, args);
         return true;
     }
 

--- a/java/test/jmri/util/JUnitAppender.java
+++ b/java/test/jmri/util/JUnitAppender.java
@@ -8,6 +8,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.apache.log4j.Level;
 import org.apache.log4j.spi.LoggingEvent;
 import org.apache.commons.lang3.StringUtils;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.python.jline.internal.Log;
 
@@ -615,14 +616,28 @@ public class JUnitAppender extends org.apache.log4j.ConsoleAppender {
      * @param msg the message to assert exists
      */
     public static void assertWarnMessage(String msg) {
-        if (list.isEmpty()) {
-            Assert.fail("No message present: " + msg);
+        assertMessage(msg, Level.WARN);
+    }
+
+    /**
+     * Check that the next queued message has a specific message
+     * and matches the expected severity level.
+     * White space is ignored.<p>
+     * Invokes a JUnit Assertion Fail if the message doesn't match,
+     * or if the Logging Level is different.
+     *
+     * @param msg the message to assert exists
+     * @param level the Logging Level which should match
+     */
+    public static void assertMessage(String msg, Level level) {
+        LoggingEvent evt = checkForMessage(msg);
+        if (evt == null) {
+            Assertions.fail("Looking for message \"" + msg + "\" and didn't find it");
             return;
         }
-        LoggingEvent evt = checkForMessage(msg);
-
-        if (evt == null) {
-            Assert.fail("Looking for message \"" + msg + "\" and didn't find it");
+        if (level != evt.getLevel() ){
+            Assertions.fail("Incorrect logging level for \"" + msg
+                + "\" expecting " + level + " was " + evt.getLevel());
         }
     }
 

--- a/java/test/jmri/util/LoggingUtilTest.java
+++ b/java/test/jmri/util/LoggingUtilTest.java
@@ -1,7 +1,10 @@
 package jmri.util;
 
+import org.apache.log4j.Level;
+
 import org.junit.Assert;
 import org.junit.jupiter.api.*;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -15,47 +18,73 @@ public class LoggingUtilTest {
     @Test
     public void testLoggingWarnMessage() {
         log.warn("WARN message succeeds");
-        jmri.util.JUnitAppender.assertWarnMessage("WARN message succeeds");
+        JUnitAppender.assertWarnMessage("WARN message succeeds");
 
         log.debug("DEBUG message"); // should be suppressed see tests.lcf
 
-        Assert.assertTrue(jmri.util.JUnitAppender.verifyNoBacklog());        
+        Assert.assertTrue(JUnitAppender.verifyNoBacklog());        
     }
 
     @Test
     public void testWarnOnceCounts() {
         Assert.assertTrue(LoggingUtil.warnOnce(log, "WARN message")); // string has to be same until further notice
         Assert.assertFalse(LoggingUtil.warnOnce(log, "WARN message"));
-        jmri.util.JUnitAppender.assertWarnMessage("WARN message");
-        Assert.assertTrue(jmri.util.JUnitAppender.verifyNoBacklog());
-        
+        JUnitAppender.assertWarnMessage("WARN message");
+        Assert.assertTrue(JUnitAppender.verifyNoBacklog());
+
         Logger log2 = LoggerFactory.getLogger("LoggingUtilTest-extra-logger"); // same message, different logger
         Assert.assertTrue(LoggingUtil.warnOnce(log2, "WARN message"));
         Assert.assertFalse(LoggingUtil.warnOnce(log2, "WARN message"));
-        jmri.util.JUnitAppender.assertWarnMessage("WARN message");
-        Assert.assertTrue(jmri.util.JUnitAppender.verifyNoBacklog());
+        JUnitAppender.assertWarnMessage("WARN message");
+        Assert.assertTrue(JUnitAppender.verifyNoBacklog());
 
         Assert.assertTrue(LoggingUtil.warnOnce(log, "WARN message 2")); // same logger, different message
-        jmri.util.JUnitAppender.assertWarnMessage("WARN message 2");        
+        JUnitAppender.assertWarnMessage("WARN message 2");
         Assert.assertFalse(LoggingUtil.warnOnce(log, "WARN message 2")); // same logger, different message
-        Assert.assertTrue(jmri.util.JUnitAppender.verifyNoBacklog());
-   }
+        Assert.assertTrue(JUnitAppender.verifyNoBacklog());
+    }
 
     @Test
     public void testWarnOnceReset() {
         Assert.assertTrue(LoggingUtil.warnOnce(log, "WARN message check")); // string has to be same until further notice
         JUnitLoggingUtil.restartWarnOnce();
         Assert.assertTrue(LoggingUtil.warnOnce(log, "WARN message check"));
-        jmri.util.JUnitAppender.assertWarnMessage("WARN message check");
-        jmri.util.JUnitAppender.assertWarnMessage("WARN message check");
-        Assert.assertTrue(jmri.util.JUnitAppender.verifyNoBacklog());
+        JUnitAppender.assertWarnMessage("WARN message check");
+        JUnitAppender.assertWarnMessage("WARN message check");
+        Assert.assertTrue(JUnitAppender.verifyNoBacklog());
     }
 
     @Test
     public void testWarnOnceArguments() {
         Assert.assertTrue(LoggingUtil.warnOnce(log, "Test {} {}", "A", "B"));
-        jmri.util.JUnitAppender.assertWarnMessage("Test A B");
-        Assert.assertTrue(jmri.util.JUnitAppender.verifyNoBacklog());
+        JUnitAppender.assertWarnMessage("Test A B");
+        Assert.assertTrue(JUnitAppender.verifyNoBacklog());
+    }
+
+    @Test
+    public void testInfoOnceCounts() {
+        Assert.assertTrue(LoggingUtil.infoOnce(log, "INFO message")); // string has to be same until further notice
+        Assert.assertFalse(LoggingUtil.infoOnce(log, "INFO message"));
+        JUnitAppender.assertMessage("INFO message", Level.INFO );
+        Assert.assertTrue(JUnitAppender.verifyNoBacklog());
+
+        Logger log2 = LoggerFactory.getLogger("LoggingUtilTest-extra-logger"); // same message, different logger
+        Assert.assertTrue(LoggingUtil.infoOnce(log2, "INFO message"));
+        Assert.assertFalse(LoggingUtil.infoOnce(log2, "INFO message"));
+        JUnitAppender.assertMessage("INFO message", Level.INFO );
+        Assert.assertTrue(JUnitAppender.verifyNoBacklog());
+
+        Assert.assertTrue(LoggingUtil.infoOnce(log, "INFO message 2")); // same logger, different message
+        JUnitAppender.assertMessage("INFO message 2", Level.INFO );
+        Assert.assertFalse(LoggingUtil.infoOnce(log, "INFO message 2")); // same logger, different message
+        Assert.assertTrue(JUnitAppender.verifyNoBacklog());
+    }
+
+     @Test
+    public void testInfoOnceArguments() {
+        Assert.assertTrue(LoggingUtil.infoOnce(log, "Test {} {}", "A", "B"));
+        JUnitAppender.assertMessage("Test A B", Level.INFO );
+        Assert.assertTrue(JUnitAppender.verifyNoBacklog());
     }
     
     // The following two tests are _identical_.  We run them twice to make
@@ -66,38 +95,39 @@ public class LoggingUtilTest {
         // on by default
         LoggingUtil.deprecationWarning(log, "method 1");
         LoggingUtil.deprecationWarning(log, "method 1");
-        jmri.util.JUnitAppender.assertWarnMessage("method 1 is deprecated, please remove references to it");
-        Assert.assertTrue(jmri.util.JUnitAppender.verifyNoBacklog());
+        JUnitAppender.assertWarnMessage("method 1 is deprecated, please remove references to it");
+        Assert.assertTrue(JUnitAppender.verifyNoBacklog());
 
         // logging turned off 
         JUnitLoggingUtil.setDeprecatedLogging(true);
         LoggingUtil.deprecationWarning(log, "method 1");
         LoggingUtil.deprecationWarning(log, "method 1");
-        Assert.assertTrue(jmri.util.JUnitAppender.verifyNoBacklog());
+        Assert.assertTrue(JUnitAppender.verifyNoBacklog());
     }
+
     @Test
     public void testDeprecatedWarning2() {
 
         // on by default
         LoggingUtil.deprecationWarning(log, "method 1");
         LoggingUtil.deprecationWarning(log, "method 1");
-        jmri.util.JUnitAppender.assertWarnMessage("method 1 is deprecated, please remove references to it");
-        Assert.assertTrue(jmri.util.JUnitAppender.verifyNoBacklog());
+        JUnitAppender.assertWarnMessage("method 1 is deprecated, please remove references to it");
+        Assert.assertTrue(JUnitAppender.verifyNoBacklog());
 
         // logging turned off 
         JUnitLoggingUtil.setDeprecatedLogging(true);
         LoggingUtil.deprecationWarning(log, "method 1");
         LoggingUtil.deprecationWarning(log, "method 1");
-        Assert.assertTrue(jmri.util.JUnitAppender.verifyNoBacklog());
+        Assert.assertTrue(JUnitAppender.verifyNoBacklog());
     }
-    
+
     private IllegalArgumentException getTraceBack() { return new IllegalArgumentException("for test"); }
-    
+
     @Test
     public void testShortenStacktrace() {
         IllegalArgumentException ex = getTraceBack();
         Assert.assertTrue("Needs long enough trace for test", ex.getStackTrace().length > 3);
-        
+
         Assert.assertEquals(3, LoggingUtil.shortenStacktrace(ex, 3).getStackTrace().length);
     }
 

--- a/tests.lcf
+++ b/tests.lcf
@@ -146,6 +146,10 @@ log4j.category.jmri.ClassPathTest = INFO
 # Needed for jmri.util.JUnitAppenderTest
 log4j.category.jmri.util.JUnitAppenderTest = INFO
 
+# Needed for jmri.util.LoggingUtilTest
+log4j.category.jmri.util.LoggingUtilTest = INFO
+log4j.category.LoggingUtilTest-extra-logger = INFO
+
 # INFO is part of application tests
 log4j.category.apps.Apps = INFO
 log4j.category.apps.AppsBase = INFO


### PR DESCRIPTION
LoggingUtil - emit a particular INFO-level message just once, infoOnce
CbusConfigPaneProvider - only log Unknown Node Provider once per session

LoggingUtilTest - add tests for infoOnce
JUnitAppender - add assertMessage(msg, Level) to check logging levels
JUnitAppender - check for Level.WARN in assertWarnMessage

Will rebase following merge of #11976 