### PR TITLE
UserPreferences Manager - add methods to pass parent Component

### DIFF
--- a/archunit_ignore_patterns.txt
+++ b/archunit_ignore_patterns.txt
@@ -28,6 +28,10 @@ Method <jmri\.UserPreferencesManager\.getWindowLocation\(java\.lang\.String\)> h
 Method <jmri\.UserPreferencesManager\.getWindowSize\(java\.lang\.String\)> has return type <java\.awt\.Dimension>.*
 Method <jmri\.UserPreferencesManager\.setWindowLocation\(java\.lang\.String, java\.awt\.Point\)> has parameter of type <java\.awt\.Point>.*
 Method <jmri\.UserPreferencesManager\.setWindowSize\(java\.lang\.String, java\.awt\.Dimension\)> has parameter of type <java\.awt\.Dimension>.*
+Method <jmri\.UserPreferencesManager\.showErrorMessage\(java\.awt\.Component, java\.lang\.String, java\.lang\.String, java\.lang\.String, java\.lang\.String, boolean, boolean\)> has parameter of type <java\.awt\.Component>.*
+Method <jmri\.UserPreferencesManager\.showInfoMessage\(java\.awt\.Component, java\.lang.String, java\.lang\.String, java\.lang\.String, java\.lang\.String\)> has parameter of type <java.awt.Component>.*
+Method <jmri\.UserPreferencesManager\.showInfoMessage\(java\.awt\.Component, java\.lang.String, java\.lang\.String, java\.lang\.String, java\.lang\.String, boolean, boolean\)> has parameter of type <java.awt.Component>.*
+Method <jmri\.UserPreferencesManager\.showWarningMessage\(java\.awt\.Component, java\.lang.String, java\.lang\.String, java\.lang\.String, java\.lang\.String, boolean, boolean\)> has parameter of type <java.awt.Component>.*
 
 # For checkJmriPackageJmrix
 

--- a/java/src/jmri/UserPreferencesManager.java
+++ b/java/src/jmri/UserPreferencesManager.java
@@ -1,7 +1,6 @@
 package jmri;
 
