### PR TITLE
Move too-verbose warning to debug level

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -374,6 +374,7 @@
         <a id="DecoderPro" name="DecoderPro"></a>
         <ul>
             <li>Added ability to identify Dietz decoder models with CV128</li>
+            <li>Moved an excessive warning message to being a debug message<li>
         </ul>
 
     <h3>CTC Tool</h3>

--- a/java/src/jmri/jmrit/symbolicprog/VariableTableModel.java
+++ b/java/src/jmri/jmrit/symbolicprog/VariableTableModel.java
@@ -1221,7 +1221,7 @@ public class VariableTableModel extends AbstractTableModel implements ActionList
         }
         for (int i = 0; i < getRowCount(); i++) {
             if (name.equals(getLabel(i))) {
-                log.warn("findVar matched '{}' by Label rather than Item", name);
+                log.debug("findVar matched '{}' by Label rather than Item", name);
                 return getVariable(i);
             }
         }

--- a/xml/decoders/tcs/CV1_CV99_FW41.xml
+++ b/xml/decoders/tcs/CV1_CV99_FW41.xml
@@ -152,12 +152,12 @@
   <variable item="F2 controls output 1" CV="33" mask="XXXXVXXX" minOut="1">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
     <label>F2 controls output 1</label>
-     <label xml:lang="it">F2 controlla uscita 1</label>
+    <label xml:lang="it">F2 controlla uscita 1</label>
   </variable>
   <variable item="F3 controls output 1" CV="33" mask="XXXVXXXX" minOut="1">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
     <label>F3 controls output 1</label>
-     <label xml:lang="it">F3 controlla uscita 1</label>
+    <label xml:lang="it">F3 controlla uscita 1</label>
   </variable>
   <variable item="F4 controls output 1" CV="33" mask="XXVXXXXX" minOut="1">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
@@ -466,7 +466,7 @@
   <variable item="F7 controls output 6" CV="42" mask="XXXXXVXX" minOut="6">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
     <label>F7 controls output 6</label>
-  <label xml:lang="it">F7 controlla uscita 6</label>
+    <label xml:lang="it">F7 controlla uscita 6</label>
   </variable>
   <variable item="F8 controls output 6" CV="42" mask="XXXXVXXX" minOut="6">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
@@ -626,7 +626,7 @@
   <variable item="F11 controls output 8" CV="46" mask="XVXXXXXX" minOut="8">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
     <label>F11 controls output 8</label>
-     <label xml:lang="it">F11 controlla uscita 8</label>
+    <label xml:lang="it">F11 controlla uscita 8</label>
   </variable>
   <variable item="F12 controls output 8" CV="46" mask="VXXXXXXX" minOut="8">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
@@ -634,14 +634,14 @@
     <label xml:lang="it">F12 controlla uscita 8</label>
   </variable>
   <variable CV="49" mask="XXXXVVVV" item="Output 1 effect generated">
-        <enumVal>
-          <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
-         <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
-         <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Momentarypulse.xml"/>
-         <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_BlinkingditchAB.xml"/>
-         <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constdim.xml"/>
-         <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_AutoMarsBrake.xml"/>
-       </enumVal>
+    <enumVal>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Momentarypulse.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_BlinkingditchAB.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constdim.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_AutoMarsBrake.xml"/>
+    </enumVal>
     <label>White Wire Effect</label>
     <label xml:lang="it">Effetti filo Bianco</label>
   </variable>
@@ -651,14 +651,14 @@
     <label xml:lang="it">Temporizzazioni filo Bianco</label>
   </variable>
   <variable CV="50" mask="XXXXVVVV" item="Output 2 effect generated">
-        <enumVal>
-          <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
-         <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
-         <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Momentarypulse.xml"/>
-         <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_BlinkingditchAB.xml"/>
-         <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constdim.xml"/>
-         <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_AutoMarsBrake.xml"/>
-       </enumVal>
+    <enumVal>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Momentarypulse.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_BlinkingditchAB.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constdim.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_AutoMarsBrake.xml"/>
+    </enumVal>
     <label>Yellow Wire Effect</label>
     <label xml:lang="it">Effetti filo Giallo</label>
   </variable>
@@ -668,14 +668,14 @@
     <label xml:lang="it">Temporizzazioni filo Giallo</label>
   </variable>
   <variable CV="51" mask="XXXXVVVV" minOut="3" item="Output 3 effect generated">
-        <enumVal>
-          <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
-         <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
-         <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Momentarypulse.xml"/>
-         <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_BlinkingditchAB.xml"/>
-         <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constdim.xml"/>
-         <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_AutoMarsBrake.xml"/>
-       </enumVal>
+    <enumVal>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Momentarypulse.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_BlinkingditchAB.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constdim.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_AutoMarsBrake.xml"/>
+    </enumVal>
     <label>Green Wire Effect</label>
     <label xml:lang="it">Effetti filo verde</label>
   </variable>
@@ -685,14 +685,14 @@
     <label xml:lang="it">Temporizzazioni filo Verde</label>
   </variable>
   <variable CV="52" mask="XXXXVVVV" minOut="4" item="Output 4 effect generated">
-        <enumVal>
-          <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
-         <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
-         <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Momentarypulse.xml"/>
-         <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_BlinkingditchAB.xml"/>
-         <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constdim.xml"/>
-         <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_AutoMarsBrake.xml"/>
-       </enumVal>
+    <enumVal>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Momentarypulse.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_BlinkingditchAB.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constdim.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_AutoMarsBrake.xml"/>
+    </enumVal>
     <label>Purple Wire Effect</label>
     <label xml:lang="it">Effetti filo Porpora</label>
   </variable>
@@ -702,14 +702,14 @@
     <label xml:lang="it">Temporizzazioni filo Porpora</label>
   </variable>
   <variable CV="53" mask="XXXXVVVV" minOut="5" item="Output 5 effect generated">
-        <enumVal>
-          <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
-         <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
-         <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Momentarypulse.xml"/>
-         <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_BlinkingditchAB.xml"/>
-         <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constdim.xml"/>
-         <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_AutoMarsBrake.xml"/>
-       </enumVal>
+    <enumVal>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Momentarypulse.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_BlinkingditchAB.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constdim.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_AutoMarsBrake.xml"/>
+    </enumVal>
     <label>Brown Wire Effect</label>
     <label xml:lang="it">Effetti filo Marrone</label>
   </variable>
@@ -719,38 +719,38 @@
     <label xml:lang="it">Temporizzazioni filo Marrone</label>
   </variable>
   <variable CV="54" mask="XXXXVVVV" minOut="6" item="Output 6 effect generated">
-        <enumVal>
-          <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
-         <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
-         <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Momentarypulse.xml"/>
-         <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_BlinkingditchAB.xml"/>
-         <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constdim.xml"/>
-         <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_AutoMarsBrake.xml"/>
-       </enumVal>
+    <enumVal>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Momentarypulse.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_BlinkingditchAB.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constdim.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_AutoMarsBrake.xml"/>
+    </enumVal>
     <label>Pink Wire Effect</label>
     <label xml:lang="it">Effetti filo Rosa</label>
   </variable>
   <variable CV="54" mask="XXVVXXXX" minOut="6" item="Output 6 behavior" default="2">
-        <enumVal>
-          <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
-         <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
-         <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Momentarypulse.xml"/>
-         <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_BlinkingditchAB.xml"/>
-         <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constdim.xml"/>
-         <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_AutoMarsBrake.xml"/>
-       </enumVal>
+    <enumVal>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Momentarypulse.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_BlinkingditchAB.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constdim.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_AutoMarsBrake.xml"/>
+    </enumVal>
     <label>Pink Wire Timing</label>
     <label xml:lang="it">Temporizzazioni filo Rosa</label>
   </variable>
   <variable CV="55" mask="XXXXVVVV" minOut="7" item="Output 7 effect generated">
-        <enumVal>
-          <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
-         <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
-         <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Momentarypulse.xml"/>
-         <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_BlinkingditchAB.xml"/>
-         <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constdim.xml"/>
-         <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_AutoMarsBrake.xml"/>
-       </enumVal>
+    <enumVal>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Momentarypulse.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_BlinkingditchAB.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constdim.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_AutoMarsBrake.xml"/>
+    </enumVal>
     <label>Pink/Purple Wire Effect</label>
     <label xml:lang="it">Effetti filo Rosa/Porpora</label>
   </variable>
@@ -772,14 +772,14 @@
     <tooltip xml:lang="it">Valori pratici da 5 (basso) a 50 (alto)</tooltip>
   </variable>
   <variable CV="58" mask="XXXXVVVV" minOut="8" item="Output 8 effect generated">
-        <enumVal>
-          <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
-         <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
-         <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Momentarypulse.xml"/>
-         <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_BlinkingditchAB.xml"/>
-         <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constdim.xml"/>
-         <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_AutoMarsBrake.xml"/>
-       </enumVal>
+    <enumVal>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Momentarypulse.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_BlinkingditchAB.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constdim.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_AutoMarsBrake.xml"/>
+    </enumVal>
     <label>Green/Brown Wire Effect</label>
     <label xml:lang="it">Effetti filo Verde/Marrone</label>
   </variable>
@@ -819,12 +819,12 @@
   <variable CV="61" mask="XVXXXXXX" item="EMF Static Config" tooltip="Motor controlled by Function button">
     <enumVal>
       <enumChoice choice="Disabled">
-         <choice xml:lang="fr">Désactivé</choice>
-            <choice xml:lang="it">Disabilitato</choice>
-            <choice xml:lang="de">Deaktiviert</choice>
+        <choice xml:lang="fr">Désactivé</choice>
+        <choice xml:lang="it">Disabilitato</choice>
+        <choice xml:lang="de">Deaktiviert</choice>
       </enumChoice>
       <enumChoice choice="Button control of motor">
-         <choice xml:lang="it">Pulsante controllo Motore</choice>
+        <choice xml:lang="it">Pulsante controllo Motore</choice>
       </enumChoice>
     </enumVal>
     <label>Motor Button Control</label>
@@ -837,7 +837,7 @@
         <choice xml:lang="it">Manuale: F2-avanti, F3-retro</choice>
       </enumChoice>
       <enumChoice choice="Auto F2 for/rev">
-         <choice xml:lang="it">Automatico: F2-avanti/retro</choice>
+        <choice xml:lang="it">Automatico: F2-avanti/retro</choice>
       </enumChoice>
     </enumVal>
     <label>Button Control Direction</label>

--- a/xml/decoders/tcs/CV1_CV99_FW86.xml
+++ b/xml/decoders/tcs/CV1_CV99_FW86.xml
@@ -153,12 +153,12 @@
   <variable item="F2 controls output 1" CV="33" mask="XXXXVXXX" minOut="1">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
     <label>F2 controls output 1</label>
-     <label xml:lang="it">F2 controlla uscita 1</label>
+    <label xml:lang="it">F2 controlla uscita 1</label>
   </variable>
   <variable item="F3 controls output 1" CV="33" mask="XXXVXXXX" minOut="1">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
     <label>F3 controls output 1</label>
-     <label xml:lang="it">F3 controlla uscita 1</label>
+    <label xml:lang="it">F3 controlla uscita 1</label>
   </variable>
   <variable item="F4 controls output 1" CV="33" mask="XXVXXXXX" minOut="1">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
@@ -451,7 +451,7 @@
     <label xml:lang="it">F9 controlla uscita 5</label>
   </variable>
   <variable item="F10 controls output 5" CV="41" mask="XXVXXXXX" minOut="5">
-     <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
     <label>F10 controls output 5</label>
     <label xml:lang="it">F10 controlla uscita 5</label>
   </variable>
@@ -638,37 +638,43 @@
   <variable CV="49" mask="XVXXXXXX" item="Output 1 options" default="0">
     <enumVal>
       <enumChoice choice="Group 0">
-          <choice xml:lang="it">Gruppo 0</choice>
+        <choice xml:lang="it">Gruppo 0</choice>
       </enumChoice>
       <enumChoice choice="Group 1">
-          <choice xml:lang="it">Gruppo 1</choice>
+        <choice xml:lang="it">Gruppo 1</choice>
       </enumChoice>
     </enumVal>
     <label>White Wire Effect Group</label>
     <label xml:lang="it">Gruppo Effetti filo Bianco</label>
   </variable>
   <variable CV="49" mask="XXXXVVVV" item="Output 1 effect generated">
-        <qualifier>
+    <qualifier>
       <variableref>White Wire Effect Group</variableref>
       <relation>eq</relation>
       <value>1</value>
     </qualifier>
-        <xi:include href="http://jmri.org/xml/decoders/tcs/enum-CVX_light_short.xml"/><label>White Wire Effect 1</label><label xml:lang="it">Gruppo Effetti filo Bianco 1</label></variable>
+    <xi:include href="http://jmri.org/xml/decoders/tcs/enum-CVX_light_short.xml"/>
+    <label>White Wire Effect 1</label>
+    <label xml:lang="it">Gruppo Effetti filo Bianco 1</label>
+  </variable>
   <variable CV="49" mask="XXXXVVVV" item="Output 1 behavior">
-        <qualifier>
+    <qualifier>
       <variableref>White Wire Effect Group</variableref>
       <relation>eq</relation>
       <value>0</value>
     </qualifier>
-        <enumVal>
+    <enumVal>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Momentarypulse.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_BlinkingditchAB.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constdim.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_AutoMarsBrake.xml"/>
-    <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_SingleStrobe2.xml"/>
-</enumVal><label>White Wire Effect 0</label><label xml:lang="it">Effetti 0 filo Bianco</label></variable>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_SingleStrobe2.xml"/>
+    </enumVal>
+    <label>White Wire Effect 0</label>
+    <label xml:lang="it">Effetti 0 filo Bianco</label>
+  </variable>
   <variable CV="49" mask="XXVVXXXX" item="Output 1 option 1">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-frw_rev_both.xml"/>
     <label>White Wire Timing</label>
@@ -677,37 +683,43 @@
   <variable CV="50" mask="XVXXXXXX" item="Output 2 options" default="0">
     <enumVal>
       <enumChoice choice="Group 0">
-          <choice xml:lang="it">Gruppo 0</choice>
+        <choice xml:lang="it">Gruppo 0</choice>
       </enumChoice>
       <enumChoice choice="Group 1">
-          <choice xml:lang="it">Gruppo 1</choice>
+        <choice xml:lang="it">Gruppo 1</choice>
       </enumChoice>
     </enumVal>
     <label>Yellow Wire Effect Group</label>
     <label xml:lang="it">Yellow Wire Effect Group</label>
   </variable>
   <variable CV="50" mask="XXXXVVVV" item="Output 2 effect generated">
-        <qualifier>
+    <qualifier>
       <variableref>Yellow Wire Effect Group</variableref>
       <relation>eq</relation>
       <value>1</value>
     </qualifier>
-        <xi:include href="http://jmri.org/xml/decoders/tcs/enum-CVX_light_short.xml"/><label>Yellow Wire Effect 1</label><label xml:lang="it">Gruppo 1 Effetti filo Giallo</label></variable>
+    <xi:include href="http://jmri.org/xml/decoders/tcs/enum-CVX_light_short.xml"/>
+    <label>Yellow Wire Effect 1</label>
+    <label xml:lang="it">Gruppo 1 Effetti filo Giallo</label>
+  </variable>
   <variable CV="50" mask="XXXXVVVV" item="Output 2 behavior">
-        <qualifier>
+    <qualifier>
       <variableref>Yellow Wire Effect Group</variableref>
       <relation>eq</relation>
       <value>0</value>
     </qualifier>
-        <enumVal>
+    <enumVal>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Momentarypulse.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_BlinkingditchAB.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constdim.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_AutoMarsBrake.xml"/>
-    <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_SingleStrobe2.xml"/>
-</enumVal><label>Yellow Wire Effect 0</label><label xml:lang="it">Gruppo 0 Effetti filo Giallo</label></variable>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_SingleStrobe2.xml"/>
+    </enumVal>
+    <label>Yellow Wire Effect 0</label>
+    <label xml:lang="it">Gruppo 0 Effetti filo Giallo</label>
+  </variable>
   <variable CV="50" mask="XXVVXXXX" default="1" item="Output 2 option 1">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-frw_rev_both.xml"/>
     <label>Yellow Wire Timing</label>
@@ -716,37 +728,43 @@
   <variable CV="51" mask="XVXXXXXX" minOut="3" item="Output 3 options" default="0">
     <enumVal>
       <enumChoice choice="Group 0">
-          <choice xml:lang="it">Gruppo 0</choice>
+        <choice xml:lang="it">Gruppo 0</choice>
       </enumChoice>
       <enumChoice choice="Group 1">
-          <choice xml:lang="it">Gruppo 1</choice>
+        <choice xml:lang="it">Gruppo 1</choice>
       </enumChoice>
     </enumVal>
     <label>Green Wire Effect Group</label>
     <label xml:lang="it">Gruppo Effetti filo Verde</label>
   </variable>
   <variable CV="51" mask="XXXXVVVV" minOut="3" item="Output 3 effect generated">
-        <qualifier>
+    <qualifier>
       <variableref>Green Wire Effect Group</variableref>
       <relation>eq</relation>
       <value>1</value>
     </qualifier>
-        <xi:include href="http://jmri.org/xml/decoders/tcs/enum-CVX_light_short.xml"/><label>Green Wire Effect 1</label><label xml:lang="it">Gruppo 1 Effetti filo Verde</label></variable>
+    <xi:include href="http://jmri.org/xml/decoders/tcs/enum-CVX_light_short.xml"/>
+    <label>Green Wire Effect 1</label>
+    <label xml:lang="it">Gruppo 1 Effetti filo Verde</label>
+  </variable>
   <variable CV="51" mask="XXXXVVVV" minOut="3" item="Output 3 behavior">
-        <qualifier>
+    <qualifier>
       <variableref>Green Wire Effect Group</variableref>
       <relation>eq</relation>
       <value>0</value>
     </qualifier>
