### PR TITLE
CBUS - Slot Monitor Update

### DIFF
--- a/java/src/jmri/jmrix/can/cbus/CbusConfigurationManager.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusConfigurationManager.java
@@ -10,9 +10,7 @@ import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.jmrix.can.cbus.simulator.CbusSimulator;
 import jmri.jmrix.can.cbus.node.CbusNodeTableDataModel;
 import jmri.jmrix.can.cbus.eventtable.CbusEventTableDataModel;
-
-// import org.slf4j.Logger;
-// import org.slf4j.LoggerFactory;
+import jmri.jmrix.can.cbus.swing.cbusslotmonitor.CbusSlotMonitorDataModel;
 
 /**
  * Does configuration for MERG CBUS CAN-based communications implementations.
@@ -116,6 +114,8 @@ public class CbusConfigurationManager extends jmri.jmrix.can.ConfigurationManage
             return true;
         } else if (type.equals(CbusSimulator.class)) {
             return true;
+        } else if (type.equals(CbusSlotMonitorDataModel.class)) {
+            return true;
         } else {
             return DEFAULT_CLASSES.contains(type);
         }
@@ -138,6 +138,8 @@ public class CbusConfigurationManager extends jmri.jmrix.can.ConfigurationManage
         } else if (T.equals(ConsistManager.class)) {
             return (T) getConsistManager();
         } else if (T.equals(CbusSimulator.class)) {
+            return provide(T);
+        } else if (T.equals(CbusSlotMonitorDataModel.class)) {
             return provide(T);
         } else if ( DEFAULT_CLASSES.contains(T) ) {
             return provide(T);
@@ -245,6 +247,9 @@ public class CbusConfigurationManager extends jmri.jmrix.can.ConfigurationManage
         else if (T.equals(CbusSimulator.class)) {
             storeToMemoAndInstance(new CbusSimulator(adapterMemo), CbusSimulator.class);
         }
+        else if (T.equals(CbusSlotMonitorDataModel.class)) {
+            storeToMemoAndInstance(new CbusSlotMonitorDataModel(adapterMemo), CbusSlotMonitorDataModel.class);
+        }
         return adapterMemo.getFromMap(T); // if class not in map, class not provided.
     }
 
@@ -292,6 +297,6 @@ public class CbusConfigurationManager extends jmri.jmrix.can.ConfigurationManage
         return ResourceBundle.getBundle("jmri.jmrix.can.CanActionListBundle");
     }
 
-    // private static final Logger log = LoggerFactory.getLogger(CbusConfigurationManager.class);
+    // private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(CbusConfigurationManager.class);
 
 }

--- a/java/src/jmri/jmrix/can/cbus/swing/cbusslotmonitor/CbusSlotMonitorDataModel.java
+++ b/java/src/jmri/jmrix/can/cbus/swing/cbusslotmonitor/CbusSlotMonitorDataModel.java
@@ -18,9 +18,6 @@ import jmri.util.swing.TextAreaFIFO;
 import jmri.util.ThreadingUtil;
 import jmri.util.TimerUtil;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
  * Table data model for display of CBUS Command Station Sessions and various Tools
  *
@@ -42,18 +39,18 @@ public class CbusSlotMonitorDataModel extends javax.swing.table.AbstractTableMod
     private static final int MAX_LINES = 5000;
 
     // column order needs to match list in column tooltips
-    static public final int SESSION_ID_COLUMN = 0;
-    static public final int LOCO_ID_COLUMN = 1;
-    static public final int ESTOP_COLUMN = 2;
-    static public final int LOCO_ID_LONG_COLUMN = 3;
-    static public final int LOCO_COMMANDED_SPEED_COLUMN = 4;
-    static public final int LOCO_DIRECTION_COLUMN = 5;
-    static public final int FUNCTION_LIST = 6;
-    static public final int SPEED_STEP_COLUMN = 7;
-    static public final int LOCO_CONSIST_COLUMN = 8;
-    static public final int FLAGS_COLUMN = 9;
+    public static final int SESSION_ID_COLUMN = 0;
+    public static final int LOCO_ID_COLUMN = 1;
+    public static final int ESTOP_COLUMN = 2;
+    public static final int LOCO_ID_LONG_COLUMN = 3;
+    public static final int LOCO_COMMANDED_SPEED_COLUMN = 4;
+    public static final int LOCO_DIRECTION_COLUMN = 5;
+    public static final int FUNCTION_LIST = 6;
+    public static final int SPEED_STEP_COLUMN = 7;
+    public static final int LOCO_CONSIST_COLUMN = 8;
+    public static final int FLAGS_COLUMN = 9;
 
-    static public final int MAX_COLUMN = 10;
+    public static final int MAX_COLUMN = 10;
 
     static final int[] CBUSSLOTMONINITIALCOLS = {0,1,2,4,5,6,9};
 
@@ -65,12 +62,13 @@ public class CbusSlotMonitorDataModel extends javax.swing.table.AbstractTableMod
     public CbusSlotMonitorDataModel(CanSystemConnectionMemo memo) {
 
         _mainArray = new ArrayList<>(0);
+        tablefeedback = new TextAreaFIFO(MAX_LINES);
+        tablefeedback.setEditable ( false );
 
         // connect to the CanInterface
         tc = memo.getTrafficController();
         addTc(tc);
-        tablefeedback = new TextAreaFIFO(MAX_LINES);
-        tablefeedback.setEditable ( false );
+        log.info("Starting {} CbusSlotMonitorDataModel", memo.getUserName());
 
     }
 
@@ -232,14 +230,15 @@ public class CbusSlotMonitorDataModel extends javax.swing.table.AbstractTableMod
                 _mainArray.get(row).setDccSpeed( (Integer) value );
                 updateGui(row,col);
                 updateGui(row,LOCO_DIRECTION_COLUMN);
+                updateMemory(_mainArray.get(row));
                 break;
             case ESTOP_COLUMN:
                 int stopspeed=1;
-                if ( _mainArray.get(row).getDirection().equals(Bundle.getMessage("FWD")) ) {
-                    if ( _mainArray.get(row).getSpeedSteps().equals("128") ) {
-                        stopspeed=129;
-                    }
-                }   CanMessage m = new CanMessage(tc.getCanid());
+                if ( _mainArray.get(row).getDirection().equals(Bundle.getMessage("FWD") )
+                    && _mainArray.get(row).getSpeedSteps().equals("128") ) {
+                    stopspeed=129;
+                }
+                CanMessage m = new CanMessage(tc.getCanid());
                 m.setNumDataElements(3);
                 CbusMessage.setPri(m, CbusConstants.DEFAULT_DYNAMIC_PRIORITY * 4 + CbusConstants.DEFAULT_MINOR_PRIORITY);
                 m.setElement(0, CbusConstants.CBUS_DSPD);
@@ -258,10 +257,40 @@ public class CbusSlotMonitorDataModel extends javax.swing.table.AbstractTableMod
     }
 
     private void updateGui(int row,int col) {
-        ThreadingUtil.runOnGUI( ()->{
-            fireTableCellUpdated(row, col);
-        });
+        ThreadingUtil.runOnGUI( ()-> fireTableCellUpdated(row, col));
+    }
 
+    private boolean maintainLocoSpdMemory = false;
+
+    /**
+     * Set true to maintain a Memory Variable for the speed of each loco.
+     * Note this is an experimental method ( 5.5.5 ) and may be subject to change.
+     * <p>
+     * The Memory System Name is in the form e.g. IM12(S) or IM789(L)
+     * i.e. Internal Memory Loco 12, Short address.
+     * It may be easier to refer to this Memory in Jython scripts
+     * by giving it a User Name.
+     * <p>
+     * The Memory Value is the commanded Loco speed, 0-126.
+     * 0 includes a normal stop and e-stop.
+     * <p>
+     * The Value updates whenever a Loco speed command is heard on the
+     * connection hence not restricted to this JMRI instance.
+     * @since 5.5.5
+     * @param newVal true to enable updates, false to stop updates.
+     *               Default is false, no updates provided.
+     */
+    public void setMaintainLocoSpdMemory(boolean newVal) {
+        maintainLocoSpdMemory = newVal;
+    }
+
+    private void updateMemory(CbusSlotMonitorSession session){
+        if ( !maintainLocoSpdMemory || session==null ){
+            return;
+        }
+        MemoryManager memMgr = InstanceManager.getDefault(MemoryManager.class);
+        memMgr.provideMemory( memMgr.getSystemNamePrefix() + session.getLocoAddr() ).setValue(
+            jmri.util.StringUtil.getFirstIntFromString(session.getCommandedSpeed()));
     }
 
     private int createnewrow(int locoid, Boolean islong){
@@ -318,7 +347,7 @@ public class CbusSlotMonitorDataModel extends javax.swing.table.AbstractTableMod
                 {
                     int rcvdIntAddr = (m.getElement(2) & 0x3f) * 256 + m.getElement(3);
                     boolean rcvdIsLong = (m.getElement(2) & 0xc0) != 0;
-                    processploc(false,m.getElement(1),new DccLocoAddress(rcvdIntAddr,rcvdIsLong),m.getElement(4),
+                    processploc(m.getElement(1),new DccLocoAddress(rcvdIntAddr,rcvdIsLong),m.getElement(4),
                             m.getElement(5),m.getElement(6),m.getElement(7));
                     break;
                 }
@@ -330,22 +359,19 @@ public class CbusSlotMonitorDataModel extends javax.swing.table.AbstractTableMod
                     break;
                 }
             case CbusConstants.CBUS_DSPD:
-                processdspd(false,m.getElement(1),m.getElement(2));
+                processdspd(m.getElement(1),m.getElement(2));
                 break;
             case CbusConstants.CBUS_DKEEP:
-                // log.warn(" kick dkeep ");
-                processdkeep(false,m.getElement(1));
+                processdkeep(m.getElement(1));
                 break;
             case CbusConstants.CBUS_KLOC:
                 processkloc(false,m.getElement(1));
                 break;
             case CbusConstants.CBUS_GLOC:
-                {
-                    int rcvdIntAddr = (m.getElement(1) & 0x3f) * 256 + m.getElement(2);
-                    boolean rcvdIsLong = (m.getElement(1) & 0xc0) != 0;
-                    processgloc(false,new DccLocoAddress(rcvdIntAddr,rcvdIsLong),m.getElement(3));
-                    break;
-                }
+                int rcvdIntAddr = (m.getElement(1) & 0x3f) * 256 + m.getElement(2);
+                boolean rcvdIsLong = (m.getElement(1) & 0xc0) != 0;
+                processgloc(false,new DccLocoAddress(rcvdIntAddr,rcvdIsLong),m.getElement(3));
+                break;
             case CbusConstants.CBUS_ERR:
                 processerr(false,m.getElement(1),m.getElement(2),m.getElement(3));
                 break;
@@ -353,37 +379,37 @@ public class CbusSlotMonitorDataModel extends javax.swing.table.AbstractTableMod
                 processstmod(false,m.getElement(1),m.getElement(2));
                 break;
             case CbusConstants.CBUS_DFUN:
-                processdfun(false,m.getElement(1),m.getElement(2),m.getElement(3));
+                processdfun(m.getElement(1),m.getElement(2),m.getElement(3));
                 break;
             case CbusConstants.CBUS_DFNON:
-                processdfnon(false,m.getElement(1),m.getElement(2),true);
+                processdfnon(m.getElement(1),m.getElement(2),true);
                 break;
             case CbusConstants.CBUS_DFNOF:
-                processdfnon(false,m.getElement(1),m.getElement(2),false); // same routine as DFNON
+                processdfnon(m.getElement(1),m.getElement(2),false); // same routine as DFNON
                 break;
             case CbusConstants.CBUS_PCON:
-                processpcon(false,m.getElement(1),m.getElement(2));
+                processpcon(m.getElement(1),m.getElement(2));
                 break;
             case CbusConstants.CBUS_KCON:
-                processpcon(false,m.getElement(1),0); // same routine as PCON
+                processpcon(m.getElement(1),0); // same routine as PCON
                 break;
             case CbusConstants.CBUS_DFLG:
-                processdflg(false,m.getElement(1),m.getElement(2));
+                processdflg(m.getElement(1),m.getElement(2));
                 break;
             case CbusConstants.CBUS_ESTOP:
-                processestop(false);
+                processestop();
                 break;
             case CbusConstants.CBUS_RTON:
-                processrton(false);
+                processrton();
                 break;
             case CbusConstants.CBUS_RTOF:
-                processrtof(false);
+                processrtof();
                 break;
             case CbusConstants.CBUS_TON:
-                processton(false);
+                processton();
                 break;
             case CbusConstants.CBUS_TOF:
-                processtof(false);
+                processtof();
                 break;
             default:
                 break;
@@ -399,8 +425,9 @@ public class CbusSlotMonitorDataModel extends javax.swing.table.AbstractTableMod
             return;
         }
         int opc = CbusMessage.getOpcode(m);
