### PR TITLE
Fix C/MRI output for "T" message 

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -26,7 +26,12 @@
 
         <h4>C/MRI</h4>
             <ul>
-                <li></li>
+                <li>Provided an extra copy of the output data when preparing
+                C/MRI output data for a "T" ("Transmit") message type.  This 
+		prevents a "data buffer overrun" in a pre-configured buffer 
+		when the output data changes when the process assemble the data.
+		(The previous implementation could run out of available bytes 
+		in the buffer, and the data would not be sent.)</li>
             </ul>
 
         <h4>DCC++ and DCC-EX</h4>

--- a/java/src/jmri/jmrit/analogclock/AnalogClockFrame.java
+++ b/java/src/jmri/jmrit/analogclock/AnalogClockFrame.java
@@ -4,7 +4,6 @@ import java.awt.Color;
 import java.awt.Font;
 import java.awt.FontMetrics;
 import java.awt.Graphics;
-import java.awt.Image;
 import java.awt.Polygon;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -18,7 +17,6 @@ import javax.swing.JPanel;
 
 import jmri.InstanceManager;
 import jmri.Timebase;
-import jmri.jmrit.catalog.NamedIcon;
 import jmri.util.JmriJFrame;
 import jmri.util.ThreadingUtil;
 
@@ -82,10 +80,6 @@ public class AnalogClockFrame extends JmriJFrame implements java.beans.PropertyC
 
         // Create a Panel that has clockface drawn on it scaled to the size of the panel
         // Define common variables
-        Image logo;
-        Image scaledLogo;
-        NamedIcon jmriIcon;
-        NamedIcon scaledIcon;
         int hourX[] = {-12, -11, -25, -10, -10, 0, 10, 10, 25, 11, 12};
         int hourY[] = {-31, -163, -170, -211, -276, -285, -276, -211, -170, -163, -31};
         int minuteX[] = {-12, -11, -24, -11, -11, 0, 11, 11, 24, 11, 12};
@@ -105,20 +99,15 @@ public class AnalogClockFrame extends JmriJFrame implements java.beans.PropertyC
         double scaleRatio;
         int faceSize;
         int size;
-        int logoWidth;
-        int logoHeight;
 
         // centreX, centreY are the coordinates of the centre of the clock
         int centreX;
         int centreY;
 
         public ClockPanel() {
-            // Load the JMRI logo and hands to put on the clock
+            // Load the hands to put on the clock.
             // Icons are the original size version kept for to allow for mulitple resizing
             // and scaled Icons are the version scaled for the panel size
-            jmriIcon = new NamedIcon("resources/logo.gif", "resources/logo.gif");
-            scaledIcon = new NamedIcon("resources/logo.gif", "resources/logo.gif");
-            logo = jmriIcon.getImage();
 
             // Create an unscaled minute hand to get the original size (height) to use
             // in the scaling calculations
@@ -134,7 +123,6 @@ public class AnalogClockFrame extends JmriJFrame implements java.beans.PropertyC
                     scaleFace();
                 }
             });
-
         }
 
         @Override
@@ -156,9 +144,6 @@ public class AnalogClockFrame extends JmriJFrame implements java.beans.PropertyC
             g.fillOval(-dotSize, -dotSize, 2 * dotSize, 2 * dotSize);
             g.setColor(Color.black);
             g.fillOval(-dotSize / 2, -dotSize / 2, dotSize, dotSize);
-
-            // Draw the JMRI logo
-            g.drawImage(scaledLogo, -logoWidth / 2, -faceSize / 4, logoWidth, logoHeight, this);
 
             // Draw the hour and minute markers
             int dashSize = size / 60;
@@ -232,7 +217,7 @@ public class AnalogClockFrame extends JmriJFrame implements java.beans.PropertyC
         }
 
         // Method called on resizing event - sets various sizing variables
-        // based on the size of the resized panel and scales the logo/hands
+        // based on the size of the resized panel and scales the hands
         public void scaleFace() {
             int panelHeight = this.getSize().height;
             int panelWidth = this.getSize().width;
@@ -241,15 +226,6 @@ public class AnalogClockFrame extends JmriJFrame implements java.beans.PropertyC
             if (faceSize == 0) {
                 faceSize = 1;
             }
-
-            // Had trouble getting the proper sizes when using Images by themselves so
-            // use the NamedIcon as a source for the sizes
-            int logoScaleWidth = faceSize / 6;
-            int logoScaleHeight = (int) ((float) logoScaleWidth * (float) jmriIcon.getIconHeight() / jmriIcon.getIconWidth());
-            scaledLogo = logo.getScaledInstance(logoScaleWidth, logoScaleHeight, Image.SCALE_SMOOTH);
-            scaledIcon.setImage(scaledLogo);
-            logoWidth = scaledIcon.getIconWidth();
-            logoHeight = scaledIcon.getIconHeight();
 
             scaleRatio = faceSize / 2.7 / minuteHeight;
             for (int i = 0; i < minuteX.length; i++) {
@@ -263,7 +239,6 @@ public class AnalogClockFrame extends JmriJFrame implements java.beans.PropertyC
 
             centreX = panelWidth / 2;
             centreY = panelHeight / 2;
-
         }
     }
 
