### PR TITLE
Tests - restrict log4j usage

### DIFF
--- a/java/test/jmri/ArchitectureCheck.java
+++ b/java/test/jmri/ArchitectureCheck.java
@@ -120,10 +120,4 @@ public class ArchitectureCheck extends ArchitectureTest {
             .should().dependOnClassesThat().resideInAPackage("jmri.jmrit..")
         );
 
-    /**
-     * jmri (but not apps) should not reference org.apache.log4j to allow jmri
-     * to be used as library in applications that choose not to use Log4J.
-     */
-    @ArchTest
-    public static final ArchRule checkLog4J = FreezingArchRule.freeze(ArchitectureTest.noLog4JinJmri);
 }

--- a/java/test/jmri/ArchitectureTest.java
+++ b/java/test/jmri/ArchitectureTest.java
@@ -273,7 +273,6 @@ public class ArchitectureTest {
     @ArchTest
     public static final ArchRule noLog4JinJmri = noClasses()
             .that().resideInAPackage("jmri..")
-            .and().areNotAnnotatedWith(Deprecated.class)
             .should().dependOnClassesThat().resideInAPackage("org.apache.log4j");
 
     /**

--- a/java/test/jmri/TestArchitectureTest.java
+++ b/java/test/jmri/TestArchitectureTest.java
@@ -76,4 +76,15 @@ public class TestArchitectureTest {
         .doNotHaveFullyQualifiedName("jmri.jmrit.display.logixng.ActionPositionableTest").and()
         .resideOutsideOfPackage("jmri.jmrit.logixng..")
         .should().dependOnClassesThat().haveFullyQualifiedName("org.junit.After");
+
+    /**
+     * jmri should not reference org.apache.log4j to allow jmri
+     * to be used as library in applications that choose not to use Log4J.
+     */
+    @ArchTest
+    public static final ArchRule noLog4JinJmriTestsRule = noClasses()
+        .that().doNotHaveFullyQualifiedName("jmri.util.JUnitAppender")
+        .and().doNotHaveFullyQualifiedName("jmri.util.TestingLoggerConfiguration")
+        .should().dependOnClassesThat().resideInAPackage("org.apache.log4j");
+
 }

--- a/java/test/jmri/jmrit/display/BlockContentsIconTest.java
+++ b/java/test/jmri/jmrit/display/BlockContentsIconTest.java
@@ -9,11 +9,11 @@ import jmri.util.JUnitUtil;
 import jmri.util.JmriJFrame;
 import jmri.util.junit.annotations.ToDo;
 
-import org.apache.log4j.Level;
 import org.junit.jupiter.api.*;
 import org.junit.Assert;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.netbeans.jemmy.QueueTool;
