### PR TITLE
Clocks - prevent Exception on resize

### DIFF
--- a/java/src/jmri/jmrit/analogclock/AnalogClockFrame.java
+++ b/java/src/jmri/jmrit/analogclock/AnalogClockFrame.java
@@ -246,7 +246,7 @@ public class AnalogClockFrame extends JmriJFrame implements java.beans.PropertyC
             // use the NamedIcon as a source for the sizes
             int logoScaleWidth = faceSize / 6;
             int logoScaleHeight = (int) ((float) logoScaleWidth * (float) jmriIcon.getIconHeight() / jmriIcon.getIconWidth());
-            scaledLogo = logo.getScaledInstance(logoScaleWidth, logoScaleHeight, Image.SCALE_SMOOTH);
+            scaledLogo = logo.getScaledInstance(Math.max(1, logoScaleWidth), Math.max(1, logoScaleHeight), Image.SCALE_SMOOTH);
             scaledIcon.setImage(scaledLogo);
             logoWidth = scaledIcon.getIconWidth();
             logoHeight = scaledIcon.getIconHeight();

--- a/java/src/jmri/jmrit/lcdclock/LcdClockFrame.java
+++ b/java/src/jmri/jmrit/lcdclock/LcdClockFrame.java
@@ -137,10 +137,10 @@ public class LcdClockFrame extends JmriJFrame implements java.beans.PropertyChan
             iconHeight = (int) (iconWidth / iconAspect);
         }
         for (int i = 0; i < 10; i++) {
-            Image scaledImage = baseTubes[i].getImage().getScaledInstance(iconWidth, iconHeight, Image.SCALE_SMOOTH);
+            Image scaledImage = baseTubes[i].getImage().getScaledInstance(Math.max(1,iconWidth), Math.max(1,iconHeight), Image.SCALE_SMOOTH);
             tubes[i].setImage(scaledImage);
         }
-        Image scaledImage = baseColon.getImage().getScaledInstance(iconWidth / 2, iconHeight, Image.SCALE_SMOOTH);
+        Image scaledImage = baseColon.getImage().getScaledInstance(Math.max(1,iconWidth / 2), Math.max(1,iconHeight), Image.SCALE_SMOOTH);
         colonIcon.setImage(scaledImage);
         // update the images on screen
         this.getContentPane().revalidate();

--- a/java/src/jmri/jmrit/nixieclock/NixieClockFrame.java
+++ b/java/src/jmri/jmrit/nixieclock/NixieClockFrame.java
@@ -134,10 +134,10 @@ public class NixieClockFrame extends JmriJFrame implements java.beans.PropertyCh
             iconHeight = (int) (iconWidth / iconAspect);
         }
         for (int i = 0; i < 10; i++) {
-            Image scaledImage = baseTubes[i].getImage().getScaledInstance(iconWidth, iconHeight, Image.SCALE_SMOOTH);
+            Image scaledImage = baseTubes[i].getImage().getScaledInstance(Math.max(1,iconWidth), Math.max(1,iconHeight), Image.SCALE_SMOOTH);
             tubes[i].setImage(scaledImage);
         }
-        Image scaledImage = baseColon.getImage().getScaledInstance(iconWidth / 2, iconHeight, Image.SCALE_SMOOTH);
+        Image scaledImage = baseColon.getImage().getScaledInstance(Math.max(1,iconWidth / 2), Math.max(1,iconHeight), Image.SCALE_SMOOTH);
         colonIcon.setImage(scaledImage);
         // update the images on screen
         this.getContentPane().revalidate();

--- a/java/src/jmri/jmrit/pragotronclock/PragotronClockFrame.java
+++ b/java/src/jmri/jmrit/pragotronclock/PragotronClockFrame.java
@@ -160,14 +160,14 @@ public class PragotronClockFrame extends JmriJFrame implements java.beans.Proper
             iconHeightDot = (int) (iconWidthDot / iconAspectDot);
         }
         for (int i = 0; i < 10; i++) {
-            Image scaledImage = baseFoldingSheets10[i].getImage().getScaledInstance(iconWidth10, iconHeight10, Image.SCALE_SMOOTH);
+            Image scaledImage = baseFoldingSheets10[i].getImage().getScaledInstance(Math.max(1,iconWidth10), Math.max(1,iconHeight10), Image.SCALE_SMOOTH);
             foldingSheets10[i].setImage(scaledImage);
         }
         for (int i = 0; i < 24; i++) {
-            Image scaledImage = baseFoldingSheets24[i].getImage().getScaledInstance(iconWidth24, iconHeight24, Image.SCALE_SMOOTH);
+            Image scaledImage = baseFoldingSheets24[i].getImage().getScaledInstance(Math.max(1,iconWidth24), Math.max(1,iconHeight24), Image.SCALE_SMOOTH);
             foldingSheets24[i].setImage(scaledImage);
         }
-        Image scaledImage = baseColon.getImage().getScaledInstance(iconWidthDot , iconHeightDot, Image.SCALE_SMOOTH);
+        Image scaledImage = baseColon.getImage().getScaledInstance(Math.max(1,iconWidthDot) , Math.max(1,iconHeightDot), Image.SCALE_SMOOTH);
         colonIcon.setImage(scaledImage);
 
         // update the images on screen


### PR DESCRIPTION
Prevents Exception when frame heights are resized to 0 ( no height ) , eg.

```
ERROR - Uncaught Exception caught by jmri.util.exceptionhandler.UncaughtExceptionHandler [AWT-EventQueue-0]
     [java] java.lang.IllegalArgumentException: Width (1) and height (0) must be non-zero
     [java]     at java.desktop/java.awt.image.ReplicateScaleFilter.<init>(ReplicateScaleFilter.java:102)
     [java]     at java.desktop/java.awt.image.AreaAveragingScaleFilter.<init>(AreaAveragingScaleFilter.java:77)
     [java]     at java.desktop/java.awt.Image.getScaledInstance(Image.java:172)
     [java]     at jmri.jmrit.analogclock.AnalogClockFrame$ClockPanel.scaleFace(AnalogClockFrame.java:249)
     [java]     at jmri.jmrit.analogclock.AnalogClockFrame$ClockPanel$1.componentResized(AnalogClockFrame.java:134)
```