### PR TITLE
Fix openlcb memory config tool "put" not initializing the dst variable.

### DIFF
--- a/java/src/jmri/jmrix/openlcb/swing/memtool/MemoryToolPane.java
+++ b/java/src/jmri/jmrix/openlcb/swing/memtool/MemoryToolPane.java
@@ -298,7 +298,7 @@ public class MemoryToolPane extends jmri.util.swing.JmriPanel
             setRunning(false);
             return;
         }
-        log.debug("Start put");
+        log.debug("Start get");
         if (fileChooser == null) {
             fileChooser = new jmri.util.swing.JmriJFileChooser();
         }
@@ -406,7 +406,8 @@ public class MemoryToolPane extends jmri.util.swing.JmriPanel
         };
 
     void pushedPutButton(ActionEvent e) {
-        log.debug("Start get");
+        farID = nodeSelector.getSelectedItem();
+        log.debug("Start put");
         if (fileChooser == null) {
             fileChooser = new jmri.util.swing.JmriJFileChooser();
         }


### PR DESCRIPTION
The code in the "pushedPutButton" never initializes the farID variable. This means that if the user opens the tool and tries to do a put operation, it never works. The operation would only work if the user does a "get" first, then followed by a "put".

If the user changes the destination node between a get and put operation, the put operation will be applied to the destination node that was selected for the get.