### PR TITLE
Graal updates

### DIFF
--- a/java/graalvm/DIFFERENCES.md
+++ b/java/graalvm/DIFFERENCES.md
@@ -8,7 +8,7 @@ The Jython property wrapper syntax that makes the next two lines the same is not
 	turnout.getState()
 ```
 
-Some super-class methods need to be called via e.g.
+Some Java super-class methods of a Python class need to be called via e.g.
 ```
 	self.__super__.waitMsec(1000)
 ```
@@ -27,14 +27,19 @@ We can't yet put JMRI symbols into the Python context, so you have to run
 ```
 	exec(open("jython/jmri_bindings.py3").read())
 ```
-at the start of each script.
+at the start of each script. This provides definitions for the usual symbols: ON, OFF, ACTIVE, turnouts, sensors etc.
 
 Referencing a class type needs a java.type wrapper:
 ```
     sm = jmri.InstanceManager.getNullableDefault(java.type('jmri.SensorManager'))
 ```
+We've put a helper method in place for that specific case
+```
+    sm = jmri.InstanceManager.getNullableDefault('jmri.SensorManager')
+```
+but you may need the `java.type('jmri.SensorManager')` syntax in other places.
 
 The debugging support is terrible:  Syntax errors generate opaque error messages that don’t point to the relevant line in the script.
 
-AbstractAutomaton subclasses occasionally cause the whole of JMRI to stop with a thread deadlock.  Not understood why the GraalVM Python interpreter is taking a lock on the Swing/AWT thread.
+AbstractAutomaton subclasses occasionally cause the whole of JMRI to stop with a thread deadlock.  Not understood why the GraalVM Python interpreter is occasionally taking a lock on the Swing/AWT thread.
 

--- a/java/graalvm/DIFFERENCES.md
+++ b/java/graalvm/DIFFERENCES.md
@@ -1,3 +1,5 @@
+The jython/test/Python3Test.py3 provides some examples of these.
+
 You can access jmri.Turnout.CLOSED but jmri.Turnout.UNKNOWN is undefined.  You have to access jmri.NamedBean.UNKNOWN instead, which is a real pain.
 
 The Jython property wrapper syntax that makes the next two lines the same is not available:

--- a/java/graalvm/jmri/script/jsr223graalpython/GraalJSEngineFactory.java
+++ b/java/graalvm/jmri/script/jsr223graalpython/GraalJSEngineFactory.java
@@ -129,7 +129,10 @@ public final class GraalJSEngineFactory implements ScriptEngineFactory {
             .allowExperimentalOptions(true)
             //.allowAllAccess(true) // no such method
             //.option("polyglot.python.allowHostAccess", "true") // option not found
-            .option("python.EmulateJython", "true") // Jython-compatible class structure
+            
+            // The following is necessary to allow e.g. "import jmri" to work
+            .option("python.EmulateJython", "true")
+            
             .build();
     }
 

--- a/jython/test/Python3Test.py3
+++ b/jython/test/Python3Test.py3
@@ -84,6 +84,24 @@ if (not listenerCheck) : raise AssertionError('listenerCheck not set True')
 # local variables require .this. syntax
 print ("local localResult:", m.this.localResult)
 
+# allow test to be run more than once
+IS1.removePropertyChangeListener(m)
+
+# check handling Python Exception
+try:
+    x = 1/0
+    print ("Expected Python exception didn't happen")
+except Exception as e:
+    print("Python exception happened as expected:", e)
+
+# check handling Java Exception
+v = java.util.Vector()
+try:
+    x = v.elementAt(7)
+    print ("Expected Java exception didn't happen")
+except java.lang.ArrayIndexOutOfBoundsException as e:
+    # We don't seem to be able to access e here
+    print("Java exception happened as expected")
 
 print ("Python3Test main execution complete")
 


### PR DESCRIPTION
1) Add demo of exception processing to the jython/test/Python3Test.py3 test file
2) Add a link to that test file in the DIFFERENCES.md file
3) Add a comment about the required python.EmulateJython option

No functional changes in normal operation.

