### PR TITLE
Interface constants can now be static final

### DIFF
--- a/java/src/jmri/DigitalIO.java
+++ b/java/src/jmri/DigitalIO.java
@@ -10,12 +10,12 @@ public interface DigitalIO extends NamedBean {
     /**
      * State value indicating output is on.
      */
-    int ON = 0x02;
+    static final int ON = 0x02;
 
     /**
      * State value indicating output is off.
      */
-    int OFF = 0x04;
+    static final int OFF = 0x04;
 
     /**
      * Show whether state is stable.

--- a/java/src/jmri/IdTag.java
+++ b/java/src/jmri/IdTag.java
@@ -57,7 +57,7 @@ public interface IdTag extends NamedBean {
      * Constant representing an "unseen" state, indicating that the ID tag has
      * not yet been seen.
      */
-    int UNSEEN = 0x02;
+    static final int UNSEEN = 0x02;
 
     /**
      * Constant representing a "seen" state, indicating that the tag has been
@@ -72,7 +72,7 @@ public interface IdTag extends NamedBean {
      * <li>{@link #getWhenLastSeen()}
      * </ul>
      */
-    int SEEN = 0x03;
+    static final int SEEN = 0x03;
 
     /**
      * Retrieve a string representation of this tag ID

--- a/java/src/jmri/Light.java
+++ b/java/src/jmri/Light.java
@@ -67,39 +67,39 @@ public interface Light extends DigitalIO {
      * State value indicating output intensity is less than maxIntensity and
      * more than minIntensity, and no transition is in progress
      */
-    int INTERMEDIATE = 0x08;
+    static final int INTERMEDIATE = 0x08;
 
     /**
      * State value indicating output intensity is currently changing toward
      * higher intensity, and will continue until full ON is reached
      */
-    int TRANSITIONINGTOFULLON = 0x310;
+    static final int TRANSITIONINGTOFULLON = 0x310;
 
     /**
      * State value indicating output intensity is currently changing toward
      * higher intensity. The current transition will stop before full ON is
      * reached.
      */
-    int TRANSITIONINGHIGHER = 0x210;
+    static final int TRANSITIONINGHIGHER = 0x210;
 
     /**
      * State value indicating output intensity is currently changing toward
      * lower intensity. The current transition will stop before full OFF is
      * reached.
      */
-    int TRANSITIONINGLOWER = 0x110;
+    static final int TRANSITIONINGLOWER = 0x110;
 
     /**
      * State value indicating output intensity is currently changing toward
      * lower intensity, and will continue until full OFF is reached
      */
-    int TRANSITIONINGTOFULLOFF = 0x010;
+    static final int TRANSITIONINGTOFULLOFF = 0x010;
 
     /**
      * State value mask representing status where output is changing due to a
      * request to transition.
      */
-    int TRANSITIONING = 0x010;
+    static final int TRANSITIONING = 0x010;
     
     /** {@inheritDoc} */
     @Override

--- a/java/src/jmri/Manager.java
+++ b/java/src/jmri/Manager.java
@@ -603,50 +603,50 @@ public interface Manager<E extends NamedBean> extends SilenceablePropertyChangeP
     /**
      * The order in which things get saved to the xml file.
      */
-    int SENSORS = 10;
-    int TURNOUTS = SENSORS + 10;
-    int LIGHTS = TURNOUTS + 10;
-    int REPORTERS = LIGHTS + 10;
-    int MEMORIES = REPORTERS + 10;
-    int SENSORGROUPS = MEMORIES + 10;
-    int SIGNALHEADS = SENSORGROUPS + 10;
-    int SIGNALMASTS = SIGNALHEADS + 10;
-    int SIGNALGROUPS = SIGNALMASTS + 10;
-    int BLOCKS = SIGNALGROUPS + 10;
-    int OBLOCKS = BLOCKS + 10;
-    int LAYOUTBLOCKS = OBLOCKS + 10;
-    int SECTIONS = LAYOUTBLOCKS + 10;
-    int TRANSITS = SECTIONS + 10;
-    int BLOCKBOSS = TRANSITS + 10;
-    int ROUTES = BLOCKBOSS + 10;
-    int WARRANTS = ROUTES + 10;
-    int SIGNALMASTLOGICS = WARRANTS + 10;
-    int IDTAGS = SIGNALMASTLOGICS + 10;
-    int ANALOGIOS = IDTAGS + 10;
-    int METERS = ANALOGIOS + 10;
-    int STRINGIOS = METERS + 10;
-    int LOGIXS = STRINGIOS + 10;
-    int CONDITIONALS = LOGIXS + 10;
-    int AUDIO = CONDITIONALS + 10;
-    int TIMEBASE = AUDIO + 10;
+    static final int SENSORS = 10;
+    static final int TURNOUTS = SENSORS + 10;
+    static final int LIGHTS = TURNOUTS + 10;
+    static final int REPORTERS = LIGHTS + 10;
+    static final int MEMORIES = REPORTERS + 10;
+    static final int SENSORGROUPS = MEMORIES + 10;
+    static final int SIGNALHEADS = SENSORGROUPS + 10;
+    static final int SIGNALMASTS = SIGNALHEADS + 10;
+    static final int SIGNALGROUPS = SIGNALMASTS + 10;
+    static final int BLOCKS = SIGNALGROUPS + 10;
+    static final int OBLOCKS = BLOCKS + 10;
+    static final int LAYOUTBLOCKS = OBLOCKS + 10;
+    static final int SECTIONS = LAYOUTBLOCKS + 10;
+    static final int TRANSITS = SECTIONS + 10;
+    static final int BLOCKBOSS = TRANSITS + 10;
+    static final int ROUTES = BLOCKBOSS + 10;
+    static final int WARRANTS = ROUTES + 10;
+    static final int SIGNALMASTLOGICS = WARRANTS + 10;
+    static final int IDTAGS = SIGNALMASTLOGICS + 10;
+    static final int ANALOGIOS = IDTAGS + 10;
+    static final int METERS = ANALOGIOS + 10;
+    static final int STRINGIOS = METERS + 10;
+    static final int LOGIXS = STRINGIOS + 10;
+    static final int CONDITIONALS = LOGIXS + 10;
+    static final int AUDIO = CONDITIONALS + 10;
+    static final int TIMEBASE = AUDIO + 10;
     // All LogixNG beans share the "Q" letter. For example, a digital expression
     // has a system name like "IQDE001".
-    int LOGIXNGS = TIMEBASE + 10;                              // LogixNG
-    int LOGIXNG_GLOBAL_VARIABLES = LOGIXNGS + 10;               // LogixNG Global Variables
-    int LOGIXNG_CONDITIONALNGS = LOGIXNG_GLOBAL_VARIABLES + 10; // LogixNG ConditionalNG
-    int LOGIXNG_MODULES = LOGIXNG_CONDITIONALNGS + 10;          // LogixNG Modules
-    int LOGIXNG_TABLES = LOGIXNG_MODULES + 10;                  // LogixNG Tables (not bean tables)
-    int LOGIXNG_DIGITAL_EXPRESSIONS = LOGIXNG_TABLES + 10;          // LogixNG Expression
-    int LOGIXNG_DIGITAL_ACTIONS = LOGIXNG_DIGITAL_EXPRESSIONS + 10; // LogixNG Action
-    int LOGIXNG_DIGITAL_BOOLEAN_ACTIONS = LOGIXNG_DIGITAL_ACTIONS + 10;   // LogixNG Digital Boolean Action
-    int LOGIXNG_ANALOG_EXPRESSIONS = LOGIXNG_DIGITAL_BOOLEAN_ACTIONS + 10;  // LogixNG AnalogExpression
-    int LOGIXNG_ANALOG_ACTIONS = LOGIXNG_ANALOG_EXPRESSIONS + 10;   // LogixNG AnalogAction
-    int LOGIXNG_STRING_EXPRESSIONS = LOGIXNG_ANALOG_ACTIONS + 10;   // LogixNG StringExpression
-    int LOGIXNG_STRING_ACTIONS = LOGIXNG_STRING_EXPRESSIONS + 10;   // LogixNG StringAction
-    int PANELFILES = LOGIXNG_STRING_ACTIONS + 10;
-    int ENTRYEXIT = PANELFILES + 10;
-    int METERFRAMES = ENTRYEXIT + 10;
-    int CTCDATA = METERFRAMES + 10;
+    static final int LOGIXNGS = TIMEBASE + 10;                              // LogixNG
+    static final int LOGIXNG_GLOBAL_VARIABLES = LOGIXNGS + 10;               // LogixNG Global Variables
+    static final int LOGIXNG_CONDITIONALNGS = LOGIXNG_GLOBAL_VARIABLES + 10; // LogixNG ConditionalNG
+    static final int LOGIXNG_MODULES = LOGIXNG_CONDITIONALNGS + 10;          // LogixNG Modules
+    static final int LOGIXNG_TABLES = LOGIXNG_MODULES + 10;                  // LogixNG Tables (not bean tables)
+    static final int LOGIXNG_DIGITAL_EXPRESSIONS = LOGIXNG_TABLES + 10;          // LogixNG Expression
+    static final int LOGIXNG_DIGITAL_ACTIONS = LOGIXNG_DIGITAL_EXPRESSIONS + 10; // LogixNG Action
+    static final int LOGIXNG_DIGITAL_BOOLEAN_ACTIONS = LOGIXNG_DIGITAL_ACTIONS + 10;   // LogixNG Digital Boolean Action
+    static final int LOGIXNG_ANALOG_EXPRESSIONS = LOGIXNG_DIGITAL_BOOLEAN_ACTIONS + 10;  // LogixNG AnalogExpression
+    static final int LOGIXNG_ANALOG_ACTIONS = LOGIXNG_ANALOG_EXPRESSIONS + 10;   // LogixNG AnalogAction
+    static final int LOGIXNG_STRING_EXPRESSIONS = LOGIXNG_ANALOG_ACTIONS + 10;   // LogixNG StringExpression
+    static final int LOGIXNG_STRING_ACTIONS = LOGIXNG_STRING_EXPRESSIONS + 10;   // LogixNG StringAction
+    static final int PANELFILES = LOGIXNG_STRING_ACTIONS + 10;
+    static final int ENTRYEXIT = PANELFILES + 10;
+    static final int METERFRAMES = ENTRYEXIT + 10;
+    static final int CTCDATA = METERFRAMES + 10;
 
     /**
      * Determine the order that types should be written when storing panel

--- a/java/src/jmri/NamedBean.java
+++ b/java/src/jmri/NamedBean.java
@@ -71,31 +71,31 @@ public interface NamedBean extends Comparable<NamedBean>, PropertyChangeProvider
      * initial state of a newly created object before communication with the
      * layout.
      */
-    int UNKNOWN = 0x01;
+    static final int UNKNOWN = 0x01;
 
     /**
      * Constant representing an "inconsistent" state, indicating that some
      * inconsistency has been detected in the hardware readback.
      */
-    int INCONSISTENT = 0x08;
+    static final int INCONSISTENT = 0x08;
 
     /**
      * Format used for {@link #getDisplayName(DisplayOptions)} when displaying
      * the user name and system name without quoation marks around the user
      * name.
      */
-    String DISPLAY_NAME_FORMAT = "%s (%s)";
+    final static String DISPLAY_NAME_FORMAT = "%s (%s)";
 
     /**
      * Format used for {@link #getDisplayName(DisplayOptions)} when displaying
      * the user name and system name with quoation marks around the user name.
      */
-    String QUOTED_NAME_FORMAT = "\"%s\" (%s)";
+    final static String QUOTED_NAME_FORMAT = "\"%s\" (%s)";
 
     /**
      * Property of changed state.
      */
-    String PROPERTY_STATE = "state";
+    final static String PROPERTY_STATE = "state";
 
     /**
      * User's identification for the item. Bound parameter so manager(s) can

--- a/java/src/jmri/ProgListener.java
+++ b/java/src/jmri/ProgListener.java
@@ -40,69 +40,69 @@ public interface ProgListener extends java.util.EventListener {
      * Constant denoting that the request completed correctly. Note this is a
      * specific value; all others are bitwise combinations
      */
-    int OK = 0;
+    static final int OK = 0;
 
     /**
      * Constant denoting the request failed, but no specific reason is known
      */
-    int UnknownError = 1;
+    static final int UnknownError = 1;
 
     /**
      * Constant denoting that no decoder was detected on the programming track
      */
-    int NoLocoDetected = 2;
+    static final int NoLocoDetected = 2;
 
     /**
      * Constant denoting that the request failed because the decoding hardware
      * was already busy
      */
-    int ProgrammerBusy = 4;
+    static final int ProgrammerBusy = 4;
 
     /**
      * Constant denoting that the request failed because it requested some
      * unimplemented capability. Note that this can also result in an exception
      * during the original request; which happens is implementation dependent
      */
-    int NotImplemented = 8;
+    static final int NotImplemented = 8;
 
     /**
      * Constant denoting that the user (human or software) aborted the request
      * before completion
      */
-    int UserAborted = 0x10;
+    static final int UserAborted = 0x10;
 
     /**
      * Constant denoting there was no acknowledge from the locomotive, so the CV
      * may or may not have been written on a write. No value was read.
      */
-    int NoAck = 0x20;
+    static final int NoAck = 0x20;
 
     /**
      * Constant denoting that confirm failed, likely due to another value being
      * present
      */
-    int ConfirmFailed = 0x40;
+    static final int ConfirmFailed = 0x40;
 
     /**
      * Constant denoting that the programming operation timed out
      */
-    int FailedTimeout = 0x80;
+    static final int FailedTimeout = 0x80;
 
     /**
      * Constant denoting that a short circuit occurred while programming
      */
-    int ProgrammingShort = 0x100;
+    static final int ProgrammingShort = 0x100;
 
     /**
      * Constant denoting that there was an error with the programming sequence
      * (such as early exit)
      */
-    int SequenceError = 0x200;
+    static final int SequenceError = 0x200;
 
     /**
      * Constant denoting that a communications error occurred between the command
      * station and the PC during programming
      */
-    int CommError = 0x400;
+    static final int CommError = 0x400;
 
 }