-        // log.warn(" opc {}",opc);
-        // process is true as incoming message
+        int rcvdIntAddr;
+        boolean rcvdIsLong;
+        DccLocoAddress addr;
         switch (opc) {
             case CbusConstants.CBUS_STAT:
                 // todo more on this when finished tested v3 firmware with all opcs
@@ -409,39 +436,33 @@ public class CbusSlotMonitorDataModel extends javax.swing.table.AbstractTableMod
                 cmndstat_fw = 4;
                 break;
             case CbusConstants.CBUS_PLOC:
-                {
-                    int rcvdIntAddr = (m.getElement(2) & 0x3f) * 256 + m.getElement(3);
-                    boolean rcvdIsLong = (m.getElement(2) & 0xc0) != 0;
-                    DccLocoAddress addr = new DccLocoAddress(rcvdIntAddr,rcvdIsLong);
-                    processploc(true,m.getElement(1),addr,m.getElement(4),
-                            m.getElement(5),m.getElement(6),m.getElement(7));
-                    break;
-                }
+                rcvdIntAddr = (m.getElement(2) & 0x3f) * 256 + m.getElement(3);
+                rcvdIsLong = (m.getElement(2) & 0xc0) != 0;
+                addr = new DccLocoAddress(rcvdIntAddr,rcvdIsLong);
+                processploc(m.getElement(1),addr,m.getElement(4),
+                        m.getElement(5),m.getElement(6),m.getElement(7));
+                break;
             case CbusConstants.CBUS_RLOC:
-                {
-                    int rcvdIntAddr = (m.getElement(1) & 0x3f) * 256 + m.getElement(2);
-                    boolean rcvdIsLong = (m.getElement(1) & 0xc0) != 0;
-                    DccLocoAddress addr = new DccLocoAddress(rcvdIntAddr,rcvdIsLong);
-                    processrloc(true,addr);
-                    break;
-                }
+                rcvdIntAddr = (m.getElement(1) & 0x3f) * 256 + m.getElement(2);
+                rcvdIsLong = (m.getElement(1) & 0xc0) != 0;
+                addr = new DccLocoAddress(rcvdIntAddr,rcvdIsLong);
+                processrloc(true,addr);
+                break;
             case CbusConstants.CBUS_DSPD:
-                processdspd(true,m.getElement(1),m.getElement(2));
+                processdspd(m.getElement(1),m.getElement(2));
                 break;
             case CbusConstants.CBUS_DKEEP:
-                processdkeep(true,m.getElement(1));
+                processdkeep(m.getElement(1));
                 break;
             case CbusConstants.CBUS_KLOC:
                 processkloc(true,m.getElement(1));
                 break;
             case CbusConstants.CBUS_GLOC:
-                {
-                    int rcvdIntAddr = (m.getElement(1) & 0x3f) * 256 + m.getElement(2);
-                    boolean rcvdIsLong = (m.getElement(1) & 0xc0) != 0;
-                    DccLocoAddress addr = new DccLocoAddress(rcvdIntAddr,rcvdIsLong);
-                    processgloc(true,addr,m.getElement(3));
-                    break;
-                }
+                rcvdIntAddr = (m.getElement(1) & 0x3f) * 256 + m.getElement(2);
+                rcvdIsLong = (m.getElement(1) & 0xc0) != 0;
+                addr = new DccLocoAddress(rcvdIntAddr,rcvdIsLong);
+                processgloc(true,addr,m.getElement(3));
+                break;
             case CbusConstants.CBUS_ERR:
                 processerr(true,m.getElement(1),m.getElement(2),m.getElement(3));
                 break;
@@ -449,37 +470,37 @@ public class CbusSlotMonitorDataModel extends javax.swing.table.AbstractTableMod
                 processstmod(true,m.getElement(1),m.getElement(2));
                 break;
             case CbusConstants.CBUS_DFUN:
-                processdfun(true,m.getElement(1),m.getElement(2),m.getElement(3));
+                processdfun(m.getElement(1),m.getElement(2),m.getElement(3));
                 break;
             case CbusConstants.CBUS_DFNON:
-                processdfnon(true,m.getElement(1),m.getElement(2),true);
+                processdfnon(m.getElement(1),m.getElement(2),true);
                 break;
             case CbusConstants.CBUS_DFNOF:
-                processdfnon(true,m.getElement(1),m.getElement(2),false);  // same routine as DFNON
+                processdfnon(m.getElement(1),m.getElement(2),false);  // same routine as DFNON
                 break;
             case CbusConstants.CBUS_PCON:
-                processpcon(true,m.getElement(1),m.getElement(2));
+                processpcon(m.getElement(1),m.getElement(2));
                 break;
             case CbusConstants.CBUS_KCON:
-                processpcon(true,m.getElement(1),0); // same routine as PCON
+                processpcon(m.getElement(1),0); // same routine as PCON
                 break;
             case CbusConstants.CBUS_DFLG:
-                processdflg(true,m.getElement(1),m.getElement(2));
+                processdflg(m.getElement(1),m.getElement(2));
                 break;
             case CbusConstants.CBUS_ESTOP:
-                processestop(true);
+                processestop();
                 break;
             case CbusConstants.CBUS_RTON:
-                processrton(true);
+                processrton();
                 break;
             case CbusConstants.CBUS_RTOF:
-                processrtof(true);
+                processrtof();
                 break;
             case CbusConstants.CBUS_TON:
-                processton(true);
+                processton();
                 break;
             case CbusConstants.CBUS_TOF:
-                processtof(true);
+                processtof();
                 break;
             default:
                 break;
@@ -487,17 +508,15 @@ public class CbusSlotMonitorDataModel extends javax.swing.table.AbstractTableMod
     }
 
     // ploc sent from a command station to a throttle
