### PR TITLE
Non zero throttle speed -> non zero hardware speed

### DIFF
--- a/java/src/jmri/jmrix/dccpp/DCCppMessage.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppMessage.java
@@ -2509,6 +2509,9 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage implements Delaye
             m.myMessage.append(" -1");
         } else {
             int speedVal = java.lang.Math.round(speed * 126);
+            if (speed > 0 && speedVal == 0) {
+                speedVal = 1;           // ensure non-zero input results in non-zero output
+            }
             speedVal = Math.min(speedVal, DCCppConstants.MAX_SPEED);
             m.myMessage.append(" ").append(speedVal);
         }
@@ -2554,6 +2557,9 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage implements Delaye
             m.myMessage.append(" -1");
         } else {
             int speedVal = java.lang.Math.round(speed * 126);
+            if (speed > 0 && speedVal == 0) {
+                speedVal = 1;           // ensure non-zero input results in non-zero output
+            }
             speedVal = Math.min(speedVal, DCCppConstants.MAX_SPEED);
             m.myMessage.append(" ").append(speedVal);
         }

--- a/java/src/jmri/jmrix/ecos/EcosDccThrottle.java
+++ b/java/src/jmri/jmrix/ecos/EcosDccThrottle.java
@@ -147,11 +147,14 @@ public class EcosDccThrottle extends AbstractThrottle implements EcosListener {
                 return;
             }
         }