--- a/java/src/jmri/Sensor.java
+++ b/java/src/jmri/Sensor.java
@@ -24,11 +24,11 @@ import org.slf4j.LoggerFactory;
 public interface Sensor extends DigitalIO {
 
     // states are parameters; both closed and thrown is possible!
-    int ACTIVE = DigitalIO.ON;
-    int INACTIVE = DigitalIO.OFF;
+    static final int ACTIVE = DigitalIO.ON;
+    static final int INACTIVE = DigitalIO.OFF;
 
-    // MAx value for Debounce Parameter
-    Long MAX_DEBOUNCE = 9999999L;
+    // Max value for Debounce Parameter
+    static final Long MAX_DEBOUNCE = 9999999L;
 
 
     /** {@inheritDoc} */
@@ -242,6 +242,6 @@ public interface Sensor extends DigitalIO {
     PullResistance getPullResistance();
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(value = "SLF4J_LOGGER_SHOULD_BE_PRIVATE",justification="Private not available in interface")
-    Logger log = LoggerFactory.getLogger(Sensor.class);
+    static final Logger log = LoggerFactory.getLogger(Sensor.class);
     
 }

--- a/java/src/jmri/Throttle.java
+++ b/java/src/jmri/Throttle.java
@@ -34,7 +34,7 @@ public interface Throttle extends PropertyChangeProvider {
     /**
      * Constant used in getThrottleInfo.
      */
-    String SPEEDSTEPMODE = "SpeedStepsMode"; // speed steps NOI18N
+    static final String SPEEDSTEPMODE = "SpeedStepsMode"; // speed steps NOI18N
 
     /*
      * Properties strings sent to property change listeners
@@ -43,137 +43,137 @@ public interface Throttle extends PropertyChangeProvider {
     /**
      * Constant sent by Throttle on Property Change.
      */
-    String SPEEDSTEPS = "SpeedSteps"; // speed steps NOI18N
+    static final String SPEEDSTEPS = "SpeedSteps"; // speed steps NOI18N
 
-    String SPEEDSETTING = "SpeedSetting"; // speed setting NOI18N
-    String ISFORWARD = "IsForward"; // direction setting NOI18N
-    String SPEEDINCREMENT = "SpeedIncrement"; // direction setting NOI18N
+    static final String SPEEDSETTING = "SpeedSetting"; // speed setting NOI18N
+    static final String ISFORWARD = "IsForward"; // direction setting NOI18N
+    static final String SPEEDINCREMENT = "SpeedIncrement"; // direction setting NOI18N
 
     /**
      * Constants to represent the functions F0 through F28.
      * @deprecated Use {@code getFunctionString(int momentFunctionNum) } instead.
      */
     @Deprecated(since="5.1.2", forRemoval=false) // used in scripts
-    String F0 = "F0"; // NOI18N
+    static final String F0 = "F0"; // NOI18N
     @Deprecated(since="5.1.2", forRemoval=false) // used in scripts
-    String F1 = "F1"; // NOI18N
+    static final String F1 = "F1"; // NOI18N
     @Deprecated(since="5.1.2", forRemoval=false) // used in scripts
-    String F2 = "F2"; // NOI18N
+    static final String F2 = "F2"; // NOI18N
     @Deprecated(since="5.1.2", forRemoval=false) // used in scripts
-    String F3 = "F3"; // NOI18N
+    static final String F3 = "F3"; // NOI18N
     @Deprecated(since="5.1.2", forRemoval=false) // used in scripts
-    String F4 = "F4"; // NOI18N
+    static final String F4 = "F4"; // NOI18N
     @Deprecated(since="5.1.2", forRemoval=false) // used in scripts
-    String F5 = "F5"; // NOI18N
+    static final String F5 = "F5"; // NOI18N
     @Deprecated(since="5.1.2", forRemoval=false) // used in scripts
-    String F6 = "F6"; // NOI18N
+    static final String F6 = "F6"; // NOI18N
     @Deprecated(since="5.1.2", forRemoval=false) // used in scripts
-    String F7 = "F7"; // NOI18N
+    static final String F7 = "F7"; // NOI18N
     @Deprecated(since="5.1.2", forRemoval=false) // used in scripts
-    String F8 = "F8"; // NOI18N
+    static final String F8 = "F8"; // NOI18N
     @Deprecated(since="5.1.2", forRemoval=false) // used in scripts
-    String F9 = "F9"; // NOI18N
+    static final String F9 = "F9"; // NOI18N
     @Deprecated(since="5.1.2", forRemoval=false) // used in scripts
-    String F10 = "F10"; // NOI18N
+    static final String F10 = "F10"; // NOI18N
     @Deprecated(since="5.1.2", forRemoval=false) // used in scripts
-    String F11 = "F11"; // NOI18N
+    static final String F11 = "F11"; // NOI18N
     @Deprecated(since="5.1.2", forRemoval=false) // used in scripts
-    String F12 = "F12"; // NOI18N
+    static final String F12 = "F12"; // NOI18N
     @Deprecated(since="5.1.2", forRemoval=false) // used in scripts
-    String F13 = "F13"; // NOI18N
+    static final String F13 = "F13"; // NOI18N
     @Deprecated(since="5.1.2", forRemoval=false) // used in scripts
-    String F14 = "F14"; // NOI18N
+    static final String F14 = "F14"; // NOI18N
     @Deprecated(since="5.1.2", forRemoval=false) // used in scripts
-    String F15 = "F15"; // NOI18N
+    static final String F15 = "F15"; // NOI18N
     @Deprecated(since="5.1.2", forRemoval=false) // used in scripts
-    String F16 = "F16"; // NOI18N
+    static final String F16 = "F16"; // NOI18N
     @Deprecated(since="5.1.2", forRemoval=false) // used in scripts
-    String F17 = "F17"; // NOI18N
+    static final String F17 = "F17"; // NOI18N
     @Deprecated(since="5.1.2", forRemoval=false) // used in scripts
-    String F18 = "F18"; // NOI18N
+    static final String F18 = "F18"; // NOI18N
     @Deprecated(since="5.1.2", forRemoval=false) // used in scripts
-    String F19 = "F19"; // NOI18N
+    static final String F19 = "F19"; // NOI18N
     @Deprecated(since="5.1.2", forRemoval=false) // used in scripts
-    String F20 = "F20"; // NOI18N
+    static final String F20 = "F20"; // NOI18N
     @Deprecated(since="5.1.2", forRemoval=false) // used in scripts
-    String F21 = "F21"; // NOI18N
+    static final String F21 = "F21"; // NOI18N
     @Deprecated(since="5.1.2", forRemoval=false) // used in scripts
-    String F22 = "F22"; // NOI18N
+    static final String F22 = "F22"; // NOI18N
     @Deprecated(since="5.1.2", forRemoval=false) // used in scripts
-    String F23 = "F23"; // NOI18N
+    static final String F23 = "F23"; // NOI18N
     @Deprecated(since="5.1.2", forRemoval=false) // used in scripts
-    String F24 = "F24"; // NOI18N
+    static final String F24 = "F24"; // NOI18N
     @Deprecated(since="5.1.2", forRemoval=false) // used in scripts
-    String F25 = "F25"; // NOI18N
+    static final String F25 = "F25"; // NOI18N
     @Deprecated(since="5.1.2", forRemoval=false) // used in scripts
-    String F26 = "F26"; // NOI18N
+    static final String F26 = "F26"; // NOI18N
     @Deprecated(since="5.1.2", forRemoval=false) // used in scripts
-    String F27 = "F27"; // NOI18N
+    static final String F27 = "F27"; // NOI18N
     @Deprecated(since="5.1.2", forRemoval=false) // used in scripts
-    String F28 = "F28"; // NOI18N
+    static final String F28 = "F28"; // NOI18N
 
     /**
      * Constants to represent the functions F0 through F28.
      * @deprecated Use {@code getFunctionMomentaryString(int momentFunctionNum) } instead.
      */
     @Deprecated(since="5.1.2", forRemoval=false) // used in scripts
-    String F0Momentary = "F0Momentary"; // NOI18N
+    static final String F0Momentary = "F0Momentary"; // NOI18N
     @Deprecated(since="5.1.2", forRemoval=false) // used in scripts
-    String F1Momentary = "F1Momentary"; // NOI18N
+    static final String F1Momentary = "F1Momentary"; // NOI18N
     @Deprecated(since="5.1.2", forRemoval=false) // used in scripts
-    String F2Momentary = "F2Momentary"; // NOI18N
+    static final String F2Momentary = "F2Momentary"; // NOI18N
     @Deprecated(since="5.1.2", forRemoval=false) // used in scripts
-    String F3Momentary = "F3Momentary"; // NOI18N
+    static final String F3Momentary = "F3Momentary"; // NOI18N
     @Deprecated(since="5.1.2", forRemoval=false) // used in scripts
-    String F4Momentary = "F4Momentary"; // NOI18N
+    static final String F4Momentary = "F4Momentary"; // NOI18N
     @Deprecated(since="5.1.2", forRemoval=false) // used in scripts
-    String F5Momentary = "F5Momentary"; // NOI18N
+    static final String F5Momentary = "F5Momentary"; // NOI18N
     @Deprecated(since="5.1.2", forRemoval=false) // used in scripts
-    String F6Momentary = "F6Momentary"; // NOI18N
+    static final String F6Momentary = "F6Momentary"; // NOI18N
     @Deprecated(since="5.1.2", forRemoval=false) // used in scripts
-    String F7Momentary = "F7Momentary"; // NOI18N
+    static final String F7Momentary = "F7Momentary"; // NOI18N
     @Deprecated(since="5.1.2", forRemoval=false) // used in scripts
-    String F8Momentary = "F8Momentary"; // NOI18N
+    static final String F8Momentary = "F8Momentary"; // NOI18N
     @Deprecated(since="5.1.2", forRemoval=false) // used in scripts
-    String F9Momentary = "F9Momentary"; // NOI18N
+    static final String F9Momentary = "F9Momentary"; // NOI18N
     @Deprecated(since="5.1.2", forRemoval=false) // used in scripts
-    String F10Momentary = "F10Momentary"; // NOI18N
+    static final String F10Momentary = "F10Momentary"; // NOI18N
     @Deprecated(since="5.1.2", forRemoval=false) // used in scripts
-    String F11Momentary = "F11Momentary"; // NOI18N
+    static final String F11Momentary = "F11Momentary"; // NOI18N
     @Deprecated(since="5.1.2", forRemoval=false) // used in scripts
-    String F12Momentary = "F12Momentary"; // NOI18N
+    static final String F12Momentary = "F12Momentary"; // NOI18N
     @Deprecated(since="5.1.2", forRemoval=false) // used in scripts
-    String F13Momentary = "F13Momentary"; // NOI18N
+    static final String F13Momentary = "F13Momentary"; // NOI18N
     @Deprecated(since="5.1.2", forRemoval=false) // used in scripts
-    String F14Momentary = "F14Momentary"; // NOI18N
+    static final String F14Momentary = "F14Momentary"; // NOI18N
     @Deprecated(since="5.1.2", forRemoval=false) // used in scripts
-    String F15Momentary = "F15Momentary"; // NOI18N
+    static final String F15Momentary = "F15Momentary"; // NOI18N
     @Deprecated(since="5.1.2", forRemoval=false) // used in scripts
-    String F16Momentary = "F16Momentary"; // NOI18N
+    static final String F16Momentary = "F16Momentary"; // NOI18N
     @Deprecated(since="5.1.2", forRemoval=false) // used in scripts
-    String F17Momentary = "F17Momentary"; // NOI18N
+    static final String F17Momentary = "F17Momentary"; // NOI18N
     @Deprecated(since="5.1.2", forRemoval=false) // used in scripts
-    String F18Momentary = "F18Momentary"; // NOI18N
+    static final String F18Momentary = "F18Momentary"; // NOI18N
     @Deprecated(since="5.1.2", forRemoval=false) // used in scripts
-    String F19Momentary = "F19Momentary"; // NOI18N
+    static final String F19Momentary = "F19Momentary"; // NOI18N
     @Deprecated(since="5.1.2", forRemoval=false) // used in scripts
-    String F20Momentary = "F20Momentary"; // NOI18N
+    static final String F20Momentary = "F20Momentary"; // NOI18N
     @Deprecated(since="5.1.2", forRemoval=false) // used in scripts
-    String F21Momentary = "F21Momentary"; // NOI18N
+    static final String F21Momentary = "F21Momentary"; // NOI18N
     @Deprecated(since="5.1.2", forRemoval=false) // used in scripts
-    String F22Momentary = "F22Momentary"; // NOI18N
+    static final String F22Momentary = "F22Momentary"; // NOI18N
     @Deprecated(since="5.1.2", forRemoval=false) // used in scripts
-    String F23Momentary = "F23Momentary"; // NOI18N
+    static final String F23Momentary = "F23Momentary"; // NOI18N
     @Deprecated(since="5.1.2", forRemoval=false) // used in scripts
-    String F24Momentary = "F24Momentary"; // NOI18N
+    static final String F24Momentary = "F24Momentary"; // NOI18N
     @Deprecated(since="5.1.2", forRemoval=false) // used in scripts
-    String F25Momentary = "F25Momentary"; // NOI18N
+    static final String F25Momentary = "F25Momentary"; // NOI18N
     @Deprecated(since="5.1.2", forRemoval=false) // used in scripts
-    String F26Momentary = "F26Momentary"; // NOI18N
+    static final String F26Momentary = "F26Momentary"; // NOI18N
     @Deprecated(since="5.1.2", forRemoval=false) // used in scripts
-    String F27Momentary = "F27Momentary"; // NOI18N
+    static final String F27Momentary = "F27Momentary"; // NOI18N
     @Deprecated(since="5.1.2", forRemoval=false) // used in scripts
-    String F28Momentary = "F28Momentary"; // NOI18N
+    static final String F28Momentary = "F28Momentary"; // NOI18N
 
     /**
      * Get the Function String for a particular Function number.

--- a/java/src/jmri/Turnout.java
+++ b/java/src/jmri/Turnout.java
@@ -79,94 +79,94 @@ public interface Turnout extends DigitalIO, VariableControlSpanBean {
      * commanded state. Note that it's possible to be both CLOSED and THROWN at
      * the same time on some systems, which should be called INCONSISTENT
      */
-    int CLOSED = DigitalIO.ON;
+    static final int CLOSED = DigitalIO.ON;
 
     /**
      * Constant representing a "thrown" state, either in readback or as a
      * commanded state. Note that it's possible to be both CLOSED and THROWN at
      * the same time on some systems, which should be called INCONSISTENT
      */
-    int THROWN = DigitalIO.OFF;
+    static final int THROWN = DigitalIO.OFF;
 
     /**
      * Constant representing "direct feedback method". In this case, the
      * commanded state is provided when the known state is requested. The two
      * states never differ. This mode is always possible!
      */
-    int DIRECT = 1;
+    static final int DIRECT = 1;
 
     /**
      * Constant representing "exact feedback method". In this case, the layout
      * hardware can sense both positions of the turnout, which is used to set
      * the known state.
      */
-    int EXACT = 2;
+    static final int EXACT = 2;
 
     /**
      * Constant representing "indirect feedback". In this case, the layout
      * hardware can only sense one setting of the turnout. The known state is
      * inferred from that info.
      */
-    int INDIRECT = 4;  // only one side directly sensed
+    static final int INDIRECT = 4;  // only one side directly sensed
 
     /**
      * Constant representing "feedback by monitoring sent commands". In this
      * case, the known state tracks commands seen on the rails or bus.
      */
-    int MONITORING = 8;
+    static final int MONITORING = 8;
 
     /**
      * Constant representing "feedback by monitoring one sensor". The sensor
      * sets the state CLOSED when INACTIVE and THROWN when ACTIVE
      */
-    int ONESENSOR = 16;
+    static final int ONESENSOR = 16;
 
     /**
      * Constant representing "feedback by monitoring two sensors". The first
      * sensor sets the state THROWN when ACTIVE; the second sensor sets the
      * state CLOSED when ACTIVE.
      */
-    int TWOSENSOR = 32;
+    static final int TWOSENSOR = 32;
 
     /**
      * Constant representing "feedback for signals" . This is DIRECT feedback,
      * with minimal delay (for use with systems that wait for responses returned
      * by from the command station).
      */
-    int SIGNAL = 64;
+    static final int SIGNAL = 64;
 
     /**
      * Constant representing "automatic delayed feedback" . This is DIRECT feedback
      * with a fixed delay before the feedback (known state) takes effect.
      */
-    int DELAYED = 128;
+    static final int DELAYED = 128;
 
     /**
      * Constant representing "loconet alternate feedback method". In this case, the layout
      * hardware can sense both positions of the turnout, which is used to set
      * the known state. Hardware use OPS_SW_REP alternate message.
      */
-    int LNALTERNATE = 256;
+    static final int LNALTERNATE = 256;
 
     /**
      * Constant representing turnout lockout cab commands
      */
-    int CABLOCKOUT = 1;
+    static final int CABLOCKOUT = 1;
 
     /**
      * Constant representing turnout lockout pushbuttons
      */
-    int PUSHBUTTONLOCKOUT = 2;
+    static final int PUSHBUTTONLOCKOUT = 2;
 
     /**
      * Constant representing a unlocked turnout
      */
-    int UNLOCKED = 0;
+    static final int UNLOCKED = 0;
 
     /**
      * Constant representing a locked turnout
      */
-    int LOCKED = 1;
+    static final int LOCKED = 1;
 
     /**
      * Get a list of valid feedback types. The valid types depend on the


### PR DESCRIPTION
Sets the constants in JMRI base interfaces to "static final".  Shouldn't be any functional changes from this.