-    private void processploc(boolean messagein, int session, DccLocoAddress addr,
+    private void processploc( int session, DccLocoAddress addr,
         int speeddir, int fa, int fb, int fc) {
-        // log.debug( Bundle.getMessage("CBUS_CMND_BR") + Bundle.getMessage("CNFO_PLOC",session,locoid));
 
         int row = provideTableRow(addr);
         setValueAt(session, row, SESSION_ID_COLUMN);
         setValueAt(speeddir, row, LOCO_COMMANDED_SPEED_COLUMN);
-        processdfun( messagein, session, 1, fa);
-        processdfun( messagein, session, 2, fb);
-        processdfun( messagein, session, 3, fc);
-
+        processdfun( session, 1, fa);
+        processdfun( session, 2, fb);
+        processdfun( session, 3, fc);
     }
 
     // kloc sent from throttle to command station to release loco, which will continue at current speed
@@ -531,10 +550,8 @@ public class CbusSlotMonitorDataModel extends javax.swing.table.AbstractTableMod
 
     // rloc sent from throttle to command station to get loco
     private void processrloc(boolean messagein, DccLocoAddress addr ) {
-
         int row = provideTableRow(addr);
         log.debug("{} new table row {}", messagein,row);
-
     }
 
     // gloc sent from throttle to command station to get loco
@@ -550,7 +567,6 @@ public class CbusSlotMonitorDataModel extends javax.swing.table.AbstractTableMod
 
         boolean stealmode = ((flags ) & 1) != 0;
         boolean sharemode = ((flags >> 1 ) & 1) != 0;
-        // log.debug("stealmode {} sharemode {} ",stealmode,sharemode);
         if (stealmode){
             flagstring.append(Bundle.getMessage("CNFO_GLOC_ST"));
         }
@@ -599,7 +615,7 @@ public class CbusSlotMonitorDataModel extends javax.swing.table.AbstractTableMod
     }
 
     // DKEEP sent as keepalive from throttle to command station
