### PR TITLE
Signalhead Annotation

### DIFF
--- a/java/src/jmri/SignalHead.java
+++ b/java/src/jmri/SignalHead.java
@@ -1,5 +1,7 @@
 package jmri;
 
+import javax.annotation.Nonnull;
+
 /**
  * Represent a single signal head. (Try saying that ten times fast!) A signal
  * may have more than one of these (e.g. a signal mast consisting of several
@@ -68,7 +70,7 @@ public interface SignalHead extends Signal {
      * Changes in this value can be listened to using the
      * {@literal Appearance} property.
      *
-     * @return the appearance
+     * @return the appearance, e.g. SignalHead.YELLOW
      */
     public int getAppearance();
 
@@ -79,37 +81,60 @@ public interface SignalHead extends Signal {
      */
     public void setAppearance(int newAppearance);
 
+    
+    /**
+     * Get the current Signal Head Appearance Key.
+     * @return Key, or empty String if no valid appearance set.
+     */
+    @Nonnull
     public String getAppearanceKey();
 
+    /**
+     * Get the Appearance Key for a particular Appearance.
+     * @param appearance id for the key, e.g. SignalHead.GREEN
+     * @return the Appearance Key, e.g. "Green" or empty String if unknown.
+     * The key can be used as a Bundle String, e.g.
+     * Bundle.getMessage(getAppearanceKey(SignalHead.RED))
+     */
+    @Nonnull
     public String getAppearanceKey(int appearance);
 
+    /**
+     * Get the current appearance name.
+     * @return Name of the Appearance, e.g. "Dark" or "Flashing Red"
+     */
+    @Nonnull
     public String getAppearanceName();
 
+    /**
+     * Get the Appearance Name for a particular Appearance.
+     * @param appearance id for the Name.
+     * @return the Appearance Name, or empty String if unknown.
+     */
+    @Nonnull
     public String getAppearanceName(int appearance);
 
     /**
-     * Get whether the signal head is lit or dark. Changes to this value can be
-     * listened to using the {@literal Lit} property.
-     *
-     * @return true if lit; false if dark
+     * {@inheritDoc}
      */
     @Override
     public boolean getLit();
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void setLit(boolean newLit);
 
     /**
-     * Get whether the signal head is held. Changes to this value can be listened to
-     * using the {@literal Held} property. It controls what mechanisms can
-     * control the head's appearance. The actual semantics are defined by those
-     * external mechanisms.
-     *
-     * @return true if held; false otherwise
+     * {@inheritDoc}
      */
     @Override
     public boolean getHeld();
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void setHeld(boolean newHeld);
 

--- a/java/src/jmri/SignalHeadManager.java
+++ b/java/src/jmri/SignalHeadManager.java
@@ -23,7 +23,7 @@ import javax.annotation.Nonnull;
  *
  * @author Bob Jacobsen Copyright (C) 2001
  */
-public interface SignalHeadManager extends Manager<SignalHead> {
+public interface SignalHeadManager extends Manager<SignalHead>, Disposable {
 
     /** {@inheritDoc} */
     @Override

--- a/java/src/jmri/implementation/AbstractSignalHead.java
+++ b/java/src/jmri/implementation/AbstractSignalHead.java
@@ -22,6 +22,10 @@ public abstract class AbstractSignalHead extends AbstractNamedBean
         super(systemName);
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Nonnull
     @Override
     public String getAppearanceName(int appearance) {
         String ret = jmri.util.StringUtil.getNameFromState(
@@ -32,11 +36,19 @@ public abstract class AbstractSignalHead extends AbstractNamedBean
         return ("");
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Nonnull
     @Override
     public String getAppearanceName() {
         return getAppearanceName(getAppearance());
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Nonnull
     @Override
     public String getAppearanceKey(int appearance) {
         String ret = jmri.util.StringUtil.getNameFromState(
@@ -47,6 +59,10 @@ public abstract class AbstractSignalHead extends AbstractNamedBean
         return ("");
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Nonnull
     @Override
     public String getAppearanceKey() {
         return getAppearanceKey(getAppearance());
@@ -54,6 +70,9 @@ public abstract class AbstractSignalHead extends AbstractNamedBean
 
     protected int mAppearance = DARK;
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public int getAppearance() {
         return mAppearance;
@@ -100,7 +119,7 @@ public abstract class AbstractSignalHead extends AbstractNamedBean
 
     /**
      * Default behavior for "lit" parameter is to track value and return it.
-     *
+     * {@inheritDoc}
      * @return is lit
      */
     @Override
@@ -115,6 +134,7 @@ public abstract class AbstractSignalHead extends AbstractNamedBean
 
     /**
      * "Held" parameter is just tracked and notified.
+     * {@inheritDoc}
      * @return is held
      */
     @Override
@@ -165,14 +185,11 @@ public abstract class AbstractSignalHead extends AbstractNamedBean
      * @param appearance the index of the appearance
      * @return translated name for appearance
      */
+    @Nonnull
     public static String getDefaultStateName(int appearance) {
         String ret = jmri.util.StringUtil.getNameFromState(
                 appearance, getDefaultValidStates(), getDefaultValidStateNames());
-        if (ret != null) {
-            return ret;
-        } else {
-            return ("");
-        }
+        return ( ret != null ? ret : "" );
     }
 
     private static final int[] validStates = new int[]{
@@ -186,6 +203,7 @@ public abstract class AbstractSignalHead extends AbstractNamedBean
         FLASHGREEN,
         FLASHLUNAR
     };
+
     private static final String[] validStateKeys = new String[]{
         "SignalHeadStateDark",
         "SignalHeadStateRed",
@@ -230,6 +248,9 @@ public abstract class AbstractSignalHead extends AbstractNamedBean
      */
     abstract boolean isTurnoutUsed(Turnout t);
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void vetoableChange(java.beans.PropertyChangeEvent evt) throws java.beans.PropertyVetoException {
         if ("CanDelete".equals(evt.getPropertyName())) { // NOI18N
@@ -240,6 +261,9 @@ public abstract class AbstractSignalHead extends AbstractNamedBean
         }
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public @Nonnull String getBeanType() {
         return Bundle.getMessage("BeanNameSignalHead");

--- a/java/src/jmri/implementation/MergSD2SignalHead.java
+++ b/java/src/jmri/implementation/MergSD2SignalHead.java
@@ -1,10 +1,11 @@
 package jmri.implementation;
 
 import java.util.Arrays;
+
+import javax.annotation.CheckForNull;
+
 import jmri.NamedBeanHandle;
 import jmri.Turnout;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Implement SignalHead for the MERG Signal Driver 2.
@@ -42,9 +43,9 @@ public class MergSD2SignalHead extends DefaultSignalHead {
         mFeather = feather;
         mHome = home;
         if (mHome) {
-            setAppearance(RED);
+            MergSD2SignalHead.this.setAppearance(RED);
         } else {
-            setAppearance(YELLOW);
+            MergSD2SignalHead.this.setAppearance(YELLOW);
         }
     }
 
@@ -61,9 +62,9 @@ public class MergSD2SignalHead extends DefaultSignalHead {
         mFeather = feather;
         mHome = home;
         if (mHome) {
-            setAppearance(RED);
+            MergSD2SignalHead.this.setAppearance(RED);
         } else {
-            setAppearance(YELLOW);
+            MergSD2SignalHead.this.setAppearance(YELLOW);
         }
     }
 
@@ -188,14 +189,17 @@ public class MergSD2SignalHead extends DefaultSignalHead {
     boolean mFeather = false;
     boolean mHome = true; //Home Signal = true, Distance Signal = false
 
+    @CheckForNull
     public NamedBeanHandle<Turnout> getInput1() {
         return mInput1;
     }
 
+    @CheckForNull
     public NamedBeanHandle<Turnout> getInput2() {
         return mInput2;
     }
 
+    @CheckForNull
     public NamedBeanHandle<Turnout> getInput3() {
         return mInput3;
     }
@@ -375,18 +379,15 @@ public class MergSD2SignalHead extends DefaultSignalHead {
 
     @Override
     boolean isTurnoutUsed(Turnout t) {
-        if (getInput1() != null && t.equals(getInput1().getBean())) {
+        if (mInput1 != null && t.equals(mInput1.getBean())) {
             return true;
         }
-        if (getInput2() != null && t.equals(getInput2().getBean())) {
+        if (mInput2 != null && t.equals(mInput2.getBean())) {
             return true;
         }
-        if (getInput3() != null && t.equals(getInput3().getBean())) {
-            return true;
-        }
-        return false;
+        return (mInput3 != null && t.equals(mInput3.getBean()));
     }
 
-    private final static Logger log = LoggerFactory.getLogger(MergSD2SignalHead.class);
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(MergSD2SignalHead.class);
 
 }

--- a/java/src/jmri/implementation/VirtualSignalHead.java
+++ b/java/src/jmri/implementation/VirtualSignalHead.java
@@ -1,6 +1,5 @@
 package jmri.implementation;
 
-
 /**
  * A signal head that exists only within the program.
  * <p>
@@ -27,12 +26,4 @@ public class VirtualSignalHead extends DefaultSignalHead {
         return false;
     }
 
-    /**
-     * Remove references to and from this object, so that it can eventually be
-     * garbage-collected.
-     */
-    @Override
-    public void dispose() {
-        super.dispose();
-    }
 }

--- a/java/src/jmri/implementation/configurexml/MergSD2SignalHeadXml.java
+++ b/java/src/jmri/implementation/configurexml/MergSD2SignalHeadXml.java
@@ -128,7 +128,7 @@ public class MergSD2SignalHeadXml extends jmri.managers.configurexml.AbstractNam
         }
 
         var aspectsAttr = shared.getAttribute("aspects");
-        if ( aspectsAttr != null ) { // considered normal if the attribute is not present
+        if ( aspectsAttr != null ) {
             try {
                     aspects = aspectsAttr.getIntValue();
             } catch (org.jdom2.DataConversionException e) {

--- a/java/src/jmri/implementation/configurexml/MergSD2SignalHeadXml.java
+++ b/java/src/jmri/implementation/configurexml/MergSD2SignalHeadXml.java
@@ -128,7 +128,7 @@ public class MergSD2SignalHeadXml extends jmri.managers.configurexml.AbstractNam
         }
 
         var aspectsAttr = shared.getAttribute("aspects");
-        if ( aspectsAttr != null ) { // considered normal if the attribute not present
+        if ( aspectsAttr != null ) { // considered normal if the attribute is not present
             try {
                     aspects = aspectsAttr.getIntValue();
             } catch (org.jdom2.DataConversionException e) {

--- a/java/src/jmri/implementation/configurexml/MergSD2SignalHeadXml.java
+++ b/java/src/jmri/implementation/configurexml/MergSD2SignalHeadXml.java
@@ -7,8 +7,6 @@ import jmri.SignalHead;
 import jmri.Turnout;
 import jmri.implementation.MergSD2SignalHead;
 import org.jdom2.Element;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Handle XML configuration for MergSD2SignalHead objects.
@@ -56,19 +54,19 @@ public class MergSD2SignalHeadXml extends jmri.managers.configurexml.AbstractNam
         //@TODO could re-arange this so that it falls through
         switch (aspects) {
             case 2:
-                element.addContent(addTurnoutElement(p.getInput1(), "input1"));
+                element.addContent(addTurnoutElement(p.getInput1(), "input1", p));
                 if (!p.getHome()) {
                     element.setAttribute("home", "no");
                 }
                 break;
             case 3:
-                element.addContent(addTurnoutElement(p.getInput1(), "input1"));
-                element.addContent(addTurnoutElement(p.getInput2(), "input2"));
+                element.addContent(addTurnoutElement(p.getInput1(), "input1", p));
+                element.addContent(addTurnoutElement(p.getInput2(), "input2", p));
                 break;
             case 4:
-                element.addContent(addTurnoutElement(p.getInput1(), "input1"));
-                element.addContent(addTurnoutElement(p.getInput2(), "input2"));
-                element.addContent(addTurnoutElement(p.getInput3(), "input3"));
+                element.addContent(addTurnoutElement(p.getInput1(), "input1", p));
+                element.addContent(addTurnoutElement(p.getInput2(), "input2", p));
+                element.addContent(addTurnoutElement(p.getInput3(), "input3", p));
                 break;
             default:
                 log.error("incorrect number of aspects {} for Signal {}", aspects, p.getDisplayName());
@@ -77,21 +75,13 @@ public class MergSD2SignalHeadXml extends jmri.managers.configurexml.AbstractNam
         return element;
     }
 
-    Element addTurnoutElement(NamedBeanHandle<Turnout> to, String which) {
+    Element addTurnoutElement(NamedBeanHandle<Turnout> to, String which, SignalHead p) {
         Element el = new Element("turnoutname");
         el.setAttribute("defines", which);
-        el.addContent(to.getName());
-        return el;
-    }
-
-    Element addSingleTurnoutElement(Turnout to) {
-        String user = to.getUserName();
-        String sys = to.getSystemName();
-
-        Element el = new Element("turnout");
-        el.setAttribute("systemName", sys);
-        if (user != null) {
-            el.setAttribute("userName", user);
+        if ( to == null ) {
+            log.error("No Turnout found for MergSD2 Head {}",  p.getDisplayName());
+        } else {
+            el.addContent(to.getName());
         }
         return el;
     }
@@ -100,7 +90,7 @@ public class MergSD2SignalHeadXml extends jmri.managers.configurexml.AbstractNam
     public boolean load(Element shared, Element perNode) {
         int aspects = 2;
         List<Element> l = shared.getChildren("turnoutname");
-        if (l.size() == 0) {
+        if (l.isEmpty()) {
             l = shared.getChildren("turnout");
             aspects = l.size() + 1;
         }
@@ -136,14 +126,16 @@ public class MergSD2SignalHeadXml extends jmri.managers.configurexml.AbstractNam
                 home = false;
             }
         }
-        try {
-            aspects = shared.getAttribute("aspects").getIntValue();
-        } catch (org.jdom2.DataConversionException e) {
-            log.warn("Could not parse level attribute!");
-        } catch (NullPointerException e) {  // considered normal if the attribute not present
+
+        var aspectsAttr = shared.getAttribute("aspects");
+        if ( aspectsAttr != null ) { // considered normal if the attribute not present
+            try {
+                    aspects = aspectsAttr.getIntValue();
+            } catch (org.jdom2.DataConversionException e) {
+                log.warn("Could not parse aspects attribute! {}", e.getMessage());
+            }
         }
 
-        SignalHead h;
         //int aspects = l.size()+1;  //Number of aspects is equal to the number of turnouts used plus 1.
         //@TODO could re-arange this so that it falls through
         switch (aspects) {
@@ -162,6 +154,8 @@ public class MergSD2SignalHeadXml extends jmri.managers.configurexml.AbstractNam
             default:
                 log.error("incorrect number of aspects {} when loading Signal {}", aspects, sys);
         }
+
+        SignalHead h;
         if (uname == null) {
             h = new MergSD2SignalHead(sys, aspects, input1, input2, input3, feather, home);
         } else {
@@ -218,6 +212,6 @@ public class MergSD2SignalHeadXml extends jmri.managers.configurexml.AbstractNam
         log.error("Invalid method called");
     }
 
-    private final static Logger log = LoggerFactory.getLogger(MergSD2SignalHeadXml.class);
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(MergSD2SignalHeadXml.class);
 
 }


### PR DESCRIPTION
Adds NonNull annotation to some SignalHead methods to match implementation.
Some JavaDoc updates.
Adds CheckForNull annotation to some MergSD2SignalHead methods.