### PR TITLE
Update the roster and locomotive schema, locomotive DTD to accept current contents

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -640,5 +640,8 @@
             <li>Improved how window preferences are stored to reduce error messages
                 when JMRI is under high load.</li>
             <li>Update the JMRI install process for Raspberry Pi computers running the Raspberry Pi OS.</li>
+            <li>Updated the roster and locomotive schema and the locomotive DTD to accept current contents.
+                JMRI has been writing extra content in its roster, and the schema and DTD files had not
+                kept up.  This resolves that.
         </ul>
 

--- a/xml/DTD/locomotive-config.dtd
+++ b/xml/DTD/locomotive-config.dtd
@@ -17,18 +17,19 @@
 <!-- for more details.                                                      -->
 
 <!ELEMENT locomotive-config (locomotive)>
-<!ATTLIST locomotive-config>
+<!ATTLIST locomotive-config xmlns:xsi CDATA #IMPLIED>
+<!ATTLIST locomotive-config xsi:noNamespaceSchemaLocation CDATA #IMPLIED>
 
 <!-- The identification attributes in locomotive and -->
 <!-- decoder must be kept the same as the ones in the roster DTD -->
 <!-- This copy is used if we have to import an existing file into a roster -->
 
 <!ELEMENT locomotive (dateupdated?,dateUpdated?, decoder, locoaddress*, functionlabels?, attributepairs?, values?) >
-<!ATTLIST locomotive id		      CDATA #REQUIRED>          
-<!ATTLIST locomotive fileName	CDATA #IMPLIED>  
-<!ATTLIST locomotive groupName  CDATA #IMPLIED>        
-<!ATTLIST locomotive roadName	  CDATA #IMPLIED>          
-<!ATTLIST locomotive roadNumber	CDATA #IMPLIED>          
+<!ATTLIST locomotive id		      CDATA #REQUIRED>
+<!ATTLIST locomotive fileName	CDATA #IMPLIED>
+<!ATTLIST locomotive groupName  CDATA #IMPLIED>
+<!ATTLIST locomotive roadName	  CDATA #IMPLIED>
+<!ATTLIST locomotive roadNumber	CDATA #IMPLIED>
 <!ATTLIST locomotive mfg	      CDATA #IMPLIED>
 <!ATTLIST locomotive owner	    CDATA #IMPLIED>
 <!ATTLIST locomotive model	    CDATA #IMPLIED>
@@ -52,18 +53,24 @@
 <!ATTLIST decoder comment CDATA #IMPLIED>
 
 <!-- define general locomotive address -->
-<!ELEMENT locoaddress (dcclocoaddress) >
+<!ELEMENT locoaddress (dcclocoaddress, number, protocol) >
 
 <!-- define DCC locomotive address -->
 <!ELEMENT dcclocoaddress EMPTY >
 <!ATTLIST dcclocoaddress number      CDATA #IMPLIED>
 <!ATTLIST dcclocoaddress longaddress ( yes | no) "no">
 
