### PR TITLE
Z21 POM delay

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -139,7 +139,8 @@
 
         <h4>Roco z21/Z21</h4>
             <ul>
-                <li></li>
+                <li>Add a delay to read/write programming operations on the main.
+                    This is intended to help when doing reads of indexed CVs.</li>
             </ul>
 
         <h4>Secsi</h4>

--- a/java/src/jmri/jmrix/roco/z21/Z21XNetOpsModeProgrammer.java
+++ b/java/src/jmri/jmrix/roco/z21/Z21XNetOpsModeProgrammer.java
@@ -22,7 +22,7 @@ public class Z21XNetOpsModeProgrammer extends jmri.jmrix.lenz.XNetOpsModeProgram
     private int _cv;
     private LnTrafficController lnTC;
 
-    static public int operationDelay = 50;
+    static public int operationDelay = 50; // public for script acccess
 
     public Z21XNetOpsModeProgrammer(int pAddress, XNetTrafficController controller) {
         this(pAddress,controller,null);

--- a/java/src/jmri/jmrix/roco/z21/Z21XNetOpsModeProgrammer.java
+++ b/java/src/jmri/jmrix/roco/z21/Z21XNetOpsModeProgrammer.java
@@ -22,6 +22,8 @@ public class Z21XNetOpsModeProgrammer extends jmri.jmrix.lenz.XNetOpsModeProgram
     private int _cv;
     private LnTrafficController lnTC;
 
+    static public int operationDelay = 250;
+
     public Z21XNetOpsModeProgrammer(int pAddress, XNetTrafficController controller) {
         this(pAddress,controller,null);
     }
@@ -37,7 +39,7 @@ public class Z21XNetOpsModeProgrammer extends jmri.jmrix.lenz.XNetOpsModeProgram
         }
     }
 
-    /** 
+    /**
      * {@inheritDoc}
      *
      * Send an ops-mode write request to the Xpressnet.
@@ -48,7 +50,7 @@ public class Z21XNetOpsModeProgrammer extends jmri.jmrix.lenz.XNetOpsModeProgram
         XNetMessage msg = XNetMessage.getWriteOpsModeCVMsg(mAddressHigh, mAddressLow, CV, val);
         msg.setBroadcastReply(); // reply comes through a loconet message.
         tc.sendXNetMessage(msg, this);
-        /* we need to save the programer and value so we can send messages 
+        /* we need to save the programer and value so we can send messages
          back to the screen when the programming screen when we receive
          something from the command station */
         progListener = p;
@@ -58,7 +60,7 @@ public class Z21XNetOpsModeProgrammer extends jmri.jmrix.lenz.XNetOpsModeProgram
         restartTimer(msg.getTimeout());
     }
 
-    /** 
+    /**
      * {@inheritDoc}
      */
     @Override
@@ -75,7 +77,7 @@ public class Z21XNetOpsModeProgrammer extends jmri.jmrix.lenz.XNetOpsModeProgram
         restartTimer(msg.getTimeout());
     }
 
-    /** 
+    /**
      * {@inheritDoc}
      */
     @Override
@@ -92,23 +94,24 @@ public class Z21XNetOpsModeProgrammer extends jmri.jmrix.lenz.XNetOpsModeProgram
         restartTimer(msg.getTimeout());
     }
 
