### PR TITLE
Update Reporter and IdTag behavior

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -612,6 +612,7 @@
     <h3>Miscellaneous</h3>
         <a id="Misc" name="Misc"></a>
         <ul>
-            <li></li>
+            <li>Improved how window preferences are stored to reduce error messages
+                when JMRI is under high load.</li>
         </ul>
 

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -553,7 +553,12 @@
     <h3>Turnouts, Lights, Sensors and other elements</h3>
         <a id="TLae" name="TLae"></a>
         <ul>
-            <li></li>
+            <li>The definition of "Last Seen" for Id Tags has been
+                clarified to mean "Location where the tag was last seen to be <u>present</u>".
+                Previously, a report that a tag was <u>absent</u> could be marked as the
+                last seen report.  The relevant code changes are specific to LocoNet
+                Reporters.
+                </li>
         </ul>
 
    <h3>Warrants</h3>

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -81,7 +81,9 @@
 
         <h4>LocoNet</h4>
             <ul>
-                <li></li>
+                <li>The handling for LocoNet Reporters (i.e. transponding)
+                    has changed.  See the description
+                    <a href="#TLae">below</a>.</li>
             </ul>
 
         <h4>Maple</h4>
@@ -553,17 +555,22 @@
     <h3>Turnouts, Lights, Sensors and other elements</h3>
         <a id="TLae" name="TLae"></a>
         <ul>
-            <li>The definition of "Last Seen" for Id Tags has been
-                clarified to mean "Location where the tag was last seen to be <u>present</u>".
-                Previously, a report that a tag was <u>absent</u> could be marked as the
-                last seen report.  The relevant code changes are specific to LocoNet
-                Reporters.
-                </li>
             <li>Fixed a bug in the Reporter Table that was causing the
                 Last Report column to actually display the Current Report.
                 Note that this is just a display bug; the underlying value and
                 property change notifications are correct, so this change won't
                 affect scripts, LogixNG, etc.</li>
+            <li>The definition of "Last Seen" for Id Tags has been
+                clarified to mean "Location where the tag was last seen to be <u>present</u>".
+                Previously, a report that a tag was <u>absent</u> could be marked as the
+                last seen report.  Not all hardware Reporters provide entry/exit reports, as
+                some just indicate that something has been observed in place; their "Last Seen" behavior
+                has not changed.
+                </li>
+            <li>Some Reporters, particularly LocoNet, would improperly clear an "enter" report
+                when an "exits" report for the same tag was seen elsewhere.  This was an
+                error that has been fixed, but if you have scripts or LogixNG that depend on
+                this behavior you might have to update them.
         </ul>
 
    <h3>Warrants</h3>

--- a/help/en/releasenotes/current-draft-warnings.shtml
+++ b/help/en/releasenotes/current-draft-warnings.shtml
@@ -1,8 +1,12 @@
 
     <!-- contains new warnings for the release under development -->
-    <li>
-        None yet
-    </li>
+    <li>The definition of "Last Seen" for Id Tags has been
+        clarified to mean "Location where the tag was last seen to be <u>present</u>".
+        Previously, a report that a tag was <u>absent</u> could be remembered as the
+        last seen report.  The relevant code changes are specific to LocoNet
+        Reporters. This might affect your scripts and LogixNG if you were assuming
+        the prior behavior.
+        </li>
     <li>
     </li>
     <li>

--- a/help/en/releasenotes/current-draft-warnings.shtml
+++ b/help/en/releasenotes/current-draft-warnings.shtml
@@ -7,7 +7,10 @@
         Reporters. This might affect your scripts and LogixNG if you were assuming
         the prior behavior.
         </li>
-    <li>
+    <li>Some Reporters, particularly LocoNet, would improperly clear an "enter" report
+        when an "exits" report for the same tag was seen elsewhere.  This was an
+        error that has been fixed, but if you have scripts or LogixNG that depend on
+        this behavior you might have to update them.
     </li>
     <li>
     </li>

