### PR TITLE
update Architecture Test html file search

### DIFF
--- a/java/test/jmri/ArchitectureTest.java
+++ b/java/test/jmri/ArchitectureTest.java
@@ -397,8 +397,15 @@ public class ArchitectureTest {
     @Test
     public void testHelpFileNamesUseShtml(){
         String path = FileUtil.getExternalFilename(FileUtil.PROGRAM + "help");
+
+        // allow
+        // local/index.html
+        // local/stub_template.html
+        // /local/stub/
+
         String[] allowList = {"local"+File.separator+ "index.html",
-            "local"+File.separator+ "stub_template.html"};
+            "local"+File.separator+ "stub_template.html",
+            File.separator + "local" + File.separator + "stub" + File.separator };
         recursivelyCheckFiles(new File(path), allowList, ".html");
     }
 


### PR DESCRIPTION
allow html files in /local/stub/

Currently failing builds, eg.
https://builds.jmri.org/jenkins/job/development/job/builds/1749/

`filename /var/lib/jenkins/workspace/development/builds/help/fr/local/stub/package.jmri.jmrit.automat.monitor.AutomattableFrame.html should not end with .html`