### PR TITLE
Add JmriJOptionPane to some BeanTable classes

### DIFF
--- a/help/en/html/doc/Technical/Swing.shtml
+++ b/help/en/html/doc/Technical/Swing.shtml
@@ -171,7 +171,12 @@
 
       <p>Prefer use of jmri.util.swing.WrapLayout to java.awt.FlowLayout, because
       WrapLayout properly handles the case of its contents wrapping into two lines.
-      When that happens, FlowLayout will often not display the second line.
+      When that happens, FlowLayout will often not display the second line.</p>
+
+      <p>jmri.util.swing.JmriJOptionPane is preferred over javax.swing.JOptionPane.
+      The Modality of the latter will block the whole JVM UI until they are closed.
+      This causes issues with Always on Top Frames, which will also be blocked,
+      potentially with the Dialog hidden behind the Frame.</p>
       
       <!--#include virtual="/Footer.shtml" -->
     </div> <!-- closes #mainContent-->

--- a/java/src/jmri/jmrit/beantable/AbstractLogixNGTableAction.java
+++ b/java/src/jmri/jmrit/beantable/AbstractLogixNGTableAction.java
@@ -22,6 +22,7 @@ import jmri.jmrit.logixng.tools.swing.AbstractLogixNGEditor;
 import jmri.jmrit.logixng.tools.swing.DeleteBean;
 import jmri.util.FileUtil;
 import jmri.util.JmriJFrame;
