### PR TITLE
Propagate signals through Mac and Linux startup scripts

### DIFF
--- a/help/en/Acknowledgements.shtml
+++ b/help/en/Acknowledgements.shtml
@@ -805,7 +805,7 @@
         <li>P&aring;l <!--paoSoft -->
         who worked on the LocoNet refresh algorithm</li>
 
-        <li>Gopal Patnaik helped with Intellibox development.</li>
+        <li>Gopal Patnaik helped with Intellibox development and improvements to startup scripts.</li>
 
         <li>Howard G. Penny provided info on the NCE D14SR decoder, then went on to become an
         active developer, including providing the code for indexed CVs (ala QSI), better support of

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -605,5 +605,8 @@
             "kill &lt;pid&gt;" command on Mac or Linux will do a normal shutdown.
             This is particularly useful for e.g. running headless on an RPi.
             "kill -HUP &lt;pid&gt;" will cause JMRI to quit and restart.
+            In addition, the Mac and Linux startup scripts were updated to 
+            pass these signals on to the running process.  Together, this
+            will allow you to run JMRI as a service on Mac and Linux, including the RPi.
         </ul>
 

--- a/scripts/AppScriptTemplate
+++ b/scripts/AppScriptTemplate
@@ -590,17 +590,27 @@ fi
 
 RESTART_CODE=100
 EXIT_STATUS=${RESTART_CODE}
+
 while [ "${EXIT_STATUS}" -eq "${RESTART_CODE}" ] ; do
-
+ 
+    trap 'kill -TERM $PID' TERM INT
+    trap 'kill -HUP $PID' HUP
+    
     if [ "$OS" = "macosx" ] ; then
-        "${JAVACMD}" "${DOCK_OPTIONS[@]}" ${OPTIONS} ${ALTPORTS} ${CONFIGFILE} -cp "${CP}" "${CLASSNAME}" ${ARGS}
+        "${JAVACMD}" "${DOCK_OPTIONS[@]}" ${OPTIONS} ${ALTPORTS} ${CONFIGFILE} -cp "${CP}" "${CLASSNAME}" ${ARGS} &
+        PID=$!
     else
-        "${JAVACMD}" ${OPTIONS} ${ALTPORTS} ${CONFIGFILE} -cp "${CP}" "${CLASSNAME}" ${ARGS}
+        "${JAVACMD}" ${OPTIONS} ${ALTPORTS} ${CONFIGFILE} -cp "${CP}" "${CLASSNAME}" ${ARGS} &
+        PID=$!
     fi
-
+    
+    wait $PID
+    trap - TERM INT HUP
+    wait $PID
     EXIT_STATUS=$?
     [ -n "${DEBUG}" ] && echo Exit Status: "${EXIT_STATUS}" | tee -a ${launcher_log}
 done
+
 if [ $EXIT_STATUS -eq 200 ] ; then
     sudo shutdown -h now
 fi


### PR DESCRIPTION
This updates the Mac and Linux startup scripts to catch the TERM, INT and HUP signals and propagate them to the underlying JMRI process.  This allows e.g. JMRI to be run as a service.

By Gopal Patnaik, following [this page](http://veithen.io/2014/11/16/sigterm-propagation.html).