### PR TITLE
update ThrottlesTableModel to prevent NPE

### DIFF
--- a/java/src/jmri/jmrit/throttle/AddressPanel.java
+++ b/java/src/jmri/jmrit/throttle/AddressPanel.java
@@ -8,6 +8,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import javax.annotation.CheckForNull;
+
 import javax.swing.JButton;
 import javax.swing.JComboBox;
 import javax.swing.JFrame;
@@ -860,7 +862,8 @@ public class AddressPanel extends JInternalFrame implements ThrottleListener, Pr
 
     /**
      * @return the current consist address if any
-     */ 
+     */
+    @CheckForNull
     public DccLocoAddress getConsistAddress() {
         return consistAddress;
     }
@@ -871,9 +874,7 @@ public class AddressPanel extends JInternalFrame implements ThrottleListener, Pr
      * @param consistAddress the consist address to use
      */ 
     public void setConsistAddress(DccLocoAddress consistAddress) {
-        if (log.isDebugEnabled()) {
-            log.debug("Setting Consist Address to {}", consistAddress);
-        }
+        log.debug("Setting Consist Address to {}", consistAddress);
         this.consistAddress = consistAddress;
         changeOfConsistAddress();
     }

--- a/java/src/jmri/jmrit/throttle/ThrottlesTableModel.java
+++ b/java/src/jmri/jmrit/throttle/ThrottlesTableModel.java
@@ -2,6 +2,7 @@ package jmri.jmrit.throttle;
 
 import java.util.*;
 
+import javax.annotation.CheckForNull;
 import javax.swing.table.AbstractTableModel;
 
 import jmri.ConsistListListener;
@@ -57,15 +58,21 @@ public class ThrottlesTableModel extends AbstractTableModel implements java.bean
         fireTableDataChanged();
     }
 
-    public int getNumberOfEntriesFor(DccLocoAddress la) {
+    /**
+     * Get the number of usages of a particular Loco Address.
+     * @param la the Loco Address, can be null.
+     * @return 0 if no usages, else number of AddressPanel usages.
+     */
+    public int getNumberOfEntriesFor(@CheckForNull DccLocoAddress la) {
         if (la == null) { 
             return 0; 
         }
         int ret = 0;
         for (ThrottleFrame tf: throttleFrames) {
-            if ( tf.getAddressPanel().getThrottle() != null && // is throttle active
-                    ( tf.getAddressPanel().getCurrentAddress().equals(la) || tf.getAddressPanel().getConsistAddress().equals(la) ) ) { // is it the one we're looking for
-                ret++;
+            AddressPanel ap = tf.getAddressPanel();
+            if ( ap.getThrottle() != null && 
+                ( la.equals( ap.getCurrentAddress()) || la.equals(ap.getConsistAddress()) ) ) {
+                ret++; // in use, increment count.
             }
         }
         return ret;
@@ -90,5 +97,7 @@ public class ThrottlesTableModel extends AbstractTableModel implements java.bean
     public void notifyConsistListChanged() {
         fireTableDataChanged();
     }
+
+    // private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ThrottlesTableModel.class);
 
 }


### PR DESCRIPTION
Reverses order of equals to prevent npe, fixes #12389 
adds CheckForNull annotation to AddressPanel getConsistAddress