### PR TITLE
TCS roster import/export

### DIFF
--- a/help/en/html/hardware/openlcb/TCS.shtml
+++ b/help/en/html/hardware/openlcb/TCS.shtml
@@ -32,19 +32,25 @@
             <span class="since">Since <a href="jmri5.3.4.shtml">JMRI 5.3.4</a></span>
 
             To copy the function labels from a DecoderPro
-            roster entry to the CS-105 command station for use
-            on UWT-100 throttles:
+            roster entry to the corresponding locomotive entry in the CS-105 command station
+            for use with UWT-100 throttles:
             <ul>
-                <li>Open the DecoderPro roster entry.
-                <li>In the File -> Export... menu, select "Roster Entry to TCS CS-105"
+                <li>Open the DecoderPro roster entry from which you want to transfer
+                    the function labels.  This must have the same DCC address as the
+                    entry in the CS-105. If you don't yet have a roster entry for the locomotive,
+                    you should create one and fill out its function labels and DCC address.
+                <li>In the File -> Export... menu on the roster entry, select "Roster Entry to TCS CS-105"
                 <li>Wait for the completion dialog.
             </ul>
 
-            To copy the function labels from a CS-105 command
-            station to a DecoderPro roster entry:
+            To copy the function labels from locomotive entry in a CS-105 command
+            station to the corresponding DecoderPro roster entry:
             <ul>
                 <li>Open the corresponding DecoderPro roster entry.
-                <li>In the File -> Import... menu, select "TCS CS-105 Roster Entry"
+                    This must have the same DCC address as the
+                    entry in the CS-105. If you don't yet have a roster entry for the locomotive,
+                    you should create one and fill out its DCC address.
+                <li>In the File -> Import... menu on the roster entry, select "TCS CS-105 Roster Entry"
                 <li>Wait for the completion dialog.
                 <li>Save your DecoderPro roster entry.
             </ul>

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -121,7 +121,10 @@
 
         <h4><a href="http://openlcb.org">OpenLCB</a> / LCC</h4>
             <ul>
-                <li></li>
+                <li>Fix some minor bugs in DecoderPro's exporting of roster entries
+                    to the CS-105 command station and to backup files.</li>
+                <li>Improved instructions for DecoderPro's import from and
+                    export to TCS CS-105 command stations.</li>
             </ul>
 
         <h4>Powerline</h4>

--- a/java/src/jmri/jmrit/symbolicprog/TcsDownloadAction.java
+++ b/java/src/jmri/jmrit/symbolicprog/TcsDownloadAction.java
@@ -18,7 +18,7 @@ import org.openlcb.cdi.CdiRep;
 import org.openlcb.cdi.impl.ConfigRepresentation;
 
 /**
- * Action to download the CV values from a TCS CS-105
+ * Action to download the function labels from a TCS CS-105
  *
  * @author Bob Jacobsen Copyright (C) 2003, 2023
  * @author Dave Heap Copyright (C) 2015
@@ -116,7 +116,7 @@ public class TcsDownloadAction extends AbstractAction implements PropertyChangeL
                 log.trace("String entry {} is {}", e.key, e.getValue());
 
                 if (e.key.startsWith("Train.User Description")) {
-                    log.info("setComment {}", e.getValue());
+                    log.info("setComment \"{}\"", e.getValue());
                     rosterEntry.setComment(e.getValue());
                  } else if (e.key.startsWith("Train.Functions")) {
                     int index = getNumberField(e.key);
@@ -126,6 +126,7 @@ public class TcsDownloadAction extends AbstractAction implements PropertyChangeL
                     }
                     if (e.key.endsWith("Description")) {
                         String value = e.getValue();
+                        log.debug("Found function {} description \"{}\"", index, value);
                         if (value==null) {
                             value = "";
                         }

--- a/java/src/jmri/jmrit/symbolicprog/TcsExportAction.java
+++ b/java/src/jmri/jmrit/symbolicprog/TcsExportAction.java
@@ -86,7 +86,7 @@ public class TcsExportAction extends AbstractAction {
 
         // Skip Consist, Directional and MU switch to allow round-trip
 
-        for (int i = 0; i < 27; i++) { // TCS sample file went to 27?
+        for (int i = 0; i <= 27; i++) { // TCS sample file went to 27
             String label = rosterEntry.getFunctionLabel(i+1);
             if (label == null) label = "";
             int displayValue = intFromFunctionString(label);

--- a/java/src/jmri/jmrit/symbolicprog/TcsUploadAction.java
+++ b/java/src/jmri/jmrit/symbolicprog/TcsUploadAction.java
@@ -19,7 +19,7 @@ import org.openlcb.NodeID;
 import org.openlcb.cdi.CdiRep;
 import org.openlcb.cdi.impl.ConfigRepresentation;
 /**
- * Action to upload the CV values to a TCS CS-105.
+ * Action to upload the function labels to a TCS CS-105.
  *
  * @author Bob Jacobsen Copyright (C) 2003
  */
