### PR TITLE
LocoNet Bluetooth lookup - prevent NPE

### DIFF
--- a/java/src/jmri/jmrix/loconet/bluetooth/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/loconet/bluetooth/ConnectionConfig.java
@@ -1,12 +1,6 @@
 package jmri.jmrix.loconet.bluetooth;
 
-import java.io.IOException;
 import java.util.Vector;
-import javax.bluetooth.DiscoveryAgent;
-import javax.bluetooth.LocalDevice;
-import javax.bluetooth.RemoteDevice;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Definition of objects to handle configuring a LocoNet Bluetooth layout
@@ -73,16 +67,7 @@ public class ConnectionConfig extends jmri.jmrix.AbstractSerialConnectionConfig 
 
     @Override
     protected Vector<String> getPortNames() {
-        Vector<String> portNameVector = new Vector<String>();
-        try {
-            RemoteDevice[] devices = LocalDevice.getLocalDevice().getDiscoveryAgent().retrieveDevices(DiscoveryAgent.PREKNOWN);
-            for (RemoteDevice device : devices) {
-                portNameVector.add(device.getFriendlyName(false));
-            }
-        } catch (IOException ex) {
-            log.error("Unable to use bluetooth device", ex);
-        }
-        return portNameVector;
+        return LocoNetBluetoothAdapter.discoverPortNames();
     }
 
     @Override
@@ -90,6 +75,6 @@ public class ConnectionConfig extends jmri.jmrix.AbstractSerialConnectionConfig 
         return new String[]{};
     }
 
-    private final static Logger log = LoggerFactory.getLogger(ConnectionConfig.class);
+    // private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ConnectionConfig.class);
 
 }

--- a/java/src/jmri/jmrix/loconet/bluetooth/LocoNetBluetoothAdapter.java
+++ b/java/src/jmri/jmrix/loconet/bluetooth/LocoNetBluetoothAdapter.java
@@ -235,7 +235,8 @@ public class LocoNetBluetoothAdapter extends LnPortController {
         return new int[]{};
     }
 
-    protected static @Nonnull Vector<String> discoverPortNames() {
+    @Nonnull
+    protected static Vector<String> discoverPortNames() {
         Vector<String> portNameVector = new Vector<>();
         try {
             RemoteDevice[] devices = LocalDevice.getLocalDevice().getDiscoveryAgent().retrieveDevices(DiscoveryAgent.PREKNOWN);

--- a/java/src/jmri/jmrix/loconet/bluetooth/LocoNetBluetoothAdapter.java
+++ b/java/src/jmri/jmrix/loconet/bluetooth/LocoNetBluetoothAdapter.java
@@ -6,6 +6,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Vector;
+
+import javax.annotation.Nonnull;
 import javax.bluetooth.BluetoothStateException;
 import javax.bluetooth.DeviceClass;
 import javax.bluetooth.DiscoveryAgent;
@@ -42,22 +44,9 @@ public class LocoNetBluetoothAdapter extends LnPortController {
                 new String[]{Bundle.getMessage("HandleNormal"), Bundle.getMessage("HandleSpread"), Bundle.getMessage("HandleOneOnly"), Bundle.getMessage("HandleBoth")})); // I18N
     }
 
-    Vector<String> portNameVector = null;
-
     @Override
     public Vector<String> getPortNames() {
-        portNameVector = new Vector<>();
-        try {
-            RemoteDevice[] devices = LocalDevice.getLocalDevice().getDiscoveryAgent().retrieveDevices(DiscoveryAgent.PREKNOWN);
-            if (devices != null) {
-                for (RemoteDevice device : devices) {
-                    portNameVector.add(device.getFriendlyName(false));
-                }
-            }
-        } catch (IOException ex) {
-            log.error("Unable to use bluetooth device", ex);
-        }
-        return portNameVector;
+        return LocoNetBluetoothAdapter.discoverPortNames();
     }
 
     @Override
@@ -244,6 +233,21 @@ public class LocoNetBluetoothAdapter extends LnPortController {
     @Override
     public int[] validBaudNumbers() {
         return new int[]{};
+    }
+
+    protected static @Nonnull Vector<String> discoverPortNames() {
+        Vector<String> portNameVector = new Vector<>();
+        try {
+            RemoteDevice[] devices = LocalDevice.getLocalDevice().getDiscoveryAgent().retrieveDevices(DiscoveryAgent.PREKNOWN);
+            if (devices != null) {
+                for (RemoteDevice device : devices) {
+                    portNameVector.add(device.getFriendlyName(false));
+                }
+            }
+        } catch (IOException ex) {
+            log.error("Unable to use bluetooth device", ex);
+        }
+        return portNameVector;
     }
 
     private final static Logger log = LoggerFactory.getLogger(LocoNetBluetoothAdapter.class);


### PR DESCRIPTION
Prevents local test failures as
`RemoteDevice[] devices = LocalDevice.getLocalDevice().getDiscoveryAgent().retrieveDevices(DiscoveryAgent.PREKNOWN);`
 may return an empty String array OR null.

While adding a null check, I realised that the code was now an exact copy of getPortNames at LocoNetBluetoothAdapter.java which is pretty much a static call, hence opportunity to rationalise.

eg. Failure
```
     [java]   JUnit Jupiter:ConnectionConfigTest:testLoadDetails()
     [java]     MethodSource [className = 'jmri.jmrix.loconet.bluetooth.ConnectionConfigTest', methodName = 'testLoadDetails', methodParameterTypes = '']
     [java]     => java.lang.NullPointerException
     [java]        jmri.jmrix.loconet.bluetooth.ConnectionConfig.getPortNames(ConnectionConfig.java:79)
     [java]        jmri.jmrix.AbstractSerialConnectionConfig.loadDetails(AbstractSerialConnectionConfig.java:285)
     [java]        jmri.jmrix.AbstractSerialConnectionConfigTestBase.lambda$testLoadDetails$0(AbstractSerialConnectionConfigTestBase.java:20)
```

