### PR TITLE
Z21 will leave track power unchanged when JMRI quits

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -136,7 +136,8 @@
 
         <h4>Roco z21/Z21</h4>
             <ul>
-                <li></li>
+                <li>JMRI will now leave the layout power unchanged when it terminates.
+                    Previously, it would turn the power on if it was off.</li>
             </ul>
 
         <h4>Secsi</h4>

--- a/java/src/jmri/jmrix/roco/z21/Z21XNetStreamPortController.java
+++ b/java/src/jmri/jmrix/roco/z21/Z21XNetStreamPortController.java
@@ -25,6 +25,11 @@ public class Z21XNetStreamPortController extends jmri.jmrix.lenz.XNetStreamPortC
             protected AbstractMRReply newReply() {
                return new Z21XNetReply();
             }
+            @Override
+            protected void terminate() {
+                // This overrides the default Lenz behavior of turning the power back on
+                // by deliberately doing nothing.
+            }
         };
         packets.connectPort(this);
 


### PR DESCRIPTION
See Issue #12212 for background and link to a JMRIusers thread.