### PR TITLE
DS78V decoder definition

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -82,7 +82,9 @@
 
         <h4>LocoNet</h4>
             <ul>
-                <li></li>
+                <li>Added a DecoderPro definition for the DS78V. This required
+                    code changes, so this definition will not work with earlier
+                    versions of JMRI.</li>
             </ul>
 
         <h4>Maple</h4>

--- a/java/src/jmri/jmrix/loconet/LnOpsModeProgrammer.java
+++ b/java/src/jmri/jmrix/loconet/LnOpsModeProgrammer.java
@@ -131,12 +131,28 @@ public class LnOpsModeProgrammer extends PropertyChangeSupport implements Addres
             doingWrite = true;
             // Board programming mode
             log.debug("write CV \"{}\" to {} addr:{}", CV, val, mAddress);
+            
+            // get prefix if any
+            String[] parts = CV.split("\\.");
+            int offset = 0;
+            int cv = 0;
+            switch (parts.length) {
+                case 1: // plain CV number
+                    cv = Integer.parseInt(parts[0])-1;
+                    break;
+                case 2:  //  offset.CV format
+                    offset = Integer.parseInt(parts[0]);
+                    cv = Integer.parseInt(parts[1])-1;
+                    break;
+                default:
+                    log.error("unexpected number of parts in CV {}", CV);
+            }
 
-            int address6th = ((mAddress-1) >> 2) & 0x3F;
-            int upper3 = ~(((mAddress-1) >> 8) & 0x07);
-            int lower2 = (mAddress-1) & 0x03;
+            int address6th = ((mAddress-1+offset) >> 2) & 0x3F;
+            int upper3 = ~(((mAddress-1+offset) >> 8) & 0x07);
+            int lower2 = (mAddress-1+offset) & 0x03;
             int address7th = ((upper3 << 4) & 0x70) | (lower2 << 1) | 0x08;
-            int cv = Integer.parseInt(CV)-1;
+            
             // make message - send immediate packet with custom content
             m = new LocoNetMessage(11);
             m.setOpCode(0xED);
@@ -288,11 +304,27 @@ public class LnOpsModeProgrammer extends PropertyChangeSupport implements Addres
             // Board programming mode
             log.debug("read CV \"{}\" addr:{}", CV, mAddress);
 
-            int address6th = ((mAddress-1) >> 2) & 0x3F;
-            int upper3 = ~(((mAddress-1) >> 8) & 0x07);
-            int lower2 = (mAddress-1) & 0x03;
+            // get prefix if any
+            parts = CV.split("\\.");
+            int offset = 0;
+            int cv = 0;
+            switch (parts.length) {
+                case 1: // plain CV number
+                    cv = Integer.parseInt(parts[0])-1;
+                    break;
+                case 2:  //  offset.CV format
+                    offset = Integer.parseInt(parts[0]);
+                    cv = Integer.parseInt(parts[1])-1;
+                    break;
+                default:
+                    log.error("unexpected number of parts in CV {}", CV);
+            }
+
+            int address6th = ((mAddress-1+offset) >> 2) & 0x3F;
+            int upper3 = ~(((mAddress-1+offset) >> 8) & 0x07);
+            int lower2 = (mAddress-1+offset) & 0x03;
             int address7th = ((upper3 << 4) & 0x70) | (lower2 << 1) | 0x08;
-            int cv = Integer.parseInt(CV)-1;
+            
             // make message - send immediate packet with custom content
             m = new LocoNetMessage(11);
             m.setOpCode(0xED);

--- a/xml/decoderIndex.xml
+++ b/xml/decoderIndex.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet href="/xml/XSLT/DecoderID.xsl" type="text/xsl"?>
 <decoderIndex-config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