-        <enumVal>
+    <enumVal>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Momentarypulse.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_BlinkingditchAB.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constdim.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_AutoMarsBrake.xml"/>
-    <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_SingleStrobe2.xml"/>
-</enumVal><label>Green Wire Effect 0</label><label xml:lang="it">Gruppo 0 Effetti filo Verde</label></variable>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_SingleStrobe2.xml"/>
+    </enumVal>
+    <label>Green Wire Effect 0</label>
+    <label xml:lang="it">Gruppo 0 Effetti filo Verde</label>
+  </variable>
   <variable CV="51" mask="XXVVXXXX" minOut="3" default="2" item="Output 3 option 1">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-frw_rev_both.xml"/>
     <label>Green Wire Timing</label>
@@ -755,37 +773,43 @@
   <variable CV="52" mask="XVXXXXXX" minOut="4" item="Output 4 options" default="0">
     <enumVal>
       <enumChoice choice="Group 0">
-          <choice xml:lang="it">Gruppo 0</choice>
+        <choice xml:lang="it">Gruppo 0</choice>
       </enumChoice>
       <enumChoice choice="Group 1">
-          <choice xml:lang="it">Gruppo 1</choice>
+        <choice xml:lang="it">Gruppo 1</choice>
       </enumChoice>
     </enumVal>
     <label>Purple Wire Effect Group</label>
     <label xml:lang="it">Gruppo Effetti filo Porpora</label>
   </variable>
   <variable CV="52" mask="XXXXVVVV" minOut="4" item="Output 4 effect generated">
-        <qualifier>
+    <qualifier>
       <variableref>Purple Wire Effect Group</variableref>
       <relation>eq</relation>
       <value>1</value>
     </qualifier>
-        <xi:include href="http://jmri.org/xml/decoders/tcs/enum-CVX_light_short.xml"/><label>Purple Wire Effect 1</label><label xml:lang="it">Gruppo 1 Effetti filo Porpora</label></variable>
+    <xi:include href="http://jmri.org/xml/decoders/tcs/enum-CVX_light_short.xml"/>
+    <label>Purple Wire Effect 1</label>
+    <label xml:lang="it">Gruppo 1 Effetti filo Porpora</label>
+  </variable>
   <variable CV="52" mask="XXXXVVVV" minOut="4" item="Output 4 behavior">
-        <qualifier>
+    <qualifier>
       <variableref>Purple Wire Effect Group</variableref>
       <relation>eq</relation>
       <value>0</value>
     </qualifier>
-        <enumVal>
+    <enumVal>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Momentarypulse.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_BlinkingditchAB.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constdim.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_AutoMarsBrake.xml"/>
-    <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_SingleStrobe2.xml"/>
-</enumVal><label>Purple Wire Effect 0</label><label xml:lang="it">Gruppo 0 Effetti filo Porpora</label></variable>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_SingleStrobe2.xml"/>
+    </enumVal>
+    <label>Purple Wire Effect 0</label>
+    <label xml:lang="it">Gruppo 0 Effetti filo Porpora</label>
+  </variable>
   <variable CV="52" mask="XXVVXXXX" minOut="4" default="2" item="Output 4 option 1">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-frw_rev_both.xml"/>
     <label>Purple Wire Timing</label>
@@ -794,37 +818,43 @@
   <variable CV="53" mask="XVXXXXXX" minOut="5" item="Output 5 options" default="0">
     <enumVal>
       <enumChoice choice="Group 0">
-          <choice xml:lang="it">Gruppo 0</choice>
+        <choice xml:lang="it">Gruppo 0</choice>
       </enumChoice>
       <enumChoice choice="Group 1">
-          <choice xml:lang="it">Gruppo 1</choice>
+        <choice xml:lang="it">Gruppo 1</choice>
       </enumChoice>
     </enumVal>
     <label>Brown Wire Effect Group</label>
     <label xml:lang="it">Gruppo Effetti filo Marrone</label>
   </variable>
   <variable CV="53" mask="XXXXVVVV" minOut="5" item="Output 5 effect generated">
-        <qualifier>
+    <qualifier>
       <variableref>Brown Wire Effect Group</variableref>
       <relation>eq</relation>
       <value>1</value>
     </qualifier>
-        <xi:include href="http://jmri.org/xml/decoders/tcs/enum-CVX_light_short.xml"/><label>Brown Wire Effect 1</label><label xml:lang="it">Gruppo 1 Effetti filo Marrone</label></variable>
+    <xi:include href="http://jmri.org/xml/decoders/tcs/enum-CVX_light_short.xml"/>
+    <label>Brown Wire Effect 1</label>
+    <label xml:lang="it">Gruppo 1 Effetti filo Marrone</label>
+  </variable>
   <variable CV="53" mask="XXXXVVVV" minOut="5" item="Output 5 behavior">
-        <qualifier>
+    <qualifier>
       <variableref>Brown Wire Effect Group</variableref>
       <relation>eq</relation>
       <value>0</value>
     </qualifier>
-        <enumVal>
+    <enumVal>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Momentarypulse.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_BlinkingditchAB.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constdim.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_AutoMarsBrake.xml"/>
-    <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_SingleStrobe2.xml"/>
-</enumVal><label>Brown Wire Effect 0</label><label xml:lang="it">Gruppo 0 Effetti filo Marrone</label></variable>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_SingleStrobe2.xml"/>
+    </enumVal>
+    <label>Brown Wire Effect 0</label>
+    <label xml:lang="it">Gruppo 0 Effetti filo Marrone</label>
+  </variable>
   <variable CV="53" mask="XXVVXXXX" minOut="5" default="2" item="Output 5 option 1">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-frw_rev_both.xml"/>
     <label>Brown Wire Timing</label>
@@ -833,37 +863,43 @@
   <variable CV="54" mask="XVXXXXXX" minOut="6" item="Output 6 options" default="0">
     <enumVal>
       <enumChoice choice="Group 0">
-          <choice xml:lang="it">Gruppo 0</choice>
+        <choice xml:lang="it">Gruppo 0</choice>
       </enumChoice>
       <enumChoice choice="Group 1">
-          <choice xml:lang="it">Gruppo 1</choice>
+        <choice xml:lang="it">Gruppo 1</choice>
       </enumChoice>
     </enumVal>
     <label>Pink Wire Effect Group</label>
     <label xml:lang="it">Gruppo Effetti filo Rosa</label>
   </variable>
   <variable CV="54" mask="XXXXVVVV" minOut="6" item="Output 6 effect generated">
-        <qualifier>
+    <qualifier>
       <variableref>Pink Wire Effect Group</variableref>
       <relation>eq</relation>
       <value>1</value>
     </qualifier>
-        <xi:include href="http://jmri.org/xml/decoders/tcs/enum-CVX_light_short.xml"/><label>Pink Wire Effect 1</label><label xml:lang="it">Gruppo 1 Effetti filo Rosa</label></variable>
+    <xi:include href="http://jmri.org/xml/decoders/tcs/enum-CVX_light_short.xml"/>
+    <label>Pink Wire Effect 1</label>
+    <label xml:lang="it">Gruppo 1 Effetti filo Rosa</label>
+  </variable>
   <variable CV="54" mask="XXXXVVVV" minOut="6" item="Output 6 behavior">
-        <qualifier>
+    <qualifier>
       <variableref>Pink Wire Effect Group</variableref>
       <relation>eq</relation>
       <value>0</value>
     </qualifier>
-        <enumVal>
+    <enumVal>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Momentarypulse.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_BlinkingditchAB.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constdim.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_AutoMarsBrake.xml"/>
-    <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_SingleStrobe2.xml"/>
-</enumVal><label>Pink Wire Effect 0</label><label xml:lang="it">Gruppo 0 Effetti filo Rosa</label></variable>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_SingleStrobe2.xml"/>
+    </enumVal>
+    <label>Pink Wire Effect 0</label>
+    <label xml:lang="it">Gruppo 0 Effetti filo Rosa</label>
+  </variable>
   <variable CV="54" mask="XXVVXXXX" minOut="6" default="2" item="Output 6 option 1">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-frw_rev_both.xml"/>
     <label>Pink Wire Timing</label>
@@ -872,37 +908,43 @@
   <variable CV="55" mask="XVXXXXXX" minOut="7" item="Output 7 options" default="0">
     <enumVal>
       <enumChoice choice="Group 0">
-          <choice xml:lang="it">Gruppo 0</choice>
+        <choice xml:lang="it">Gruppo 0</choice>
       </enumChoice>
       <enumChoice choice="Group 1">
-          <choice xml:lang="it">Gruppo 1</choice>
+        <choice xml:lang="it">Gruppo 1</choice>
       </enumChoice>
     </enumVal>
     <label>Pink/Purple Wire Effect Group</label>
     <label xml:lang="it">Gruppo Effetti filo Rosa/Porpora</label>
   </variable>
   <variable CV="55" mask="XXXXVVVV" minOut="7" item="Output 7 effect generated">
-        <qualifier>
+    <qualifier>
       <variableref>Pink/Purple Wire Effect Group</variableref>
       <relation>eq</relation>
       <value>1</value>
     </qualifier>
-        <xi:include href="http://jmri.org/xml/decoders/tcs/enum-CVX_light_short.xml"/><label>Pink/Purple Wire Effect 1</label><label xml:lang="it">Gruppo 1 Effetti filo Rosa/Porpora</label></variable>
+    <xi:include href="http://jmri.org/xml/decoders/tcs/enum-CVX_light_short.xml"/>
+    <label>Pink/Purple Wire Effect 1</label>
+    <label xml:lang="it">Gruppo 1 Effetti filo Rosa/Porpora</label>
+  </variable>
   <variable CV="55" mask="XXXXVVVV" minOut="7" item="Output 7 behavior">
-        <qualifier>
+    <qualifier>
       <variableref>Pink/Purple Wire Effect Group</variableref>
       <relation>eq</relation>
       <value>0</value>
     </qualifier>
-        <enumVal>
+    <enumVal>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Momentarypulse.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_BlinkingditchAB.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constdim.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_AutoMarsBrake.xml"/>
-    <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_SingleStrobe2.xml"/>
-</enumVal><label>Pink/Purple Wire Effect 0</label><label xml:lang="it">Gruppo 0 Effetti filo Rosa/Porpora</label></variable>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_SingleStrobe2.xml"/>
+    </enumVal>
+    <label>Pink/Purple Wire Effect 0</label>
+    <label xml:lang="it">Gruppo 0 Effetti filo Rosa/Porpora</label>
+  </variable>
   <variable CV="55" mask="XXVVXXXX" minOut="7" default="2" item="Output 7 option 1">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-frw_rev_both.xml"/>
     <label>Pink/Purple Wire Timing</label>
@@ -923,37 +965,43 @@
   <variable CV="58" mask="XVXXXXXX" minOut="8" item="Output 8 options" default="0">
     <enumVal>
       <enumChoice choice="Group 0">
-          <choice xml:lang="it">Gruppo 0</choice>
+        <choice xml:lang="it">Gruppo 0</choice>
       </enumChoice>
       <enumChoice choice="Group 1">
-          <choice xml:lang="it">Gruppo 1</choice>
+        <choice xml:lang="it">Gruppo 1</choice>
       </enumChoice>
     </enumVal>
     <label>Green/Brown Wire Effect Group</label>
     <label xml:lang="it">Gruppo Effetti filo Verde/Marrone</label>
   </variable>
   <variable CV="58" mask="XXXXVVVV" minOut="8" item="Output 8 effect generated">
-        <qualifier>
+    <qualifier>
       <variableref>Green/Brown Wire Effect Group</variableref>
       <relation>eq</relation>
       <value>1</value>
     </qualifier>
-        <xi:include href="http://jmri.org/xml/decoders/tcs/enum-CVX_light_short.xml"/><label>Green/Brown Wire Effect 1</label><label xml:lang="it">Gruppo 1 Effetti filo Verde/Marrone</label></variable>
+    <xi:include href="http://jmri.org/xml/decoders/tcs/enum-CVX_light_short.xml"/>
+    <label>Green/Brown Wire Effect 1</label>
+    <label xml:lang="it">Gruppo 1 Effetti filo Verde/Marrone</label>
+  </variable>
   <variable CV="58" mask="XXXXVVVV" minOut="8" item="Output 8 behavior">
-        <qualifier>
+    <qualifier>
       <variableref>Green/Brown Wire Effect Group</variableref>
       <relation>eq</relation>
       <value>0</value>
     </qualifier>
-        <enumVal>
+    <enumVal>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Momentarypulse.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_BlinkingditchAB.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constdim.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_AutoMarsBrake.xml"/>
-    <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_SingleStrobe2.xml"/>
-</enumVal><label>Green/Brown Wire Effect 0</label><label xml:lang="it">Gruppo 0 Effetti filo Verde/Marrone</label></variable>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_SingleStrobe2.xml"/>
+    </enumVal>
+    <label>Green/Brown Wire Effect 0</label>
+    <label xml:lang="it">Gruppo 0 Effetti filo Verde/Marrone</label>
+  </variable>
   <variable CV="58" mask="XXVVXXXX" minOut="8" default="2" item="Output 8 option 1">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-frw_rev_both.xml"/>
     <label>Green/Brown Wire Timing</label>
@@ -974,7 +1022,7 @@
   <variable CV="61" mask="XXXXVXXX" item="Motor Option 4" tooltip="Disable(default)/Enable button control of Brake">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-disabledEnabled.xml"/>
     <label>Enable Brake Button Control</label>
-    <label xml:lang="it">Abilita pulsante controllo Freni</label> 
+    <label xml:lang="it">Abilita pulsante controllo Freni</label>
     <tooltip xml:lang="it">Disabilita(default)/Abilita controllo Freni da pulsante</tooltip>
   </variable>
   <variable CV="61" mask="XXXVXXXX" item="Directional Headlights">
@@ -985,7 +1033,7 @@
   <variable CV="61" mask="VXXXXXXX" default="0" item="Function 5 effect generated" tooltip="Disable(default)/Enable button control of Brake Light (Trolley)">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-disabledEnabled.xml"/>
     <label>Button Control of Brake Light</label>
-	    <label xml:lang="it">Abilita pulsante di controllo della luce Freno</label>
+    <label xml:lang="it">Abilita pulsante di controllo della luce Freno</label>
     <tooltip xml:lang="it">Disabilitare (default) / Abilita controllo pulsante di luce Freno (Trolley)</tooltip>
   </variable>
   <variable CV="61" mask="XXVXXXXX" item="Global lighting option 1">
@@ -996,12 +1044,12 @@
   <variable CV="61" mask="XVXXXXXX" item="Motor Option 1" tooltip="Motor controlled by Function button">
     <enumVal>
       <enumChoice choice="Disabled">
-         <choice xml:lang="fr">Désactivé</choice>
-            <choice xml:lang="it">Disabilitato</choice>
-            <choice xml:lang="de">Deaktiviert</choice>
+        <choice xml:lang="fr">Désactivé</choice>
+        <choice xml:lang="it">Disabilitato</choice>
+        <choice xml:lang="de">Deaktiviert</choice>
       </enumChoice>
       <enumChoice choice="Button control of motor">
-         <choice xml:lang="it">Pulsante controllo Motore</choice>
+        <choice xml:lang="it">Pulsante controllo Motore</choice>
       </enumChoice>
     </enumVal>
     <label>Motor Button Control</label>
@@ -1014,7 +1062,7 @@
         <choice xml:lang="it">Manuale: F2-avanti, F3-retro</choice>
       </enumChoice>
       <enumChoice choice="Auto F2 for/rev">
-         <choice xml:lang="it">Automatico: F2-avanti/retro</choice>
+        <choice xml:lang="it">Automatico: F2-avanti/retro</choice>
       </enumChoice>
     </enumVal>
     <label>Button Control Direction</label>

--- a/xml/decoders/tcs/CV1_CV99_FW89.xml
+++ b/xml/decoders/tcs/CV1_CV99_FW89.xml
@@ -168,12 +168,12 @@
   <variable item="F2 controls output 1" CV="33" mask="XXXXVXXX" minOut="1">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
     <label>F2 controls output 1</label>
-     <label xml:lang="it">F2 controlla uscita 1</label>
+    <label xml:lang="it">F2 controlla uscita 1</label>
   </variable>
   <variable item="F3 controls output 1" CV="33" mask="XXXVXXXX" minOut="1">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
     <label>F3 controls output 1</label>
-     <label xml:lang="it">F3 controlla uscita 1</label>
+    <label xml:lang="it">F3 controlla uscita 1</label>
   </variable>
   <variable item="F4 controls output 1" CV="33" mask="XXVXXXXX" minOut="1">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
@@ -472,7 +472,7 @@
     <label xml:lang="it">F9 controlla uscita 5</label>
   </variable>
   <variable item="F10 controls output 5" CV="41" mask="XXVXXXXX" minOut="5">
-     <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
     <label>F10 controls output 5</label>
     <label xml:lang="it">F10 controlla uscita 5</label>
   </variable>
@@ -659,37 +659,43 @@
   <variable CV="49" mask="XVXXXXXX" item="Output 1 options" default="0">
     <enumVal>
       <enumChoice choice="Group 0">
-          <choice xml:lang="it">Gruppo 0</choice>
+        <choice xml:lang="it">Gruppo 0</choice>
       </enumChoice>
       <enumChoice choice="Group 1">
-          <choice xml:lang="it">Gruppo 1</choice>
+        <choice xml:lang="it">Gruppo 1</choice>
       </enumChoice>
     </enumVal>
     <label>White Wire Effect Group</label>
     <label xml:lang="it">Gruppo Effetti filo Bianco</label>
   </variable>
   <variable CV="49" mask="XXXXVVVV" item="Output 1 effect generated">
-        <qualifier>
+    <qualifier>
       <variableref>White Wire Effect Group</variableref>
       <relation>eq</relation>
       <value>1</value>
     </qualifier>
-        <xi:include href="http://jmri.org/xml/decoders/tcs/enum-CVX_light_short.xml"/><label>White Wire Effect 1</label><label xml:lang="it">Gruppo Effetti filo Bianco 1</label></variable>
+    <xi:include href="http://jmri.org/xml/decoders/tcs/enum-CVX_light_short.xml"/>
+    <label>White Wire Effect 1</label>
+    <label xml:lang="it">Gruppo Effetti filo Bianco 1</label>
+  </variable>
   <variable CV="49" mask="XXXXVVVV" item="Output 1 behavior">
