### PR TITLE
Add handler for signals to cause shutdown and restart

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -670,6 +670,7 @@
                    deprecation="@{javac.deprecation}"
                    debug="${java.debugging}">
                 <classpath refid="@{javac.classpath}"/>
+                <compilerarg value="-XDignore.symbol.file"/> <!-- suppresses sun.misc warnings on Java 9 -->
                 <compilerarg line="-encoding utf-8"/>
                 <compilerarg value="-Xlint:unchecked"/>
                 <compilerarg value="-Xpkginfo:always"/>  <!-- compile all package-info.java to avoid empty-file warnings -->

--- a/help/en/html/doc/Technical/JVMCapabilities.shtml
+++ b/help/en/html/doc/Technical/JVMCapabilities.shtml
@@ -250,7 +250,7 @@
             Improved handling and reporting of NPE, which will help
             debugging
           </td>
-          <td>14/td>
+          <td>14</td>
           <td>14</td>
         </tr>
 
@@ -271,6 +271,15 @@
           </td>
           <td>15</td>
           <td>15</td>
+        </tr>
+
+        <tr>
+          <td>
+            GraalVM provides "complete" Python 3.7 and JavaScript.
+            At least this version will be required for Nashorn replacement.
+          </td>
+          <td>16</td>
+          <td>16</td>
         </tr>
 
         <tr>
@@ -326,6 +335,24 @@
           </td>
           <td>17</td>
           <td>17</td>
+        </tr>
+
+        <tr>
+          <td>
+            The sun.misc package is replaced by jdk.internal.misc, access
+            to which requires the use of the module system.
+          </td>
+          <td>18</td>
+          <td>18</td>
+        </tr>
+
+        <tr>
+          <td>
+            Various elements of the Thread and Locale APIs are marked for deletion, 
+            resulting in about 50 compilation warnings.
+          </td>
+          <td>20</td>
+          <td>20</td>
         </tr>
 
         <tr>

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -600,7 +600,7 @@
         <a id="Misc" name="Misc"></a>
         <ul>
             <li>A signal handler has been added to the Shutdown manager such that a 
-            "kill -HUP &lt;pid&gt;"</li> command on Mac or Linux will do a normal shutdown.
+            "kill &lt;pid&gt;"</li> command on Mac or Linux will do a normal shutdown.
             This is particularly useful for e.g. running headless on an RPi.
         </ul>
 

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -599,6 +599,8 @@
     <h3>Miscellaneous</h3>
         <a id="Misc" name="Misc"></a>
         <ul>
-            <li></li>
+            <li>A signal handler has been added to the Shutdown manager such that a 
+            "kill -HUP &lt;pid&gt;"</li> command on Mac or Linux will do a normal shutdown.
+            This is particularly useful for e.g. running headless on an RPi.
         </ul>
 

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -600,7 +600,8 @@
         <a id="Misc" name="Misc"></a>
         <ul>
             <li>A signal handler has been added to the Shutdown manager such that a 
-            "kill &lt;pid&gt;"</li> command on Mac or Linux will do a normal shutdown.
+            "kill &lt;pid&gt;" command on Mac or Linux will do a normal shutdown.
             This is particularly useful for e.g. running headless on an RPi.
+            "kill -HUP &lt;pid&gt;" will cause JMRI to quit and restart.
         </ul>
 

--- a/java/src/jmri/managers/DefaultShutDownManager.java
+++ b/java/src/jmri/managers/DefaultShutDownManager.java
@@ -87,20 +87,33 @@ public class DefaultShutDownManager extends Bean implements ShutDownManager {
         }
         
         // register a Signal handlers that do shutdown
-        SignalHandler handler = new SignalHandler () {
-            public void handle(Signal sig) {
-                shutdown();
-            }
-        };
         try {
             if (SystemType.isMacOSX() || SystemType.isLinux()) {
-                Signal.handle(new Signal("HUP"), handler);
+                SignalHandler handler = new SignalHandler () {
+                    public void handle(Signal sig) {
+                        shutdown();
+                    }
+                };
                 Signal.handle(new Signal("TERM"), handler);
                 Signal.handle(new Signal("INT"), handler);
+                
+                handler = new SignalHandler () {
+                    public void handle(Signal sig) {
+                        restart();
+                    }
+                };
+                Signal.handle(new Signal("HUP"), handler);     
             } 
-            if (SystemType.isWindows()) {
+            
+            else if (SystemType.isWindows()) {
+                SignalHandler handler = new SignalHandler () {
+                    public void handle(Signal sig) {
+                        shutdown();
+                    }
+                };
                 Signal.handle(new Signal("TERM"), handler);
             }
+            
         } catch (NullPointerException e) {
             log.warn("Failed to add signal handler due to missing signal definition");
         }

--- a/java/src/jmri/managers/DefaultShutDownManager.java
+++ b/java/src/jmri/managers/DefaultShutDownManager.java
@@ -98,9 +98,9 @@ public class DefaultShutDownManager extends Bean implements ShutDownManager {
             Signal.handle(new Signal("INT"), handler);
         } 
         if (SystemType.isWindows()) {
-            Signal.handle(new Signal("BREAK"), handler);
+            //Signal.handle(new Signal("BREAK"), handler);
             Signal.handle(new Signal("TERM"), handler);
-            Signal.handle(new Signal("INT"), handler);
+            //Signal.handle(new Signal("INT"), handler);
         } 
     }
 

