### PR TITLE
Align Py3 convenience constants with Jython

### DIFF
--- a/jython/jmri_bindings.py3
+++ b/jython/jmri_bindings.py3
@@ -18,10 +18,11 @@ audio       = jmri.InstanceManager.getNullableDefault(java.type('jmri.AudioManag
 shutdown    = jmri.InstanceManager.getNullableDefault(java.type('jmri.ShutDownManager'))
 layoutblocks    = jmri.InstanceManager.getNullableDefault(java.type('jmri.jmrit.display.layoutEditor.LayoutBlockManager'))
 warrants    = jmri.InstanceManager.getNullableDefault(java.type('jmri.jmrit.logix.WarrantManager'))
+sections    = jmri.InstanceManager.getNullableDefault(java.type('SectionManager'))
+transits    = jmri.InstanceManager.getNullableDefault(java.type('TransitManager'))
+beans       = jmri.InstanceManager.getNullableDefault(java.type('NamedBeanHandleManager'))
 
 THROWN = jmri.Turnout.THROWN
-
-
 CLOSED  = jmri.Turnout.CLOSED
 THROWN  = jmri.Turnout.THROWN
 CABLOCKOUT = jmri.Turnout.CABLOCKOUT


### PR DESCRIPTION
This adds a few symbols to the jmri_bindings.py3 file so that it has the same constants as are available now in JMRI Jython.