### PR TITLE
update WarrantFrame Test

### DIFF
--- a/java/test/jmri/jmrit/logix/WarrantFrameTest.java
+++ b/java/test/jmri/jmrit/logix/WarrantFrameTest.java
@@ -11,8 +11,7 @@ import jmri.util.swing.JemmyUtil;
 
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
-import org.netbeans.jemmy.operators.JButtonOperator;
-import org.netbeans.jemmy.operators.JDialogOperator;
+
 import org.netbeans.jemmy.operators.JFrameOperator;
 
 /**
@@ -57,15 +56,16 @@ public class WarrantFrameTest {
         Warrant startW = _warrantMgr.getWarrant("WestBoundStart");
         Warrant endW = _warrantMgr.getWarrant("WestBoundFinish");
 
-        new Thread(() -> {
-            JFrameOperator jfo = new JFrameOperator(WarrantTableFrame.getDefault());
-            JDialogOperator jdo = new JDialogOperator(jfo, Bundle.getMessage("QuestionTitle"));
-            JButtonOperator jbo = new JButtonOperator(jdo, Bundle.getMessage("ButtonYes"));
-            jbo.push();
-        }).start();
+        Thread t = new Thread(() -> {
+            JemmyUtil.pressDialogButton(Bundle.getMessage("QuestionTitle"), Bundle.getMessage("ButtonYes"));
+        });
+        t.setName("WarrantFrameTest Answer Question stop train");
+        t.start();
         
         WarrantFrame warrantFrame= new WarrantFrame(startW, endW);
         assertThat(warrantFrame).withFailMessage("JoinWFrame exits").isNotNull();
+
+        JUnitUtil.waitFor( () -> (!t.isAlive()), "dialogue stop train in block east main? answered");
 
         warrantFrame._userNameBox.setText("WestBoundLocal");
         JFrameOperator editFrame = new JFrameOperator(warrantFrame);


### PR DESCRIPTION
assert dialogue answered or fails in timely manner.  eg. failure https://github.com/JMRI/JMRI/pull/11902#issuecomment-1495996958