### PR TITLE
Improve responsiveness of Memory and Block displays on Layout Editor panels

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -402,7 +402,7 @@
     <h3>Layout Editor</h3>
         <a id="LE" name="LE"></a>
         <ul>
-	        <li>This a problem that was causing Memory contents to be slow to update.</li>
+	        <li>This a problem that was causing Memory and Block contents to be slow to update.</li>
         </ul>
 
         <h4>NX - Entry/Exit Tool</h4>

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -402,7 +402,7 @@
     <h3>Layout Editor</h3>
         <a id="LE" name="LE"></a>
         <ul>
-	        <li></li>
+	        <li>This a problem that was causing Memory contents to be slow to update.</li>
         </ul>
 
         <h4>NX - Entry/Exit Tool</h4>

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -402,7 +402,7 @@
     <h3>Layout Editor</h3>
         <a id="LE" name="LE"></a>
         <ul>
-	        <li>This a problem that was causing Memory and Block contents to be slow to update.</li>
+	        <li>Fixed a problem that was causing Memory and Block contents to be slow to update.</li>
         </ul>
 
         <h4>NX - Entry/Exit Tool</h4>

--- a/java/src/jmri/jmrit/display/layoutEditor/BlockContentsIcon.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/BlockContentsIcon.java
@@ -21,10 +21,12 @@ public class BlockContentsIcon extends jmri.jmrit.display.BlockContentsIcon {
 
     public BlockContentsIcon(String s, LayoutEditor panel) {
         super(s, panel);
+        this.panel = panel;
         log.debug("BlockContentsIcon ctor= {}", BlockContentsIcon.class.getName());
     }
 
     private LayoutBlock lBlock = null;
+    LayoutEditor panel;
 
     /**
      * {@inheritDoc}
@@ -96,6 +98,13 @@ public class BlockContentsIcon extends jmri.jmrit.display.BlockContentsIcon {
         } else {
             setValue(roster);
         }
+    }
+
+    // force a redisplay when content changes
+    @Override
+    public void propertyChange(java.beans.PropertyChangeEvent e) {
+        super.propertyChange(e);
+        panel.redrawPanel();
     }
 
     private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(BlockContentsIcon.class);

--- a/java/src/jmri/jmrit/display/layoutEditor/MemoryIcon.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/MemoryIcon.java
@@ -26,8 +26,11 @@ public class MemoryIcon extends jmri.jmrit.display.MemoryIcon {
 
     public MemoryIcon(String s, LayoutEditor panel) {
         super(s, panel);
+        this.panel = panel;
         log.debug("MemoryIcon ctor= {}", MemoryIcon.class.getName());
     }
+
+    LayoutEditor panel;
 
     @Override
     public void setText(String text) {
@@ -144,6 +147,13 @@ public class MemoryIcon extends jmri.jmrit.display.MemoryIcon {
     }
 
     private final JCheckBoxMenuItem updateBlockItem = new JCheckBoxMenuItem("Update Block Details");
+
+    // force a redisplay when content changes
+    @Override
+    public void propertyChange(java.beans.PropertyChangeEvent e) {
+        super.propertyChange(e);
+        panel.redrawPanel();
+    }
 
     @Override
     public boolean showPopUp(JPopupMenu popup) {


### PR DESCRIPTION
Sometimes content updates of Layout Editor memory and block icons would be delayed when the LE panel is zoomed.  

This PR fixes that by forcing a repaint at the appropriate times.