### PR TITLE
Add new LogixNG expression "File as flag"

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -424,6 +424,8 @@
     <h3>LogixNG</h3>
         <a id="LogixNG" name="LogixNG"></a>
         <ul>
+          <li>The expression <strong>File as flag</strong> has been added. It returns true if
+              a particular file exists.</li>
           <li></li>
         </ul>
 

--- a/java/src/jmri/jmrit/logixng/expressions/DigitalFactory.java
+++ b/java/src/jmri/jmrit/logixng/expressions/DigitalFactory.java
@@ -46,6 +46,7 @@ public class DigitalFactory implements DigitalExpressionFactory {
                                 new AbstractMap.SimpleEntry<>(Category.ITEM, ExpressionTurnout.class),
                                 new AbstractMap.SimpleEntry<>(Category.ITEM, ExpressionWarrant.class),
                                 new AbstractMap.SimpleEntry<>(Category.OTHER, False.class),
+                                new AbstractMap.SimpleEntry<>(Category.OTHER, FileAsFlag.class),
                                 new AbstractMap.SimpleEntry<>(Category.COMMON, DigitalFormula.class),
                                 new AbstractMap.SimpleEntry<>(Category.OTHER, Hold.class),
                                 new AbstractMap.SimpleEntry<>(Category.OTHER, LastResultOfDigitalExpression.class),

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionBundle.properties
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionBundle.properties
@@ -103,7 +103,7 @@ False_Long            = Always false
 
 FileAsFlag_Short      = File as flag
 FileAsFlag_Long       = File as flag. Filename: {0}. {1}
-FileAsFlag_Delete     = Delete file if it exists
+FileAsFlag_Delete     = Delete file
 FileAsFlag_Keep       = Keep file
 
 Hold_Short            = Hold

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionBundle.properties
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionBundle.properties
@@ -101,6 +101,11 @@ EntryExit_DestinationPointsInUseEntryExitExpressionVeto = DestinationPoints is i
 False_Short           = Always false
 False_Long            = Always false
 
+FileAsFlag_Short      = File as flag
+FileAsFlag_Long       = File as flag. Filename: {0}. {1}
+FileAsFlag_Delete     = Delete file if it exists
+FileAsFlag_Keep       = Keep file
+
 Hold_Short            = Hold
 Hold_Long             = Trigger on expression {0}. Hold while expression {1}
 # Important! These strings MUST be valid female socket names!!

--- a/java/src/jmri/jmrit/logixng/expressions/FileAsFlag.java
+++ b/java/src/jmri/jmrit/logixng/expressions/FileAsFlag.java
@@ -1,0 +1,204 @@
+package jmri.jmrit.logixng.expressions;
+
+import java.beans.*;
+import java.io.*;
+import java.nio.file.Files;
+import java.util.*;
+
+import jmri.InstanceManager;
+import jmri.JmriException;
+import jmri.jmrit.logixng.*;
+import jmri.jmrit.logixng.util.*;
+import jmri.util.TimerUtil;
+
+
+/**
+ * Does a file exists? If so, delete the file and return true.
+ *
+ * @author Daniel Bergqvist Copyright 2023
+ */
+public class FileAsFlag extends AbstractDigitalExpression
+        implements PropertyChangeListener {
+
+    private final LogixNG_SelectString _selectFilename =
+            new LogixNG_SelectString(this, this);
+
+    private final LogixNG_SelectEnum<DeleteOrKeep> _selectDeleteOrKeep =
+            new LogixNG_SelectEnum<>(this, DeleteOrKeep.values(), DeleteOrKeep.Keep, this);
+
+    private ProtectedTimerTask _timerTask;
+    private final int _delay = 5;
+    private boolean _lastResult;
+    private JmriException _thrownException;
+
+
+    public FileAsFlag(String sys, String user)
+            throws BadUserNameException, BadSystemNameException {
+        super(sys, user);
+
+        try {
+            _lastResult = internalEvaluate();
+        } catch (JmriException e) {
+            _thrownException = e;
+        }
+    }
+
+    @Override
+    public Base getDeepCopy(Map<String, String> systemNames, Map<String, String> userNames) throws JmriException {
+        DigitalExpressionManager manager = InstanceManager.getDefault(DigitalExpressionManager.class);
+        String sysName = systemNames.get(getSystemName());
+        String userName = userNames.get(getSystemName());
+        if (sysName == null) sysName = manager.getAutoSystemName();
+        FileAsFlag copy = new FileAsFlag(sysName, userName);
+        copy.setComment(getComment());
+        _selectFilename.copy(copy._selectFilename);
+        _selectDeleteOrKeep.copy(copy._selectDeleteOrKeep);
+        return manager.registerExpression(copy);
+    }
+
+    public LogixNG_SelectString getSelectFilename() {
+        return _selectFilename;
+    }
+
+    public LogixNG_SelectEnum<DeleteOrKeep> getSelectDeleteOrKeep() {
+        return _selectDeleteOrKeep;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Category getCategory() {
+        return Category.OTHER;
+    }
+
+    private boolean internalEvaluate() throws JmriException {
+
+        String filename = _selectFilename.evaluateValue(getConditionalNG());
+        DeleteOrKeep deleteOrKeep = _selectDeleteOrKeep.evaluateEnum(getConditionalNG());
+
+        if (filename == null) return false;
+
+        try {
+            File file = new File(jmri.util.FileUtil.getExternalFilename(filename));
+            if (file.exists()) {
+                if (deleteOrKeep == DeleteOrKeep.Delete) {
+                    Files.delete(file.toPath());
+                }
+                return true;
+            } else {
+                return false;
+            }
+        } catch (IOException e) {
+            throw new JmriException("IOException has occurred: " + e.getLocalizedMessage(), e);
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean evaluate() throws JmriException {
+
+        if (_thrownException != null) {
+            JmriException e = _thrownException;
+            _thrownException = null;
+            throw e;
+        }
+
+        // Check this every ?? seconds
+        return internalEvaluate();
+    }
+
+    @Override
+    public FemaleSocket getChild(int index) throws IllegalArgumentException, UnsupportedOperationException {
+        throw new UnsupportedOperationException("Not supported.");
+    }
+
+    @Override
+    public int getChildCount() {
+        return 0;
+    }
+
+    @Override
+    public String getShortDescription(Locale locale) {
+        return Bundle.getMessage(locale, "FileAsFlag_Short");
+    }
+
+    @Override
+    public String getLongDescription(Locale locale) {
+        String filename = _selectFilename.getDescription(locale);
+        String deleteOrKeep = _selectDeleteOrKeep.getDescription(locale);
+
+        return Bundle.getMessage(locale, "FileAsFlag_Long", filename, deleteOrKeep);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void setup() {
+        // Do nothing
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void registerListenersForThisClass() {
+        if (!_listenersAreRegistered) {
+            _timerTask = new ProtectedTimerTask() {
+                @Override
+                public void execute() {
+                    try {
+                        boolean _lastLastResult = _lastResult;
+                        _lastResult = internalEvaluate();
+                        if (_lastResult != _lastLastResult) {
+                            getConditionalNG().execute();
+                        }
+                    } catch (JmriException e) {
+                        _thrownException = e;
+                    }
+                }
+            };
+
+            TimerUtil.schedule(_timerTask, _delay*1000, _delay*1000);
+            _listenersAreRegistered = true;
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void unregisterListenersForThisClass() {
+        if (_listenersAreRegistered) {
+            _timerTask.cancel();
+            _listenersAreRegistered = false;
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void propertyChange(PropertyChangeEvent evt) {
+        getConditionalNG().execute();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void disposeMe() {
+        // Do nothing
+    }
+
+
+    public enum DeleteOrKeep {
+        Delete(Bundle.getMessage("FileAsFlag_Delete")),
+        Keep(Bundle.getMessage("FileAsFlag_Keep"));
+
+        private final String _text;
+
+        private DeleteOrKeep(String text) {
+            this._text = text;
+        }
+
+        @Override
+        public String toString() {
+            return _text;
+        }
+
+    }
+
+
+//    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(FileAsFlag.class);
+
+}

--- a/java/src/jmri/jmrit/logixng/expressions/configurexml/FileAsFlagXml.java
+++ b/java/src/jmri/jmrit/logixng/expressions/configurexml/FileAsFlagXml.java
@@ -1,0 +1,68 @@
+package jmri.jmrit.logixng.expressions.configurexml;
+
+import jmri.*;
+import jmri.configurexml.JmriConfigureXmlException;
+import jmri.jmrit.logixng.DigitalExpressionManager;
+import jmri.jmrit.logixng.expressions.FileAsFlag;
+import jmri.jmrit.logixng.expressions.FileAsFlag.DeleteOrKeep;
+import jmri.jmrit.logixng.util.configurexml.LogixNG_SelectEnumXml;
+import jmri.jmrit.logixng.util.configurexml.LogixNG_SelectStringXml;
+
+import org.jdom2.Element;
+
+/**
+ * Handle XML configuration for FileAsFlag objects.
+ *
+ * @author Bob Jacobsen Copyright: Copyright (c) 2004, 2008, 2010
+ * @author Daniel Bergqvist Copyright (C) 2023
+ */
+public class FileAsFlagXml extends jmri.managers.configurexml.AbstractNamedBeanManagerConfigXML {
+
+    public FileAsFlagXml() {
+    }
+
+    /**
+     * Default implementation for storing the contents of a SE8cSignalMast
+     *
+     * @param o Object to store, of type TripleLightSignalMast
+     * @return Element containing the complete info
+     */
+    @Override
+    public Element store(Object o) {
+        FileAsFlag p = (FileAsFlag) o;
+
+        var selectFilenameXml = new LogixNG_SelectStringXml();
+        var selectDeleteOrKeepXml = new LogixNG_SelectEnumXml<DeleteOrKeep>();
+
+        Element element = new Element("FileAsFlag");
+        element.setAttribute("class", this.getClass().getName());
+        element.addContent(new Element("systemName").addContent(p.getSystemName()));
+
+        storeCommon(p, element);
+
+        element.addContent(selectFilenameXml.store(p.getSelectFilename(), "filename"));
+        element.addContent(selectDeleteOrKeepXml.store(p.getSelectDeleteOrKeep(), "deleteOrKeep"));
+
+        return element;
+    }
+
+    @Override
+    public boolean load(Element shared, Element perNode) throws JmriConfigureXmlException {
+        String sys = getSystemName(shared);
+        String uname = getUserName(shared);
+        FileAsFlag h = new FileAsFlag(sys, uname);
+
+        var selectFilenameXml = new LogixNG_SelectStringXml();
+        var selectDeleteOrKeepXml = new LogixNG_SelectEnumXml<DeleteOrKeep>();
+
+        loadCommon(h, shared);
+
+        selectFilenameXml.load(shared.getChild("filename"), h.getSelectFilename());
+        selectDeleteOrKeepXml.load(shared.getChild("deleteOrKeep"), h.getSelectDeleteOrKeep());
+
+        InstanceManager.getDefault(DigitalExpressionManager.class).registerExpression(h);
+        return true;
+    }
+
+//    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(FileAsFlagXml.class);
+}

--- a/java/src/jmri/jmrit/logixng/expressions/swing/DigitalExpressionSwingBundle.properties
+++ b/java/src/jmri/jmrit/logixng/expressions/swing/DigitalExpressionSwingBundle.properties
@@ -141,7 +141,7 @@ ExpressionScript_RegisterListener       = Register listener
 ExpressionScript_UnregisterListener     = Unregister listener
 ExpressionScript_ScriptSelector         = Type of script
 
-FileAsFlag_Components                   = File name: {0}. Delete or keep: {1}
+FileAsFlag_Components                   = File name: {0} Delete or keep: {1}
 
 StringExpressionConstant_Constant       = Constant
 

--- a/java/src/jmri/jmrit/logixng/expressions/swing/DigitalExpressionSwingBundle.properties
+++ b/java/src/jmri/jmrit/logixng/expressions/swing/DigitalExpressionSwingBundle.properties
@@ -141,6 +141,8 @@ ExpressionScript_RegisterListener       = Register listener
 ExpressionScript_UnregisterListener     = Unregister listener
 ExpressionScript_ScriptSelector         = Type of script
 
+FileAsFlag_Components                   = File name: {0}. Delete or keep: {1}
+
 StringExpressionConstant_Constant       = Constant
 
 StringFormula_Formula               = Formula

--- a/java/src/jmri/jmrit/logixng/expressions/swing/DigitalExpressionSwingBundle.properties
+++ b/java/src/jmri/jmrit/logixng/expressions/swing/DigitalExpressionSwingBundle.properties
@@ -141,7 +141,7 @@ ExpressionScript_RegisterListener       = Register listener
 ExpressionScript_UnregisterListener     = Unregister listener
 ExpressionScript_ScriptSelector         = Type of script
 
-FileAsFlag_Components                   = File name: {0} Delete or keep: {1}
+FileAsFlag_Components                   = File name: {0} When found: {1}
 
 StringExpressionConstant_Constant       = Constant
 

--- a/java/src/jmri/jmrit/logixng/expressions/swing/FileAsFlagSwing.java
+++ b/java/src/jmri/jmrit/logixng/expressions/swing/FileAsFlagSwing.java
@@ -1,0 +1,103 @@
+package jmri.jmrit.logixng.expressions.swing;
+
+import java.util.List;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import javax.swing.*;
+
+import jmri.InstanceManager;
+import jmri.jmrit.logixng.*;
+import jmri.jmrit.logixng.expressions.FileAsFlag;
+import jmri.jmrit.logixng.expressions.FileAsFlag.DeleteOrKeep;
+import jmri.jmrit.logixng.swing.SwingConfiguratorInterface;
+import jmri.jmrit.logixng.util.swing.LogixNG_SelectEnumSwing;
+import jmri.jmrit.logixng.util.swing.LogixNG_SelectStringSwing;
+
+/**
+ * Configures an FileAsFlag object with a Swing JPanel.
+ *
+ * @author Daniel Bergqvist 2023
+ */
+public class FileAsFlagSwing extends AbstractDigitalExpressionSwing {
+
+    private LogixNG_SelectStringSwing _selectFilenameSwing;
+    private LogixNG_SelectEnumSwing<DeleteOrKeep> _selectDeleteOrKeepSwing;
+
+
+    @Override
+    protected void createPanel(@CheckForNull Base object, @Nonnull JPanel buttonPanel) {
+        FileAsFlag expression = (FileAsFlag)object;
+
+        if (expression == null) {
+            // Create a temporary expression
+            expression = new FileAsFlag("IQDE1", null);
+        }
+
+        _selectFilenameSwing = new LogixNG_SelectStringSwing(getJDialog(), this);
+        _selectDeleteOrKeepSwing = new LogixNG_SelectEnumSwing<>(getJDialog(), this);
+
+        panel = new JPanel();
+
+        JPanel tabbedPaneNamedBean;
+        JPanel tabbedPaneState;
+
+        tabbedPaneNamedBean = _selectFilenameSwing.createFilenamePanel(expression.getSelectFilename());
+        tabbedPaneState = _selectDeleteOrKeepSwing.createPanel(expression.getSelectDeleteOrKeep(), DeleteOrKeep.values());
+
+        JComponent[] components = new JComponent[]{
+            tabbedPaneNamedBean,
+            tabbedPaneState};
+
+        List<JComponent> componentList = SwingConfiguratorInterface.parseMessage(
+                Bundle.getMessage("FileAsFlag_Components"), components);
+
+        for (JComponent c : componentList) panel.add(c);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean validate(@Nonnull List<String> errorMessages) {
+        // Create a temporary expression to test formula
+        FileAsFlag expression = new FileAsFlag("IQDE1", null);
+
+        _selectFilenameSwing.validate(expression.getSelectFilename(), errorMessages);
+        _selectDeleteOrKeepSwing.validate(expression.getSelectDeleteOrKeep(), errorMessages);
+
+        return errorMessages.isEmpty();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public MaleSocket createNewObject(@Nonnull String systemName, @CheckForNull String userName) {
+        FileAsFlag expression = new FileAsFlag(systemName, userName);
+        updateObject(expression);
+        return InstanceManager.getDefault(DigitalExpressionManager.class).registerExpression(expression);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void updateObject(@Nonnull Base object) {
+        if (! (object instanceof FileAsFlag)) {
+            throw new IllegalArgumentException("object must be an FileAsFlag but is a: "+object.getClass().getName());
+        }
+        FileAsFlag expression = (FileAsFlag)object;
+
+        _selectFilenameSwing.updateObject(expression.getSelectFilename());
+        _selectDeleteOrKeepSwing.updateObject(expression.getSelectDeleteOrKeep());
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String toString() {
+        return Bundle.getMessage("FileAsFlag_Short");
+    }
+
+    @Override
+    public void dispose() {
+    }
+
+
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(FileAsFlagSwing.class);
+
+}

--- a/java/src/jmri/jmrit/logixng/expressions/swing/FileAsFlagSwing.java
+++ b/java/src/jmri/jmrit/logixng/expressions/swing/FileAsFlagSwing.java
@@ -43,7 +43,7 @@ public class FileAsFlagSwing extends AbstractDigitalExpressionSwing {
         JPanel tabbedPaneNamedBean;
         JPanel tabbedPaneState;
 
-        tabbedPaneNamedBean = _selectFilenameSwing.createFilenamePanel(expression.getSelectFilename(), FileUtil.getPreferencesPath());
+        tabbedPaneNamedBean = _selectFilenameSwing.createFilenamePanel(expression.getSelectFilename(), FileUtil.getUserFilesPath());
         tabbedPaneState = _selectDeleteOrKeepSwing.createPanel(expression.getSelectDeleteOrKeep(), DeleteOrKeep.values());
 
         JComponent[] components = new JComponent[]{

--- a/java/src/jmri/jmrit/logixng/expressions/swing/FileAsFlagSwing.java
+++ b/java/src/jmri/jmrit/logixng/expressions/swing/FileAsFlagSwing.java
@@ -98,6 +98,6 @@ public class FileAsFlagSwing extends AbstractDigitalExpressionSwing {
     }
 
 
-    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(FileAsFlagSwing.class);
+//    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(FileAsFlagSwing.class);
 
 }

--- a/java/src/jmri/jmrit/logixng/expressions/swing/FileAsFlagSwing.java
+++ b/java/src/jmri/jmrit/logixng/expressions/swing/FileAsFlagSwing.java
@@ -13,6 +13,7 @@ import jmri.jmrit.logixng.expressions.FileAsFlag.DeleteOrKeep;
 import jmri.jmrit.logixng.swing.SwingConfiguratorInterface;
 import jmri.jmrit.logixng.util.swing.LogixNG_SelectEnumSwing;
 import jmri.jmrit.logixng.util.swing.LogixNG_SelectStringSwing;
+import jmri.util.FileUtil;
 
 /**
  * Configures an FileAsFlag object with a Swing JPanel.
@@ -42,7 +43,7 @@ public class FileAsFlagSwing extends AbstractDigitalExpressionSwing {
         JPanel tabbedPaneNamedBean;
         JPanel tabbedPaneState;
 
-        tabbedPaneNamedBean = _selectFilenameSwing.createFilenamePanel(expression.getSelectFilename());
+        tabbedPaneNamedBean = _selectFilenameSwing.createFilenamePanel(expression.getSelectFilename(), FileUtil.getPreferencesPath());
         tabbedPaneState = _selectDeleteOrKeepSwing.createPanel(expression.getSelectDeleteOrKeep(), DeleteOrKeep.values());
 
         JComponent[] components = new JComponent[]{

--- a/java/src/jmri/jmrit/logixng/util/LogixNG_SelectString.java
+++ b/java/src/jmri/jmrit/logixng/util/LogixNG_SelectString.java
@@ -30,6 +30,7 @@ public class LogixNG_SelectString implements VetoableChangeListener {
     private final PropertyChangeListener _listener;
     private boolean _listenToMemory;
     private boolean _listenersAreRegistered;
+    private boolean _onlyDirectAddressingAllowed;
 
     private NamedBeanAddressing _addressing = NamedBeanAddressing.Direct;
     private String _value;
@@ -56,6 +57,14 @@ public class LogixNG_SelectString implements VetoableChangeListener {
         _value = defaultValue;
     }
 
+    public void setOnlyDirectAddressingAllowed() {
+        _onlyDirectAddressingAllowed = true;
+    }
+
+    public boolean isOnlyDirectAddressingAllowed() {
+        return _onlyDirectAddressingAllowed;
+    }
+
     public void copy(LogixNG_SelectString copy) throws ParserException {
         copy.setAddressing(_addressing);
         copy.setValue(_value);
@@ -68,6 +77,9 @@ public class LogixNG_SelectString implements VetoableChangeListener {
     }
 
     public void setAddressing(@Nonnull NamedBeanAddressing addressing) throws ParserException {
+        if (_onlyDirectAddressingAllowed && (addressing != NamedBeanAddressing.Direct)) {
+            throw new IllegalArgumentException("Addressing must be Direct");
+        }
         this._addressing = addressing;
         parseFormula();
     }

--- a/java/src/jmri/jmrit/logixng/util/swing/LogixNG_SelectStringSwing.java
+++ b/java/src/jmri/jmrit/logixng/util/swing/LogixNG_SelectStringSwing.java
@@ -1,5 +1,6 @@
 package jmri.jmrit.logixng.util.swing;
 
+import java.awt.event.ActionEvent;
 import java.util.List;
 
 import javax.annotation.CheckForNull;
@@ -11,6 +12,8 @@ import jmri.jmrit.logixng.*;
 import jmri.jmrit.logixng.swing.SwingConfiguratorInterface;
 import jmri.jmrit.logixng.util.LogixNG_SelectString;
 import jmri.jmrit.logixng.util.parser.ParserException;
+import jmri.script.swing.ScriptFileChooser;
+import jmri.util.FileUtil;
 import jmri.util.swing.BeanSelectPanel;
 
 /**
@@ -46,17 +49,60 @@ public class LogixNG_SelectStringSwing {
     }
 
     public JPanel createPanel(@CheckForNull LogixNG_SelectString selectStr) {
+        _panelDirect = new javax.swing.JPanel();
+
+        _valueTextField = new JTextField(30);
+        _panelDirect.add(_valueTextField);
+
+        return internalCreatePanel(selectStr);
+    }
+
+    public JPanel createFilenamePanel(@CheckForNull LogixNG_SelectString selectStr) {
+        _panelDirect = new javax.swing.JPanel();
+
+        JButton selectFileButton = new JButton("..."); // "File" replaced by ...
+        selectFileButton.setMaximumSize(selectFileButton.getPreferredSize());
+        selectFileButton.setToolTipText(Bundle.getMessage("FileButtonHint"));  // NOI18N
+        selectFileButton.addActionListener((ActionEvent e) -> {
+            ScriptFileChooser scriptFileChooser = new ScriptFileChooser(FileUtil.getScriptsPath());
+            scriptFileChooser.rescanCurrentDirectory();
+            int retVal = scriptFileChooser.showOpenDialog(null);
+            // handle selection or cancel
+            if (retVal == JFileChooser.APPROVE_OPTION) {
+                // set selected file location
+                try {
+                    _valueTextField.setText(FileUtil.getPortableFilename(scriptFileChooser.getSelectedFile().getCanonicalPath()));
+                } catch (java.io.IOException ex) {
+                    log.error("exception setting file location", ex);  // NOI18N
+                    _valueTextField.setText("");
+                }
+            }
+        });
+        _valueTextField = new JTextField(30);
+        _panelDirect.add(_valueTextField);
+        _panelDirect.add(selectFileButton);
+
+        return internalCreatePanel(selectStr);
+    }
+
+    private JPanel internalCreatePanel(@CheckForNull LogixNG_SelectString selectStr) {
 
         JPanel panel = new JPanel();
 
         _tabbedPane = new JTabbedPane();
-        _panelDirect = new javax.swing.JPanel();
         _panelReference = new javax.swing.JPanel();
         _panelMemory = new JPanel();
         _panelLocalVariable = new javax.swing.JPanel();
         _panelFormula = new javax.swing.JPanel();
         if (selectStr != null) {
             _panelTable = _selectTableSwing.createPanel(selectStr.getSelectTable());
+            if (selectStr.isOnlyDirectAddressingAllowed()) {
+                _tabbedPane.setEnabled(false);
+                _panelReference.setEnabled(false);
+                _panelMemory.setEnabled(false);
+                _panelLocalVariable.setEnabled(false);
+                _panelFormula.setEnabled(false);
+            }
         } else {
             _panelTable = _selectTableSwing.createPanel(null);
         }
@@ -74,9 +120,6 @@ public class LogixNG_SelectStringSwing {
         _tabbedPane.addTab(NamedBeanAddressing.LocalVariable.toString(), _panelLocalVariable);
         _tabbedPane.addTab(NamedBeanAddressing.Formula.toString(), _panelFormula);
         _tabbedPane.addTab(NamedBeanAddressing.Table.toString(), _panelTable);
-
-        _valueTextField = new JTextField(30);
-        _panelDirect.add(_valueTextField);
 
         _referenceTextField = new JTextField();
         _referenceTextField.setColumns(30);
@@ -195,4 +238,5 @@ public class LogixNG_SelectStringSwing {
         _selectTableSwing.dispose();
     }
 
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LogixNG_SelectStringSwing.class);
 }

--- a/java/src/jmri/jmrit/logixng/util/swing/LogixNG_SelectStringSwing.java
+++ b/java/src/jmri/jmrit/logixng/util/swing/LogixNG_SelectStringSwing.java
@@ -12,9 +12,9 @@ import jmri.jmrit.logixng.*;
 import jmri.jmrit.logixng.swing.SwingConfiguratorInterface;
 import jmri.jmrit.logixng.util.LogixNG_SelectString;
 import jmri.jmrit.logixng.util.parser.ParserException;
-import jmri.script.swing.ScriptFileChooser;
 import jmri.util.FileUtil;
 import jmri.util.swing.BeanSelectPanel;
+import jmri.util.swing.JmriJFileChooser;
 
 /**
  * Swing class for jmri.jmrit.logixng.util.LogixNG_SelectString.
@@ -57,21 +57,21 @@ public class LogixNG_SelectStringSwing {
         return internalCreatePanel(selectStr);
     }
 
-    public JPanel createFilenamePanel(@CheckForNull LogixNG_SelectString selectStr) {
+    public JPanel createFilenamePanel(@CheckForNull LogixNG_SelectString selectStr, String path) {
         _panelDirect = new javax.swing.JPanel();
 
         JButton selectFileButton = new JButton("..."); // "File" replaced by ...
         selectFileButton.setMaximumSize(selectFileButton.getPreferredSize());
         selectFileButton.setToolTipText(Bundle.getMessage("FileButtonHint"));  // NOI18N
         selectFileButton.addActionListener((ActionEvent e) -> {
-            ScriptFileChooser scriptFileChooser = new ScriptFileChooser(FileUtil.getScriptsPath());
-            scriptFileChooser.rescanCurrentDirectory();
-            int retVal = scriptFileChooser.showOpenDialog(null);
+            JmriJFileChooser fileChooser = new JmriJFileChooser(path);
+            fileChooser.rescanCurrentDirectory();
+            int retVal = fileChooser.showOpenDialog(null);
             // handle selection or cancel
             if (retVal == JFileChooser.APPROVE_OPTION) {
                 // set selected file location
                 try {
-                    _valueTextField.setText(FileUtil.getPortableFilename(scriptFileChooser.getSelectedFile().getCanonicalPath()));
+                    _valueTextField.setText(FileUtil.getPortableFilename(fileChooser.getSelectedFile().getCanonicalPath()));
                 } catch (java.io.IOException ex) {
                     log.error("exception setting file location", ex);  // NOI18N
                     _valueTextField.setText("");

--- a/java/src/jmri/jmrit/logixng/util/swing/SwingBundle.properties
+++ b/java/src/jmri/jmrit/logixng/util/swing/SwingBundle.properties
@@ -2,6 +2,8 @@
 #
 # Default properties for the jmri.jmrit.logixng.tools.util.swing.SwingBundle
 
+FileButtonHint      = Click to select a file from disk
+
 Error_InSelectMode  = Select in progress. Complete the selection before closing the dialog.
 
 LogixNG_SelectTableSwing_Table          = Table {0}

--- a/java/test/jmri/jmrit/logixng/CreateLogixNGTreeScaffold.java
+++ b/java/test/jmri/jmrit/logixng/CreateLogixNGTreeScaffold.java
@@ -32,10 +32,10 @@ import org.junit.*;
 public class CreateLogixNGTreeScaffold {
 
     private static boolean setupHasBeenCalled = false;
-    
+
     private static void setUpCalled(boolean newVal){
         setupHasBeenCalled = newVal;
-    } 
+    }
 
     private LocoNetSystemConnectionMemo _locoNetMemo;
     private MqttSystemConnectionMemo _mqttMemo;
@@ -4381,6 +4381,27 @@ public class CreateLogixNGTreeScaffold {
         false1 = new False(digitalExpressionManager.getAutoSystemName(), null);
         false1.setComment("A comment");
         maleSocket = digitalExpressionManager.registerExpression(false1);
+        and.getChild(indexExpr++).connect(maleSocket);
+
+
+        FileAsFlag fileAsFlag = new FileAsFlag(digitalExpressionManager.getAutoSystemName(), null);
+        maleSocket = digitalExpressionManager.registerExpression(fileAsFlag);
+        maleSocket.setEnabled(false);
+        and.getChild(indexExpr++).connect(maleSocket);
+
+        fileAsFlag = new FileAsFlag(digitalExpressionManager.getAutoSystemName(), null);
+        fileAsFlag.setComment("A comment");
+        fileAsFlag.getSelectFilename().setValue("file.txt");
+        fileAsFlag.getSelectFilename().setAddressing(NamedBeanAddressing.Direct);
+        fileAsFlag.getSelectFilename().setFormula("\"IT\"+index");
+        fileAsFlag.getSelectFilename().setLocalVariable("index");
+        fileAsFlag.getSelectFilename().setReference("{IM1}");
+        fileAsFlag.getSelectDeleteOrKeep().setEnum(FileAsFlag.DeleteOrKeep.Delete);
+        fileAsFlag.getSelectDeleteOrKeep().setAddressing(NamedBeanAddressing.Direct);
+        fileAsFlag.getSelectDeleteOrKeep().setFormula("\"IT\"+index");
+        fileAsFlag.getSelectDeleteOrKeep().setLocalVariable("index");
+        fileAsFlag.getSelectDeleteOrKeep().setReference("{IM1}");
+        maleSocket = digitalExpressionManager.registerExpression(fileAsFlag);
         and.getChild(indexExpr++).connect(maleSocket);
 
 

--- a/java/test/jmri/jmrit/logixng/implementation/DefaultFemaleDigitalExpressionSocketTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/DefaultFemaleDigitalExpressionSocketTest.java
@@ -127,6 +127,7 @@ public class DefaultFemaleDigitalExpressionSocketTest extends FemaleSocketTestBa
         classes = new ArrayList<>();
         classes.add(jmri.jmrit.logixng.expressions.ConnectionName.class);
         classes.add(jmri.jmrit.logixng.expressions.False.class);
+        classes.add(jmri.jmrit.logixng.expressions.FileAsFlag.class);
         classes.add(jmri.jmrit.logixng.expressions.Hold.class);
         classes.add(jmri.jmrit.logixng.expressions.LastResultOfDigitalExpression.class);
         classes.add(jmri.jmrit.logixng.expressions.LogData.class);

--- a/xml/schema/logixng/digital-expressions/digital-expressions-4.23.1.xsd
+++ b/xml/schema/logixng/digital-expressions/digital-expressions-4.23.1.xsd
@@ -53,6 +53,7 @@
   <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/digital-expressions/expression-turnout-4.23.1.xsd"/>
   <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/digital-expressions/expression-warrant-4.23.1.xsd"/>
   <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/digital-expressions/false-4.23.1.xsd"/>
+  <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/digital-expressions/file-as-flag.5.5.2.xsd"/>
   <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/digital-expressions/formula-4.23.1.xsd"/>
   <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/digital-expressions/hold-4.23.1.xsd"/>
   <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/digital-expressions/last-result-of-digital-expression-4.23.1.xsd"/>
@@ -107,6 +108,7 @@
             <xs:element name="ExpressionTurnout"  type="LogixNG_DigitalExpression_ExpressionTurnoutType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="ExpressionWarrant"  type="LogixNG_DigitalExpression_ExpressionWarrantType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="False"              type="LogixNG_DigitalExpression_FalseType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="FileAsFlag"         type="LogixNG_DigitalExpression_FileAsFlagType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="DigitalFormula"     type="LogixNG_DigitalExpression_FormulaType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="Hold"               type="LogixNG_DigitalExpression_HoldType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="LastResultOfDigitalExpression"  type="LogixNG_DigitalExpression_LastResultOfDigitalExpressionType" minOccurs="0" maxOccurs="unbounded" />

--- a/xml/schema/logixng/digital-expressions/file-as-flag.5.5.2.xsd
+++ b/xml/schema/logixng/digital-expressions/file-as-flag.5.5.2.xsd
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="../schema2xhtml.xsl" type="text/xsl"?>
+
+<!-- This schema is part of JMRI. Copyright 2018.                           -->
+<!--                                                                        -->
+<!-- JMRI is free software; you can redistribute it and/or modify it under  -->
+<!-- the terms of version 2 of the GNU General Public License as published  -->
+<!-- by the Free Software Foundation. See the "COPYING" file for a copy     -->
+<!-- of this license.                                                       -->
+<!--                                                                        -->
+<!-- JMRI is distributed in the hope that it will be useful, but WITHOUT    -->
+<!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
+<!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
+<!-- for more details.                                                      -->
+
+<!-- This file contains definitions for LogixNG                             -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:xsi ="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:docbook="http://docbook.org/ns/docbook"
+           xmlns:jmri="http://jmri.org/xml/schema/JMRIschema"
+           xsi:schemaLocation="
+                http://jmri.org/xml/schema/JMRIschema http://jmri.org/xml/schema/JMRIschema.xsd
+                http://docbook.org/ns/docbook http://jmri.org/xml/schema/docbook/docbook.xsd
+            "
+        >
+
+    <xs:complexType name="LogixNG_DigitalExpression_FileAsFlagType">
+      <xs:annotation>
+        <xs:documentation>
+          Define the XML stucture for storing the contents of a FileAsFlag class.
+        </xs:documentation>
+        <xs:appinfo>
+            <jmri:usingclass configurexml="true">jmri.jmrit.logixng.digital.expressions.configurexml.FileAsFlagXml</jmri:usingclass>
+        </xs:appinfo>
+      </xs:annotation>
+
+            <xs:sequence>
+
+              <xs:element name="systemName" type="systemNameType" minOccurs="1" maxOccurs="1"/>
+              <xs:element name="userName" type="userNameType" minOccurs="0" maxOccurs="1"/>
+              <xs:element name="comment" type="commentType" minOccurs="0" maxOccurs="unbounded"/>
+
+              <xs:element name="filename" type="LogixNG_SelectStringType" minOccurs="0" maxOccurs="1" />
+              <xs:element name="deleteOrKeep" type="LogixNG_SelectEnumType" minOccurs="0" maxOccurs="1" />
+
+<!--              <xs:element name="enabled" type="yesNoType" /> -->
+
+              <xs:element name="MaleSocket" type="LogixNG_MaleSocket_Type" minOccurs="0" maxOccurs="1"/>
+
+            </xs:sequence>
+<!--            <xs:attribute name="enabled" type="yesNoType" /> -->
+            <xs:attribute name="class" type="classType" use="required"/>
+
+    </xs:complexType>
+
+</xs:schema>

--- a/xml/schema/logixng/digital-expressions/file-as-flag.5.5.2.xsd
+++ b/xml/schema/logixng/digital-expressions/file-as-flag.5.5.2.xsd
@@ -44,12 +44,10 @@
               <xs:element name="filename" type="LogixNG_SelectStringType" minOccurs="0" maxOccurs="1" />
               <xs:element name="deleteOrKeep" type="LogixNG_SelectEnumType" minOccurs="0" maxOccurs="1" />
 
-<!--              <xs:element name="enabled" type="yesNoType" /> -->
-
               <xs:element name="MaleSocket" type="LogixNG_MaleSocket_Type" minOccurs="0" maxOccurs="1"/>
 
             </xs:sequence>
-<!--            <xs:attribute name="enabled" type="yesNoType" /> -->
+
             <xs:attribute name="class" type="classType" use="required"/>
 
     </xs:complexType>


### PR DESCRIPTION
This PR started by this JMRI users thread: https://groups.io/g/jmriusers/message/218821

Bob J solved that by letting JMRI listen on kill signals, which for that particular case was the best solution.

But sometimes a user might want to do other things with JMRI from the OS. This new expression lets the user do just that. It checks if a particular file exists and if so, returns true. It's recommended to use a timer to run this test continuously.

The expression has the option to delete the file if it exists. This means that a Linux user only needs to run `touch <filename>` from the command line to create the file. And when the expression finds the file, the file is deleted. The touch command could be run from a bash script. Or another program (Python, C, ...) could create the file if desired.

Example panel which closes JMRI if the file `profile:shutdown.txt` exists.
[LogixNG_FileAsFlag.xml.txt](https://github.com/JMRI/JMRI/files/12023296/LogixNG_FileAsFlag.xml.txt)

```
LogixNG: IQ:AUTO:0001
    ConditionalNG: IQC:AUTO:0001
        ! A
            Timer
                ? Start
                    
                ? Stop
                    
                ! A1
                    If Then Else. Execute on change
                        ? If
                            File as flag. Filename: profile:shutdown.txt. Delete file if it exists
                        ! Then
                            Shutdown JMRI/computer: Shut down JMRI
                        ! Else

```