@@ -106,82 +106,88 @@ public class TcsUploadAction extends AbstractAction implements PropertyChangeLis
      *
      *<p>TODO: Code further up takes initial address from GUI, not RosterEntry.
      */
-    void processValuesFromRosterElement() {
-        configRep.visit(new ConfigRepresentation.Visitor() {
-            @Override
-            public void visitString(ConfigRepresentation.StringEntry e) {
-                log.trace("String entry {} is {}", e.key, e.getValue());
-
-                if (e.key.startsWith("Train.User Description")) {
-                    e.setValue(rosterEntry.getComment());
-                 } else if (e.key.startsWith("Train.Functions")) {
-                    int index = getNumberField(e.key);
-                    if (index == -1) {
-                        log.warn("Unexpected format \"{}\"", e.key);
-                        return;
-                    }
-                    if (e.key.endsWith("Description")) {
-                        String value = rosterEntry.getFunctionLabel(index+1);
-                        if (value==null) {
-                            value = "";
-                        }
-                        if (TcsExportAction.intFromFunctionString(
-                                        rosterEntry.getFunctionLabel(index+1)
-                                    ) != 0) {
-                            e.setValue(value);
-                        }
-                    } else {
-                        log.warn("Unexpected content \"{}\"", e.key);
-                    }
-                }
-            }
-
-            @Override
-            public void visitInt(ConfigRepresentation.IntegerEntry e) {
-                log.trace("Integer entry {} is {}", e.key, e.getValue());
-
-                // is this the last entry?
-                if (e.key.startsWith("Train.Delete From Roster")) {
-                    // TODO: This is firing much too soon
-                    JOptionPane.showMessageDialog(frame, "Upload complete.");
-                } else if (e.key.startsWith("Train.Functions")) {
-                    int index = getNumberField(e.key);
-                    if (index == -1) {
-                        log.warn("Unexpected format \"{}\"", e.key);
-                        return;
-                    }
-                    if (e.key.endsWith(".Momentary")) {
-                        long value = 1;
-                        if (rosterEntry.getFunctionLockable(index+1)) {
-                            value = 0;  // lockable is not Momentary
-                        }
-                        e.setValue(value);
-                    } else if (e.key.endsWith(".Consist Behavior")) {
-                        // TODO: get value from consisting CVs
-                    } else if (e.key.endsWith(".Display")) {
-                        // do a reverse lookup and store
-                        int value = TcsExportAction.intFromFunctionString(
-                                        rosterEntry.getFunctionLabel(index+1)
-                                    );
-                        e.setValue(value);
-                    } else {
-                        log.warn("Unexpected content \"{}\"", e.key);
-                    }
-                }
-            }
-
-            @Override
-            public void visitEvent(ConfigRepresentation.EventEntry e) {
-                log.trace("Event entry {} is {}", e.key, e.getValue());
-            }
-        });
-    }
+//     void processValuesFromRosterElement() {
+//         log.trace("processValuesFromRosterElement");
+//         configRep.visit(new ConfigRepresentation.Visitor() {
+//             @Override
+//             public void visitString(ConfigRepresentation.StringEntry e) {
+//                 log.trace("String entry {} is {}", e.key, e.getValue());
+//
+//                 if (e.key.startsWith("Train.User Description")) {
+//                     e.setValue(rosterEntry.getComment());
+//                  } else if (e.key.startsWith("Train.Functions")) {
+//                     int index = getNumberField(e.key);
+//                     if (index == -1) {
+//                         log.warn("Unexpected format \"{}\"", e.key);
+//                         return;
+//                     }
+//                     if (e.key.endsWith("Description")) {
+//                         String value = rosterEntry.getFunctionLabel(index+1);
+//                         log.debug("Train.Functions found function {} roster description \"{}\"", index, value);
+//                         if (value==null) {
+//                             value = "";
+//                         }
+//                         log.trace("   mapping gives {}", TcsExportAction.intFromFunctionString(
+//                                         rosterEntry.getFunctionLabel(index+1)) );
+//                         if (TcsExportAction.intFromFunctionString(
+//                                         rosterEntry.getFunctionLabel(index+1)
+//                                     ) != 0) {
+//                             e.setValue(value);
+//                         }
+//                     } else {
+//                         log.warn("Unexpected content \"{}\"", e.key);
+//                     }
+//                 }
+//             }
+//
+//             @Override
+//             public void visitInt(ConfigRepresentation.IntegerEntry e) {
+//                 log.trace("Integer entry {} is {}", e.key, e.getValue());
+//
+//                 // is this the last entry?
+//                 if (e.key.startsWith("Train.Delete From Roster")) {
+//                     // TODO: This is firing much too soon
+//                     JOptionPane.showMessageDialog(frame, "Upload complete.");
+//                 } else if (e.key.startsWith("Train.Functions")) {
+//                     int index = getNumberField(e.key);
+//                     if (index == -1) {
+//                         log.warn("Unexpected format \"{}\"", e.key);
+//                         return;
+//                     }
+//                     if (e.key.endsWith(".Momentary")) {
+//                         long value = 1;
+//                         if (rosterEntry.getFunctionLockable(index+1)) {
+//                             value = 0;  // lockable is not Momentary
+//                         }
+//                         e.setValue(value);
+//                     } else if (e.key.endsWith(".Consist Behavior")) {
+//                         // TODO: get value from consisting CVs
+//                     } else if (e.key.endsWith(".Display")) {
+//                         // do a reverse lookup and store
+//                         int value = TcsExportAction.intFromFunctionString(
+//                                         rosterEntry.getFunctionLabel(index+1)
+//                                     );
+//                         e.setValue(value);
+//                         log.debug(".display found function {} roster description \"{}\"", index, value);
+//                     } else {
+//                         log.warn("Unexpected content \"{}\"", e.key);
+//                     }
+//                 }
+//             }
+//
+//             @Override
+//             public void visitEvent(ConfigRepresentation.EventEntry e) {
+//                 log.trace("Event entry {} is {}", e.key, e.getValue());
+//             }
+//         });
+//     }
 
     /**
      * Construct and execute a listener that sets
      * the appropriate values from the GUI elements.
      */
     void processValuesFromGUI() {
+        log.trace("processValuesFromGUI");
         configRep.visit(new ConfigRepresentation.Visitor() {
             @Override
             public void visitString(ConfigRepresentation.StringEntry e) {
@@ -200,9 +206,12 @@ public class TcsUploadAction extends AbstractAction implements PropertyChangeLis
                         if (value==null) {
                             value = "";
                         }
+                        log.debug(".Description found function {} roster description \"{}\"", index, value);
+                        log.trace("   mapping gives {}", TcsExportAction.intFromFunctionString(
+                                        rosterEntry.getFunctionLabel(index+1)) );
                         if (TcsExportAction.intFromFunctionString(
                                         frame.getFnLabelPane().getLabel(index+1).getText()
-                                    ) != 0) {
+                                    ) == 0) {
                             e.setValue(value);
                         }
                     } else {
@@ -239,6 +248,7 @@ public class TcsUploadAction extends AbstractAction implements PropertyChangeLis
                                         frame.getFnLabelPane().getLabel(index+1).getText()
                                     );
                         e.setValue(value);
+                        log.debug(".display found function {} roster description \"{}\"", index, value);
                     } else {
                         log.warn("Unexpected content \"{}\"", e.key);
                     }


### PR DESCRIPTION
 - Improve instructions for TCS roster entry import/export 
 - Fix export to backup file through F27
 - Fix export directly to TCS CS-105

This is a minor & localised change which I request be added to the 5.3.8 release at the appropriate time.