### PR TITLE
Control CBus Reporter timeout

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -21,7 +21,7 @@
 
         <h4>CBUS</h4>
             <ul>
-                <li>The default behavior for CBus Reporters has been changes to
+                <li>The default behavior for CBus Reporters has been changed to
                     <u>not</u> clear the report after a timeout. A new
                     CbusReporterTimeoutControl.py script is provided to
                     restore the previous behavior:  After a timeout, the

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -21,7 +21,12 @@
 
         <h4>CBUS</h4>
             <ul>
-                <li></li>
+                <li>The default behavior for CBus Reporters has been changes to
+                    <u>not</u> clear the report after a timeout. A new
+                    CbusReporterTimeoutControl.py script is provided to
+                    restore the previous behavior:  After a timeout, the
+                    report is cleared.  The script also demonstrates how to
+                    get a more granular control over this behavior.</li>
             </ul>
 
         <h4>C/MRI</h4>

--- a/java/src/jmri/jmrix/can/cbus/CbusReporter.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusReporter.java
@@ -39,6 +39,22 @@ public class CbusReporter extends AbstractRailComReporter implements CanListener
     private final CanSystemConnectionMemo _memo;
 
     /**
+     * All CbusReporters should clear themselves after a timeout.
+     * <p>
+     * Default behavior is to not timeout; this is public access
+     * so it can be updated from a script
+     */
+    public static boolean eraseOnTimeoutAll = false;
+
+    /**
+     * This CbusReporter should clear itself after a timeout.
+     * <p>
+     * Default behavior is to not timeout; this is public access
+     * so it can be updated from a script
+     */
+    public boolean eraseOnTimeoutThisReporter = false;
+
+    /**
      * Create a new CbusReporter.
      * <p>
      *
@@ -177,6 +193,9 @@ public class CbusReporter extends AbstractRailComReporter implements CanListener
 
     // delay can be set to non-null memo when older constructor fully deprecated.
     private void startTimeout(IdTag tag){
+        // only timeout when enabled
+        if (! eraseOnTimeoutAll && ! eraseOnTimeoutThisReporter) return;
+
         int delay = (_memo==null ? 2000 : ((CbusReporterManager)_memo.get(jmri.ReporterManager.class)).getTimeout() );
         ThreadingUtil.runOnLayoutDelayed( () -> {
             if (!disposed && getCurrentReport() == tag) {

--- a/java/src/jmri/jmrix/can/cbus/CbusReporter.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusReporter.java
@@ -39,7 +39,7 @@ public class CbusReporter extends AbstractRailComReporter implements CanListener
     private final CanSystemConnectionMemo _memo;
 
     /**
-     * All CbusReporters should clear themselves after a timeout.
+     * Should all CbusReporters clear themselves after a timeout?
      * <p>
      * Default behavior is to not timeout; this is public access
      * so it can be updated from a script
@@ -47,7 +47,7 @@ public class CbusReporter extends AbstractRailComReporter implements CanListener
     public static boolean eraseOnTimeoutAll = false;
 
     /**
-     * This CbusReporter should clear itself after a timeout.
+     * Should this CbusReporter clear itself after a timeout?
      * <p>
      * Default behavior is to not timeout; this is public access
      * so it can be updated from a script

--- a/jython/CbusReporterTimeoutControl.py
+++ b/jython/CbusReporterTimeoutControl.py
@@ -1,0 +1,16 @@
+# Staring with JMRI 5.3.7, the default behavior or CBus Reporters was
+# changed to _not_ clear themselves after a short delay.
+
+# You can restore the prior behavior by running this script.
+# CBus Reporters will then clear themselves after a short delay.
+
+import jmri
+
+jmri.jmrix.can.cbus.CbusReporter.eraseOnTimeoutAll = True
+
+# You can also turn on the old behavior for just one reporter with e.g.
+#
+# reporters.getReporter("NameHere").eraseOnTimeoutThisReporter = True
+#
+
+


### PR DESCRIPTION
The default behavior for CBus Reporters has been changed to _not_clear the report after a timeout. 

A new `CbusReporterTimeoutControl.py` script is provided to restore the previous behavior:  After a timeout, the report is cleared.  The script also demonstrates how to get a more granular control over this behavior.