### PR TITLE
Fix TurnoutStatePersistence.py , add test to SampleScriptTest

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -483,7 +483,7 @@
     <h3>Scripting</h3>
         <a id="Scripting" name="Scripting"></a>
         <ul>
-            <li></li>
+            <li>TurnoutStatePersistence.py was not correctly updated to use SLF4J in 5.5.3, fixed in 5.5.4</li>
         </ul>
 
     <h3>Signals</h3>

--- a/java/test/jmri/jmrit/jython/SampleScriptTest.java
+++ b/java/test/jmri/jmrit/jython/SampleScriptTest.java
@@ -6,15 +6,20 @@ import java.util.stream.Stream;
 
 import javax.annotation.Nonnull;
 
+import jmri.InstanceManager;
+import jmri.ShutDownManager;
+import jmri.Turnout;
+import jmri.TurnoutManager;
 import jmri.util.JUnitUtil;
 import jmri.script.JmriScriptEngineManager;
 import jmri.util.JUnitAppender;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Invokes Python-language scripts in jython/tests
@@ -76,6 +81,75 @@ public class SampleScriptTest {
 
     }
 
+    // test for jython/TurnoutStatePersistence.py
+    @Test
+    public void testTurnoutStatePersistencePy() {
+
+        TurnoutManager turnouts = InstanceManager.getDefault(TurnoutManager.class);
+        Assertions.assertEquals(0, turnouts.getNamedBeanSet().size());
+
+        File turnoutFile = new File(jmri.util.FileUtil.getUserFilesPath() + "TurnoutState.csv");
+        Assertions.assertFalse(turnoutFile.exists());
+
+        Turnout myt1 = turnouts.provideTurnout("IT701");
+        myt1.setCommandedState(Turnout.THROWN);
+        Turnout myt2 = turnouts.provideTurnout("IT702");
+        myt2.setCommandedState(Turnout.CLOSED);
+        Turnout myt3 = turnouts.provideTurnout("IT703");
+        myt3.setCommandedState(Turnout.INCONSISTENT);
+        Turnout myt4 = turnouts.provideTurnout("IT704");
+        myt4.setCommandedState(Turnout.UNKNOWN);
+        Assertions.assertEquals(4, turnouts.getNamedBeanSet().size());
+
+        int initialSize = InstanceManager.getDefault(ShutDownManager.class).getRunnables().size();
+
+        // register Shutdown Task
+        File file = new File("jython/TurnoutStatePersistence.py");
+        try {
+            jmri.script.JmriScriptEngineManager.getDefault().eval(file);
+        } catch (javax.script.ScriptException ex1) {
+            Assertions.fail("ScriptException during register Shutdown Task of " + file, ex1);
+        } catch (java.io.IOException ex2) {
+            Assertions.fail("IOException during register Shutdown Task of " + file, ex2);
+        }
+        JUnitAppender.suppressWarnMessageStartsWith("Turnout state file "); // does not exist . . . .
+
+        int size = InstanceManager.getDefault(ShutDownManager.class).getRunnables().size();
+        Assertions.assertNotEquals(initialSize, size, "ShutDown task not registered");
+
+        // run shutdown task with blocking
+        ((jmri.managers.DefaultShutDownManager)InstanceManager.getDefault(ShutDownManager.class)).setBlockingShutdown(true);
+        InstanceManager.getDefault(ShutDownManager.class).shutdown();
+
+        File newTurnoutFile = new File(jmri.util.FileUtil.getUserFilesPath() + "TurnoutState.csv");
+        Assertions.assertTrue(newTurnoutFile.exists(),"user TurnoutState.csv exists");
+
+        // set the Turnouts to a different state
+        myt1.setCommandedState(Turnout.CLOSED);
+        myt2.setCommandedState(Turnout.THROWN);
+        myt3.setCommandedState(Turnout.UNKNOWN);
+        myt4.setCommandedState(Turnout.INCONSISTENT);
+
+        // re-run the script to reload the Turnout States
+        try {
+            jmri.script.JmriScriptEngineManager.getDefault().eval(file);
+        } catch (javax.script.ScriptException ex1) {
+            Assertions.fail("ScriptException during Restore of " + file, ex1);
+        } catch (java.io.IOException ex2) {
+            Assertions.fail("IOException during Restore of " + file, ex2);
+        }
+
+        // # clear Shutdown tasks as no longer required
+        jmri.util.JUnitUtil.clearShutDownManager();
+
+        // check Turnout State
+        JUnitUtil.waitFor(() ->  ( myt1.getCommandedState() == Turnout.THROWN),"Turnout did not return to Thrown" );
+        JUnitUtil.waitFor(() ->  ( myt2.getCommandedState() == Turnout.CLOSED),"Turnout did not return to Closed" );
+        JUnitUtil.waitFor(() ->  ( myt3.getCommandedState() == Turnout.INCONSISTENT),"Turnout did not return to Inconsistent" );
+        JUnitUtil.waitFor(() ->  ( myt4.getCommandedState() == Turnout.UNKNOWN),"Turnout did not return to Unknown" );
+
+    }
+
     @BeforeAll
     static public void startTests() {
         // this is to System.out because that's where the test output goes
@@ -83,7 +157,7 @@ public class SampleScriptTest {
     }
 
     @BeforeEach
-    public void setUp() throws Exception {
+    public void setUp(@TempDir java.nio.file.Path tempDir) throws java.io.IOException  {
         JUnitUtil.setUp();
 
         // it's not really understood why, but doing these inside of the
@@ -91,7 +165,8 @@ public class SampleScriptTest {
         // is working with a different InstanceManager. So we
         // include a comprehensive set here.
         JUnitUtil.resetInstanceManager();
-        JUnitUtil.resetProfileManager();
+        JUnitUtil.resetProfileManager( new jmri.profile.NullProfile( tempDir.toFile()));
+        
         JUnitUtil.initConfigureManager();
         JUnitUtil.initDefaultUserMessagePreferences();
         JUnitUtil.initDebugPowerManager();

--- a/jython/TurnoutStatePersistence.py
+++ b/jython/TurnoutStatePersistence.py
@@ -124,7 +124,7 @@ class PersistTurnoutStateTask(jmri.implementation.AbstractShutDownTask):
 class LoadTurnoutState(jmri.jmrit.automat.AbstractAutomaton):
 
     # Get reference to the logger
-    log = Logger.getLogger("jmri.jmrit.jython.exec.TurnoutStatePersistence.LoadTurnoutState")
+    log = LoggerFactory.getLogger("jmri.jmrit.jython.exec.TurnoutStatePersistence.LoadTurnoutState")
 
     # Perform any initialisation
     def init(self):


### PR DESCRIPTION
Fully update TurnoutStatePersistence.py to SLF4J method, missed in #12237 

SampleScriptTest -
add test for TurnoutStatePersistence.py
run tests with a temp user profile