### PR TITLE
CAN Consoles - add to start of TrafficController notifications

### DIFF
--- a/java/src/jmri/jmrix/AbstractMRTrafficController.java
+++ b/java/src/jmri/jmrix/AbstractMRTrafficController.java
@@ -5,6 +5,8 @@ import java.io.DataInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.*;
+
+import javax.annotation.Nonnull;
 import javax.swing.SwingUtilities;
 
 import jmri.InstanceManager;
@@ -128,6 +130,10 @@ public abstract class AbstractMRTrafficController {
 
     protected final Vector<AbstractMRListener> cmdListeners = new Vector<>();
 
+    /**
+     * Add a Listener to the Listener list.
+     * @param l The Listener to be added, not null.
+     */
     protected synchronized void addListener(AbstractMRListener l) {
         // add only if not already registered
         if (l == null) {
@@ -138,6 +144,24 @@ public abstract class AbstractMRTrafficController {
         }
     }
 
+    /**
+     * Add a Listener to start of the Listener list.
+     * Intended for use only by system Consoles which may prefer notification
+     * before other objects have processed a Message and sent a Reply.
+     * @param l The Listener to be added, not null.
+     */
+    protected synchronized void addConsoleListener(@Nonnull AbstractMRListener l){
+        // add only if not already registered
+        if (!cmdListeners.contains(l)) {
+            cmdListeners.insertElementAt(l, 0);
+        }
+    }
+
+    /**
+     * Remove a Listener from the Listener list.
+     * The Listener will receive no further notifications.
+     * @param l The Listener to be removed.
+     */
     protected synchronized void removeListener(AbstractMRListener l) {
         if (cmdListeners.contains(l)) {
             cmdListeners.removeElement(l);

--- a/java/src/jmri/jmrix/can/AbstractCanTrafficController.java
+++ b/java/src/jmri/jmrix/can/AbstractCanTrafficController.java
@@ -38,6 +38,16 @@ abstract public class AbstractCanTrafficController
     }
 
     /**
+     * Add a CanListener to start of the notification list.
+     * This is intended only for Consoles to receive the CanFrame 1st,
+     * not after another Listener has sent a response to that Frame.
+     * @param l The CanListener to add.
+     */
+    public synchronized void addCanConsoleListener(CanListener l) {
+        this.addConsoleListener(l);
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Override

--- a/java/src/jmri/jmrix/can/cbus/swing/console/CbusConsoleDecodeOptionsPane.java
+++ b/java/src/jmri/jmrix/can/cbus/swing/console/CbusConsoleDecodeOptionsPane.java
@@ -16,9 +16,6 @@ import jmri.jmrix.can.cbus.CbusMessage;
 import jmri.jmrix.can.cbus.CbusNameService;
 import jmri.jmrix.can.cbus.CbusOpCodes;
 
-// import org.slf4j.Logger;
-// import org.slf4j.LoggerFactory;
-
 /**
  * Panel for CBUS Console Options.
  * <p>
@@ -67,7 +64,7 @@ public class CbusConsoleDecodeOptionsPane extends javax.swing.JPanel implements 
         p = jmri.InstanceManager.getDefault(jmri.UserPreferencesManager.class);
         makePane();
         df = new SimpleDateFormat("HH:mm:ss.SSS");
-        addTc(_mainPane.tc);
+        _mainPane.tc.addCanConsoleListener(CbusConsoleDecodeOptionsPane.this);
         
         nameService = new CbusNameService(_mainPane.getMemo());
     }
@@ -294,5 +291,5 @@ public class CbusConsoleDecodeOptionsPane extends javax.swing.JPanel implements 
         p.setSimplePreferenceState(getClass().getName() + SHOWRTR_CB, showRtrCheckBox.isSelected());
     }
     
-    // private final static Logger log = LoggerFactory.getLogger(CbusConsoleDecodeOptionsPane.class);
+    // private final static org.slf4j.Logger log = LoggerFactory.getLogger(CbusConsoleDecodeOptionsPane.class);
 }

--- a/java/src/jmri/jmrix/can/swing/monitor/MonitorPane.java
+++ b/java/src/jmri/jmrix/can/swing/monitor/MonitorPane.java
@@ -32,7 +32,7 @@ public class MonitorPane extends jmri.jmrix.AbstractMonPane implements CanListen
     public void initComponents(CanSystemConnectionMemo memo) {
         this.memo = memo;
 
-        memo.getTrafficController().addCanListener(this);
+        memo.getTrafficController().addCanConsoleListener(this);
         try {
             initComponents();
         } catch (Exception e) {

--- a/java/src/jmri/jmrix/openlcb/swing/monitor/MonitorPane.java
+++ b/java/src/jmri/jmrix/openlcb/swing/monitor/MonitorPane.java
@@ -71,7 +71,7 @@ public class MonitorPane extends jmri.jmrix.AbstractMonPane implements CanListen
     public void initComponents(CanSystemConnectionMemo memo) {
         this.memo = memo;
 
-        memo.getTrafficController().addCanListener(this);
+        memo.getTrafficController().addCanConsoleListener(this);
 
         aliasMap = memo.get(org.openlcb.can.AliasMap.class);
         messageBuilder = new MessageBuilder(aliasMap);

--- a/java/test/jmri/jmrix/can/cbus/swing/CbusEventHighlightFrameTest.java
+++ b/java/test/jmri/jmrix/can/cbus/swing/CbusEventHighlightFrameTest.java
@@ -49,9 +49,11 @@ public class CbusEventHighlightFrameTest extends jmri.util.JmriJFrameTestBase{
     
     @Test
     public void testEnableWithCanReplyAndConsole() {
-        
+
+        jmri.jmrix.can.TrafficControllerScaffold tc = new jmri.jmrix.can.TrafficControllerScaffold();
         CanSystemConnectionMemo memo = new CanSystemConnectionMemo();
-        
+        memo.setTrafficController(tc);
+
         CbusConsolePane pane = new CbusConsolePane();
         pane.initComponents(memo,false);
         CbusEventHighlightFrame cbframe = new CbusEventHighlightFrame(pane,null);
@@ -73,6 +75,7 @@ public class CbusEventHighlightFrameTest extends jmri.util.JmriJFrameTestBase{
         assertEquals("Node 0 Event 1 On Received by JMRI OR sent by JMRI\n",pane.monTextPaneCbus.getText(),"console updated");
         
         pane.dispose();
+        tc.terminateThreads();
         memo.dispose();
     
     }


### PR DESCRIPTION
This may resolve issues with Console logging sometimes appearing in the incorrect order.

If a Console is added towards the end of a list of TrafficContoller Listeners, another Listener may send a response to that message before the original message appears in the Console.

No changes to Interfaces to prevent accidental usage.