-        <qualifier>
+    <qualifier>
       <variableref>White Wire Effect Group</variableref>
       <relation>eq</relation>
       <value>0</value>
     </qualifier>
-        <enumVal>
+    <enumVal>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Momentarypulse.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_BlinkingditchAB.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constdim.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_AutoMarsBrake.xml"/>
-    <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_SingleStrobe2.xml"/>
-</enumVal><label>White Wire Effect 0</label><label xml:lang="it">Effetti 0 filo Bianco</label></variable>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_SingleStrobe2.xml"/>
+    </enumVal>
+    <label>White Wire Effect 0</label>
+    <label xml:lang="it">Effetti 0 filo Bianco</label>
+  </variable>
   <variable CV="49" mask="XXVVXXXX" item="Output 1 option 1">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-frw_rev_both.xml"/>
     <label>White Wire Timing</label>
@@ -698,37 +704,43 @@
   <variable CV="50" mask="XVXXXXXX" item="Output 2 options" default="0">
     <enumVal>
       <enumChoice choice="Group 0">
-          <choice xml:lang="it">Gruppo 0</choice>
+        <choice xml:lang="it">Gruppo 0</choice>
       </enumChoice>
       <enumChoice choice="Group 1">
-          <choice xml:lang="it">Gruppo 1</choice>
+        <choice xml:lang="it">Gruppo 1</choice>
       </enumChoice>
     </enumVal>
     <label>Yellow Wire Effect Group</label>
     <label xml:lang="it">Yellow Wire Effect Group</label>
   </variable>
   <variable CV="50" mask="XXXXVVVV" item="Output 2 effect generated">
-        <qualifier>
+    <qualifier>
       <variableref>Yellow Wire Effect Group</variableref>
       <relation>eq</relation>
       <value>1</value>
     </qualifier>
-        <xi:include href="http://jmri.org/xml/decoders/tcs/enum-CVX_light_short.xml"/><label>Yellow Wire Effect 1</label><label xml:lang="it">Gruppo 1 Effetti filo Giallo</label></variable>
+    <xi:include href="http://jmri.org/xml/decoders/tcs/enum-CVX_light_short.xml"/>
+    <label>Yellow Wire Effect 1</label>
+    <label xml:lang="it">Gruppo 1 Effetti filo Giallo</label>
+  </variable>
   <variable CV="50" mask="XXXXVVVV" item="Output 2 behavior">
-        <qualifier>
+    <qualifier>
       <variableref>Yellow Wire Effect Group</variableref>
       <relation>eq</relation>
       <value>0</value>
     </qualifier>
-        <enumVal>
+    <enumVal>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Momentarypulse.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_BlinkingditchAB.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constdim.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_AutoMarsBrake.xml"/>
-    <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_SingleStrobe2.xml"/>
-</enumVal><label>Yellow Wire Effect 0</label><label xml:lang="it">Gruppo 0 Effetti filo Giallo</label></variable>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_SingleStrobe2.xml"/>
+    </enumVal>
+    <label>Yellow Wire Effect 0</label>
+    <label xml:lang="it">Gruppo 0 Effetti filo Giallo</label>
+  </variable>
   <variable CV="50" mask="XXVVXXXX" default="1" item="Output 2 option 1">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-frw_rev_both.xml"/>
     <label>Yellow Wire Timing</label>
@@ -737,22 +749,25 @@
   <variable CV="51" mask="XVXXXXXX" minOut="3" item="Output 3 options" default="0">
     <enumVal>
       <enumChoice choice="Group 0">
-          <choice xml:lang="it">Gruppo 0</choice>
+        <choice xml:lang="it">Gruppo 0</choice>
       </enumChoice>
       <enumChoice choice="Group 1">
-          <choice xml:lang="it">Gruppo 1</choice>
+        <choice xml:lang="it">Gruppo 1</choice>
       </enumChoice>
     </enumVal>
     <label>Green Wire Effect Group</label>
     <label xml:lang="it">Gruppo Effetti filo Verde</label>
   </variable>
   <variable CV="51" mask="XXXXVVVV" minOut="3" item="Output 3 effect generated">
-        <qualifier>
+    <qualifier>
       <variableref>Green Wire Effect Group</variableref>
       <relation>eq</relation>
       <value>1</value>
     </qualifier>
-        <xi:include href="http://jmri.org/xml/decoders/tcs/enum-CVX_light_short.xml"/><label>Green Wire Effect 1</label><label xml:lang="it">Gruppo 1 Effetti filo Verde</label></variable>
+    <xi:include href="http://jmri.org/xml/decoders/tcs/enum-CVX_light_short.xml"/>
+    <label>Green Wire Effect 1</label>
+    <label xml:lang="it">Gruppo 1 Effetti filo Verde</label>
+  </variable>
   <variable CV="51" mask="XXXXVVVV" minOut="3" item="Output 3 behavior">
     <qualifier>
       <variableref>Green Wire Effect Group</variableref>
@@ -768,7 +783,8 @@
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_AutoMarsBrake.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_SingleStrobe2.xml"/>
     </enumVal>
-    <label>Green Wire Effect 0</label><label xml:lang="it">Gruppo 0 Effetti filo Verde</label>
+    <label>Green Wire Effect 0</label>
+    <label xml:lang="it">Gruppo 0 Effetti filo Verde</label>
   </variable>
   <variable CV="51" mask="XXVVXXXX" minOut="3" default="2" item="Output 3 option 1">
     <defaultItem default="1" include="46"/>
@@ -779,10 +795,10 @@
   <variable CV="52" mask="XVXXXXXX" minOut="4" item="Output 4 options" default="0">
     <enumVal>
       <enumChoice choice="Group 0">
-          <choice xml:lang="it">Gruppo 0</choice>
+        <choice xml:lang="it">Gruppo 0</choice>
       </enumChoice>
       <enumChoice choice="Group 1">
-          <choice xml:lang="it">Gruppo 1</choice>
+        <choice xml:lang="it">Gruppo 1</choice>
       </enumChoice>
     </enumVal>
     <label>Purple Wire Effect Group</label>
@@ -825,37 +841,43 @@
   <variable CV="53" mask="XVXXXXXX" minOut="5" item="Output 5 options" default="0">
     <enumVal>
       <enumChoice choice="Group 0">
-          <choice xml:lang="it">Gruppo 0</choice>
+        <choice xml:lang="it">Gruppo 0</choice>
       </enumChoice>
       <enumChoice choice="Group 1">
-          <choice xml:lang="it">Gruppo 1</choice>
+        <choice xml:lang="it">Gruppo 1</choice>
       </enumChoice>
     </enumVal>
     <label>Brown Wire Effect Group</label>
     <label xml:lang="it">Gruppo Effetti filo Marrone</label>
   </variable>
   <variable CV="53" mask="XXXXVVVV" minOut="5" item="Output 5 effect generated">
-        <qualifier>
+    <qualifier>
       <variableref>Brown Wire Effect Group</variableref>
       <relation>eq</relation>
       <value>1</value>
     </qualifier>
-        <xi:include href="http://jmri.org/xml/decoders/tcs/enum-CVX_light_short.xml"/><label>Brown Wire Effect 1</label><label xml:lang="it">Gruppo 1 Effetti filo Marrone</label></variable>
+    <xi:include href="http://jmri.org/xml/decoders/tcs/enum-CVX_light_short.xml"/>
+    <label>Brown Wire Effect 1</label>
+    <label xml:lang="it">Gruppo 1 Effetti filo Marrone</label>
+  </variable>
   <variable CV="53" mask="XXXXVVVV" minOut="5" item="Output 5 behavior">
-        <qualifier>
+    <qualifier>
       <variableref>Brown Wire Effect Group</variableref>
       <relation>eq</relation>
       <value>0</value>
     </qualifier>
-        <enumVal>
+    <enumVal>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Momentarypulse.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_BlinkingditchAB.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constdim.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_AutoMarsBrake.xml"/>
-    <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_SingleStrobe2.xml"/>
-</enumVal><label>Brown Wire Effect 0</label><label xml:lang="it">Gruppo 0 Effetti filo Marrone</label></variable>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_SingleStrobe2.xml"/>
+    </enumVal>
+    <label>Brown Wire Effect 0</label>
+    <label xml:lang="it">Gruppo 0 Effetti filo Marrone</label>
+  </variable>
   <variable CV="53" mask="XXVVXXXX" minOut="5" default="2" item="Output 5 option 1">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-frw_rev_both.xml"/>
     <label>Brown Wire Timing</label>
@@ -864,37 +886,43 @@
   <variable CV="54" mask="XVXXXXXX" minOut="6" item="Output 6 options" default="0">
     <enumVal>
       <enumChoice choice="Group 0">
-          <choice xml:lang="it">Gruppo 0</choice>
+        <choice xml:lang="it">Gruppo 0</choice>
       </enumChoice>
       <enumChoice choice="Group 1">
-          <choice xml:lang="it">Gruppo 1</choice>
+        <choice xml:lang="it">Gruppo 1</choice>
       </enumChoice>
     </enumVal>
     <label>Pink Wire Effect Group</label>
     <label xml:lang="it">Gruppo Effetti filo Rosa</label>
   </variable>
   <variable CV="54" mask="XXXXVVVV" minOut="6" item="Output 6 effect generated">
-        <qualifier>
+    <qualifier>
       <variableref>Pink Wire Effect Group</variableref>
       <relation>eq</relation>
       <value>1</value>
     </qualifier>
-        <xi:include href="http://jmri.org/xml/decoders/tcs/enum-CVX_light_short.xml"/><label>Pink Wire Effect 1</label><label xml:lang="it">Gruppo 1 Effetti filo Rosa</label></variable>
+    <xi:include href="http://jmri.org/xml/decoders/tcs/enum-CVX_light_short.xml"/>
+    <label>Pink Wire Effect 1</label>
+    <label xml:lang="it">Gruppo 1 Effetti filo Rosa</label>
+  </variable>
   <variable CV="54" mask="XXXXVVVV" minOut="6" item="Output 6 behavior">
-        <qualifier>
+    <qualifier>
       <variableref>Pink Wire Effect Group</variableref>
       <relation>eq</relation>
       <value>0</value>
     </qualifier>
-        <enumVal>
+    <enumVal>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Momentarypulse.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_BlinkingditchAB.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constdim.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_AutoMarsBrake.xml"/>
-    <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_SingleStrobe2.xml"/>
-</enumVal><label>Pink Wire Effect 0</label><label xml:lang="it">Gruppo 0 Effetti filo Rosa</label></variable>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_SingleStrobe2.xml"/>
+    </enumVal>
+    <label>Pink Wire Effect 0</label>
+    <label xml:lang="it">Gruppo 0 Effetti filo Rosa</label>
+  </variable>
   <variable CV="54" mask="XXVVXXXX" minOut="6" default="2" item="Output 6 option 1">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-frw_rev_both.xml"/>
     <label>Pink Wire Timing</label>
@@ -903,37 +931,43 @@
   <variable CV="55" mask="XVXXXXXX" minOut="7" item="Output 7 options" default="0">
     <enumVal>
       <enumChoice choice="Group 0">
-          <choice xml:lang="it">Gruppo 0</choice>
+        <choice xml:lang="it">Gruppo 0</choice>
       </enumChoice>
       <enumChoice choice="Group 1">
-          <choice xml:lang="it">Gruppo 1</choice>
+        <choice xml:lang="it">Gruppo 1</choice>
       </enumChoice>
     </enumVal>
     <label>Pink/Purple Wire Effect Group</label>
     <label xml:lang="it">Gruppo Effetti filo Rosa/Porpora</label>
   </variable>
   <variable CV="55" mask="XXXXVVVV" minOut="7" item="Output 7 effect generated">
-        <qualifier>
+    <qualifier>
       <variableref>Pink/Purple Wire Effect Group</variableref>
       <relation>eq</relation>
       <value>1</value>
     </qualifier>
-        <xi:include href="http://jmri.org/xml/decoders/tcs/enum-CVX_light_short.xml"/><label>Pink/Purple Wire Effect 1</label><label xml:lang="it">Gruppo 1 Effetti filo Rosa/Porpora</label></variable>
+    <xi:include href="http://jmri.org/xml/decoders/tcs/enum-CVX_light_short.xml"/>
+    <label>Pink/Purple Wire Effect 1</label>
+    <label xml:lang="it">Gruppo 1 Effetti filo Rosa/Porpora</label>
+  </variable>
   <variable CV="55" mask="XXXXVVVV" minOut="7" item="Output 7 behavior">
-        <qualifier>
+    <qualifier>
       <variableref>Pink/Purple Wire Effect Group</variableref>
       <relation>eq</relation>
       <value>0</value>
     </qualifier>
-        <enumVal>
+    <enumVal>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Momentarypulse.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_BlinkingditchAB.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constdim.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_AutoMarsBrake.xml"/>
-    <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_SingleStrobe2.xml"/>
-</enumVal><label>Pink/Purple Wire Effect 0</label><label xml:lang="it">Gruppo 0 Effetti filo Rosa/Porpora</label></variable>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_SingleStrobe2.xml"/>
+    </enumVal>
+    <label>Pink/Purple Wire Effect 0</label>
+    <label xml:lang="it">Gruppo 0 Effetti filo Rosa/Porpora</label>
+  </variable>
   <variable CV="55" mask="XXVVXXXX" minOut="7" default="2" item="Output 7 option 1">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-frw_rev_both.xml"/>
     <label>Pink/Purple Wire Timing</label>
@@ -954,37 +988,43 @@
   <variable CV="58" mask="XVXXXXXX" minOut="8" item="Output 8 options" default="0">
     <enumVal>
       <enumChoice choice="Group 0">
-          <choice xml:lang="it">Gruppo 0</choice>
+        <choice xml:lang="it">Gruppo 0</choice>
       </enumChoice>
       <enumChoice choice="Group 1">
-          <choice xml:lang="it">Gruppo 1</choice>
+        <choice xml:lang="it">Gruppo 1</choice>
       </enumChoice>
     </enumVal>
     <label>Green/Brown Wire Effect Group</label>
     <label xml:lang="it">Gruppo Effetti filo Verde/Marrone</label>
   </variable>
   <variable CV="58" mask="XXXXVVVV" minOut="8" item="Output 8 effect generated">
-        <qualifier>
+    <qualifier>
       <variableref>Green/Brown Wire Effect Group</variableref>
       <relation>eq</relation>
       <value>1</value>
     </qualifier>
-        <xi:include href="http://jmri.org/xml/decoders/tcs/enum-CVX_light_short.xml"/><label>Green/Brown Wire Effect 1</label><label xml:lang="it">Gruppo 1 Effetti filo Verde/Marrone</label></variable>
+    <xi:include href="http://jmri.org/xml/decoders/tcs/enum-CVX_light_short.xml"/>
+    <label>Green/Brown Wire Effect 1</label>
+    <label xml:lang="it">Gruppo 1 Effetti filo Verde/Marrone</label>
+  </variable>
   <variable CV="58" mask="XXXXVVVV" minOut="8" item="Output 8 behavior">
-        <qualifier>
+    <qualifier>
       <variableref>Green/Brown Wire Effect Group</variableref>
       <relation>eq</relation>
       <value>0</value>
     </qualifier>
-        <enumVal>
+    <enumVal>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Momentarypulse.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_BlinkingditchAB.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constdim.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_AutoMarsBrake.xml"/>
-    <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_SingleStrobe2.xml"/>
-</enumVal><label>Green/Brown Wire Effect 0</label><label xml:lang="it">Gruppo 0 Effetti filo Verde/Marrone</label></variable>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_SingleStrobe2.xml"/>
+    </enumVal>
+    <label>Green/Brown Wire Effect 0</label>
+    <label xml:lang="it">Gruppo 0 Effetti filo Verde/Marrone</label>
+  </variable>
   <variable CV="58" mask="XXVVXXXX" minOut="8" default="2" item="Output 8 option 1">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-frw_rev_both.xml"/>
     <label>Green/Brown Wire Timing</label>
@@ -1005,7 +1045,7 @@
   <variable CV="61" mask="XXXXVXXX" item="Motor Option 4" tooltip="Disable(default)/Enable button control of Brake">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-disabledEnabled.xml"/>
     <label>Enable Brake Button Control</label>
-    <label xml:lang="it">Abilita pulsante controllo Freni</label> 
+    <label xml:lang="it">Abilita pulsante controllo Freni</label>
     <tooltip xml:lang="it">Disabilita(default)/Abilita controllo Freni da pulsante</tooltip>
   </variable>
   <variable CV="61" mask="XXXVXXXX" item="Directional Headlights">
@@ -1016,7 +1056,7 @@
   <variable CV="61" mask="VXXXXXXX" default="0" item="Function 5 effect generated" tooltip="Disable(default)/Enable button control of Brake Light (Trolley)">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-disabledEnabled.xml"/>
     <label>Button Control of Brake Light</label>
-	    <label xml:lang="it">Abilita pulsante di controllo della luce Freno</label>
+    <label xml:lang="it">Abilita pulsante di controllo della luce Freno</label>
     <tooltip xml:lang="it">Disabilitare (default) / Abilita controllo pulsante di luce Freno (Trolley)</tooltip>
   </variable>
   <variable CV="61" mask="XXVXXXXX" item="Global lighting option 1">
@@ -1027,12 +1067,12 @@
   <variable CV="61" mask="XVXXXXXX" item="Motor Option 1" tooltip="Motor controlled by Function button">
     <enumVal>
       <enumChoice choice="Disabled">
-         <choice xml:lang="fr">Désactivé</choice>
-            <choice xml:lang="it">Disabilitato</choice>
-            <choice xml:lang="de">Deaktiviert</choice>
+        <choice xml:lang="fr">Désactivé</choice>
+        <choice xml:lang="it">Disabilitato</choice>
+        <choice xml:lang="de">Deaktiviert</choice>
       </enumChoice>
       <enumChoice choice="Button control of motor">