+<!-- define DCC locomotive number -->
+<!ELEMENT number (#PCDATA) >
+
+<!-- define DCC locomotive protocol -->
+<!ELEMENT protocol (#PCDATA) >
+
 <!-- The values section defines values for CVs and/or variables -->
 <!ELEMENT values (decoderDef, (CVvalue | varValue)*, indexedCVvalue* )>
 
 <!ELEMENT decoderDef (varValue*) >   <!-- Where the variable definitions came from -->
-		  						
+
 <!ELEMENT CVvalue EMPTY>
 <!ATTLIST CVvalue name    CDATA #IMPLIED>         <!-- CV number, used for identification -->
 <!ATTLIST CVvalue value   CDATA #REQUIRED>        <!-- Value of specified CV -->
@@ -88,8 +95,8 @@
 <!ELEMENT functionlabels (functionlabel*) >
 
 <!ELEMENT functionlabel (#PCDATA) >
-<!ATTLIST functionlabel	num	      CDATA #REQUIRED>   
-<!ATTLIST functionlabel	lockable (true | false) "true">   
+<!ATTLIST functionlabel	num	      CDATA #REQUIRED>
+<!ATTLIST functionlabel	lockable (true | false) "true">
 <!ATTLIST functionlabel functionImage CDATA #IMPLIED>
 <!ATTLIST functionlabel functionImagePressed  CDATA #IMPLIED>
 

--- a/xml/schema/locomotive-config.xsd
+++ b/xml/schema/locomotive-config.xsd
@@ -32,7 +32,7 @@
         >
 
   <xs:include schemaLocation="http://jmri.org/xml/schema/types/general.xsd"/>
-  
+
   <xs:element name="locomotive-config">
     <xs:annotation>
         <xs:documentation>
@@ -48,7 +48,7 @@
       </xs:sequence>
     </xs:complexType>
   </xs:element>
-  
+
     <xs:complexType name="LocomotiveType">
       <xs:sequence>
         <xs:element name="dateUpdated" minOccurs="0" maxOccurs="1">
@@ -58,15 +58,15 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:element>
-        
+
         <xs:element name="decoder" type="DecoderType" minOccurs="1" maxOccurs="1" />
-        
+
         <xs:element name="locoaddress" type="LocoAddressType" minOccurs="0" maxOccurs="1" />
-        
+
         <xs:element name="functionlabels" type="FunctionLabelType" minOccurs="0" maxOccurs="1" />
-        
+
         <xs:element name="soundlabels" type="SoundLabelType" minOccurs="0" maxOccurs="1" />
-        
+
         <xs:element name="attributepairs" type="AttributePairsType" minOccurs="0" maxOccurs="unbounded" />
 
         <xs:element name="speedprofile" type="SpeedProfileType" minOccurs="0" maxOccurs="1" />
@@ -121,7 +121,7 @@
           </xs:complexType>
         </xs:element>
       </xs:sequence>
-      
+
         <xs:attribute name="id" type="xs:string" use="required"/>
         <xs:attribute name="dccAddress" type="xs:string"/> <!-- deprecated -->
         <xs:attribute name="fileName" type="xs:string"/>
@@ -133,6 +133,9 @@
         <xs:attribute name="roadName" type="xs:string"/>
         <xs:attribute name="roadNumber" type="xs:string"/>
         <xs:attribute name="mfg" type="xs:string"/>
+        <xs:attribute name="manufacturerID" type="xs:string"/>
+        <xs:attribute name="productID" type="xs:string"/>
+        <xs:attribute name="developerID" type="xs:string"/>
         <xs:attribute name="owner" type="xs:string"/>
         <xs:attribute name="model" type="xs:string"/>
         <xs:attribute name="comment" type="xs:string"/>
@@ -141,9 +144,9 @@
             maximum speed as a fraction from 0 to 1.0
         </xs:documentation></xs:annotation>
         </xs:attribute>
-          
+
     </xs:complexType>
-    
+
     <xs:complexType name="LocoAddressType"><xs:sequence>
       <xs:element name="dcclocoaddress" minOccurs="1" maxOccurs="1">
         <xs:complexType>
@@ -166,7 +169,7 @@
           </xs:simpleType>
         </xs:element>
     </xs:sequence></xs:complexType>
-    
+
   <xs:complexType name="AttributePairsType"><xs:sequence>
       <xs:element name="keyvaluepair" minOccurs="0" maxOccurs="unbounded">
         <xs:complexType><xs:sequence>
@@ -175,14 +178,14 @@
         </xs:sequence></xs:complexType>
       </xs:element>
   </xs:sequence></xs:complexType>
-  
+
   <xs:complexType name="DecoderType">
     <xs:attribute name="family" type="xs:string" use="required"/>
     <xs:attribute name="model" type="xs:string" use="required"/>
     <xs:attribute name="comment" type="xs:string"/>
     <xs:attribute name="maxFnNum" type="xs:int"/>
   </xs:complexType>
-  
+
 
   <xs:complexType name="FunctionLabelType">
     <xs:sequence>

--- a/xml/schema/roster.xsd
+++ b/xml/schema/roster.xsd
@@ -31,7 +31,7 @@
             "
         >
   <xs:include schemaLocation="http://jmri.org/xml/schema/locomotive-config.xsd"/>
-  
+
   <xs:element name="roster-config">
     <xs:annotation>
         <xs:documentation>
@@ -43,11 +43,11 @@
     </xs:annotation>
     <xs:complexType>
       <xs:sequence>
-        
+
         <xs:element name="roster" minOccurs="1" maxOccurs="unbounded">
           <xs:complexType>
             <xs:sequence>
-                <xs:element name="locomotive"  type="LocomotiveType" minOccurs="1" maxOccurs="unbounded">
+              <xs:element name="locomotive"  type="LocomotiveType" minOccurs="1" maxOccurs="unbounded">
               </xs:element>
             </xs:sequence>
             <xs:attribute name="filter" type="xs:string" use="optional">
@@ -59,10 +59,10 @@
             </xs:attribute>
           </xs:complexType>
         </xs:element>
-        
+
         <xs:element name="rosterGroup" minOccurs="0" maxOccurs="unbounded">
           <xs:complexType><xs:sequence>
-              
+
               <xs:element name="group" minOccurs="0" maxOccurs="unbounded">
                 <xs:complexType>
                   <xs:simpleContent>
@@ -71,12 +71,12 @@
                   </xs:simpleContent>
                 </xs:complexType>
               </xs:element>
-              
+
           </xs:sequence></xs:complexType>
         </xs:element>
-        
+
       </xs:sequence>
     </xs:complexType>
   </xs:element>
-  
+
 </xs:schema>


### PR DESCRIPTION
JMRI has been writing extra content in its roster, and the schema and DTD files had not kept up.  This resolves that.