### PR TITLE
Transit xml no sections

### DIFF
--- a/java/src/jmri/managers/configurexml/DefaultTransitManagerXml.java
+++ b/java/src/jmri/managers/configurexml/DefaultTransitManagerXml.java
@@ -60,7 +60,7 @@ public class DefaultTransitManagerXml extends jmri.managers.configurexml.Abstrac
 
                 ArrayList<TransitSection> tsList = transit.getTransitSectionList();
                 if ( tsList.isEmpty() ){
-                    log.error("Not Storing Transit \"{}\" as it has no TransitSections", transit.getDisplayName());
+                    log.warn("Not Storing Transit \"{}\" as it has no TransitSections", transit.getDisplayName());
                     continue;
                 }
 

--- a/java/src/jmri/managers/configurexml/DefaultTransitManagerXml.java
+++ b/java/src/jmri/managers/configurexml/DefaultTransitManagerXml.java
@@ -13,8 +13,6 @@ import jmri.TransitSectionAction;
 
 import org.jdom2.DataConversionException;
 import org.jdom2.Element;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Provides the functionality for configuring a TransitManager.
@@ -60,11 +58,16 @@ public class DefaultTransitManagerXml extends jmri.managers.configurexml.Abstrac
                     elem.setAttribute("userName", uName);
                 }
 
+                ArrayList<TransitSection> tsList = transit.getTransitSectionList();
+                if ( tsList.isEmpty() ){
+                    log.error("Not Storing Transit \"{}\" as it has no TransitSections", transit.getDisplayName());
+                    continue;
+                }
+
                 // store common part
                 storeCommon(transit, elem);
 
                 // save child transitsection entries
-                ArrayList<TransitSection> tsList = transit.getTransitSectionList();
                 Element tsElem;
                 for (TransitSection ts : tsList) {
                     if ((ts != null) && !ts.isTemporary()) {
@@ -232,6 +235,6 @@ public class DefaultTransitManagerXml extends jmri.managers.configurexml.Abstrac
         return InstanceManager.getDefault(TransitManager.class).getXMLOrder();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(DefaultTransitManagerXml.class);
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(DefaultTransitManagerXml.class);
 
 }


### PR DESCRIPTION
Do not store Transit if it has no TransitSections.
Prevents load Exception eg.
```
     [java] 23:47:08,528 jmri.configurexml.ErrorHandler        ERROR - Load Error: Parse error while parsing file /C:/Users/Steve/Desktop/tst.xml Exception: org.jdom2.input.JDOMParseException: Error on line 712: cvc-complex-type.2.4.b: The content of element 'transit' is not complete. One of '{comment, transitsection}' is expected.
     [java] See http://jmri.org/help/en/package/jmri/configurexml/ErrorHandler.shtml for possibly more information. [AWT-EventQueue-0]
     [java] org.jdom2.input.JDOMParseException: Error on line 712: cvc-complex-type.2.4.b: The content of element 'transit' is not complete. One of '{comment, transitsection}' is expected.
```