### PR TITLE
Enable turntable feedback

### DIFF
--- a/java/src/jmri/implementation/AbstractTurnout.java
+++ b/java/src/jmri/implementation/AbstractTurnout.java
@@ -159,6 +159,8 @@ public abstract class AbstractTurnout extends AbstractNamedBean implements
                 newKnownState(INCONSISTENT);
                 jmri.util.ThreadingUtil.runOnLayoutDelayed( () -> { newKnownState(s); },
                          DELAYED_FEEDBACK_INTERVAL );
+            } else if (_activeFeedbackType == ONESENSOR) {      // required for turntable only
+                newKnownState(INCONSISTENT);
             }
         } else {
             log.debug("myOperator NOT NULL");

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutTurntableView.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutTurntableView.java
@@ -874,7 +874,8 @@ public class LayoutTurntableView extends LayoutTrackView {
             if (main == isMain) {
                 g2.draw(new Line2D.Double(pt1, pt2));
             }
-            if (isMain && isTurnoutControlled() && (getPosition() == j)) {
+            if (isMain && isTurnoutControlled() && (getPosition() == j ) &&
+                    getRayTurnout(j).getKnownState() != jmri.Turnout.INCONSISTENT) {
                 if (isBlock) {
                     LayoutBlock lb = getLayoutBlock();
                     if (lb != null) {
@@ -930,7 +931,8 @@ public class LayoutTurntableView extends LayoutTrackView {
                 g2.draw(new Line2D.Double(pt1L, pt2L));
                 g2.draw(new Line2D.Double(pt1R, pt2R));
             }
-            if (isMain && isTurnoutControlled() && (getPosition() == j)) {
+            if (isMain && isTurnoutControlled() && (getPosition() == j ) &&
+                    getRayTurnout(j).getKnownState() != jmri.Turnout.INCONSISTENT) {
 //                LayoutBlock lb = getLayoutBlock();
 //                if (lb != null) {
 //                    c = g2.getColor();


### PR DESCRIPTION
This definitely needs a review. All i can say in my defense is that deleayed and onesensor feedback works , which should allow dispatcher to work in automated mode with turntables.

Two sensor feedback is not required for turntables

I don't like the mod in Abstract turnout which was required to enable the ONESENSOR feedback to work. RH amd LH turnouts work without the mod, but I could not manage to get the turntable to work without it. RH and LG turnouts still work I think but need to check that I have not caused mayhem anywhere else.