-  <!--Written by JMRI version 5.5.2plus+jake+20230804T1827Z+Re46d2cd2ef on Fri Aug 04 14:28:40 EDT 2023-->
-  <decoderIndex version="39">
+  <!--Written by JMRI version 5.5.3plus+jake+20230902T1654Z+Rb3fe09d632 on Sat Sep 02 12:54:49 EDT 2023-->
+  <decoderIndex version="41">
     <!--The manufacturer list is from the nmra_mfg_list.xml file-->
     <mfgList nmraListDate="2021-03-06" updated="2023-01-25" lastadd="169">
       <manufacturer mfg="NMRA" mfgID="999" />
@@ -2038,6 +2038,9 @@
       </family>
       <family name="Series 7 Boards" mfg="Digitrax" file="Digitrax_DS74.xml">
         <model model="DS74" />
+      </family>
+      <family name="Series 7 Boards" mfg="Digitrax" file="Digitrax_DS78V.xml">
+        <model model="DS78V" />
       </family>
       <family name="Economy Series 3 with FX3, silent" mfg="Digitrax" lowVersionID="35" highVersionID="36" file="Digitrax_Economy.xml">
         <model model="DH123" numOuts="2" numFns="5" lowVersionID="35" highVersionID="36">
@@ -6281,10 +6284,10 @@
         </soundlabels>
       </family>
       <family name="ESU LokPilot Basic 1.0" mfg="Electronic Solutions Ulm GmbH" lowVersionID="0" highVersionID="255" file="ESU_LokPilotBasic1.0.xml">
-        <model model="LokPilot Basic 1.0" numOuts="5" numFns="5">
+        <model model="LokPilot Basic 1.0" numOuts="5" numFns="5" productID="52690">
           <output name="1" label="Front|light" />
           <output name="2" label="Rear|light" />
-          <output name="3" label="   AUX1    " />
+          <output name="3" label="AUX1" />
           <output name="4" label="Shunting|gear" />
           <output name="5" label="Acceleration|brake delay" />
         </model>

--- a/xml/decoders/Digitrax_DS78V.xml
+++ b/xml/decoders/Digitrax_DS78V.xml
@@ -28,6 +28,8 @@
             <label>Board Address</label>
           </variable>
 
+           <!-- CV7 is the product ID. Should be 0x7c (124 decimal) -->
+           
            <variable CV="11" item="Output Type" default="0"
                 tooltip="OpSw1-4" mask="XXXXVVVV">
             <enumVal>