-         <choice xml:lang="it">Pulsante controllo Motore</choice>
+        <choice xml:lang="it">Pulsante controllo Motore</choice>
       </enumChoice>
     </enumVal>
     <label>Motor Button Control</label>
@@ -1045,7 +1085,7 @@
         <choice xml:lang="it">Manuale: F2-avanti, F3-retro</choice>
       </enumChoice>
       <enumChoice choice="Auto F2 for/rev">
-         <choice xml:lang="it">Automatico: F2-avanti/retro</choice>
+        <choice xml:lang="it">Automatico: F2-avanti/retro</choice>
       </enumChoice>
     </enumVal>
     <label>Button Control Direction</label>

--- a/xml/decoders/tcs/CV1_CV99_wow.xml
+++ b/xml/decoders/tcs/CV1_CV99_wow.xml
@@ -768,19 +768,22 @@
 	<label xml:lang="it">Gruppo Effetti filo Bianco</label>
   </variable>
   <variable CV="49" mask="XXXXVVVV" item="Output 1 effect generated">
-        <qualifier>
+    <qualifier>
 	  <variableref>White Wire Effect Group</variableref>
 	  <relation>eq</relation>
 	  <value>1</value>
 	</qualifier>
-        <xi:include href="http://jmri.org/xml/decoders/tcs/enum-CVX_light_short.xml"/><label>White Wire Effect 1</label><label xml:lang="it">Gruppo Effetti filo Bianco 1</label></variable>
+    <xi:include href="http://jmri.org/xml/decoders/tcs/enum-CVX_light_short.xml"/>
+    <label>White Wire Effect 1</label>
+    <label xml:lang="it">Gruppo Effetti filo Bianco 1</label>
+  </variable>
   <variable CV="49" mask="XXXXVVVV" item="Output 1 behavior" exclude="220">
-        <qualifier>
+    <qualifier>
 	  <variableref>White Wire Effect Group</variableref>
 	  <relation>eq</relation>
 	  <value>0</value>
 	</qualifier>
-        <enumVal>
+    <enumVal>
 	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
 	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
 	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Momentarypulse.xml"/>
@@ -793,12 +796,12 @@
     <label xml:lang="it">Effetti 0 filo Bianco</label>
   </variable>
   <variable CV="49" mask="XXXXVVVV" item="Output 1 behavior" default="8" include="220">
-        <qualifier>
+    <qualifier>
 	  <variableref>White Wire Effect Group</variableref>
 	  <relation>eq</relation>
 	  <value>0</value>
 	</qualifier>
-        <enumVal>
+    <enumVal>
 	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
 	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
 	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Momentarypulse.xml"/>
@@ -828,19 +831,22 @@
 	<label xml:lang="it">Yellow Wire Effect Group</label>
   </variable>
   <variable CV="50" mask="XXXXVVVV" item="Output 2 effect generated">
-        <qualifier>
+    <qualifier>
 	  <variableref>Yellow Wire Effect Group</variableref>
 	  <relation>eq</relation>
 	  <value>1</value>
 	</qualifier>
-        <xi:include href="http://jmri.org/xml/decoders/tcs/enum-CVX_light_short.xml"/><label>Yellow Wire Effect 1</label><label xml:lang="it">Gruppo 1 Effetti filo Giallo</label></variable>
+    <xi:include href="http://jmri.org/xml/decoders/tcs/enum-CVX_light_short.xml"/>
+    <label>Yellow Wire Effect 1</label>
+    <label xml:lang="it">Gruppo 1 Effetti filo Giallo</label>
+  </variable>
   <variable CV="50" mask="XXXXVVVV" item="Output 2 behavior" exclude="220">
-        <qualifier>
+    <qualifier>
 	  <variableref>Yellow Wire Effect Group</variableref>
 	  <relation>eq</relation>
 	  <value>0</value>
 	</qualifier>
-        <enumVal>
+    <enumVal>
 	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
 	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
 	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Momentarypulse.xml"/>
@@ -848,14 +854,17 @@
 	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constdim.xml"/>
 	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_AutoMarsBrake.xml"/>
 	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_SingleStrobe2.xml"/>
-	</enumVal><label>Yellow Wire Effect 0</label><label xml:lang="it">Gruppo 0 Effetti filo Giallo</label></variable>
+	</enumVal>
+	<label>Yellow Wire Effect 0</label>
+	<label xml:lang="it">Gruppo 0 Effetti filo Giallo</label>
+  </variable>
   <variable CV="50" mask="XXXXVVVV" item="Output 2 behavior" default="8" include="220">
-        <qualifier>
+    <qualifier>
 	  <variableref>Yellow Wire Effect Group</variableref>
 	  <relation>eq</relation>
 	  <value>0</value>
 	</qualifier>
-        <enumVal>
+    <enumVal>
 	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
 	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
 	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Momentarypulse.xml"/>
@@ -863,7 +872,10 @@
 	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constdim.xml"/>
 	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_AutoMarsBrake.xml"/>
 	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_SingleStrobe2.xml"/>
-	</enumVal><label>Yellow Wire Effect 0</label><label xml:lang="it">Gruppo 0 Effetti filo Giallo</label></variable>
+	</enumVal>
+	<label>Yellow Wire Effect 0</label>
+	<label xml:lang="it">Gruppo 0 Effetti filo Giallo</label>
+  </variable>
   <variable CV="50" mask="XXVVXXXX" default="1" item="Output 2 option 1">
 	<xi:include href="http://jmri.org/xml/decoders/parts/enum-frw_rev_both.xml"/>
 	<label>Yellow Wire Timing</label>
@@ -882,19 +894,22 @@
 	<label xml:lang="it">Gruppo Effetti filo Verde</label>
   </variable>
   <variable CV="51" mask="XXXXVVVV" minOut="3" item="Output 3 effect generated">
-        <qualifier>
+    <qualifier>
 	  <variableref>Green Wire Effect Group</variableref>
 	  <relation>eq</relation>
 	  <value>1</value>
 	</qualifier>
-        <xi:include href="http://jmri.org/xml/decoders/tcs/enum-CVX_light_short.xml"/><label>Green Wire Effect 1</label><label xml:lang="it">Gruppo 1 Effetti filo Verde</label></variable>
+    <xi:include href="http://jmri.org/xml/decoders/tcs/enum-CVX_light_short.xml"/>
+    <label>Green Wire Effect 1</label>
+    <label xml:lang="it">Gruppo 1 Effetti filo Verde</label>
+  </variable>
   <variable CV="51" mask="XXXXVVVV" minOut="3" item="Output 3 behavior" exclude="220">
-        <qualifier>
+    <qualifier>
 	  <variableref>Green Wire Effect Group</variableref>
 	  <relation>eq</relation>
 	  <value>0</value>
 	</qualifier>
-        <enumVal>
+    <enumVal>
 	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
 	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
 	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Momentarypulse.xml"/>
@@ -902,14 +917,17 @@
 	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constdim.xml"/>
 	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_AutoMarsBrake.xml"/>
 	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_SingleStrobe2.xml"/>
-	</enumVal><label>Green Wire Effect 0</label><label xml:lang="it">Gruppo 0 Effetti filo Verde</label></variable>
+	</enumVal>
+	<label>Green Wire Effect 0</label>
+	<label xml:lang="it">Gruppo 0 Effetti filo Verde</label>
+  </variable>
   <variable CV="51" mask="XXXXVVVV" minOut="3" item="Output 3 behavior" default="10" include="220">
-        <qualifier>
+    <qualifier>
 	  <variableref>Green Wire Effect Group</variableref>
 	  <relation>eq</relation>
 	  <value>0</value>
 	</qualifier>
-        <enumVal>
+    <enumVal>
 	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
 	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
 	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Momentarypulse.xml"/>
@@ -917,7 +935,10 @@
 	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constdim.xml"/>
 	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_AutoMarsBrake.xml"/>
 	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_SingleStrobe2.xml"/>
-	</enumVal><label>Green Wire Effect 0</label><label xml:lang="it">Gruppo 0 Effetti filo Verde</label></variable>
+	</enumVal>
+	<label>Green Wire Effect 0</label>
+	<label xml:lang="it">Gruppo 0 Effetti filo Verde</label>
+  </variable>
   <variable CV="51" mask="XXVVXXXX" minOut="3" default="2" item="Output 3 option 1" exclude="220">
 	<xi:include href="http://jmri.org/xml/decoders/parts/enum-frw_rev_both.xml"/>
 	<label>Green Wire Timing</label>
@@ -941,19 +962,22 @@
 	<label xml:lang="it">Gruppo Effetti filo Porpora</label>
   </variable>
   <variable CV="52" mask="XXXXVVVV" minOut="4" item="Output 4 effect generated">
-        <qualifier>
+    <qualifier>
 	  <variableref>Purple Wire Effect Group</variableref>
 	  <relation>eq</relation>
 	  <value>1</value>
 	</qualifier>
-        <xi:include href="http://jmri.org/xml/decoders/tcs/enum-CVX_light_short.xml"/><label>Purple Wire Effect 1</label><label xml:lang="it">Gruppo 1 Effetti filo Porpora</label></variable>
+    <xi:include href="http://jmri.org/xml/decoders/tcs/enum-CVX_light_short.xml"/>
+    <label>Purple Wire Effect 1</label>
+    <label xml:lang="it">Gruppo 1 Effetti filo Porpora</label>
+  </variable>
   <variable CV="52" mask="XXXXVVVV" minOut="4" item="Output 4 behavior" exclude="220">
-        <qualifier>
+    <qualifier>
 	  <variableref>Purple Wire Effect Group</variableref>
 	  <relation>eq</relation>
 	  <value>0</value>
 	</qualifier>
-        <enumVal>
+    <enumVal>
 	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
 	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
 	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Momentarypulse.xml"/>
@@ -961,14 +985,17 @@
 	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constdim.xml"/>
 	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_AutoMarsBrake.xml"/>
 	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_SingleStrobe2.xml"/>
-	</enumVal><label>Purple Wire Effect 0</label><label xml:lang="it">Gruppo 0 Effetti filo Porpora</label></variable>
+	</enumVal>
+	<label>Purple Wire Effect 0</label>
+	<label xml:lang="it">Gruppo 0 Effetti filo Porpora</label>
+  </variable>
   <variable CV="52" mask="XXXXVVVV" minOut="4" item="Output 4 behavior" default="11" include="220">
-        <qualifier>
+    <qualifier>
 	  <variableref>Purple Wire Effect Group</variableref>
 	  <relation>eq</relation>
 	  <value>0</value>
 	</qualifier>
-        <enumVal>
+    <enumVal>
 	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
 	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
 	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Momentarypulse.xml"/>
@@ -976,7 +1003,10 @@
 	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constdim.xml"/>
 	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_AutoMarsBrake.xml"/>
 	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_SingleStrobe2.xml"/>
-	</enumVal><label>Purple Wire Effect 0</label><label xml:lang="it">Gruppo 0 Effetti filo Porpora</label></variable>
+	</enumVal>
+	<label>Purple Wire Effect 0</label>
+	<label xml:lang="it">Gruppo 0 Effetti filo Porpora</label>
+  </variable>
   <variable CV="52" mask="XXVVXXXX" minOut="4" default="2" item="Output 4 option 1" exclude="220">
 	<xi:include href="http://jmri.org/xml/decoders/parts/enum-frw_rev_both.xml"/>
 	<label>Purple Wire Timing</label>
@@ -1000,19 +1030,22 @@
 	<label xml:lang="it">Gruppo Effetti filo Marrone</label>
   </variable>
   <variable CV="53" mask="XXXXVVVV" minOut="5" item="Output 5 effect generated" exclude="61">
-        <qualifier>
+    <qualifier>
 	  <variableref>Brown Wire Effect Group</variableref>
 	  <relation>eq</relation>
 	  <value>1</value>
 	</qualifier>
-        <xi:include href="http://jmri.org/xml/decoders/tcs/enum-CVX_light_short.xml"/><label>Brown Wire Effect 1</label><label xml:lang="it">Gruppo 1 Effetti filo Marrone</label></variable>
+    <xi:include href="http://jmri.org/xml/decoders/tcs/enum-CVX_light_short.xml"/>
+    <label>Brown Wire Effect 1</label>
+    <label xml:lang="it">Gruppo 1 Effetti filo Marrone</label>
+  </variable>
   <variable CV="53" mask="XXXXVVVV" minOut="5" item="Output 5 behavior" exclude="61,220">
-        <qualifier>
+    <qualifier>
 	  <variableref>Brown Wire Effect Group</variableref>
 	  <relation>eq</relation>
 	  <value>0</value>
 	</qualifier>
-        <enumVal>
+    <enumVal>
 	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
 	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
 	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Momentarypulse.xml"/>
@@ -1020,14 +1053,17 @@
 	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constdim.xml"/>
 	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_AutoMarsBrake.xml"/>
 	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_SingleStrobe2.xml"/>
-	</enumVal><label>Brown Wire Effect 0</label><label xml:lang="it">Gruppo 0 Effetti filo Marrone</label></variable>
+	</enumVal>
+	<label>Brown Wire Effect 0</label>
+	<label xml:lang="it">Gruppo 0 Effetti filo Marrone</label>
+  </variable>
   <variable CV="53" mask="XXXXVVVV" minOut="5" item="Output 5 behavior" default="10" include="220">
-        <qualifier>
+    <qualifier>
 	  <variableref>Brown Wire Effect Group</variableref>
 	  <relation>eq</relation>
 	  <value>0</value>
 	</qualifier>
-        <enumVal>
+    <enumVal>
 	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
 	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
 	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Momentarypulse.xml"/>
@@ -1035,7 +1071,10 @@
 	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constdim.xml"/>
 	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_AutoMarsBrake.xml"/>
 	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_SingleStrobe2.xml"/>
-	</enumVal><label>Brown Wire Effect 0</label><label xml:lang="it">Gruppo 0 Effetti filo Marrone</label></variable>
+	</enumVal>
+	<label>Brown Wire Effect 0</label>
+	<label xml:lang="it">Gruppo 0 Effetti filo Marrone</label>
+  </variable>
   <variable CV="53" mask="XXVVXXXX" minOut="5" default="2" item="Output 5 option 1" exclude="61,220">
 	<xi:include href="http://jmri.org/xml/decoders/parts/enum-frw_rev_both.xml"/>
 	<label>Brown Wire Timing</label>
@@ -1059,19 +1098,22 @@
 	<label xml:lang="it">Gruppo Effetti filo Rosa</label>
   </variable>
   <variable CV="54" mask="XXXXVVVV" minOut="6" item="Output 6 effect generated" exclude="61">
-        <qualifier>
+    <qualifier>
 	  <variableref>Pink Wire Effect Group</variableref>
 	  <relation>eq</relation>
 	  <value>1</value>
 	</qualifier>
-        <xi:include href="http://jmri.org/xml/decoders/tcs/enum-CVX_light_short.xml"/><label>Pink Wire Effect 1</label><label xml:lang="it">Gruppo 1 Effetti filo Rosa</label></variable>
+    <xi:include href="http://jmri.org/xml/decoders/tcs/enum-CVX_light_short.xml"/>
+    <label>Pink Wire Effect 1</label>
+    <label xml:lang="it">Gruppo 1 Effetti filo Rosa</label>
+  </variable>
   <variable CV="54" mask="XXXXVVVV" minOut="6" item="Output 6 behavior" exclude="61,220">
-        <qualifier>
+    <qualifier>
 	  <variableref>Pink Wire Effect Group</variableref>
 	  <relation>eq</relation>
 	  <value>0</value>
 	</qualifier>
-        <enumVal>
+    <enumVal>
 	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
 	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
 	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Momentarypulse.xml"/>
@@ -1079,14 +1121,17 @@
 	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constdim.xml"/>
 	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_AutoMarsBrake.xml"/>
 	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_SingleStrobe2.xml"/>
-	</enumVal><label>Pink Wire Effect 0</label><label xml:lang="it">Gruppo 0 Effetti filo Rosa</label></variable>
+	</enumVal>
+	<label>Pink Wire Effect 0</label>
+	<label xml:lang="it">Gruppo 0 Effetti filo Rosa</label>
+  </variable>
   <variable CV="54" mask="XXXXVVVV" minOut="6" item="Output 6 behavior" default="11" include="220">
-        <qualifier>
+    <qualifier>
 	  <variableref>Pink Wire Effect Group</variableref>
 	  <relation>eq</relation>
 	  <value>0</value>
 	</qualifier>
-        <enumVal>
+    <enumVal>
 	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
 	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
 	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Momentarypulse.xml"/>
@@ -1094,7 +1139,10 @@
 	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constdim.xml"/>
 	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_AutoMarsBrake.xml"/>
 	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_SingleStrobe2.xml"/>
-	</enumVal><label>Pink Wire Effect 0</label><label xml:lang="it">Gruppo 0 Effetti filo Rosa</label></variable>
+	</enumVal>
+	<label>Pink Wire Effect 0</label>
+	<label xml:lang="it">Gruppo 0 Effetti filo Rosa</label>
+  </variable>
   <variable CV="54" mask="XXVVXXXX" minOut="6" default="2" item="Output 6 option 1" exclude="61,220">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-frw_rev_both.xml"/>
     <label>Pink Wire Timing</label>
@@ -1115,43 +1163,43 @@
     <label>Outputs 7 and 8 effect generated</label>
   </variable>
   <variable CV="61" mask="XXXXXXXV" default="1" item="EMF Enable" tooltip="BEMF always enabled, Dither disabled">
-  <enumVal>
-    <enumChoice choice="BEMF always enabled, Dither disabled" value="1">
-    </enumChoice>
-  </enumVal>
+    <enumVal>
+      <enumChoice choice="BEMF always enabled, Dither disabled" value="1">
+      </enumChoice>
+    </enumVal>
     <label>BEMF Enable</label>
     <label xml:lang="it">Abilitazione BEMF</label>
   </variable>
   <variable CV="61" mask="XXXXVXXX" default="1" item="Function 5 effect generated" tooltip="Disable(default)/Enable button control of Brake">
