### PR TITLE
Mqtt tests - add MqttAdaptorScaffold

### DIFF
--- a/java/src/jmri/jmrix/mqtt/MqttAdapter.java
+++ b/java/src/jmri/jmrix/mqtt/MqttAdapter.java
@@ -22,7 +22,7 @@ import org.slf4j.LoggerFactory;
  * Communications adapter for Mqtt communications links.
  *
  * @author Lionel Jeanson
- * @author Bob Jacobsen   Copyright (c) 2091, 2029
+ * @author Bob Jacobsen   Copyright (c) 2019, 2023
  */
 @API(status=API.Status.MAINTAINED)
 public class MqttAdapter extends jmri.jmrix.AbstractNetworkPortController implements MqttCallback {
@@ -154,9 +154,7 @@ public class MqttAdapter extends jmri.jmrix.AbstractNetworkPortController implem
             String tempdirName = jmri.util.FileUtil.getExternalFilename(jmri.util.FileUtil.PROFILE);
             log.debug("will use {} as temporary directory", tempdirName);
 
-            mqttClient = new MqttClient(PROTOCOL + getCurrentPortName(),
-                                        clientID,
-                                        new MqttDefaultFilePersistence(tempdirName));
+            mqttClient = getNewMqttClient(clientID, tempdirName);
 
             if ((getOptionState(MQTT_USERNAME_OPTION) != null
                     && ! getOptionState(MQTT_USERNAME_OPTION).isEmpty())
@@ -170,6 +168,11 @@ public class MqttAdapter extends jmri.jmrix.AbstractNetworkPortController implem
         } catch (MqttException ex) {
             throw new IOException("Can't create MQTT client", ex);
         }
+    }
+
+    MqttClient getNewMqttClient(String clientID, String tempdirName) throws MqttException {
+        return new MqttClient(PROTOCOL + getCurrentPortName(),
+            clientID, new MqttDefaultFilePersistence(tempdirName));
     }
 
     @Override
@@ -307,7 +310,7 @@ public class MqttAdapter extends jmri.jmrix.AbstractNetworkPortController implem
 
         boolean found = false;
         Map<String,ArrayList<MqttEventListener>> tempMap