+import jmri.util.swing.JmriJOptionPane;
 
 /**
  * Swing action to create and register a LogixNG Table.
@@ -312,7 +313,7 @@ public abstract class AbstractLogixNGTableAction<E extends NamedBean> extends Ab
         Runnable t = new Runnable() {
             @Override
             public void run() {
-//                JOptionPane.showMessageDialog(null, "Copy is not implemented yet.", "Error", JOptionPane.ERROR_MESSAGE);
+//                JmriJOptionPane.showMessageDialog(null, "Copy is not implemented yet.", "Error", JmriJOptionPane.ERROR_MESSAGE);
 
                 JPanel panel5 = makeAddFrame("TitleCopyLogixNG", "Copy");    // NOI18N
                 // Create bean
@@ -381,11 +382,11 @@ public abstract class AbstractLogixNGTableAction<E extends NamedBean> extends Ab
             boolean createLogix = true;
             targetBean = getManager().getBySystemName(sName);
             if (targetBean != null) {
-                int result = JOptionPane.showConfirmDialog(f,
+                int result = JmriJOptionPane.showConfirmDialog(f,
                         Bundle.getMessage("ConfirmLogixDuplicate", sName, _logixNGSysName), // NOI18N
-                        Bundle.getMessage("QuestionTitle"), JOptionPane.YES_NO_OPTION,    // NOI18N
-                        JOptionPane.QUESTION_MESSAGE);
-                if (JOptionPane.NO_OPTION == result) {
+                        Bundle.getMessage("QuestionTitle"), JmriJOptionPane.YES_NO_OPTION,    // NOI18N
+                        JmriJOptionPane.QUESTION_MESSAGE);
+                if (JmriJOptionPane.NO_OPTION == result) {
                     return;
                 }
                 createLogix = false;
@@ -430,9 +431,9 @@ public abstract class AbstractLogixNGTableAction<E extends NamedBean> extends Ab
             E x = getManager().getByUserName(uName);
             if (x != null) {
                 // A bean with this user name already exists
-                JOptionPane.showMessageDialog(addLogixNGFrame,
+                JmriJOptionPane.showMessageDialog(addLogixNGFrame,
                         Bundle.getMessage("LogixNGError3"), Bundle.getMessage("ErrorTitle"), // NOI18N
-                        JOptionPane.ERROR_MESSAGE);
+                        JmriJOptionPane.ERROR_MESSAGE);
                 return false;
             }
         }
@@ -450,9 +451,9 @@ public abstract class AbstractLogixNGTableAction<E extends NamedBean> extends Ab
         String sName = _systemName.getText();
         if ((sName.length() < 1)) {
             // Entered system name is blank or too short
-            JOptionPane.showMessageDialog(addLogixNGFrame,
+            JmriJOptionPane.showMessageDialog(addLogixNGFrame,
                     Bundle.getMessage("LogixNGError8"), Bundle.getMessage("ErrorTitle"), // NOI18N
-                    JOptionPane.ERROR_MESSAGE);
+                    JmriJOptionPane.ERROR_MESSAGE);
             return false;
         }
         if ((sName.length() < 2) || (sName.charAt(0) != 'I')
@@ -475,10 +476,10 @@ public abstract class AbstractLogixNGTableAction<E extends NamedBean> extends Ab
     boolean checkFlags(String sName) {
         if (_inEditMode) {
             // Already editing a bean, ask for completion of that edit
-            JOptionPane.showMessageDialog(null,
+            JmriJOptionPane.showMessageDialog(null,
                     Bundle.getMessage("LogixNGError32", _curNamedBean.getSystemName()),
                     Bundle.getMessage("ErrorTitle"),
-                    JOptionPane.ERROR_MESSAGE);
+                    JmriJOptionPane.ERROR_MESSAGE);
             if (_editor != null) {
                 _editor.bringToFront();
             }
@@ -487,10 +488,10 @@ public abstract class AbstractLogixNGTableAction<E extends NamedBean> extends Ab
 
         if (_inCopyMode) {
             // Already editing a bean, ask for completion of that edit
-            JOptionPane.showMessageDialog(null,
+            JmriJOptionPane.showMessageDialog(null,
                     Bundle.getMessage("LogixNGError31", _logixNGSysName),
                     Bundle.getMessage("ErrorTitle"), // NOI18N
-                    JOptionPane.ERROR_MESSAGE);
+                    JmriJOptionPane.ERROR_MESSAGE);
             return false;
         }
 
@@ -500,10 +501,10 @@ public abstract class AbstractLogixNGTableAction<E extends NamedBean> extends Ab
             if (x == null) {
                 // bean does not exist, so cannot be edited
                 log.error("No bean with system name: {}", sName);
-                JOptionPane.showMessageDialog(null,
+                JmriJOptionPane.showMessageDialog(null,
                         Bundle.getMessage("LogixNGError5"),
                         Bundle.getMessage("ErrorTitle"), // NOI18N
-                        JOptionPane.ERROR_MESSAGE);
+                        JmriJOptionPane.ERROR_MESSAGE);
                 return false;
             }
         }
@@ -530,9 +531,9 @@ public abstract class AbstractLogixNGTableAction<E extends NamedBean> extends Ab
             try {
                 _curNamedBean = createBean(uName);
             } catch (BadSystemNameException | BadUserNameException ex) {
-                JOptionPane.showMessageDialog(addLogixNGFrame, ex.getLocalizedMessage(),
+                JmriJOptionPane.showMessageDialog(addLogixNGFrame, ex.getLocalizedMessage(),
                         Bundle.getMessage("ErrorTitle"), // NOI18N
-                        JOptionPane.ERROR_MESSAGE);
+                        JmriJOptionPane.ERROR_MESSAGE);
                 return;
             }
             if (_curNamedBean == null) {
@@ -557,9 +558,9 @@ public abstract class AbstractLogixNGTableAction<E extends NamedBean> extends Ab
             }
             if (x != null) {
                 // bean already exists
-                JOptionPane.showMessageDialog(addLogixNGFrame, Bundle.getMessage("LogixNGError1"),
+                JmriJOptionPane.showMessageDialog(addLogixNGFrame, Bundle.getMessage("LogixNGError1"),
                         Bundle.getMessage("ErrorTitle"), // NOI18N
-                        JOptionPane.ERROR_MESSAGE);
+                        JmriJOptionPane.ERROR_MESSAGE);
                 return;
             }
             if (!checkLogixNGUserName(uName)) {
@@ -582,10 +583,10 @@ public abstract class AbstractLogixNGTableAction<E extends NamedBean> extends Ab
     }
 
     void handleCreateException(String sysName) {
-        JOptionPane.showMessageDialog(addLogixNGFrame,
+        JmriJOptionPane.showMessageDialog(addLogixNGFrame,
                 Bundle.getMessage("ErrorLogixAddFailed", sysName), // NOI18N
                 Bundle.getMessage("ErrorTitle"), // NOI18N
-                JOptionPane.ERROR_MESSAGE);
+                JmriJOptionPane.ERROR_MESSAGE);
     }
 
     // ------------ Methods for Edit bean Pane ------------
@@ -772,10 +773,10 @@ public abstract class AbstractLogixNGTableAction<E extends NamedBean> extends Ab
         JButton helpBrowse = new JButton(Bundle.getMessage("MenuHelp"));   // NOI18N
         bottomPanel.add(helpBrowse, BorderLayout.WEST);
         helpBrowse.addActionListener((ActionEvent e) -> {
-            JOptionPane.showMessageDialog(condBrowserFrame,
+            JmriJOptionPane.showMessageDialog(condBrowserFrame,
                     Bundle.getMessage("LogixNG_Browse_HelpText"),   // NOI18N
                     Bundle.getMessage("BrowserHelpTitle"),  // NOI18N
-                    JOptionPane.INFORMATION_MESSAGE);
+                    JmriJOptionPane.INFORMATION_MESSAGE);
         });
 
         JPanel settingsPanel = getSettingsPanel();
@@ -817,11 +818,11 @@ public abstract class AbstractLogixNGTableAction<E extends NamedBean> extends Ab
             Object[] options = {Bundle.getMessage("BrowserSaveDuplicateReplace"),  // NOI18N
                     Bundle.getMessage("BrowserSaveDuplicateAppend"),  // NOI18N
                     Bundle.getMessage("ButtonCancel")};               // NOI18N
-            int selectedOption = JOptionPane.showOptionDialog(null,
+            int selectedOption = JmriJOptionPane.showOptionDialog(null,
                     Bundle.getMessage("BrowserSaveDuplicatePrompt", file.getName()), // NOI18N
                     Bundle.getMessage("BrowserSaveDuplicateTitle"),   // NOI18N
-                    JOptionPane.DEFAULT_OPTION,
-                    JOptionPane.WARNING_MESSAGE,
+                    JmriJOptionPane.DEFAULT_OPTION,
+                    JmriJOptionPane.WARNING_MESSAGE,
                     null, options, options[0]);
             if (selectedOption == 2 || selectedOption == -1) {
                 log.debug("Save browser content stopped, file replace/append cancelled");  // NOI18N

--- a/java/src/jmri/jmrit/beantable/BlockTableAction.java
+++ b/java/src/jmri/jmrit/beantable/BlockTableAction.java
@@ -15,9 +15,7 @@ import jmri.UserPreferencesManager;
 import jmri.jmrit.beantable.block.BlockTableDataModel;
 import jmri.BlockManager;
 import jmri.util.JmriJFrame;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import jmri.util.swing.JmriJOptionPane;
 
 /**
  * Swing action to create and register a BlockTable GUI.
@@ -39,7 +37,7 @@ public class BlockTableAction extends AbstractTableAction<Block> {
         super(actionName);
 
         // disable ourself if there is no primary Block manager available
-        if (jmri.InstanceManager.getNullableDefault(jmri.BlockManager.class) == null) {
+        if (InstanceManager.getNullableDefault(BlockManager.class) == null) {
             BlockTableAction.this.setEnabled(false);
         }
     }
@@ -115,7 +113,7 @@ public class BlockTableAction extends AbstractTableAction<Block> {
      */
     @Override
     public void setMenuBar(BeanTableFrame<Block> f) {
-        final jmri.util.JmriJFrame finalF = f; // needed for anonymous ActionListener class
+        final JmriJFrame finalF = f; // needed for anonymous ActionListener class
         JMenuBar menuBar = f.getJMenuBar();
         int pos = menuBar.getMenuCount() - 1; // count the number of menus to insert the TableMenus before 'Window' and 'Help'
         int offset = 1;
@@ -220,10 +218,10 @@ public class BlockTableAction extends AbstractTableAction<Block> {
             numberOfBlocks = (Integer) numberToAddSpinner.getValue();
         }
         if (numberOfBlocks >= 65) { // limited by JSpinnerModel to 100
-            if (JOptionPane.showConfirmDialog(addFrame,
+            if (JmriJOptionPane.showConfirmDialog(addFrame,
                     Bundle.getMessage("WarnExcessBeans", Bundle.getMessage("Blocks"), numberOfBlocks),
                     Bundle.getMessage("WarningTitle"),
-                    JOptionPane.YES_NO_OPTION) == 1) {
+                    JmriJOptionPane.YES_NO_OPTION) != JmriJOptionPane.YES_OPTION) {
                 return;
             }
         }
@@ -258,7 +256,7 @@ public class BlockTableAction extends AbstractTableAction<Block> {
                     while (true) {
                         system = nextName(system);
                         // log.warn("Trying " + system);
-                        Block blk = InstanceManager.getDefault(jmri.BlockManager.class).getBySystemName(system);
+                        Block blk = InstanceManager.getDefault(BlockManager.class).getBySystemName(system);
                         if (blk == null) {
                             sName = system;
                             break;
@@ -270,7 +268,7 @@ public class BlockTableAction extends AbstractTableAction<Block> {
                     while (true) {
                         user = nextName(user);
                         //log.warn("Trying " + user);
-                        Block blk = InstanceManager.getDefault(jmri.BlockManager.class).getByUserName(user);
+                        Block blk = InstanceManager.getDefault(BlockManager.class).getByUserName(user);
                         if (blk == null) {
                             uName = user;
                             break;
@@ -282,13 +280,13 @@ public class BlockTableAction extends AbstractTableAction<Block> {
             String xName = "";
             try {
                 if (_autoSystemNameCheckBox.isSelected()) {
-                    blk = InstanceManager.getDefault(jmri.BlockManager.class).createNewBlock(uName);
+                    blk = InstanceManager.getDefault(BlockManager.class).createNewBlock(uName);
                     if (blk == null) {
                         xName = uName;
                         throw new java.lang.IllegalArgumentException();
                     }
                 } else {
-                    blk = InstanceManager.getDefault(jmri.BlockManager.class).createNewBlock(sName, uName);
+                    blk = InstanceManager.getDefault(BlockManager.class).createNewBlock(sName, uName);
                     if (blk == null) {
                         xName = sName;
                         throw new java.lang.IllegalArgumentException();
@@ -321,29 +319,29 @@ public class BlockTableAction extends AbstractTableAction<Block> {
     }
 
     void handleCreateException(String sysName) {
-        JOptionPane.showMessageDialog(addFrame,
+        JmriJOptionPane.showMessageDialog(addFrame,
                 Bundle.getMessage("ErrorBlockAddFailed", sysName) + "\n" + Bundle.getMessage("ErrorAddFailedCheck"),
                 Bundle.getMessage("ErrorTitle"),
-                JOptionPane.ERROR_MESSAGE);
+                JmriJOptionPane.ERROR_MESSAGE);
     }
     //private boolean noWarn = false;
 
-    void deletePaths(jmri.util.JmriJFrame f) {
+    void deletePaths(JmriJFrame f) {
         // Set option to prevent the path information from being saved.
 
         Object[] options = {Bundle.getMessage("ButtonRemove"),
             Bundle.getMessage("ButtonKeep")};
 
-        int retval = JOptionPane.showOptionDialog(f,
+        int retval = JmriJOptionPane.showOptionDialog(f,
                 Bundle.getMessage("BlockPathMessage"),
                 Bundle.getMessage("BlockPathSaveTitle"),
-                JOptionPane.YES_NO_OPTION,
-                JOptionPane.QUESTION_MESSAGE, null, options, options[1]);
+                JmriJOptionPane.YES_NO_OPTION,
+                JmriJOptionPane.QUESTION_MESSAGE, null, options, options[1]);
         if (retval != 0) {
-            InstanceManager.getDefault(jmri.BlockManager.class).setSavedPathInfo(true);
+            InstanceManager.getDefault(BlockManager.class).setSavedPathInfo(true);
             log.info("Requested to save path information via Block Menu.");
         } else {
-            InstanceManager.getDefault(jmri.BlockManager.class).setSavedPathInfo(false);
+            InstanceManager.getDefault(BlockManager.class).setSavedPathInfo(false);
             log.info("Requested not to save path information via Block Menu.");
         }
     }
@@ -358,6 +356,6 @@ public class BlockTableAction extends AbstractTableAction<Block> {
         return BlockTableAction.class.getName();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(BlockTableAction.class);
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(BlockTableAction.class);
 
 }

--- a/java/src/jmri/jmrit/beantable/IdTagTableAction.java
+++ b/java/src/jmri/jmrit/beantable/IdTagTableAction.java
@@ -8,7 +8,6 @@ import java.beans.PropertyChangeListener;
 import javax.annotation.Nonnull;
 import javax.swing.BoxLayout;
 import javax.swing.JCheckBox;
-import javax.swing.JOptionPane;
 import javax.swing.JTextField;
 
 import jmri.IdTag;
@@ -18,8 +17,7 @@ import jmri.Manager;
 import jmri.managers.DefaultRailComManager;
 import jmri.managers.ProxyIdTagManager;
 import jmri.util.JmriJFrame;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import jmri.util.swing.JmriJOptionPane;
 
 /**
  * Swing action to create and register a IdTagTable GUI.
@@ -137,11 +135,11 @@ public class IdTagTableAction extends AbstractTableAction<IdTag> implements Prop
     //private boolean noWarn = false;
 
     void handleCreateException(String sysName, IllegalArgumentException ex) {
-        JOptionPane.showMessageDialog(addFrame,
+        JmriJOptionPane.showMessageDialog(addFrame,
                 Bundle.getMessage("ErrorIdTagAddFailed", sysName) + "\n" + Bundle.getMessage("ErrorAddFailedCheck")
                 + "\n" + ex.getLocalizedMessage() ,
                 Bundle.getMessage("ErrorTitle"),
-                JOptionPane.ERROR_MESSAGE);
+                JmriJOptionPane.ERROR_MESSAGE);
     }
 
     @Override
@@ -208,6 +206,6 @@ public class IdTagTableAction extends AbstractTableAction<IdTag> implements Prop
         super.dispose();
     }
     
-    private static final Logger log = LoggerFactory.getLogger(IdTagTableAction.class);
+    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(IdTagTableAction.class);
 
 }

--- a/java/src/jmri/jmrit/beantable/LRouteTableAction.java
+++ b/java/src/jmri/jmrit/beantable/LRouteTableAction.java
@@ -18,6 +18,7 @@ import jmri.implementation.DefaultConditionalAction;
 import jmri.script.swing.ScriptFileChooser;
 import jmri.util.FileUtil;
 import jmri.util.JmriJFrame;
+import jmri.util.swing.JmriJOptionPane;
 
 /**
  * Swing action to create and register groups of Logix Condtionals to perform a
@@ -65,7 +66,8 @@ public class LRouteTableAction extends AbstractTableAction<Logix> {
 
     class LBeanTableDataModel extends BeanTableDataModel<Logix> {
 
-        // overlay the state column with the edit column
+        // overlay the value column with the enable column
+        // overlay the delete column with the edit column
         static public final int ENABLECOL = VALUECOL;
         static public final int EDITCOL = DELETECOL;
         protected String enabledString = Bundle.getMessage("ColumnHeadEnabled");
@@ -556,10 +558,10 @@ public class LRouteTableAction extends AbstractTableAction<Logix> {
                         soundFile.setText(action.getActionString());
                         continue;
                     default:
-                        JOptionPane.showMessageDialog(
+                        JmriJOptionPane.showMessageDialog(
                                 _addFrame, java.text.MessageFormat.format(rbx.getString("TypeWarn"),
                                         new Object[]{action.toString(), c.getSystemName()}),
-                                rbx.getString("EditDiff"), JOptionPane.WARNING_MESSAGE);
+                                rbx.getString("EditDiff"), JmriJOptionPane.WARNING_MESSAGE);
                         continue;
                 }
                 String name = action.getDeviceName();
@@ -569,10 +571,10 @@ public class LRouteTableAction extends AbstractTableAction<Logix> {
                     elt = _outputMap.get(key);
                 }
                 if (elt == null) {
-                    JOptionPane.showMessageDialog(
+                    JmriJOptionPane.showMessageDialog(
                             _addFrame, java.text.MessageFormat.format(rbx.getString("TypeWarn"),
                                     new Object[]{action.toString(), c.getSystemName()}),
-                            rbx.getString("EditDiff"), JOptionPane.WARNING_MESSAGE);
+                            rbx.getString("EditDiff"), JmriJOptionPane.WARNING_MESSAGE);
                 } else {
                     elt.setIncluded(true);
                     elt.setState(action.getActionData());
@@ -580,10 +582,10 @@ public class LRouteTableAction extends AbstractTableAction<Logix> {
                     if (k == 0) {
                         onChange = change;
                     } else if (change != onChange) {
-                        JOptionPane.showMessageDialog(
+                        JmriJOptionPane.showMessageDialog(
                                 _addFrame, java.text.MessageFormat.format(rbx.getString("OnChangeWarn"),
                                         new Object[]{action.toString(), c.getSystemName()}),
-                                rbx.getString("EditDiff"), JOptionPane.WARNING_MESSAGE);
+                                rbx.getString("EditDiff"), JmriJOptionPane.WARNING_MESSAGE);
                     }
                 }
             }
@@ -631,10 +633,10 @@ public class LRouteTableAction extends AbstractTableAction<Logix> {
                         break;
                     default:
                         if (!getLogixInitializer().equals(variable.getName())) {
-                            JOptionPane.showMessageDialog(
+                            JmriJOptionPane.showMessageDialog(
                                     _addFrame, java.text.MessageFormat.format(rbx.getString("TypeWarnVar"),
                                             new Object[]{variable.toString(), c.getSystemName()}),
-                                    rbx.getString("EditDiff"), JOptionPane.WARNING_MESSAGE);
+                                    rbx.getString("EditDiff"), JmriJOptionPane.WARNING_MESSAGE);
                         }
                         continue;
                 }
@@ -654,10 +656,10 @@ public class LRouteTableAction extends AbstractTableAction<Logix> {
                 }
                 if (elt == null) {
                     if (!getLogixInitializer().equals(name)) {
-                        JOptionPane.showMessageDialog(
+                        JmriJOptionPane.showMessageDialog(
                                 _addFrame, java.text.MessageFormat.format(rbx.getString("TypeWarnVar"),
                                         new Object[]{variable.toString(), c.getSystemName()}),
-                                rbx.getString("EditDiff"), JOptionPane.WARNING_MESSAGE);
+                                rbx.getString("EditDiff"), JmriJOptionPane.WARNING_MESSAGE);
                     }
                 } else {
                     elt.setIncluded(true);
@@ -680,10 +682,10 @@ public class LRouteTableAction extends AbstractTableAction<Logix> {
             for (int k = 0; k < actionList.size(); k++) {
                 ConditionalAction action = actionList.get(k);
                 if (action.getType() != Conditional.Action.SET_SENSOR) {
-                    JOptionPane.showMessageDialog(
+                    JmriJOptionPane.showMessageDialog(
                             _addFrame, java.text.MessageFormat.format(rbx.getString("AlignWarn1"),
                                     new Object[]{action.toString(), c.getSystemName()}),
-                            rbx.getString("EditDiff"), JOptionPane.WARNING_MESSAGE);
+                            rbx.getString("EditDiff"), JmriJOptionPane.WARNING_MESSAGE);
                 } else {
                     String name = action.getDeviceName();
                     String key = SENSOR_TYPE + name;
@@ -692,16 +694,16 @@ public class LRouteTableAction extends AbstractTableAction<Logix> {
                         element = _alignMap.get(key);
                     }
                     if (element == null) {
-                        JOptionPane.showMessageDialog(
+                        JmriJOptionPane.showMessageDialog(
                                 _addFrame, java.text.MessageFormat.format(rbx.getString("TypeWarn"),
                                         new Object[]{action.toString(), c.getSystemName()}),
-                                rbx.getString("EditDiff"), JOptionPane.WARNING_MESSAGE);
+                                rbx.getString("EditDiff"), JmriJOptionPane.WARNING_MESSAGE);
 
                     } else if (!name.equals(action.getDeviceName())) {
-                        JOptionPane.showMessageDialog(
+                        JmriJOptionPane.showMessageDialog(
                                 _addFrame, java.text.MessageFormat.format(rbx.getString("AlignWarn2"),
                                         new Object[]{action.toString(), action.getDeviceName(), c.getSystemName()}),
-                                rbx.getString("EditDiff"), JOptionPane.WARNING_MESSAGE);
+                                rbx.getString("EditDiff"), JmriJOptionPane.WARNING_MESSAGE);
 
                     } else {
                         element.setIncluded(true);
@@ -742,10 +744,10 @@ public class LRouteTableAction extends AbstractTableAction<Logix> {
                         break;
                     default:
                         if (!getLogixInitializer().equals(variable.getName())) {
-                            JOptionPane.showMessageDialog(
+                            JmriJOptionPane.showMessageDialog(
                                     _addFrame, java.text.MessageFormat.format(rbx.getString("TypeWarnVar"),
                                             new Object[]{variable.toString(), c.getSystemName()}),
-                                    rbx.getString("EditDiff"), JOptionPane.WARNING_MESSAGE);
+                                    rbx.getString("EditDiff"), JmriJOptionPane.WARNING_MESSAGE);
                         }
                         continue;
                 }
@@ -776,19 +778,19 @@ public class LRouteTableAction extends AbstractTableAction<Logix> {
             ArrayList<RouteOutputElement> tList = makeTurnoutLockList();
             List<ConditionalAction> actionList = c.getCopyOfActions();
             if (actionList.size() != tList.size()) {
-                JOptionPane.showMessageDialog(
+                JmriJOptionPane.showMessageDialog(
                         _addFrame, java.text.MessageFormat.format(rbx.getString("LockWarn1"),
                                 new Object[]{Integer.toString(tList.size()), c.getSystemName(),
                                     Integer.toString(actionList.size())}),
-                        rbx.getString("EditDiff"), JOptionPane.WARNING_MESSAGE);
+                        rbx.getString("EditDiff"), JmriJOptionPane.WARNING_MESSAGE);
             }
             for (int k = 0; k < actionList.size(); k++) {
                 ConditionalAction action = actionList.get(k);
                 if (action.getType() != Conditional.Action.LOCK_TURNOUT) {
-                    JOptionPane.showMessageDialog(
+                    JmriJOptionPane.showMessageDialog(
                             _addFrame, java.text.MessageFormat.format(rbx.getString("LockWarn2"),
                                     new Object[]{action.getDeviceName(), c.getSystemName()}),
-                            rbx.getString("EditDiff"), JOptionPane.WARNING_MESSAGE);
+                            rbx.getString("EditDiff"), JmriJOptionPane.WARNING_MESSAGE);
                 } else {
                     String name = action.getDeviceName();
                     boolean found = false;
@@ -801,10 +803,10 @@ public class LRouteTableAction extends AbstractTableAction<Logix> {
                         }
                     }
                     if (!found) {
-                        JOptionPane.showMessageDialog(
+                        JmriJOptionPane.showMessageDialog(
                                 _addFrame, java.text.MessageFormat.format(rbx.getString("LockWarn3"),
                                         new Object[]{name, c.getSystemName()}),
-                                rbx.getString("EditDiff"), JOptionPane.WARNING_MESSAGE);
+                                rbx.getString("EditDiff"), JmriJOptionPane.WARNING_MESSAGE);
                     }
                 }
             }
@@ -1236,9 +1238,9 @@ public class LRouteTableAction extends AbstractTableAction<Logix> {
 
     void showMessage(String msg) {
 
-        JOptionPane.showMessageDialog(
+        JmriJOptionPane.showMessageDialog(
                 _addFrame, rbx.getString(msg), Bundle.getMessage("WarningTitle"),
-                JOptionPane.WARNING_MESSAGE);
+                JmriJOptionPane.WARNING_MESSAGE);
     }
 
     boolean checkNewNamesOK() {
@@ -1500,9 +1502,9 @@ public class LRouteTableAction extends AbstractTableAction<Logix> {
                 }
             }
             if (actionList.isEmpty()) {
-                JOptionPane.showMessageDialog(
+                JmriJOptionPane.showMessageDialog(
                         _addFrame, rbx.getString("noAction"),
-                        rbx.getString("addErr"), JOptionPane.ERROR_MESSAGE);
+                        rbx.getString("addErr"), JmriJOptionPane.ERROR_MESSAGE);
                 return;
             }
         } else {
@@ -1565,9 +1567,9 @@ public class LRouteTableAction extends AbstractTableAction<Logix> {
             }
         }
         if (numConds == 1) {
-            JOptionPane.showMessageDialog(
+            JmriJOptionPane.showMessageDialog(
                     _addFrame, rbx.getString("noVars"),
-                    rbx.getString("addErr"), JOptionPane.ERROR_MESSAGE);
+                    rbx.getString("addErr"), JmriJOptionPane.ERROR_MESSAGE);
             return;
         }
 
@@ -1704,10 +1706,10 @@ public class LRouteTableAction extends AbstractTableAction<Logix> {
             if (vList.size() > 0) {
                 numConds = makeAlignConditional(numConds, aList, vList, logix, sName, uName);
             } else {
-                JOptionPane.showMessageDialog(
+                JmriJOptionPane.showMessageDialog(
                         _addFrame, java.text.MessageFormat.format(rbx.getString("NoAlign"),
                                 new Object[]{name, sensor.getAlignType()}),
-                        Bundle.getMessage("WarningTitle"), JOptionPane.WARNING_MESSAGE);
+                        Bundle.getMessage("WarningTitle"), JmriJOptionPane.WARNING_MESSAGE);
             }
         }
         ///////////////// Make Lock Conditional //////////////////////////
@@ -1849,10 +1851,10 @@ public class LRouteTableAction extends AbstractTableAction<Logix> {
     }
 
     void handleCreateException(String sysName) {
-        JOptionPane.showMessageDialog(_addFrame,
+        JmriJOptionPane.showMessageDialog(_addFrame,
                 Bundle.getMessage("ErrorLRouteAddFailed", sysName) + "\n" + Bundle.getMessage("ErrorAddFailedCheck"),
                 Bundle.getMessage("ErrorTitle"),
-                JOptionPane.ERROR_MESSAGE);
+                JmriJOptionPane.ERROR_MESSAGE);
     }
 
     /**

--- a/java/src/jmri/jmrit/beantable/LightTableAction.java
+++ b/java/src/jmri/jmrit/beantable/LightTableAction.java
@@ -19,9 +19,7 @@ import jmri.NamedBean.DisplayOptions;
 import jmri.swing.ManagerComboBox;
 import jmri.swing.SystemNameValidator;
 import jmri.util.JmriJFrame;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import jmri.util.swing.JmriJOptionPane;
 
 /**
  * Swing action to create and register a LightTable GUI.
@@ -429,10 +427,10 @@ public class LightTableAction extends AbstractTableAction<Light> {
             // Address (number) is already used as a Turnout
             log.warn("Requested Light {} uses same address as Turnout {}", suName, testT);
             if (!noWarn) {
-                int selectedValue = JOptionPane.showOptionDialog(addFrame,
+                int selectedValue = JmriJOptionPane.showOptionDialog(addFrame,
                         Bundle.getMessage("LightWarn5", suName, testSN),
                         Bundle.getMessage("WarningTitle"),
-                        JOptionPane.YES_NO_CANCEL_OPTION, JOptionPane.QUESTION_MESSAGE, null,
+                        JmriJOptionPane.YES_NO_CANCEL_OPTION, JmriJOptionPane.QUESTION_MESSAGE, null,
                         new Object[]{Bundle.getMessage("ButtonYes"), Bundle.getMessage("ButtonYesPlus"),
                                 Bundle.getMessage("ButtonNo")}, Bundle.getMessage("ButtonNo")); // default choice = No
                 if (selectedValue == 1) {
@@ -512,8 +510,8 @@ public class LightTableAction extends AbstractTableAction<Light> {
         status1.setText(ex.getLocalizedMessage());
         String err = Bundle.getMessage("ErrorBeanCreateFailed",
             InstanceManager.getDefault(LightManager.class).getBeanTypeHandled(),sysName);
-        JOptionPane.showMessageDialog(addFrame, err + "\n" + ex.getLocalizedMessage(),
-                err, JOptionPane.ERROR_MESSAGE);
+        JmriJOptionPane.showMessageDialog(addFrame, err + "\n" + ex.getLocalizedMessage(),
+                err, JmriJOptionPane.ERROR_MESSAGE);
     }
 
     /**
@@ -617,9 +615,9 @@ public class LightTableAction extends AbstractTableAction<Light> {
         if (t == null) {
             //There is no turnout corresponding to this name
             if (inOpenPane != null) {
-                JOptionPane.showMessageDialog(inOpenPane,
+                JmriJOptionPane.showMessageDialog(inOpenPane,
                         java.text.MessageFormat.format(Bundle.getMessage("LightWarn2"), inTurnoutName),
-                        Bundle.getMessage("ErrorTitle"), JOptionPane.ERROR_MESSAGE);
+                        Bundle.getMessage("ErrorTitle"), JmriJOptionPane.ERROR_MESSAGE);
             }
             return false;
         }
@@ -643,6 +641,6 @@ public class LightTableAction extends AbstractTableAction<Light> {
         return LightTableAction.class.getName();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(LightTableAction.class);
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LightTableAction.class);
 
 }

--- a/java/src/jmri/jmrit/beantable/LogixNGGlobalVariableTableAction.java
+++ b/java/src/jmri/jmrit/beantable/LogixNGGlobalVariableTableAction.java
@@ -409,10 +409,10 @@ public class LogixNGGlobalVariableTableAction extends AbstractLogixNGTableAction
                     try {
                         gv.initialize();
                     } catch (JmriException | RuntimeException e) {
-                        JOptionPane.showMessageDialog(null,
+                        jmri.util.swing.JmriJOptionPane.showMessageDialog(null,
                                 e.getLocalizedMessage(),
                                 Bundle.getMessage("ErrorTitle"), // NOI18N
-                                JOptionPane.ERROR_MESSAGE);
+                                jmri.util.swing.JmriJOptionPane.ERROR_MESSAGE);
                     }
                     break;
 

--- a/java/src/jmri/jmrit/beantable/LogixNGTableTableAction.java
+++ b/java/src/jmri/jmrit/beantable/LogixNGTableTableAction.java
@@ -116,9 +116,9 @@ public class LogixNGTableTableAction extends AbstractLogixNGTableAction<NamedTab
         if (_typeExternalTable.isSelected()) {
             String fileName = _csvFileName.getText();
             if (fileName == null || fileName.isEmpty()) {
-                JOptionPane.showMessageDialog(addLogixNGFrame,
+                jmri.util.swing.JmriJOptionPane.showMessageDialog(addLogixNGFrame,
                         Bundle.getMessage("LogixNGError2"), Bundle.getMessage("ErrorTitle"), // NOI18N
-                        JOptionPane.ERROR_MESSAGE);
+                        jmri.util.swing.JmriJOptionPane.ERROR_MESSAGE);
                 return null;
             }
             if (_csvTabbed.isSelected()) {

--- a/java/src/jmri/jmrit/beantable/LogixTableAction.java
+++ b/java/src/jmri/jmrit/beantable/LogixTableAction.java
@@ -29,7 +29,6 @@ import javax.swing.JFileChooser;
 import javax.swing.JLabel;
 import javax.swing.JMenu;
 import javax.swing.JMenuItem;
-import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JRadioButtonMenuItem;
 import javax.swing.JScrollPane;
@@ -48,6 +47,7 @@ import jmri.jmrit.logixng.tools.ImportLogix;
 import jmri.jmrit.sensorgroup.SensorGroupFrame;
 import jmri.util.FileUtil;
 import jmri.util.JmriJFrame;
+import jmri.util.swing.JmriJOptionPane;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -993,12 +993,12 @@ public class LogixTableAction extends AbstractTableAction<Logix> {
                 targetLogix = _logixManager.getByUserName(uName);
             }
             if (targetLogix != null) {
-                int result = JOptionPane.showConfirmDialog(f,
+                int result = JmriJOptionPane.showConfirmDialog(f,
                         Bundle.getMessage("ConfirmLogixDuplicate",
                                 targetLogix.getDisplayName(DisplayOptions.USERNAME_SYSTEMNAME), lgxName), // NOI18N
-                        Bundle.getMessage("QuestionTitle"), JOptionPane.YES_NO_OPTION,    // NOI18N
-                        JOptionPane.QUESTION_MESSAGE);
-                if (JOptionPane.NO_OPTION == result) {
+                        Bundle.getMessage("QuestionTitle"), JmriJOptionPane.YES_NO_OPTION,    // NOI18N
+                        JmriJOptionPane.QUESTION_MESSAGE);
+                if (JmriJOptionPane.YES_OPTION != result) {
                     return;
                 }
             }
@@ -1055,9 +1055,9 @@ public class LogixTableAction extends AbstractTableAction<Logix> {
             Logix x = _logixManager.getByUserName(uName);
             if (x != null) {
                 // Logix with this user name already exists
-                JOptionPane.showMessageDialog(getFrame(),
+                JmriJOptionPane.showMessageDialog(getFrame(),
                         Bundle.getMessage("LogixError3"), Bundle.getMessage("ErrorTitle"),
-                        JOptionPane.ERROR_MESSAGE);
+                        JmriJOptionPane.ERROR_MESSAGE);
                 return false;
             }
         }
@@ -1077,9 +1077,9 @@ public class LogixTableAction extends AbstractTableAction<Logix> {
         try {
             sName = InstanceManager.getDefault(jmri.LogixManager.class).makeSystemName(sName);
         } catch (jmri.NamedBean.BadSystemNameException ex) {
-            JOptionPane.showMessageDialog(getFrame(),
+            JmriJOptionPane.showMessageDialog(getFrame(),
                     Bundle.getMessage("LogixError8"), Bundle.getMessage("ErrorTitle"),
-                    JOptionPane.ERROR_MESSAGE);
+                    JmriJOptionPane.ERROR_MESSAGE);
             return false;
         }
         _systemName.setText(sName);
@@ -1096,30 +1096,30 @@ public class LogixTableAction extends AbstractTableAction<Logix> {
     boolean checkFlags(String sName) {
         if (_inEditMode) {
             // Already editing a Logix, ask for completion of that edit
-            JOptionPane.showMessageDialog(getFrame(),
+            JmriJOptionPane.showMessageDialog(getFrame(),
                     Bundle.getMessage("LogixError32", _curLogix.getSystemName()),
                     Bundle.getMessage("ErrorTitle"),
-                    JOptionPane.ERROR_MESSAGE);
+                    JmriJOptionPane.ERROR_MESSAGE);
             _baseEdit.bringToFront();
             return false;
         }
 
         if (_inAddMode) {
             // Adding a Logix, ask for completion of that edit
-            JOptionPane.showMessageDialog(getFrame(),
+            JmriJOptionPane.showMessageDialog(getFrame(),
                     Bundle.getMessage("LogixError33"),
                     Bundle.getMessage("ErrorTitle"), // NOI18N
-                    JOptionPane.ERROR_MESSAGE);
+                    JmriJOptionPane.ERROR_MESSAGE);
             addLogixFrame.toFront();
             return false;
         }
 
         if (_inCopyMode) {
             // Already copying a Logix, ask for completion of that edit
-            JOptionPane.showMessageDialog(getFrame(),
+            JmriJOptionPane.showMessageDialog(getFrame(),
                     Bundle.getMessage("LogixError31", _curLogix.getSystemName()),
                     Bundle.getMessage("ErrorTitle"), // NOI18N
-                    JOptionPane.ERROR_MESSAGE);
+                    JmriJOptionPane.ERROR_MESSAGE);
             _baseEdit.bringToFront();
             return false;
         }
@@ -1130,10 +1130,10 @@ public class LogixTableAction extends AbstractTableAction<Logix> {
             if (x == null) {
                 // Logix does not exist, so cannot be edited
                 log.error("No Logix with system name: {}", sName);
-                JOptionPane.showMessageDialog(getFrame(),
+                JmriJOptionPane.showMessageDialog(getFrame(),
                         Bundle.getMessage("LogixError5"),
                         Bundle.getMessage("ErrorTitle"), // NOI18N
-                        JOptionPane.ERROR_MESSAGE);
+                        JmriJOptionPane.ERROR_MESSAGE);
                 return false;
             }
         }
@@ -1176,9 +1176,9 @@ public class LogixTableAction extends AbstractTableAction<Logix> {
             }
             if (x != null) {
                 // Logix already exists
-                JOptionPane.showMessageDialog(getFrame(), Bundle.getMessage("LogixError1"),
+                JmriJOptionPane.showMessageDialog(getFrame(), Bundle.getMessage("LogixError1"),
                         Bundle.getMessage("ErrorTitle"), // NOI18N
-                        JOptionPane.ERROR_MESSAGE);
+                        JmriJOptionPane.ERROR_MESSAGE);
                 return;
             }
             if (!checkLogixUserName(uName)) {
@@ -1201,10 +1201,10 @@ public class LogixTableAction extends AbstractTableAction<Logix> {
     }
 
     void handleCreateException(String sysName) {
-        JOptionPane.showMessageDialog(getFrame(),
+        JmriJOptionPane.showMessageDialog(getFrame(),
                 Bundle.getMessage("ErrorLogixAddFailed", sysName), // NOI18N
                 Bundle.getMessage("ErrorTitle"), // NOI18N
-                JOptionPane.ERROR_MESSAGE);
+                JmriJOptionPane.ERROR_MESSAGE);
     }
 
     // ------------ Methods for Edit Logix Pane ------------
@@ -1221,10 +1221,10 @@ public class LogixTableAction extends AbstractTableAction<Logix> {
 
         if (sName.equals(SensorGroupFrame.logixSysName)) {
             // Sensor group message
-            JOptionPane.showMessageDialog(getFrame(),
+            JmriJOptionPane.showMessageDialog(getFrame(),
                     Bundle.getMessage("LogixWarn8", SensorGroupFrame.logixUserName, SensorGroupFrame.logixSysName),
                     Bundle.getMessage("WarningTitle"), // NOI18N
-                    JOptionPane.WARNING_MESSAGE);
+                    JmriJOptionPane.WARNING_MESSAGE);
             return;
         }
         _curLogix = _logixManager.getBySystemName(sName);
@@ -1422,13 +1422,13 @@ public class LogixTableAction extends AbstractTableAction<Logix> {
             try {
                 ImportLogix importLogix = new ImportLogix(logix, true, false);
                 importLogix.doImport();
-                JOptionPane.showMessageDialog(f, Bundle.getMessage("LogixIsExported", logix.getDisplayName()), Bundle.getMessage("TitleLogixExportSuccess"), JOptionPane.INFORMATION_MESSAGE);
+                JmriJOptionPane.showMessageDialog(f, Bundle.getMessage("LogixIsExported", logix.getDisplayName()), Bundle.getMessage("TitleLogixExportSuccess"), JmriJOptionPane.INFORMATION_MESSAGE);
             } catch (JmriException e) {
                 throw new RuntimeException("Unexpected error: "+e.getMessage(), e);
             }
         } else {
             errorMessage.append("</table></html>");
-            JOptionPane.showMessageDialog(f, errorMessage.toString(), Bundle.getMessage("TitleLogixExportError"), JOptionPane.ERROR_MESSAGE);
+            JmriJOptionPane.showMessageDialog(f, errorMessage.toString(), Bundle.getMessage("TitleLogixExportError"), JmriJOptionPane.ERROR_MESSAGE);
         }
     }
 
@@ -1456,10 +1456,10 @@ public class LogixTableAction extends AbstractTableAction<Logix> {
             if (p != null) {
                 // Conditional with this user name already exists
                 log.error("Failure to update Conditional with Duplicate User Name: {}", uName);
-                JOptionPane.showMessageDialog(getFrame(),
+                JmriJOptionPane.showMessageDialog(getFrame(),
                         Bundle.getMessage("LogixError10"), // NOI18N
                         Bundle.getMessage("ErrorTitle"), // NOI18N
-                        JOptionPane.ERROR_MESSAGE);
+                        JmriJOptionPane.ERROR_MESSAGE);
                 return false;
             }
         }
@@ -1519,11 +1519,11 @@ public class LogixTableAction extends AbstractTableAction<Logix> {
                         // External references have to be removed before the Logix can be deleted.
                         Conditional c = x.getConditional(csName);
                         Conditional cRef = xRef.getConditional(refName);
-                        JOptionPane.showMessageDialog(getFrame(),
+                        JmriJOptionPane.showMessageDialog(getFrame(),
                                 Bundle.getMessage("LogixError11", c.getUserName(), c.getSystemName(), cRef.getUserName(),
                                         cRef.getSystemName(), xRef.getUserName(), xRef.getSystemName()), // NOI18N
                                 Bundle.getMessage("ErrorTitle"),
-                                JOptionPane.ERROR_MESSAGE);  // NOI18N
+                                JmriJOptionPane.ERROR_MESSAGE);  // NOI18N
                         return false;
                     }
                 }
@@ -1744,10 +1744,10 @@ public class LogixTableAction extends AbstractTableAction<Logix> {
         helpBrowse.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {
-                JOptionPane.showMessageDialog(condBrowserFrame,
+                JmriJOptionPane.showMessageDialog(condBrowserFrame,
                         Bundle.getMessage("BrowserHelpText"),   // NOI18N
                         Bundle.getMessage("BrowserHelpTitle"),  // NOI18N
-                        JOptionPane.INFORMATION_MESSAGE);
+                        JmriJOptionPane.INFORMATION_MESSAGE);
             }
         });
         JButton saveBrowse = new JButton(Bundle.getMessage("BrowserSaveButton"));   // NOI18N
@@ -1799,11 +1799,11 @@ public class LogixTableAction extends AbstractTableAction<Logix> {
             Object[] options = {Bundle.getMessage("BrowserSaveDuplicateReplace"),  // NOI18N
                     Bundle.getMessage("BrowserSaveDuplicateAppend"),  // NOI18N
                     Bundle.getMessage("ButtonCancel")};               // NOI18N
-            int selectedOption = JOptionPane.showOptionDialog(null,
+            int selectedOption = JmriJOptionPane.showOptionDialog(null,
                     Bundle.getMessage("BrowserSaveDuplicatePrompt", file.getName()), // NOI18N
                     Bundle.getMessage("BrowserSaveDuplicateTitle"),   // NOI18N
-                    JOptionPane.DEFAULT_OPTION,
-                    JOptionPane.WARNING_MESSAGE,
+                    JmriJOptionPane.DEFAULT_OPTION,
+                    JmriJOptionPane.WARNING_MESSAGE,
                     null, options, options[0]);
             if (selectedOption == 2 || selectedOption == -1) {
                 log.debug("Save browser content stopped, file replace/append cancelled");  // NOI18N

--- a/java/src/jmri/jmrit/beantable/MemoryTableAction.java
+++ b/java/src/jmri/jmrit/beantable/MemoryTableAction.java
@@ -7,7 +7,6 @@ import java.awt.event.ActionListener;
 import javax.swing.BoxLayout;
 import javax.swing.JCheckBox;
 import javax.swing.JLabel;
-import javax.swing.JOptionPane;
 import javax.swing.JSpinner;
 import javax.swing.JTextField;
 import javax.swing.SpinnerNumberModel;
@@ -18,6 +17,7 @@ import jmri.MemoryManager;
 import jmri.NamedBean;
 import jmri.UserPreferencesManager;
 import jmri.util.JmriJFrame;
+import jmri.util.swing.JmriJOptionPane;
 
 // import org.slf4j.Logger;
 // import org.slf4j.LoggerFactory;
@@ -133,10 +133,10 @@ public class MemoryTableAction extends AbstractTableAction<Memory> {
         }
 
         if (numberOfMemory >= 65) { // limited by JSpinnerModel to 100
-            if (JOptionPane.showConfirmDialog(addFrame,
+            if (JmriJOptionPane.showConfirmDialog(addFrame,
                     Bundle.getMessage("WarnExcessBeans", Bundle.getMessage("Memories"), numberOfMemory),
                     Bundle.getMessage("WarningTitle"),
-                    JOptionPane.YES_NO_OPTION) == 1) {
+                    JmriJOptionPane.YES_NO_OPTION) != JmriJOptionPane.YES_OPTION) {
                 return;
             }
         }
@@ -228,10 +228,10 @@ public class MemoryTableAction extends AbstractTableAction<Memory> {
     }
 
     void handleCreateException(String sysName) {
-        JOptionPane.showMessageDialog(addFrame,
+        JmriJOptionPane.showMessageDialog(addFrame,
                 Bundle.getMessage("ErrorMemoryAddFailed", sysName) + "\n" + Bundle.getMessage("ErrorAddFailedCheck"),
                 Bundle.getMessage("ErrorTitle"),
-                JOptionPane.ERROR_MESSAGE);
+                JmriJOptionPane.ERROR_MESSAGE);
     }
 
     /** {@inheritDoc} */

--- a/java/src/jmri/jmrit/beantable/beanedit/BeanEditAction.java
+++ b/java/src/jmri/jmrit/beantable/beanedit/BeanEditAction.java
@@ -24,9 +24,7 @@ import jmri.NamedBean.DisplayOptions;
 import jmri.jmrit.display.layoutEditor.LayoutBlock;
 import jmri.jmrit.display.layoutEditor.LayoutBlockManager;
 import jmri.util.JmriJFrame;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import jmri.util.swing.JmriJOptionPane;
 
 /**
  * Provides the basic information and structure for for a editing the details of
@@ -453,9 +451,9 @@ public abstract class BeanEditAction<B extends NamedBean> extends AbstractAction
                 String msg;
                 msg = java.text.MessageFormat.format(Bundle.getMessage("WarningUserName"),
                         new Object[]{("" + value)});
-                JOptionPane.showMessageDialog(f, msg,
+                JmriJOptionPane.showMessageDialog(f, msg,
                         Bundle.getMessage("WarningTitle"),
-                        JOptionPane.ERROR_MESSAGE);
+                        JmriJOptionPane.ERROR_MESSAGE);
                 return;
             }
         }
@@ -468,10 +466,10 @@ public abstract class BeanEditAction<B extends NamedBean> extends AbstractAction
                 }
                 String msg = Bundle.getMessage("UpdateToUserName",
                         new Object[]{nBean.getBeanType(), value, nBean.getSystemName()});
-                int optionPane = JOptionPane.showConfirmDialog(f,
+                int optionPane = JmriJOptionPane.showConfirmDialog(f,
                         msg, Bundle.getMessage("UpdateToUserNameTitle"),
-                        JOptionPane.YES_NO_OPTION);
-                if (optionPane == JOptionPane.YES_OPTION) {
+                        JmriJOptionPane.YES_NO_OPTION);
+                if (optionPane == JmriJOptionPane.YES_OPTION) {
                     //This will update the bean reference from the systemName to the userName
                     try {
                         nbMan.updateBeanFromSystemToUser(nBean);
@@ -497,10 +495,10 @@ public abstract class BeanEditAction<B extends NamedBean> extends AbstractAction
         if (!allowBlockNameChange("Remove", "")) return;  // NOI18N
         String msg = java.text.MessageFormat.format(Bundle.getMessage("UpdateToSystemName"),
                 new Object[]{bean.getBeanType()});
-        int optionPane = JOptionPane.showConfirmDialog(f,
+        int optionPane = JmriJOptionPane.showConfirmDialog(f,
                 msg, Bundle.getMessage("UpdateToSystemNameTitle"),
-                JOptionPane.YES_NO_OPTION);
-        if (optionPane == JOptionPane.YES_OPTION) {
+                JmriJOptionPane.YES_NO_OPTION);
+        if (optionPane == JmriJOptionPane.YES_OPTION) {
             nbMan.updateBeanFromUserToSystem(bean);
         }
         bean.setUserName(null);
@@ -526,19 +524,19 @@ public abstract class BeanEditAction<B extends NamedBean> extends AbstractAction
         // Remove is not allowed if there is a layout block
         if (changeType.equals("Remove")) {
             log.warn("Cannot remove user name for block {}", oldName);  // NOI18N
-                JOptionPane.showMessageDialog(f,
+                JmriJOptionPane.showMessageDialog(f,
                         Bundle.getMessage("BlockRemoveUserNameWarning", oldName),  // NOI18N
                         Bundle.getMessage("WarningTitle"),  // NOI18N
-                        JOptionPane.WARNING_MESSAGE);
+                        JmriJOptionPane.WARNING_MESSAGE);
             return false;
         }
 
         // Confirmation dialog
-        int optionPane = JOptionPane.showConfirmDialog(f,
+        int optionPane = JmriJOptionPane.showConfirmDialog(f,
                 Bundle.getMessage("BlockChangeUserName", oldName, newName),  // NOI18N
                 Bundle.getMessage("QuestionTitle"),  // NOI18N
-                JOptionPane.YES_NO_OPTION);
-        return optionPane == JOptionPane.YES_OPTION;
+                JmriJOptionPane.YES_NO_OPTION);
+        return optionPane == JmriJOptionPane.YES_OPTION;
     }
 
     /**
@@ -695,6 +693,6 @@ public abstract class BeanEditAction<B extends NamedBean> extends AbstractAction
         }
     }
 
-    private final static Logger log = LoggerFactory.getLogger(BeanEditAction.class);
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(BeanEditAction.class);
 
 }

--- a/java/src/jmri/jmrit/beantable/beanedit/BlockEditAction.java
+++ b/java/src/jmri/jmrit/beantable/beanedit/BlockEditAction.java
@@ -148,7 +148,7 @@ public class BlockEditAction extends BeanEditAction<Block> {
                 try {
                     bean.setBlockSpeed(speed);
                 } catch (JmriException ex) {
-                    JOptionPane.showMessageDialog(f, ex.getMessage() + "\n" + speed);
+                    jmri.util.swing.JmriJOptionPane.showMessageDialog(f, ex.getMessage() + "\n" + speed);
                     return;
                 }
                 if (!speedList.contains(speed) && !speed.contains("Global")) {

--- a/java/src/jmri/jmrit/beantable/beanedit/OBlockEditAction.java
+++ b/java/src/jmri/jmrit/beantable/beanedit/OBlockEditAction.java
@@ -240,7 +240,7 @@ public class OBlockEditAction extends BeanEditAction<OBlock> {
                 try {
                     bean.setBlockSpeed(speed);
                 } catch (JmriException ex) {
-                    JOptionPane.showMessageDialog(f, ex.getMessage() + "\n" + speed);
+                    jmri.util.swing.JmriJOptionPane.showMessageDialog(f, ex.getMessage() + "\n" + speed);
                     return;
                 }
                 if (speed != null && !speedList.contains(speed) && !speed.contains("Global")) {

--- a/java/src/jmri/jmrit/beantable/beanedit/TurnoutEditAction.java
+++ b/java/src/jmri/jmrit/beantable/beanedit/TurnoutEditAction.java
@@ -6,7 +6,6 @@ import java.awt.event.ActionListener;
 import javax.swing.AbstractAction;
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
-import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
 import jmri.InstanceManager;
@@ -19,6 +18,7 @@ import jmri.implementation.SignalSpeedMap;
 import jmri.util.swing.JComboBoxUtil;
 import jmri.jmrit.turnoutoperations.TurnoutOperationConfig;
 import jmri.swing.NamedBeanComboBox;
+import jmri.util.swing.JmriJOptionPane;
 
 /**
  * Provides an edit panel for a turnout object.
@@ -85,7 +85,7 @@ public class TurnoutEditAction extends BeanEditAction<Turnout> {
     private String useBlockSpeed = Bundle.getMessage("UseGlobal", "Block Speed");
     private TurnoutOperationConfig config;
     private BeanItemPanel feedback;
-    private JPanel turnoutOperation = new JPanel();
+    private final JPanel turnoutOperation = new JPanel();
 
     private BeanItemPanel feedback() {
         feedback = new BeanItemPanel();
@@ -158,10 +158,10 @@ public class TurnoutEditAction extends BeanEditAction<Turnout> {
                 String newName = operationsName.getText();
                 if ((currentOperation != null) && (newName != null) && !newName.isEmpty()) {
                     if (!currentOperation.rename(newName)) {
-                        JOptionPane.showMessageDialog(null,
+                        JmriJOptionPane.showMessageDialog(turnoutOperation,
                                 Bundle.getMessage("ErrorDuplicateUserName", newName),
                                 Bundle.getMessage("ErrorTitle"),
-                                JOptionPane.ERROR_MESSAGE);
+                                JmriJOptionPane.ERROR_MESSAGE);
                     } else {
                         automationBox.addItem(newName);
                         automationBox.setSelectedItem(newName);
@@ -193,12 +193,12 @@ public class TurnoutEditAction extends BeanEditAction<Turnout> {
                 try {
                     bean.provideFirstFeedbackSensor(sensorFeedBack1ComboBox.getSelectedItemDisplayName());
                 } catch (jmri.JmriException ex) {
-                    JOptionPane.showMessageDialog(null, ex.toString());
+                    JmriJOptionPane.showMessageDialog(turnoutOperation, ex.toString());
                 }
                 try {
                     bean.provideSecondFeedbackSensor(sensorFeedBack2ComboBox.getSelectedItemDisplayName());
                 } catch (jmri.JmriException ex) {
-                    JOptionPane.showMessageDialog(null, ex.toString());
+                    JmriJOptionPane.showMessageDialog(turnoutOperation, ex.toString());
                 }
             }
         });
@@ -449,26 +449,26 @@ public class TurnoutEditAction extends BeanEditAction<Turnout> {
       speed.setSaveItem(new AbstractAction() {
             @Override
             public void actionPerformed(ActionEvent e) {
-                String speed = (String) closedSpeedBox.getSelectedItem();
-                if (speed != null) {
+                String newSpeed = (String) closedSpeedBox.getSelectedItem();
+                if (newSpeed != null) {
                     try {
-                        bean.setStraightSpeed(speed);
-                        if ((!speedListClosed.contains(speed)) && !speed.contains("Global")) {
-                            speedListClosed.add(speed);
+                        bean.setStraightSpeed(newSpeed);
+                        if ((!speedListClosed.contains(newSpeed)) && !newSpeed.contains("Global")) {
+                            speedListClosed.add(newSpeed);
                         }
                     } catch (jmri.JmriException ex) {
-                        JOptionPane.showMessageDialog(null, ex.getMessage() + "\n" + speed);
+                        JmriJOptionPane.showMessageDialog(speed, ex.getMessage() + "\n" + newSpeed);
                     }
                 }
-                speed = (String) thrownSpeedBox.getSelectedItem();
-                if (speed != null) {
+                newSpeed = (String) thrownSpeedBox.getSelectedItem();
+                if (newSpeed != null) {
                     try {
-                        bean.setDivergingSpeed(speed);
-                        if ((!speedListThrown.contains(speed)) && !speed.contains("Global")) {
-                            speedListThrown.add(speed);
+                        bean.setDivergingSpeed(newSpeed);
+                        if ((!speedListThrown.contains(newSpeed)) && !newSpeed.contains("Global")) {
+                            speedListThrown.add(newSpeed);
                         }
                     } catch (jmri.JmriException ex) {
-                        JOptionPane.showMessageDialog(null, ex.getMessage() + "\n" + speed);
+                        JmriJOptionPane.showMessageDialog(speed, ex.getMessage() + "\n" + newSpeed);
                     }
                 }
             }

--- a/java/src/jmri/jmrit/beantable/block/BlockTableDataModel.java
+++ b/java/src/jmri/jmrit/beantable/block/BlockTableDataModel.java
@@ -28,9 +28,7 @@ import jmri.jmrit.beantable.*;
 import jmri.jmrit.beantable.beanedit.BlockEditAction;
 import jmri.util.gui.GuiLafPreferencesManager;
 import jmri.util.swing.JComboBoxUtil;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import jmri.util.swing.JmriJOptionPane;
 
 /**
  * Data model for a Block Table.
@@ -243,7 +241,7 @@ public class BlockTableDataModel extends BeanTableDataModel<Block> {
                 try {
                     b.setBlockSpeed(speed);
                 } catch (JmriException ex) {
-                    JOptionPane.showMessageDialog(null, ex.getMessage() + "\n" + speed);
+                    JmriJOptionPane.showMessageDialog(null, ex.getMessage() + "\n" + speed);
                     return;
                 }
                 if (!speedList.contains(speed) && !speed.contains("Global")) { // NOI18N
@@ -508,14 +506,14 @@ public class BlockTableDataModel extends BeanTableDataModel<Block> {
         block.setAlignmentX(Component.LEFT_ALIGNMENT);
         speedspanel.add(block);
 
-        int retval = JOptionPane.showConfirmDialog(
+        int retval = JmriJOptionPane.showConfirmDialog(
                 _who,
                 speedspanel,
                 title,
-                JOptionPane.OK_CANCEL_OPTION,
-                JOptionPane.INFORMATION_MESSAGE);
+                JmriJOptionPane.OK_CANCEL_OPTION,
+                JmriJOptionPane.INFORMATION_MESSAGE);
         log.debug("Retval = {}", retval);
-        if (retval != JOptionPane.OK_OPTION) { // OK button not clicked
+        if (retval != JmriJOptionPane.OK_OPTION) { // OK button not clicked
             return;
         }
 
@@ -524,7 +522,7 @@ public class BlockTableDataModel extends BeanTableDataModel<Block> {
         try {
             InstanceManager.getDefault(BlockManager.class).setDefaultSpeed(speedValue);
         } catch (IllegalArgumentException ex) {
-            JOptionPane.showMessageDialog(_who, ex.getMessage() + "\n" + speedValue);
+            JmriJOptionPane.showMessageDialog(_who, ex.getMessage() + "\n" + speedValue);
         }
     }
 
@@ -675,6 +673,6 @@ public class BlockTableDataModel extends BeanTableDataModel<Block> {
 
     } // end of ImageIconRenderer class
 
-    private final static Logger log = LoggerFactory.getLogger(BlockTableDataModel.class);
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(BlockTableDataModel.class);
 
 }

--- a/java/src/jmri/jmrit/beantable/light/LightTableDataModel.java
+++ b/java/src/jmri/jmrit/beantable/light/LightTableDataModel.java
@@ -17,9 +17,6 @@ import jmri.*;
 import jmri.jmrit.beantable.BeanTableDataModel;
 import static jmri.jmrit.beantable.LightTableAction.getDescriptionText;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
  * Data model for a Light Table.
  * Code originally within LightTableAction.
@@ -245,7 +242,7 @@ public class LightTableDataModel extends BeanTableDataModel<Light> {
                         l.setCommandedState( intensity > 0.5 ? Light.ON : Light.OFF);
                     }
                 } catch (IllegalArgumentException e1) {
-                    JOptionPane.showMessageDialog(null,  e1.getMessage());
+                    jmri.util.swing.JmriJOptionPane.showMessageDialog(null,  e1.getMessage());
                 }
                 break;
             case ENABLECOL:
@@ -460,6 +457,6 @@ public class LightTableDataModel extends BeanTableDataModel<Light> {
 
     }
     
-    private final static Logger log = LoggerFactory.getLogger(LightTableDataModel.class);
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LightTableDataModel.class);
             
 }

--- a/java/src/jmri/util/swing/JmriJOptionPane.java
+++ b/java/src/jmri/util/swing/JmriJOptionPane.java
@@ -1,0 +1,254 @@
+package jmri.util.swing;
+
+import java.awt.*;
+import java.util.Locale;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import javax.swing.*;
+
+/**
+ * JmriJOptionPane provides a set of static methods to display Dialogs and retrieve user input.
+ * These can directly replace the javax.swing.JOptionPane static methods.
+ * <p>
+ * If the parentComponent is null, all Dialogs created will be Modal.
+ * These will block the whole JVM UI until they are closed.
+ * These may appear behind Window frames with Always On Top enabled and may not be accessible.
+ * These Dialogs are positioned in the centre of the screen.
+ * <p>
+ * If a parentComponent is provided, the Dialogs will be created Modal to
+ * ( will block ) the parent Window Frame, other Frames are not blocked.
+ * These Dialogs will appear in the centre of the parent Frame.
+ *
+ * @since 5.5.4
+ * @author Steve Young Copyright (C) 2023
+ */
+public class JmriJOptionPane {
+
+    public final static int CANCEL_OPTION = JOptionPane.CANCEL_OPTION;
+    public final static int OK_OPTION = JOptionPane.OK_OPTION;
+    public final static int OK_CANCEL_OPTION = JOptionPane.OK_CANCEL_OPTION;
+    public final static int YES_OPTION = JOptionPane.YES_OPTION;
+    public final static int YES_NO_OPTION = JOptionPane.YES_NO_OPTION;
+    public static final int YES_NO_CANCEL_OPTION = JOptionPane.YES_NO_CANCEL_OPTION;
+    public final static int NO_OPTION = JOptionPane.NO_OPTION;
+
+    public final static int CLOSED_OPTION = JOptionPane.CLOSED_OPTION;
+    public final static int DEFAULT_OPTION = JOptionPane.DEFAULT_OPTION;
+    public final static Object UNINITIALIZED_VALUE = JOptionPane.UNINITIALIZED_VALUE;
+
+    public final static int ERROR_MESSAGE = JOptionPane.ERROR_MESSAGE;
+    public final static int INFORMATION_MESSAGE = JOptionPane.INFORMATION_MESSAGE;
+    public final static int QUESTION_MESSAGE = JOptionPane.QUESTION_MESSAGE;
+    public final static int WARNING_MESSAGE = JOptionPane.WARNING_MESSAGE;
+
+    // class only supplies static methods
+    protected JmriJOptionPane(){}
+
+    /**
+     * Displays an informational message dialog with an OK button.
+     * @param parentComponent The parent component relative to which the dialog is displayed.
+     * @param message         The message to be displayed in the dialog.
+     * @throws HeadlessException if the current environment is headless (no GUI available).
+     */
+    public static void showMessageDialog(@CheckForNull Component parentComponent,
+        Object message) throws HeadlessException {
+        showMessageDialog(parentComponent, message, 
+            UIManager.getString("OptionPane.messageDialogTitle", Locale.getDefault()),
+            INFORMATION_MESSAGE);
+    }
+
+    /**
+     * Displays a message dialog with an OK button.
+     * @param parentComponent The parent component relative to which the dialog is displayed.
+     * @param message         The message to be displayed in the dialog.
+     * @param title           The title of the dialog.
+     * @param messageType     The type of message to be displayed (e.g., {@link #WARNING_MESSAGE}).
+     * @throws HeadlessException if the current environment is headless (no GUI available).
+     */
+    public static void showMessageDialog(@CheckForNull Component parentComponent,
+        Object message, String title, int messageType) {
+        showOptionDialog(parentComponent, message, title, DEFAULT_OPTION,
+            messageType, null, null, null);
+    }
+
+    /**
+     * Displays a confirmation dialog with a message and title.
+     * The dialog includes options for the user to confirm or cancel an action.
+     *
+     * @param parentComponent The parent component relative to which the dialog is displayed.
+     * @param message         The message to be displayed in the dialog.
+     * @param title           The title of the dialog.
+     * @param optionType      The type of options to be displayed (e.g., {@link #YES_NO_OPTION}, {@link #OK_CANCEL_OPTION}).
+     * @return An integer representing the user's choice: {@link #YES_OPTION}, {@link #NO_OPTION}, {@link #CANCEL_OPTION}, or {@link #CLOSED_OPTION}.
+     * @throws HeadlessException if the current environment is headless (no GUI available).
+     */
+    public static int showConfirmDialog(@CheckForNull Component parentComponent,
+        Object message, String title, int optionType)
+        throws HeadlessException {
+        return showOptionDialog(parentComponent, message, title, optionType,
+            QUESTION_MESSAGE, null, null, null);
+    }
+
+    /**
+     * Displays a confirmation dialog with a message and title.The dialog includes options for the user to confirm or cancel an action.
+     *
+     * @param parentComponent The parent component relative to which the dialog is displayed.
+     * @param message         The message to be displayed in the dialog.
+     * @param title           The title of the dialog.
+     * @param optionType      The type of options to be displayed (e.g., {@link #YES_NO_OPTION}, {@link #OK_CANCEL_OPTION}).
+     * @param messageType     The type of message to be displayed (e.g., {@link #ERROR_MESSAGE}).
+     * @return An integer representing the user's choice: {@link #YES_OPTION}, {@link #NO_OPTION}, {@link #CANCEL_OPTION}, or {@link #CLOSED_OPTION}.
+     * @throws HeadlessException if the current environment is headless (no GUI available).
+     */
+    public static int showConfirmDialog(@CheckForNull Component parentComponent,
+        Object message, String title, int optionType, int messageType)
+        throws HeadlessException {
+        return showOptionDialog(parentComponent, message, title, optionType,
+            messageType, null, null, null);
+    }
+
+    /**
+     * Displays a custom option dialog.
+     * @param parentComponent The parent component relative to which the dialog is displayed.
+     * @param message         The message to be displayed in the dialog.
+     * @param title           The title of the dialog.
+     * @param optionType      The type of options to be displayed (e.g., {@link #YES_NO_OPTION}, {@link #OK_CANCEL_OPTION}).
+     * @param messageType     The type of message to be displayed (e.g., {@link #INFORMATION_MESSAGE}, {@link #WARNING_MESSAGE}).
+     * @param icon            The icon to be displayed in the dialog.
+     * @param options         An array of objects representing the options available to the user.
+     * @param initialValue    The initial value selected in the dialog.
+     * @return An integer representing the index of the selected option, or {@link #CLOSED_OPTION} if the dialog is closed.
+     * @throws HeadlessException If the current environment is headless (no GUI available).
+     */
+    public static int showOptionDialog(@CheckForNull Component parentComponent,
+        Object message, String title, int optionType, int messageType,
+        Icon icon, Object[] options, Object initialValue)
+        throws HeadlessException {
+        log.debug("showConfirmDialog comp {} ", parentComponent);
+
+        JOptionPane pane = new JOptionPane(message, messageType,
+            optionType, icon, options, initialValue);
+        pane.setInitialValue(initialValue);
+        displayDialog(pane, parentComponent, title);
+
+        Object selectedValue = pane.getValue();
+        if ( selectedValue == null ) {
+            return CLOSED_OPTION;
+        }
+        if ( options == null ) {
+            if ( selectedValue instanceof Integer ) {
+                return ((Integer)selectedValue);
+            }
+            return CLOSED_OPTION;
+        }
+        for(int counter = 0, maxCounter = options.length; counter < maxCounter; counter++ ) {
+            if ( options[counter].equals(selectedValue)) {
+                return counter;
+            }
+        }
+        return CLOSED_OPTION;
+    }
+
+    /**
+     * Displays an input dialog.
+     * @param parentComponent       The parent component relative to which the dialog is displayed.
+     * @param message               The message to be displayed in the dialog.
+     * @param initialSelectionValue The initial value pre-selected in the input dialog.
+     * @return The user's input value, or {@code null} if the dialog is closed or the input value is uninitialized.
+     * @throws HeadlessException   if the current environment is headless (no GUI available).
+     */
+    @CheckForNull
+    public static String showInputDialog(@CheckForNull Component parentComponent,
+        String message, String initialSelectionValue ){
+        return (String)showInputDialog(parentComponent, message,
+            UIManager.getString("OptionPane.inputDialogTitle",
+            Locale.getDefault()), QUESTION_MESSAGE, null, null,
+            initialSelectionValue);
+    }
+
+    /**
+     * Displays an input dialog.
+     * @param parentComponent      The parent component relative to which the dialog is displayed.
+     * @param message              The message to be displayed in the dialog.
+     * @param title                The title of the dialog.
+     * @param messageType          The type of message to be displayed (e.g., {@link #INFORMATION_MESSAGE}, {@link #WARNING_MESSAGE}).
+     * @param icon                 The icon to be displayed in the dialog.
+     * @param selectionValues      An array of objects representing the input selection values.
+     * @param initialSelectionValue The initial value pre-selected in the input dialog.
+     * @return The user's input value, or {@code null} if the dialog is closed or the input value is uninitialized.
+     * @throws HeadlessException   if the current environment is headless (no GUI available).
+     */
+    @CheckForNull
+    public static Object showInputDialog(@CheckForNull Component parentComponent,
+        Object message, String title, int messageType, Icon icon,
+        Object[] selectionValues, Object initialSelectionValue)
+        throws HeadlessException {
+        JOptionPane pane = new JOptionPane(message, messageType,
+            OK_CANCEL_OPTION, icon, null, initialSelectionValue);
+
+        pane.setWantsInput(true);
+        pane.setSelectionValues(selectionValues);
+        pane.setInitialSelectionValue(initialSelectionValue);
+        pane.selectInitialValue();
+        displayDialog(pane, parentComponent, title);
+
+        Object value = pane.getInputValue();
+        if (value == UNINITIALIZED_VALUE) {
+            return null;
+        }
+        return value;
+    }
+
+    private static void displayDialog(JOptionPane pane, Component parentComponent, String title){
+        pane.setComponentOrientation(JOptionPane.getRootFrame().getComponentOrientation());
+        JDialog dialog = pane.createDialog(parentComponent, title);
+        if ( parentComponent != null ) {
+            dialog.setModalityType(Dialog.ModalityType.DOCUMENT_MODAL);
+        }
+        setDialogLocation(parentComponent, dialog);
+        dialog.setVisible(true);
+        dialog.dispose();
+    }
+
+    /**
+     * Sets the position of a dialog relative to a parent component.
+     * This method positions the dialog at the centre of
+     * the parent component or its parent window.
+     *
+     * @param parentComponent The parent component relative to which the dialog should be positioned.
+     * @param dialog           The dialog whose position is being set.
+     */
+    private static void setDialogLocation( @CheckForNull Component parentComponent, @Nonnull Dialog dialog) {
+        log.debug("set dialog position for comp {} dialog {}", parentComponent, dialog.getTitle());
+        int centreWidth;
+        int centreHeight;
+        Window w = findWindowForComponent(parentComponent);
+        if ( w == null) {
+            centreWidth = Toolkit.getDefaultToolkit().getScreenSize().width / 2;
+            centreHeight = Toolkit.getDefaultToolkit().getScreenSize().height / 2;
+        } else {
+            Point topLeft = w.getLocationOnScreen();
+            Dimension size = w.getSize();
+            centreWidth = topLeft.x + ( size.width / 2 );
+            centreHeight = topLeft.y + ( size.height / 2 );
+        }
+        int centerX = centreWidth - ( dialog.getWidth() / 2 );
+        int centerY = centreHeight - ( dialog.getHeight() / 2 );
+        dialog.setLocation( new Point(centerX, centerY));
+    }
+
+    @CheckForNull
+    private static Window findWindowForComponent(Component component){
+        if (component == null) {
+            return null;
+        }
+        if (component instanceof Window) {
+            return (Window) component;
+        }
+        return findWindowForComponent(component.getParent());
+    }
+
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(JmriJOptionPane.class);
+
+}

--- a/java/test/jmri/util/swing/JmriJOptionPaneTest.java
+++ b/java/test/jmri/util/swing/JmriJOptionPaneTest.java
@@ -1,0 +1,179 @@
+package jmri.util.swing;
+
+import java.util.Locale;
+
+import javax.swing.*;
+
+import jmri.util.JUnitUtil;
+
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.netbeans.jemmy.operators.*;
+
+/**
+ * Tests for JmriJOptionPane.
+ * @author Steve Young Copyright (C) 2023
+ */
+@DisabledIfSystemProperty(named = "java.awt.headless", matches = "true")
+public class JmriJOptionPaneTest {
+
+    @Test
+    public void testShowConfirmDialogOkCanel() {
+
+        JFrame frame = new JFrame("JFrame Window");
+        JPanel panel = new JPanel();
+        JLabel label = new JLabel("Label in JFrame");
+
+        panel.add(label);
+        frame.add(panel);
+        frame.pack();
+        jmri.util.ThreadingUtil.runOnGUI( () -> frame.setVisible(true) );
+        JFrameOperator jfo = new JFrameOperator("JFrame Window");
+
+        Thread canelButtonThread = JemmyUtil.createModalDialogOperatorThread(
+            "OptionPane Title", Bundle.getMessage("ButtonCancel"));
+
+        int optionPressed = JmriJOptionPane.showConfirmDialog(panel, "Message", "OptionPane Title", JmriJOptionPane.OK_CANCEL_OPTION );
+        JUnitUtil.waitFor(()-> !(canelButtonThread.isAlive()), "cancel dialog finished");
+        Assertions.assertEquals(JmriJOptionPane.CANCEL_OPTION, optionPressed);
+
+        Thread okButtonThread = JemmyUtil.createModalDialogOperatorThread(
+            "OptionPane Title", Bundle.getMessage("ButtonOK"));
+        optionPressed = JmriJOptionPane.showConfirmDialog(panel, "Message", "OptionPane Title", JmriJOptionPane.OK_CANCEL_OPTION );
+        JUnitUtil.waitFor(()-> !(okButtonThread.isAlive()), "ok dialog finished");  // NOI18N
+        Assertions.assertEquals(JmriJOptionPane.OK_OPTION, optionPressed);
+
+        jfo.requestClose();
+        jfo.waitClosed();
+
+    }
+
+    @Test
+    public void testMessageDialogueNoOptions() {
+        Thread okButtonThread = JemmyUtil.createModalDialogOperatorThread(
+            "Error Title", Bundle.getMessage("ButtonOK"));
+        JmriJOptionPane.showMessageDialog(null, "testMessageDialogMessage", "Error Title", JmriJOptionPane.ERROR_MESSAGE);
+        JUnitUtil.waitFor(()-> !( okButtonThread.isAlive()), "ok error dialog finished");
+    }
+
+    @Test
+    public void testYesNoOptions() {
+
+        JFrame frame = new JFrame("JFrame testYesNoOptions");
+        JPanel panel = new JPanel();
+        JLabel label = new JLabel("Label in testYesNoOptions JFrame");
+
+        panel.add(label);
+        frame.add(panel);
+        frame.pack();
+        frame.setLocation(100, 100);
+        jmri.util.ThreadingUtil.runOnGUI( () -> frame.setVisible(true) );
+        JFrameOperator jfo = new JFrameOperator("JFrame testYesNoOptions");
+
+        Thread yesButtonThread = JemmyUtil.createModalDialogOperatorThread(
+            "Question Title", Bundle.getMessage("ButtonYes"));
+
+        int result = JmriJOptionPane.showConfirmDialog(panel,"Yes or no message",
+            "Question Title", JmriJOptionPane.YES_NO_OPTION, JmriJOptionPane.QUESTION_MESSAGE);
+        JUnitUtil.waitFor(()-> !( yesButtonThread.isAlive()), "yes dialog finished");
+        Assertions.assertEquals(JmriJOptionPane.YES_OPTION, result);
+
+        Thread noButtonThread = JemmyUtil.createModalDialogOperatorThread(
+            "Question Title", Bundle.getMessage("ButtonNo"));
+        result = JmriJOptionPane.showConfirmDialog(panel,"Yes or no message",
+            "Question Title", JmriJOptionPane.YES_NO_OPTION, JmriJOptionPane.QUESTION_MESSAGE);
+        JUnitUtil.waitFor(()-> !( noButtonThread.isAlive()), "no dialog finished");
+        Assertions.assertEquals(JmriJOptionPane.NO_OPTION, result);
+
+        jfo.requestClose();
+        jfo.waitClosed();
+    }
+    
+    @Test
+    public void testModalNoFrameMessage() {
+        Thread okButtonThread = JemmyUtil.createModalDialogOperatorThread(
+            "Error Title", Bundle.getMessage("ButtonOK"));
+        JmriJOptionPane.showMessageDialog(null, "testMessageDialogMessage", "Error Title", JmriJOptionPane.ERROR_MESSAGE);
+        JUnitUtil.waitFor(()-> !( okButtonThread.isAlive()), "ok error dialog finished");
+    }
+
+    @Test
+    public void testShowStringInput() {
+        Thread t = new Thread(() -> {
+            // constructor for jdo will wait until the dialog is visible
+            JDialogOperator jdo = new JDialogOperator(UIManager.getString("OptionPane.inputDialogTitle",
+            Locale.getDefault()));
+            JTextFieldOperator jtfo = new JTextFieldOperator(jdo,0);
+            Assertions.assertEquals("Initial Foo", jtfo.getText());
+
+            jtfo.setText("New Foo");
+            JButtonOperator jbo = new JButtonOperator(jdo, Bundle.getMessage("ButtonOK"));
+            jbo.pushNoBlock();
+        });
+        t.setName("Close String Input Dialog Thread");
+        t.start();
+        String s = JmriJOptionPane.showInputDialog(null, "Enter a new String value for Foo", "Initial Foo");
+        JUnitUtil.waitFor(()-> !( t.isAlive()), "string input dialog finished");
+        Assertions.assertEquals("New Foo", s);
+    }
+
+    @Test
+    public void testCancelInputString() {
+
+        JFrame frame = new JFrame("JFrame testCancelInputString");
+        JPanel panel = new JPanel();
+        JLabel label = new JLabel("Label in testCancelInputString JFrame");
+
+        panel.add(label);
+        frame.add(panel);
+        frame.pack();
+        frame.setLocation(150, 150);
+        jmri.util.ThreadingUtil.runOnGUI( () -> frame.setVisible(true) );
+        JFrameOperator jfo = new JFrameOperator("JFrame testCancelInputString");
+
+        Thread t = new Thread(() -> {
+            // constructor for jdo will wait until the dialog is visible
+            JDialogOperator jdo = new JDialogOperator(UIManager.getString("OptionPane.inputDialogTitle", Locale.getDefault()));
+            JButtonOperator jbo = new JButtonOperator(jdo, Bundle.getMessage("ButtonCancel"));
+            jbo.pushNoBlock();
+        });
+        t.setName("cancel String Input Dialog Thread");
+        t.start();
+        String s = JmriJOptionPane.showInputDialog(panel, "Cancel Enter a new String value for Foo", "Initial Foo Cancel");
+        JUnitUtil.waitFor(()-> !( t.isAlive()), "cancel string input dialog finished");
+        Assertions.assertNull( s);
+
+        jfo.requestClose();
+        jfo.waitClosed();
+
+    }
+
+    @Test
+    public void testInfoDialog() {
+        Thread okButtonThread = JemmyUtil.createModalDialogOperatorThread(
+            UIManager.getString("OptionPane.messageDialogTitle", Locale.getDefault()), Bundle.getMessage("ButtonOK"));
+        JmriJOptionPane.showMessageDialog(null, "testInfoDialogMessage" );
+        JUnitUtil.waitFor(()-> !( okButtonThread.isAlive()), "ok info dialog finished");
+    }
+
+    @Test
+    public void testCustomOptionsDialog(){
+        Thread okButtonThread = JemmyUtil.createModalDialogOperatorThread(
+            "My Title", "Option B");
+        int value = JmriJOptionPane.showOptionDialog(null, "My Custom Message", "My Title",
+            JmriJOptionPane.DEFAULT_OPTION, JmriJOptionPane.QUESTION_MESSAGE, null, new String[]{"Option A", "Option B", "Option C"}, "Option C");
+        JUnitUtil.waitFor(()-> !( okButtonThread.isAlive()), "ok info dialog finished");
+        Assertions.assertEquals(1, value,"returns Option B at position 1 in Array");
+    }
+
+    @BeforeEach
+    public void setUp() {
+        JUnitUtil.setUp();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        JUnitUtil.tearDown();
+    }
+
+}


### PR DESCRIPTION
Adds JmriJOptionPane, a set of static methods to display Dialogs and retrieve user input.
These can directly replace the javax.swing.JOptionPane static methods which have no option to change the Modality.

Dialogs are tailored towards JMRI multi-frame use, ie not blocking Frames with Always ON Top enabled.
If a parent Component is provided in the method call, the Dialogs will be created Modal to ( ie. will block ) the parent Window Frame, other Frames are not blocked.
These Dialogs will appear in the centre of the parent Frame to highlight which Frame is the owner.

Converts a small number of the BeanTable classes to use the new method for evaluation.