### PR TITLE
Add git sharing link

### DIFF
--- a/help/en/html/setup/Dropbox.shtml
+++ b/help/en/html/setup/Dropbox.shtml
@@ -66,7 +66,7 @@
 
         <li>Note that neither Dropbox or a shared network drive provide a fully isolated non-live
         off-line copy (external device such as USB drive or CD/DVD) by default. That responsibility
-        is still up to you.</li>
+        is still up to you.
       </ul>
 
       <p>The following approach should also work with other cloud-based file-synchronisation
@@ -74,7 +74,11 @@
       and <a href="https://www.microsoft.com/en-us/microsoft-365/onedrive/online-cloud-storage"
       target="_blank">OneDrive</a>. However the <a href="https://www.dropbox.com" target=
       "_blank">Dropbox</a> solution is well tested, having been used by a number of JMRI developers
-      and users for quite some time.</p>
+      and users for quite some time.
+      You can also use a revision control system like Git;
+      <a href="git.shtml">those instructions</a>
+      are somewhat different.</li>
+      </p>
 
       <h3>Step 1</h3>
 

--- a/help/en/html/setup/git.shtml
+++ b/help/en/html/setup/git.shtml
@@ -36,7 +36,7 @@
         <li>In normal use, Git will keep the entire history of your files locally so that you can
         always back up to an earlier configuration.</li>
 
-        <li>Git provides every powerful tools for managing updates when you're making changes on
+        <li>Git provides very powerful tools for managing updates when you're making changes on
         multiple computers, i.e. the main layout computer and some convenient laptoo.</li>
 
         <li>Git can be used with a sneaker-net connection by pushing/pulling from a copy of a


### PR DESCRIPTION
Adds a link on the Dropbox page to a page describing file sharing via GitHub.  

Not that so many people are likely to use Git to version control their layout files, but [it has been done](https://github.com/bobjacobsen/SPShasta).