### PR TITLE
Put appending text on the swing thread

### DIFF
--- a/java/src/jmri/util/PipeListener.java
+++ b/java/src/jmri/util/PipeListener.java
@@ -35,6 +35,9 @@ public class PipeListener extends Thread {
                     int nRead = pr.read(cbuf, 0, BUFFER_SIZE);  // blocking read
                     String content = new String(Arrays.copyOf(cbuf, nRead)); // retain only filled chars
 
+                    // The following used to be runOnGui (i.e. not "Eventually")
+                    // but that occasionally caused the Swing/AWT thread to block
+                    // with very large input strings.  Please don't change it back.
                     jmri.util.ThreadingUtil.runOnGUIEventually(() -> {
                         ta.append(content);
                     });

--- a/java/src/jmri/util/PipeListener.java
+++ b/java/src/jmri/util/PipeListener.java
@@ -35,7 +35,7 @@ public class PipeListener extends Thread {
                     int nRead = pr.read(cbuf, 0, BUFFER_SIZE);  // blocking read
                     String content = new String(Arrays.copyOf(cbuf, nRead)); // retain only filled chars
 
-                    jmri.util.ThreadingUtil.runOnGUI(() -> {
+                    jmri.util.ThreadingUtil.runOnGUIEventually(() -> {
                         ta.append(content);
                     });
 

--- a/java/src/jmri/util/PipeListener.java
+++ b/java/src/jmri/util/PipeListener.java
@@ -27,9 +27,11 @@ public class PipeListener extends Thread {
             while (true) {
                 try {
                     c[0] = (char) pr.read();
-                    ta.append(new String(c));   // odd way to do this, but only
-                    // way I could think of with only one
-                    // new object created
+                    jmri.util.ThreadingUtil.runOnGUI(() -> {
+                        ta.append(new String(c));   // odd way to do this, but only
+                        // way I could think of with only one
+                        // new object created
+                    });
                 } catch (IOException ex) {
                     if (ex.getMessage().equals("Write end dead") || ex.getMessage().equals("Pipe broken")) {
                         // happens when the writer thread, possibly a script, terminates


### PR DESCRIPTION
Updates PipeListener, used for script output, so that it appends characters to the display on the Swing thread.

This is needed when running multiple scripts under Graal.