### PR TITLE
Add LogixNG expression Audio

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -424,6 +424,8 @@
         <ul>
           <li>The <strong>Icon/Label by class on panel</strong> action is added.
               It allows LogixNG to control all icons/labels of a class.</li>
+          <li>The <strong>Audio</strong> expression has been added. It lets
+              LogixNG listen on an Audio and take appropriate action.</li>
         </ul>
 
     <h3>Meters and MeterFrames</h3>

--- a/java/src/jmri/jmrit/logixng/expressions/DigitalFactory.java
+++ b/java/src/jmri/jmrit/logixng/expressions/DigitalFactory.java
@@ -24,6 +24,7 @@ public class DigitalFactory implements DigitalExpressionFactory {
                                 new AbstractMap.SimpleEntry<>(Category.COMMON, Antecedent.class),
                                 new AbstractMap.SimpleEntry<>(Category.FLOW_CONTROL, DigitalCallModule.class),
                                 new AbstractMap.SimpleEntry<>(Category.OTHER, ConnectionName.class),
+                                new AbstractMap.SimpleEntry<>(Category.ITEM, ExpressionAudio.class),
                                 new AbstractMap.SimpleEntry<>(Category.ITEM, ExpressionBlock.class),
                                 new AbstractMap.SimpleEntry<>(Category.ITEM, ExpressionClock.class),
                                 new AbstractMap.SimpleEntry<>(Category.ITEM, ExpressionConditional.class),

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionAudio.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionAudio.java
@@ -1,0 +1,405 @@
+package jmri.jmrit.logixng.expressions;
+
+import java.beans.*;
+import java.util.*;
+
+import javax.annotation.Nonnull;
+
+import jmri.*;
+import jmri.Audio;
+import jmri.AudioManager;
+import jmri.jmrit.logixng.*;
+import jmri.jmrit.logixng.util.LogixNG_SelectNamedBean;
+import jmri.jmrit.logixng.util.ReferenceUtil;
+import jmri.jmrit.logixng.util.parser.*;
+import jmri.jmrit.logixng.util.parser.ExpressionNode;
+import jmri.jmrit.logixng.util.parser.RecursiveDescentParser;
+import jmri.util.TypeConversionUtil;
+
+/**
+ * This expression evaluates the state of an Audio.
+ *
+ * @author Daniel Bergqvist Copyright 2023
+ */
+public class ExpressionAudio extends AbstractDigitalExpression
+        implements PropertyChangeListener {
+
+    private final LogixNG_SelectNamedBean<Audio> _selectNamedBean =
+            new LogixNG_SelectNamedBean<>(
+                    this, Audio.class, InstanceManager.getDefault(AudioManager.class), this);
+
+    private Is_IsNot_Enum _is_IsNot = Is_IsNot_Enum.Is;
+
+    private NamedBeanAddressing _stateAddressing = NamedBeanAddressing.Direct;
+    private AudioState _audioState = AudioState.Initial;
+    private String _stateReference = "";
+    private String _stateLocalVariable = "";
+    private String _stateFormula = "";
+    private ExpressionNode _stateExpressionNode;
+
+    private NamedBeanAddressing _dataAddressing = NamedBeanAddressing.Direct;
+    private String _dataReference = "";
+    private String _dataLocalVariable = "";
+    private String _dataFormula = "";
+    private ExpressionNode _dataExpressionNode;
+
+    private String _blockValue = "";
+
+    public ExpressionAudio(String sys, String user)
+            throws BadUserNameException, BadSystemNameException {
+        super(sys, user);
+    }
+
+    @Override
+    public Base getDeepCopy(Map<String, String> systemNames, Map<String, String> userNames) throws ParserException {
+        DigitalExpressionManager manager = InstanceManager.getDefault(DigitalExpressionManager.class);
+        String sysName = systemNames.get(getSystemName());
+        String userName = userNames.get(getSystemName());
+        if (sysName == null) sysName = manager.getAutoSystemName();
+        ExpressionAudio copy = new ExpressionAudio(sysName, userName);
+        copy.setComment(getComment());
+
+        _selectNamedBean.copy(copy._selectNamedBean);
+
+        copy.set_Is_IsNot(_is_IsNot);
+
+        copy.setStateAddressing(_stateAddressing);
+        copy.setBeanState(_audioState);
+        copy.setStateReference(_stateReference);
+        copy.setStateLocalVariable(_stateLocalVariable);
+        copy.setStateFormula(_stateFormula);
+
+        copy.setDataAddressing(_dataAddressing);
+        copy.setDataReference(_dataReference);
+        copy.setDataLocalVariable(_dataLocalVariable);
+        copy.setDataFormula(_dataFormula);
+        copy.setAudioValue(_blockValue);
+        return manager.registerExpression(copy);
+    }
+
+    public LogixNG_SelectNamedBean<Audio> getSelectNamedBean() {
+        return _selectNamedBean;
+    }
+
+    public void set_Is_IsNot(Is_IsNot_Enum is_IsNot) {
+        _is_IsNot = is_IsNot;
+    }
+
+    public Is_IsNot_Enum get_Is_IsNot() {
+        return _is_IsNot;
+    }
+
+
+    public void setStateAddressing(NamedBeanAddressing addressing) throws ParserException {
+        _stateAddressing = addressing;
+        parseStateFormula();
+    }
+
+    public NamedBeanAddressing getStateAddressing() {
+        return _stateAddressing;
+    }
+
+    public void setBeanState(AudioState state) {
+        _audioState = state;
+    }
+
+    public AudioState getBeanState() {
+        return _audioState;
+    }
+
+    public void setStateReference(@Nonnull String reference) {
+        if ((! reference.isEmpty()) && (! ReferenceUtil.isReference(reference))) {
+            throw new IllegalArgumentException("The reference \"" + reference + "\" is not a valid reference");
+        }
+        _stateReference = reference;
+    }
+
+    public String getStateReference() {
+        return _stateReference;
+    }
+
+    public void setStateLocalVariable(@Nonnull String localVariable) {
+        _stateLocalVariable = localVariable;
+    }
+
+    public String getStateLocalVariable() {
+        return _stateLocalVariable;
+    }
+
+    public void setStateFormula(@Nonnull String formula) throws ParserException {
+        _stateFormula = formula;
+        parseStateFormula();
+    }
+
+    public String getStateFormula() {
+        return _stateFormula;
+    }
+
+    private void parseStateFormula() throws ParserException {
+        if (_stateAddressing == NamedBeanAddressing.Formula) {
+            Map<String, Variable> variables = new HashMap<>();
+
+            RecursiveDescentParser parser = new RecursiveDescentParser(variables);
+            _stateExpressionNode = parser.parseExpression(_stateFormula);
+        } else {
+            _stateExpressionNode = null;
+        }
+    }
+
+
+    public void setDataAddressing(NamedBeanAddressing addressing) throws ParserException {
+        _dataAddressing = addressing;
+        parseDataFormula();
+    }
+
+    public NamedBeanAddressing getDataAddressing() {
+        return _dataAddressing;
+    }
+
+    public void setDataReference(@Nonnull String reference) {
+        if ((! reference.isEmpty()) && (! ReferenceUtil.isReference(reference))) {
+            throw new IllegalArgumentException("The reference \"" + reference + "\" is not a valid reference");
+        }
+        _dataReference = reference;
+    }
+
+    public String getDataReference() {
+        return _dataReference;
+    }
+
+    public void setDataLocalVariable(@Nonnull String localVariable) {
+        _dataLocalVariable = localVariable;
+    }
+
+    public String getDataLocalVariable() {
+        return _dataLocalVariable;
+    }
+
+    public void setDataFormula(@Nonnull String formula) throws ParserException {
+        _dataFormula = formula;
+        parseDataFormula();
+    }
+
+    public String getDataFormula() {
+        return _dataFormula;
+    }
+
+    private void parseDataFormula() throws ParserException {
+        if (_dataAddressing == NamedBeanAddressing.Formula) {
+            Map<String, Variable> variables = new HashMap<>();
+
+            RecursiveDescentParser parser = new RecursiveDescentParser(variables);
+            _dataExpressionNode = parser.parseExpression(_dataFormula);
+        } else {
+            _dataExpressionNode = null;
+        }
+    }
+
+
+    public void setAudioValue(@Nonnull String value) {
+        _blockValue = value;
+    }
+
+    public String getAudioValue() {
+        return _blockValue;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Category getCategory() {
+        return Category.ITEM;
+    }
+
+    private String getNewState() throws JmriException {
+
+        switch (_stateAddressing) {
+            case Reference:
+                return ReferenceUtil.getReference(
+                        getConditionalNG().getSymbolTable(), _stateReference);
+
+            case LocalVariable:
+                SymbolTable symbolTable =
+                        getConditionalNG().getSymbolTable();
+                return TypeConversionUtil
+                        .convertToString(symbolTable.getValue(_stateLocalVariable), false);
+
+            case Formula:
+                return _stateExpressionNode != null
+                        ? TypeConversionUtil.convertToString(
+                                _stateExpressionNode.calculate(
+                                        getConditionalNG().getSymbolTable()), false)
+                        : null;
+
+            default:
+                throw new IllegalArgumentException("invalid _addressing state: " + _stateAddressing.name());
+        }
+    }
+
+    private String getNewData() throws JmriException {
+
+        switch (_dataAddressing) {
+            case Reference:
+                return ReferenceUtil.getReference(
+                        getConditionalNG().getSymbolTable(), _dataReference);
+
+            case LocalVariable:
+                SymbolTable symbolTable =
+                        getConditionalNG().getSymbolTable();
+                return TypeConversionUtil
+                        .convertToString(symbolTable.getValue(_dataLocalVariable), false);
+
+            case Formula:
+                return _dataExpressionNode != null
+                        ? TypeConversionUtil.convertToString(
+                                _dataExpressionNode.calculate(
+                                        getConditionalNG().getSymbolTable()), false)
+                        : null;
+
+            default:
+                throw new IllegalArgumentException("invalid _addressing state: " + _dataAddressing.name());
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean evaluate() throws JmriException {
+        Audio audio = _selectNamedBean.evaluateNamedBean(getConditionalNG());
+
+        if (audio == null) return false;
+
+        AudioState checkAudioState;
+
+        if ((_stateAddressing == NamedBeanAddressing.Direct)) {
+            checkAudioState = _audioState;
+        } else {
+            checkAudioState = AudioState.valueOf(getNewState());
+        }
+
+        int currentState = audio.getState();
+
+        if (_is_IsNot == Is_IsNot_Enum.Is) {
+            return currentState == checkAudioState.getID();
+        } else {
+            return currentState != checkAudioState.getID();
+        }
+    }
+
+    @Override
+    public FemaleSocket getChild(int index) throws IllegalArgumentException, UnsupportedOperationException {
+        throw new UnsupportedOperationException("Not supported.");
+    }
+
+    @Override
+    public int getChildCount() {
+        return 0;
+    }
+
+    @Override
+    public String getShortDescription(Locale locale) {
+        return Bundle.getMessage(locale, "Audio_Short");
+    }
+
+    @Override
+    public String getLongDescription(Locale locale) {
+        String namedBean = _selectNamedBean.getDescription(locale);
+        String state;
+
+        switch (_stateAddressing) {
+            case Direct:
+                state = Bundle.getMessage(locale, "AddressByDirect", _audioState._text);
+                break;
+
+            case Reference:
+                state = Bundle.getMessage(locale, "AddressByReference", _stateReference);
+                break;
+
+            case LocalVariable:
+                state = Bundle.getMessage(locale, "AddressByLocalVariable", _stateLocalVariable);
+                break;
+
+            case Formula:
+                state = Bundle.getMessage(locale, "AddressByFormula", _stateFormula);
+                break;
+
+            default:
+                throw new IllegalArgumentException("invalid _stateAddressing state: " + _stateAddressing.name());
+        }
+
+
+        return Bundle.getMessage(locale, "Audio_Long", namedBean, _is_IsNot.toString(), state);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void setup() {
+        // Do nothing
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void registerListenersForThisClass() {
+        if (!_listenersAreRegistered) {
+            _selectNamedBean.addPropertyChangeListener(this);
+            _selectNamedBean.registerListeners();
+            _listenersAreRegistered = true;
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void unregisterListenersForThisClass() {
+        if (_listenersAreRegistered) {
+            _selectNamedBean.removePropertyChangeListener(this);
+            _selectNamedBean.unregisterListeners();
+            _listenersAreRegistered = false;
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void propertyChange(PropertyChangeEvent evt) {
+        getConditionalNG().execute();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void disposeMe() {
+    }
+
+    public enum AudioState {
+        Initial(Audio.STATE_INITIAL, Bundle.getMessage("Audio_StateInitial")),
+        Stopped(Audio.STATE_STOPPED, Bundle.getMessage("Audio_StateStopped")),
+        Playing(Audio.STATE_PLAYING, Bundle.getMessage("Audio_StatePlaying")),
+        Empty(Audio.STATE_EMPTY, Bundle.getMessage("Audio_StateEmpty")),
+        Loaded(Audio.STATE_LOADED, Bundle.getMessage("Audio_StateLoaded")),
+        Positioned(Audio.STATE_POSITIONED, Bundle.getMessage("Audio_StatePositioned")),
+        Moving(Audio.STATE_MOVING, Bundle.getMessage("Audio_StateMoving"));
+
+        private final int _id;
+        private final String _text;
+
+        private AudioState(int id, String text) {
+            this._id = id;
+            this._text = text;
+        }
+
+        public int getID() {
+            return _id;
+        }
+
+        @Override
+        public String toString() {
+            return _text;
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void getUsageDetail(int level, NamedBean bean, List<NamedBeanUsageReport> report, NamedBean cdl) {
+        log.debug("getUsageReport :: ExpressionAudio: bean = {}, report = {}", cdl, report);
+        _selectNamedBean.getUsageDetail(level, bean, report, cdl, this, LogixNG_SelectNamedBean.Type.Expression);
+    }
+
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ExpressionAudio.class);
+
+}

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionBundle.properties
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionBundle.properties
@@ -29,6 +29,16 @@ Antecedent_Short      = Antecedent
 Antecedent_Long       = Antecedent: {0}
 Antecedent_Long_Empty = Antecedent: empty
 
+Audio_Short             = Audio
+Audio_Long              = Audio {0} {1} {2}
+Audio_StateInitial      = Initial
+Audio_StateStopped      = Stopped
+Audio_StatePlaying      = Playing
+Audio_StateEmpty        = Empty
+Audio_StateLoaded       = Loaded
+Audio_StatePositioned   = Positioned
+Audio_StateMoving       = Moving
+
 Block_Short            = Block
 Block_Long             = Block "{0}" {1} {2}
 Block_Long_Value       = Block "{0}" value {1} to "{2}"

--- a/java/src/jmri/jmrit/logixng/expressions/configurexml/ExpressionAudioXml.java
+++ b/java/src/jmri/jmrit/logixng/expressions/configurexml/ExpressionAudioXml.java
@@ -1,0 +1,98 @@
+package jmri.jmrit.logixng.expressions.configurexml;
+
+import jmri.*;
+import jmri.configurexml.JmriConfigureXmlException;
+import jmri.jmrit.logixng.*;
+import jmri.jmrit.logixng.expressions.ExpressionAudio;
+import jmri.jmrit.logixng.util.configurexml.LogixNG_SelectNamedBeanXml;
+import jmri.jmrit.logixng.util.parser.ParserException;
+
+import org.jdom2.Element;
+
+/**
+ * Handle XML configuration for ExpressionAudioXml objects.
+ *
+ * @author Bob Jacobsen Copyright: Copyright (c) 2004, 2008, 2010
+ * @author Daniel Bergqvist Copyright (C) 2023
+ */
+public class ExpressionAudioXml extends jmri.managers.configurexml.AbstractNamedBeanManagerConfigXML {
+
+    public ExpressionAudioXml() {
+    }
+
+    /**
+     * Default implementation for storing the contents of a ExpressionAudio
+     *
+     * @param o Object to store, of type TripleAudioSignalHead
+     * @return Element containing the complete info
+     */
+    @Override
+    public Element store(Object o) {
+        ExpressionAudio p = (ExpressionAudio) o;
+
+        Element element = new Element("ExpressionAudio");
+        element.setAttribute("class", this.getClass().getName());
+        element.addContent(new Element("systemName").addContent(p.getSystemName()));
+
+        storeCommon(p, element);
+
+        var selectNamedBeanXml = new LogixNG_SelectNamedBeanXml<Audio>();
+        element.addContent(selectNamedBeanXml.store(p.getSelectNamedBean(), "namedBean"));
+
+        element.addContent(new Element("is_isNot").addContent(p.get_Is_IsNot().name()));
+
+        element.addContent(new Element("stateAddressing").addContent(p.getStateAddressing().name()));
+        element.addContent(new Element("audioState").addContent(p.getBeanState().name()));
+        element.addContent(new Element("stateReference").addContent(p.getStateReference()));
+        element.addContent(new Element("stateLocalVariable").addContent(p.getStateLocalVariable()));
+        element.addContent(new Element("stateFormula").addContent(p.getStateFormula()));
+
+        return element;
+    }
+
+    @Override
+    public boolean load(Element shared, Element perNode) throws JmriConfigureXmlException {     // Test class that inherits this class throws exception
+        String sys = getSystemName(shared);
+        String uname = getUserName(shared);
+        ExpressionAudio h = new ExpressionAudio(sys, uname);
+
+        loadCommon(h, shared);
+
+        var selectNamedBeanXml = new LogixNG_SelectNamedBeanXml<Audio>();
+        selectNamedBeanXml.load(shared.getChild("namedBean"), h.getSelectNamedBean());
+
+        try {
+            Element is_IsNot = shared.getChild("is_isNot");
+            if (is_IsNot != null) {
+                h.set_Is_IsNot(Is_IsNot_Enum.valueOf(is_IsNot.getTextTrim()));
+            }
+
+            Element elem = shared.getChild("stateAddressing");
+            if (elem != null) {
+                h.setStateAddressing(NamedBeanAddressing.valueOf(elem.getTextTrim()));
+            }
+
+            Element audioState = shared.getChild("audioState");
+            if (audioState != null) {
+                h.setBeanState(ExpressionAudio.AudioState.valueOf(audioState.getTextTrim()));
+            }
+
+            elem = shared.getChild("stateReference");
+            if (elem != null) h.setStateReference(elem.getTextTrim());
+
+            elem = shared.getChild("stateLocalVariable");
+            if (elem != null) h.setStateLocalVariable(elem.getTextTrim());
+
+            elem = shared.getChild("stateFormula");
+            if (elem != null) h.setStateFormula(elem.getTextTrim());
+
+        } catch (ParserException e) {
+            throw new JmriConfigureXmlException(e);
+        }
+
+        InstanceManager.getDefault(DigitalExpressionManager.class).registerExpression(h);
+        return true;
+    }
+
+//    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ExpressionAudioXml.class);
+}

--- a/java/src/jmri/jmrit/logixng/expressions/swing/DigitalExpressionSwingBundle.properties
+++ b/java/src/jmri/jmrit/logixng/expressions/swing/DigitalExpressionSwingBundle.properties
@@ -45,6 +45,8 @@ It's recommended to use Formula instead of Antecedent. Formula is much more powe
 Antecedent. And Formula uses the name of the children in the formula, instead of R1, R2, ...    \
 </table></html>
 
+ExpressionAudio_Components              = Audio {0} {1} {2}
+
 ExpressionConditional_Components        = Conditional {0} {1} {2}
 
 DigitalFormula_Formula                  = Formula

--- a/java/src/jmri/jmrit/logixng/expressions/swing/ExpressionAudioSwing.java
+++ b/java/src/jmri/jmrit/logixng/expressions/swing/ExpressionAudioSwing.java
@@ -1,0 +1,203 @@
+package jmri.jmrit.logixng.expressions.swing;
+
+import java.util.List;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import javax.swing.*;
+
+import jmri.*;
+import jmri.jmrit.logixng.*;
+import jmri.jmrit.logixng.expressions.ExpressionAudio;
+import jmri.jmrit.logixng.expressions.ExpressionAudio.AudioState;
+import jmri.jmrit.logixng.swing.SwingConfiguratorInterface;
+import jmri.jmrit.logixng.util.parser.ParserException;
+import jmri.jmrit.logixng.util.swing.LogixNG_SelectNamedBeanSwing;
+import jmri.util.swing.JComboBoxUtil;
+
+/**
+ * Configures an ExpressionAudio object with a Swing JPanel.
+ *
+ * @author Daniel Bergqvist Copyright 2023
+ */
+public class ExpressionAudioSwing extends AbstractDigitalExpressionSwing {
+
+    private LogixNG_SelectNamedBeanSwing<Audio> _selectNamedBeanSwing;
+
+    private JComboBox<Is_IsNot_Enum> _is_IsNot_ComboBox;
+
+    private JTabbedPane _tabbedPaneAudioState;
+    private JComboBox<AudioState> _stateComboBox;
+    private JPanel _panelAudioStateDirect;
+    private JPanel _panelAudioStateReference;
+    private JPanel _panelAudioStateLocalVariable;
+    private JPanel _panelAudioStateFormula;
+    private JTextField _turnoutStateReferenceTextField;
+    private JTextField _turnoutStateLocalVariableTextField;
+    private JTextField _turnoutStateFormulaTextField;
+
+
+    public ExpressionAudioSwing() {
+    }
+
+    public ExpressionAudioSwing(JDialog dialog) {
+        super.setJDialog(dialog);
+    }
+
+    @Override
+    protected void createPanel(@CheckForNull Base object, @Nonnull JPanel buttonPanel) {
+        ExpressionAudio expression = (ExpressionAudio)object;
+
+        panel = new JPanel();
+
+        _selectNamedBeanSwing = new LogixNG_SelectNamedBeanSwing<>(
+                InstanceManager.getDefault(AudioManager.class), getJDialog(), this);
+
+        JPanel _tabbedPaneNamedBean;
+        if (expression != null) {
+            _tabbedPaneNamedBean = _selectNamedBeanSwing.createPanel(expression.getSelectNamedBean());
+        } else {
+            _tabbedPaneNamedBean = _selectNamedBeanSwing.createPanel(null);
+        }
+
+
+        _is_IsNot_ComboBox = new JComboBox<>();
+        for (Is_IsNot_Enum e : Is_IsNot_Enum.values()) {
+            _is_IsNot_ComboBox.addItem(e);
+        }
+        JComboBoxUtil.setupComboBoxMaxRows(_is_IsNot_ComboBox);
+
+
+        _tabbedPaneAudioState = new JTabbedPane();
+        _panelAudioStateDirect = new javax.swing.JPanel();
+        _panelAudioStateReference = new javax.swing.JPanel();
+        _panelAudioStateLocalVariable = new javax.swing.JPanel();
+        _panelAudioStateFormula = new javax.swing.JPanel();
+
+        _tabbedPaneAudioState.addTab(NamedBeanAddressing.Direct.toString(), _panelAudioStateDirect);
+        _tabbedPaneAudioState.addTab(NamedBeanAddressing.Reference.toString(), _panelAudioStateReference);
+        _tabbedPaneAudioState.addTab(NamedBeanAddressing.LocalVariable.toString(), _panelAudioStateLocalVariable);
+        _tabbedPaneAudioState.addTab(NamedBeanAddressing.Formula.toString(), _panelAudioStateFormula);
+
+        _stateComboBox = new JComboBox<>();
+        for (AudioState e : AudioState.values()) {
+            _stateComboBox.addItem(e);
+        }
+        JComboBoxUtil.setupComboBoxMaxRows(_stateComboBox);
+
+        _panelAudioStateDirect.add(_stateComboBox);
+
+        _turnoutStateReferenceTextField = new JTextField();
+        _turnoutStateReferenceTextField.setColumns(30);
+        _panelAudioStateReference.add(_turnoutStateReferenceTextField);
+
+        _turnoutStateLocalVariableTextField = new JTextField();
+        _turnoutStateLocalVariableTextField.setColumns(30);
+        _panelAudioStateLocalVariable.add(_turnoutStateLocalVariableTextField);
+
+        _turnoutStateFormulaTextField = new JTextField();
+        _turnoutStateFormulaTextField.setColumns(30);
+        _panelAudioStateFormula.add(_turnoutStateFormulaTextField);
+
+
+        if (expression != null) {
+            _is_IsNot_ComboBox.setSelectedItem(expression.get_Is_IsNot());
+
+            switch (expression.getStateAddressing()) {
+                case Direct: _tabbedPaneAudioState.setSelectedComponent(_panelAudioStateDirect); break;
+                case Reference: _tabbedPaneAudioState.setSelectedComponent(_panelAudioStateReference); break;
+                case LocalVariable: _tabbedPaneAudioState.setSelectedComponent(_panelAudioStateLocalVariable); break;
+                case Formula: _tabbedPaneAudioState.setSelectedComponent(_panelAudioStateFormula); break;
+                default: throw new IllegalArgumentException("invalid _addressing state: " + expression.getStateAddressing().name());
+            }
+            _stateComboBox.setSelectedItem(expression.getBeanState());
+            _turnoutStateReferenceTextField.setText(expression.getStateReference());
+            _turnoutStateLocalVariableTextField.setText(expression.getStateLocalVariable());
+            _turnoutStateFormulaTextField.setText(expression.getStateFormula());
+        }
+
+        JComponent[] components = new JComponent[]{
+            _tabbedPaneNamedBean,
+            _is_IsNot_ComboBox,
+            _tabbedPaneAudioState};
+
+        List<JComponent> componentList = SwingConfiguratorInterface.parseMessage(
+                Bundle.getMessage("ExpressionAudio_Components"), components);
+
+        for (JComponent c : componentList) panel.add(c);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean validate(@Nonnull List<String> errorMessages) {
+        // Create a temporary expression to test formula
+        ExpressionAudio expression = new ExpressionAudio("IQDE1", null);
+
+        _selectNamedBeanSwing.validate(expression.getSelectNamedBean(), errorMessages);
+
+        try {
+            if (_tabbedPaneAudioState.getSelectedComponent() == _panelAudioStateReference) {
+                expression.setStateReference(_turnoutStateReferenceTextField.getText());
+            }
+        } catch (IllegalArgumentException e) {
+            errorMessages.add(e.getMessage());
+        }
+
+        return errorMessages.isEmpty();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public MaleSocket createNewObject(@Nonnull String systemName, @CheckForNull String userName) {
+        ExpressionAudio expression = new ExpressionAudio(systemName, userName);
+        updateObject(expression);
+        return InstanceManager.getDefault(DigitalExpressionManager.class).registerExpression(expression);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void updateObject(@Nonnull Base object) {
+        if (! (object instanceof ExpressionAudio)) {
+            throw new IllegalArgumentException("object must be an ExpressionAudio but is a: "+object.getClass().getName());
+        }
+        ExpressionAudio expression = (ExpressionAudio)object;
+
+        _selectNamedBeanSwing.updateObject(expression.getSelectNamedBean());
+
+        try {
+            expression.set_Is_IsNot((Is_IsNot_Enum)_is_IsNot_ComboBox.getSelectedItem());
+
+            if (_tabbedPaneAudioState.getSelectedComponent() == _panelAudioStateDirect) {
+                expression.setStateAddressing(NamedBeanAddressing.Direct);
+                expression.setBeanState((AudioState)_stateComboBox.getSelectedItem());
+            } else if (_tabbedPaneAudioState.getSelectedComponent() == _panelAudioStateReference) {
+                expression.setStateAddressing(NamedBeanAddressing.Reference);
+                expression.setStateReference(_turnoutStateReferenceTextField.getText());
+            } else if (_tabbedPaneAudioState.getSelectedComponent() == _panelAudioStateLocalVariable) {
+                expression.setStateAddressing(NamedBeanAddressing.LocalVariable);
+                expression.setStateLocalVariable(_turnoutStateLocalVariableTextField.getText());
+            } else if (_tabbedPaneAudioState.getSelectedComponent() == _panelAudioStateFormula) {
+                expression.setStateAddressing(NamedBeanAddressing.Formula);
+                expression.setStateFormula(_turnoutStateFormulaTextField.getText());
+            } else {
+                throw new IllegalArgumentException("_tabbedPaneAudioState has unknown selection");
+            }
+        } catch (ParserException e) {
+            throw new RuntimeException("ParserException: "+e.getMessage(), e);
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String toString() {
+        return Bundle.getMessage("Audio_Short");
+    }
+
+    @Override
+    public void dispose() {
+    }
+
+
+//    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ExpressionAudioSwing.class);
+
+}

--- a/java/test/jmri/jmrit/logixng/CreateLogixNGTreeScaffold.java
+++ b/java/test/jmri/jmrit/logixng/CreateLogixNGTreeScaffold.java
@@ -3218,6 +3218,111 @@ public class CreateLogixNGTreeScaffold {
         and.getChild(indexExpr++).connect(maleSocket);
 
 
+        ExpressionAudio expressionAudio = new ExpressionAudio(digitalExpressionManager.getAutoSystemName(), null);
+        maleSocket = digitalExpressionManager.registerExpression(expressionAudio);
+        maleSocket.setEnabled(false);
+        and.getChild(indexExpr++).connect(maleSocket);
+
+        expressionAudio = new ExpressionAudio(digitalExpressionManager.getAutoSystemName(), null);
+        expressionAudio.setComment("A comment");
+//        expressionAudio.getSelectNamedBean().setNamedBean(turnout1);
+        expressionAudio.setBeanState(ExpressionAudio.AudioState.Initial);
+        expressionAudio.getSelectNamedBean().setAddressing(NamedBeanAddressing.Direct);
+        expressionAudio.getSelectNamedBean().setFormula("\"IT\"+index");
+        expressionAudio.getSelectNamedBean().setLocalVariable("index");
+        expressionAudio.getSelectNamedBean().setReference("{IM1}");
+        expressionAudio.set_Is_IsNot(Is_IsNot_Enum.IsNot);
+        expressionAudio.setStateAddressing(NamedBeanAddressing.LocalVariable);
+        expressionAudio.setStateFormula("\"IT\"+index2");
+        expressionAudio.setStateLocalVariable("index2");
+        expressionAudio.setStateReference("{IM2}");
+        maleSocket = digitalExpressionManager.registerExpression(expressionAudio);
+        and.getChild(indexExpr++).connect(maleSocket);
+
+        expressionAudio = new ExpressionAudio(digitalExpressionManager.getAutoSystemName(), null);
+        expressionAudio.setComment("A comment");
+//        expressionAudio.getSelectNamedBean().setNamedBean(turnout1);
+        expressionAudio.setBeanState(ExpressionAudio.AudioState.Stopped);
+        expressionAudio.getSelectNamedBean().setAddressing(NamedBeanAddressing.LocalVariable);
+        expressionAudio.getSelectNamedBean().setFormula("\"IT\"+index");
+        expressionAudio.getSelectNamedBean().setLocalVariable("index");
+        expressionAudio.getSelectNamedBean().setReference("{IM1}");
+        expressionAudio.set_Is_IsNot(Is_IsNot_Enum.Is);
+        expressionAudio.setStateAddressing(NamedBeanAddressing.Formula);
+        expressionAudio.setStateFormula("\"IT\"+index2");
+        expressionAudio.setStateLocalVariable("index2");
+        expressionAudio.setStateReference("{IM2}");
+        maleSocket = digitalExpressionManager.registerExpression(expressionAudio);
+        and.getChild(indexExpr++).connect(maleSocket);
+
+        expressionAudio = new ExpressionAudio(digitalExpressionManager.getAutoSystemName(), null);
+        expressionAudio.setComment("A comment");
+//        expressionAudio.getSelectNamedBean().setNamedBean(turnout1);
+        expressionAudio.setBeanState(ExpressionAudio.AudioState.Playing);
+        expressionAudio.getSelectNamedBean().setAddressing(NamedBeanAddressing.Formula);
+        expressionAudio.getSelectNamedBean().setFormula("\"IT\"+index");
+        expressionAudio.getSelectNamedBean().setLocalVariable("index");
+        expressionAudio.getSelectNamedBean().setReference("{IM1}");
+        expressionAudio.set_Is_IsNot(Is_IsNot_Enum.IsNot);
+        expressionAudio.setStateAddressing(NamedBeanAddressing.Reference);
+        expressionAudio.setStateFormula("\"IT\"+index2");
+        expressionAudio.setStateLocalVariable("index2");
+        expressionAudio.setStateReference("{IM2}");
+        maleSocket = digitalExpressionManager.registerExpression(expressionAudio);
+        and.getChild(indexExpr++).connect(maleSocket);
+
+        expressionAudio = new ExpressionAudio(digitalExpressionManager.getAutoSystemName(), null);
+        expressionAudio.setComment("A comment");
+//        expressionAudio.getSelectNamedBean().setNamedBean(turnout1);
+        expressionAudio.setBeanState(ExpressionAudio.AudioState.Positioned);
+        expressionAudio.getSelectNamedBean().setAddressing(NamedBeanAddressing.Reference);
+        expressionAudio.getSelectNamedBean().setFormula("\"IT\"+index");
+        expressionAudio.getSelectNamedBean().setLocalVariable("index");
+        expressionAudio.getSelectNamedBean().setReference("{IM1}");
+        expressionAudio.set_Is_IsNot(Is_IsNot_Enum.Is);
+        expressionAudio.setStateAddressing(NamedBeanAddressing.Direct);
+        expressionAudio.setStateFormula("\"IT\"+index2");
+        expressionAudio.setStateLocalVariable("index2");
+        expressionAudio.setStateReference("{IM2}");
+        maleSocket = digitalExpressionManager.registerExpression(expressionAudio);
+        and.getChild(indexExpr++).connect(maleSocket);
+
+        expressionAudio = new ExpressionAudio(digitalExpressionManager.getAutoSystemName(), null);
+        expressionAudio.setBeanState(ExpressionAudio.AudioState.Empty);
+        maleSocket = digitalExpressionManager.registerExpression(expressionAudio);
+        and.getChild(indexExpr++).connect(maleSocket);
+
+        expressionAudio = new ExpressionAudio(digitalExpressionManager.getAutoSystemName(), null);
+        expressionAudio.setBeanState(ExpressionAudio.AudioState.Initial);
+        maleSocket = digitalExpressionManager.registerExpression(expressionAudio);
+        and.getChild(indexExpr++).connect(maleSocket);
+
+        expressionAudio = new ExpressionAudio(digitalExpressionManager.getAutoSystemName(), null);
+        expressionAudio.setBeanState(ExpressionAudio.AudioState.Loaded);
+        maleSocket = digitalExpressionManager.registerExpression(expressionAudio);
+        and.getChild(indexExpr++).connect(maleSocket);
+
+        expressionAudio = new ExpressionAudio(digitalExpressionManager.getAutoSystemName(), null);
+        expressionAudio.setBeanState(ExpressionAudio.AudioState.Moving);
+        maleSocket = digitalExpressionManager.registerExpression(expressionAudio);
+        and.getChild(indexExpr++).connect(maleSocket);
+
+        expressionAudio = new ExpressionAudio(digitalExpressionManager.getAutoSystemName(), null);
+        expressionAudio.setBeanState(ExpressionAudio.AudioState.Playing);
+        maleSocket = digitalExpressionManager.registerExpression(expressionAudio);
+        and.getChild(indexExpr++).connect(maleSocket);
+
+        expressionAudio = new ExpressionAudio(digitalExpressionManager.getAutoSystemName(), null);
+        expressionAudio.setBeanState(ExpressionAudio.AudioState.Positioned);
+        maleSocket = digitalExpressionManager.registerExpression(expressionAudio);
+        and.getChild(indexExpr++).connect(maleSocket);
+
+        expressionAudio = new ExpressionAudio(digitalExpressionManager.getAutoSystemName(), null);
+        expressionAudio.setBeanState(ExpressionAudio.AudioState.Stopped);
+        maleSocket = digitalExpressionManager.registerExpression(expressionAudio);
+        and.getChild(indexExpr++).connect(maleSocket);
+
+
         ExpressionBlock expressionBlock = new ExpressionBlock(digitalExpressionManager.getAutoSystemName(), null);
         maleSocket = digitalExpressionManager.registerExpression(expressionBlock);
         maleSocket.setEnabled(false);

--- a/java/test/jmri/jmrit/logixng/implementation/DefaultFemaleDigitalExpressionSocketTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/DefaultFemaleDigitalExpressionSocketTest.java
@@ -89,6 +89,7 @@ public class DefaultFemaleDigitalExpressionSocketTest extends FemaleSocketTestBa
         Map<Category, List<Class<? extends Base>>> map = new HashMap<>();
 
         List<Class<? extends Base>> classes = new ArrayList<>();
+        classes.add(jmri.jmrit.logixng.expressions.ExpressionAudio.class);
         classes.add(jmri.jmrit.logixng.expressions.ExpressionBlock.class);
         classes.add(jmri.jmrit.logixng.expressions.ExpressionClock.class);
         classes.add(jmri.jmrit.logixng.expressions.ExpressionConditional.class);

--- a/xml/schema/logixng/digital-expressions/digital-expressions-4.23.1.xsd
+++ b/xml/schema/logixng/digital-expressions/digital-expressions-4.23.1.xsd
@@ -29,6 +29,7 @@
   <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/digital-expressions/antecedent-4.23.1.xsd"/>
   <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/digital-expressions/connection-name-5.1.3.xsd"/>
   <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/digital-expressions/digital-call-module-4.23.4.xsd"/>
+  <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/digital-expressions/expression-audio-5.5.4.xsd"/>
   <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/digital-expressions/expression-block-4.23.1.xsd"/>
   <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/digital-expressions/expression-clock-4.23.1.xsd"/>
   <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/digital-expressions/expression-conditional-4.23.1.xsd"/>
@@ -83,6 +84,7 @@
             <xs:element name="Antecedent"         type="LogixNG_DigitalExpression_AntecedentType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="CallDigitalExpressionModule"  type="LogixNG_DigitalExpression_CallModuleType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="ConnectionName"     type="LogixNG_DigitalExpression_ConnectionNameType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="ExpressionAudio"    type="LogixNG_DigitalExpression_ExpressionAudioType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="ExpressionBlock"    type="LogixNG_DigitalExpression_ExpressionBlockType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="ExpressionClock"    type="LogixNG_DigitalExpression_ExpressionClockType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="ExpressionConditional"  type="LogixNG_DigitalExpression_ExpressionConditionalType" minOccurs="0" maxOccurs="unbounded" />

--- a/xml/schema/logixng/digital-expressions/expression-audio-5.5.4.xsd
+++ b/xml/schema/logixng/digital-expressions/expression-audio-5.5.4.xsd
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="../schema2xhtml.xsl" type="text/xsl"?>
+
+<!-- This schema is part of JMRI. Copyright 2018.                           -->
+<!--                                                                        -->
+<!-- JMRI is free software; you can redistribute it and/or modify it under  -->
+<!-- the terms of version 2 of the GNU General Public License as published  -->
+<!-- by the Free Software Foundation. See the "COPYING" file for a copy     -->
+<!-- of this license.                                                       -->
+<!--                                                                        -->
+<!-- JMRI is distributed in the hope that it will be useful, but WITHOUT    -->
+<!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
+<!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
+<!-- for more details.                                                      -->
+
+<!-- This file contains definitions for LogixNG                             -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:xsi ="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:docbook="http://docbook.org/ns/docbook"
+           xmlns:jmri="http://jmri.org/xml/schema/JMRIschema"
+           xsi:schemaLocation="
+                http://jmri.org/xml/schema/JMRIschema http://jmri.org/xml/schema/JMRIschema.xsd
+                http://docbook.org/ns/docbook http://jmri.org/xml/schema/docbook/docbook.xsd
+            "
+        >
+
+    <xs:complexType name="LogixNG_DigitalExpression_ExpressionAudioType">
+      <xs:annotation>
+        <xs:documentation>
+          Define the XML stucture for storing the contents of a ExpressionAudio class.
+        </xs:documentation>
+        <xs:appinfo>
+            <jmri:usingclass configurexml="true">jmri.jmrit.logixng.digital.expressions.configurexml.ExpressionAudioXml</jmri:usingclass>
+        </xs:appinfo>
+      </xs:annotation>
+
+            <xs:sequence>
+
+              <xs:element name="systemName" type="systemNameType" minOccurs="1" maxOccurs="1"/>
+              <xs:element name="userName" type="userNameType" minOccurs="0" maxOccurs="1"/>
+              <xs:element name="comment" type="commentType" minOccurs="0" maxOccurs="unbounded"/>
+
+              <xs:element name="namedBean" type="LogixNG_SelectNamedBeanType" minOccurs="0" maxOccurs="1" />
+
+              <xs:element name="addressing" type="LogixNG_Addressing_Type" minOccurs="0" maxOccurs="1" />
+              <xs:element name="reference" type="xs:string" minOccurs="0" maxOccurs="1" />
+              <xs:element name="localVariable" type="xs:string" minOccurs="0" maxOccurs="1" />
+              <xs:element name="formula" type="xs:string" minOccurs="0" maxOccurs="1" />
+
+              <xs:element name="is_isNot" type="LogixNG_Is_IsNot_Type" minOccurs="0" maxOccurs="1"/>
+
+              <xs:element name="stateAddressing" type="LogixNG_Addressing_Type" minOccurs="0" maxOccurs="1" />
+
+              <xs:element name="audioState" minOccurs="1" maxOccurs="1">
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="Initial"/>
+                    <xs:enumeration value="Stopped"/>
+                    <xs:enumeration value="Playing"/>
+                    <xs:enumeration value="Empty"/>
+                    <xs:enumeration value="Loaded"/>
+                    <xs:enumeration value="Positioned"/>
+                    <xs:enumeration value="Moving"/>
+                  </xs:restriction>
+                </xs:simpleType>
+              </xs:element>
+
+              <xs:element name="stateReference" type="xs:string" minOccurs="0" maxOccurs="1" />
+              <xs:element name="stateLocalVariable" type="xs:string" minOccurs="0" maxOccurs="1" />
+              <xs:element name="stateFormula" type="xs:string" minOccurs="0" maxOccurs="1" />
+
+<!--              <xs:element name="enabled" type="yesNoType" /> -->
+
+              <xs:element name="MaleSocket" type="LogixNG_MaleSocket_Type" minOccurs="0" maxOccurs="1"/>
+
+            </xs:sequence>
+<!--            <xs:attribute name="enabled" type="yesNoType" /> -->
+            <xs:attribute name="class" type="classType" use="required"/>
+
+    </xs:complexType>
+
+</xs:schema>


### PR DESCRIPTION
This PR solves this JMRI users list request:
https://groups.io/g/jmriusers/message/220391

It adds the LogixNG expression Audio which lets LogixNG listen on an Audio and then take appropriate action.

The attached panel file demostrates this action. Click on the LS1 sensor (the leftmost one on the panel) and the sound will start playing. When the sound is completed, the LS1 sensor will be set to inactive.

[daniel.txt](https://github.com/JMRI/JMRI/files/12447000/daniel.txt)