### PR TITLE
Updates LNCV-programmer pane documentation.

### DIFF
--- a/help/en/package/jmri/jmrix/loconet/swing/lncvprog/LncvProgPane.shtml
+++ b/help/en/package/jmri/jmrix/loconet/swing/lncvprog/LncvProgPane.shtml
@@ -42,7 +42,8 @@
 
       <p>Uhlenbrock and Digikeijs/Digirails publish the Article number for each (new) device. For
       example, the Digikeijs DigiBoost DR5033 has Article number 5033, which was registered with
-      Uhlenbrock.<br>
+      Uhlenbrock. The Uhlenbrock 63330 has Article number 6333, the Uhlenbrock 63410 has 6341
+      (skip last zero).<br>
       Enter the Article number eg. 5033 in the "Article" field before proceeding.<br>
       Next, enter the Module Address in the corresponding field.</p>
 


### PR DESCRIPTION
Adds examples of how Uhlenbrock's 5-digit product code is used as 4-digit Article number. Without the Article number it is not possible to program Uhlenbrock devices. The manual shipped with these devices lists a 5-digit product code, which is also printed on the device. Uhlenbrock's Intellibox user interface expects this five-digit code as article number, but JMRI only accepts article numbers up to 9999.