@@ -278,12 +253,6 @@ public class AnalogClockFrame extends JmriJFrame implements java.beans.PropertyC
             amPm = "AM ";
         } else {
             amPm = "PM ";
-        }
-        if (hours == 12 && minutes == 0) {
-            amPm = "Noon";
-        }
-        if (hours == 0 && minutes == 0) {
-            amPm = "Midnight";
         }
 
         String rate = ""+(int)clock.userGetRate();

--- a/java/src/jmri/jmrit/simpleclock/SimpleClockFrame.java
+++ b/java/src/jmri/jmrit/simpleclock/SimpleClockFrame.java
@@ -514,8 +514,10 @@ public class SimpleClockFrame extends JmriJFrame implements PropertyChangeListen
      * Handle synchronize check box change
      */
     private void synchronizeChanged(ActionEvent e) {
-        clock.setSynchronize(synchronizeCheckBox.isSelected(), true);
-        changed = true;
+        if (synchronizeCheckBox != null) {
+            clock.setSynchronize(synchronizeCheckBox.isSelected(), true);
+            changed = true;
+        }
     }
 
     /**
@@ -741,7 +743,9 @@ public class SimpleClockFrame extends JmriJFrame implements PropertyChangeListen
                 updateTime();
                 break;
             case "config": //indicates that something in the clock config has changed, so update all
-                synchronizeCheckBox.setSelected(clock.getSynchronize());
+                if (synchronizeCheckBox != null) {
+                    synchronizeCheckBox.setSelected(clock.getSynchronize());
+                }
                 timeSourceBox.setSelectedIndex(clock.getInternalMaster() ? internalSourceIndex : hardwareSourceIndex);
                 switch (clock.getClockInitialRunState()) {
                     case DO_STOP:

--- a/java/src/jmri/jmrit/simpleclock/SimpleTimebase.java
+++ b/java/src/jmri/jmrit/simpleclock/SimpleTimebase.java
@@ -7,7 +7,15 @@ import java.time.Instant;
 import java.util.Calendar;
 import java.util.Date;
 
-import jmri.*;
+import jmri.ClockControl;
+import jmri.InstanceManager;
+import jmri.JmriException;
+import jmri.Memory;
+import jmri.MemoryManager;
+import jmri.SystemConnectionMemo;
+import jmri.Sensor;
+import jmri.Timebase;
+import jmri.TimebaseRateException;
 import jmri.jmrix.internal.InternalSystemConnectionMemo;
 
 import org.slf4j.Logger;

--- a/java/src/jmri/jmrix/cmri/serial/SerialNode.java
+++ b/java/src/jmri/jmrix/cmri/serial/SerialNode.java
@@ -1172,8 +1172,10 @@ public class SerialNode extends AbstractNode {
         // Count the number of DLE's to be inserted
         int nOutBytes = numOutputCards() * (bitsPerCard / 8);
         int nDLE = 0;
+        byte[] oA = outputArray.clone();
+
         for (int i = 0; i < nOutBytes; i++) {
-            if ((outputArray[i] == 2) || (outputArray[i] == 3) || (outputArray[i] == 16)) {
+            if ((oA[i] == 2) || (oA[i] == 3) || (oA[i] == 16)) {
                 nDLE++;
             }
         }
@@ -1185,12 +1187,12 @@ public class SerialNode extends AbstractNode {
         int k = 2;
         for (int i = 0; i < nOutBytes; i++) {
             // perform C/MRI required DLE processing
-            if ((outputArray[i] == 2) || (outputArray[i] == 3) || (outputArray[i] == 16)) {
+            if ((oA[i] == 2) || (oA[i] == 3) || (oA[i] == 16)) {
                 m.setElement(k, 16);  // DLE
                 k++;
             }
             // add output byte
-            m.setElement(k, outputArray[i]);
+            m.setElement(k, oA[i]);
             k++;
         }
         return m;


### PR DESCRIPTION
Prevent C/MRI "T" message preparation from seeing off-thread output changes.  Prevents an "out-of-bounds" array reference if the output data changes and the DLE insertion needs to add one or more DLEs.

fixes #12204 .
