### PR TITLE
center dialogs on VSD manager window

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -591,6 +591,9 @@
         <a id="VSD" name="VSD"></a>
         <ul>
             <li>Fixed a bug with wrong direction in an oval layout.</li>
+            <li>Minor change on the Manager window GUI. The windows for adding
+            a VSDecoder and to handle the option now are centered to the manager
+            window. This is not a functional change.</li>
         </ul>
 
     <h3>Miscellaneous</h3>

--- a/java/src/jmri/jmrit/vsdecoder/swing/VSDConfigDialog.java
+++ b/java/src/jmri/jmrit/vsdecoder/swing/VSDConfigDialog.java
@@ -111,6 +111,7 @@ public class VSDConfigDialog extends JDialog {
             }
         });
         initComponents();
+        setLocationRelativeTo(parent);
     }
 
     /**

--- a/java/src/jmri/jmrit/vsdecoder/swing/VSDOptionsDialog.java
+++ b/java/src/jmri/jmrit/vsdecoder/swing/VSDOptionsDialog.java
@@ -39,6 +39,7 @@ public class VSDOptionsDialog extends JDialog {
     public VSDOptionsDialog(JPanel parent, String title) {
         super(SwingUtilities.getWindowAncestor(parent), title);
         initComponents();
+        setLocationRelativeTo(parent);
     }
 
     public void initComponents() {


### PR DESCRIPTION
While the VSD Manager window is free in its position, the two VSD dialogs are fixed to the top left corner.
Use setLocationRelativeTo to center the VSD dialogs to the Manager window.