--- a/java/src/jmri/IdTag.java
+++ b/java/src/jmri/IdTag.java
@@ -7,7 +7,7 @@ import org.jdom2.Element;
 
 /**
  * IdTag is a pre-parsed representation of an identification message from the
- * layout.  One use of an IdTag is a device that might be attached to any 
+ * layout.  One use of an IdTag is a device that might be attached to any
  * specific piece of rolling stock to uniquely identify it.
  * <p>
  * Examples include
@@ -27,9 +27,15 @@ import org.jdom2.Element;
  *   <li>A list of key/value pairs holding properties</li>
  * </ul>
  * <p>
- * The system name is of the form IDxxxx where xxxx is the same value as the TagID.
+ * "Seen" is defined as a Reporter has indicated that the IdTag is within the
+ * area served by that Reporter.  "Seen" is not updated to a Reporter reports that the IdTag is
+ * leaving that area.
  * <p>
- * The list of key value pairs is maintained by the reporters parsing and 
+ * The system name is of the form "sDxxxx" where "xxxx" is the same value as the TagID
+ * and "s" is the system prefix for the relevant Reporter (for Reporter-type-specific tags)
+ * or "I" in the more general case.
+ * <p>
+ * The list of key value pairs is maintained by the reporters parsing and
  * updating the list.  This information may vary between implementations.
  * <hr>
  * This file is part of JMRI.

--- a/java/src/jmri/implementation/AbstractIdTagReporter.java
+++ b/java/src/jmri/implementation/AbstractIdTagReporter.java
@@ -38,18 +38,26 @@ public class AbstractIdTagReporter extends AbstractReporter
     public void notify(IdTag id) {
         log.debug("Notify: {}",mSystemName);
         if (id != null) {
-            log.debug("Tag: {}",id);
-            Reporter r = id.getWhereLastSeen();
-            if (r != null) {
-                notifyPreviousReporter(r,id);
+            log.debug("Tag {} notified in {}",id, this);
+            // do not update last reporter and last seen if this is an "exit" report
+            // Only happens on LocoNet transponding reports
+            var entryexit = id.getProperty("entryexit");
+            if (entryexit == null || ! entryexit.equals("exits")) {
+                Reporter r = id.getWhereLastSeen();
+                if (r != null) {
+                    log.trace("{} notifyPreviousReporter {}", id, r);
+                    notifyPreviousReporter(r,id);
+                }
+                id.setWhereLastSeen(this);
+                log.trace("{} last seen here: {}",id, this.mSystemName);
+            } else {
+                log.trace("{} skipping setWhereLastSeen on {} exits report", this, id);
             }
-            id.setWhereLastSeen(this);
-            log.debug("Seen here: {}",this.mSystemName);
         }
         setReport(id);
         setState(id != null ? IdTag.SEEN : IdTag.UNSEEN);
     }
-    
+
     private void notifyPreviousReporter(Reporter r, IdTag id) {
         log.debug("Previous reporter: {}",r.getSystemName());
         if (!(r.equals(this)) && r.getCurrentReport() == id
@@ -74,7 +82,7 @@ public class AbstractIdTagReporter extends AbstractReporter
     public int getState() {
         return state;
     }
-    
+
     /** {@inheritDoc} */
     @Override
     @Nonnull
@@ -90,7 +98,7 @@ public class AbstractIdTagReporter extends AbstractReporter
     }
 
     // Methods to support PhysicalLocationReporter interface
-    
+
     /**
      * Get the locomotive address we're reporting about from the current report.
      * {@inheritDoc}
@@ -116,9 +124,9 @@ public class AbstractIdTagReporter extends AbstractReporter
     }
 
     /**
-     * Gets the direction (ENTER/EXIT) of the report. 
+     * Gets the direction (ENTER/EXIT) of the report.
      * <p>
-     * Because of the way 
+     * Because of the way
      * IdTag Reporters work, all reports are ENTER type.
      * {@inheritDoc}
      */
@@ -131,10 +139,10 @@ public class AbstractIdTagReporter extends AbstractReporter
     /**
      * Get the PhysicalLocation of the Reporter
      *
-     * Reports its own location, for now. 
+     * Reports its own location, for now.
      * Not sure if that's the right thing or
      * not. NOT DONE YET
-     * 
+     *
      * {@inheritDoc}
      */
     @Override

--- a/java/src/jmri/util/TimerUtil.java
+++ b/java/src/jmri/util/TimerUtil.java
@@ -10,7 +10,7 @@ import javax.annotation.Nonnull;
  * Common utility methods for working with (@link java.util.Timer)
  * <p>
  * Each {@link java.util.Timer} uses a thread, which means that they're
- * not throw-away timers:  You either track when you can destroy them 
+ * not throw-away timers:  You either track when you can destroy them
  * (and that destruction is not obvious), or they stick around consuming
  * resources.
  * <p>
