### PR TITLE
Add LogixNG tool WhereUsed

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -423,7 +423,7 @@
         <ul>
           <li>A new tool <strong>Where Used</strong> has been added to LogixNG.
           It shows where in the LogixNG tree an item is used. The tool is found
-          on menu item <strong>Tools &rarr; LogixNG &rarr; Where Used</strong>.</li>
+          on menu item <strong>Tools &rArr; LogixNG &rArr; Where Used</strong>.</li>
         </ul>
 
     <h3>Meters and MeterFrames</h3>

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -421,7 +421,9 @@
     <h3>LogixNG</h3>
         <a id="LogixNG" name="LogixNG"></a>
         <ul>
-          <li></li>
+          <li>A new tool <strong>Where Used</strong> has been added to LogixNG.
+          It shows where in the LogixNG tree an item is used. The tool is found
+          on menu item <strong>Tools &rarr; LogixNG &rarr; Where Used</strong>.</li>
         </ul>
 
     <h3>Meters and MeterFrames</h3>

--- a/java/src/jmri/jmrit/logixng/tools/swing/LogixNGMenu.java
+++ b/java/src/jmri/jmrit/logixng/tools/swing/LogixNGMenu.java
@@ -24,6 +24,7 @@ public class LogixNGMenu extends JMenu {
         add(new LogixNGInitializationTableAction());
         add(new ImportLogixAction());
         add(new InlineLogixNGsAction());
+        add(new WhereUsedAction(Bundle.getMessage("MenuItemWhereUsed")));
     }
 
 //    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LogixNGMenu.class);

--- a/java/src/jmri/jmrit/logixng/tools/swing/LogixNGMenu.java
+++ b/java/src/jmri/jmrit/logixng/tools/swing/LogixNGMenu.java
@@ -1,6 +1,7 @@
 package jmri.jmrit.logixng.tools.swing;
 
 import javax.swing.JMenu;
+import javax.swing.JSeparator;
 
 /**
  * Create a "LogixNG" menu
@@ -21,6 +22,7 @@ public class LogixNGMenu extends JMenu {
 
         add(new StartStopAllLogixNGsAction(Bundle.getMessage("MenuStartLogixNG"), true));
         add(new StartStopAllLogixNGsAction(Bundle.getMessage("MenuStopLogixNG"), false));
+        add(new JSeparator());
         add(new LogixNGInitializationTableAction());
         add(new ImportLogixAction());
         add(new InlineLogixNGsAction());

--- a/java/src/jmri/jmrit/logixng/tools/swing/LogixNGSwingBundle.properties
+++ b/java/src/jmri/jmrit/logixng/tools/swing/LogixNGSwingBundle.properties
@@ -266,4 +266,10 @@ InlineLogixNGsTableModel_TableMenuDelete    = Delete
 
 ReminderInUse                        = It is in use by {0} other objects including.
 
-Error_UserNameInUse     = New user name is already in use. Cannot update this LogixNG.\nPlease change user name and try again.
+Error_UserNameInUse         = New user name is already in use. Cannot update this LogixNG.\nPlease change user name and try again.
+
+WhereUsed_Title             = Where Used Report
+WhereUsed_LabelItemType     = Select Item Type
+WhereUsed_LabelItemName     = Select Item Name
+WhereUsed_SaveButton        = Save to Text File
+WhereUsed_SaveButtonHint    = Save the where used content to a text file

--- a/java/src/jmri/jmrit/logixng/tools/swing/LogixNGSwingBundle.properties
+++ b/java/src/jmri/jmrit/logixng/tools/swing/LogixNGSwingBundle.properties
@@ -273,3 +273,4 @@ WhereUsed_LabelItemType     = Select Item Type
 WhereUsed_LabelItemName     = Select Item Name
 WhereUsed_SaveButton        = Save to Text File
 WhereUsed_SaveButtonHint    = Save the where used content to a text file
+WhereUsed_NotInUse          = The item is not in use by LogixNG

--- a/java/src/jmri/jmrit/logixng/tools/swing/WhereUsedAction.java
+++ b/java/src/jmri/jmrit/logixng/tools/swing/WhereUsedAction.java
@@ -1,0 +1,33 @@
+package jmri.jmrit.logixng.tools.swing;
+
+import java.awt.event.ActionEvent;
+
+import jmri.util.swing.JmriAbstractAction;
+
+/**
+ * Swing action to create and register a WhereUsedFrame
+ *
+ * @author Dave Sand Copyright (C) 2020
+ */
+public class WhereUsedAction extends JmriAbstractAction {
+
+    public WhereUsedAction(String s) {
+        super(s);
+    }
+
+    public WhereUsedAction() {
+        this("WhereUsed");  // NOI18N
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        WhereUsedFrame f = new WhereUsedFrame();
+        f.setVisible(true);
+    }
+
+    // never invoked, because we overrode actionPerformed above
+    @Override
+    public jmri.util.swing.JmriPanel makePanel() {
+        throw new IllegalArgumentException("Should not be invoked");  // NOI18N
+    }
+}