+import org.slf4j.event.Level;
 
 /**
  * Test simple functioning of BlockContentsIcon

--- a/java/test/jmri/jmrit/display/GlobalVariableIconTest.java
+++ b/java/test/jmri/jmrit/display/GlobalVariableIconTest.java
@@ -15,13 +15,14 @@ import jmri.jmrit.logixng.GlobalVariableManager;
 import jmri.util.JUnitAppender;
 import jmri.util.JUnitUtil;
 import jmri.util.JmriJFrame;
-import org.apache.log4j.Level;
+
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.jupiter.api.*;
 import org.netbeans.jemmy.ComponentChooser;
 import org.netbeans.jemmy.QueueTool;
 import org.netbeans.jemmy.operators.JLabelOperator;
+import org.slf4j.event.Level;
 
 /**
  * Test simple functioning of GlobalVariableIcon.

--- a/java/test/jmri/jmrit/display/MemoryIconTest.java
+++ b/java/test/jmri/jmrit/display/MemoryIconTest.java
@@ -14,13 +14,14 @@ import jmri.jmrit.catalog.NamedIcon;
 import jmri.util.JUnitAppender;
 import jmri.util.JUnitUtil;
 import jmri.util.JmriJFrame;
-import org.apache.log4j.Level;
+
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.jupiter.api.*;
 import org.netbeans.jemmy.ComponentChooser;
 import org.netbeans.jemmy.QueueTool;
 import org.netbeans.jemmy.operators.JLabelOperator;
+import org.slf4j.event.Level;
 
 /**
  * Test simple functioning of MemoryIcon.

--- a/java/test/jmri/jmrit/display/layoutEditor/BlockContentsIconTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/BlockContentsIconTest.java
@@ -7,11 +7,11 @@ import jmri.util.JUnitAppender;
 import jmri.util.JUnitUtil;
 import jmri.util.JmriJFrame;
 
-import org.apache.log4j.Level;
 import org.junit.jupiter.api.*;
 import org.junit.Assert;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.netbeans.jemmy.QueueTool;
+import org.slf4j.event.Level;
 
 /**
  * Test simple functioning of BlockContentsIcon

--- a/java/test/jmri/jmrit/jython/JythonWindowsTest.java
+++ b/java/test/jmri/jmrit/jython/JythonWindowsTest.java
@@ -53,7 +53,7 @@ public class JythonWindowsTest {
         JUnitUtil.dispose(f);
 
         // error messages are a fail
-        if (jmri.util.JUnitAppender.clearBacklog(org.apache.log4j.Level.WARN) != 0) {
+        if (jmri.util.JUnitAppender.clearBacklog(org.slf4j.event.Level.WARN) != 0) {
            Assert.fail("Emitted error messages caused test to fail");
         }
     }
@@ -71,7 +71,7 @@ public class JythonWindowsTest {
     public void setUp() throws Exception {
         JUnitUtil.setUp();
         JUnitUtil.resetProfileManager();
-        jmri.util.JUnitUtil.initDefaultUserMessagePreferences();
+        JUnitUtil.initDefaultUserMessagePreferences();
     }
 
     @AfterEach

--- a/java/test/jmri/jmrit/logixng/tools/ImportActionTestBase.java
+++ b/java/test/jmri/jmrit/logixng/tools/ImportActionTestBase.java
@@ -1,7 +1,6 @@
 package jmri.jmrit.logixng.tools;
 
 import java.util.ArrayList;
-import java.util.List;
 
 import jmri.*;
 import jmri.jmrit.logixng.ConditionalNG_Manager;
@@ -9,12 +8,9 @@ import jmri.jmrit.logixng.LogixNG_Manager;
 import jmri.util.JUnitAppender;
 import jmri.util.JUnitUtil;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.spi.LoggingEvent;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -288,14 +284,7 @@ public abstract class ImportActionTestBase {
     public void tearDown() {
         // JUnitAppender.clearBacklog();    REMOVE THIS!!!
 
-        List<LoggingEvent> list = new ArrayList<>(JUnitAppender.getBacklog());
-        for (LoggingEvent event : list) {
-            if ((event.getLevel() == Level.WARN)
-                    && event.getMessage().toString().equals(
-                            "Import Conditional 'IX1C1' to LogixNG 'IQ:AUTO:0001'")) {
-                JUnitAppender.suppressErrorMessage(event.getMessage().toString());
-            }
-        }
+        JUnitAppender.suppressWarnMessage("Import Conditional 'IX1C1' to LogixNG 'IQ:AUTO:0001'");
 
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.deregisterBlockManagerShutdownTask();

--- a/java/test/jmri/jmrit/logixng/tools/ImportEntryExitTest.java
+++ b/java/test/jmri/jmrit/logixng/tools/ImportEntryExitTest.java
@@ -3,8 +3,6 @@ package jmri.jmrit.logixng.tools;
 import java.awt.GraphicsEnvironment;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.List;
 
 import jmri.*;
 import jmri.jmrit.entryexit.DestinationPoints;
@@ -15,8 +13,6 @@ import jmri.util.JUnitAppender;
 import jmri.util.JUnitUtil;
 import jmri.util.junit.rules.*;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.spi.LoggingEvent;
 import org.junit.*;
 
 /**
@@ -215,15 +211,9 @@ public class ImportEntryExitTest {
 
     @After
     public void tearDown() {
-        List<LoggingEvent> list = new ArrayList<>(JUnitAppender.getBacklog());
-        for (LoggingEvent event : list) {
-            if ((event.getLevel() == Level.WARN)
-                    && (event.getMessage().toString().startsWith("Import Conditional 'IX1C1' to LogixNG 'IQ:AUTO:000'")
-                        || event.getMessage().toString().equals("Import Conditional 'IX:RTXINITIALIZER1T' to LogixNG 'IQ:AUTO:0005'"))
-                    ) {
-                JUnitAppender.suppressErrorMessage(event.getMessage().toString());
-            }
-        }
+
+        JUnitAppender.suppressWarnMessageStartsWith("Import Conditional 'IX1C1' to LogixNG 'IQ:AUTO:000'");
+        JUnitAppender.suppressWarnMessage("Import Conditional 'IX:RTXINITIALIZER1T' to LogixNG 'IQ:AUTO:0005'");
 
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.clearTurnoutThreads();

--- a/java/test/jmri/jmrit/logixng/tools/ImportExpressionComplexTestBase.java
+++ b/java/test/jmri/jmrit/logixng/tools/ImportExpressionComplexTestBase.java
@@ -268,14 +268,7 @@ public abstract class ImportExpressionComplexTestBase {
     public void teardownTest() {
         // JUnitAppender.clearBacklog();    REMOVE THIS!!!
 
-        List<LoggingEvent> list = new ArrayList<>(JUnitAppender.getBacklog());
-        for (LoggingEvent event : list) {
-            if ((event.getLevel() == Level.WARN)
-                    && event.getMessage().toString().equals(
-                            "Import Conditional 'IX1C1' to LogixNG 'IQ:AUTO:0001'")) {
-                JUnitAppender.suppressErrorMessage(event.getMessage().toString());
-            }
-        }
+        JUnitAppender.suppressWarnMessage("Import Conditional 'IX1C1' to LogixNG 'IQ:AUTO:0001'");
 
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.deregisterBlockManagerShutdownTask();

--- a/java/test/jmri/jmrit/logixng/tools/ImportExpressionTestBase.java
+++ b/java/test/jmri/jmrit/logixng/tools/ImportExpressionTestBase.java
@@ -1,7 +1,6 @@
 package jmri.jmrit.logixng.tools;
 
 import java.util.ArrayList;
-import java.util.List;
 
 import jmri.*;
 import jmri.implementation.DefaultConditionalAction;
@@ -10,12 +9,9 @@ import jmri.jmrit.logixng.LogixNG_Manager;
 import jmri.util.JUnitAppender;
 import jmri.util.JUnitUtil;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.spi.LoggingEvent;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -230,14 +226,7 @@ public abstract class ImportExpressionTestBase {
     public void tearDown() {
         // JUnitAppender.clearBacklog();    REMOVE THIS!!!
 
-        List<LoggingEvent> list = new ArrayList<>(JUnitAppender.getBacklog());
-        for (LoggingEvent event : list) {
-            if ((event.getLevel() == Level.WARN)
-                    && event.getMessage().toString().equals(
-                            "Import Conditional 'IX1C1' to LogixNG 'IQ:AUTO:0001'")) {
-                JUnitAppender.suppressErrorMessage(event.getMessage().toString());
-            }
-        }
+        JUnitAppender.suppressWarnMessage("Import Conditional 'IX1C1' to LogixNG 'IQ:AUTO:0001'");
 
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.deregisterBlockManagerShutdownTask();

--- a/java/test/jmri/jmrix/ipocs/IpocsLightTest.java
+++ b/java/test/jmri/jmrix/ipocs/IpocsLightTest.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
 
-import org.apache.log4j.Level;
 import org.junit.jupiter.api.*;
 
 import jmri.Light;
@@ -29,7 +28,6 @@ public class IpocsLightTest extends jmri.implementation.AbstractLightTestBase {
     light.doNewState(-1, Light.OFF);
     //assertEquals(Light.OFF, light.getState());
     light.doNewState(-1, Light.UNKNOWN);
-    jmri.util.JUnitAppender.suppressMessage(Level.DEBUG, "Unknown light order state");
     //assertEquals(Light.OFF, light.getState());
   }
 

--- a/java/test/jmri/jmrix/roco/z21/simulator/Z21SimulatorAdapterTest.java
+++ b/java/test/jmri/jmrix/roco/z21/simulator/Z21SimulatorAdapterTest.java
@@ -169,8 +169,8 @@ public class Z21SimulatorAdapterTest {
         }
         a.terminateThread();
         // suppress two timeout messages that occur
-        JUnitAppender.suppressMessageStartsWith(org.apache.log4j.Level.WARN, "Timeout on reply to message:");
-        JUnitAppender.suppressMessageStartsWith(org.apache.log4j.Level.WARN, "Timeout on reply to message:");
+        JUnitAppender.suppressWarnMessageStartsWith("Timeout on reply to message:");
+        JUnitAppender.suppressWarnMessageStartsWith("Timeout on reply to message:");
         a.dispose();
         JUnitUtil.tearDown();
     }

--- a/java/test/jmri/managers/AbstractProvidingManagerTestBase.java
+++ b/java/test/jmri/managers/AbstractProvidingManagerTestBase.java
@@ -5,7 +5,7 @@ import jmri.*;
 import java.beans.PropertyVetoException;
 import java.lang.reflect.Field;
 import jmri.util.JUnitAppender;
-import org.apache.log4j.Level;
+import org.slf4j.event.Level;
 
 import org.junit.Assert;
 import org.junit.Assume;

--- a/java/test/jmri/util/JUnitAppender.java
+++ b/java/test/jmri/util/JUnitAppender.java
@@ -114,7 +114,11 @@ public class JUnitAppender extends org.apache.log4j.ConsoleAppender {
         unexpectedInfoContent = content;
     }
 
-    public static boolean unexpectedMessageSeen(Level l) {
+    public static boolean unexpectedMessageSeen(org.slf4j.event.Level l) {
+        return unexpectedMessageSeen(convertSlf4jLevelToLog4jLevel(l));
+    }
+
+    private static boolean unexpectedMessageSeen(Level l) {
         if (l == Level.FATAL) {
             return unexpectedFatalSeen;
         }
@@ -130,7 +134,11 @@ public class JUnitAppender extends org.apache.log4j.ConsoleAppender {
         throw new java.lang.IllegalArgumentException("Did not expect " + l);
     }
 
-    public static String unexpectedMessageContent(Level l) {
+    public static String unexpectedMessageContent(org.slf4j.event.Level l) {
+        return unexpectedMessageContent(convertSlf4jLevelToLog4jLevel(l));
+    }
+
+    private static String unexpectedMessageContent(Level l) {
         if (l == Level.FATAL) {
             return unexpectedFatalContent;
         }
@@ -152,10 +160,14 @@ public class JUnitAppender extends org.apache.log4j.ConsoleAppender {
         throw new java.lang.IllegalArgumentException("Did not expect " + l);
     }
 
+    public static void resetUnexpectedMessageFlags(org.slf4j.event.Level severity) {
+        resetUnexpectedMessageFlags(convertSlf4jLevelToLog4jLevel(severity));
+    }
+
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings( value = "SF_SWITCH_FALLTHROUGH",
         justification = "cases statements are organized to flow")
     @SuppressWarnings("fallthrough")
-    public static void resetUnexpectedMessageFlags(Level severity) {
+    private static void resetUnexpectedMessageFlags(Level severity) {
         switch (severity.toInt()) {
             case Level.INFO_INT:
                 setUnexpectedInfoSeen(false);
@@ -237,12 +249,16 @@ public class JUnitAppender extends org.apache.log4j.ConsoleAppender {
      * used to skip over messages that don't matter, e.g. during setting up a
      * test. Removed messages are not sent for further logging.
      *
-     * @param level lowest level counted in return value, e.g. WARN means WARN
+     * @param l lowest level counted in return value, e.g. WARN means WARN
      *                  and higher will be counted
      * @return count of skipped messages
      * @see #clearBacklog()
      */