@@ -34,34 +34,70 @@ import javax.annotation.Nonnull;
 final public class TimerUtil {
 
     // Timer implementation methods
-    
+
     static public void schedule(@Nonnull TimerTask task, @Nonnull Date time) {
-        commonTimer.schedule(task, time);
+        synchronized (commonTimer) {
+            try {
+                commonTimer.schedule(task, time);
+            } catch (IllegalStateException e) {
+                log.warn("During schedule()", e);
+            }
+        }
     }
 
     static public void schedule(@Nonnull TimerTask task, @Nonnull Date firstTime, long period) {
-        commonTimer.schedule(task, firstTime, period);
+        synchronized (commonTimer) {
+            try {
+                commonTimer.schedule(task, firstTime, period);
+            } catch (IllegalStateException e) {
+                log.warn("During schedule()", e);
+            }
+        }
     }
-    
+
     static public void schedule(@Nonnull TimerTask task, long delay) {
-        commonTimer.schedule(task, delay);
+        synchronized (commonTimer) {
+            try {
+                commonTimer.schedule(task, delay);
+            } catch (IllegalStateException e) {
+                log.warn("During schedule()", e);
+            }
+        }
     }
-    
+
     static public void schedule(@Nonnull TimerTask task, long delay, long period) {
-        commonTimer.schedule(task, delay, period);
+        synchronized (commonTimer) {
+            try {
+                commonTimer.schedule(task, delay, period);
+            } catch (IllegalStateException e) {
+                log.warn("During schedule()", e);
+            }
+        }
     }
-    
+
     static public void scheduleAtFixedRate(@Nonnull TimerTask task, @Nonnull Date firstTime, long period) {
-        commonTimer.schedule(task, firstTime, period);
+        synchronized (commonTimer) {
+            try {
+                commonTimer.schedule(task, firstTime, period);
+            } catch (IllegalStateException e) {
+                log.warn("During schedule()", e);
+            }
+        }
     }
-    
+
     static public void scheduleAtFixedRate(@Nonnull TimerTask task, long delay, long period) {
-        commonTimer.schedule(task, delay, period);
+        synchronized (commonTimer) {
+            try {
+                commonTimer.schedule(task, delay, period);
+            } catch (IllegalStateException e) {
+                log.warn("During schedule()", e);
+            }
+        }
     }
-   
-   
+
+
     // GUI-thread implementation methods
-    
+
     // arrange to run on GUI thread
     static private TimerTask gtask(TimerTask task) {
         return new TimerTask(){
@@ -73,30 +109,66 @@ final public class TimerUtil {
     }
 
     static public void scheduleOnGUIThread(@Nonnull TimerTask task, @Nonnull Date time) {
-        commonTimer.schedule(gtask(task), time);
+        synchronized (commonTimer) {
+            try {
+                commonTimer.schedule(gtask(task), time);
+            } catch (IllegalStateException e) {
+                log.warn("During schedule()", e);
+            }
+        }
     }
 
     static public void scheduleOnGUIThread(@Nonnull TimerTask task, @Nonnull Date firstTime, long period) {
-        commonTimer.schedule(gtask(task), firstTime, period);
+        synchronized (commonTimer) {
+            try {
+                commonTimer.schedule(gtask(task), firstTime, period);
+            } catch (IllegalStateException e) {
+                log.warn("During schedule()", e);
+            }
+        }
     }
-    
+
     static public void scheduleOnGUIThread(@Nonnull TimerTask task, long delay) {
-        commonTimer.schedule(gtask(task), delay);
+        synchronized (commonTimer) {
+            try {
+                commonTimer.schedule(gtask(task), delay);
+            } catch (IllegalStateException e) {
+                log.warn("During schedule()", e);
+            }
+        }
     }
-    
+
     static public void scheduleOnGUIThread(@Nonnull TimerTask task, long delay, long period) {
-        commonTimer.schedule(gtask(task), delay, period);
+        synchronized (commonTimer) {
+            try {
+                commonTimer.schedule(gtask(task), delay, period);
+            } catch (IllegalStateException e) {
+                log.warn("During schedule()", e);
+            }
+        }
     }
-    
+
     static public void scheduleAtFixedRateOnGUIThread(@Nonnull TimerTask task, @Nonnull Date firstTime, long period) {
-        commonTimer.schedule(gtask(task), firstTime, period);
+        synchronized (commonTimer) {
+            try {
+                commonTimer.schedule(gtask(task), firstTime, period);
+            } catch (IllegalStateException e) {
+                log.warn("During schedule()", e);
+            }
+        }
     }
-    
+
     static public void scheduleAtFixedRateOnGUIThread(@Nonnull TimerTask task, long delay, long period) {
-        commonTimer.schedule(gtask(task), delay, period);
+        synchronized (commonTimer) {
+            try {
+                commonTimer.schedule(gtask(task), delay, period);
+            } catch (IllegalStateException e) {
+                log.warn("During schedule()", e);
+            }
+        }
     }
-   
-   
+
+
     // arrange to run on layout thread
     static private TimerTask ltask(TimerTask task) {
         return new TimerTask(){
@@ -106,33 +178,69 @@ final public class TimerUtil {
                 }
         };
     }
-    
+
     static public void scheduleOnLayoutThread(@Nonnull TimerTask task, @Nonnull Date time) {
-        commonTimer.schedule(ltask(task), time);
+        synchronized (commonTimer) {
+            try {
+                commonTimer.schedule(ltask(task), time);
+            } catch (IllegalStateException e) {
+                log.warn("During schedule()", e);
+            }
+        }
     }
 
     static public void scheduleOnLayoutThread(@Nonnull TimerTask task, @Nonnull Date firstTime, long period) {
-        commonTimer.schedule(ltask(task), firstTime, period);
+        synchronized (commonTimer) {
+            try {
+                commonTimer.schedule(ltask(task), firstTime, period);
+            } catch (IllegalStateException e) {
+                log.warn("During schedule()", e);
+            }
+        }
     }
-    
+
     static public void scheduleOnLayoutThread(@Nonnull TimerTask task, long delay) {
-        commonTimer.schedule(ltask(task), delay);
+        synchronized (commonTimer) {
+            try {
+                commonTimer.schedule(ltask(task), delay);
+            } catch (IllegalStateException e) {
+                log.warn("During schedule()", e);
+            }
+        }
     }
-    
+
     static public void scheduleOnLayoutThread(@Nonnull TimerTask task, long delay, long period) {
-        commonTimer.schedule(ltask(task), delay, period);
+        synchronized (commonTimer) {
+            try {
+                commonTimer.schedule(ltask(task), delay, period);
+            } catch (IllegalStateException e) {
+                log.warn("During schedule()", e);
+            }
+        }
     }
-    
+
     static public void scheduleAtFixedRateOnLayoutThread(@Nonnull TimerTask task, @Nonnull Date firstTime, long period) {
-        commonTimer.schedule(ltask(task), firstTime, period);
+        synchronized (commonTimer) {
+            try {
+                commonTimer.schedule(ltask(task), firstTime, period);
+            } catch (IllegalStateException e) {
+                log.warn("During schedule()", e);
+            }
+        }
     }
-    
+
     static public void scheduleAtFixedRateOnLayoutThread(@Nonnull TimerTask task, long delay, long period) {
-        commonTimer.schedule(ltask(task), delay, period);
+        synchronized (commonTimer) {
+            try {
+                commonTimer.schedule(ltask(task), delay, period);
+            } catch (IllegalStateException e) {
+                log.warn("During schedule()", e);
+            }
+        }
     }
-   
-   
+
+
     final static Timer commonTimer = new Timer("JMRI Common Timer", true);
-    
-    // private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(TimerUtil.class);
+
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(TimerUtil.class);
 }


### PR DESCRIPTION
- Fixed a bug in the Reporter Table that was causing the Last Report column to actually display the Current Report. Note that this is just a display bug; the underlying value and property change notifications are correct, so this change won't affect scripts, LogixNG, etc.
 - The definition of "Last Seen" for Id Tags has been clarified to mean "Location where the tag was last seen to be *present*". Previously, a report that a tag was *absent* could be marked as the last seen report.  Not all hardware Reporters provide entry/exit reports, as some just indicate that something has been observed in place; their "Last Seen" behavior has not changed.
 - Some Reporters, particularly LocoNet, would improperly clear an "enter" report when an "exits" report for the same tag was seen elsewhere.  This was an error that has been fixed, but if you have scripts or LogixNG that depend on this behavior you might have to update them.

Also includes some fixes for exceptions that occur in the preferences system due to Timer threading at large load factors.