### PR TITLE
Logging - session.log max size , tweak name of rolling appender files.

### DIFF
--- a/default_lcf.xml
+++ b/default_lcf.xml
@@ -56,16 +56,20 @@
 
         <!-- R File Appender  set to output to a single log file.
             This is defined for systems that can't (or don't want to) have rolling files. -->
-        <File name="R" fileName="${sys:jmri.log.path}session.log" append="false">
+        <RollingFile name="R" fileName="${sys:jmri.log.path}session.log"
+            filePattern="${sys:jmri.log.path}session.log" append="false">
             <PatternLayout pattern="%d{ISO8601} %-37.37c{2} %-5p - %m [%t]%n"/>
-        </File>
+            <Policies>
+                <SizeBasedTriggeringPolicy size="5MB"/>
+            </Policies>
+        </RollingFile>
 
         <!-- T Rolling File Appender is set to output to a rolling file.
             This only works for certain systems, but manages files in a convenient way.
             T is defined to preserve messages between sessions and to keep up to
             2 previous log files in addition to the current. -->
         <RollingFile name="T" fileName="${sys:jmri.log.path}messages.log"
-            filePattern="${sys:jmri.log.path}messages.log.%i" append="true">
+            filePattern="${sys:jmri.log.path}messages.%i.log" append="true">
             <PatternLayout pattern="%d{ISO8601} %-37.37c{2} %-5p - %m [%t]%n"/>
             <Policies>
                 <SizeBasedTriggeringPolicy size="1000KB"/>

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -624,6 +624,7 @@
             <li>Logging levels ( eg. INFO, DEBUG ) can be changed for the current session in
             <a href="https://www.jmri.org/help/en/package/apps/jmrit/log/Log4JTreePane.shtml">Display / Edit Log Categories</a></li>
             <li>Logging Libraries have been fully updated to Log4J 2.20</li>
+            <li>The Rolling Log files have been renamd from messages.log.1 and messages.log.2 to messages.1.log and messages.2.log</li>
             <li>The way data is entered in memory icons, block icons
                 and global variable icons have been improved.</li>
             <li>You can now set the preferences to open the RailCom table at startup.</li>


### PR DESCRIPTION
Set maximum session.log file size to 5MB as per comments within thread https://groups.io/g/jmriusers/message/220506
When maximum size is reach, text is trimmed from top of file for new entries at bottom.

Rename messages.log.1 and messages.log.2 to messages.1.log and messages.2.log for easier access on some systems.