-  <xi:include href="http://jmri.org/xml/decoders/parts/enum-disabledEnabled.xml"/>
-  <label>Enable Brake Button Control</label>
-  <label xml:lang="it">Abilita pulsante controllo Freni</label>
-  <tooltip xml:lang="it">Disabilita(default)/Abilita controllo Freni da pulsante</tooltip>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-disabledEnabled.xml"/>
+    <label>Enable Brake Button Control</label>
+    <label xml:lang="it">Abilita pulsante controllo Freni</label>
+    <tooltip xml:lang="it">Disabilita(default)/Abilita controllo Freni da pulsante</tooltip>
   </variable>
   <variable CV="61" mask="XXXVXXXX" item="Directional Headlights">
-  <xi:include href="http://jmri.org/xml/decoders/parts/enum-disabledEnabled.xml"/>
-  <label>Headlight Dim When Stopped</label>
-  <label xml:lang="it">Luce frontale smorzata da fermo</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-disabledEnabled.xml"/>
+    <label>Headlight Dim When Stopped</label>
+    <label xml:lang="it">Luce frontale smorzata da fermo</label>
   </variable>
   <variable CV="61" mask="XXVXXXXX" item="Global lighting option 1">
-  <xi:include href="http://jmri.org/xml/decoders/parts/enum-disabledEnabled.xml"/>
-  <label>Opposite Headlight Dim</label>
-  <label xml:lang="it">Smorzamento luci opposte</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-disabledEnabled.xml"/>
+    <label>Opposite Headlight Dim</label>
+    <label xml:lang="it">Smorzamento luci opposte</label>
   </variable>
   <variable CV="61" mask="XVXXXXXX" item="EMF Static Config" tooltip="Motor controlled by Function button">
-  <enumVal>
-    <enumChoice choice="Disabled">
-     <choice xml:lang="fr">Désactivé</choice>
-      <choice xml:lang="it">Disabilitato</choice>
-      <choice xml:lang="de">Deaktiviert</choice>
-    </enumChoice>
-    <enumChoice choice="Button control of motor">
-     <choice xml:lang="it">Pulsante controllo Motore</choice>
-    </enumChoice>
-  </enumVal>
-  <label>Motor Button Control</label>
-  <label xml:lang="it">Pulsante controllo Motore</label>
-  <tooltip xml:lang="it">Motore controllato da Pulsante Funzione</tooltip>
+    <enumVal>
+      <enumChoice choice="Disabled">
+        <choice xml:lang="fr">Désactivé</choice>
+        <choice xml:lang="it">Disabilitato</choice>
+        <choice xml:lang="de">Deaktiviert</choice>
+      </enumChoice>
+      <enumChoice choice="Button control of motor">
+        <choice xml:lang="it">Pulsante controllo Motore</choice>
+      </enumChoice>
+    </enumVal>
+    <label>Motor Button Control</label>
+    <label xml:lang="it">Pulsante controllo Motore</label>
+    <tooltip xml:lang="it">Motore controllato da Pulsante Funzione</tooltip>
   </variable>
   <variable CV="61" mask="XXXXXVXX" item="EMF Dynamic Config" tooltip="If motor button control is active">
 	<enumVal>

--- a/xml/decoders/tcs/CV1_CV99_wow.xml
+++ b/xml/decoders/tcs/CV1_CV99_wow.xml
@@ -17,168 +17,168 @@
 <variables xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
   <xi:include href="http://jmri.org/xml/decoders/nmra/shortAndLongAddress.xml"/>
   <variable CV="2" item="Vstart" default="0" tooltip="sets the motor voltage at Speed Step 1, range 0(default)-255" comment="Range 0-255, 0 in CV 2, 6, 5 produces straight line acceleration">
-	<decVal/>
-	<label>Start voltage</label>
-	<label xml:lang="it">Volt di Partenza</label>
-	<comment xml:lang="it">Valori 0-255, 0 in CV2, CV5, CV6 produce accellerazione lineare</comment>
-	<tooltip xml:lang="it">Progr. tensione motore a Velocità Step 1, valori 0(default)-255. Vedi anche CV56</tooltip>
+    <decVal/>
+    <label>Start voltage</label>
+    <label xml:lang="it">Volt di Partenza</label>
+    <comment xml:lang="it">Valori 0-255, 0 in CV2, CV5, CV6 produce accellerazione lineare</comment>
+    <tooltip xml:lang="it">Progr. tensione motore a Velocità Step 1, valori 0(default)-255. Vedi anche CV56</tooltip>
   </variable>
   <variable CV="5" item="Vhigh" default="0" tooltip="sets the motor voltage at top throttle Speed Setting, range 0(default)-255" comment="Range 0-255, A value of 255 corresponds to 100%. 0 in CV 2, 6, 5 produces straight line acceleration">
-	<decVal/>
-	<label>Maximum Voltage</label>
-	<label xml:lang="it">Volt Massimi</label>
-	<label xml:lang="de">Höchstgeschwindigkeit</label>
-	<comment xml:lang="it">Valori 0-255, Un valore di 255 corrisponde al 100%. 0 in CV 2, 6, 5 produce curva accellerazione linea retta</comment>
-	<tooltip xml:lang="it">Progr tensione motore alla massima velocità, valori 0(default)-255</tooltip>
-  </variable> 
+    <decVal/>
+    <label>Maximum Voltage</label>
+    <label xml:lang="it">Volt Massimi</label>
+    <label xml:lang="de">Höchstgeschwindigkeit</label>
+    <comment xml:lang="it">Valori 0-255, Un valore di 255 corrisponde al 100%. 0 in CV 2, 6, 5 produce curva accellerazione linea retta</comment>
+    <tooltip xml:lang="it">Progr tensione motore alla massima velocità, valori 0(default)-255</tooltip>
+  </variable>
   <variable CV="6" item="Vmid" tooltip="sets the motor voltage at midrange throttle Speed Setting, range 0(default)-255" comment="Range 0-255, 0 in CV 2, 6, 5 produces straight line acceleration">
-	<decVal/>
-	<label>Midpoint Voltage</label>
-	<label xml:lang="it">Volts intermedi</label>
-	<label xml:lang="de">Vmittel (0-255)</label>
-	<comment xml:lang="it">valori 0-255, 0 in CV 2, 6, 5 produce curva accellerazione linea retta</comment>
-	<tooltip xml:lang="it">Progr tensione motore a velocità intermedia, valori 0(default)-255</tooltip>
+    <decVal/>
+    <label>Midpoint Voltage</label>
+    <label xml:lang="it">Volts intermedi</label>
+    <label xml:lang="de">Vmittel (0-255)</label>
+    <comment xml:lang="it">valori 0-255, 0 in CV 2, 6, 5 produce curva accellerazione linea retta</comment>
+    <tooltip xml:lang="it">Progr tensione motore a velocità intermedia, valori 0(default)-255</tooltip>
   </variable>
   <variable CV="7" item="Decoder Version" readOnly="yes" tooltip="=41-46 for all TCS with Back EMF models, Read Only">
-	<decVal/>
-	<label>Version ID</label>
-	<label xml:lang="it">ID Versione</label>
-	<tooltip xml:lang="it">=41-46 per tutti i modelli TCS con Back EMF, Sola Lettura</tooltip>
+    <decVal/>
+    <label>Version ID</label>
+    <label xml:lang="it">ID Versione</label>
+    <tooltip xml:lang="it">=41-46 per tutti i modelli TCS con Back EMF, Sola Lettura</tooltip>
   </variable>
   <variable CV="8" readOnly="yes" item="Manufacturer" default="153" tooltip="=153 for TCS, Read Only">
-	<decVal/>
-	<label>Manufacturer ID</label>
-	<label xml:lang="it">ID Costruttore</label>
-	<tooltip xml:lang="it">=153 per TCS, Sola Lettura</tooltip>
+    <decVal/>
+    <label>Manufacturer ID</label>
+    <label xml:lang="it">ID Costruttore</label>
+    <tooltip xml:lang="it">=153 per TCS, Sola Lettura</tooltip>
   </variable>
   <variable CV="13" mask="XXXXXXXV" default="1" minOut="2" item="Analog Mode Function Status - FL(f)">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-	<label>Analog Mode White/Yellow</label>
-	<label xml:lang="it">Modo Analogico Bianco/Giallo</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+    <label>Analog Mode White/Yellow</label>
+    <label xml:lang="it">Modo Analogico Bianco/Giallo</label>
   </variable>
   <variable CV="13" mask="XXXXXXVX" default="1" minOut="3" item="Analog Mode Function Status - FL(r)">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-	<label>Analog Mode Green</label>
-	<label xml:lang="it">Modo Analogico Verde</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+    <label>Analog Mode Green</label>
+    <label xml:lang="it">Modo Analogico Verde</label>
   </variable>
   <variable CV="13" mask="XXXXXVXX" default="1" minOut="4" item="Analog Mode Function Status - F1">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-	<label>Analog Mode Purple</label>
-	<label xml:lang="it">Modo Analogico Porpora</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+    <label>Analog Mode Purple</label>
+    <label xml:lang="it">Modo Analogico Porpora</label>
   </variable>
   <variable CV="13" mask="XXXXVXXX" default="1" minOut="5" item="Analog Mode Function Status - F2">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-	<label>Analog Mode Brown</label>
-	<label xml:lang="it">Modo Analogico Marrone</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+    <label>Analog Mode Brown</label>
+    <label xml:lang="it">Modo Analogico Marrone</label>
   </variable>
   <variable CV="13" mask="XXXVXXXX" default="1" minOut="6" item="Analog Mode Function Status - F3">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-	<label>Analog Mode Pink</label>
-	<label xml:lang="it">Modo Analogico Rosa</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+    <label>Analog Mode Pink</label>
+    <label xml:lang="it">Modo Analogico Rosa</label>
   </variable>
   <variable CV="13" mask="XXVXXXXX" default="1" minOut="7" item="Analog Mode Function Status - F4">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-	<label>Analog Mode Pink/Purple</label>
-	<label xml:lang="it">Modo Analogico Rosa/Porpora</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+    <label>Analog Mode Pink/Purple</label>
+    <label xml:lang="it">Modo Analogico Rosa/Porpora</label>
   </variable>
   <variable CV="13" mask="XVXXXXXX" default="1" minOut="8" item="Analog Mode Function Status - F5">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-	<label>Analog Mode Green/Brown</label>
-	<label xml:lang="it">Modo Analogico Verde/Marrone</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+    <label>Analog Mode Green/Brown</label>
+    <label xml:lang="it">Modo Analogico Verde/Marrone</label>
   </variable>
   <variable item="Decoder Lock control number" CV="15" mask="XXXXXVVV" default="0" tooltip="To unlock a decoder make CV15=0 or CV15=CV16">
-	<decVal/>
-	<label>Decoder Lock control number</label>
-	<label xml:lang="it">Codice Blocco Decoder</label>
-	<tooltip xml:lang="it">Per sbloccare il decoder metti CV15=0 o CV15=CV16</tooltip>
+    <decVal/>
+    <label>Decoder Lock control number</label>
+    <label xml:lang="it">Codice Blocco Decoder</label>
+    <tooltip xml:lang="it">Per sbloccare il decoder metti CV15=0 o CV15=CV16</tooltip>
   </variable>
   <variable item="Decoder Lock ID number" CV="16" mask="XXXXXVVV" default="2" tooltip="Set this decoder's locking ID number, range 1-6, default 2">
-	<decVal/>
-	<label>Decoder Lock ID number</label>
-	<label xml:lang="it">Codice ID Blocco Decoder</label>
-	<tooltip xml:lang="it">Progr. ID di questo decoder, valori 1-6, default 2</tooltip>
+    <decVal/>
+    <label>Decoder Lock ID number</label>
+    <label xml:lang="it">Codice ID Blocco Decoder</label>
+    <tooltip xml:lang="it">Progr. ID di questo decoder, valori 1-6, default 2</tooltip>
   </variable>
   <xi:include href="http://jmri.org/xml/decoders/nmra/consistAddrDirection.xml"/>
   <variable CV="21" mask="XXXXXXXV" default="0" item="Consist Address Active For F1">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-LocoAddrConsistAddr.xml"/>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-LocoAddrConsistAddr.xml"/>
   </variable>
   <variable CV="21" mask="XXXXXXVX" default="0" item="Consist Address Active For F2">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-LocoAddrConsistAddr.xml"/>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-LocoAddrConsistAddr.xml"/>
   </variable>
   <variable CV="21" mask="XXXXXVXX" default="0" item="Consist Address Active For F3">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-LocoAddrConsistAddr.xml"/>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-LocoAddrConsistAddr.xml"/>
   </variable>
   <variable CV="21" mask="XXXXVXXX" default="0" item="Consist Address Active For F4">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-LocoAddrConsistAddr.xml"/>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-LocoAddrConsistAddr.xml"/>
   </variable>
   <variable CV="21" mask="XXXVXXXX" default="0" item="Consist Address Active For F5" include="220">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-LocoAddrConsistAddr.xml"/>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-LocoAddrConsistAddr.xml"/>
   </variable>
   <variable CV="21" mask="XXXVXXXX" default="1" item="Consist Address Active For F5" exclude="220">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-LocoAddrConsistAddr.xml"/>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-LocoAddrConsistAddr.xml"/>
   </variable>
   <variable CV="21" mask="XXVXXXXX" default="0" item="Consist Address Active For F6" include="220">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-LocoAddrConsistAddr.xml"/>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-LocoAddrConsistAddr.xml"/>
   </variable>
   <variable CV="21" mask="XXVXXXXX" default="1" item="Consist Address Active For F6" exclude="220">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-LocoAddrConsistAddr.xml"/>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-LocoAddrConsistAddr.xml"/>
   </variable>
   <variable CV="21" mask="XVXXXXXX" default="0" item="Consist Address Active For F7" include="220">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-LocoAddrConsistAddr.xml"/>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-LocoAddrConsistAddr.xml"/>
   </variable>
   <variable CV="21" mask="XVXXXXXX" default="1" item="Consist Address Active For F7" exclude="220">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-LocoAddrConsistAddr.xml"/>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-LocoAddrConsistAddr.xml"/>
   </variable>
   <variable CV="21" mask="VXXXXXXX" default="0" item="Consist Address Active For F8" include="220">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-LocoAddrConsistAddr.xml"/>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-LocoAddrConsistAddr.xml"/>
   </variable>
   <variable CV="21" mask="VXXXXXXX" default="1" item="Consist Address Active For F8" exclude="220">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-LocoAddrConsistAddr.xml"/>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-LocoAddrConsistAddr.xml"/>
   </variable>
   <variable CV="22" mask="XXXXXXXV" item="Consist Address Active For FL in Forward">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-LocoAddrConsistAddr.xml"/>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-LocoAddrConsistAddr.xml"/>
   </variable>
   <variable CV="22" mask="XXXXXXVX" item="Consist Address Active For FL in Reverse">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-LocoAddrConsistAddr.xml"/>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-LocoAddrConsistAddr.xml"/>
   </variable>
   <variable CV="22" mask="XXXXXVXX" item="Consist Address Active For F9">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-LocoAddrConsistAddr.xml"/>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-LocoAddrConsistAddr.xml"/>
   </variable>
   <variable CV="22" mask="XXXXVXXX" item="Consist Address Active For F10">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-LocoAddrConsistAddr.xml"/>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-LocoAddrConsistAddr.xml"/>
   </variable>
   <variable CV="22" mask="XXXVXXXX" item="Consist Address Active For F11">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-LocoAddrConsistAddr.xml"/>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-LocoAddrConsistAddr.xml"/>
   </variable>
   <variable CV="22" mask="XXVXXXXX" item="Consist Address Active For F12">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-LocoAddrConsistAddr.xml"/>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-LocoAddrConsistAddr.xml"/>
   </variable>
   <variable item="Consist Acceleration Adjustment" CV="23" tooltip="Values above 128 increase adjustment, below 128 decrease adjustment">
-	<decVal max="255"/>
-	<label>Consist Acceleration Adjustment</label>
-	<label xml:lang="it">Correzione Accellerazione Consist</label>
-	<tooltip xml:lang="it">Valori oltre 128 incrementano correzzione, minori di 128 decrementano</tooltip>
+    <decVal max="255"/>
+    <label>Consist Acceleration Adjustment</label>
+    <label xml:lang="it">Correzione Accellerazione Consist</label>
+    <tooltip xml:lang="it">Valori oltre 128 incrementano correzzione, minori di 128 decrementano</tooltip>
   </variable>
   <variable item="Consist Deceleration Adjustment" CV="24" tooltip="Values above 128 increase adjustment, below 128 decrease adjustment">
-	<decVal max="255"/>
-	<label>Consist Deceleration Adjustment</label>
-	<label xml:lang="it">Correzione Decellazione Consist</label>
-	<tooltip xml:lang="it">Valori oltre 128 incrementano correzzione, minori di 128 decrementano</tooltip>
+    <decVal max="255"/>
+    <label>Consist Deceleration Adjustment</label>
+    <label xml:lang="it">Correzione Decellazione Consist</label>
+    <tooltip xml:lang="it">Valori oltre 128 incrementano correzzione, minori di 128 decrementano</tooltip>
   </variable>
   <variable item="Advanced Group 2 Option 12" CV="28" default="0" mask="XXXXXXXV">
-   <xi:include href="http://jmri.org/xml/decoders/parts/enum-disabledEnabled.xml"/>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-disabledEnabled.xml"/>
     <label>RailCom Enable Unsolicited Decoder Initiated Transmission</label>
-	<tooltip>NOTE: A value of 8 must be added to CV29 to Enable RailCom</tooltip>
+    <tooltip>NOTE: A value of 8 must be added to CV29 to Enable RailCom</tooltip>
   </variable>
   <variable item="Advanced Group 2 Option 13" CV="28" default="0" mask="XXXXXXVX">
-   <xi:include href="http://jmri.org/xml/decoders/parts/enum-disabledEnabled.xml"/>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-disabledEnabled.xml"/>
     <label>RailCom Enable Initiated Broadcast Transmission using Asymmetrical DCC Signal</label>