-    private void processdkeep(boolean messagein, int session) {
+    private void processdkeep(int session) {
         int row=getrowfromsession(session);
         if ( row < 0 ) {
             log.debug("Requesting loco details for session {}.",session );
@@ -607,8 +623,7 @@ public class CbusSlotMonitorDataModel extends javax.swing.table.AbstractTableMod
     }
 
     // DSPD sent from throttle to command station , speed / direction
-    private void processdspd(boolean messagein, int session, int speeddir) {
-        // log.warn("processing dspd");
+    private void processdspd( int session, int speeddir) {
         int row=getrowfromsession(session);
         if ( row > -1 ) {
             setValueAt(speeddir, row, LOCO_COMMANDED_SPEED_COLUMN);
@@ -616,11 +631,9 @@ public class CbusSlotMonitorDataModel extends javax.swing.table.AbstractTableMod
     }
 
     // DFLG sent from throttle to command station to notify engine change in flags
-    private void processdflg(boolean messagein, int session, int flags) {
-        // log.debug("processing dflg session {} flag int {}",session,flags);
+    private void processdflg( int session, int flags) {
         int row=getrowfromsession(session);
         if ( row>-1 ) {
-
             _mainArray.get(row).setFlags(flags);
             updateGui(row,SPEED_STEP_COLUMN);
             updateGui(row,FLAGS_COLUMN);
@@ -629,7 +642,7 @@ public class CbusSlotMonitorDataModel extends javax.swing.table.AbstractTableMod
 
     // DFNON Sent by a cab to turn on a specific loco function, alternative method to DFUN
     // also used to process function responses from DFNOF
-    private void processdfnon(boolean messagein, int session, int function, boolean trueorfalse) {
+    private void processdfnon( int session, int function, boolean trueorfalse) {
         int row=getrowfromsession(session);
         if ( row>-1 && function>-1 && function<29 ) {
             _mainArray.get(row).setFunction(function,trueorfalse);
@@ -639,8 +652,7 @@ public class CbusSlotMonitorDataModel extends javax.swing.table.AbstractTableMod
 
     // DFUN Sent by a cab to trigger loco function
     // also used to process function responses from PLOC
-    private void processdfun(boolean messagein, int session, int range, int functionbyte) {
-        //  log.warn("processing dfun, session {} range {} functionbyte {}",session,range,functionbyte);
+    private void processdfun( int session, int range, int functionbyte) {
         int row=getrowfromsession(session);
         if ( row > -1 ) {
             switch (range) {
@@ -692,10 +704,7 @@ public class CbusSlotMonitorDataModel extends javax.swing.table.AbstractTableMod
 
     // ERR sent by command station
     private void processerr(boolean messagein, int one, int two, int errnum) {
-        // log.warn("processing err");
         int rcvdIntAddr = (one & 0x3f) * 256 + two;
-        // boolean rcvdIsLong = (one & 0xc0) != 0;
-        // DccLocoAddress addr = new DccLocoAddress(rcvdIntAddr,rcvdIsLong);
 
         StringBuilder buf = new StringBuilder();
         if (messagein){ // external throttle
@@ -747,7 +756,7 @@ public class CbusSlotMonitorDataModel extends javax.swing.table.AbstractTableMod
 
     // PCON sent by throttle to add to consist
     // also used to process remove from consist KCON
-    private void processpcon(boolean messagein, int session, int consist){
+    private void processpcon( int session, int consist){
         log.debug("processing pcon");
         int row=getrowfromsession(session);
         if ( row>-1 ) {
@@ -766,25 +775,25 @@ public class CbusSlotMonitorDataModel extends javax.swing.table.AbstractTableMod
         }
     }
 
-    private void processestop(boolean messagein){
+    private void processestop(){
         addToLog(1,"Command station acknowledges estop");
         clearEStopTask();
     }
 
-    private void processrton(boolean messagein){
+    private void processrton(){
         setPowerTask();
     }
 
-    private void processrtof(boolean messagein){
+    private void processrtof(){
         setPowerTask();
     }
 
-    private void processton(boolean messagein){
+    private void processton(){
         clearPowerTask();
         log.debug("Track on confirmed from command station.");
     }
 
-    private void processtof(boolean messagein){
+    private void processtof(){
         clearPowerTask();
         log.debug("Track off confirmed from command station.");
     }
@@ -801,7 +810,7 @@ public class CbusSlotMonitorDataModel extends javax.swing.table.AbstractTableMod
         setEstopTask();
     }
 
-    private TimerTask eStopTask;
+    private transient TimerTask eStopTask;
 
     private void clearEStopTask() {
         if (eStopTask != null ) {
@@ -822,7 +831,7 @@ public class CbusSlotMonitorDataModel extends javax.swing.table.AbstractTableMod
         TimerUtil.schedule(eStopTask, ( CS_TIMEOUT ) );
     }
 
-    private TimerTask powerTask;
+    private transient TimerTask powerTask;
 
     private void clearPowerTask() {
         if (powerTask != null ) {
@@ -849,9 +858,7 @@ public class CbusSlotMonitorDataModel extends javax.swing.table.AbstractTableMod
      * @param cbustext String console message
      */
     public void addToLog(int cbuserror, String cbustext){
-        ThreadingUtil.runOnGUI( ()->{
-            tablefeedback.append( "\n"+cbustext);
-        });
+        ThreadingUtil.runOnGUI( ()-> tablefeedback.append( System.lineSeparator()+cbustext));
     }
 
     /**
@@ -868,5 +875,7 @@ public class CbusSlotMonitorDataModel extends javax.swing.table.AbstractTableMod
         tablefeedback.dispose();
 
     }
-    private final static Logger log = LoggerFactory.getLogger(CbusSlotMonitorDataModel.class);
+
+    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(CbusSlotMonitorDataModel.class);
+
 }

--- a/java/src/jmri/jmrix/can/cbus/swing/cbusslotmonitor/CbusSlotMonitorSession.java
+++ b/java/src/jmri/jmrix/can/cbus/swing/cbusslotmonitor/CbusSlotMonitorSession.java
@@ -11,15 +11,15 @@ import jmri.jmrix.can.cbus.CbusOpCodes;
  * @author Steve Young Copyright (C) 2019
  */
 public class CbusSlotMonitorSession  {
-    
+
     private final DccLocoAddress _locoAddr;
     private int _sessionId;
     private int _speed;
     private String _speedSteps;
-    private final boolean[] _function;
+    private boolean[] function;
     private int _flags;
     private int _consistId;
-    
+
     /**
      * The table provides and maintains 1 row per loco address
      *
@@ -30,15 +30,15 @@ public class CbusSlotMonitorSession  {
         _sessionId = -1; // unset
         _speed = 0;
         _speedSteps="";
-        _function = new boolean[29];
+        function = new boolean[29];
         _flags = -1; // unset
         _consistId = 0;
     }
-    
+
     protected DccLocoAddress getLocoAddr(){
         return _locoAddr;
     }
-    
+
     protected void setSessionId( int session ) {
         _sessionId = session;
     }
@@ -46,7 +46,7 @@ public class CbusSlotMonitorSession  {
     protected int getSessionId() {
         return _sessionId;
     }
-    
+
     protected void setDccSpeed( int speed) {
         _speed = speed;
     }
@@ -62,7 +62,7 @@ public class CbusSlotMonitorSession  {
     protected void setSpeedSteps ( String steps ) {
         _speedSteps = steps;
     }
-    
+
     protected String getSpeedSteps() {
         if ( _speedSteps.isEmpty() ) {
             return ("128");
@@ -73,20 +73,25 @@ public class CbusSlotMonitorSession  {
     }
 
     protected void setFunction( int fn, boolean tof ) {
-        _function[fn] = tof;
+        if (fn >= function.length) {
+            boolean[] newArray = new boolean[fn+1];
+            System.arraycopy(function, 0, newArray, 0, function.length);
+            function = newArray;
+        }
+        function[fn] = tof;
     }
-    
+
     protected String getFunctionString() {
         StringBuilder buf = new StringBuilder();
-        for (int i=0; i<29; i++) {
-            if ( _function[i] ==true ) {
+        for (int i=0; i<function.length; i++) {
+            if ( function[i] ) {
                 buf.append(i);
                 buf.append(" ");
             }
         }
-        return buf.toString();
+        return buf.toString().trim();
     }
-    
+
     protected void setFlags( int flags ){
         _flags = flags;
         int mask = 0b11; // last 2 bits
@@ -104,7 +109,7 @@ public class CbusSlotMonitorSession  {
                 _speedSteps="128";
         }
     }
-    
+
     protected String getFlagString() {
         
         if ( _flags < 0 ){
@@ -142,7 +147,7 @@ public class CbusSlotMonitorSession  {
     protected void setConsistId( int consistid ) {
         _consistId = consistid;
     }
-    
+
     protected int getConsistId() {
         return _consistId;
     }

--- a/java/test/jmri/jmrix/can/cbus/CbusConfigurationManagerTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusConfigurationManagerTest.java
@@ -9,6 +9,7 @@ import jmri.jmrix.can.*;
 import jmri.jmrix.can.cbus.eventtable.CbusEventTableDataModel;
 import jmri.jmrix.can.cbus.node.CbusNodeTableDataModel;
 import jmri.jmrix.can.cbus.simulator.CbusSimulator;
+import jmri.jmrix.can.cbus.swing.cbusslotmonitor.CbusSlotMonitorDataModel;
 import jmri.util.JUnitUtil;
 
 import org.junit.jupiter.api.*;
@@ -70,6 +71,8 @@ public class CbusConfigurationManagerTest {
         assertTrue( t.provides(CabSignalManager.class) );
         assertTrue( t.provides(ConsistManager.class) );
         assertTrue( t.provides(ClockControl.class) );
+        assertTrue( t.provides(CbusSimulator.class)); // created by default
+        assertTrue( t.provides(CbusSlotMonitorDataModel.class)); // created by default
         
         assertFalse( t.provides(CbusNodeTableDataModel.class) ); // not created by default
         assertFalse( t.provides(CbusEventTableDataModel.class) ); // not created by default
@@ -180,6 +183,7 @@ public class CbusConfigurationManagerTest {
         toReturn.add(CabSignalManager.class);
         toReturn.add(CbusPredefinedMeters.class);
         toReturn.add(CbusSimulator.class);
+        toReturn.add(CbusSlotMonitorDataModel.class);
         return toReturn;
     }
     
@@ -214,6 +218,22 @@ public class CbusConfigurationManagerTest {
         t.disposeOf(sim, CbusSimulator.class);
         simA = memo.getFromMap(CbusSimulator.class);
         assertNull(simA);
+    }
+
+    @Test
+    public void testGetDisposeSlotMonitor() {
+        
+        CbusSlotMonitorDataModel smdm = memo.getFromMap(CbusSlotMonitorDataModel.class);
+        assertNull(smdm);
+        CbusSlotMonitorDataModel smdm2 = memo.get(CbusSlotMonitorDataModel.class);
+        assertNotNull(smdm2);
+        smdm = memo.getFromMap(CbusSlotMonitorDataModel.class);
+        assertNotNull(smdm);
+        assertTrue(smdm2 == smdm);
+        
+        t.disposeOf(smdm2, CbusSlotMonitorDataModel.class);
+        smdm = memo.getFromMap(CbusSlotMonitorDataModel.class);
+        assertNull(smdm);
     }
 
     private CanSystemConnectionMemo memo;

--- a/java/test/jmri/jmrix/can/cbus/swing/cbusslotmonitor/CbusSlotMonitorDataModelTest.java
+++ b/java/test/jmri/jmrix/can/cbus/swing/cbusslotmonitor/CbusSlotMonitorDataModelTest.java
@@ -111,7 +111,7 @@ public class CbusSlotMonitorDataModelTest {
         String spdStepb = (String) t.getValueAt(2,CbusSlotMonitorDataModel.SPEED_STEP_COLUMN);
         Assert.assertEquals("reply ploc 4 cell val speedstep","128",spdStepb );
         String funcb = (String) t.getValueAt(2,CbusSlotMonitorDataModel.FUNCTION_LIST);
-        Assert.assertEquals("reply ploc 4 cell val funcs","2 5 6 8 ",funcb );
+        Assert.assertEquals("reply ploc 4 cell val funcs","2 5 6 8",funcb );
         String locoSpd = (String) t.getValueAt(2,CbusSlotMonitorDataModel.LOCO_COMMANDED_SPEED_COLUMN);
         Assert.assertEquals("reply ploc 4 cell val speed","38",locoSpd );
         String dirb = (String) t.getValueAt(2,CbusSlotMonitorDataModel.LOCO_DIRECTION_COLUMN);
@@ -157,11 +157,11 @@ public class CbusSlotMonitorDataModelTest {
     
     @Test
     public void testCanListenAndRemove() {
-        Assert.assertTrue("table listening",1 == tcis.numListeners());
+        int startListeners = tcis.numListeners();
         t.dispose();
-        Assert.assertEquals("no listener after didpose",0,tcis.numListeners());
+        Assertions.assertEquals(startListeners-1, tcis.numListeners(),"no listener after dispose");
         t = new CbusSlotMonitorDataModel(memo);
-        Assert.assertTrue("table listening again",1 == tcis.numListeners());     
+        Assertions.assertEquals( startListeners, tcis.numListeners(),"table listening again");     
     }
     
     @Test
@@ -277,14 +277,14 @@ public class CbusSlotMonitorDataModelTest {
         Assert.assertTrue(((String)t.getValueAt(0,CbusSlotMonitorDataModel.FUNCTION_LIST)).contains("5 "));
         Assert.assertTrue(((String)t.getValueAt(0,CbusSlotMonitorDataModel.FUNCTION_LIST)).contains("6 "));
         Assert.assertTrue(((String)t.getValueAt(0,CbusSlotMonitorDataModel.FUNCTION_LIST)).contains("7 "));
-        Assert.assertTrue(((String)t.getValueAt(0,CbusSlotMonitorDataModel.FUNCTION_LIST)).contains("8 "));
+        Assert.assertTrue(((String)t.getValueAt(0,CbusSlotMonitorDataModel.FUNCTION_LIST)).contains("8"));
         
         r.setElement(3, 0x00);
         t.reply(r);
         Assert.assertFalse(((String)t.getValueAt(0,CbusSlotMonitorDataModel.FUNCTION_LIST)).contains("5 "));
         Assert.assertFalse(((String)t.getValueAt(0,CbusSlotMonitorDataModel.FUNCTION_LIST)).contains("6 "));
         Assert.assertFalse(((String)t.getValueAt(0,CbusSlotMonitorDataModel.FUNCTION_LIST)).contains("7 "));
-        Assert.assertFalse(((String)t.getValueAt(0,CbusSlotMonitorDataModel.FUNCTION_LIST)).contains("8 "));
+        Assert.assertFalse(((String)t.getValueAt(0,CbusSlotMonitorDataModel.FUNCTION_LIST)).contains("8"));
         
         // make sure that CanMessages also acted on
         CanMessage m = new CanMessage( tcis.getCanid() );
@@ -530,6 +530,8 @@ public class CbusSlotMonitorDataModelTest {
         tcis = new jmri.jmrix.can.TrafficControllerScaffold();
         memo = new jmri.jmrix.can.CanSystemConnectionMemo();
         memo.setTrafficController(tcis);
+        memo.setProtocol(jmri.jmrix.can.CanConfigurationManager.MERGCBUS);
+        memo.configureManagers();
         t = new CbusSlotMonitorDataModel(memo);
     }
 
@@ -541,6 +543,7 @@ public class CbusSlotMonitorDataModelTest {
         memo=null;
         tcis.terminateThreads();
         tcis=null;
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();    
     }
 

--- a/java/test/jmri/jmrix/can/cbus/swing/cbusslotmonitor/CbusSlotMonitorPaneTest.java
+++ b/java/test/jmri/jmrix/can/cbus/swing/cbusslotmonitor/CbusSlotMonitorPaneTest.java
@@ -111,6 +111,7 @@ public class CbusSlotMonitorPaneTest extends jmri.util.swing.JmriPanelTest {
         memo = new CanSystemConnectionMemo();
         tcis = new TrafficControllerScaffold();
         memo.setTrafficController(tcis);
+        memo.setProtocol(jmri.jmrix.can.CanConfigurationManager.MERGCBUS);
         panel = new CbusSlotMonitorPane();
         title = Bundle.getMessage("MenuItemCbusSlotMonitor");
         helpTarget = "package.jmri.jmrix.can.cbus.swing.cbusslotmonitor.CbusSlotMonitorPane";

--- a/java/test/jmri/jmrix/can/cbus/swing/cbusslotmonitor/CbusSlotMonitorSessionTest.java
+++ b/java/test/jmri/jmrix/can/cbus/swing/cbusslotmonitor/CbusSlotMonitorSessionTest.java
@@ -100,7 +100,7 @@ public class CbusSlotMonitorSessionTest {
             Assert.assertTrue( t.getFunctionString().contains(Integer.toString(i) ) );
         }
         Assert.assertEquals("Full function string",
-            "0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 ",
+            "0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28",
             t.getFunctionString()
         );
 
@@ -109,7 +109,7 @@ public class CbusSlotMonitorSessionTest {
         t.setFunction(22,false);
         
         Assert.assertEquals("Partial function string",
-            "0 1 2 3 5 6 7 8 9 10 11 12 13 14 15 16 17 18 20 21 23 24 25 26 27 28 ",
+            "0 1 2 3 5 6 7 8 9 10 11 12 13 14 15 16 17 18 20 21 23 24 25 26 27 28",
             t.getFunctionString()
         );
         
@@ -119,7 +119,29 @@ public class CbusSlotMonitorSessionTest {
         Assert.assertTrue( t.getFunctionString().isEmpty() );
 
     }
-    
+
+    @Test
+    public void testLargeFunctionNumbers() {
+        CbusSlotMonitorSession t = new CbusSlotMonitorSession( new DccLocoAddress (1234,true) );
+        t.setFunction(3, true);
+        Assertions.assertEquals("3", t.getFunctionString());
+        
+        t.setFunction(27, true);
+        Assertions.assertEquals("3 27", t.getFunctionString());
+        
+        t.setFunction(28, true);
+        Assertions.assertEquals("3 27 28", t.getFunctionString());
+        
+        t.setFunction(29, true);
+        Assertions.assertEquals("3 27 28 29", t.getFunctionString());
+        
+        t.setFunction(30, true);
+        Assertions.assertEquals("3 27 28 29 30", t.getFunctionString());
+        
+        t.setFunction(31, true);
+        Assertions.assertEquals("3 27 28 29 30 31", t.getFunctionString());
+    }
+
     @Test
     public void testFlags() {
         
@@ -181,8 +203,7 @@ public class CbusSlotMonitorSessionTest {
         Assert.assertTrue("flags 3",t.getFlagString().contains("Direction:1"));
         
     }
-    
-    
+
     @BeforeEach
     public void setUp() {
         JUnitUtil.setUp();


### PR DESCRIPTION
CbusSlotMonitorDataModel -
Adds public void setMaintainLocoSpdMemory(boolean newVal) which updates a Memory Variable with the Loco speed.
Removes some unused variables in private method calls

CbusConfigurationManager - adds CbusSlotMonitorDataModel as memo instance
CbusSlotMonitorSession - add support for functions > 28