-        int value = (int) ((127 - 1) * speed);     // -1 for rescale to avoid estop
-        if (value > 128) {
+        int value = Math.round((127 - 1) * speed);     // -1 for rescale to avoid estop
+        if (value == 0 && speed > 0) {                 // make sure to output non-zero speed for non-zero input speed
+            value = 1;
+        }
+        if (value > 126) {
             value = 126;    // max possible speed
         }
-        if ((value > 0) || (value == 0.0)) {
+        if ((value > 0) || (value == 0)) {
             String message = "set(" + this.objectNumber + ", speed[" + value + "])";
             EcosMessage m = new EcosMessage(message);
             tc.sendEcosMessage(m, this);

--- a/java/src/jmri/jmrix/marklin/MarklinThrottle.java
+++ b/java/src/jmri/jmrix/marklin/MarklinThrottle.java
@@ -124,6 +124,11 @@ public class MarklinThrottle extends AbstractThrottle implements MarklinListener
         if (value > 1000) {
             value = 1000;    // max possible speed
         }
+        
+        if (this.speedSetting > 0 && value == 0) {
+            value = 1;      // ensure non-zero input results in non-zero output
+        }
+        
         if (value < 0) {
             //Emergency Stop
             tc.sendMarklinMessage(MarklinMessage.setLocoEmergencyStop(getCANAddress()), this);

--- a/java/src/jmri/jmrix/mqtt/MqttThrottle.java
+++ b/java/src/jmri/jmrix/mqtt/MqttThrottle.java
@@ -130,11 +130,20 @@ import jmri.ThrottleListener;
             log.debug("sent address {} direction {}", address, "STOP");
         }
 
-        String intSpeed = String.valueOf(Math.round(speed * 100));
+        int intSpeed = Math.round(speed * 100);
+        
+        // ensure non-zero input will result in non-zero output
+        if (speed > 0 && intSpeed == 0)
+        {
+            intSpeed = 1;
+        }
 
+        final String stringSpeed = String.valueOf(intSpeed);
+        
         // Send MQTT message
         jmri.util.ThreadingUtil.runOnLayout(() -> {
-            mqttAdapter.publish(this.sendThrottleTopic.replaceFirst("\\{0\\}", String.valueOf(address)), intSpeed);
+
+            mqttAdapter.publish(this.sendThrottleTopic.replaceFirst("\\{0\\}", String.valueOf(address)), stringSpeed);
         });
         log.debug("sent address {} speed {}", address, intSpeed);
 

--- a/java/src/jmri/jmrix/mrc/MrcThrottle.java
+++ b/java/src/jmri/jmrix/mrc/MrcThrottle.java
@@ -270,6 +270,7 @@ public class MrcThrottle extends AbstractThrottle implements MrcTrafficListener 
                             firePropertyChange(ISFORWARD, !isForward, isForward);
                             //speed = m.getElement(8);
                         }
+                        // does this handle emergency stop in any way?
                         speed = (speed & 0x7f) - 1;
                         if (speed < 0) {
                             speed = 0;

--- a/java/src/jmri/jmrix/nce/NceThrottle.java
+++ b/java/src/jmri/jmrix/nce/NceThrottle.java
@@ -265,10 +265,10 @@ public class NceThrottle extends AbstractThrottle {
                 locoAddr += 0xC000;
             }
             value = Math.round((127 - 1) * speed);     // -1 for rescale to avoid estop
-            if (this.speedSetting > 0 && value == 0) {
+            if (speed > 0 && value == 0) {
                 value = 1;          // ensure non-zero input results in non-zero output
             }
-            if (this.speedSetting < 0) {
+            if (speed < 0) {
                 value = -1;         // ensure small negative speeds don't get caught by Math.round above
             }
             if (value > 126) {
@@ -302,7 +302,7 @@ public class NceThrottle extends AbstractThrottle {
 
             if (super.speedStepMode == jmri.SpeedStepMode.NMRA_DCC_128) {
                 value = Math.round((127 - 1) * speed);     // -1 for rescale to avoid estop
-                if (this.speedSetting > 0 && value == 0) {
+                if (speed > 0 && value == 0) {
                     value = 1;          // ensure non-zero input results in non-zero output
                 }
                 if (value > 0) {
@@ -311,7 +311,7 @@ public class NceThrottle extends AbstractThrottle {
                 if (value > 127) {
                     value = 127;    // max possible speed
                 }
-                if (this.speedSetting < 0) {
+                if (speed < 0) {
                     value = 1;      // emergency stop
                                     // ensure small negative speeds don't get caught by Math.round above
                 }
@@ -338,7 +338,7 @@ public class NceThrottle extends AbstractThrottle {
                  *     address.isLongAddress(), value, isForward);
                  */
                 value = Math.round((28-1) * speed); // -1 for rescale to avoid estop
-                if (this.speedSetting > 0 && value == 0) {
+                if (speed > 0 && value == 0) {
                     value = 1;          // ensure non-zero input results in non-zero output
                 }
                 if (value > 0) {
@@ -347,7 +347,7 @@ public class NceThrottle extends AbstractThrottle {
                 if (value > 28) {
                     value = 28; // max possible speed
                 }
-                if (this.speedSetting < 0) {
+                if (speed < 0) {
                     value = 1;      // emergency stop
                                     // ensure small negative speeds don't get caught by Math.round above
                 }

--- a/java/src/jmri/jmrix/nce/NceThrottle.java
+++ b/java/src/jmri/jmrix/nce/NceThrottle.java
@@ -264,7 +264,13 @@ public class NceThrottle extends AbstractThrottle {
             if (address.isLongAddress()) {
                 locoAddr += 0xC000;
             }
-            value = (int) ((127 - 1) * speed);     // -1 for rescale to avoid estop
+            value = Math.round((127 - 1) * speed);     // -1 for rescale to avoid estop
+            if (this.speedSetting > 0 && value == 0) {
+                value = 1;          // ensure non-zero input results in non-zero output
+            }
+            if (this.speedSetting < 0) {
+                value = -1;         // ensure small negative speeds don't get caught by Math.round above
+            }
             if (value > 126) {
                 value = 126;    // max possible speed, 127 can crash PowerCab!
             }   // emergency stop?
@@ -295,15 +301,19 @@ public class NceThrottle extends AbstractThrottle {
             int value;
 
             if (super.speedStepMode == jmri.SpeedStepMode.NMRA_DCC_128) {
-                value = (int) ((127 - 1) * speed);     // -1 for rescale to avoid estop
+                value = Math.round((127 - 1) * speed);     // -1 for rescale to avoid estop
+                if (this.speedSetting > 0 && value == 0) {
+                    value = 1;          // ensure non-zero input results in non-zero output
+                }
                 if (value > 0) {
                     value = value + 1;  // skip estop
                 }
                 if (value > 127) {
                     value = 127;    // max possible speed
                 }
-                if (value < 0) {
-                    value = 1;        // emergency stop
+                if (this.speedSetting < 0) {
+                    value = 1;      // emergency stop
+                                    // ensure small negative speeds don't get caught by Math.round above
                 }
                 bl = jmri.NmraPacket.speedStep128Packet(address.getNumber(),
                         address.isLongAddress(), value, isForward);
@@ -327,15 +337,19 @@ public class NceThrottle extends AbstractThrottle {
                  *   bl = jmri.NmraPacket.speedStep28Packet(true, address.getNumber(),
                  *     address.isLongAddress(), value, isForward);
                  */
-                value = (int) ((28) * speed); // -1 for rescale to avoid estop
+                value = Math.round((28-1) * speed); // -1 for rescale to avoid estop
+                if (this.speedSetting > 0 && value == 0) {
+                    value = 1;          // ensure non-zero input results in non-zero output
+                }
                 if (value > 0) {
                     value = value + 1; // skip estop
                 }
                 if (value > 28) {
                     value = 28; // max possible speed
                 }
-                if (value < 0) {
-                    value = 1; // emergency stop
+                if (this.speedSetting < 0) {
+                    value = 1;      // emergency stop
+                                    // ensure small negative speeds don't get caught by Math.round above
                 }
                 bl = jmri.NmraPacket.speedStep28Packet(address.getNumber(),
                         address.isLongAddress(), value, isForward);

--- a/java/src/jmri/jmrix/sprog/SprogCSThrottle.java
+++ b/java/src/jmri/jmrix/sprog/SprogCSThrottle.java
@@ -239,7 +239,10 @@ public class SprogCSThrottle extends AbstractThrottle {
             // stop, estop, stop, estop, 4, 5, ..., 31
             float oldSpeed = this.speedSetting;
             this.speedSetting = speed;
-            int value = (int) ((31 - 3) * speed);     // -1 for rescale to avoid estop
+            int value = Math.round((31 - 3) * speed);     // -3 for rescale to avoid estopx2 and stop
+            if (this.speedSetting > 0 && value == 0) {
+                value = 1;          // ensure non-zero input results in non-zero output
+            }
             if (value > 0) {
                 value = value + 3;  // skip estopx2 and stop
             }
@@ -256,7 +259,10 @@ public class SprogCSThrottle extends AbstractThrottle {
             // stop, estop, 2, 3, ..., 127
             float oldSpeed = this.speedSetting;
             this.speedSetting = speed;
-            int value = (int) ((127 - 1) * speed);     // -1 for rescale to avoid estop
+            int value = Math.round((127 - 1) * speed);     // -1 for rescale to avoid estop
+            if (this.speedSetting > 0 && value == 0) {
+                value = 1;          // ensure non-zero input results in non-zero output
+            }
             if (value > 0) {
                 value = value + 1;  // skip estop
             }

--- a/java/src/jmri/jmrix/sprog/SprogThrottle.java
+++ b/java/src/jmri/jmrix/sprog/SprogThrottle.java
@@ -244,6 +244,9 @@ public class SprogThrottle extends AbstractThrottle {
             float oldSpeed = this.speedSetting;
             this.speedSetting = speed;
             int value = Math.round((31 - 3) * speed);     // -3 for rescale to avoid estopx2 and stop
+            if (this.speedSetting > 0 && value == 0) {
+                value = 1;          // ensure non-zero input results in non-zero output
+            }
 
             log.debug("Speed: {} value: {}", speed, value);
 
@@ -278,6 +281,9 @@ public class SprogThrottle extends AbstractThrottle {
             float oldSpeed = this.speedSetting;
             this.speedSetting = speed;
             int value = Math.round((127 - 1) * speed);     // -1 for rescale to avoid estop
+            if (this.speedSetting > 0 && value == 0) {
+                value = 1;          // ensure non-zero input results in non-zero output
+            }
             if (value > 0) {
                 value = value + 1;  // skip estop
             }

--- a/java/src/jmri/jmrix/srcp/SRCPThrottle.java
+++ b/java/src/jmri/jmrix/srcp/SRCPThrottle.java
@@ -136,14 +136,28 @@ public class SRCPThrottle extends AbstractThrottle {
     void sendUpdate() {
         String msg = "SET " + bus + " GL ";
 
+        int outSpeed;
+        
+        synchronized(this) {
+            outSpeed = Math.round(speedSetting * maxsteps);
+            if (speedSetting > 0 && outSpeed == 0) {
+                outSpeed = 1;       //  ensure non-zero input results in non-zero output
+            }
+        }
+        
         // address
         msg += (address.getNumber());
 
         // direction and speed
-        msg += (isForward ? " 1" : " 0");
         synchronized(this) {
-            msg += " " + ((int) (speedSetting * maxsteps));
+            if (speedSetting >= 0) {
+                msg += (isForward ? " 1" : " 0");
+            }
+            else {
+                msg += " 2";        // handle emergency stop
+            }
         }
+        msg += " " + outSpeed;
         msg += " ";
         msg += maxsteps;
 

--- a/java/src/jmri/jmrix/tams/TamsThrottle.java
+++ b/java/src/jmri/jmrix/tams/TamsThrottle.java
@@ -171,7 +171,10 @@ public class TamsThrottle extends AbstractThrottle implements TamsListener {
         float oldSpeed = this.speedSetting;
         this.speedSetting = speed;
 
-        int value = (int) ((127 - 1) * this.speedSetting);     // -1 for rescale to avoid estop
+        int value = Math.round((127 - 1) * this.speedSetting);     // -1 for rescale to avoid estop
+        if (this.speedSetting > 0 && value == 0) {
+            value = 1;          // ensure non-zero input results in non-zero output
+        }
         if (value > 0) {
             value = value + 1;  // skip estop
         }
@@ -250,6 +253,7 @@ public class TamsThrottle extends AbstractThrottle implements TamsListener {
         } else if (super.speedStepMode == jmri.SpeedStepMode.NMRA_DCC_128) {
             return ((lSpeed - 1) / 126.f);
         } else {
+            // pretty sure this is wrong, it's definitely never going to be < 1.
             return (int) (lSpeed * 27.f + 0.5) + 1;
         }
     }

--- a/java/src/jmri/jmrix/xpa/XpaThrottle.java
+++ b/java/src/jmri/jmrix/xpa/XpaThrottle.java
@@ -48,9 +48,12 @@ public class XpaThrottle extends AbstractThrottle {
     @Override
     public void setSpeedSetting(float speed) {
         super.setSpeedSetting(speed);
-        int value = (int) ((127) * speed);
+        int value = Math.round((127) * speed);
         if (value > 127) {
             value = 127;    // max possible speed
+        }
+        if (speed > 0 && value == 0) {
+            value = 1;
         }
         if (this.speedvalue != value) {
             XpaMessage m;

--- a/java/src/jmri/jmrix/zimo/Mx1Throttle.java
+++ b/java/src/jmri/jmrix/zimo/Mx1Throttle.java
@@ -179,7 +179,10 @@ public class Mx1Throttle extends AbstractThrottle implements Mx1Listener {
         synchronized(this) {
             if (super.speedStepMode == jmri.SpeedStepMode.NMRA_DCC_128) {
                 //m = Mx1Message.getSendSpeed128(addressLo, addressHi, value);
-                value = (int) ((127 - 1) * speedSetting); // -1 for rescale to avoid estop
+                value = Math.round((127 - 1) * speedSetting); // -1 for rescale to avoid estop
+                if (speedSetting > 0 && value == 0) {
+                    value = 1;          // ensure non-zero speed for non-zero input
+                }
                 if (value > 0) {
                     value = value + 1;  // skip estop
                 }
@@ -192,7 +195,10 @@ public class Mx1Throttle extends AbstractThrottle implements Mx1Listener {
                 value = (value & 0x7F);
                 cData1 = cData1 + 0xc;
             } else if (super.speedStepMode == jmri.SpeedStepMode.NMRA_DCC_28) {
-                value = (int) ((28) * speedSetting); // -1 for rescale to avoid estop
+                value = Math.round((28) * speedSetting); // -1 for rescale to avoid estop
+                if (speedSetting > 0 && value == 0) {
+                    value = 1;          // ensure non-zero speed for non-zero input
+                }
                 if (value > 0) {
                     value = value + 3; // skip estop
                 }


### PR DESCRIPTION
As mentioned in #12337 : While I've attempted to fix the issue, I've stumbled over a lot of inconsistencies in:

- how the different throttle implementations interpret very small JMRI-internal speed values - most used to take anything below 1/speedStepNum as zero, which is at odds with the implementation in AbstractThrottle.intSpeed, where any small value is taken as "move the loco". We've discussed this at length a couple of years ago on the developers' list: https://jmri-developers.groups.io/g/jmri/message/5176 and my takeaway was "any non-zero value should result in loco movement commands"

- how they calculate their hardware speed step from that float value at maximum. Most used (int) fSpeed * maxSpeedStep, which will only allow the max speed to be reached for fSpeed >= 1.0.

This PR aligns the following throttle implementations' behavior with AbstractThrottle.intSpeed:
EcosDccThrottle
MrcThrottle
TamsThrottle
MqttThrottle
MarkinThrottle
SprogCSThrottle
SprogThrottle
Mx1Throttle
DCCppThrottle
XpaThrottle
NceThrottle
SCRPThrottle (which I also added emergency stop handling to while I had it open)

I did not understand:
Z21XNetThrottle
ElilteXNetThrottle
XNetThrottle
RocoXNetThrottle (inherits from XNetThrottle wrt to this issue)
OlcbThrottle

I ignored:
DebugThrottle (no float->int conversion in setSpeedSetting)
SerialThrottle