### PR TITLE
C/MRI serial output ignores new outputs if currently making a buffer

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -26,7 +26,12 @@
 
         <h4>C/MRI</h4>
             <ul>
-                <li></li>
+                <li>Provided an extra copy of the output data when preparing
+                C/MRI output data for a "T" ("Transmit") message type.  This 
+		prevents a "data buffer overrun" in a pre-configured buffer 
+		when the output data changes when the process assemble the data.
+		(The previous implementation could run out of available bytes 
+		in the buffer, and the data would not be sent.)</li>
             </ul>
 
         <h4>DCC++ and DCC-EX</h4>

--- a/java/src/jmri/jmrix/cmri/serial/SerialNode.java
+++ b/java/src/jmri/jmrix/cmri/serial/SerialNode.java
@@ -1172,8 +1172,12 @@ public class SerialNode extends AbstractNode {
         // Count the number of DLE's to be inserted
         int nOutBytes = numOutputCards() * (bitsPerCard / 8);
         int nDLE = 0;
+        byte[] oA; // current values of the output bits for this node
+        
+        oA = outputArray.clone();
+
         for (int i = 0; i < nOutBytes; i++) {
-            if ((outputArray[i] == 2) || (outputArray[i] == 3) || (outputArray[i] == 16)) {
+            if ((oA[i] == 2) || (oA[i] == 3) || (oA[i] == 16)) {
                 nDLE++;
             }
         }
@@ -1185,17 +1189,16 @@ public class SerialNode extends AbstractNode {
         int k = 2;
         for (int i = 0; i < nOutBytes; i++) {
             // perform C/MRI required DLE processing
-            if ((outputArray[i] == 2) || (outputArray[i] == 3) || (outputArray[i] == 16)) {
+            if ((oA[i] == 2) || (oA[i] == 3) || (oA[i] == 16)) {
                 m.setElement(k, 16);  // DLE
                 k++;
             }
             // add output byte
-            m.setElement(k, outputArray[i]);
+            m.setElement(k, oA[i]);
             k++;
         }
         return m;
     }
-
     boolean warned = false;
 
     void warn(String s) {


### PR DESCRIPTION
C/MRI could generate new output while an "T"ransmit buffer was being generated.  This could cause the data to change _after_ the "DLE" bytes were pre-calculated but before the data was put into the buffer.  This can be a problem if the number of actual DLE bytes is greater than the calculated number - causing a "buffer out of range" error.

This code grabs a clone of the output data for the node, and uses that clone to pre-compute the DLE bytes and data bytes.  Then it uses the clone data to build the actual "T"ransmit message and the required number of DLE bytes, thus guaranteeing that each message sends correct bytes and appropriate DLEs.

Fixes #12204 .