### PR TITLE
Add Inverted option to OpenLCB Turnouts

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -121,7 +121,7 @@
 
         <h4><a href="http://openlcb.org">OpenLCB</a> / LCC</h4>
             <ul>
-                <li></li>
+                <li>Added the invert option to OpenLCB/LCC Turnouts.</li>
             </ul>
 
         <h4>Powerline</h4>

--- a/java/src/jmri/jmrix/openlcb/OlcbTurnout.java
+++ b/java/src/jmri/jmrix/openlcb/OlcbTurnout.java
@@ -108,7 +108,7 @@ public class OlcbTurnout extends jmri.implementation.AbstractTurnout {
         turnoutListener = new VersionedValueListener<Boolean>(pc.getValue()) {
             @Override
             public void update(Boolean value) {
-                int s = value ? THROWN : CLOSED;
+                int s = ((value ^ getInverted()) ? THROWN : CLOSED);
                 if (_activeFeedbackType != DIRECT) {
                     newCommandedState(s);
                     if (_activeFeedbackType == MONITORING) {
@@ -183,12 +183,12 @@ public class OlcbTurnout extends jmri.implementation.AbstractTurnout {
     @Override
     protected void forwardCommandChangeToLayout(int s) {
         if (s == Turnout.THROWN) {
-            turnoutListener.setFromOwnerWithForceNotify(true);
+            turnoutListener.setFromOwnerWithForceNotify(true ^ getInverted());
             if (_activeFeedbackType == MONITORING) {
                 newKnownState(THROWN);
             }
         } else if (s == Turnout.CLOSED) {
-            turnoutListener.setFromOwnerWithForceNotify(false);
+            turnoutListener.setFromOwnerWithForceNotify(false ^ getInverted());
             if (_activeFeedbackType == MONITORING) {
                 newKnownState(CLOSED);
             }
@@ -217,13 +217,9 @@ public class OlcbTurnout extends jmri.implementation.AbstractTurnout {
         // to perform a lockout change on the turnout decoder itself.
     }
 
-    /*
-     * since the events that drive a turnout can be whichever state a user
-     * wants, the order of the event pair determines what is the 'closed' state
-     */
     @Override
     public boolean canInvert() {
-        return false;
+        return true;
     }
 
     @Override


### PR DESCRIPTION
This enables the "invert" option for OpenLCB/LCC turnouts.  

This was originally prompted by using turnout-number notation (e.g. "MTT123") to DCC via a Lenz system.  There's a report that that throws the turnouts backwards from what's expected.  Adding the invert capability lets people compensate for that.

Not that although this was motivated for turnout-number notation, it works with the original MT-plus-two-eventIDs notation too.