-	<tooltip>NOTE: A value of 8 must be added to CV29 to Enable RailCom</tooltip>
+    <tooltip>NOTE: A value of 8 must be added to CV29 to Enable RailCom</tooltip>
   </variable>
   <variable item="Advanced Group 2 Option 14" CV="28" default="0" mask="XXXXXVXX">
-   <xi:include href="http://jmri.org/xml/decoders/parts/enum-disabledEnabled.xml"/>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-disabledEnabled.xml"/>
     <label>RailCom Enable Initiated Broadcast Transmission using Signal Controlled Influence Signal</label>
-	<tooltip>NOTE: A value of 8 must be added to CV29 to Enable RailCom</tooltip>
+    <tooltip>NOTE: A value of 8 must be added to CV29 to Enable RailCom</tooltip>
   </variable>
   <variable CV="29" mask="XXXXXXXV" item="Locomotive Direction">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-FwdRev.xml"/>
@@ -213,105 +213,105 @@
   </variable>
   <variable CV="29" mask="XXXVXXXX" item="Speed Table Definition">
     <enumVal>
-       <enumChoice choice="Use Vstart, Vmid, Vhigh">
-         <choice xml:lang="it">Usa Vstart, Vmid, Vhigh</choice>
+      <enumChoice choice="Use Vstart, Vmid, Vhigh">
+        <choice xml:lang="it">Usa Vstart, Vmid, Vhigh</choice>
       </enumChoice>
       <enumChoice choice="Use Table">
-         <choice xml:lang="it">Usa Tabella Velocità</choice>
+        <choice xml:lang="it">Usa Tabella Velocità</choice>
       </enumChoice>
     </enumVal>
     <label>Use Speed Table</label>
     <label xml:lang="it">Usa Tabella Velocità</label>
   </variable>
   <variable item="FL(f) controls output 1" CV="33" mask="XXXXXXXV" minOut="1" default="1">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
-	<label>FL(f) controls output 1</label>
-	<label xml:lang="it">Luci (in avanti) controlla uscita 1</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+    <label>FL(f) controls output 1</label>
+    <label xml:lang="it">Luci (in avanti) controlla uscita 1</label>
   </variable>
   <variable item="FL(r) controls output 1" CV="33" mask="XXXXXXVX" minOut="1">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
-	<label>FL(r) controls output 1</label>
-	<label xml:lang="it">Luci (in retro) controlla uscita 1</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+    <label>FL(r) controls output 1</label>
+    <label xml:lang="it">Luci (in retro) controlla uscita 1</label>
   </variable>
   <variable item="F1 controls output 1" CV="33" mask="XXXXXVXX" minOut="1">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
-	<label>F1 controls output 1</label>
-	<label xml:lang="it">F1 controlla uscita 1</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+    <label>F1 controls output 1</label>
+    <label xml:lang="it">F1 controlla uscita 1</label>
   </variable>
   <variable item="F2 controls output 1" CV="33" mask="XXXXVXXX" minOut="1">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
-	<label>F2 controls output 1</label>
-	 <label xml:lang="it">F2 controlla uscita 1</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+    <label>F2 controls output 1</label>
+    <label xml:lang="it">F2 controlla uscita 1</label>
   </variable>
   <variable item="F3 controls output 1" CV="33" mask="XXXVXXXX" minOut="1">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
-	<label>F3 controls output 1</label>
-	 <label xml:lang="it">F3 controlla uscita 1</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+    <label>F3 controls output 1</label>
+    <label xml:lang="it">F3 controlla uscita 1</label>
   </variable>
   <variable item="F4 controls output 1" CV="33" mask="XXVXXXXX" minOut="1">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
-	<label>F4 controls output 1</label>
-	<label xml:lang="it">F4 controlla uscita 1</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+    <label>F4 controls output 1</label>
+    <label xml:lang="it">F4 controlla uscita 1</label>
   </variable>
   <variable item="F5 controls output 1" CV="33" mask="XVXXXXXX" minOut="1">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
-	<label>F5 controls output 1</label>
-	<label xml:lang="it">F5 controlla uscita 1</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+    <label>F5 controls output 1</label>
+    <label xml:lang="it">F5 controlla uscita 1</label>
   </variable>
   <variable item="F6 controls output 1" CV="33" mask="VXXXXXXX" minOut="1">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
-	<label>F6 controls output 1</label>
-	<label xml:lang="it">F6 controlla uscita 1</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+    <label>F6 controls output 1</label>
+    <label xml:lang="it">F6 controlla uscita 1</label>
   </variable>
   <variable item="FL(f) controls output 2" CV="34" mask="XXXXXXXV" minOut="2">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
-	<label>FL(f) controls output 2</label>
-	<label xml:lang="it">Luci (in avanti) controlla uscita 2</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+    <label>FL(f) controls output 2</label>
+    <label xml:lang="it">Luci (in avanti) controlla uscita 2</label>
   </variable>
   <variable item="FL(r) controls output 2" CV="34" mask="XXXXXXVX" minOut="2" default="1">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
-	<label>FL(r) controls output 2</label>
-	<label xml:lang="it">Luci (in retro) controlla uscita 2</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+    <label>FL(r) controls output 2</label>
+    <label xml:lang="it">Luci (in retro) controlla uscita 2</label>
   </variable>
   <variable item="F1 controls output 2" CV="34" mask="XXXXXVXX" minOut="2">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
-	<label>F1 controls output 2</label>
-	<label xml:lang="it">F1 controlla uscita 2</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+    <label>F1 controls output 2</label>
+    <label xml:lang="it">F1 controlla uscita 2</label>
   </variable>
   <variable item="F2 controls output 2" CV="34" mask="XXXXVXXX" minOut="2">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
-	<label>F2 controls output 2</label>
-	<label xml:lang="it">F2 controlla uscita 2</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+    <label>F2 controls output 2</label>
+    <label xml:lang="it">F2 controlla uscita 2</label>
   </variable>
   <variable item="F3 controls output 2" CV="34" mask="XXXVXXXX" minOut="2">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
-	<label>F3 controls output 2</label>
-	<label xml:lang="it">F3 controlla uscita 2</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+    <label>F3 controls output 2</label>
+    <label xml:lang="it">F3 controlla uscita 2</label>
   </variable>
   <variable item="F4 controls output 2" CV="34" mask="XXVXXXXX" minOut="2">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
-	<label>F4 controls output 2</label>
-	<label xml:lang="it">F4 controlla uscita 2</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+    <label>F4 controls output 2</label>
+    <label xml:lang="it">F4 controlla uscita 2</label>
   </variable>
   <variable item="F5 controls output 2" CV="34" mask="XVXXXXXX" minOut="2">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
-	<label>F5 controls output 2</label>
-	<label xml:lang="it">F5 controlla uscita 2</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+    <label>F5 controls output 2</label>
+    <label xml:lang="it">F5 controlla uscita 2</label>
   </variable>
   <variable item="F6 controls output 2" CV="34" mask="VXXXXXXX" minOut="2">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
-	<label>F6 controls output 2</label>
-	<label xml:lang="it">F6 controlla uscita 2</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+    <label>F6 controls output 2</label>
+    <label xml:lang="it">F6 controlla uscita 2</label>
   </variable>
   <variable item="FL(f) controls output 3" CV="35" mask="XXXXXXXV" minOut="3">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
-	<label>FL(f) controls output 3</label>
-	<label xml:lang="it">Luci (in avanti) controlla uscita 3</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+    <label>FL(f) controls output 3</label>
+    <label xml:lang="it">Luci (in avanti) controlla uscita 3</label>
   </variable>
   <variable item="FL(r) controls output 3" CV="35" mask="XXXXXXVX" minOut="3">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
-	<label>FL(r) controls output 3</label>
-	<label xml:lang="it">Luci (in retro) controlla uscita 3</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+    <label>FL(r) controls output 3</label>
+    <label xml:lang="it">Luci (in retro) controlla uscita 3</label>
   </variable>
   <variable item="F1 controls output 3" CV="35" mask="XXXXXVXX" minOut="3" default="0" include="220">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
@@ -324,9 +324,9 @@
     <label xml:lang="it">F1 controlla uscita 3</label>
   </variable>
   <variable item="F2 controls output 3" CV="35" mask="XXXXVXXX" minOut="3">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
-	<label>F2 controls output 3</label>
-	<label xml:lang="it">F2 controlla uscita 3</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+    <label>F2 controls output 3</label>
+    <label xml:lang="it">F2 controlla uscita 3</label>
   </variable>
   <variable item="F3 controls output 3" CV="35" mask="XXXVXXXX" minOut="3" exclude="220">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
@@ -339,29 +339,29 @@
     <label xml:lang="it">F3 controlla uscita 3</label>
   </variable>
   <variable item="F4 controls output 3" CV="35" mask="XXVXXXXX" minOut="3">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
-	<label>F4 controls output 3</label>
-	<label xml:lang="it">F4 controlla uscita 3</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+    <label>F4 controls output 3</label>
+    <label xml:lang="it">F4 controlla uscita 3</label>
   </variable>
   <variable item="F5 controls output 3" CV="35" mask="XVXXXXXX" minOut="3">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
-	<label>F5 controls output 3</label>
-	<label xml:lang="it">F5 controlla uscita 3</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+    <label>F5 controls output 3</label>
+    <label xml:lang="it">F5 controlla uscita 3</label>
   </variable>
   <variable item="F6 controls output 3" CV="35" mask="VXXXXXXX" minOut="3">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
-	<label>F6 controls output 3</label>
-	<label xml:lang="it">F6 controlla uscita 3</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+    <label>F6 controls output 3</label>
+    <label xml:lang="it">F6 controlla uscita 3</label>
   </variable>
   <variable item="FL(f) controls output 4" CV="36" mask="XXXXXXXV" minOut="4">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
-	<label>FL(f) controls output 4</label>
-	<label xml:lang="it">Luci (in avanti) controlla uscita 4</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+    <label>FL(f) controls output 4</label>
+    <label xml:lang="it">Luci (in avanti) controlla uscita 4</label>
   </variable>
   <variable item="FL(r) controls output 4" CV="36" mask="XXXXXXVX" minOut="4">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
-	<label>FL(r) controls output 4</label>
-	<label xml:lang="it">Luci (in retro) controlla uscita 4</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+    <label>FL(r) controls output 4</label>
+    <label xml:lang="it">Luci (in retro) controlla uscita 4</label>
   </variable>
   <variable item="F1 controls output 4" CV="36" mask="XXXXXVXX" minOut="4">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
@@ -389,129 +389,129 @@
     <label xml:lang="it">F3 controlla uscita 4</label>
   </variable>
   <variable item="F4 controls output 4" CV="36" mask="XXVXXXXX" minOut="4">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
-	<label>F4 controls output 4</label>
-	<label xml:lang="it">F4 controlla uscita 4</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+    <label>F4 controls output 4</label>
+    <label xml:lang="it">F4 controlla uscita 4</label>
   </variable>
   <variable item="F5 controls output 4" CV="36" mask="XVXXXXXX" minOut="4">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
-	<label>F5 controls output 4</label>
-	<label xml:lang="it">F5 controlla uscita 4</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+    <label>F5 controls output 4</label>
+    <label xml:lang="it">F5 controlla uscita 4</label>
   </variable>
   <variable item="F6 controls output 4" CV="36" mask="VXXXXXXX" minOut="4">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
-	<label>F6 controls output 4</label>
-	<label xml:lang="it">F6 controlla uscita 4</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+    <label>F6 controls output 4</label>
+    <label xml:lang="it">F6 controlla uscita 4</label>
   </variable>
   <variable item="F7 controls output 3" CV="37" mask="XXXXXVXX" minOut="3">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
-	<label>F7 controls output 3</label>
-	<label xml:lang="it">F7 controlla uscita 3</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+    <label>F7 controls output 3</label>
+    <label xml:lang="it">F7 controlla uscita 3</label>
   </variable>
   <variable item="F8 controls output 3" CV="37" mask="XXXXVXXX" minOut="3">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
-	<label>F8 controls output 3</label>
-	<label xml:lang="it">F8 controlla uscita 3</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+    <label>F8 controls output 3</label>
+    <label xml:lang="it">F8 controlla uscita 3</label>
   </variable>
   <variable item="F9 controls output 3" CV="37" mask="XXXVXXXX" minOut="3">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
-	<label>F9 controls output 3</label>
-	<label xml:lang="it">F9 controlla uscita 3</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+    <label>F9 controls output 3</label>
+    <label xml:lang="it">F9 controlla uscita 3</label>
   </variable>
   <variable item="F10 controls output 3" CV="37" mask="XXVXXXXX" minOut="3">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
-	<label>F10 controls output 3</label>
-	<label xml:lang="it">F10 controlla uscita 3</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+    <label>F10 controls output 3</label>
+    <label xml:lang="it">F10 controlla uscita 3</label>
   </variable>
   <variable item="F11 controls output 3" CV="37" mask="XVXXXXXX" minOut="3">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
-	<label>F11 controls output 3</label>
-	<label xml:lang="it">F11 controlla uscita 3</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+    <label>F11 controls output 3</label>
+    <label xml:lang="it">F11 controlla uscita 3</label>
   </variable>
   <variable item="F12 controls output 3" CV="37" mask="VXXXXXXX" minOut="3">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
-	<label>F12 controls output 3</label>
-	<label xml:lang="it">F12 controlla uscita 3</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+    <label>F12 controls output 3</label>
+    <label xml:lang="it">F12 controlla uscita 3</label>
   </variable>
   <variable item="F7 controls output 4" CV="38" mask="XXXXXVXX" minOut="4">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
-	<label>F7 controls output 4</label>
-	<label xml:lang="it">F7 controlla uscita 4</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+    <label>F7 controls output 4</label>
+    <label xml:lang="it">F7 controlla uscita 4</label>
   </variable>
   <variable item="F8 controls output 4" CV="38" mask="XXXXVXXX" minOut="4">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
-	<label>F8 controls output 4</label>
-	<label xml:lang="it">F8 controlla uscita 4</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+    <label>F8 controls output 4</label>
+    <label xml:lang="it">F8 controlla uscita 4</label>
   </variable>
   <variable item="F9 controls output 4" CV="38" mask="XXXVXXXX" minOut="4">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
-	<label>F9 controls output 4</label>
-	<label xml:lang="it">F9 controlla uscita 4</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+    <label>F9 controls output 4</label>
+    <label xml:lang="it">F9 controlla uscita 4</label>
   </variable>
   <variable item="F10 controls output 4" CV="38" mask="XXVXXXXX" minOut="4">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
-	<label>F10 controls output 4</label>
-	<label xml:lang="it">F10 controlla uscita 4</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+    <label>F10 controls output 4</label>
+    <label xml:lang="it">F10 controlla uscita 4</label>
   </variable>
   <variable item="F11 controls output 4" CV="38" mask="XVXXXXXX" minOut="4">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
-	<label>F11 controls output 4</label>
-	<label xml:lang="it">F11 controlla uscita 4</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+    <label>F11 controls output 4</label>
+    <label xml:lang="it">F11 controlla uscita 4</label>
   </variable>
   <variable item="F12 controls output 4" CV="38" mask="VXXXXXXX" minOut="4">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
-	<label>F12 controls output 4</label>
-	<label xml:lang="it">F12 controlla uscita 4</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+    <label>F12 controls output 4</label>
+    <label xml:lang="it">F12 controlla uscita 4</label>
   </variable>
   <variable item="FL(f) controls output 5" CV="39" mask="XXXXXXXV" minOut="5">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
-	<label>FL(f) controls output 5</label>
-	<label xml:lang="it">Luci (in avanti) controlla uscita 5</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+    <label>FL(f) controls output 5</label>
+    <label xml:lang="it">Luci (in avanti) controlla uscita 5</label>
   </variable>
   <variable item="FL(r) controls output 5" CV="39" mask="XXXXXXVX" minOut="5">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
-	<label>FL(r) controls output 5</label>
-	<label xml:lang="it">Luci(in retro) controlla uscita 5</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+    <label>FL(r) controls output 5</label>
+    <label xml:lang="it">Luci(in retro) controlla uscita 5</label>
   </variable>
   <variable item="F1 controls output 5" CV="39" mask="XXXXXVXX" minOut="5">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
-	<label>F1 controls output 5</label>
-	<label xml:lang="it">F1 controlla uscita 5</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+    <label>F1 controls output 5</label>
+    <label xml:lang="it">F1 controlla uscita 5</label>
   </variable>
   <variable item="F2 controls output 5" CV="39" mask="XXXXVXXX" minOut="5">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
-	<label>F2 controls output 5</label>
-	<label xml:lang="it">F2 controlla uscita 5</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+    <label>F2 controls output 5</label>
+    <label xml:lang="it">F2 controlla uscita 5</label>
   </variable>
   <variable item="F3 controls output 5" CV="39" mask="XXXVXXXX" minOut="5" default="1">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
-	<label>F3 controls output 5</label>
-	<label xml:lang="it">F3 controlla uscita 5</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+    <label>F3 controls output 5</label>
+    <label xml:lang="it">F3 controlla uscita 5</label>
   </variable>
   <variable item="F4 controls output 5" CV="39" mask="XXVXXXXX" minOut="5">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
-	<label>F4 controls output 5</label>
-	<label xml:lang="it">F4 controlla uscita 5</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+    <label>F4 controls output 5</label>
+    <label xml:lang="it">F4 controlla uscita 5</label>
   </variable>
   <variable item="F5 controls output 5" CV="39" mask="XVXXXXXX" minOut="5">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
-	<label>F5 controls output 5</label>
-	<label xml:lang="it">F5 controlla uscita 5</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+    <label>F5 controls output 5</label>
+    <label xml:lang="it">F5 controlla uscita 5</label>
   </variable>
   <variable item="F6 controls output 5" CV="39" mask="VXXXXXXX" minOut="5">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
