### PR TITLE
CBUS Sonar lint tweaks

### DIFF
--- a/java/src/jmri/jmrix/can/cbus/CbusOpCodes.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusOpCodes.java
@@ -18,9 +18,6 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
  * Methods to decode CBUS opcodes
  *
@@ -30,7 +27,9 @@ import org.slf4j.LoggerFactory;
  */
 public class CbusOpCodes {
 
-    private final static Logger log = LoggerFactory.getLogger(CbusOpCodes.class);
+    private CbusOpCodes() {
+        throw new IllegalStateException("Utility class");
+    }
 
     /**
      * Return a string representation of a decoded CBUS Message
@@ -189,7 +188,7 @@ public class CbusOpCodes {
         return sb.toString();
     }
 
-        /**
+    /**
      * Get loco speed from byte value.
      * @param speed byte value 0-255 of speed containing direction flag.
      * @return interpreted String, maybe with EStop localised text.
@@ -527,6 +526,9 @@ public class CbusOpCodes {
         Map<Integer, CbusOpc> result = new HashMap<>(150); // 134 as of April 2022
         try {
             DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            // disable DOCTYPE declaration & setXIncludeAware to reduce Sonar security warnings
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            factory.setXIncludeAware(false);
             DocumentBuilder builder = factory.newDocumentBuilder();
             Document document = builder.parse(FileUtil.getFile("program:xml/cbus/CbusOpcData.xml"));
             document.getDocumentElement().normalize();
@@ -612,5 +614,7 @@ public class CbusOpCodes {
             return EnumSet.copyOf(_filterMap);
         }
     }
+
+    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(CbusOpCodes.class);
 
 }

--- a/java/src/jmri/jmrix/can/cbus/swing/bootloader/CbusPicHexFile.java
+++ b/java/src/jmri/jmrix/can/cbus/swing/bootloader/CbusPicHexFile.java
@@ -56,7 +56,7 @@ public class CbusPicHexFile extends HexFile{
         int pStart = 0;
         int checksum = 0;
         
-        if (r.type == HexRecord.DATA) {
+        if (r.type == HexRecord.TYPE_DATA) {
             // Look for "old" 8-byte paraneter block at 0x810, assuming aligned hex address
             if (r.address == PARAM_OLD_START) {
                 for (int i = 0; i <= PARAM_OLD_LEN; i++) {

--- a/java/src/jmri/jmrix/can/cbus/swing/bootloader/HexFile.java
+++ b/java/src/jmri/jmrix/can/cbus/swing/bootloader/HexFile.java
@@ -122,7 +122,7 @@ public class HexFile {
     /**
      * Read a hex file.
      * <p>
-     * Read hex records and store DATA records in the array.
+     * Read hex records and store TYPE_DATA records in the array.
      * 
      * @throws IOException on read error
      */
@@ -143,7 +143,7 @@ public class HexFile {
                 log.debug("Found extended adress record for address {}", Integer.toHexString(address));
                 continue;
             }
-            if (r.type == HexRecord.DATA) {
+            if (r.type == HexRecord.TYPE_DATA) {
                 address = (address & 0xffff0000) + r.getAddress();
                 hexRecords[lineNo].address = address;
                 log.debug("Hex record for address {}", Integer.toHexString(hexRecords[lineNo].address));
@@ -230,7 +230,7 @@ public class HexFile {
 
     
     /**
-     * Return the next DATA record from the file
+     * Return the next TYPE_DATA record from the file
      * 
      * @return the next hex record
      */
@@ -256,7 +256,7 @@ public class HexFile {
         while (true) { 
             try {
                 r = hexRecords[readIndex++];
-                if ((r.type == HexRecord.DATA)
+                if ((r.type == HexRecord.TYPE_DATA)
                         && (addr >= r.address) && (addr < (r.address + r.len))) {
                     return Optional.of(r);
                 }

--- a/java/src/jmri/jmrix/can/cbus/swing/bootloader/HexRecord.java
+++ b/java/src/jmri/jmrix/can/cbus/swing/bootloader/HexRecord.java
@@ -15,7 +15,7 @@ public class HexRecord {
 
     // Record types
     static final byte EXT_ADDR = 4;
-    static final byte DATA = 0;
+    static final byte TYPE_DATA = 0;
     static final byte END = 1;
     // Maximum data length
     static final int MAX_LEN = 256;

--- a/java/src/jmri/jmrix/can/cbus/swing/eventtable/CbusEventTablePrintAction.java
+++ b/java/src/jmri/jmrix/can/cbus/swing/eventtable/CbusEventTablePrintAction.java
@@ -230,14 +230,6 @@ public class CbusEventTablePrintAction extends AbstractAction {
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Object clone() throws CloneNotSupportedException {
-        return super.clone();
-    }
-
     private final static Logger log = LoggerFactory.getLogger(CbusEventTablePrintAction.class);
 
 }

--- a/java/src/jmri/jmrix/can/cbus/swing/nodeconfig/CbusNodeRestoreFcuFrame.java
+++ b/java/src/jmri/jmrix/can/cbus/swing/nodeconfig/CbusNodeRestoreFcuFrame.java
@@ -24,6 +24,7 @@ import jmri.jmrix.can.cbus.eventtable.CbusEventTableDataModel;
 import jmri.jmrix.can.cbus.node.*;
 import jmri.util.JmriJFrame;
 import jmri.util.StringUtil;
+import jmri.util.swing.JmriJOptionPane;
 
 import org.w3c.dom.Document;
 import org.w3c.dom.DOMException;
@@ -279,8 +280,8 @@ public class CbusNodeRestoreFcuFrame extends JmriJFrame {
         if ( obj == null ) {
             return null;
         }
-        int _targetnodenum =  StringUtil.getFirstIntFromString(obj);
-        return nodeModel.getNodeByNodeNum(_targetnodenum);
+        int targetnodenum =  StringUtil.getFirstIntFromString(obj);
+        return nodeModel.getNodeByNodeNum(targetnodenum);
     }
 
     private void updateTabs() {
@@ -333,11 +334,15 @@ public class CbusNodeRestoreFcuFrame extends JmriJFrame {
 
     private static JFileChooser chooser;
 
-    private void selectInputFile(ActionEvent e){
-
+    private static void initChooser(){
         if (chooser == null) {
             chooser = jmri.jmrit.XmlFile.userFileChooser("XML Files", "xml", "XML");
         }
+    }
+
+    private void selectInputFile(ActionEvent e){
+
+        initChooser();
         chooser.rescanCurrentDirectory();
         int retVal = chooser.showOpenDialog(this);
         if (retVal != JFileChooser.APPROVE_OPTION) {
@@ -347,8 +352,8 @@ public class CbusNodeRestoreFcuFrame extends JmriJFrame {
         File testForXml = chooser.getSelectedFile();
 
         if (!testForXml.getPath().toUpperCase().endsWith("XML")) {
-            JOptionPane.showMessageDialog(null, Bundle.getMessage("ImportNotXml"),
-                Bundle.getMessage("WarningTitle"), JOptionPane.ERROR_MESSAGE);
+            JmriJOptionPane.showMessageDialog(this, Bundle.getMessage("ImportNotXml"),
+                Bundle.getMessage("WarningTitle"), JmriJOptionPane.ERROR_MESSAGE);
             return;
         }
 
@@ -364,6 +369,9 @@ public class CbusNodeRestoreFcuFrame extends JmriJFrame {
         try {
             cbusNodeFcuDataModel.resetData();
             DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
+            // disable DOCTYPE declaration & setXIncludeAware to reduce Sonar security warnings
+            dbFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            dbFactory.setXIncludeAware(false);
             DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
             Document doc = dBuilder.parse(inputFile);
             doc.getDocumentElement().normalize();
@@ -374,8 +382,8 @@ public class CbusNodeRestoreFcuFrame extends JmriJFrame {
         }
         catch (NumberFormatException | DOMException | IOException | ParserConfigurationException | SAXException e) {
             log.warn("Error importing xml file. Valid xml?", e);
-            JOptionPane.showMessageDialog(this, (Bundle.getMessage("ImportError") + " Valid XML?"),
-                Bundle.getMessage("WarningTitle"), JOptionPane.ERROR_MESSAGE);
+            JmriJOptionPane.showMessageDialog(this, (Bundle.getMessage("ImportError") + " Valid XML?"),
+                Bundle.getMessage("WarningTitle"), JmriJOptionPane.ERROR_MESSAGE);
         }
     }
 


### PR DESCRIPTION
Fixes some high priority items.

Renamed bootloader HexRecord.DATA to TYPE_DATA to avoid conflict with HexRecord.data

CbusEventTablePrintAction - do not override clone

CbusOpCodes & CbusNodeRestoreFcuFrame
Disabled DOCTYPE declaration & setXIncludeAware

CbusNodeRestoreFcuFrame - Static write from instance