-    /** 
+    /**
      * {@inheritDoc}
      */
     @Override
     synchronized public void message(XNetReply l) {
         if (progState == NOTPROGRAMMING) {
-            // We really don't care about any messages unless we send a 
+            // We really don't care about any messages unless we send a
             // request, so just ignore anything that comes in
         } else if (progState == REQUESTSENT) {
             if (l.isOkMessage()) {
-                // Before we set the programmer state to not programming, 
-                // delay for a short time to give the decoder a chance to 
+                // Before we set the programmer state to not programming,
+                // delay for a short time to give the decoder a chance to
                 // process the request.
-                new jmri.util.WaitHandler(this,250);
-                progState = NOTPROGRAMMING;
                 stopTimer();
-                notifyProgListenerEnd(progListener, value, jmri.ProgListener.OK);
+                jmri.util.ThreadingUtil.runOnLayoutDelayed (() -> {
+                    progState = NOTPROGRAMMING;
+                    notifyProgListenerEnd(progListener, value, jmri.ProgListener.OK);
+                }, operationDelay);
             } else if (l.getElement(0) == Z21Constants.LAN_X_CV_RESULT_XHEADER
                     && l.getElement(1) == Z21Constants.LAN_X_CV_RESULT_DB0) {
                 // valid operation response, but does it belong to us?
@@ -117,11 +120,13 @@ public class Z21XNetOpsModeProgrammer extends jmri.jmrix.lenz.XNetOpsModeProgram
                     return; // not for us.
                 }
                 value = l.getElement(4);
-                progState = NOTPROGRAMMING;
                 stopTimer();
-                // if this was a read, we cached the value earlier.  If its a
-                // write, we're to return the original write value
-                notifyProgListenerEnd(progListener, value, jmri.ProgListener.OK);
+                jmri.util.ThreadingUtil.runOnLayoutDelayed (() -> {
+                    progState = NOTPROGRAMMING;
+                    // if this was a read, we cached the value earlier.  If its a
+                    // write, we're to return the original write value
+                    notifyProgListenerEnd(progListener, value, jmri.ProgListener.OK);
+                }, operationDelay);
             } else {
                 /* this is an error */
                 if (l.isRetransmittableErrorMsg()) {
@@ -153,7 +158,7 @@ public class Z21XNetOpsModeProgrammer extends jmri.jmrix.lenz.XNetOpsModeProgram
      */
     @Override
     synchronized public void message(LocoNetMessage m){
-      // the Roco Z21 responds to Operations mode write requests with a 
+      // the Roco Z21 responds to Operations mode write requests with a
       // LocoNet message.
         log.debug("LocoNet message received: {}", m);
 
@@ -164,7 +169,7 @@ public class Z21XNetOpsModeProgrammer extends jmri.jmrix.lenz.XNetOpsModeProgram
             // so let's see if it is for us.
             log.debug("Right message slot and programming");
 
-            // the following 8 lines and assignment of val were copied 
+            // the following 8 lines and assignment of val were copied
             // from the loconet monitor.
             int hopsa = m.getElement(5); // Ops mode - 7 high address bits
             // of loco to program
@@ -176,7 +181,7 @@ public class Z21XNetOpsModeProgrammer extends jmri.jmrix.lenz.XNetOpsModeProgram
             int cvNumber = (((((cvh & LnConstants.CVH_CV8_CV9) >> 3) | (cvh & LnConstants.CVH_CV7)) * 128) + (cvl & 0x7f)) + 1;
             int address =  hopsa * 128 + lopsa;
 
-            // if we attempt to verify the cvNumber, this fails for 
+            // if we attempt to verify the cvNumber, this fails for
             // multiple writes from the Symbolic Programmer.
             if(address!=mAddress || cvNumber != _cv ){
                log.debug("message for address {} expecting {}; cv {} expecting {}",
@@ -189,7 +194,7 @@ public class Z21XNetOpsModeProgrammer extends jmri.jmrix.lenz.XNetOpsModeProgram
             if ((m.getElement(2) & 0x20) != 0) {
                val = (((cvh & LnConstants.CVH_D7) << 6) | (data7 & 0x7f));
             }
-  
+
             log.debug("received value {} for cv {} on address {}",val,cvNumber,address);
 
             // successful read if LACK return status is not 0x7F

--- a/java/src/jmri/jmrix/roco/z21/Z21XNetOpsModeProgrammer.java
+++ b/java/src/jmri/jmrix/roco/z21/Z21XNetOpsModeProgrammer.java
@@ -22,7 +22,7 @@ public class Z21XNetOpsModeProgrammer extends jmri.jmrix.lenz.XNetOpsModeProgram
     private int _cv;
     private LnTrafficController lnTC;
 
-    static public int operationDelay = 250;
+    static public int operationDelay = 50;
 
     public Z21XNetOpsModeProgrammer(int pAddress, XNetTrafficController controller) {
         this(pAddress,controller,null);

--- a/java/test/jmri/jmrix/lenz/XNetOpsModeProgrammerTest.java
+++ b/java/test/jmri/jmrix/lenz/XNetOpsModeProgrammerTest.java
@@ -64,7 +64,7 @@ public class XNetOpsModeProgrammerTest extends jmri.jmrix.AbstractOpsModeProgram
         Assert.assertEquals("outbound message",m,tc.outbound.elementAt(0));
         op.message(new XNetReply("01 04 05")); // send "OK" message to the programmer.
         // and now we need to check the status is right
-        Assert.assertEquals("written value",5,lastValue);
+        jmri.util.JUnitUtil.waitFor( ()->{ return lastValue == 5; }, "written value" );
         Assert.assertEquals("status",jmri.ProgListener.OK,lastStatus);
     }
 
@@ -75,12 +75,12 @@ public class XNetOpsModeProgrammerTest extends jmri.jmrix.AbstractOpsModeProgram
         Assert.assertEquals("outbound message sent",1,tc.outbound.size());
         Assert.assertEquals("outbound message",m,tc.outbound.elementAt(0));
         // and now we need to check the status is right
-        Assert.assertEquals("written value",29,lastValue);
+        jmri.util.JUnitUtil.waitFor( ()->{ return lastValue == 29; }, "written value" );
         Assert.assertEquals("status",jmri.ProgListener.NotImplemented,lastStatus);
         // send a message reply
         op.message(new XNetReply("01 04 05")); // send "OK" message to the programmer.
         // and verify the status is the same.
-        Assert.assertEquals("written value",29,lastValue);
+        jmri.util.JUnitUtil.waitFor( ()->{ return lastValue == 29; }, "written value" );
         Assert.assertEquals("status",jmri.ProgListener.NotImplemented,lastStatus);
     }
 
@@ -91,12 +91,12 @@ public class XNetOpsModeProgrammerTest extends jmri.jmrix.AbstractOpsModeProgram
         Assert.assertEquals("outbound message sent",1,tc.outbound.size());
         Assert.assertEquals("outbound message",m,tc.outbound.elementAt(0));
         // and now we need to check the status is right
-        Assert.assertEquals("written value",5,lastValue);
+        jmri.util.JUnitUtil.waitFor( ()->{ return lastValue == 5; }, "written value" );
         Assert.assertEquals("status",jmri.ProgListener.NotImplemented,lastStatus);
         // send a message reply
         op.message(new XNetReply("01 04 05")); // send "OK" message to the programmer.
         // and verify the status is the same.
-        Assert.assertEquals("written value",5,lastValue);
+        jmri.util.JUnitUtil.waitFor( ()->{ return lastValue == 5; }, "written value" );
         Assert.assertEquals("status",jmri.ProgListener.NotImplemented,lastStatus);
     }
 
@@ -108,7 +108,7 @@ public class XNetOpsModeProgrammerTest extends jmri.jmrix.AbstractOpsModeProgram
         Assert.assertEquals("outbound message",m,tc.outbound.elementAt(0));
         op.message(new XNetReply("61 82 E3")); // send "Not Supported" message to the programmer.
         // and now we need to check the status is right
-        Assert.assertEquals("written value",5,lastValue);
+        jmri.util.JUnitUtil.waitFor( ()->{ return lastValue == 5; }, "written value" );
         Assert.assertEquals("status",jmri.ProgListener.NotImplemented,lastStatus);
     }
 
@@ -128,7 +128,7 @@ public class XNetOpsModeProgrammerTest extends jmri.jmrix.AbstractOpsModeProgram
         // then finish without an error (tc will retransmit).
         op.message(new XNetReply("01 04 05")); // send "OK" message to the programmer.
         // and now we need to check the status is right
-        Assert.assertEquals("written value",5,lastValue);
+        jmri.util.JUnitUtil.waitFor( ()->{ return lastValue == 5; }, "written value" );
         Assert.assertEquals("status",jmri.ProgListener.OK,lastStatus);
     }
 
@@ -140,7 +140,7 @@ public class XNetOpsModeProgrammerTest extends jmri.jmrix.AbstractOpsModeProgram
         Assert.assertEquals("outbound message",m,tc.outbound.elementAt(0));
         op.message(new XNetReply("61 02 63")); // send "Service Mode Entry" message to the programmer, which is an error here.
         // and now we need to check the status is right
-        Assert.assertEquals("written value",5,lastValue);
+        jmri.util.JUnitUtil.waitFor( ()->{ return lastValue == 5; }, "written value" );
         Assert.assertEquals("status",jmri.ProgListener.UnknownError,lastStatus);
     }
 

--- a/java/test/jmri/jmrix/roco/z21/Z21XNetOpsModeProgrammerTest.java
+++ b/java/test/jmri/jmrix/roco/z21/Z21XNetOpsModeProgrammerTest.java
@@ -27,7 +27,7 @@ public class Z21XNetOpsModeProgrammerTest extends jmri.jmrix.lenz.XNetOpsModePro
         Assert.assertEquals("outbound message",m,tc.outbound.elementAt(0));
         op.message(new XNetReply("01 04 05")); // send "OK" message to the programmer.
         // and now we need to check the status is right
-        Assert.assertEquals("written value",5,lastValue);
+        jmri.util.JUnitUtil.waitFor( ()->{ return lastValue == 5; }, "written value" );
         Assert.assertEquals("status",jmri.ProgListener.OK,lastStatus);
     }
 


### PR DESCRIPTION
Add a short delay to Roco Z21 POM reads and writes to make reading and writing indexed CVs more reliable.