### PR TITLE
Add "idtags" to script shortcuts

### DIFF
--- a/help/en/html/tools/scripting/Start.shtml
+++ b/help/en/html/tools/scripting/Start.shtml
@@ -219,6 +219,8 @@ method calls.
 
           <li>reporters</li>
 
+          <li>idtags</li>
+
           <li>memories</li>
 
           <li>powermanager</li>
@@ -258,7 +260,10 @@ method calls.
         <p>where the assignment is actually invoking the set method.</p>
 
         <p>Also note that THROWN was defined when running the Python script at startup;<br>
-        CLOSED, ACTIVE, INACTIVE, RED, YELLOW and GREEN are also defined. ( <a href=
+        CLOSED, ACTIVE, INACTIVE, ON, OFF, INCONSISTENT, <br>
+        LOCKED, UNLOCKED, PUSHBUTTONLOCKOUT, CABLOCKOUT, <br>
+        RED, YELLOW, GREEN, LUNAR, DARK, <br>
+        FLASHRED, FLASHYELLOW, FLASHGREEN are also defined. ( <a href=
         "https://github.com/JMRI/JMRI/blob/master/java/src/jmri/script/JmriScriptEngineManager.java">
         These shortcut bindings are defined in Java</a> )</p>
 

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -487,7 +487,7 @@
     <h3>Scripting</h3>
         <a id="Scripting" name="Scripting"></a>
         <ul>
-            <li></li>
+            <li>Add "idtags" as a script shortcut to the manager like "turnouts" and "sensors"</li>
         </ul>
 
     <h3>Signals</h3>

--- a/java/src/jmri/script/JmriScriptEngineManager.java
+++ b/java/src/jmri/script/JmriScriptEngineManager.java
@@ -123,6 +123,7 @@ public final class JmriScriptEngineManager implements InstanceManagerAutoDefault
 
         // this should agree with help/en/html/tools/scripting/Start.shtml
         Bindings bindings = new SimpleBindings();
+        
         bindings.put("sensors", InstanceManager.getNullableDefault(SensorManager.class));
         bindings.put("turnouts", InstanceManager.getNullableDefault(TurnoutManager.class));
         bindings.put("lights", InstanceManager.getNullableDefault(LightManager.class));
@@ -131,6 +132,7 @@ public final class JmriScriptEngineManager implements InstanceManagerAutoDefault
         bindings.put("routes", InstanceManager.getNullableDefault(RouteManager.class));
         bindings.put("blocks", InstanceManager.getNullableDefault(BlockManager.class));
         bindings.put("reporters", InstanceManager.getNullableDefault(ReporterManager.class));
+        bindings.put("idtags", InstanceManager.getNullableDefault(IdTagManager.class));
         bindings.put("memories", InstanceManager.getNullableDefault(MemoryManager.class));
         bindings.put("powermanager", InstanceManager.getNullableDefault(PowerManager.class));
         bindings.put("addressedProgrammers", InstanceManager.getNullableDefault(AddressedProgrammerManager.class));
@@ -143,6 +145,7 @@ public final class JmriScriptEngineManager implements InstanceManagerAutoDefault
         bindings.put("sections", InstanceManager.getNullableDefault(SectionManager.class));
         bindings.put("transits", InstanceManager.getNullableDefault(TransitManager.class));
         bindings.put("beans", InstanceManager.getNullableDefault(NamedBeanHandleManager.class));
+        
         bindings.put("CLOSED", Turnout.CLOSED);
         bindings.put("THROWN", Turnout.THROWN);
         bindings.put("CABLOCKOUT", Turnout.CABLOCKOUT);
@@ -164,7 +167,9 @@ public final class JmriScriptEngineManager implements InstanceManagerAutoDefault
         bindings.put("FLASHYELLOW", SignalHead.FLASHYELLOW);
         bindings.put("FLASHGREEN", SignalHead.FLASHGREEN);
         bindings.put("FLASHLUNAR", SignalHead.FLASHLUNAR);
+        
         bindings.put("FileUtil", FileUtilSupport.getDefault());
+        
         this.context = new SimpleScriptContext();
         this.context.setBindings(bindings, ScriptContext.GLOBAL_SCOPE);
         this.context.setBindings(bindings, ScriptContext.ENGINE_SCOPE);

--- a/java/src/jmri/script/JmriScriptEngineManager.java
+++ b/java/src/jmri/script/JmriScriptEngineManager.java
@@ -27,6 +27,7 @@ import jmri.AudioManager;
 import jmri.BlockManager;
 import jmri.CommandStation;
 import jmri.GlobalProgrammerManager;
+import jmri.IdTagManager;
 import jmri.InstanceManager;
 import jmri.InstanceManagerAutoDefault;
 import jmri.Light;


### PR DESCRIPTION
 - add "idtags" as a script shortcut to the manager like "turnouts" and "sensors"
 - update some corresponding documentation