-import java.awt.Dimension;
-import java.awt.Point;
+import java.awt.*;
 import java.beans.PropertyChangeListener;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -214,6 +213,21 @@ public interface UserPreferencesManager {
     void showInfoMessage(String title, String message, String classString, String item);
 
     /**
+     * Show an info message ("don't forget ...") with a given dialog title and
+     * user message.
+     * Use a given preference name to determine whether to show it in the future.
+     * The combination of the classString and item parameters should form a unique value.
+     *
+     * @param parentComponent Used to improve Dialog display, can be null.
+     * @param title       message Box title
+     * @param message     message to be displayed
+     * @param classString name of the calling class
+     * @param item        name of the specific item this is used for
+     */
+    void showInfoMessage(@CheckForNull Component parentComponent, String title,
+        String message, String classString, String item);
+    
+    /**
      * Show an error message ("don't forget ...") with a given dialog title and
      * user message. Use a given preference name to determine whether to show it
      * in the future. added flag to indicate that the message should be
@@ -229,7 +243,28 @@ public interface UserPreferencesManager {
      * @param alwaysRemember Means that the suppression of the message will be
      *                       saved
      */
-    void showErrorMessage(String title, String message, String classString, String item, boolean sessionOnly, boolean alwaysRemember);
+    void showErrorMessage(String title, String message, String classString,
+        String item, boolean sessionOnly, boolean alwaysRemember);
+
+    /**
+     * Show an error message ("don't forget ...") with a given dialog title and
+     * user message.
+     * Use a given preference name to determine whether to show it in the future.
+     * Flag to indicate that the message should be suppressed JMRI session only.
+     * The classString and item parameters should form a unique value.
+     *
+     * @param parentComponent Used to improve Dialog display, can be null.
+     * @param title          Message Box title
+     * @param message        Message to be displayed
+     * @param classString    String value of the calling class
+     * @param item           String value of the specific item this is used for
+     * @param sessionOnly    Means this message will be suppressed in this JMRI
+     *                       session and not be remembered
+     * @param alwaysRemember Means that the suppression of the message will be
+     *                       saved
+     */
+    void showErrorMessage(@CheckForNull Component parentComponent, String title,
+        String message, String classString, String item, boolean sessionOnly, boolean alwaysRemember);
 
     /**
      * Show an info message ("don't forget ...") with a given dialog title and
@@ -250,6 +285,26 @@ public interface UserPreferencesManager {
     void showInfoMessage(String title, String message, String classString, String item, boolean sessionOnly, boolean alwaysRemember);
 
     /**
+     * Show an info message ("don't forget ...") with a given dialog title and
+     * user message.
+     * Use a given preference name to determine whether to show it in the future.
+     * Flag to indicate that the message should be suppressed JMRI session only.
+     * The classString and item parameters should form a unique value.
+     *
+     * @param parentComponent Used to improve Dialog display, can be null.
+     * @param title          Message Box title
+     * @param message        Message to be displayed
+     * @param classString    String value of the calling class
+     * @param item           String value of the specific item this is used for
+     * @param sessionOnly    Means this message will be suppressed in this JMRI
+     *                       session and not be remembered
+     * @param alwaysRemember Means that the suppression of the message will be
+     *                       saved
+     */
+    void showInfoMessage(@CheckForNull Component parentComponent, String title,
+        String message, String classString, String item, boolean sessionOnly, boolean alwaysRemember);
+
+    /**
      * Show a warning message ("don't forget ...") with a given dialog title and
      * user message. Use a given preference name to determine whether to show it
      * in the future. added flag to indicate that the message should be
@@ -265,7 +320,28 @@ public interface UserPreferencesManager {
      * @param alwaysRemember Means that the suppression of the message will be
      *                       saved
      */
-    void showWarningMessage(String title, String message, String classString, String item, boolean sessionOnly, boolean alwaysRemember);
+    void showWarningMessage(String title, String message, String classString,
+        String item, boolean sessionOnly, boolean alwaysRemember);
+
+    /**
+     * Show a warning message ("don't forget ...") with a given dialog title and
+     * user message.
+     * Use a given preference name to determine whether to show it in the future.
+     * Flag to indicate that the message should be suppressed JMRI session only.
+     * The classString and item parameters should form a unique value.
+     *
+     * @param parentComponent Used to improve Dialog display, can be null.
+     * @param title          Message Box title
+     * @param message        Message to be displayed
+     * @param classString    String value of the calling class
+     * @param item           String value of the specific item this is used for
+     * @param sessionOnly    Means this message will be suppressed in this JMRI
+     *                       session and not be remembered
+     * @param alwaysRemember Means that the suppression of the message will be
+     *                       saved
+     */
+    void showWarningMessage(@CheckForNull Component parentComponent, String title,
+        String message, String classString, String item, boolean sessionOnly, boolean alwaysRemember);
 
     /**
      * The last selected value in a given combo box.

--- a/java/src/jmri/jmrit/simpleturnoutctrl/SimpleTurnoutCtrlFrame.java
+++ b/java/src/jmri/jmrit/simpleturnoutctrl/SimpleTurnoutCtrlFrame.java
@@ -7,8 +7,6 @@ import javax.swing.BoxLayout;
 import javax.swing.JPanel;
 import jmri.InstanceManager;
 import jmri.Turnout;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Frame to control a single turnout.
@@ -382,7 +380,7 @@ public class SimpleTurnoutCtrlFrame extends jmri.util.JmriJFrame implements java
 
     void invalidTurnout(String name, Exception ex) {
         jmri.InstanceManager.getDefault(jmri.UserPreferencesManager.class)
-                .showErrorMessage(Bundle.getMessage("ErrorTitle"),
+                .showErrorMessage(this, Bundle.getMessage("ErrorTitle"),
                         (Bundle.getMessage("ErrorConvertHW", name)),
                         ex.toString(), "", true, false);
     }
@@ -390,6 +388,6 @@ public class SimpleTurnoutCtrlFrame extends jmri.util.JmriJFrame implements java
     Turnout turnout = null;
     String newState = "";
 
-    private final static Logger log = LoggerFactory.getLogger(SimpleTurnoutCtrlFrame.class);
+    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(SimpleTurnoutCtrlFrame.class);
 
 }

--- a/java/src/jmri/managers/JmriUserPreferencesManager.java
+++ b/java/src/jmri/managers/JmriUserPreferencesManager.java
@@ -2,6 +2,7 @@ package jmri.managers;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.Point;
 import java.awt.Toolkit;
@@ -21,7 +22,6 @@ import javax.annotation.CheckForNull;
 import javax.swing.BoxLayout;
 import javax.swing.JCheckBox;
 import javax.swing.JLabel;
-import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import jmri.ConfigureManager;
 import jmri.InstanceInitializer;
@@ -39,12 +39,11 @@ import jmri.util.FileUtil;
 import jmri.util.JmriJFrame;
 import jmri.util.jdom.JDOMUtil;
 import jmri.util.node.NodeIdentity;
+import jmri.util.swing.JmriJOptionPane;
 import org.jdom2.DataConversionException;
 import org.jdom2.Element;
 import org.jdom2.JDOMException;
 import org.openide.util.lookup.ServiceProvider;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Implementation of {@link UserPreferencesManager} that saves user interface
@@ -72,7 +71,7 @@ public class JmriUserPreferencesManager extends Bean implements UserPreferencesM
     private static final String SETTINGS_ELEMENT = "settings"; // NOI18N
     private static final String WINDOWS_NAMESPACE = "http://jmri.org/xml/schema/auxiliary-configuration/window-details-4-3-5.xsd"; // NOI18N
     private static final String WINDOWS_ELEMENT = "windowDetails"; // NOI18N
-    private static final Logger log = LoggerFactory.getLogger(JmriUserPreferencesManager.class);
+
     private static final String REMINDER = "reminder";
     private static final String JMRI_UTIL_JMRI_JFRAME = "jmri.util.JmriJFrame";
     private static final String CLASS = "class";
@@ -268,7 +267,7 @@ public class JmriUserPreferencesManager extends Bean implements UserPreferencesM
      * should start with the package name (package.Class) for the primary using
      * class.
      *
-     * @param name A unique identifer for preference.
+     * @param name A unique identifier for preference.
      */
     @Override
     public void setSessionPreferenceState(String name, boolean state) {
@@ -281,21 +280,16 @@ public class JmriUserPreferencesManager extends Bean implements UserPreferencesM
         }
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public boolean getSessionPreferenceState(String name) {
         return sessionPreferenceList.contains(name);
     }
 
     /**
-     * Show an info message ("don't forget ...") with a given dialog title and
-     * user message. Use a given preference name to determine whether to show it
-     * in the future. The combination of the classString and item parameters
-     * should form a unique value.
-     *
-     * @param title    message Box title
-     * @param message  message to be displayed
-     * @param strClass name of the calling class
-     * @param item     name of the specific item this is used for
+     * {@inheritDoc}
      */
     @Override
     public void showInfoMessage(String title, String message, String strClass, String item) {
@@ -303,69 +297,63 @@ public class JmriUserPreferencesManager extends Bean implements UserPreferencesM
     }
 
     /**
-     * Show an info message ("don't forget ...") with a given dialog title and
-     * user message. Use a given preference name to determine whether to show it
-     * in the future. added flag to indicate that the message should be
-     * suppressed JMRI session only. The classString and item
-     * parameters should form a unique value
-     *
-     * @param title          Message Box title
-     * @param message        Message to be displayed
-     * @param strClass       String value of the calling class
-     * @param item           String value of the specific item this is used for
-     * @param sessionOnly    Means this message will be suppressed in this JMRI
-     *                       session and not be remembered
-     * @param alwaysRemember Means that the suppression of the message will be
-     *                       saved
+     * {@inheritDoc}
+     */
+    @Override
+    public void showInfoMessage(@CheckForNull Component parentComponent, String title, String message, String strClass, String item) {
+        showInfoMessage(parentComponent, title, message, strClass, item, false, true);
+    }
+
+    /**
+     * {@inheritDoc}
      */
     @Override
     public void showErrorMessage(String title, String message, final String strClass, final String item, final boolean sessionOnly, final boolean alwaysRemember) {
-        this.showMessage(title, message, strClass, item, sessionOnly, alwaysRemember, JOptionPane.ERROR_MESSAGE);
+        this.showMessage(null, title, message, strClass, item, sessionOnly, alwaysRemember, JmriJOptionPane.ERROR_MESSAGE);
     }
 
     /**
-     * Show an info message ("don't forget ...") with a given dialog title and
-     * user message. Use a given preference name to determine whether to show it
-     * in the future. added flag to indicate that the message should be
-     * suppressed JMRI session only. The classString and item
-     * parameters should form a unique value
-     *
-     * @param title          Message Box title
-     * @param message        Message to be displayed
-     * @param strClass       String value of the calling class
-     * @param item           String value of the specific item this is used for
-     * @param sessionOnly    Means this message will be suppressed in this JMRI
-     *                       session and not be remembered
-     * @param alwaysRemember Means that the suppression of the message will be
-     *                       saved
+     * {@inheritDoc}
+     */
+    @Override
+    public void showErrorMessage(@CheckForNull Component parentComponent, String title, String message, final String strClass, final String item, final boolean sessionOnly, final boolean alwaysRemember) {
+        this.showMessage(parentComponent, title, message, strClass, item, sessionOnly, alwaysRemember, JmriJOptionPane.ERROR_MESSAGE);
+    }
+
+    /**
+     * {@inheritDoc}
      */
     @Override
     public void showInfoMessage(String title, String message, final String strClass, final String item, final boolean sessionOnly, final boolean alwaysRemember) {
-        this.showMessage(title, message, strClass, item, sessionOnly, alwaysRemember, JOptionPane.INFORMATION_MESSAGE);
+        this.showMessage(null, title, message, strClass, item, sessionOnly, alwaysRemember, JmriJOptionPane.INFORMATION_MESSAGE);
     }
 
     /**
-     * Show an info message ("don't forget ...") with a given dialog title and
-     * user message. Use a given preference name to determine whether to show it
-     * in the future. added flag to indicate that the message should be
-     * suppressed JMRI session only. The classString and item
-     * parameters should form a unique value
-     *
-     * @param title          Message Box title
-     * @param message        Message to be displayed
-     * @param strClass       String value of the calling class
-     * @param item           String value of the specific item this is used for
-     * @param sessionOnly    Means this message will be suppressed in this JMRI
-     *                       session and not be remembered
-     * @param alwaysRemember Means that the suppression of the message will be
-     *                       saved
+     * {@inheritDoc}
+     */
+    @Override
+    public void showInfoMessage(@CheckForNull Component parentComponent, String title, String message, final String strClass, final String item, final boolean sessionOnly, final boolean alwaysRemember) {
+        this.showMessage(parentComponent, title, message, strClass, item, sessionOnly, alwaysRemember, JmriJOptionPane.INFORMATION_MESSAGE);
+    }
+
+    /**
+     * {@inheritDoc}
      */
     @Override
     public void showWarningMessage(String title, String message, final String strClass, final String item, final boolean sessionOnly, final boolean alwaysRemember) {
-        this.showMessage(title, message, strClass, item, sessionOnly, alwaysRemember, JOptionPane.WARNING_MESSAGE);
+        this.showMessage(null, title, message, strClass, item, sessionOnly, alwaysRemember, JmriJOptionPane.WARNING_MESSAGE);
     }
 
-    protected void showMessage(String title, String message, final String strClass, final String item, final boolean sessionOnly, final boolean alwaysRemember, int type) {
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void showWarningMessage(@CheckForNull Component parentComponent, String title, String message, final String strClass, final String item, final boolean sessionOnly, final boolean alwaysRemember) {
+        this.showMessage(parentComponent, title, message, strClass, item, sessionOnly, alwaysRemember, JmriJOptionPane.WARNING_MESSAGE);
+    }
+
+    protected void showMessage(@CheckForNull Component parentComponent, String title, String message, final String strClass,
+        final String item, final boolean sessionOnly, final boolean alwaysRemember, int type) {
         final String preference = strClass + "." + item;
 
         if (this.getSessionPreferenceState(preference)) {
@@ -387,7 +375,7 @@ public class JmriUserPreferencesManager extends Bean implements UserPreferencesM
                 remember.setFont(remember.getFont().deriveFont(10f));
                 container.add(remember);
             }
-            JOptionPane.showMessageDialog(null, // center over parent component
+            JmriJOptionPane.showMessageDialog(parentComponent, // center over parent component if present
                     container,
                     title,
                     type);
@@ -1416,4 +1404,7 @@ public class JmriUserPreferencesManager extends Bean implements UserPreferencesM
             return set;
         }
     }
+
+    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(JmriUserPreferencesManager.class);
+
 }

--- a/java/test/jmri/managers/JmriUserPreferencesManagerTest.java
+++ b/java/test/jmri/managers/JmriUserPreferencesManagerTest.java
@@ -2,6 +2,7 @@ package jmri.managers;
 
 import apps.AppConfigBase;
 
+import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.GraphicsEnvironment;
 import java.awt.Point;
@@ -29,8 +30,6 @@ import org.junit.Assert;
 import org.junit.jupiter.api.*;
 import org.junit.Assume;
 import org.junit.jupiter.api.io.TempDir;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Tests for the jmri.managers.JmriUserPreferencesManager class.
@@ -40,7 +39,6 @@ import org.slf4j.LoggerFactory;
  */
 public class JmriUserPreferencesManagerTest {
 
-    private final static Logger log = LoggerFactory.getLogger(JmriUserPreferencesManagerTest.class);
     private final String strClass = JmriUserPreferencesManagerTest.class.getName();
 
     @Test
@@ -386,14 +384,14 @@ public class JmriUserPreferencesManagerTest {
         Assert.assertNull(m.alwaysRemember);
         Assert.assertNull(m.sessionOnly);
         Assert.assertEquals(-1, m.type);
-        m.showMessage("title1", "message1", strClass, "item1", true, true, JOptionPane.INFORMATION_MESSAGE);
+        m.showMessage(null, "title1", "message1", strClass, "item1", true, true, JOptionPane.INFORMATION_MESSAGE);
         Assert.assertEquals("title1", m.title);
         Assert.assertEquals("message1", m.message);
         Assert.assertEquals(strClass, m.strClass);
         Assert.assertEquals("item1", m.item);
         Assert.assertTrue(m.alwaysRemember);
         Assert.assertTrue(m.sessionOnly);
-        m.showMessage("title2", "message2", strClass, "item2", false, false, JOptionPane.INFORMATION_MESSAGE);
+        m.showMessage(null, "title2", "message2", strClass, "item2", false, false, JOptionPane.INFORMATION_MESSAGE);
         Assert.assertEquals("title2", m.title);
         Assert.assertEquals("message2", m.message);
         Assert.assertEquals(strClass, m.strClass);
@@ -930,9 +928,9 @@ public class JmriUserPreferencesManagerTest {
         JmriUserPreferencesManager m2 = new JmriUserPreferencesManager();
         m2.readUserPreferences();
         Assert.assertEquals("value1", m2.getProperty(strClass, "test1"));
-        Assert.assertEquals(42, m2.getProperty(strClass, "intTest"));
-        Assert.assertEquals(Math.PI, m2.getProperty(strClass, "doubleTest"));
-        Assert.assertEquals(true, m2.getProperty(strClass, "booleanTest"));
+        Assert.assertEquals(42, (int)m2.getProperty(strClass, "intTest"));
+        Assert.assertEquals(Math.PI, (double)m2.getProperty(strClass, "doubleTest"), 0.001);
+        Assert.assertEquals(true, (boolean)m2.getProperty(strClass, "booleanTest"));
         Assert.assertEquals(location, m2.getWindowLocation(strClass));
         Assert.assertEquals(windowSize, m2.getWindowSize(strClass));
         Assert.assertEquals(true, m2.getPreferenceState(strClass, "test2"));
@@ -972,9 +970,9 @@ public class JmriUserPreferencesManagerTest {
         JmriUserPreferencesManager m2 = new JmriUserPreferencesManager();
         m2.readUserPreferences();
         Assert.assertEquals("value1", m2.getProperty(strClass, "test1"));
-        Assert.assertEquals(42, m2.getProperty(strClass, "intTest"));
-        Assert.assertEquals(Math.PI, m2.getProperty(strClass, "doubleTest"));
-        Assert.assertEquals(true, m2.getProperty(strClass, "booleanTest"));
+        Assert.assertEquals(42, (int)m2.getProperty(strClass, "intTest"));
+        Assert.assertEquals(Math.PI, (double)m2.getProperty(strClass, "doubleTest"), 0.001);
+        Assert.assertEquals(true, (boolean)m2.getProperty(strClass, "booleanTest"));
         Assert.assertEquals(location, m2.getWindowLocation(strClass));
         Assert.assertEquals(windowSize, m2.getWindowSize(strClass));
         Assert.assertEquals(true, m2.getPreferenceState(strClass, "test2"));
@@ -1013,7 +1011,8 @@ public class JmriUserPreferencesManagerTest {
         }
 
         @Override
-        protected void showMessage(String title, String message, final String strClass, final String item, final boolean sessionOnly, final boolean alwaysRemember, int type) {
+        protected void showMessage(@javax.annotation.CheckForNull Component parent, String title,
+            String message, final String strClass, final String item, final boolean sessionOnly, final boolean alwaysRemember, int type) {
             this.title = title;
             this.message = message;
             this.strClass = strClass;
@@ -1055,4 +1054,7 @@ public class JmriUserPreferencesManagerTest {
             this.event = evt;
         }
     }
+
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(JmriUserPreferencesManagerTest.class);
+
 }

--- a/java/test/jmri/managers/TestUserPreferencesManager.java
+++ b/java/test/jmri/managers/TestUserPreferencesManager.java
@@ -16,7 +16,7 @@ public class TestUserPreferencesManager extends JmriUserPreferencesManager {
     }
 
     @Override
-    protected void showMessage(String title, String message, final String strClass, final String item, final boolean sessionOnly, final boolean alwaysRemember, int type) {
+    protected void showMessage(java.awt.Component parent, String title, String message, final String strClass, final String item, final boolean sessionOnly, final boolean alwaysRemember, int type) {
         // Uncomment to force failure if wanting to verify that showMessage does not get called.
         //org.slf4j.LoggerFactory.getLogger(TestUserPreferencesManager.class).error("showMessage called.", new Exception());
     }


### PR DESCRIPTION
Allows methods to pass parent Components, improving Dialog behaviour.
Updates User Preference Dialogs to JmriJOptionPane #12280 
Use inherited JavaDoc

Requires override in Architecture Tests, although there is an existing precedent for java.awt in jmri.UserPreferencesManager