-	<label>F6 controls output 5</label>
-	<label xml:lang="it">F6 controlla uscita 5</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+    <label>F6 controls output 5</label>
+    <label xml:lang="it">F6 controlla uscita 5</label>
   </variable>
   <variable item="FL(f) controls output 6" CV="40" mask="XXXXXXXV" minOut="6">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
-	<label>FL(f) controls output 6</label>
-	<label xml:lang="it">"Luci(in avanti) controlla uscita 6</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+    <label>FL(f) controls output 6</label>
+    <label xml:lang="it">"Luci(in avanti) controlla uscita 6</label>
   </variable>
   <variable item="FL(r) controls output 6" CV="40" mask="XXXXXXVX" minOut="6">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
-	<label>FL(r) controls output 6</label>
-	<label xml:lang="it">Luci(in retro) controlla uscita 6</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+    <label>FL(r) controls output 6</label>
+    <label xml:lang="it">Luci(in retro) controlla uscita 6</label>
   </variable>
   <variable item="F1 controls output 6" CV="40" mask="XXXXXVXX" minOut="6">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
@@ -519,9 +519,9 @@
     <label xml:lang="it">F1 controlla uscita 6</label>
   </variable>
   <variable item="F2 controls output 6" CV="40" mask="XXXXVXXX" minOut="6">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
-	<label>F2 controls output 6</label>
-	<label xml:lang="it">F2 controlla uscita 6</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+    <label>F2 controls output 6</label>
+    <label xml:lang="it">F2 controlla uscita 6</label>
   </variable>
   <variable item="F3 controls output 6" CV="40" mask="XXXVXXXX" minOut="6" exclude="220">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
@@ -544,74 +544,74 @@
     <label xml:lang="it">F4 controlla uscita 6</label>
   </variable>
   <variable item="F5 controls output 6" CV="40" mask="XVXXXXXX" minOut="6">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
-	<label>F5 controls output 6</label>
-	<label xml:lang="it">F5 controlla uscita 6</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+    <label>F5 controls output 6</label>
+    <label xml:lang="it">F5 controlla uscita 6</label>
   </variable>
   <variable item="F6 controls output 6" CV="40" mask="VXXXXXXX" minOut="6">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
-	<label>F6 controls output 6</label>
-	<label xml:lang="it">F6 controlla uscita 6</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+    <label>F6 controls output 6</label>
+    <label xml:lang="it">F6 controlla uscita 6</label>
   </variable>
   <variable item="F7 controls output 5" CV="41" mask="XXXXXVXX" minOut="5">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
-	<label>F7 controls output 5</label>
-	<label xml:lang="it">F7 controlla uscita 5</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+    <label>F7 controls output 5</label>
+    <label xml:lang="it">F7 controlla uscita 5</label>
   </variable>
   <variable item="F8 controls output 5" CV="41" mask="XXXXVXXX" minOut="5">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
-	<label>F8 controls output 5</label>
-	<label xml:lang="it">F8 controlla uscita 5</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+    <label>F8 controls output 5</label>
+    <label xml:lang="it">F8 controlla uscita 5</label>
   </variable>
   <variable item="F9 controls output 5" CV="41" mask="XXXVXXXX" minOut="5">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
-	<label>F9 controls output 5</label>
-	<label xml:lang="it">F9 controlla uscita 5</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+    <label>F9 controls output 5</label>
+    <label xml:lang="it">F9 controlla uscita 5</label>
   </variable>
   <variable item="F10 controls output 5" CV="41" mask="XXVXXXXX" minOut="5">
-	 <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
-	<label>F10 controls output 5</label>
-	<label xml:lang="it">F10 controlla uscita 5</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+    <label>F10 controls output 5</label>
+    <label xml:lang="it">F10 controlla uscita 5</label>
   </variable>
   <variable item="F11 controls output 5" CV="41" mask="XVXXXXXX" minOut="5">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
-	<label>F11 controls output 5</label>
-	<label xml:lang="it">F11 controlla uscita 5</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+    <label>F11 controls output 5</label>
+    <label xml:lang="it">F11 controlla uscita 5</label>
   </variable>
   <variable item="F12 controls output 5" CV="41" mask="VXXXXXXX" minOut="5">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
-	<label>F12 controls output 5</label>
-	<label xml:lang="it">F12 controlla uscita 5</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+    <label>F12 controls output 5</label>
+    <label xml:lang="it">F12 controlla uscita 5</label>
   </variable>
   <variable item="F7 controls output 6" CV="42" mask="XXXXXVXX" minOut="6">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
-	<label>F7 controls output 6</label>
-	<label xml:lang="it">F7 controlla uscita 6</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+    <label>F7 controls output 6</label>
+    <label xml:lang="it">F7 controlla uscita 6</label>
   </variable>
   <variable item="F8 controls output 6" CV="42" mask="XXXXVXXX" minOut="6">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
-	<label>F8 controls output 6</label>
-	<label xml:lang="it">F8 controlla uscita 6</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+    <label>F8 controls output 6</label>
+    <label xml:lang="it">F8 controlla uscita 6</label>
   </variable>
   <variable item="F9 controls output 6" CV="42" mask="XXXVXXXX" minOut="6">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
-	<label>F9 controls output 6</label>
-	<label xml:lang="it">F9 controlla uscita 6</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+    <label>F9 controls output 6</label>
+    <label xml:lang="it">F9 controlla uscita 6</label>
   </variable>
   <variable item="F10 controls output 6" CV="42" mask="XXVXXXXX" minOut="6">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
-	<label>F10 controls output 6</label>
-	<label xml:lang="it">F10 controlla uscita 6</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+    <label>F10 controls output 6</label>
+    <label xml:lang="it">F10 controlla uscita 6</label>
   </variable>
   <variable item="F11 controls output 6" CV="42" mask="XVXXXXXX" minOut="6">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
-	<label>F11 controls output 6</label>
-	<label xml:lang="it">F11 controlla uscita 6</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+    <label>F11 controls output 6</label>
+    <label xml:lang="it">F11 controlla uscita 6</label>
   </variable>
   <variable item="F12 controls output 6" CV="42" mask="VXXXXXXX" minOut="6">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
-	<label>F12 controls output 6</label>
-	<label xml:lang="it">F12 controlla uscita 6</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+    <label>F12 controls output 6</label>
+    <label xml:lang="it">F12 controlla uscita 6</label>
   </variable>
   <variable item="FL(f) controls output 7" CV="43" mask="XXXXXXXV" minOut="7" exclude="132,172">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
@@ -756,392 +756,392 @@
   <constant item="F5 controls output 7" minOut="7" minFn="5" default="1" include="132,172"/>
   <constant item="F6 controls output 8" minOut="8" minFn="6" default="1" include="132,172"/>
   <variable CV="49" mask="XVXXXXXX" item="Output 1 options" default="0">
-	<enumVal>
-	  <enumChoice choice="Group 0">
-		  <choice xml:lang="it">Gruppo 0</choice>
-	  </enumChoice>
-	  <enumChoice choice="Group 1">
-		  <choice xml:lang="it">Gruppo 1</choice>
-	  </enumChoice>
-	</enumVal>
-	<label>White Wire Effect Group</label>
-	<label xml:lang="it">Gruppo Effetti filo Bianco</label>
+    <enumVal>
+      <enumChoice choice="Group 0">
+        <choice xml:lang="it">Gruppo 0</choice>
+      </enumChoice>
+      <enumChoice choice="Group 1">
+        <choice xml:lang="it">Gruppo 1</choice>
+      </enumChoice>
+    </enumVal>
+    <label>White Wire Effect Group</label>
+    <label xml:lang="it">Gruppo Effetti filo Bianco</label>
   </variable>
   <variable CV="49" mask="XXXXVVVV" item="Output 1 effect generated">
     <qualifier>
-	  <variableref>White Wire Effect Group</variableref>
-	  <relation>eq</relation>
-	  <value>1</value>
-	</qualifier>
+      <variableref>White Wire Effect Group</variableref>
+      <relation>eq</relation>
+      <value>1</value>
+    </qualifier>
     <xi:include href="http://jmri.org/xml/decoders/tcs/enum-CVX_light_short.xml"/>
     <label>White Wire Effect 1</label>
     <label xml:lang="it">Gruppo Effetti filo Bianco 1</label>
   </variable>
   <variable CV="49" mask="XXXXVVVV" item="Output 1 behavior" exclude="220">
     <qualifier>
-	  <variableref>White Wire Effect Group</variableref>
-	  <relation>eq</relation>
-	  <value>0</value>
-	</qualifier>
+      <variableref>White Wire Effect Group</variableref>
+      <relation>eq</relation>
+      <value>0</value>
+    </qualifier>
     <enumVal>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Momentarypulse.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_BlinkingditchAB.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constdim.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_AutoMarsBrake.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_SingleStrobe2.xml"/>
-	</enumVal>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Momentarypulse.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_BlinkingditchAB.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constdim.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_AutoMarsBrake.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_SingleStrobe2.xml"/>
+    </enumVal>
     <label>White Wire Effect 0</label>
     <label xml:lang="it">Effetti 0 filo Bianco</label>
   </variable>
   <variable CV="49" mask="XXXXVVVV" item="Output 1 behavior" default="8" include="220">
     <qualifier>
-	  <variableref>White Wire Effect Group</variableref>
-	  <relation>eq</relation>
-	  <value>0</value>
-	</qualifier>
+      <variableref>White Wire Effect Group</variableref>
+      <relation>eq</relation>
+      <value>0</value>
+    </qualifier>
     <enumVal>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Momentarypulse.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_BlinkingditchAB.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constdim.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_AutoMarsBrake.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_SingleStrobe2.xml"/>
-	</enumVal>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Momentarypulse.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_BlinkingditchAB.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constdim.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_AutoMarsBrake.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_SingleStrobe2.xml"/>
+    </enumVal>
     <label>White Wire Effect 0</label>
     <label xml:lang="it">Effetti 0 filo Bianco</label>
   </variable>
   <variable CV="49" mask="XXVVXXXX" item="Output 1 option 1">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-frw_rev_both.xml"/>
-	<label>White Wire Timing</label>
-	<label xml:lang="it">Temporizzazioni filo Bianco</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-frw_rev_both.xml"/>
+    <label>White Wire Timing</label>
+    <label xml:lang="it">Temporizzazioni filo Bianco</label>
   </variable>
   <variable CV="50" mask="XVXXXXXX" item="Output 2 options" default="0">
-	<enumVal>
-	  <enumChoice choice="Group 0">
-		  <choice xml:lang="it">Gruppo 0</choice>
-	  </enumChoice>
-	  <enumChoice choice="Group 1">
-		  <choice xml:lang="it">Gruppo 1</choice>
-	  </enumChoice>
-	</enumVal>
-	<label>Yellow Wire Effect Group</label>
-	<label xml:lang="it">Yellow Wire Effect Group</label>
+    <enumVal>
+      <enumChoice choice="Group 0">
+        <choice xml:lang="it">Gruppo 0</choice>
+      </enumChoice>
+      <enumChoice choice="Group 1">
+        <choice xml:lang="it">Gruppo 1</choice>
+      </enumChoice>
+    </enumVal>
+    <label>Yellow Wire Effect Group</label>
+    <label xml:lang="it">Yellow Wire Effect Group</label>
   </variable>
   <variable CV="50" mask="XXXXVVVV" item="Output 2 effect generated">
     <qualifier>
-	  <variableref>Yellow Wire Effect Group</variableref>
-	  <relation>eq</relation>
-	  <value>1</value>
-	</qualifier>
+      <variableref>Yellow Wire Effect Group</variableref>
+      <relation>eq</relation>
+      <value>1</value>
+    </qualifier>
     <xi:include href="http://jmri.org/xml/decoders/tcs/enum-CVX_light_short.xml"/>
     <label>Yellow Wire Effect 1</label>
     <label xml:lang="it">Gruppo 1 Effetti filo Giallo</label>
   </variable>
   <variable CV="50" mask="XXXXVVVV" item="Output 2 behavior" exclude="220">
     <qualifier>
-	  <variableref>Yellow Wire Effect Group</variableref>
-	  <relation>eq</relation>
-	  <value>0</value>
-	</qualifier>
+      <variableref>Yellow Wire Effect Group</variableref>
+      <relation>eq</relation>
+      <value>0</value>
+    </qualifier>
     <enumVal>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Momentarypulse.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_BlinkingditchAB.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constdim.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_AutoMarsBrake.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_SingleStrobe2.xml"/>
-	</enumVal>
-	<label>Yellow Wire Effect 0</label>
-	<label xml:lang="it">Gruppo 0 Effetti filo Giallo</label>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Momentarypulse.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_BlinkingditchAB.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constdim.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_AutoMarsBrake.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_SingleStrobe2.xml"/>
+    </enumVal>
+    <label>Yellow Wire Effect 0</label>
+    <label xml:lang="it">Gruppo 0 Effetti filo Giallo</label>
   </variable>
   <variable CV="50" mask="XXXXVVVV" item="Output 2 behavior" default="8" include="220">
     <qualifier>
-	  <variableref>Yellow Wire Effect Group</variableref>
-	  <relation>eq</relation>
-	  <value>0</value>
-	</qualifier>
+      <variableref>Yellow Wire Effect Group</variableref>
+      <relation>eq</relation>
+      <value>0</value>
+    </qualifier>
     <enumVal>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Momentarypulse.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_BlinkingditchAB.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constdim.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_AutoMarsBrake.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_SingleStrobe2.xml"/>
-	</enumVal>
-	<label>Yellow Wire Effect 0</label>
-	<label xml:lang="it">Gruppo 0 Effetti filo Giallo</label>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Momentarypulse.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_BlinkingditchAB.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constdim.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_AutoMarsBrake.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_SingleStrobe2.xml"/>
+    </enumVal>
+    <label>Yellow Wire Effect 0</label>
+    <label xml:lang="it">Gruppo 0 Effetti filo Giallo</label>
   </variable>
   <variable CV="50" mask="XXVVXXXX" default="1" item="Output 2 option 1">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-frw_rev_both.xml"/>
-	<label>Yellow Wire Timing</label>
-	<label xml:lang="it">Temporizzazioni filo Giallo</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-frw_rev_both.xml"/>
+    <label>Yellow Wire Timing</label>
+    <label xml:lang="it">Temporizzazioni filo Giallo</label>
   </variable>
   <variable CV="51" mask="XVXXXXXX" minOut="3" item="Output 3 options" default="0">
-	<enumVal>
-	  <enumChoice choice="Group 0">
-		  <choice xml:lang="it">Gruppo 0</choice>
-	  </enumChoice>
-	  <enumChoice choice="Group 1">
-		  <choice xml:lang="it">Gruppo 1</choice>
-	  </enumChoice>
-	</enumVal>
-	<label>Green Wire Effect Group</label>
-	<label xml:lang="it">Gruppo Effetti filo Verde</label>
+    <enumVal>
+      <enumChoice choice="Group 0">
+        <choice xml:lang="it">Gruppo 0</choice>
+      </enumChoice>
+      <enumChoice choice="Group 1">
+        <choice xml:lang="it">Gruppo 1</choice>
+      </enumChoice>
+    </enumVal>
+    <label>Green Wire Effect Group</label>
+    <label xml:lang="it">Gruppo Effetti filo Verde</label>
   </variable>
   <variable CV="51" mask="XXXXVVVV" minOut="3" item="Output 3 effect generated">
     <qualifier>
-	  <variableref>Green Wire Effect Group</variableref>
-	  <relation>eq</relation>
-	  <value>1</value>
-	</qualifier>
+      <variableref>Green Wire Effect Group</variableref>
+      <relation>eq</relation>
+      <value>1</value>
+    </qualifier>
     <xi:include href="http://jmri.org/xml/decoders/tcs/enum-CVX_light_short.xml"/>
     <label>Green Wire Effect 1</label>
     <label xml:lang="it">Gruppo 1 Effetti filo Verde</label>
   </variable>
   <variable CV="51" mask="XXXXVVVV" minOut="3" item="Output 3 behavior" exclude="220">
     <qualifier>
-	  <variableref>Green Wire Effect Group</variableref>
-	  <relation>eq</relation>
-	  <value>0</value>
-	</qualifier>
+      <variableref>Green Wire Effect Group</variableref>
+      <relation>eq</relation>
+      <value>0</value>
+    </qualifier>
     <enumVal>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Momentarypulse.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_BlinkingditchAB.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constdim.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_AutoMarsBrake.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_SingleStrobe2.xml"/>
-	</enumVal>
-	<label>Green Wire Effect 0</label>
-	<label xml:lang="it">Gruppo 0 Effetti filo Verde</label>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Momentarypulse.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_BlinkingditchAB.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constdim.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_AutoMarsBrake.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_SingleStrobe2.xml"/>
+    </enumVal>
+    <label>Green Wire Effect 0</label>
+    <label xml:lang="it">Gruppo 0 Effetti filo Verde</label>
   </variable>
   <variable CV="51" mask="XXXXVVVV" minOut="3" item="Output 3 behavior" default="10" include="220">
     <qualifier>
-	  <variableref>Green Wire Effect Group</variableref>
-	  <relation>eq</relation>
-	  <value>0</value>
-	</qualifier>
+      <variableref>Green Wire Effect Group</variableref>
+      <relation>eq</relation>
+      <value>0</value>
+    </qualifier>
     <enumVal>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Momentarypulse.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_BlinkingditchAB.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constdim.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_AutoMarsBrake.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_SingleStrobe2.xml"/>
-	</enumVal>
-	<label>Green Wire Effect 0</label>
-	<label xml:lang="it">Gruppo 0 Effetti filo Verde</label>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Momentarypulse.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_BlinkingditchAB.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constdim.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_AutoMarsBrake.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_SingleStrobe2.xml"/>
+    </enumVal>
+    <label>Green Wire Effect 0</label>
+    <label xml:lang="it">Gruppo 0 Effetti filo Verde</label>
   </variable>
   <variable CV="51" mask="XXVVXXXX" minOut="3" default="2" item="Output 3 option 1" exclude="220">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-frw_rev_both.xml"/>
