### PR TITLE
Memories  - set username if null

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -559,7 +559,7 @@
     <h3>Turnouts, Lights, Sensors and other elements</h3>
         <a id="TLae" name="TLae"></a>
         <ul>
-            <li></li>
+            <li>Memory Usernames for IMCURRENTTIME and IMRATEFACTOR can now be loaded from xml file.</li>
         </ul>
 
    <h3>Warrants</h3>

--- a/java/src/jmri/managers/AbstractMemoryManager.java
+++ b/java/src/jmri/managers/AbstractMemoryManager.java
@@ -89,7 +89,7 @@ public abstract class AbstractMemoryManager extends AbstractManager<Memory>
             // handle user name from request
             if (userName != null) {
                 // check if already on set in Object, might be inconsistent
-                if (!userName.equals(m.getUserName())) {
+                if (m.getUserName()!=null && !userName.equals(m.getUserName())) {
                     // this is a problem
                     log.warn("newMemory request for system name \"{}\" user name \"{}\" found memory with existing user name \"{}\"", systemName, userName, m.getUserName());
                 } else {


### PR DESCRIPTION
If existing Memory userName is null allow it to be set to requested value.

Enables userNames to be loaded for IMCURRENTTIME, IMRATEFACTOR

Prevents
```
 [java] 11:18:25,425 jmri.configurexml.LoadXmlConfigAction INFO  - Loading selected file: C:\Users\Steve\Desktop\tst.xml [AWT-EventQueue-0]
 [java] 11:18:26,065 jmri.managers.AbstractMemoryManager   WARN  - newMemory request for system name "IMCURRENTTIME" user name "Current Time UserName" found memory with existing user name "null" [AWT-EventQueue-0]
```