--- a/xml/decoders/Digitrax_DS78V.xml
+++ b/xml/decoders/Digitrax_DS78V.xml
@@ -1,0 +1,333 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet type="text/xsl" href="../XSLT/decoder.xsl"?>
+<decoder-config xmlns:xi="http://www.w3.org/2001/XInclude"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd"
+                showEmptyPanes="no"
+                suppressFunctionLabels="yes"
+                suppressRosterMedia="yes"
+                >
+
+    <version author="Bob Jacobsen" version="1" lastUpdated="20230205" />
+
+    <decoder>
+
+        <family name="Series 7 Boards" mfg="Digitrax">
+            <model model="DS78V"/>
+        </family>
+
+        <programming direct="no" paged="yes" register="no" ops="no"><!-- paged yes allows initial setup and change of address -->
+            <mode>LOCONETBD7OPSWMODE</mode>
+        </programming>
+
+        <variables>
+
+          <variable CV="1" comment="Board address" item="Long Address" default="40" infoOnly="yes">
+            <!-- needed to set the board address value -->
+            <decVal min="1" max="2045" />
+            <label>Board Address</label>
+          </variable>
+
+           <variable CV="11" item="Output Type" default="0"
+                tooltip="OpSw1-4" mask="XXXXVVVV">
+            <enumVal>
+              <enumChoice>
+                <choice value="13">Two Position Servo (Thrown/Closed)</choice>
+              </enumChoice>
+              <enumChoice>
+                <choice value="9">Three Position Servo (Semaphore)</choice>
+              </enumChoice>
+            </enumVal>
+            <label>Output type: </label>
+          </variable>
+
+          <variable CV="11" item="Internal Routes" default="0"
+                tooltip="OpSw06" mask="XXVXXXXX">
+            <enumVal>
+              <enumChoice>
+                <choice>enabled</choice>
+              </enumChoice>
+              <enumChoice>
+                <choice>disabled</choice>
+              </enumChoice>
+            </enumVal>
+            <label>Internal Routes are</label>
+          </variable>
+
+          <variable CV="12" item="Bushby" default="0"
+                tooltip="OpSw10" mask="XXXXXXVX">
+            <enumVal>
+              <enumChoice>
+                <choice>disabled</choice>
+              </enumChoice>
+              <enumChoice>
+                <choice>enabled</choice>
+              </enumChoice>
+            </enumVal>
+            <label>Bushby Bit is</label>
+          </variable>
+
+          <variable CV="12" item="Input Lines" default="0"
+                tooltip="OpSw11" mask="XXXXXVXX">
+            <enumVal>
+              <enumChoice>
+                <choice>do turnout, sensor commands</choice>
+              </enumChoice>
+              <enumChoice>
+                <choice>trigger routes</choice>
+              </enumChoice>
+            </enumVal>
+            <label>Input Lines</label>
+          </variable>
+
+          <variable CV="12" item="Command Source" default="0"
+                tooltip="OpSw14" mask="XXVXXXXX">
+            <enumVal>
+              <enumChoice>
+                <choice>Loconet switch commands</choice>
+              </enumChoice>
+              <enumChoice>
+                <choice>DCC switch commands only</choice>
+              </enumChoice>
+            </enumVal>
+            <label>Command source is</label>
+          </variable>
+
+          <variable CV="12" item="Route Echo" default="0"
+                tooltip="OpSw15" mask="XVXXXXXX">
+            <enumVal>
+              <enumChoice>
+                <choice>echo to Loconet</choice>
+              </enumChoice>
+              <enumChoice>
+                <choice>do not echo to Loconet</choice>
+              </enumChoice>
+            </enumVal>
+            <label>Route Switch Commands</label>
+          </variable>
+
+          <variable CV="0.25" item="Servo 1 Thrown Angle" default="10">
+            <decVal min="1" max="2045" />
+          </variable>
+          <variable CV="0.26" item="Servo 1 Closed Angle" default="240">
+            <decVal min="1" max="2045" />
+          </variable>
+          <variable CV="0.27" item="Servo 1 Approach Angle" default="125">
+            <decVal min="1" max="2045" />
+          </variable>
+          <variable CV="0.28" item="Servo 1 Approach Medium Angle" default="125">
+            <decVal min="1" max="2045" />
+          </variable>
+
+          <variable CV="1.25" item="Servo 2 Thrown Angle" default="10">
+            <decVal min="1" max="2045" />
+          </variable>
+          <variable CV="1.26" item="Servo 2 Closed Angle" default="240">
+            <decVal min="1" max="2045" />
+          </variable>
+          <variable CV="1.27" item="Servo 2 Approach Angle" default="125">
+            <decVal min="1" max="2045" />
+          </variable>
+          <variable CV="1.28" item="Servo 2 Approach Medium Angle" default="125">
+            <decVal min="1" max="2045" />
+          </variable>
+
+          <variable CV="2.25" item="Servo 3 Thrown Angle" default="10">
+            <decVal min="1" max="2045" />
+          </variable>
+          <variable CV="2.26" item="Servo 3 Closed Angle" default="240">
+            <decVal min="1" max="2045" />
+          </variable>
+          <variable CV="2.27" item="Servo 3 Approach Angle" default="125">
+            <decVal min="1" max="2045" />
+          </variable>
+          <variable CV="2.28" item="Servo 3 Approach Medium Angle" default="125">
+            <decVal min="1" max="2045" />
+          </variable>
+
+          <variable CV="3.25" item="Servo 4 Thrown Angle" default="10">
+            <decVal min="1" max="2045" />
+          </variable>
+          <variable CV="3.26" item="Servo 4 Closed Angle" default="240">
+            <decVal min="1" max="2045" />
+          </variable>
+          <variable CV="3.27" item="Servo 4 Approach Angle" default="125">
+            <decVal min="1" max="2045" />
+          </variable>
+          <variable CV="3.28" item="Servo 4 Approach Medium Angle" default="125">
+            <decVal min="1" max="2045" />
+          </variable>
+
+          <variable CV="4.25" item="Servo 5 Thrown Angle" default="10">
+            <decVal min="1" max="2045" />
+          </variable>
+          <variable CV="4.26" item="Servo 5 Closed Angle" default="240">
+            <decVal min="1" max="2045" />
+          </variable>
+          <variable CV="4.27" item="Servo 5 Approach Angle" default="125">
+            <decVal min="1" max="2045" />
+          </variable>
+          <variable CV="4.28" item="Servo 5 Approach Medium Angle" default="125">
+            <decVal min="1" max="2045" />
+          </variable>
+
+          <variable CV="5.25" item="Servo 6 Thrown Angle" default="10">
+            <decVal min="1" max="2045" />
+          </variable>
+          <variable CV="5.26" item="Servo 6 Closed Angle" default="240">
+            <decVal min="1" max="2045" />
+          </variable>
+          <variable CV="5.27" item="Servo 6 Approach Angle" default="125">
+            <decVal min="1" max="2045" />
+          </variable>
+          <variable CV="5.28" item="Servo 6 Approach Medium Angle" default="125">
+            <decVal min="1" max="2045" />
+          </variable>
+
+          <variable CV="6.25" item="Servo 7 Thrown Angle" default="10">
+            <decVal min="1" max="2045" />
+          </variable>
+          <variable CV="6.26" item="Servo 7 Closed Angle" default="240">
+            <decVal min="1" max="2045" />
+          </variable>
+          <variable CV="6.27" item="Servo 7 Approach Angle" default="125">
+            <decVal min="1" max="2045" />
+          </variable>
+          <variable CV="6.28" item="Servo 7 Approach Medium Angle" default="125">
+            <decVal min="1" max="2045" />
+          </variable>
+
+          <variable CV="7.25" item="Servo 8 Thrown Angle" default="10">
+            <decVal min="1" max="2045" />
+          </variable>
+          <variable CV="7.26" item="Servo 8 Closed Angle" default="240">
+            <decVal min="1" max="2045" />
+          </variable>
+          <variable CV="7.27" item="Servo 8 Approach Angle" default="125">
+            <decVal min="1" max="2045" />
+          </variable>
+          <variable CV="7.28" item="Servo 8 Approach Medium Angle" default="125">
+            <decVal min="1" max="2045" />
+          </variable>
+
+        </variables>
+        <resets>
+            <mode>LOCONETBD7OPSWMODE</mode>
+            <factReset label="Factory Reset" CV="15" default="128">
+                <label>Reset All CVs</label>
+            </factReset>
+        </resets>
+    </decoder>
+  <pane xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/programmer.xsd">
+    <name>CVs</name>
+    <column>
+        <row>
+            <cvtable/>
+        </row>
+        <row>
+            <column>
+                <label>
+                    <text>&lt;html&gt;The "CV" column in the table above shows CV
+                        numbers, not the Op Switch number.  To see those, hover
+                        your mouse over a variable on the OpSw Settings pane.
+                        &lt;p&gt;&lt;p&gt;The top-most row above reflects the Board
+                        Address configured on the "Basic" sheet.
+                    </text>
+                </label>
+                <label>
+                    <text> </text>
+                </label>
+            </column>
+        </row>
+    </column>
+
+  </pane>
+  <pane>
+      <name>Basic</name>
+      <column>
+          <display item="Long Address"/>
+          <label>
+              <text> </text>
+          </label>
+          <label>
+            <text>&lt;html&gt;&lt;p&gt;
+                &lt;p&gt;This roster entry will only access the specified
+                board if the Board Address (i.e. Board ID), specified above,
+                &lt;br&gt;was correctly entered when the roster entry was first created.
+                You cannot change it here.
+                &lt;p&gt;Note that some Digitrax documentation refers
+                to Board Address, while other documentation refers to
+                &lt;p&gt;Board ID.  These are equivalent concepts.
+            &lt;/html&gt;</text>
+          </label>
+      </column>
+  </pane>
+
+    <pane>
+        <name>OpSw Settings</name>
+        <column>
+            <display item="Output Type"/>
+            <display item="Internal Routes"/>
+            <display item="Bushby"/>
+
+            <display item="Input Lines"/>
+            <display item="Command Source"/>
+            <display item="Route Echo"/>
+        </column>
+    </pane>
+
+    <pane>
+        <name>Servos</name>
+        <column>
+            <row>
+                <display item="Servo 1 Thrown Angle"/>
+                <display item="Servo 1 Closed Angle"/>
+                <display item="Servo 1 Approach Angle"/>
+                <display item="Servo 1 Approach Medium Angle"/>
+            </row>
+            <row>
+                <display item="Servo 2 Thrown Angle"/>
+                <display item="Servo 2 Closed Angle"/>
+                <display item="Servo 2 Approach Angle"/>
+                <display item="Servo 2 Approach Medium Angle"/>
+            </row>
+            <row>
+                <display item="Servo 3 Thrown Angle"/>
+                <display item="Servo 3 Closed Angle"/>
+                <display item="Servo 3 Approach Angle"/>
+                <display item="Servo 3 Approach Medium Angle"/>
+            </row>
+            <row>
+                <display item="Servo 4 Thrown Angle"/>
+                <display item="Servo 4 Closed Angle"/>
+                <display item="Servo 4 Approach Angle"/>
+                <display item="Servo 4 Approach Medium Angle"/>
+            </row>
+            <row>
+                <display item="Servo 5 Thrown Angle"/>
+                <display item="Servo 5 Closed Angle"/>
+                <display item="Servo 5 Approach Angle"/>
+                <display item="Servo 5 Approach Medium Angle"/>
+            </row>
+            <row>
+                <display item="Servo 6 Thrown Angle"/>
+                <display item="Servo 6 Closed Angle"/>
+                <display item="Servo 6 Approach Angle"/>
+                <display item="Servo 6 Approach Medium Angle"/>
+            </row>
+            <row>
+                <display item="Servo 7 Thrown Angle"/>
+                <display item="Servo 7 Closed Angle"/>
+                <display item="Servo 7 Approach Angle"/>
+                <display item="Servo 7 Approach Medium Angle"/>
+            </row>
+            <row>
+                <display item="Servo 8 Thrown Angle"/>
+                <display item="Servo 8 Closed Angle"/>
+                <display item="Servo 8 Approach Angle"/>
+                <display item="Servo 8 Approach Medium Angle"/>
+            </row>
+        </column>
+    </pane>
+
+</decoder-config>