-            = new HashMap<String,ArrayList<MqttEventListener>> (mqttEventListeners); // Avoid ConcurrentModificationException
+            = new HashMap<> (mqttEventListeners); // Avoid ConcurrentModificationException
         for (Map.Entry<String,ArrayList<MqttEventListener>> e : tempMap.entrySet()) {
             // does key match received topic, including wildcards?
             if (MqttTopic.isMatched(e.getKey(), topic) ) {

--- a/java/src/jmri/jmrix/mqtt/MqttReporter.java
+++ b/java/src/jmri/jmrix/mqtt/MqttReporter.java
@@ -1,7 +1,5 @@
 package jmri.jmrix.mqtt;
 
-import java.util.HashSet;
-
 import jmri.IdTagManager;
 import jmri.InstanceManager;
 import jmri.IdTag;
@@ -26,7 +24,7 @@ class MqttReporter extends AbstractIdTagReporter implements MqttEventListener {
         super(systemName);
         this.rcvTopic = rcvTopic;
         mqttAdapter = ma;
-        mqttAdapter.subscribe(rcvTopic, this);
+        mqttAdapter.subscribe(rcvTopic, MqttReporter.this);
     }
 
     private final MqttAdapter mqttAdapter;

--- a/java/src/jmri/jmrix/mqtt/MqttSystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/mqtt/MqttSystemConnectionMemo.java
@@ -18,7 +18,7 @@ public class MqttSystemConnectionMemo extends DefaultSystemConnectionMemo implem
 
     public MqttSystemConnectionMemo() {
         super("M", "MQTT");
-        InstanceManager.store(this, MqttSystemConnectionMemo.class);
+        InstanceManager.store(MqttSystemConnectionMemo.this, MqttSystemConnectionMemo.class);
     }
 
     @Override
@@ -26,10 +26,10 @@ public class MqttSystemConnectionMemo extends DefaultSystemConnectionMemo implem
 //        setPowerManager(new jmri.jmrix.jmriclient.JMRIClientPowerManager(this));
 //        jmri.InstanceManager.store(getPowerManager(), jmri.PowerManager.class);
 
-        jmri.InstanceManager.setTurnoutManager(getTurnoutManager());
-        jmri.InstanceManager.setSensorManager(getSensorManager());
-        jmri.InstanceManager.setLightManager(getLightManager());
-        jmri.InstanceManager.setReporterManager(getReporterManager());
+        InstanceManager.setTurnoutManager(getTurnoutManager());
+        InstanceManager.setSensorManager(getSensorManager());
+        InstanceManager.setLightManager(getLightManager());
+        InstanceManager.setReporterManager(getReporterManager());
 
 //        jmri.InstanceManager.setReporterManager(getReporterManager());
 

--- a/java/test/jmri/jmrix/mqtt/MqttAdapterScaffold.java
+++ b/java/test/jmri/jmrix/mqtt/MqttAdapterScaffold.java
@@ -1,0 +1,100 @@
+package jmri.jmrix.mqtt;
+
+import java.io.IOException;
+
+import org.eclipse.paho.client.mqttv3.MqttClient;
+import org.eclipse.paho.client.mqttv3.MqttException;
+
+import org.junit.jupiter.api.Assertions;
+
+import org.mockito.ArgumentCaptor;
+import static org.mockito.Mockito.*;
+
+/**
+ * MqttAdapterScaffold serves as a scaffold for testing purposes.
+ * It provides a mock MqttClient object.
+ * It captures arguments passed to the publish method of the MqttClient.
+ * @author Steve Young Copyright(C) 2023
+ */
+public class MqttAdapterScaffold extends MqttAdapter {
+
+    private MqttClient mockClient;
+
+    // Argument captors for the publish method of MqttClient
+    private ArgumentCaptor<String> topicCaptor = ArgumentCaptor.forClass(String.class);
+    private ArgumentCaptor<byte[]> payloadCaptor = ArgumentCaptor.forClass(byte[].class);
+    private ArgumentCaptor<Integer> qosCaptor = ArgumentCaptor.forClass(Integer.class);
+    private ArgumentCaptor<Boolean> retainedCaptor = ArgumentCaptor.forClass(Boolean.class);
+
+    /**
+     * Create a new Mqtt Adapter Scaffold.
+     * @param connectAndConfigure true to call the connect and configure methods 
+     * to more fully setup the connection. 
+     */
+    public MqttAdapterScaffold(boolean connectAndConfigure){
+        super();
+        if (connectAndConfigure){
+            try {
+                connect();
+                configure();
+            }
+            catch (IOException ex) {
+                Assertions.fail("could not connect to AdapterScaffold", ex);
+            }
+        }
+    }
+
+    private int publishCount = 0;
+
+    @Override
+    MqttClient getNewMqttClient(String clientID, String tempdirName) throws MqttException {
+        mockClient = mock(MqttClient.class);
+        doAnswer(invocation -> {
+            publishCount++;
+            return null;
+        }).when(mockClient).publish(anyString(), any(byte[].class), anyInt(), anyBoolean());
+        return mockClient;
+    }
+
+    /**
+     * Get Number of counts that publish has been called.
+     * @return number of times an item has been published, default 0
+     */
+    public int getPublishCount(){
+        return publishCount;
+    }
+
+    /**
+     * Returns the last Topic passed to the
+     * publish(String, byte[], Integer, Boolean)
+     * method of the mock MqttClient.
+     * Verifies that at least 1 message has been published.
+     * @return The last captured topic.
+     */
+    public String getLastTopic(){
+        verifyPublishCapture();
+        return topicCaptor.getValue();
+    }
+
+    /**
+     * Returns the last Payload passed to the
+     * publish(String, byte[], Integer, Boolean)
+     * method of the mock MqttClient.
+     * Verifies that at least 1 message has been published.
+     * @return The last captured topic.
+     */
+    public byte[] getLastPayload() {
+        verifyPublishCapture();
+        return payloadCaptor.getValue();
+    }
+
+    private void verifyPublishCapture() {
+        try {
+            verify(mockClient, atLeastOnce()).publish(topicCaptor.capture(),
+                payloadCaptor.capture(), qosCaptor.capture(), retainedCaptor.capture());
+        } catch (MqttException ex) {
+            Assertions.fail("Could not verify mockclient Publish", ex);
+        }
+    }
+
+}

--- a/java/test/jmri/jmrix/mqtt/MqttReporterManagerTest.java
+++ b/java/test/jmri/jmrix/mqtt/MqttReporterManagerTest.java
@@ -1,14 +1,7 @@
 package jmri.jmrix.mqtt;
 
-import java.util.List;
-
-import jmri.*;
-import jmri.Manager.NameValidity;
-import jmri.jmrix.can.CanSystemConnectionMemo;
-import jmri.jmrix.can.TrafficControllerScaffold;
 import jmri.util.JUnitUtil;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.*;
 
 /**
@@ -30,28 +23,31 @@ public class MqttReporterManagerTest extends jmri.managers.AbstractReporterMgrTe
         return "MR" + i;
     }
 
+    @Override
     public void testRegisterDuplicateSystemName() {}
+    @Override
     public void testMakeSystemNameWithNoPrefixNotASystemName() {}
+    @Override
     public void testMakeSystemNameWithPrefixNotASystemName() {}
 
-    private MqttSystemConnectionMemo memo = null;
+    private MqttAdapterScaffold adapter = null;
 
     @BeforeEach
     @Override
     public void setUp() {
         JUnitUtil.setUp();
         JUnitUtil.resetInstanceManager();
-        memo = new MqttSystemConnectionMemo();
-        memo.setMqttAdapter(new MqttAdapter());
-        l = new MqttReporterManager(memo);
+        adapter = new MqttAdapterScaffold(true);
+
+        Assertions.assertNotNull(adapter.getSystemConnectionMemo());
+        l = new MqttReporterManager(adapter.getSystemConnectionMemo());
     }
 
     @AfterEach
     public void tearDown() {
         l = null;
-        Assertions.assertNotNull(memo);
-        memo.dispose();
-        memo = null;
+        Assertions.assertNotNull(adapter);
+        adapter.dispose();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrix/mqtt/MqttReporterTest.java
+++ b/java/test/jmri/jmrix/mqtt/MqttReporterTest.java
@@ -3,7 +3,6 @@ package jmri.jmrix.mqtt;
 import jmri.*;
 import jmri.util.*;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.*;
 
 /**
@@ -18,34 +17,24 @@ public class MqttReporterTest extends jmri.implementation.AbstractReporterTestBa
         return InstanceManager.getDefault(IdTagManager.class).provideIdTag("123");
     }
 
-    MqttAdapter a;
-    String saveTopic;
-    byte[] savePayload;
+    MqttAdapterScaffold a = null;
 
     @Override
     @BeforeEach
     public void setUp() {
-        jmri.util.JUnitUtil.setUp();
+        JUnitUtil.setUp();
         JUnitUtil.initDefaultUserMessagePreferences();
         // prepare an interface
-        saveTopic = null;
-        savePayload = null;
-        a = new MqttAdapter(){
-                @Override
-                public void publish(String topic, byte[] payload) {
-                    saveTopic = topic;
-                    savePayload = payload;
-                }
-            };
+        a = new MqttAdapterScaffold(true);
         r = new MqttReporter(a, "MR1", "track/reporter/1");
-        JUnitAppender.assertWarnMessage("Trying to subscribe before connect/configure is done");
     }
 
     @Override
     @AfterEach
     public void tearDown() {
-        jmri.InstanceManager.getDefault(jmri.IdTagManager.class).dispose();
+        InstanceManager.getDefault(IdTagManager.class).dispose();
         r.dispose();
+        a.dispose();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrix/mqtt/MqttSensorTest.java
+++ b/java/test/jmri/jmrix/mqtt/MqttSensorTest.java
@@ -2,7 +2,6 @@ package jmri.jmrix.mqtt;
 
 import jmri.util.*;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.*;
 
 /**
@@ -10,54 +9,44 @@ import org.junit.jupiter.api.*;
  * @author Bob Jacobsen Coyright (C) 2020
  */
 public class MqttSensorTest extends jmri.implementation.AbstractSensorTestBase {
-    
+
     @Override
     public int numListeners() {return 0;}
 
     @Override
     public void checkStatusRequestMsgSent() {}
 
+    private MqttAdapterScaffold a = null;
 
-    MqttAdapter a;
-    String saveTopic;
-    byte[] savePayload;
-    
     @Override
     @BeforeEach
     public void setUp() {
-        jmri.util.JUnitUtil.setUp();
+        JUnitUtil.setUp();
         JUnitUtil.initDefaultUserMessagePreferences();
         // prepare an interface
-        saveTopic = null;
-        savePayload = null;
-        a = new MqttAdapter(){
-                @Override
-                public void publish(String topic, byte[] payload) {
-                    saveTopic = topic;
-                    savePayload = payload;
-                }
-            };
+        a = new MqttAdapterScaffold(true);
         t = new MqttSensor(a, "MS1", "track/sensor/1", "track/sensor/1");
-        JUnitAppender.assertWarnMessage("Trying to subscribe before connect/configure is done");
+        Assertions.assertEquals( 0, a.getPublishCount());
     }
 
     @Override
     @AfterEach
     public void tearDown() {
         t.dispose();
+        a.dispose();
         JUnitUtil.tearDown();
     }
 
     @Override
     public void checkActiveMsgSent() {
-        Assert.assertEquals("topic", "track/sensor/1", saveTopic);
-        Assert.assertEquals("topic", "ACTIVE", new String(savePayload));
+        Assertions.assertEquals( "track/sensor/1", a.getLastTopic(), "topic");
+        Assertions.assertEquals("ACTIVE", new String(a.getLastPayload()), "payload");
     }
 
     @Override
     public void checkInactiveMsgSent() {
-        Assert.assertEquals("topic", "track/sensor/1", saveTopic);
-        Assert.assertEquals("topic", "INACTIVE", new String(savePayload));
+        Assertions.assertEquals( "track/sensor/1", a.getLastTopic(),"topic");
+        Assertions.assertEquals("INACTIVE", new String(a.getLastPayload()), "payload");
     }
 
     // private final static Logger log = LoggerFactory.getLogger(MqttSensorTest.class);

--- a/java/test/jmri/jmrix/mqtt/logixng/PublishTest.java
+++ b/java/test/jmri/jmrix/mqtt/logixng/PublishTest.java
@@ -35,6 +35,7 @@ public class PublishTest {
 
     @AfterEach
     public void tearDown() {
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 


### PR DESCRIPTION
MqttAdapterScaffold serves as a scaffold for testing purposes.
It provides a mock MqttClient.
It captures arguments passed to the publish method of the MqttClient.