### PR TITLE
populate version String in Javadoc

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -2055,7 +2055,7 @@
     <!-- Requires Graphviz from http://www.graphviz.org            -->
     <!-- Does not work with Java 10 or later,                      -->
     <!-- see https://github.com/gboersma/uml-java-doclet           -->
-    <target name="javadoc-uml" depends="check-java-version-requirement, init, jjdoc, compile-generated-source, plantuml"
+    <target name="javadoc-uml" depends="check-java-version-requirement, init, jjdoc, compile-generated-source, plantuml, get-version-string"
                     description="create Javadocs with UML, requires Java 11">
         <javadoc packagenames="jmri.*, apps.*"
                  maxmemory="1536m"


### PR DESCRIPTION
Currently version string at bottom of UML JavaDoc is not being populated.

eg. at bottom of https://www.jmri.org/JavaDoc/doc/jmri/Memory.html
`Made from JMRI version ${release.version-string}`

see #12115 