### PR TITLE
Restore linking text labels

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -475,7 +475,8 @@
     <h3>Control Panel Editor</h3>
         <a id="CPE" name="CPE"></a>
         <ul>
-            <li></li>
+            <li>Restored the linking input field when adding labels.  This had been
+                inadvertently removed some time in the past.</li>
         </ul>
         <h4>Circuit Builder</h4>
             <a id="CPE-CB" name="CPE-CB"></a>

--- a/java/src/jmri/jmrit/display/palette/TextItemPanel.java
+++ b/java/src/jmri/jmrit/display/palette/TextItemPanel.java
@@ -137,6 +137,7 @@ public class TextItemPanel extends ItemPanel {
                 log.debug("end init: TextItemPanel size {}", getPreferredSize());
             }
             super.init();
+            initLinkPanel();
         }
     }
 
@@ -415,6 +416,25 @@ public class TextItemPanel extends ItemPanel {
         JPanel panel = makeTextPanel(type, sample, editText);
         _samplePanel.add(sample);
         return panel;
+    }
+
+    protected void initLinkPanel() {
+        JPanel blurb = new JPanel();
+        blurb.setLayout(new BoxLayout(blurb, BoxLayout.Y_AXIS));
+        blurb.add(Box.createVerticalStrut(ItemPalette.STRUT_SIZE));
+        blurb.add(new JLabel(Bundle.getMessage("ToLinkToURL", "Text")));
+        blurb.add(new JLabel(Bundle.getMessage("enterPanel")));
+        blurb.add(new JLabel(Bundle.getMessage("enterURL")));
+        blurb.add(Box.createVerticalStrut(ItemPalette.STRUT_SIZE));
+        blurb.add(new JLabel(Bundle.getMessage("LinkName")));
+        blurb.add(_linkName);
+        _linkName.setToolTipText(Bundle.getMessage("ToolTipLink"));
+        blurb.setToolTipText(Bundle.getMessage("ToolTipLink"));
+        JPanel panel = new JPanel();
+        panel.add(blurb);
+        JPanel linkPanel = new JPanel();
+        linkPanel.add(panel);
+        add(linkPanel);
     }
 
     private void makeColorChooser() {


### PR DESCRIPTION
At some point, the ability to include a link in a CPE text field was lost.  (It's still present for icons). This restores that capability by adding the input field and labels to the "add text field" window in CPE.