### PR TITLE
Improve null checks for SignalMast.getAspect implementation

### DIFF
--- a/java/src/jmri/implementation/DccSignalMast.java
+++ b/java/src/jmri/implementation/DccSignalMast.java
@@ -98,7 +98,7 @@ public class DccSignalMast extends AbstractSignalMast {
         configureAspectTable(system, mast);
     }
 
-    protected HashMap<String, Integer> appearanceToOutput = new HashMap<String, Integer>();
+    protected HashMap<String, Integer> appearanceToOutput = new HashMap<>();
 
     public void setOutputForAppearance(String appearance, int number) {
         if (appearanceToOutput.containsKey(appearance)) {
@@ -176,7 +176,6 @@ public class DccSignalMast extends AbstractSignalMast {
         return useAddressOffSet;
     }
 
-
     @Override
     public void setLit(boolean newLit) {
         if (!allowUnLit() || newLit == getLit()) {
@@ -184,7 +183,10 @@ public class DccSignalMast extends AbstractSignalMast {
         }
         super.setLit(newLit);
         if (newLit) {
-            setAspect(getAspect());
+            String newAspect = getAspect();
+            if (newAspect != null){
+                setAspect(newAspect);
+            }
         } else {
             if (useAddressOffSet) {
                 c.sendPacket(NmraPacket.accSignalDecoderPkt(dccSignalDecoderAddress, unLitId), packetSendCount);

--- a/java/src/jmri/implementation/DefaultSignalMastLogic.java
+++ b/java/src/jmri/implementation/DefaultSignalMastLogic.java
@@ -38,9 +38,6 @@ public class DefaultSignalMastLogic extends AbstractNamedBean implements SignalM
     Hashtable<SignalMast, DestinationMast> destList = new Hashtable<>();
     LayoutEditor editor;
 
-    boolean useAutoGenBlock = true;
-    boolean useAutoGenTurnouts = true;
-
     LayoutBlock facingBlock = null;
     LayoutBlock remoteProtectingBlock = null;
 
@@ -1989,12 +1986,13 @@ public class DefaultSignalMastLogic extends AbstractNamedBean implements SignalM
             Enumeration<SignalMast> mastKeys = autoMasts.keys();
             while (mastKeys.hasMoreElements()) {
                 SignalMast key = mastKeys.nextElement();
-                log.debug("key {} {} {}", key.getDisplayName(), key.getAspect(), autoMasts.get(key));
-                if ((key.getAspect() != null) && (!key.getAspect().equals(autoMasts.get(key)))) {
+                String aspect = key.getAspect();
+                log.debug("key {} {} {}", key.getDisplayName(), aspect, autoMasts.get(key));
+                if ((aspect != null) && (!aspect.equals(autoMasts.get(key)))) {
                     if (isSignalMastIncluded(key)) {
                         //Basically if we have a blank aspect, we don't care about the state of the signalmast
                         if (!getSignalMastState(key).isEmpty()) {
-                            if (!key.getAspect().equals(getSignalMastState(key))) {
+                            if (!aspect.equals(getSignalMastState(key))) {
                                 state = false;
                             }
                         }
@@ -2005,7 +2003,8 @@ public class DefaultSignalMastLogic extends AbstractNamedBean implements SignalM
             }
             for (NamedBeanSetting nbh : userSetMasts) {
                 SignalMast key = (SignalMast) nbh.getBean();
-                if ((key.getAspect() == null) || (!key.getAspect().equals(nbh.getStringSetting()))) {
+                String aspect = key.getAspect();
+                if ((aspect == null) || (!aspect.equals(nbh.getStringSetting()))) {
                     state = false;
                 }
             }
@@ -2156,9 +2155,10 @@ public class DefaultSignalMastLogic extends AbstractNamedBean implements SignalM
                 SignalMast key = mastKeys.nextElement();
                 log.debug("{} auto mast add list {}", destination.getDisplayName(), key.getDisplayName());
                 key.addPropertyChangeListener(propertySignalMastListener);
-                if (!key.getAspect().equals(autoMasts.get(key))) {
+                String aspect = key.getAspect();
+                if ( aspect != null && !aspect.equals(autoMasts.get(key))) {
                     if (isSignalMastIncluded(key)) {
-                        if (key.getAspect().equals(getSignalMastState(key))) {
+                        if (aspect.equals(getSignalMastState(key))) {
                             routeclear = false;
                         }
                     } else {
@@ -2170,8 +2170,9 @@ public class DefaultSignalMastLogic extends AbstractNamedBean implements SignalM
             for (NamedBeanSetting nbh : userSetMasts) {
                 SignalMast key = (SignalMast) nbh.getBean();
                 key.addPropertyChangeListener(propertySignalMastListener);
-                log.debug("mast '{}' key aspect '{}'", destination.getDisplayName(), key.getAspect());
-                if ((key.getAspect() == null) || (!key.getAspect().equals(nbh.getStringSetting()))) {
+                String aspect = key.getAspect();
+                log.debug("mast '{}' key aspect '{}'", destination.getDisplayName(), aspect);
+                if ((aspect == null) || (!aspect.equals(nbh.getStringSetting()))) {
                     routeclear = false;
                 }
             }

--- a/java/src/jmri/implementation/TurnoutSignalMast.java
+++ b/java/src/jmri/implementation/TurnoutSignalMast.java
@@ -155,7 +155,10 @@ public class TurnoutSignalMast extends AbstractSignalMast {
         super.setLit(newLit);
         if (newLit) {
             // This will force the signalmast to send out the commands to set the aspect again.
-            setAspect(getAspect());
+            String litAspect = getAspect();
+            if (litAspect != null ) {
+                setAspect(litAspect);
+            }
         } else {
             if (unLit != null) {
                 // there is a specific unlit output defined
@@ -165,13 +168,13 @@ public class TurnoutSignalMast extends AbstractSignalMast {
                 }
             } else {
                 // turn everything off
-                for (TurnoutAspect aspect : turnouts.values()) {
+                for (TurnoutAspect tAspect : turnouts.values()) {
                     int setState = Turnout.CLOSED;
-                    if (aspect.getTurnoutState() == Turnout.CLOSED) {
+                    if (tAspect.getTurnoutState() == Turnout.CLOSED) {
                         setState = Turnout.THROWN;
                     }
-                    if (aspect.getTurnout().getKnownState() != setState) {
-                        aspect.getTurnout().setCommandedState(setState);
+                    if (tAspect.getTurnout().getKnownState() != setState) {
+                        tAspect.getTurnout().setCommandedState(setState);
                     }
                 }
             }
@@ -179,17 +182,17 @@ public class TurnoutSignalMast extends AbstractSignalMast {
     }
 
     public String getTurnoutName(String appearance) {
-        TurnoutAspect aspect = turnouts.get(appearance);
-        if (aspect != null) {
-            return aspect.getTurnoutName();
+        TurnoutAspect tAspect = turnouts.get(appearance);
+        if (tAspect != null) {
+            return tAspect.getTurnoutName();
         }
         return "";
     }
 
     public int getTurnoutState(String appearance) {
-        TurnoutAspect aspect = turnouts.get(appearance);
-        if (aspect != null) {
-            return aspect.getTurnoutState();
+        TurnoutAspect tAspect = turnouts.get(appearance);
+        if (tAspect != null) {
+            return tAspect.getTurnoutState();
         }
         return -1;
     }
@@ -262,14 +265,11 @@ public class TurnoutSignalMast extends AbstractSignalMast {
                 return true;
             }
         }
-        if (t.equals(getUnLitTurnout())) {
-            return true;
-        }
-        return false;
+        return t.equals(getUnLitTurnout());
     }
 
     public List<NamedBeanHandle<Turnout>> getHeadsUsed() {
-        return new ArrayList<NamedBeanHandle<Turnout>>();
+        return new ArrayList<>();
     }
 
     /**
@@ -304,11 +304,6 @@ public class TurnoutSignalMast extends AbstractSignalMast {
                 }
             }
         }
-    }
-
-    @Override
-    public void dispose() {
-        super.dispose();
     }
 
     private final static Logger log = LoggerFactory.getLogger(TurnoutSignalMast.class);


### PR DESCRIPTION
DccSignalMast / TurnoutSignalMast - only setAspect when going unlit if aspect is not null
DefaultSignalMastLogic