### PR TITLE
add note that layout editor supports scaling of icons

### DIFF
--- a/help/en/releasenotes/jmri5.3-master.shtml
+++ b/help/en/releasenotes/jmri5.3-master.shtml
@@ -397,7 +397,7 @@
     <h3>Layout Editor</h3>
         <a id="LE" name="LE"></a>
         <ul>
-	        <li></li>
+	        <li>Layout Editor now supports scaling of icons</li>
         </ul>
 
         <h4>NX - Entry/Exit Tool</h4>


### PR DESCRIPTION
it appears there are actually some cases where icons use the fixed size stuff - so not removing it. However I still owe the release note for the fact that scaling now works.

Hopefully I've done this correctly.