-    public static int clearBacklog(Level level) {
+    public static int clearBacklog(org.slf4j.event.Level l) {
+        return clearBacklog(convertSlf4jLevelToLog4jLevel(l));
+    }
+
+    private static int clearBacklog(Level level) {
         if (list.isEmpty()) {
             return 0;
         }
@@ -424,7 +440,7 @@ public class JUnitAppender extends org.apache.log4j.ConsoleAppender {
      * @param level the level at which to suppress the message
      * @param msg   the message to suppress
      */
-    public static void suppressMessage(Level level, String msg) {
+    private static void suppressMessage(Level level, String msg) {
         if (list.isEmpty()) {
             return;
         }
@@ -473,7 +489,7 @@ public class JUnitAppender extends org.apache.log4j.ConsoleAppender {
      * @param level the level at which to suppress the message
      * @param msg   text at start of the message to suppress
      */
-    public static void suppressMessageStartsWith(Level level, String msg) {
+    private static void suppressMessageStartsWith(Level level, String msg) {
         if (list.isEmpty()) {
             return;
         }
@@ -629,7 +645,11 @@ public class JUnitAppender extends org.apache.log4j.ConsoleAppender {
      * @param msg the message to assert exists
      * @param level the Logging Level which should match
      */
-    public static void assertMessage(String msg, Level level) {
+    public static void assertMessage(String msg, org.slf4j.event.Level level) {
+        assertMessage(msg, convertSlf4jLevelToLog4jLevel(level));
+    }
+
+    private static void assertMessage(String msg, Level level) {
         LoggingEvent evt = checkForMessage(msg);
         if (evt == null) {
             Assertions.fail("Looking for message \"" + msg + "\" and didn't find it");
@@ -727,6 +747,22 @@ public class JUnitAppender extends org.apache.log4j.ConsoleAppender {
         }
         String s1 = e1.getMessage().toString();
         return StringUtils.deleteWhitespace(s1).startsWith(StringUtils.deleteWhitespace(s2));
+    }
+
+    private static Level convertSlf4jLevelToLog4jLevel(org.slf4j.event.Level slf4jLevel) {
+        switch (slf4jLevel) {
+            case TRACE:
+                return Level.TRACE;
+            case DEBUG:
+                return Level.DEBUG;
+            case INFO:
+                return Level.INFO;
+            case WARN:
+                return Level.WARN;
+            case ERROR:
+            default:
+                return Level.ERROR;
+        }
     }
 
     public static JUnitAppender instance() {

--- a/java/test/jmri/util/JUnitAppenderTest.java
+++ b/java/test/jmri/util/JUnitAppenderTest.java
@@ -1,11 +1,12 @@
 package jmri.util;
 
-import org.apache.log4j.Level;
 import org.junit.jupiter.api.*;
 import org.junit.Assert;
 import org.junit.Assume;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
 
 /**
  * Tests for the jmri.util.JUnitAppender class.
@@ -126,7 +127,6 @@ public class JUnitAppenderTest {
         JUnitAppender.setUnexpectedWarnSeen(false);
         JUnitAppender.setUnexpectedInfoSeen(false);
 
-        Assert.assertFalse("initial FATAL", JUnitAppender.unexpectedMessageSeen(Level.FATAL));
         Assert.assertFalse("initial ERROR", JUnitAppender.unexpectedMessageSeen(Level.ERROR));
         Assert.assertFalse("initial WARN",  JUnitAppender.unexpectedMessageSeen(Level.WARN));
         Assert.assertFalse("initial INFO",  JUnitAppender.unexpectedMessageSeen(Level.INFO));
@@ -245,15 +245,15 @@ public class JUnitAppenderTest {
     public void testClearBacklogAtInfoWithInfo() {
         Assume.assumeTrue(log.isInfoEnabled());
         log.info("info message");
-        Assert.assertEquals(1,JUnitAppender.clearBacklog(org.apache.log4j.Level.INFO));
-        Assert.assertEquals(0,JUnitAppender.clearBacklog(org.apache.log4j.Level.INFO));
+        Assert.assertEquals(1,JUnitAppender.clearBacklog(Level.INFO));
+        Assert.assertEquals(0,JUnitAppender.clearBacklog(Level.INFO));
     }
 
     @Test
     public void testClearBacklogAtInfoWithWarn() {
         log.warn("warn message");
-        Assert.assertEquals(1,JUnitAppender.clearBacklog(org.apache.log4j.Level.INFO));
-        Assert.assertEquals(0,JUnitAppender.clearBacklog(org.apache.log4j.Level.INFO));
+        Assert.assertEquals(1,JUnitAppender.clearBacklog(Level.INFO));
+        Assert.assertEquals(0,JUnitAppender.clearBacklog(Level.INFO));
     }
 
     public void suppressErrorMessage() {
@@ -288,11 +288,10 @@ public class JUnitAppenderTest {
     @AfterEach
     public void tearDown() {
 
-        jmri.util.JUnitUtil.tearDown();     
+        JUnitUtil.tearDown();     
 
         // continue the testUnexpectedCheck test
         if (testingUnexpected) {
-            Assert.assertFalse("post FATAL", JUnitAppender.unexpectedMessageSeen(Level.FATAL));
             Assert.assertFalse("post ERROR", JUnitAppender.unexpectedMessageSeen(Level.ERROR));
             Assert.assertFalse("post WARN",  JUnitAppender.unexpectedMessageSeen(Level.WARN));
 

--- a/java/test/jmri/util/JUnitUtil.java
+++ b/java/test/jmri/util/JUnitUtil.java
@@ -46,7 +46,7 @@ import jmri.util.prefs.*;
 import jmri.util.zeroconf.MockZeroConfServiceManager;
 import jmri.util.zeroconf.ZeroConfServiceManager;
 
-import org.apache.log4j.Level;
+import org.slf4j.event.Level;
 import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
 import org.netbeans.jemmy.*;

--- a/java/test/jmri/util/Log4JErrorIsErrorTest.java
+++ b/java/test/jmri/util/Log4JErrorIsErrorTest.java
@@ -14,7 +14,8 @@ public class Log4JErrorIsErrorTest {
 
     @Test
     public void testNoLog4JMessages() {
-        Assert.assertFalse("Unexpected ERROR or FATAL messages emitted", jmri.util.JUnitAppender.unexpectedMessageSeen(org.apache.log4j.Level.ERROR));
+        Assert.assertFalse("Unexpected ERROR or FATAL messages emitted", 
+            jmri.util.JUnitAppender.unexpectedMessageSeen(org.slf4j.event.Level.ERROR));
     }
 
     @BeforeEach

--- a/java/test/jmri/util/LoggingUtilTest.java
+++ b/java/test/jmri/util/LoggingUtilTest.java
@@ -1,12 +1,11 @@
 package jmri.util;
 
-import org.apache.log4j.Level;
-
 import org.junit.Assert;
 import org.junit.jupiter.api.*;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
 
 /**
  * Tests for the jmri.util.LoggingUtil and jmir.util.JUnitLoggingUtil classes.


### PR DESCRIPTION
ArchitectureTest - remove Freeze rule for noLog4JinJmri
TestArchitectureTest - add Rule to restrict Log4j in tests

JUnitAppender - 
Update public methods to accept org.slf4j.event.Level
Restrict public access to org.apache.log4j.Level

Moves tests to slf4j / JUnitAppender methods.