--- a/xml/decoders/Digitrax_PM74.xml
+++ b/xml/decoders/Digitrax_PM74.xml
@@ -28,6 +28,8 @@
             <label>Board Address</label>
           </variable>
 
+           <!-- CV7 is the product ID. Should be 0x4a, 74 decimal -->
+           
            <variable CV="11" item="DS1 mode" default="0"
                 tooltip="OpSw1" mask="XXXXXXXV"><!-- opsw 1 -->
             <enumVal>

--- a/xml/decoders/Digitrax_SE74.xml
+++ b/xml/decoders/Digitrax_SE74.xml
@@ -27,6 +27,8 @@
             <label>Board Address</label>
           </variable>
 
+           <!-- CV7 is the product ID. Should be 0x70, decimal 112 -->
+           
           <variable CV="11" item="Turnout Type" default="0"
                 tooltip="OpSw01" mask="XXXXXXXV">
             <enumVal>


### PR DESCRIPTION
Adds a decoder definition for the Digitrax DS78V servo accessory decoder.

This required code changes to add a new CV name format to the LOCONETBD7OPSWMODE mode: Offset.CV where the offset is added to the address before the CV is read or written.  This means that this DS78V decoder definition won't work with earlier releases of DecoderPro.

Done with a lot of help from @devel-bobm, but all mistakes and infelicitous code are my responsibility.