### PR TITLE
AbstractShutDownTask - add Task name to toString

### DIFF
--- a/java/src/jmri/implementation/AbstractShutDownTask.java
+++ b/java/src/jmri/implementation/AbstractShutDownTask.java
@@ -47,6 +47,11 @@ public abstract class AbstractShutDownTask implements ShutDownTask {
         return mName;
     }
 
+    @Override
+    public String toString() {
+        return "ShutDownTask: " + getName();
+    }
+
     /**
      * {@inheritDoc}
      *


### PR DESCRIPTION
add Task name to toString

Makes a failure more identifiable, eg. from

`Could not complete Shutdown Task in time: java.util.concurrent.FutureTask@6aa6ef3f[Not completed, task = java.util.concurrent.Executors$RunnableAdapter@cba4f60[Wrapped task = jmri.managers.DefaultShutDownManagerTest$CallTrueShutDownTask@53988832]] `

to

`Could not complete Shutdown Task in time: java.util.concurrent.FutureTask@65b8ac52[Not completed, task = java.util.concurrent.Executors$RunnableAdapter@20ba2621[Wrapped task = ShutDownTask: EarlyShutDownTask testEarlyTasks]]`