### PR TITLE
Fix truncated LayoutConnectivity tables caused by edge connectors

### DIFF
--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorAuxTools.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorAuxTools.java
@@ -87,13 +87,14 @@ final public class LayoutEditorAuxTools {
      * 2) and 3) above. For case 1), two track segments, the direction reflects
      * an "average" over the two track segments. See LayoutConnectivity for the
      * allowed values of direction.
+     * <p>
+     * Normally the initialization only occurs once after the panel is loaded.  When edge
+     * connectors are used, an incomplete LayoutConnectivity table can occur due to the
+     * panel loading sequence and the complexity of edge connector relationships.
+     * An additional initialization is allowed to build the final LayoutConnectivity table.
      */
     public void initializeBlockConnectivity() {
-        if (initialized) {
-            log.error("Call to initialize a connectivity list that has already been initialized");  // NOI18N
-            return;
-        }
-        cList.clear(); 
+        cList.clear();
         List<LayoutConnectivity> lcs = null;
 
         for (LayoutTrackView ltv : models.getLayoutTrackViews()) {
@@ -294,7 +295,7 @@ final public class LayoutEditorAuxTools {
                             || ((ltz.getTurnoutType() == LayoutTurnout.TurnoutType.LH_XOVER)
                             && ((lc.getConnectedType() == HitPointType.TURNOUT_A)
                             || (lc.getConnectedType() == HitPointType.TURNOUT_C)))) {
-                            
+
                         Turnout ltzto = ltz.getTurnout();
                         if (ltzto != null) {
                             bs = new BeanSetting(ltzto, ltz.getTurnoutName(), Turnout.CLOSED);


### PR DESCRIPTION
**LayoutEditorAuxTools:initializeBlockConnectivity** has been changed to allow multiple calls by removing the **initialized** check.

When a Layout Editor panel has been loaded, **LayoutEditor:setConnections** is called by the Layout Editor panel xml load process to build the connectivity map.  The first step initializes the layout track objects.  The second step calls **initializeBlockConnectivity** to build the **cList** which is a list of **LayoutConnectivity** objects. Each one describes a block boundary.

The initialization process for edge connector layout track objects includes working with the links between edge connector pairs. Depending on the load order of the panels and the complexity of the link relationships, **LayoutEditorAuxTools:getConnectivityList** might be called. **getConnectivityList** calls **initializeBlockConnectivity** if **initialized** is false.  This can result in a premature block connectivity initialization which can result in truncated block routing lists. By allowing the final call from **setConnections**, a complete **cList** is created.