--- a/java/src/jmri/jmrit/logixng/tools/swing/WhereUsedFrame.java
+++ b/java/src/jmri/jmrit/logixng/tools/swing/WhereUsedFrame.java
@@ -65,7 +65,7 @@ public class WhereUsedFrame extends jmri.util.JmriJFrame {
 
         // Build an empty where used listing
         JScrollPane scrollPane;
-//        buildWhereUsedListing(ItemType.NONE, null);
+        buildWhereUsedListing(ItemType.NONE, null);
         scrollPane = new JScrollPane(_scrolltext);
         contentPane.add(scrollPane);
 
@@ -122,7 +122,7 @@ public class WhereUsedFrame extends jmri.util.JmriJFrame {
      */
     void setItemNameBox(ItemType itemType) {
         _createButton.setEnabled(false);
-//        buildWhereUsedListing(ItemType.NONE, null);
+        buildWhereUsedListing(ItemType.NONE, null);
         NamedBeanComboBox<?> newNameBox = createNameBox(itemType);
         if (newNameBox == null) {
             _itemNameBox.setSelectedIndex(-1);
@@ -155,7 +155,11 @@ public class WhereUsedFrame extends jmri.util.JmriJFrame {
      * @param bean The bean being examined
      */
     void buildWhereUsedListing(ItemType type, NamedBean bean) {
-        _textArea.setText(WhereUsed.whereUsed(bean));
+        if (type != ItemType.NONE && bean != null) {
+            _textArea.setText(WhereUsed.whereUsed(bean));
+        } else {
+            _textArea.setText("");
+        }
         _textArea.setFont(new Font(Font.MONOSPACED, Font.PLAIN, 12));
         _textArea.setTabSize(4);
         _textArea.setEditable(false);

--- a/java/src/jmri/jmrit/logixng/tools/swing/WhereUsedFrame.java
+++ b/java/src/jmri/jmrit/logixng/tools/swing/WhereUsedFrame.java
@@ -25,8 +25,8 @@ import jmri.util.swing.JmriJOptionPane;
  * where a bean is used by LogixNG. On the other hand, it shows where in the LogixNG
  * tree the bean is used.
  *
- * @author Dave Sand Copyright (C) 2020
- * @author Dave Sand Copyright (C) 20203
+ * @author Dave Sand         Copyright (C) 2020
+ * @author Daniel Bergqvist  Copyright (C) 2023
  */
 public class WhereUsedFrame extends jmri.util.JmriJFrame {
     ItemType _itemType = ItemType.NONE;

--- a/java/src/jmri/jmrit/logixng/tools/swing/WhereUsedFrame.java
+++ b/java/src/jmri/jmrit/logixng/tools/swing/WhereUsedFrame.java
@@ -156,7 +156,11 @@ public class WhereUsedFrame extends jmri.util.JmriJFrame {
      */
     void buildWhereUsedListing(ItemType type, NamedBean bean) {
         if (type != ItemType.NONE && bean != null) {
-            _textArea.setText(WhereUsed.whereUsed(bean));
+            String str = WhereUsed.whereUsed(bean);
+            if (str.isEmpty()) {
+                str = Bundle.getMessage("WhereUsed_NotInUse");
+            }
+            _textArea.setText(str);
         } else {
             _textArea.setText("");
         }

--- a/java/src/jmri/jmrit/logixng/tools/swing/WhereUsedFrame.java
+++ b/java/src/jmri/jmrit/logixng/tools/swing/WhereUsedFrame.java
@@ -1,0 +1,312 @@
+package jmri.jmrit.logixng.tools.swing;
+
+import java.awt.*;
+import java.awt.event.*;
+import java.io.File;
+import java.io.IOException;
+
+import javax.swing.*;
+
+import jmri.*;
+import jmri.jmrit.entryexit.EntryExitPairs;
+import jmri.jmrit.logix.OBlockManager;
+import jmri.jmrit.logix.WarrantManager;
+import jmri.jmrit.logixng.util.WhereUsed;
+import jmri.swing.NamedBeanComboBox;
+import jmri.util.FileUtil;
+import jmri.util.swing.JComboBoxUtil;
+import jmri.util.swing.JmriJOptionPane;
+
+/**
+ * Create a where used report based on the selected bean.  The selection combo box is
+ * based on the selected type.
+ * <P>
+ * This class is a copy of jmri.jmrit.whereused.WhereUsedFrame, but it only shows
+ * where a bean is used by LogixNG. On the other hand, it shows where in the LogixNG
+ * tree the bean is used.
+ *
+ * @author Dave Sand Copyright (C) 2020
+ * @author Dave Sand Copyright (C) 20203
+ */
+public class WhereUsedFrame extends jmri.util.JmriJFrame {
+    ItemType _itemType = ItemType.NONE;
+    JComboBox<ItemType> _itemTypeBox;
+
+    NamedBean _itemBean;
+    NamedBeanComboBox<?> _itemNameBox = new NamedBeanComboBox<>(
+                        InstanceManager.getDefault(SensorManager.class));
+
+    JPanel _topPanel;
+    JPanel _bottomPanel;
+    JPanel _scrolltext = new JPanel();
+    JTextArea _textArea = new JTextArea();
+    JButton _createButton;
+    JLabel itemNameLabel;
+
+    public WhereUsedFrame() {
+        super(true, true);
+        setTitle(Bundle.getMessage("WhereUsed_Title"));  // NOI18N
+        createFrame();
+//        addHelpMenu("package.jmri.jmrit.whereused.WhereUsed", true);  // NOI18N
+    }
+
+    /**
+     * Create the window frame.  The top part contains the item type, the item name
+     * combo box, and a Create button.  The middle contains the scrollable "where used" text area and the
+     * bottom part has a button for saving the content to a file.
+     */
+    void createFrame() {
+        Container contentPane = getContentPane();
+        contentPane.setLayout(new BorderLayout());
+
+        // Build the top panel
+        buildTopPanel();
+        contentPane.add(_topPanel, BorderLayout.NORTH);
+
+        // Build an empty where used listing
+        JScrollPane scrollPane;
+//        buildWhereUsedListing(ItemType.NONE, null);
+        scrollPane = new JScrollPane(_scrolltext);
+        contentPane.add(scrollPane);
+
+        // Build the bottom panel
+        buildBottomPanel();
+        contentPane.add(_bottomPanel, BorderLayout.SOUTH);
+
+        pack();
+    }
+
+    void buildTopPanel() {
+        _topPanel = new JPanel();
+        JLabel itemTypeLabel = new JLabel(Bundle.getMessage("MakeLabel", Bundle.getMessage("WhereUsed_LabelItemType")));  // NOI18N
+        _topPanel.add(itemTypeLabel);
+        _itemTypeBox = new JComboBox<>();
+        itemTypeLabel.setLabelFor(_itemTypeBox);
+        for (ItemType itemType : ItemType.values()) {
+            _itemTypeBox.addItem(itemType);
+        }
+        JComboBoxUtil.setupComboBoxMaxRows(_itemTypeBox);
+        _topPanel.add(_itemTypeBox);
+
+        itemNameLabel = new JLabel(Bundle.getMessage("MakeLabel", Bundle.getMessage("WhereUsed_LabelItemName")));  // NOI18N
+        _topPanel.add(itemNameLabel);
+        itemNameLabel.setLabelFor(_itemNameBox);
+        _topPanel.add(_itemNameBox);
+        _itemTypeBox.addActionListener((e) -> {
+            _itemType = _itemTypeBox.getItemAt(_itemTypeBox.getSelectedIndex());
+            setItemNameBox(_itemType);
+        });
+
+        _createButton = new JButton(Bundle.getMessage("ButtonCreate"));  // NOI18N
+        _createButton.addActionListener((e) -> buildWhereUsedListing(_itemType, _itemBean));
+
+        _topPanel.add(_createButton);
+        _itemNameBox.setEnabled(false);
+        _createButton.setEnabled(false);
+    }
+
+    void buildBottomPanel() {
+        _bottomPanel = new JPanel();
+        _bottomPanel.setLayout(new BorderLayout());
+
+        JButton saveButton = new JButton(Bundle.getMessage("WhereUsed_SaveButton"));   // NOI18N
+        saveButton.setToolTipText(Bundle.getMessage("WhereUsed_SaveButtonHint"));      // NOI18N
+        _bottomPanel.add(saveButton, BorderLayout.EAST);
+        saveButton.addActionListener((ActionEvent e) -> saveWhereUsedPressed());
+    }
+
+    /**
+     * Create a new NamedBeanComboBox based on the item type and refresh the panel.
+     * A selection listener saves the selection and enables the Create button.
+     * @param itemType The enum for the selected item type.
+     */
+    void setItemNameBox(ItemType itemType) {
+        _createButton.setEnabled(false);
+//        buildWhereUsedListing(ItemType.NONE, null);
+        NamedBeanComboBox<?> newNameBox = createNameBox(itemType);
+        if (newNameBox == null) {
+            _itemNameBox.setSelectedIndex(-1);
+            _itemNameBox.setEnabled(false);
+            return;
+        }
+        _itemNameBox = newNameBox;
+        itemNameLabel.setLabelFor(newNameBox);
+        _itemNameBox.setSelectedIndex(-1);
+        _topPanel.remove(3);
+        _topPanel.add(_itemNameBox, 3);
+
+        _itemNameBox.setEnabled(true);
+        _itemNameBox.addItemListener((e) -> {
+            if (e.getStateChange() == ItemEvent.SELECTED) {
+                _itemBean = (NamedBean) e.getItem();
+                _createButton.setEnabled(true);
+            }
+        });
+        pack();
+        repaint();
+    }
+
+    /**
+     * Build the where used content and update the JScrollPane.
+     * <p>
+     * The selected object is passed to the appropriate detail class which returns a populated textarea.
+     * The textarea is formatted and inserted into a scrollable panel.
+     * @param type Indicated type of item being examined
+     * @param bean The bean being examined
+     */
+    void buildWhereUsedListing(ItemType type, NamedBean bean) {
+        _textArea.setText(WhereUsed.whereUsed(bean));
+        _textArea.setFont(new Font(Font.MONOSPACED, Font.PLAIN, 12));
+        _textArea.setTabSize(4);
+        _textArea.setEditable(false);
+        _textArea.setCaretPosition(0);
+        if (_scrolltext.getComponentCount() > 0) {
+            _scrolltext.remove(0);
+        }
+        _scrolltext.add(_textArea);
+        pack();
+        repaint();
+    }
+
+    JFileChooser userFileChooser = new jmri.util.swing.JmriJFileChooser(FileUtil.getUserFilesPath());
+
+    /**
+     * Save the where used textarea content to a text file.
+     */
+    void saveWhereUsedPressed() {
+        userFileChooser.setApproveButtonText(Bundle.getMessage("SaveDialogApprove"));  // NOI18N
+        userFileChooser.setDialogTitle(Bundle.getMessage("SaveDialogTitle"));  // NOI18N
+        userFileChooser.rescanCurrentDirectory();
+
+        String itemName = _itemNameBox.getSelectedItemDisplayName();
+        String fileName = Bundle.getMessage("SaveFileName", (itemName == null) ? "Unknown" : itemName);  // NOI18N
+        userFileChooser.setSelectedFile(new File(fileName));
+        int retVal = userFileChooser.showSaveDialog(null);
+        if (retVal != JFileChooser.APPROVE_OPTION) {
+            log.debug("Save where used content stopped, no file selected");  // NOI18N
+            return;  // give up if no file selected or cancel pressed
+        }
+        File file = userFileChooser.getSelectedFile();
+        log.debug("Save where used content to '{}'", file);  // NOI18N
+
+        if (file.exists()) {
+            Object[] options = {Bundle.getMessage("SaveDuplicateReplace"),  // NOI18N
+                    Bundle.getMessage("SaveDuplicateAppend"),  // NOI18N
+                    Bundle.getMessage("ButtonCancel")};               // NOI18N
+            int selectedOption = JmriJOptionPane.showOptionDialog(null,
+                    Bundle.getMessage("SaveDuplicatePrompt", file.getName(),
+                            Bundle.getMessage("SaveDuplicateAppend"),
+                            Bundle.getMessage("SaveDuplicateReplace")), // NOI18N
+                    Bundle.getMessage("SaveDuplicateTitle"),   // NOI18N
+                    JmriJOptionPane.DEFAULT_OPTION,
+                    JmriJOptionPane.WARNING_MESSAGE,
+                    null, options, options[0]);
+            if (selectedOption == 2 || selectedOption == -1) {
+                log.debug("Save where used content stopped, file replace/append cancelled");  // NOI18N
+                return;  // Cancel selected or dialog box closed
+            }
+            if (selectedOption == 0) {
+                FileUtil.delete(file);  // Replace selected
+            }
+        }
+
+        // Create the file content
+        try {
+            FileUtil.appendTextToFile(file, _textArea.getText());
+        } catch (IOException e) {
+            log.error("Unable to write where used content to '{}', exception", file, e);  // NOI18N
+        }
+    }
+
+    /**
+     * Create a combo name box for name selection.
+     *
+     * @param itemType The selected bean type
+     * @return a combo box based on the item type or null if no match
+     */
+    NamedBeanComboBox<?> createNameBox(ItemType itemType) {
+        NamedBeanComboBox<?> nameBox;
+        switch (itemType) {
+            case TURNOUT:
+                nameBox = new NamedBeanComboBox<>(InstanceManager.getDefault(TurnoutManager.class));
+                break;
+            case SENSOR:
+                nameBox = new NamedBeanComboBox<>(InstanceManager.getDefault(SensorManager.class));
+                break;
+            case LIGHT:
+                nameBox = new NamedBeanComboBox<>(InstanceManager.getDefault(LightManager.class));
+                break;
+            case SIGNALHEAD:
+                nameBox = new NamedBeanComboBox<>(InstanceManager.getDefault(SignalHeadManager.class));
+                break;
+            case SIGNALMAST:
+                nameBox = new NamedBeanComboBox<>(InstanceManager.getDefault(SignalMastManager.class));
+                break;
+            case REPORTER:
+                nameBox = new NamedBeanComboBox<>(InstanceManager.getDefault(ReporterManager.class));
+                break;
+            case MEMORY:
+                nameBox = new NamedBeanComboBox<>(InstanceManager.getDefault(MemoryManager.class));
+                break;
+            case ROUTE:
+                nameBox = new NamedBeanComboBox<>(InstanceManager.getDefault(RouteManager.class));
+                break;
+            case OBLOCK:
+                nameBox = new NamedBeanComboBox<>(InstanceManager.getDefault(OBlockManager.class));
+                break;
+            case BLOCK:
+                nameBox = new NamedBeanComboBox<>(InstanceManager.getDefault(BlockManager.class));
+                break;
+            case SECTION:
+                nameBox = new NamedBeanComboBox<>(InstanceManager.getDefault(SectionManager.class));
+                break;
+            case WARRANT:
+                nameBox = new NamedBeanComboBox<>(InstanceManager.getDefault(WarrantManager.class));
+                break;
+            case ENTRYEXIT:
+                nameBox = new NamedBeanComboBox<>(InstanceManager.getDefault(EntryExitPairs.class));
+                break;
+            default:
+                return null;             // Skip any other items.
+        }
+        nameBox.setEditable(false);
+        nameBox.setValidatingInput(false);
+        JComboBoxUtil.setupComboBoxMaxRows(nameBox);
+        return nameBox;
+    }
+
+    /**
+     * The item types.  A bundle key for each type is stored with the type to
+     * create a language dependent toString result.
+     */
+    enum ItemType {
+        NONE("ItemTypeNone"),
+        TURNOUT("BeanNameTurnout"),
+        SENSOR("BeanNameSensor"),
+        LIGHT("BeanNameLight"),
+        SIGNALHEAD("BeanNameSignalHead"),
+        SIGNALMAST("BeanNameSignalMast"),
+        REPORTER("BeanNameReporter"),
+        MEMORY("BeanNameMemory"),
+        ROUTE("BeanNameRoute"),
+        OBLOCK("BeanNameOBlock"),
+        BLOCK("BeanNameBlock"),
+        SECTION("BeanNameSection"),
+        WARRANT("BeanNameWarrant"),
+        ENTRYEXIT("BeanNameEntryExit");
+
+        private final String _bundleKey;
+
+        ItemType(String bundleKey) {
+            _bundleKey = bundleKey;
+        }
+
+        @Override
+        public String toString() {
+            return Bundle.getMessage(_bundleKey);
+        }
+    }
+
+    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(WhereUsedFrame.class);
+
+}

--- a/java/src/jmri/jmrit/logixng/util/UtilBundle.properties
+++ b/java/src/jmri/jmrit/logixng/util/UtilBundle.properties
@@ -2,6 +2,8 @@
 #
 # Default properties for the jmri.jmrit.logixng.tools.util.UtilBundle
 
+Clipboard               = Clipboard
+
 LogixNG_Thread          = LogixNG thread
 LogixNG_DebugThread     = Debug thread
 

--- a/java/src/jmri/jmrit/logixng/util/WhereUsed.java
+++ b/java/src/jmri/jmrit/logixng/util/WhereUsed.java
@@ -112,7 +112,11 @@ public class WhereUsed {
             }
         }
 
-        return sb.toString();
+        if (sb.length() > 0) {
+            return sb.toString();
+        } else {
+            return null;
+        }
     }
 
 }

--- a/java/src/jmri/jmrit/logixng/util/WhereUsed.java
+++ b/java/src/jmri/jmrit/logixng/util/WhereUsed.java
@@ -1,0 +1,116 @@
+package jmri.jmrit.logixng.util;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jmri.InstanceManager;
+import jmri.NamedBean;
+import jmri.NamedBeanUsageReport;
+import jmri.Reference;
+import jmri.jmrit.logixng.*;
+
+/**
+ * List the places where an item is used.
+ *
+ * @author Daniel Bergqvist (C) 2023
+ */
+public class WhereUsed {
+
+
+    private static final String PAD = "   ";
+
+
+    private WhereUsed() {
+    }
+
+
+    public static String whereUsed(NamedBean bean) {
+
+        Reference<String> ref = new Reference<>();
+
+        // Iterate all the LogixNGs
+        InstanceManager.getDefault(LogixNG_Manager.class).getNamedBeanSet().forEach((logixNG) -> {
+            StringBuilder sb = new StringBuilder();
+            for (int i=0; i < logixNG.getNumConditionalNGs(); i++) {
+                ConditionalNG conditionalNG = logixNG.getConditionalNG(i);
+                String s = checkFemaleSocket(conditionalNG.getFemaleSocket(), bean, conditionalNG, PAD+PAD);
+                if (s != null) {
+                    sb.append(PAD);
+                    sb.append(conditionalNG.getLongDescription());
+                    sb.append(String.format("%n"));
+                    sb.append(s);
+                }
+            }
+            if (sb.length() > 0) {
+                String str = logixNG.getLongDescription() + String.format("%n") + sb.toString() + String.format("%n");
+                if (ref.get() != null) ref.set(ref.get() + str);
+                else ref.set(str);
+            }
+        });
+
+        // Iterate all the Modules
+        InstanceManager.getDefault(ModuleManager.class).getNamedBeanSet().forEach((module) -> {
+            String s = checkFemaleSocket(module.getRootSocket(), bean, null, PAD);
+            if (s != null) {
+                String str = module.getLongDescription() + String.format("%n") + s + String.format("%n");
+                if (ref.get() != null) ref.set(ref.get() + str);
+                else ref.set(str);
+            }
+        });
+
+        String result = ref.get();
+
+        // Iterate the Clipboard
+        String s = checkFemaleSocket(InstanceManager.getDefault(LogixNG_Manager.class).getClipboard().getFemaleSocket(), bean, null, PAD);
+        if (s != null) {
+            String str = Bundle.getMessage("Clipboard") + String.format("%n") + s;
+            if (result != null) result += str;
+            else result = str;
+        }
+
+        return result != null ? result : "";
+    }
+
+    private static String checkFemaleSocket(FemaleSocket femaleSocket, NamedBean bean, ConditionalNG conditionalNG, String pad) {
+
+        if (!femaleSocket.isConnected()) return null;
+
+        Base b = femaleSocket.getConnectedSocket();
+
+        while (b instanceof MaleSocket) {
+            b = ((MaleSocket)b).getObject();
+        }
+
+        if (b == null) {
+            throw new UnsupportedOperationException("object is null");
+        }
+
+        List<NamedBeanUsageReport> report = new ArrayList<>();
+        b.getUsageDetail(0, bean, report, conditionalNG);
+
+        String s = null;
+        if (!report.isEmpty()) {
+            s = pad + femaleSocket.getLongDescription() + String.format("%n");
+            s += pad + PAD + b.getLongDescription() + String.format("   <<====%n");
+            pad += PAD;
+        }
+
+
+        String padding = s != null ? pad+PAD : pad+PAD+PAD;
+
+        for (int i=0; i < b.getChildCount(); i++) {
+            String temp = checkFemaleSocket(b.getChild(i), bean, conditionalNG, padding);
+            if (temp != null) {
+                if (s == null) {
+                    s = pad + femaleSocket.getLongDescription() + String.format("%n");
+                    s += pad + PAD + b.getLongDescription() + String.format("%n");
+                    pad += PAD;
+                }
+                s += temp;
+            }
+        }
+
+        return s;
+    }
+
+}

--- a/java/src/jmri/jmrit/logixng/util/WhereUsed.java
+++ b/java/src/jmri/jmrit/logixng/util/WhereUsed.java
@@ -17,6 +17,8 @@ import jmri.jmrit.logixng.*;
 public class WhereUsed {
 
 
+    private static final String NEW_LINE = System.getProperty("line.separator");
+
     private static final String PAD = "   ";
 
 
@@ -37,12 +39,12 @@ public class WhereUsed {
                 if (s != null) {
                     sb.append(PAD);
                     sb.append(conditionalNG.getLongDescription());
-                    sb.append(String.format("%n"));
+                    sb.append(NEW_LINE);
                     sb.append(s);
                 }
             }
             if (sb.length() > 0) {
-                String str = logixNG.getLongDescription() + String.format("%n") + sb.toString() + String.format("%n");
+                String str = logixNG.getLongDescription() + NEW_LINE + sb.toString() + NEW_LINE;
                 if (ref.get() != null) ref.set(ref.get() + str);
                 else ref.set(str);
             }
@@ -52,7 +54,7 @@ public class WhereUsed {
         InstanceManager.getDefault(ModuleManager.class).getNamedBeanSet().forEach((module) -> {
             String s = checkFemaleSocket(module.getRootSocket(), bean, null, PAD);
             if (s != null) {
-                String str = module.getLongDescription() + String.format("%n") + s + String.format("%n");
+                String str = module.getLongDescription() + NEW_LINE + s + NEW_LINE;
                 if (ref.get() != null) ref.set(ref.get() + str);
                 else ref.set(str);
             }
@@ -63,7 +65,7 @@ public class WhereUsed {
         // Iterate the Clipboard
         String s = checkFemaleSocket(InstanceManager.getDefault(LogixNG_Manager.class).getClipboard().getFemaleSocket(), bean, null, PAD);
         if (s != null) {
-            String str = Bundle.getMessage("Clipboard") + String.format("%n") + s;
+            String str = Bundle.getMessage("Clipboard") + NEW_LINE + s;
             if (result != null) result += str;
             else result = str;
         }
@@ -90,8 +92,8 @@ public class WhereUsed {
 
         String s = null;
         if (!report.isEmpty()) {
-            s = pad + femaleSocket.getLongDescription() + String.format("%n");
-            s += pad + PAD + b.getLongDescription() + String.format("   <<====%n");
+            s = pad + femaleSocket.getLongDescription() + NEW_LINE;
+            s += pad + PAD + b.getLongDescription() + "   <<====" + NEW_LINE;
             pad += PAD;
         }
 
@@ -102,8 +104,8 @@ public class WhereUsed {
             String temp = checkFemaleSocket(b.getChild(i), bean, conditionalNG, padding);
             if (temp != null) {
                 if (s == null) {
-                    s = pad + femaleSocket.getLongDescription() + String.format("%n");
-                    s += pad + PAD + b.getLongDescription() + String.format("%n");
+                    s = pad + femaleSocket.getLongDescription() + NEW_LINE;
+                    s += pad + PAD + b.getLongDescription() + NEW_LINE;
                     pad += PAD;
                 }
                 s += temp;

--- a/java/src/jmri/jmrit/logixng/util/WhereUsed.java
+++ b/java/src/jmri/jmrit/logixng/util/WhereUsed.java
@@ -90,29 +90,29 @@ public class WhereUsed {
         List<NamedBeanUsageReport> report = new ArrayList<>();
         b.getUsageDetail(0, bean, report, conditionalNG);
 
-        String s = null;
+        StringBuilder sb = new StringBuilder();
         if (!report.isEmpty()) {
-            s = pad + femaleSocket.getLongDescription() + NEW_LINE;
-            s += pad + PAD + b.getLongDescription() + "   <<====" + NEW_LINE;
+            sb.append(pad).append(femaleSocket.getLongDescription()).append(NEW_LINE);
+            sb.append(pad).append(PAD).append(b.getLongDescription()).append("   <<====").append(NEW_LINE);
             pad += PAD;
         }
 
 
-        String padding = s != null ? pad+PAD : pad+PAD+PAD;
+        String padding = sb.length() > 0 ? pad+PAD : pad+PAD+PAD;
 
         for (int i=0; i < b.getChildCount(); i++) {
             String temp = checkFemaleSocket(b.getChild(i), bean, conditionalNG, padding);
             if (temp != null) {
-                if (s == null) {
-                    s = pad + femaleSocket.getLongDescription() + NEW_LINE;
-                    s += pad + PAD + b.getLongDescription() + NEW_LINE;
+                if (sb.length() == 0) {
+                    sb.append(pad).append(femaleSocket.getLongDescription()).append(NEW_LINE);
+                    sb.append(pad).append(PAD).append(b.getLongDescription()).append(NEW_LINE);
                     pad += PAD;
                 }
-                s += temp;
+                sb.append(temp);
             }
         }
 
-        return s;
+        return sb.toString();
     }
 
 }

--- a/java/test/jmri/jmrit/logixng/util/WhereUsedTest.java
+++ b/java/test/jmri/jmrit/logixng/util/WhereUsedTest.java
@@ -1,0 +1,304 @@
+package jmri.jmrit.logixng.util;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import jmri.*;
+import jmri.jmrit.logixng.*;
+import jmri.jmrit.logixng.Module;
+import jmri.jmrit.logixng.actions.ActionAtomicBoolean;
+import jmri.jmrit.logixng.actions.ActionSensor;
+import jmri.jmrit.logixng.actions.IfThenElse;
+import jmri.jmrit.logixng.expressions.ExpressionSensor;
+import jmri.jmrit.logixng.expressions.Or;
+import jmri.jmrit.logixng.implementation.DefaultConditionalNGScaffold;
+import jmri.util.JUnitUtil;
+
+import org.junit.jupiter.api.*;
+import org.junit.Assert;
+
+/**
+ * Test WhereUsed
+ *
+ * @author Daniel Bergqvist (C) 2023
+ */
+public class WhereUsedTest {
+
+    public void setUpLogixNG() throws SocketAlreadyConnectedException {
+
+        Sensor sensor = InstanceManager.getDefault(SensorManager.class).provide("IS1");
+
+
+        // Create a LogixNG
+
+        LogixNG logixNG = InstanceManager.getDefault(LogixNG_Manager.class).createLogixNG("A new logixng for test");  // NOI18N
+        ConditionalNG conditionalNG = new DefaultConditionalNGScaffold("IQC1", "A conditionalNG");  // NOI18N;
+        InstanceManager.getDefault(ConditionalNG_Manager.class).register(conditionalNG);
+        conditionalNG.setRunDelayed(false);
+        conditionalNG.setEnabled(true);
+
+        logixNG.addConditionalNG(conditionalNG);
+
+        ActionSensorWithChildren actionSensorWithChildren1 = new ActionSensorWithChildren("IQDA111", null);
+        actionSensorWithChildren1.getSelectNamedBean().setNamedBean(sensor);
+        actionSensorWithChildren1.getSelectEnum().setEnum(ActionSensor.SensorState.Active);
+        MaleSocket maleSocket =
+                InstanceManager.getDefault(DigitalActionManager.class).registerAction(actionSensorWithChildren1);
+        conditionalNG.getChild(0).connect(maleSocket);
+
+        ActionSensorWithChildren actionSensorWithChildren2 = new ActionSensorWithChildren("IQDA112", null);
+        actionSensorWithChildren2.getSelectNamedBean().setNamedBean(sensor);
+        actionSensorWithChildren2.getSelectEnum().setEnum(ActionSensor.SensorState.Active);
+        maleSocket =
+                InstanceManager.getDefault(DigitalActionManager.class).registerAction(actionSensorWithChildren2);
+        actionSensorWithChildren1.getChild(0).connect(maleSocket);
+
+        ActionSensorWithChildren actionSensorWithChildren3 = new ActionSensorWithChildren("IQDA113", null);
+        actionSensorWithChildren3.getSelectNamedBean().setNamedBean(sensor);
+        actionSensorWithChildren3.getSelectEnum().setEnum(ActionSensor.SensorState.Active);
+        maleSocket =
+                InstanceManager.getDefault(DigitalActionManager.class).registerAction(actionSensorWithChildren3);
+        actionSensorWithChildren2.getChild(0).connect(maleSocket);
+
+        IfThenElse ifThenElse = new IfThenElse("IQDA114", null);
+        maleSocket =
+                InstanceManager.getDefault(DigitalActionManager.class).registerAction(ifThenElse);
+        actionSensorWithChildren3.getChild(0).connect(maleSocket);
+
+        Or or1 = new Or("IQDE111", null);
+        MaleSocket maleSocket2 =
+                InstanceManager.getDefault(DigitalExpressionManager.class).registerExpression(or1);
+        ifThenElse.getChild(0).connect(maleSocket2);
+
+        Or or2 = new Or("IQDE112", null);
+        maleSocket2 =
+                InstanceManager.getDefault(DigitalExpressionManager.class).registerExpression(or2);
+        or1.getChild(0).connect(maleSocket2);
+
+        ExpressionSensor expressionSensor = new ExpressionSensor("IQDE113", null);
+        maleSocket2 =
+                InstanceManager.getDefault(DigitalExpressionManager.class).registerExpression(expressionSensor);
+        or2.getChild(0).connect(maleSocket2);
+
+        AtomicBoolean atomicBoolean = new AtomicBoolean(false);
+        ActionAtomicBoolean actionAtomicBoolean = new ActionAtomicBoolean(atomicBoolean, true);
+        MaleSocket socketAtomicBoolean = InstanceManager.getDefault(DigitalActionManager.class).registerAction(actionAtomicBoolean);
+        ifThenElse.getChild(1).connect(socketAtomicBoolean);
+
+        expressionSensor.getSelectNamedBean().setNamedBean(sensor);
+        sensor.setCommandedState(Sensor.ACTIVE);
+
+        if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
+        logixNG.activate();
+        logixNG.setEnabled(true);
+
+
+        // Create another LogixNG
+
+        logixNG = InstanceManager.getDefault(LogixNG_Manager.class).createLogixNG("Another logixng for test");  // NOI18N
+        conditionalNG = new DefaultConditionalNGScaffold("IQC2", "A conditionalNG");  // NOI18N;
+        InstanceManager.getDefault(ConditionalNG_Manager.class).register(conditionalNG);
+        conditionalNG.setRunDelayed(false);
+        conditionalNG.setEnabled(true);
+
+        logixNG.addConditionalNG(conditionalNG);
+
+        ifThenElse = new IfThenElse("IQDA222", null);
+        maleSocket =
+                InstanceManager.getDefault(DigitalActionManager.class).registerAction(ifThenElse);
+        conditionalNG.getChild(0).connect(maleSocket);
+
+        expressionSensor = new ExpressionSensor("IQDE221", null);
+        maleSocket2 =
+                InstanceManager.getDefault(DigitalExpressionManager.class).registerExpression(expressionSensor);
+        ifThenElse.getChild(0).connect(maleSocket2);
+
+        atomicBoolean = new AtomicBoolean(false);
+        actionAtomicBoolean = new ActionAtomicBoolean(atomicBoolean, true);
+        socketAtomicBoolean = InstanceManager.getDefault(DigitalActionManager.class).registerAction(actionAtomicBoolean);
+        ifThenElse.getChild(1).connect(socketAtomicBoolean);
+
+        expressionSensor.getSelectNamedBean().setNamedBean(sensor);
+        sensor.setCommandedState(Sensor.ACTIVE);
+
+        if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
+        logixNG.activate();
+        logixNG.setEnabled(true);
+
+
+        // Create a Module
+
+        Module module = InstanceManager.getDefault(ModuleManager.class)
+                .createModule("A new module for test",
+                        InstanceManager.getDefault(FemaleSocketManager.class)
+                                .getSocketTypeByType("DefaultFemaleDigitalActionSocket"));  // NOI18N
+
+        actionSensorWithChildren3 = new ActionSensorWithChildren("IQDA421", null);
+        actionSensorWithChildren3.getSelectNamedBean().setNamedBean(sensor);
+        actionSensorWithChildren3.getSelectEnum().setEnum(ActionSensor.SensorState.Active);
+        maleSocket =
+                InstanceManager.getDefault(DigitalActionManager.class).registerAction(actionSensorWithChildren3);
+        module.getRootSocket().connect(maleSocket);
+
+        ifThenElse = new IfThenElse("IQDA422", null);
+        maleSocket =
+                InstanceManager.getDefault(DigitalActionManager.class).registerAction(ifThenElse);
+        actionSensorWithChildren3.getChild(0).connect(maleSocket);
+
+        expressionSensor = new ExpressionSensor("IQDE421", null);
+        maleSocket2 =
+                InstanceManager.getDefault(DigitalExpressionManager.class).registerExpression(expressionSensor);
+        ifThenElse.getChild(0).connect(maleSocket2);
+
+        atomicBoolean = new AtomicBoolean(false);
+        actionAtomicBoolean = new ActionAtomicBoolean(atomicBoolean, true);
+        socketAtomicBoolean = InstanceManager.getDefault(DigitalActionManager.class).registerAction(actionAtomicBoolean);
+        ifThenElse.getChild(1).connect(socketAtomicBoolean);
+
+        expressionSensor.getSelectNamedBean().setNamedBean(sensor);
+        sensor.setCommandedState(Sensor.ACTIVE);
+
+        if (! module.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
+
+
+        // Add an item to the clipboard
+
+        actionSensorWithChildren3 = new ActionSensorWithChildren("IQDA521", null);
+        actionSensorWithChildren3.getSelectNamedBean().setNamedBean(sensor);
+        actionSensorWithChildren3.getSelectEnum().setEnum(ActionSensor.SensorState.Active);
+        maleSocket =
+                InstanceManager.getDefault(DigitalActionManager.class).registerAction(actionSensorWithChildren3);
+        List<String> errors = new ArrayList<>();
+        InstanceManager.getDefault(LogixNG_Manager.class).getClipboard().add(maleSocket, errors);
+        if (!errors.isEmpty()) {
+            throw new RuntimeException(String.join(String.format(", "), errors));
+        }
+
+        ifThenElse = new IfThenElse("IQDA522", null);
+        maleSocket =
+                InstanceManager.getDefault(DigitalActionManager.class).registerAction(ifThenElse);
+        actionSensorWithChildren3.getChild(0).connect(maleSocket);
+
+        expressionSensor = new ExpressionSensor("IQDE521", null);
+        maleSocket2 =
+                InstanceManager.getDefault(DigitalExpressionManager.class).registerExpression(expressionSensor);
+        ifThenElse.getChild(0).connect(maleSocket2);
+
+        atomicBoolean = new AtomicBoolean(false);
+        actionAtomicBoolean = new ActionAtomicBoolean(atomicBoolean, true);
+        socketAtomicBoolean = InstanceManager.getDefault(DigitalActionManager.class).registerAction(actionAtomicBoolean);
+        ifThenElse.getChild(1).connect(socketAtomicBoolean);
+
+        expressionSensor.getSelectNamedBean().setNamedBean(sensor);
+        sensor.setCommandedState(Sensor.ACTIVE);
+
+        if (! module.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
+
+
+        // Add another item to the clipboard
+
+        actionSensorWithChildren3 = new ActionSensorWithChildren("IQDA621", null);
+        actionSensorWithChildren3.getSelectNamedBean().setNamedBean(sensor);
+        actionSensorWithChildren3.getSelectEnum().setEnum(ActionSensor.SensorState.Active);
+        maleSocket =
+                InstanceManager.getDefault(DigitalActionManager.class).registerAction(actionSensorWithChildren3);
+        errors = new ArrayList<>();
+        InstanceManager.getDefault(LogixNG_Manager.class).getClipboard().add(maleSocket, errors);
+        if (!errors.isEmpty()) {
+            throw new RuntimeException(String.join(String.format(", "), errors));
+        }
+
+        ifThenElse = new IfThenElse("IQDA622", null);
+        maleSocket =
+                InstanceManager.getDefault(DigitalActionManager.class).registerAction(ifThenElse);
+        actionSensorWithChildren3.getChild(0).connect(maleSocket);
+
+        expressionSensor = new ExpressionSensor("IQDE621", null);
+        maleSocket2 =
+                InstanceManager.getDefault(DigitalExpressionManager.class).registerExpression(expressionSensor);
+        ifThenElse.getChild(0).connect(maleSocket2);
+
+        atomicBoolean = new AtomicBoolean(false);
+        actionAtomicBoolean = new ActionAtomicBoolean(atomicBoolean, true);
+        socketAtomicBoolean = InstanceManager.getDefault(DigitalActionManager.class).registerAction(actionAtomicBoolean);
+        ifThenElse.getChild(1).connect(socketAtomicBoolean);
+
+        expressionSensor.getSelectNamedBean().setNamedBean(sensor);
+        sensor.setCommandedState(Sensor.ACTIVE);
+
+        if (! module.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
+    }
+
+    @Test
+    public void testWhereUsed() throws SocketAlreadyConnectedException {
+        setUpLogixNG();
+
+
+        org.apache.commons.lang3.mutable.MutableInt lineNumber = new org.apache.commons.lang3.mutable.MutableInt();
+        java.io.PrintWriter writer = new java.io.PrintWriter(System.out);
+        InstanceManager.getDefault(LogixNG_Manager.class).printTree(writer, "   ", lineNumber);
+        writer.flush();
+
+
+//        Turnout t1 = InstanceManager.getDefault(TurnoutManager.class).provide("Turnout1");
+        Sensor s1 = InstanceManager.getDefault(SensorManager.class).provide("IS1");
+        String result = WhereUsed.whereUsed(s1);
+        System.out.format("%n%n---------------%nResult:%n%s-----------------------%n%n", result);
+//        ReferenceUtil t = new ReferenceUtil();
+//        Assert.assertNotNull("not null", t);
+    }
+
+    // The minimal setup for log4J
+    @BeforeEach
+    public void setUp() {
+        JUnitUtil.setUp();
+        JUnitUtil.resetInstanceManager();
+        JUnitUtil.resetProfileManager();
+        JUnitUtil.initConfigureManager();
+        JUnitUtil.initInternalSensorManager();
+        JUnitUtil.initInternalTurnoutManager();
+        JUnitUtil.initLogixNGManager();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
+        JUnitUtil.tearDown();
+    }
+
+
+    private static class ActionSensorWithChildren extends ActionSensor implements FemaleSocketListener {
+
+        FemaleSocket _socket;
+
+        public ActionSensorWithChildren(String sys, String user) {
+            super(sys, user);
+            _socket = InstanceManager.getDefault(DigitalActionManager.class)
+                    .createFemaleSocket(this, this, "E");
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        public FemaleSocket getChild(int index) throws IllegalArgumentException, UnsupportedOperationException {
+            return _socket;
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        public int getChildCount() {
+            return 1;
+        }
+
+        @Override
+        public void connected(FemaleSocket socket) {
+        }
+
+        @Override
+        public void disconnected(FemaleSocket socket) {
+        }
+
+    }
+
+}

--- a/java/test/jmri/jmrit/logixng/util/WhereUsedTest.java
+++ b/java/test/jmri/jmrit/logixng/util/WhereUsedTest.java
@@ -25,6 +25,57 @@ import org.junit.Assert;
  */
 public class WhereUsedTest {
 
+    private static final String NEW_LINE = System.getProperty("line.separator");
+
+    private static final String EXPECTED_RESULT =
+            "LogixNG: A new logixng for test" + NEW_LINE +
+            "   ConditionalNG: IQC1" + NEW_LINE +
+            "      ! A" + NEW_LINE +
+            "         Set sensor IS1 to state Active   <<====" + NEW_LINE +
+            "            ! E" + NEW_LINE +
+            "               Set sensor IS1 to state Active   <<====" + NEW_LINE +
+            "                  ! E" + NEW_LINE +
+            "                     Set sensor IS1 to state Active   <<====" + NEW_LINE +
+            "                        ! E" + NEW_LINE +
+            "                           If Then Else. Execute on change" + NEW_LINE +
+            "                              ? If" + NEW_LINE +
+            "                                 Or. Evaluate All" + NEW_LINE +
+            "                                    ? E1" + NEW_LINE +
+            "                                       Or. Evaluate All" + NEW_LINE +
+            "                                          ? E1" + NEW_LINE +
+            "                                             Sensor IS1 is Active   <<====" + NEW_LINE +
+            "" + NEW_LINE +
+            "LogixNG: Another logixng for test" + NEW_LINE +
+            "   ConditionalNG: A conditionalNG" + NEW_LINE +
+            "      ! A" + NEW_LINE +
+            "         If Then Else. Execute on change" + NEW_LINE +
+            "            ? If" + NEW_LINE +
+            "               Sensor IS1 is Active   <<====" + NEW_LINE +
+            "" + NEW_LINE +
+            "Module: A new module for test" + NEW_LINE +
+            "   ! Root" + NEW_LINE +
+            "      Set sensor IS1 to state Active   <<====" + NEW_LINE +
+            "         ! E" + NEW_LINE +
+            "            If Then Else. Execute on change" + NEW_LINE +
+            "               ? If" + NEW_LINE +
+            "                  Sensor IS1 is Active   <<====" + NEW_LINE +
+            "" + NEW_LINE +
+            "Clipboard" + NEW_LINE +
+            "   * A" + NEW_LINE +
+            "      Many" + NEW_LINE +
+            "         * X2" + NEW_LINE +
+            "            Set sensor IS1 to state Active   <<====" + NEW_LINE +
+            "               ! E" + NEW_LINE +
+            "                  If Then Else. Execute on change" + NEW_LINE +
+            "                     ? If" + NEW_LINE +
+            "                        Sensor IS1 is Active   <<====" + NEW_LINE +
+            "         * X1" + NEW_LINE +
+            "            Set sensor IS1 to state Active   <<====" + NEW_LINE +
+            "               ! E" + NEW_LINE +
+            "                  If Then Else. Execute on change" + NEW_LINE +
+            "                     ? If" + NEW_LINE +
+            "                        Sensor IS1 is Active   <<====" + NEW_LINE;
+
     public void setUpLogixNG() throws SocketAlreadyConnectedException {
 
         Sensor sensor = InstanceManager.getDefault(SensorManager.class).provide("IS1");
@@ -235,18 +286,17 @@ public class WhereUsedTest {
         setUpLogixNG();
 
 
-        org.apache.commons.lang3.mutable.MutableInt lineNumber = new org.apache.commons.lang3.mutable.MutableInt();
-        java.io.PrintWriter writer = new java.io.PrintWriter(System.out);
-        InstanceManager.getDefault(LogixNG_Manager.class).printTree(writer, "   ", lineNumber);
-        writer.flush();
+//        org.apache.commons.lang3.mutable.MutableInt lineNumber = new org.apache.commons.lang3.mutable.MutableInt();
+//        java.io.PrintWriter writer = new java.io.PrintWriter(System.out);
+//        InstanceManager.getDefault(LogixNG_Manager.class).printTree(writer, "   ", lineNumber);
+//        writer.flush();
 
 
 //        Turnout t1 = InstanceManager.getDefault(TurnoutManager.class).provide("Turnout1");
         Sensor s1 = InstanceManager.getDefault(SensorManager.class).provide("IS1");
         String result = WhereUsed.whereUsed(s1);
-        System.out.format("%n%n---------------%nResult:%n%s-----------------------%n%n", result);
-//        ReferenceUtil t = new ReferenceUtil();
-//        Assert.assertNotNull("not null", t);
+//        System.out.format("%n%n---------------%nResult:%n%s-----------------------%n%n", result);
+        Assert.assertEquals(EXPECTED_RESULT, result);
     }
 
     // The minimal setup for log4J

--- a/java/test/jmri/jmrit/logixng/util/WhereUsedTest.java
+++ b/java/test/jmri/jmrit/logixng/util/WhereUsedTest.java
@@ -325,11 +325,16 @@ public class WhereUsedTest {
 //        writer.flush();
 
 
-//        Turnout t1 = InstanceManager.getDefault(TurnoutManager.class).provide("Turnout1");
         Sensor s1 = InstanceManager.getDefault(SensorManager.class).provide("IS1");
         String result = WhereUsed.whereUsed(s1);
 //        System.out.format("%n%n---------------%nResult:%n%s-----------------------%n%n", result);
         Assert.assertEquals(EXPECTED_RESULT, result);
+
+
+        Turnout t1 = InstanceManager.getDefault(TurnoutManager.class).provide("Turnout1");
+        result = WhereUsed.whereUsed(t1);
+//        System.out.format("%n%n---------------%nResult:%n%s-----------------------%n%n", result);
+        Assert.assertEquals("", result);    // Turnout Turnout1 is not used so empty string is expected
     }
 
     // The minimal setup for log4J

--- a/java/test/jmri/jmrit/logixng/util/WhereUsedTest.java
+++ b/java/test/jmri/jmrit/logixng/util/WhereUsedTest.java
@@ -46,7 +46,7 @@ public class WhereUsedTest {
             "                                             Sensor IS1 is Active   <<====" + NEW_LINE +
             "" + NEW_LINE +
             "LogixNG: Another logixng for test" + NEW_LINE +
-            "   ConditionalNG: A conditionalNG" + NEW_LINE +
+            "   ConditionalNG: IQC2" + NEW_LINE +
             "      ! A" + NEW_LINE +
             "         If Then Else. Execute on change" + NEW_LINE +
             "            ? If" + NEW_LINE +
@@ -138,7 +138,7 @@ public class WhereUsedTest {
         ifThenElse.getChild(1).connect(socketAtomicBoolean);
 
         expressionSensor.getSelectNamedBean().setNamedBean(sensor);
-        sensor.setCommandedState(Sensor.ACTIVE);
+        expressionSensor.setBeanState(ExpressionSensor.SensorState.Active);
 
         if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
         logixNG.activate();
@@ -171,7 +171,40 @@ public class WhereUsedTest {
         ifThenElse.getChild(1).connect(socketAtomicBoolean);
 
         expressionSensor.getSelectNamedBean().setNamedBean(sensor);
-        sensor.setCommandedState(Sensor.ACTIVE);
+        expressionSensor.setBeanState(ExpressionSensor.SensorState.Active);
+
+        if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
+        logixNG.activate();
+        logixNG.setEnabled(true);
+
+
+        // Create a third LogixNG that doesn't have the sensor
+
+        logixNG = InstanceManager.getDefault(LogixNG_Manager.class).createLogixNG("A third logixng for test");  // NOI18N
+        conditionalNG = new DefaultConditionalNGScaffold("IQC3", "A conditionalNG");  // NOI18N;
+        InstanceManager.getDefault(ConditionalNG_Manager.class).register(conditionalNG);
+        conditionalNG.setRunDelayed(false);
+        conditionalNG.setEnabled(true);
+
+        logixNG.addConditionalNG(conditionalNG);
+
+        ifThenElse = new IfThenElse("IQDA322", null);
+        maleSocket =
+                InstanceManager.getDefault(DigitalActionManager.class).registerAction(ifThenElse);
+        conditionalNG.getChild(0).connect(maleSocket);
+
+        expressionSensor = new ExpressionSensor("IQDE321", null);
+        maleSocket2 =
+                InstanceManager.getDefault(DigitalExpressionManager.class).registerExpression(expressionSensor);
+        ifThenElse.getChild(0).connect(maleSocket2);
+
+        atomicBoolean = new AtomicBoolean(false);
+        actionAtomicBoolean = new ActionAtomicBoolean(atomicBoolean, true);
+        socketAtomicBoolean = InstanceManager.getDefault(DigitalActionManager.class).registerAction(actionAtomicBoolean);
+        ifThenElse.getChild(1).connect(socketAtomicBoolean);
+
+//        expressionSensor.getSelectNamedBean().setNamedBean(sensor);
+        expressionSensor.setBeanState(ExpressionSensor.SensorState.Active);
 
         if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
         logixNG.activate();


### PR DESCRIPTION
@dsand47 
This PR adds the new tool `Where Used` to LogixNG. It works similar to the `Where Used` tool you created, but with the difference that this tool only shows items used by LogixNG. On the other hand, it shows where in the LogixNG tree the item is used, even if it's used by a module or by the Clipboard. The tool is found on menu item `Tools -> LogixNG -> Where Used`.

Actions and expressions that uses the item are marked with `<<====` on the right. For now, it's probably only leaves in the tree that uses an item, but it's technically possible that an action/expression could both use a NamedBean and have children. Think of a Timer action which uses sensors directly for start/stop. I'm not sure that will ever be implemented, but having the `<<====` arrow makes it clear which actions/expressions that are using the item.