-	<label>Green Wire Timing</label>
-	<label xml:lang="it">Temporizzazioni filo Verde</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-frw_rev_both.xml"/>
+    <label>Green Wire Timing</label>
+    <label xml:lang="it">Temporizzazioni filo Verde</label>
   </variable>
   <variable CV="51" mask="XXVVXXXX" minOut="3" default="0" item="Output 3 option 1" include="220">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-frw_rev_both.xml"/>
-	<label>Green Wire Timing</label>
-	<label xml:lang="it">Temporizzazioni filo Verde</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-frw_rev_both.xml"/>
+    <label>Green Wire Timing</label>
+    <label xml:lang="it">Temporizzazioni filo Verde</label>
   </variable>
   <variable CV="52" mask="XVXXXXXX" minOut="4" item="Output 4 options" default="0">
-	<enumVal>
-	  <enumChoice choice="Group 0">
-		  <choice xml:lang="it">Gruppo 0</choice>
-	  </enumChoice>
-	  <enumChoice choice="Group 1">
-		  <choice xml:lang="it">Gruppo 1</choice>
-	  </enumChoice>
-	</enumVal>
-	<label>Purple Wire Effect Group</label>
-	<label xml:lang="it">Gruppo Effetti filo Porpora</label>
+    <enumVal>
+      <enumChoice choice="Group 0">
+        <choice xml:lang="it">Gruppo 0</choice>
+      </enumChoice>
+      <enumChoice choice="Group 1">
+        <choice xml:lang="it">Gruppo 1</choice>
+      </enumChoice>
+    </enumVal>
+    <label>Purple Wire Effect Group</label>
+    <label xml:lang="it">Gruppo Effetti filo Porpora</label>
   </variable>
   <variable CV="52" mask="XXXXVVVV" minOut="4" item="Output 4 effect generated">
     <qualifier>
-	  <variableref>Purple Wire Effect Group</variableref>
-	  <relation>eq</relation>
-	  <value>1</value>
-	</qualifier>
+      <variableref>Purple Wire Effect Group</variableref>
+      <relation>eq</relation>
+      <value>1</value>
+    </qualifier>
     <xi:include href="http://jmri.org/xml/decoders/tcs/enum-CVX_light_short.xml"/>
     <label>Purple Wire Effect 1</label>
     <label xml:lang="it">Gruppo 1 Effetti filo Porpora</label>
   </variable>
   <variable CV="52" mask="XXXXVVVV" minOut="4" item="Output 4 behavior" exclude="220">
     <qualifier>
-	  <variableref>Purple Wire Effect Group</variableref>
-	  <relation>eq</relation>
-	  <value>0</value>
-	</qualifier>
+      <variableref>Purple Wire Effect Group</variableref>
+      <relation>eq</relation>
+      <value>0</value>
+    </qualifier>
     <enumVal>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Momentarypulse.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_BlinkingditchAB.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constdim.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_AutoMarsBrake.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_SingleStrobe2.xml"/>
-	</enumVal>
-	<label>Purple Wire Effect 0</label>
-	<label xml:lang="it">Gruppo 0 Effetti filo Porpora</label>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Momentarypulse.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_BlinkingditchAB.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constdim.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_AutoMarsBrake.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_SingleStrobe2.xml"/>
+    </enumVal>
+    <label>Purple Wire Effect 0</label>
+    <label xml:lang="it">Gruppo 0 Effetti filo Porpora</label>
   </variable>
   <variable CV="52" mask="XXXXVVVV" minOut="4" item="Output 4 behavior" default="11" include="220">
     <qualifier>
-	  <variableref>Purple Wire Effect Group</variableref>
-	  <relation>eq</relation>
-	  <value>0</value>
-	</qualifier>
+      <variableref>Purple Wire Effect Group</variableref>
+      <relation>eq</relation>
+      <value>0</value>
+    </qualifier>
     <enumVal>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Momentarypulse.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_BlinkingditchAB.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constdim.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_AutoMarsBrake.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_SingleStrobe2.xml"/>
-	</enumVal>
-	<label>Purple Wire Effect 0</label>
-	<label xml:lang="it">Gruppo 0 Effetti filo Porpora</label>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Momentarypulse.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_BlinkingditchAB.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constdim.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_AutoMarsBrake.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_SingleStrobe2.xml"/>
+    </enumVal>
+    <label>Purple Wire Effect 0</label>
+    <label xml:lang="it">Gruppo 0 Effetti filo Porpora</label>
   </variable>
   <variable CV="52" mask="XXVVXXXX" minOut="4" default="2" item="Output 4 option 1" exclude="220">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-frw_rev_both.xml"/>
-	<label>Purple Wire Timing</label>
-	<label xml:lang="it">Temporizzazioni filo Porpora</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-frw_rev_both.xml"/>
+    <label>Purple Wire Timing</label>
+    <label xml:lang="it">Temporizzazioni filo Porpora</label>
   </variable>
   <variable CV="52" mask="XXVVXXXX" minOut="4" default="0" item="Output 4 option 1" include="220">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-frw_rev_both.xml"/>
-	<label>Purple Wire Timing</label>
-	<label xml:lang="it">Temporizzazioni filo Porpora</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-frw_rev_both.xml"/>
+    <label>Purple Wire Timing</label>
+    <label xml:lang="it">Temporizzazioni filo Porpora</label>
   </variable>
   <variable CV="53" mask="XVXXXXXX" minOut="5" item="Output 5 options" default="0" exclude="61">
-	<enumVal>
-	  <enumChoice choice="Group 0">
-		  <choice xml:lang="it">Gruppo 0</choice>
-	  </enumChoice>
-	  <enumChoice choice="Group 1">
-		  <choice xml:lang="it">Gruppo 1</choice>
-	  </enumChoice>
-	</enumVal>
-	<label>Brown Wire Effect Group</label>
-	<label xml:lang="it">Gruppo Effetti filo Marrone</label>
+    <enumVal>
+      <enumChoice choice="Group 0">
+        <choice xml:lang="it">Gruppo 0</choice>
+      </enumChoice>
+      <enumChoice choice="Group 1">
+        <choice xml:lang="it">Gruppo 1</choice>
+      </enumChoice>
+    </enumVal>
+    <label>Brown Wire Effect Group</label>
+    <label xml:lang="it">Gruppo Effetti filo Marrone</label>
   </variable>
   <variable CV="53" mask="XXXXVVVV" minOut="5" item="Output 5 effect generated" exclude="61">
     <qualifier>
-	  <variableref>Brown Wire Effect Group</variableref>
-	  <relation>eq</relation>
-	  <value>1</value>
-	</qualifier>
+      <variableref>Brown Wire Effect Group</variableref>
+      <relation>eq</relation>
+      <value>1</value>
+    </qualifier>
     <xi:include href="http://jmri.org/xml/decoders/tcs/enum-CVX_light_short.xml"/>
     <label>Brown Wire Effect 1</label>
     <label xml:lang="it">Gruppo 1 Effetti filo Marrone</label>
   </variable>
   <variable CV="53" mask="XXXXVVVV" minOut="5" item="Output 5 behavior" exclude="61,220">
     <qualifier>
-	  <variableref>Brown Wire Effect Group</variableref>
-	  <relation>eq</relation>
-	  <value>0</value>
-	</qualifier>
+      <variableref>Brown Wire Effect Group</variableref>
+      <relation>eq</relation>
+      <value>0</value>
+    </qualifier>
     <enumVal>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Momentarypulse.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_BlinkingditchAB.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constdim.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_AutoMarsBrake.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_SingleStrobe2.xml"/>
-	</enumVal>
-	<label>Brown Wire Effect 0</label>
-	<label xml:lang="it">Gruppo 0 Effetti filo Marrone</label>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Momentarypulse.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_BlinkingditchAB.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constdim.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_AutoMarsBrake.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_SingleStrobe2.xml"/>
+    </enumVal>
+    <label>Brown Wire Effect 0</label>
+    <label xml:lang="it">Gruppo 0 Effetti filo Marrone</label>
   </variable>
   <variable CV="53" mask="XXXXVVVV" minOut="5" item="Output 5 behavior" default="10" include="220">
     <qualifier>
-	  <variableref>Brown Wire Effect Group</variableref>
-	  <relation>eq</relation>
-	  <value>0</value>
-	</qualifier>
+      <variableref>Brown Wire Effect Group</variableref>
+      <relation>eq</relation>
+      <value>0</value>
+    </qualifier>
     <enumVal>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Momentarypulse.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_BlinkingditchAB.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constdim.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_AutoMarsBrake.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_SingleStrobe2.xml"/>
-	</enumVal>
-	<label>Brown Wire Effect 0</label>
-	<label xml:lang="it">Gruppo 0 Effetti filo Marrone</label>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Momentarypulse.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_BlinkingditchAB.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constdim.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_AutoMarsBrake.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_SingleStrobe2.xml"/>
+    </enumVal>
+    <label>Brown Wire Effect 0</label>
+    <label xml:lang="it">Gruppo 0 Effetti filo Marrone</label>
   </variable>
   <variable CV="53" mask="XXVVXXXX" minOut="5" default="2" item="Output 5 option 1" exclude="61,220">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-frw_rev_both.xml"/>
-	<label>Brown Wire Timing</label>
-	<label xml:lang="it">Temporizzazioni filo Marrone</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-frw_rev_both.xml"/>
+    <label>Brown Wire Timing</label>
+    <label xml:lang="it">Temporizzazioni filo Marrone</label>
   </variable>
   <variable CV="53" mask="XXVVXXXX" minOut="5" default="1" item="Output 5 option 1" include="220">
-	<xi:include href="http://jmri.org/xml/decoders/parts/enum-frw_rev_both.xml"/>
-	<label>Brown Wire Timing</label>
-	<label xml:lang="it">Temporizzazioni filo Marrone</label>
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-frw_rev_both.xml"/>
+    <label>Brown Wire Timing</label>
+    <label xml:lang="it">Temporizzazioni filo Marrone</label>
   </variable>
   <variable CV="54" mask="XVXXXXXX" minOut="6" item="Output 6 options" default="0" exclude="61">
-	<enumVal>
-	  <enumChoice choice="Group 0">
-		  <choice xml:lang="it">Gruppo 0</choice>
-	  </enumChoice>
-	  <enumChoice choice="Group 1">
-		  <choice xml:lang="it">Gruppo 1</choice>
-	  </enumChoice>
-	</enumVal>
-	<label>Pink Wire Effect Group</label>
-	<label xml:lang="it">Gruppo Effetti filo Rosa</label>
+    <enumVal>
+      <enumChoice choice="Group 0">
+        <choice xml:lang="it">Gruppo 0</choice>
+      </enumChoice>
+      <enumChoice choice="Group 1">
+        <choice xml:lang="it">Gruppo 1</choice>
+      </enumChoice>
+    </enumVal>
+    <label>Pink Wire Effect Group</label>
+    <label xml:lang="it">Gruppo Effetti filo Rosa</label>
   </variable>
   <variable CV="54" mask="XXXXVVVV" minOut="6" item="Output 6 effect generated" exclude="61">
     <qualifier>
-	  <variableref>Pink Wire Effect Group</variableref>
-	  <relation>eq</relation>
-	  <value>1</value>
-	</qualifier>
+      <variableref>Pink Wire Effect Group</variableref>
+      <relation>eq</relation>
+      <value>1</value>
+    </qualifier>
     <xi:include href="http://jmri.org/xml/decoders/tcs/enum-CVX_light_short.xml"/>
     <label>Pink Wire Effect 1</label>
     <label xml:lang="it">Gruppo 1 Effetti filo Rosa</label>
   </variable>
   <variable CV="54" mask="XXXXVVVV" minOut="6" item="Output 6 behavior" exclude="61,220">
     <qualifier>
-	  <variableref>Pink Wire Effect Group</variableref>
-	  <relation>eq</relation>
-	  <value>0</value>
-	</qualifier>
+      <variableref>Pink Wire Effect Group</variableref>
+      <relation>eq</relation>
+      <value>0</value>
+    </qualifier>
     <enumVal>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Momentarypulse.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_BlinkingditchAB.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constdim.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_AutoMarsBrake.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_SingleStrobe2.xml"/>
-	</enumVal>
-	<label>Pink Wire Effect 0</label>
-	<label xml:lang="it">Gruppo 0 Effetti filo Rosa</label>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Momentarypulse.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_BlinkingditchAB.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constdim.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_AutoMarsBrake.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_SingleStrobe2.xml"/>
+    </enumVal>
+    <label>Pink Wire Effect 0</label>
+    <label xml:lang="it">Gruppo 0 Effetti filo Rosa</label>
   </variable>
   <variable CV="54" mask="XXXXVVVV" minOut="6" item="Output 6 behavior" default="11" include="220">
     <qualifier>
-	  <variableref>Pink Wire Effect Group</variableref>
-	  <relation>eq</relation>
-	  <value>0</value>
-	</qualifier>
+      <variableref>Pink Wire Effect Group</variableref>
+      <relation>eq</relation>
+      <value>0</value>
+    </qualifier>
     <enumVal>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Momentarypulse.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_BlinkingditchAB.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constdim.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_AutoMarsBrake.xml"/>
-	  <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_SingleStrobe2.xml"/>
-	</enumVal>
-	<label>Pink Wire Effect 0</label>
-	<label xml:lang="it">Gruppo 0 Effetti filo Rosa</label>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Momentarypulse.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_BlinkingditchAB.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constdim.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_AutoMarsBrake.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tcs/Choice_SingleStrobe2.xml"/>
+    </enumVal>
+    <label>Pink Wire Effect 0</label>
+    <label xml:lang="it">Gruppo 0 Effetti filo Rosa</label>
   </variable>
   <variable CV="54" mask="XXVVXXXX" minOut="6" default="2" item="Output 6 option 1" exclude="61,220">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-frw_rev_both.xml"/>
@@ -1202,41 +1202,41 @@
     <tooltip xml:lang="it">Motore controllato da Pulsante Funzione</tooltip>
   </variable>
   <variable CV="61" mask="XXXXXVXX" item="EMF Dynamic Config" tooltip="If motor button control is active">
-	<enumVal>
-	  <enumChoice choice="Manual F2 for, F3 rev">
-		<choice xml:lang="it">Manuale: F2-avanti, F3-retro</choice>
-	  </enumChoice>
-	  <enumChoice choice="Auto F2 for/rev">
-		 <choice xml:lang="it">Automatico: F2-avanti/retro</choice>
-	  </enumChoice>
-	</enumVal>
-	<label>Button Control Direction</label>
-	<label xml:lang="it">Pulsante Controllo Direzione</label>
-	<tooltip xml:lang="it">Se attivo pulsante Controllo Motore</tooltip>
+    <enumVal>
+      <enumChoice choice="Manual F2 for, F3 rev">
+        <choice xml:lang="it">Manuale: F2-avanti, F3-retro</choice>
+      </enumChoice>
+      <enumChoice choice="Auto F2 for/rev">
+        <choice xml:lang="it">Automatico: F2-avanti/retro</choice>
+      </enumChoice>
+    </enumVal>
+    <label>Button Control Direction</label>
+    <label xml:lang="it">Pulsante Controllo Direzione</label>
+    <tooltip xml:lang="it">Se attivo pulsante Controllo Motore</tooltip>
   </variable>
   <variable CV="62" default="0" item="Function 6 effect generated" tooltip="1 second = 60 to 4 seconds = 255">
-	<decVal/>
-	<label>Momentary Pulse</label>
-	<label xml:lang="it">Impulso Momentaneo</label>
-	<tooltip xml:lang="it">1 secondo = 60 a 4 secondi = 255</tooltip>
+    <decVal/>
+    <label>Momentary Pulse</label>
+    <label xml:lang="it">Impulso Momentaneo</label>
+    <tooltip xml:lang="it">1 secondo = 60 a 4 secondi = 255</tooltip>
   </variable>
   <variable CV="63" default="63" item="Function 2 effect generated" tooltip="1 second = about 12" exclude="220">
-	<decVal/>
-	<label>Ditch Light Blink Holdover Time</label>
-	<label xml:lang="it">Tempo strascico lampeggio Luce Ditch </label>
-	<tooltip xml:lang="it">1 secondo = circa 12</tooltip>
+    <decVal/>
+    <label>Ditch Light Blink Holdover Time</label>
+    <label xml:lang="it">Tempo strascico lampeggio Luce Ditch </label>
+    <tooltip xml:lang="it">1 secondo = circa 12</tooltip>
   </variable>
   <variable CV="63" default="10" item="Function 2 effect generated" tooltip="1 second = about 12" include="220">
-	<decVal/>
-	<label>Ditch Light Blink Holdover Time</label>
-	<label xml:lang="it">Tempo strascico lampeggio Luce Ditch </label>
-	<tooltip xml:lang="it">1 secondo = circa 12</tooltip>
+    <decVal/>
+    <label>Ditch Light Blink Holdover Time</label>
+    <label xml:lang="it">Tempo strascico lampeggio Luce Ditch </label>
+    <tooltip xml:lang="it">1 secondo = circa 12</tooltip>
   </variable>
   <variable CV="64" default="6" item="Global lighting option 2" tooltip="16 = 50% for incandescent bulbs, 2-6 for LEDs">
-	<decVal max="32"/>
-	<label>Constant Dim 1 Brightness</label>
-	<label xml:lang="it">Luminosità costante di smorzamento</label>
-	<tooltip xml:lang="it">16 = 50% per bulbi incandescenti, 2-6 per LEDs</tooltip>
+    <decVal max="32"/>
+    <label>Constant Dim 1 Brightness</label>
+    <label xml:lang="it">Luminosità costante di smorzamento</label>
+    <tooltip xml:lang="it">16 = 50% per bulbi incandescenti, 2-6 per LEDs</tooltip>
   </variable>
   <xi:include href="http://jmri.org/xml/decoders/nmra/fwdTrim128.xml"/>
   <xi:include href="http://jmri.org/xml/decoders/nmra/cv67speedTableBasic.xml"/>


### PR DESCRIPTION
 - Changed a WARN message to DEBUG as it really wasn't warning about anything
 - Cleaned up XML file's formatting (encountered while checking out the first item)