### PR TITLE
Check support pages for html files

### DIFF
--- a/java/test/jmri/ArchitectureTest.java
+++ b/java/test/jmri/ArchitectureTest.java
@@ -1,11 +1,15 @@
 package jmri;
 
+import java.io.File;
+
 import org.junit.jupiter.api.*;
 
 import com.tngtech.archunit.lang.*;
 import com.tngtech.archunit.junit.*;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+import jmri.util.FileUtil;
 
 /**
  * Check the architecture of the JMRI library
@@ -389,4 +393,41 @@ public class ArchitectureTest {
             .should()
             .dependOnClassesThat().haveFullyQualifiedName("jmri.util.swing.BeanSelectPanel");
 */
+
+    @Test
+    public void testHelpFileNamesUseShtml(){
+        String path = FileUtil.getExternalFilename(FileUtil.PROGRAM + "help");
+        String[] allowList = {"local"+File.separator+ "index.html",
+            "local"+File.separator+ "stub_template.html"};
+        recursivelyCheckFiles(new File(path), allowList, ".html");
+    }
+
+    private void recursivelyCheckFiles(File directory, String[] allowList, String deniedsuffix) {
+        File[] files = directory.listFiles();
+        if (files == null) {
+            Assertions.fail("Failed to list files in the directory: " + directory.getAbsolutePath());
+            return;
+        }
+        for (File file : files) {
+            if (file.isDirectory()) {
+                recursivelyCheckFiles(file, allowList, deniedsuffix);
+            } else {
+                String fname = file.getAbsolutePath();
+                if (fname.endsWith(deniedsuffix) && notOnAllowList(fname,allowList)) {
+                    System.out.println("Incorrect fileType: "+fname);
+                    // Assertions.fail("filename " +fname+ " should not end with "+deniedsuffix);
+                }
+            }
+        }
+    }
+
+    private boolean notOnAllowList(@javax.annotation.Nonnull String filePath, String[] allowList) {
+        for (String allowed : allowList) {
+            if ( filePath.contains(allowed) ) {
+                return false;
+            }
+        }
+        return true;
+    }
+
 }

--- a/java/test/jmri/ArchitectureTest.java
+++ b/java/test/jmri/ArchitectureTest.java
@@ -414,8 +414,8 @@ public class ArchitectureTest {
             } else {
                 String fname = file.getAbsolutePath();
                 if (fname.endsWith(deniedsuffix) && notOnAllowList(fname,allowList)) {
-                    System.out.println("Incorrect fileType: "+fname);
-                    // Assertions.fail("filename " +fname+ " should not end with "+deniedsuffix);
+                    // System.out.println("Incorrect fileType: "+fname);
+                    Assertions.fail("filename " +fname+ " should not end with "+deniedsuffix);
                 }
             }
         }


### PR DESCRIPTION
Tests for files with .html extension ( should be .shtml )

Marked WIP while resolving current issues, ie.

```
Incorrect fileType: /home/runner/work/JMRI/JMRI/help/fr/html/tools/signaling/IntroToSignalingYourMRR.html
Incorrect fileType: /home/runner/work/JMRI/JMRI/help/en/manual/DecoderPro/Main_Throttle_functionPanel.html
Incorrect fileType: /home/runner/work/JMRI/JMRI/help/en/manual/DecoderPro/Main_Throttle_controlPanel.html
Incorrect fileType: /home/runner/work/JMRI/JMRI/help/en/package/jmri/jmrix/openlcb/swing/downloader/OpenLCBlibrary.html
Incorrect fileType: /home/runner/work/JMRI/JMRI/help/en/html/doc/Technical/logixng/Tutorial/chapter10.html
Incorrect fileType: /home/runner/work/JMRI/JMRI/help/en/html/doc/Technical/logixng/Tutorial/chapter5.html
Incorrect fileType: /home/runner/work/JMRI/JMRI/help/en/html/doc/Technical/logixng/Tutorial/index.html
Incorrect fileType: /home/runner/work/JMRI/JMRI/help/en/html/doc/Technical/logixng/Tutorial/chapter21.html
Incorrect fileType: /home/runner/work/JMRI/JMRI/help/en/html/doc/Technical/logixng/Tutorial/chapter19.html
Incorrect fileType: /home/runner/work/JMRI/JMRI/help/en/html/doc/Technical/logixng/Tutorial/chapter1.html
Incorrect fileType: /home/runner/work/JMRI/JMRI/help/en/html/doc/Technical/logixng/Tutorial/chapter99.html
Incorrect fileType: /home/runner/work/JMRI/JMRI/help/en/html/doc/Technical/logixng/Tutorial/chapter23.html
Incorrect fileType: /home/runner/work/JMRI/JMRI/help/en/html/doc/Technical/logixng/Tutorial/chapter9.html
Incorrect fileType: /home/runner/work/JMRI/JMRI/help/en/html/doc/Technical/logixng/Tutorial/chapter22.html
Incorrect fileType: /home/runner/work/JMRI/JMRI/help/en/html/doc/Technical/logixng/Tutorial/chapter14.html
Incorrect fileType: /home/runner/work/JMRI/JMRI/help/en/html/doc/Technical/logixng/Tutorial/chapter7.html
Incorrect fileType: /home/runner/work/JMRI/JMRI/help/en/html/doc/Technical/logixng/Tutorial/chapter6.html
Incorrect fileType: /home/runner/work/JMRI/JMRI/help/en/html/doc/Technical/logixng/Tutorial/chapter16.html
Incorrect fileType: /home/runner/work/JMRI/JMRI/help/en/html/doc/Technical/logixng/Tutorial/chapter4.html
Incorrect fileType: /home/runner/work/JMRI/JMRI/help/en/html/doc/Technical/logixng/Tutorial/chapter0.html
Incorrect fileType: /home/runner/work/JMRI/JMRI/help/en/html/doc/Technical/logixng/Tutorial/chapter8.html
Incorrect fileType: /home/runner/work/JMRI/JMRI/help/en/html/doc/Technical/logixng/Tutorial/chapter2.html
Incorrect fileType: /home/runner/work/JMRI/JMRI/help/en/html/doc/Technical/logixng/Tutorial/chapter11.html
Incorrect fileType: /home/runner/work/JMRI/JMRI/help/en/html/doc/Technical/logixng/Tutorial/chapter12.html
Incorrect fileType: /home/runner/work/JMRI/JMRI/help/en/html/doc/Technical/logixng/Tutorial/chapter3.html
Incorrect fileType: /home/runner/work/JMRI/JMRI/help/en/html/doc/Technical/logixng/Tutorial/chapter13.html
Incorrect fileType: /home/runner/work/JMRI/JMRI/help/en/html/doc/Technical/logixng/Tutorial/chapter15.html
Incorrect fileType: /home/runner/work/JMRI/JMRI/help/en/html/tools/signaling/IntroToSignalingYourMRR.html
```