### PR TITLE
Update LogixNG WebRequest Test - ConnectException to SocketException 

### DIFF
--- a/java/test/jmri/jmrit/logixng/actions/WebRequestTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/WebRequestTest.java
@@ -52,7 +52,7 @@ public class WebRequestTest extends AbstractDigitalActionTestBase {
             // If the HTTPS request has response code HTTP 200 OK, assume we can
             // access the test script on the JMRI web server.
             return con.getResponseCode() == 200;
-        } catch (UnknownHostException | java.net.ConnectException e) {
+        } catch (UnknownHostException | java.net.SocketException e) {
             // We couldn't access the web site
             log.warn("Unable to connect to {} {}",JMRI_ORG_URL,e.getMessage());
             return false;


### PR DESCRIPTION
catch SocketException which covers both ConnectException and NoRouteToHostException
Slightly different exception currently being shown by build server, ie https://builds.jmri.org/jenkins/job/development/job/builds/1730/