--- a/java/src/jmri/managers/DefaultShutDownManager.java
+++ b/java/src/jmri/managers/DefaultShutDownManager.java
@@ -92,16 +92,18 @@ public class DefaultShutDownManager extends Bean implements ShutDownManager {
                 shutdown();
             }
         };
-        if (SystemType.isMacOSX() || SystemType.isLinux()) {
-            Signal.handle(new Signal("HUP"), handler);
-            Signal.handle(new Signal("TERM"), handler);
-            Signal.handle(new Signal("INT"), handler);
-        } 
-        if (SystemType.isWindows()) {
-            //Signal.handle(new Signal("BREAK"), handler);
-            Signal.handle(new Signal("TERM"), handler);
-            //Signal.handle(new Signal("INT"), handler);
-        } 
+        try {
+            if (SystemType.isMacOSX() || SystemType.isLinux()) {
+                Signal.handle(new Signal("HUP"), handler);
+                Signal.handle(new Signal("TERM"), handler);
+                Signal.handle(new Signal("INT"), handler);
+            } 
+            if (SystemType.isWindows()) {
+                Signal.handle(new Signal("TERM"), handler);
+            }
+        } catch (NullPointerException e) {
+            log.warn("Failed to add signal handler due to missing signal definition");
+        }
     }
 
     /**

--- a/java/src/jmri/managers/DefaultShutDownManager.java
+++ b/java/src/jmri/managers/DefaultShutDownManager.java
@@ -86,14 +86,21 @@ public class DefaultShutDownManager extends Bean implements ShutDownManager {
             // thrown only if System.exit() has been called, so ignore
         }
         
+        // register a Signal handlers that do shutdown
+        SignalHandler handler = new SignalHandler () {
+            public void handle(Signal sig) {
+                shutdown();
+            }
+        };
         if (SystemType.isMacOSX() || SystemType.isLinux()) {
-            // register an HUP handler that does shutdown
-            SignalHandler handler = new SignalHandler () {
-                public void handle(Signal sig) {
-                    shutdown();
-                }
-            };
             Signal.handle(new Signal("HUP"), handler);
+            Signal.handle(new Signal("TERM"), handler);
+            Signal.handle(new Signal("INT"), handler);
+        } 
+        if (SystemType.isWindows()) {
+            Signal.handle(new Signal("BREAK"), handler);
+            Signal.handle(new Signal("TERM"), handler);
+            Signal.handle(new Signal("INT"), handler);
         } 
     }
 

--- a/java/src/jmri/managers/DefaultShutDownManager.java
+++ b/java/src/jmri/managers/DefaultShutDownManager.java
@@ -14,6 +14,7 @@ import java.util.concurrent.*;
 
 import jmri.ShutDownManager;
 import jmri.ShutDownTask;
+import jmri.util.SystemType;
 
 import jmri.beans.Bean;
 import jmri.util.ThreadingUtil;
@@ -84,13 +85,16 @@ public class DefaultShutDownManager extends Bean implements ShutDownManager {
         } catch (IllegalStateException ex) {
             // thrown only if System.exit() has been called, so ignore
         }
-        // register an STOP handler that does shutdown
-        SignalHandler handler = new SignalHandler () {
-            public void handle(Signal sig) {
-                shutdown();
-            }
-        };
-        Signal.handle(new Signal("HUP"), handler); 
+        
+        if (SystemType.isMacOSX() || SystemType.isLinux()) {
+            // register an HUP handler that does shutdown
+            SignalHandler handler = new SignalHandler () {
+                public void handle(Signal sig) {
+                    shutdown();
+                }
+            };
+            Signal.handle(new Signal("HUP"), handler);
+        } 
     }
 
     /**

--- a/java/src/jmri/managers/DefaultShutDownManager.java
+++ b/java/src/jmri/managers/DefaultShutDownManager.java
@@ -2,6 +2,9 @@ package jmri.managers;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+import sun.misc.Signal;
+import sun.misc.SignalHandler;
+
 import java.awt.Frame;
 import java.awt.GraphicsEnvironment;
 import java.awt.event.WindowEvent;
@@ -81,6 +84,13 @@ public class DefaultShutDownManager extends Bean implements ShutDownManager {
         } catch (IllegalStateException ex) {
             // thrown only if System.exit() has been called, so ignore
         }
+        // register an STOP handler that does shutdown
+        SignalHandler handler = new SignalHandler () {
+            public void handle(Signal sig) {
+                shutdown();
+            }
+        };
+        Signal.handle(new Signal("HUP"), handler); 
     }
 
     /**
@@ -252,6 +262,7 @@ public class DefaultShutDownManager extends Bean implements ShutDownManager {
      */
     @SuppressFBWarnings(value = "DM_EXIT", justification = "OK to directly exit standalone main")
     private void doShutdown(int status, boolean exit) {
+        log.debug("shutdown called with {} {}", status, exit);
         if (!shuttingDown) {
             Date start = new Date();
             log.debug("Shutting down with {} callable and {} runnable tasks",


### PR DESCRIPTION
This adds a Signal handler to the DefaultShutdownManager that will cause an orderly shutdown. 

- On Mac and Linux: SIG TERM (and in some cases SIG INT) will cause JMRI to quit; SIG HUP will cause JMRI to quit and restart
- On Windows, SIG TERM will cause JMRI to quit