### PR TITLE
addConditional always succeeds

### DIFF
--- a/java/src/jmri/Logix.java
+++ b/java/src/jmri/Logix.java
@@ -93,10 +93,8 @@ public interface Logix extends NamedBean {
      * @param order      the order this conditional should calculate in if
      *                   order is negative, the conditional is added at the end
      *                   of current group of conditionals
-     * @return true if the Conditional was added, false otherwise (most likely
-     *         false indicates that maximum number of Conditionals was exceeded)
      */
-    public boolean addConditional(String systemName, int order);
+    public void addConditional(String systemName, int order);
 
     /**
      * Add a child Conditional to the parent Logix.

--- a/java/src/jmri/implementation/DefaultLogix.java
+++ b/java/src/jmri/implementation/DefaultLogix.java
@@ -109,9 +109,7 @@ public class DefaultLogix extends AbstractNamedBean
     }
 
     /**
-     * Add a Conditional to this Logix Returns true if Conditional was
-     * successfully added, returns false if the maximum number of conditionals
-     * has been exceeded.
+     * Add a Conditional to this Logix R
      *
      * @param systemName The Conditional system name
      * @param order       the order this conditional should calculate in if
@@ -119,9 +117,8 @@ public class DefaultLogix extends AbstractNamedBean
      *                   of current group of conditionals
      */
     @Override
-    public boolean addConditional(String systemName, int order) {
+    public void addConditional(String systemName, int order) {
         _conditionalSystemNames.add(systemName);
-        return (true);
     }
 
     /**

--- a/jython/DispatcherSystem/CreateIcons.py
+++ b/jython/DispatcherSystem/CreateIcons.py
@@ -590,16 +590,16 @@ class processPanels(jmri.jmrit.automat.AbstractAutomaton):
         cdlManager = jmri.InstanceManager.getDefault(jmri.ConditionalManager)
         lgx = lgxManager.createNewLogix('IX:DSLX:1', 'Run Dispatcher')
         cdl = cdlManager.createNewConditional('IX:DSLX:1C1', 'Run Dispatcher')
-        if lgx.addConditional('IX:DSLX:1C1', 0):
-            if cdl is not None:
-                cdl.setUserName('Run Dispatcher')
-                vars = []
-                vars.append(jmri.ConditionalVariable(False, jmri.Conditional.Operator.AND, jmri.Conditional.Type.SENSOR_ACTIVE, 'startDispatcherSensor', True))
-                cdl.setStateVariables(vars)
-                actions = []
-                actions.append(jmri.implementation.DefaultConditionalAction(1, jmri.Conditional.Action.RUN_SCRIPT, '', -1, 'program:jython/DispatcherSystem/RunDispatchMaster.py'))
-                cdl.setAction(actions)
-                lgx.activateLogix()
+        lgx.addConditional('IX:DSLX:1C1', 0):
+        if cdl is not None:
+            cdl.setUserName('Run Dispatcher')
+            vars = []
+            vars.append(jmri.ConditionalVariable(False, jmri.Conditional.Operator.AND, jmri.Conditional.Type.SENSOR_ACTIVE, 'startDispatcherSensor', True))
+            cdl.setStateVariables(vars)
+            actions = []
+            actions.append(jmri.implementation.DefaultConditionalAction(1, jmri.Conditional.Action.RUN_SCRIPT, '', -1, 'program:jython/DispatcherSystem/RunDispatchMaster.py'))
+            cdl.setAction(actions)
+            lgx.activateLogix()
 
     # **************************************************
     # add Icons


### PR DESCRIPTION
`Logix.addConditional` has historically returned false if no more Conditionals could be added due to array length limitations.  But the Logix implementation has been changed to Lists, so there are no fixed limits.  This PR changes the return type of `addConditional` to void and adjusts the Javadoc.