### PR TITLE
Fix display of Last Report in Reporter Table

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -553,7 +553,11 @@
     <h3>Turnouts, Lights, Sensors and other elements</h3>
         <a id="TLae" name="TLae"></a>
         <ul>
-            <li></li>
+            <li>Fixed a bug in the Reporter Table that was causing the
+                Last Report column to actually display the Current Report.
+                Note that this is just a display bug; the underlying value and
+                property change notifications are correct, so this change won't
+                affect scripts, LogixNG, etc.</li>
         </ul>
 
    <h3>Warrants</h3>

--- a/java/src/jmri/jmrit/beantable/ReporterTableDataModel.java
+++ b/java/src/jmri/jmrit/beantable/ReporterTableDataModel.java
@@ -17,21 +17,21 @@ import org.slf4j.LoggerFactory;
 /**
  * Data model for a Reporter Table.
  * Code originally within ReporterTableAction.
- * 
+ *
  * @author Bob Jacobsen Copyright (C) 2003
  * @author Steve Young Copyright (C) 2021
  */
 public class ReporterTableDataModel extends BeanTableDataModel<Reporter> {
-    
+
     public static final int LASTREPORTCOL = NUMCOLUMN;
-    
+
     public ReporterTableDataModel(Manager<Reporter> mgr){
         super();
         setManager(mgr);
     }
-    
+
     private ReporterManager reporterManager;
-    
+
     /**
      * {@inheritDoc}
      */
@@ -75,7 +75,7 @@ public class ReporterTableDataModel extends BeanTableDataModel<Reporter> {
         getManager().addPropertyChangeListener(this);
         updateNameList();
     }
-    
+
     /**
      * {@inheritDoc}
      */
@@ -189,7 +189,21 @@ public class ReporterTableDataModel extends BeanTableDataModel<Reporter> {
     @Override
     public Object getValueAt(int row, int col) {
         if (col == LASTREPORTCOL) {
-            return getValue(sysNameList.get(row));
+
+            String name = sysNameList.get(row);
+            Object value;
+            Reporter r = getManager().getBySystemName(name);
+            if (r == null) {
+                return "";
+            }
+            value = r.getLastReport();
+            if (value == null) {
+                return null;
+            } else if (value instanceof Reportable) {
+                return ((Reportable) value).toReportString();
+            } else {
+                return value.toString();
+            }
         } else
         return super.getValueAt(row, col);
     }
@@ -232,5 +246,5 @@ public class ReporterTableDataModel extends BeanTableDataModel<Reporter> {
     }
 
     private final static Logger log = LoggerFactory.getLogger(ReporterTableDataModel.class);
-    
+
 }

--- a/java/src/jmri/jmrix/loconet/LnReporter.java
+++ b/java/src/jmri/jmrix/loconet/LnReporter.java
@@ -130,6 +130,7 @@ public class LnReporter extends AbstractIdTagReporter implements CollectingRepor
         }
         loco = getLocoAddrFromTranspondingMsg(l); // get loco address
 
+        log.debug("Transponding Report at {} for {}",_number, loco);
         notify(null); // set report to null to make sure listeners update
 
         idTag = InstanceManager.getDefault(TranspondingTagManager.class).provideIdTag("" + loco);
@@ -145,7 +146,7 @@ public class LnReporter extends AbstractIdTagReporter implements CollectingRepor
                 entrySet.remove(idTag);
             }
         }
-        log.debug("Tag: {}", idTag);
+        log.debug("Tag: {} entry {}", idTag, enter);
         notify(idTag);
         setState(enter ? loco : -1);
     }
@@ -171,19 +172,19 @@ public class LnReporter extends AbstractIdTagReporter implements CollectingRepor
      * @param l Message from which to extract LISSY content
      */
     void lissyReport(LocoNetMessage l) {
-        
-        // Only report messages where bit 6 is set in element 3, 
-        // because these are the only messages with valid loco addresses     
-        if ((l.getElement(3) & 0x40) != 0) { 
+
+        // Only report messages where bit 6 is set in element 3,
+        // because these are the only messages with valid loco addresses
+        if ((l.getElement(3) & 0x40) != 0) {
             int loco = (l.getElement(6) & 0x7F) + 128 * (l.getElement(5) & 0x7F);
-            
+
             // train category - Perhaps add to idTag as property?
             int category = l.getElement(2) + 1;
-    
+
             // get direction
             // north assumes loco is passing sensors S1->S2
             boolean north = ((l.getElement(3) & 0x20) == 0);
-    
+
             notify(null); // set report to null to make sure listeners update
             // get loco address
             IdTag idTag = InstanceManager.getDefault(TranspondingTagManager.class).provideIdTag(""+loco+":"+category);

--- a/java/src/jmri/jmrix/loconet/LnReporterManager.java
+++ b/java/src/jmri/jmrix/loconet/LnReporterManager.java
@@ -23,7 +23,7 @@ import org.slf4j.LoggerFactory;
 public class LnReporterManager extends jmri.managers.AbstractReporterManager implements LocoNetListener {
 
     protected final LnTrafficController tc;
-    
+
     // ctor has to register for LocoNet events
     public LnReporterManager(LocoNetSystemConnectionMemo memo) {
         super(memo);
@@ -130,7 +130,7 @@ public class LnReporterManager extends jmri.managers.AbstractReporterManager imp
             default:
                 return;
         }
-        log.debug("Reporter[{}]", addr);
+        log.debug("Message for Reporter[{}]", addr);
         LnReporter r = (LnReporter) provideReporter(getSystemNamePrefix() + addr); // NOI18N
         r.messageFromManager(l); // make sure it got the message
     }


### PR DESCRIPTION
The “Last Report” column in the table had a display bug.  It was actually displaying the Current Report, instead of the Last Report, in the Last Report column. Fixed here.

Note that this is just a problem with the display in the table.  The underlying value seems to be correct, and the property listeners seem to be being notified appropriately.  So fixing this won’t affect scripts, Logix and LogixNG, etc.
