### PR TITLE
LocoNet Monitor for some Extended Accessory "long CV" accesses

### DIFF
--- a/java/src/jmri/jmrix/loconet/messageinterp/LocoNetMessageInterpret.java
+++ b/java/src/jmri/jmrix/loconet/messageinterp/LocoNetMessageInterpret.java
@@ -4215,18 +4215,21 @@ public class LocoNetMessageInterpret {
                                      * will be generated in response to the second 
                                      * identical WRITE BIT instruction if appropriate.
                                      */
+                                    if ((packetInt[4]& 0xE0) != 0xE0) {
+                                        break;
+                                    }
                                     log.debug("CV # {}, Bit Manipulation: {} {} (of bits 0-7) with {}", 
-                                            cvnum, (packetInt[4] & 0x10) == 0x10 ? "Write bit" : "Verify bit",
+                                            cvnum, (packetInt[4] & 0x10) == 0x10 ? "Write" : "Verify",
                                             (packetInt[4] & 0x7),
-                                            (packetInt[4] >>4) & 0x1);
+                                            (packetInt[4] >> 3) & 0x1);
                                     
                                     // "Extended Accessory Decoder CV Bit {} bit, 
                                     // Address {}, CV {}, bit # {} (of bits 0-7) 
                                     // with value {}.\n"
                                     return Bundle.getMessage("LN_MSG_EXTEND_ACCY_CV_BIT_ACCESS",
-                                            ((packetInt[4] & 0x10) == 0x10 ? "Write bit" : "Verify bit"),
+                                            ((packetInt[4] & 0x10) == 0x10 ? "Write" : "Verify"),
                                             addr, cvnum, (packetInt[4] & 0x7),
-                                            ((packetInt[4] >>4) & 0x1) );
+                                            ((packetInt[4] >>3) & 0x1) );
                                 case 0x0c:
                                     // GG=11 Write byte
                                     /*

--- a/java/src/jmri/jmrix/loconet/messageinterp/LocoNetMessageInterpret.java
+++ b/java/src/jmri/jmrix/loconet/messageinterp/LocoNetMessageInterpret.java
@@ -4194,7 +4194,7 @@ public class LocoNetMessageInterpret {
                                     log.warn("CV # {}, Write Byte: {}", cvnum, packetInt[4]);
                                     return "Extended Accessory Decoder CV 'Verify': Address "
                                             + addr +  " CV " + cvnum + ", check if it is " +
-                                            packetInt[4] + ".";
+                                            packetInt[4] + ".\n";
                                 case 0x08:
                                     // GG=10 Bit manipulation
                                     /*
@@ -4228,12 +4228,13 @@ public class LocoNetMessageInterpret {
                                             (packetInt[4] >>4) & 0x1);
                                     return "Extended Accessory Decoder CV Bit " +
                                             ((packetInt[4] & 0x10) == 0x10 ? "Write bit" : "Verify bit") +
-                                            " Address CV # " + 
+                                            " Address CV " + 
                                             cvnum + 
                                             ", " +
                                             (packetInt[4] & 0x7) +
                                             "(of bits 0-7) with " +
-                                            ((packetInt[4] >>4) & 0x1);
+                                            ((packetInt[4] >>4) & 0x1) +
+                                            ".\n";
                                 case 0x0c:
                                     // GG=11 Write byte
                                     /*
@@ -4251,7 +4252,7 @@ public class LocoNetMessageInterpret {
                                      */
                                     log.warn("CV # {}, Write Byte: {}", cvnum, packetInt[4]);
                                     return "Extended Accessory Decoder CV Write: Address "
-                                            + addr +  " CV " + cvnum + " with " + packetInt[4] + ".";
+                                            + addr +  " CV " + cvnum + " with " + packetInt[4] + ".\n";
                                 case 0x0:
                                 default:
                                     // GG=00 Reserved for future use

--- a/java/src/jmri/jmrix/loconet/messageinterp/LocoNetMessageInterpret.java
+++ b/java/src/jmri/jmrix/loconet/messageinterp/LocoNetMessageInterpret.java
@@ -4109,9 +4109,8 @@ public class LocoNetMessageInterpret {
                         * {preamble} 10AAAAAA 0 0AAA0AA1 0 (1110CCVV 0 VVVVVVVV 0 DDDDDDDD) 0 EEEEEEEE 1
                         * Signal Decoder Address (Configuration Variable Access Instruction) Error Byte
                         */
-                        log.warn("***************");
-                        log.warn("Is an Extended Accessory Ops-mode CV access");
-                        log.warn("   LocoNet message: {} {} {} {} {} {} {} {} {} {} {}",
+                        log.debug("Is an Extended Accessory Ops-mode CV access");
+                        log.debug("   LocoNet message: {} {} {} {} {} {} {} {} {} {} {}",
                                 StringUtil.twoHexFromInt(l.getElement(0)),
                                 StringUtil.twoHexFromInt(l.getElement(1)),
                                 StringUtil.twoHexFromInt(l.getElement(2)),
@@ -4124,14 +4123,13 @@ public class LocoNetMessageInterpret {
                                 StringUtil.twoHexFromInt(l.getElement(9)),
                                 StringUtil.twoHexFromInt(l.getElement(10))
                                 );
-                        log.warn("   NMRA packet: {} {} {} {} {}",
+                        log.debug("   NMRA packet: {} {} {} {} {}",
                                 StringUtil.twoHexFromInt(packetInt[0]),
                                 StringUtil.twoHexFromInt(packetInt[1]),
                                 StringUtil.twoHexFromInt(packetInt[2]),
                                 StringUtil.twoHexFromInt(packetInt[3]),
                                 StringUtil.twoHexFromInt(packetInt[4])
                                 );
-                        log.warn("***************");
                         
                         if ((packetInt[2] & 0xF0) == 0xF0) {
                             /*
@@ -4141,9 +4139,7 @@ public class LocoNetMessageInterpret {
                             * The 8 bit data DDDDDDDD is placed in the configuration 
                             * variable identified by GGGG according
                             */
-                            log.warn("***************");
-                            log.warn("Is an Short-form Extended Accessory Ops-mode CV access");
-                            log.warn("***************");
+                            log.debug("Is an Short-form Extended Accessory Ops-mode CV access");
                         }
                         if ((packetInt[2] & 0xf0) == 0xe0) {
                             /*
@@ -4171,11 +4167,10 @@ public class LocoNetMessageInterpret {
                             *       GG=11 Write byte
                             *       GG=10 Bit manipulation
                             * */
-                            log.warn("***************");
                             int addr = 1 + ((packetInt[0] & 0x3F) << 2) + 
                                     ((( ~ packetInt[1]) & 0x70) << 4)
                                     + ((packetInt[1] & 0x06) >> 1);
-                            log.warn("Long-format Extended Accessory Ops-mode CV access: Extended Acceccory Address {}", addr);
+                            log.debug("Long-format Extended Accessory Ops-mode CV access: Extended Acceccory Address {}", addr);
                             int cvnum = 1 + ((packetInt[2] & 0x03) << 2) + (packetInt[3] & 0xff);
                             switch (packetInt[2] & 0x0C) {
                                 case 0x04:
@@ -4190,8 +4185,7 @@ public class LocoNetMessageInterpret {
                                      * Decoder shall respond with the contents of the CV as 
                                      * the Decoder Response Transmission, if enabled.
                                     */
-                                    log.warn("CV # {}, Verify Byte: {}", cvnum, packetInt[4]);
-                                    log.warn("CV # {}, Write Byte: {}", cvnum, packetInt[4]);
+                                    log.debug("CV # {}, Verify Byte: {}", cvnum, packetInt[4]);
                                     return Bundle.getMessage("LN_MSG_EXTEND_ACCY_CV_VERIFY",
                                             addr, cvnum, packetInt[4] );
                                 case 0x08:
@@ -4221,19 +4215,18 @@ public class LocoNetMessageInterpret {
                                      * will be generated in response to the second 
                                      * identical WRITE BIT instruction if appropriate.
                                      */
-                                    log.warn("CV # {}, Bit Manipulation: {} {} (of bits 0-7) with {}", 
+                                    log.debug("CV # {}, Bit Manipulation: {} {} (of bits 0-7) with {}", 
                                             cvnum, (packetInt[4] & 0x10) == 0x10 ? "Write bit" : "Verify bit",
                                             (packetInt[4] & 0x7),
                                             (packetInt[4] >>4) & 0x1);
-                                    return "Extended Accessory Decoder CV Bit " +
-                                            ((packetInt[4] & 0x10) == 0x10 ? "Write bit" : "Verify bit") +
-                                            " Address CV " + 
-                                            cvnum + 
-                                            ", " +
-                                            (packetInt[4] & 0x7) +
-                                            "(of bits 0-7) with " +
-                                            ((packetInt[4] >>4) & 0x1) +
-                                            ".\n";
+                                    
+                                    // "Extended Accessory Decoder CV Bit {} bit, 
+                                    // Address {}, CV {}, bit # {} (of bits 0-7) 
+                                    // with value {}.\n"
+                                    return Bundle.getMessage("LN_MSG_EXTEND_ACCY_CV_BIT_ACCESS",
+                                            ((packetInt[4] & 0x10) == 0x10 ? "Write bit" : "Verify bit"),
+                                            addr, cvnum, (packetInt[4] & 0x7),
+                                            ((packetInt[4] >>4) & 0x1) );
                                 case 0x0c:
                                     // GG=11 Write byte
                                     /*
@@ -4249,16 +4242,14 @@ public class LocoNetMessageInterpret {
                                      * this second identical packet, it shall respond with a 
                                      * configuration variable access acknowledgment.
                                      */
-                                    log.warn("CV # {}, Write Byte: {}", cvnum, packetInt[4]);
+                                    log.debug("CV # {}, Write Byte: {}", cvnum, packetInt[4]);
                                     return Bundle.getMessage("LN_MSG_EXTEND_ACCY_CV_WRITE",
                                             addr, cvnum, packetInt[4] );
                                 case 0x0:
                                 default:
                                     // GG=00 Reserved for future use
-                                    log.warn("CV # {}, Reserved (GG=0); {}", cvnum, packetInt[4]);    
-                                    break;
+                                    log.debug("CV # {}, Reserved (GG=0); {}", cvnum, packetInt[4]);    
                             }
-                            log.warn("***************");
                         }
                     }
                     return Bundle.getMessage("LN_MSG_OPC_IMM_PKT_GENERIC",

--- a/java/src/jmri/jmrix/loconet/messageinterp/LocoNetMessageInterpret.java
+++ b/java/src/jmri/jmrix/loconet/messageinterp/LocoNetMessageInterpret.java
@@ -3878,12 +3878,15 @@ public class LocoNetMessageInterpret {
     }
 
     private static String interpretOpcImmPacket(LocoNetMessage l) {
+        String result;
+        result = "";
+
         /*
          * OPC_IMM_PACKET   0xED
          */
         if (l.getElement(1) == 0x0F) { // length = 15
             // check for a specific type - Uhlenbrock LNSV Programming messages format
-            String result = interpretLncvMessage(l);
+            result = interpretLncvMessage(l);
             if (result.length() > 0) {
                 return result;
             }
@@ -4094,6 +4097,170 @@ public class LocoNetMessageInterpret {
                             Bundle.getMessage(((packetInt[1] & 0x08) != 0 ? "LN_MSG_FUNC_ON" : "LN_MSG_FUNC_OFF")));
                 } else {
                     // Unknown
+                    if ((packetInt[0] & 0xC0) == 0x80 ) {
+                        /*
+                        * 2.4.7 Extended Decoder Control Packet address for 
+                        * operations mode programming
+                        * 10AAAAAA 0 0AAA0AA1
+                        * Please note that the use of 0 in bit 3 of byte 2 is to 
+                        * ensure that this packet cannot be confused with the 
+                        * legacy accessory-programming packets. The resulting packet 
+                        * would be:
+                        * {preamble} 10AAAAAA 0 0AAA0AA1 0 (1110CCVV 0 VVVVVVVV 0 DDDDDDDD) 0 EEEEEEEE 1
+                        * Signal Decoder Address (Configuration Variable Access Instruction) Error Byte
+                        */
+                        log.warn("***************");
+                        log.warn("Is an Extended Accessory Ops-mode CV access");
+                        log.warn("   LocoNet message: {} {} {} {} {} {} {} {} {} {} {}",
+                                StringUtil.twoHexFromInt(l.getElement(0)),
+                                StringUtil.twoHexFromInt(l.getElement(1)),
+                                StringUtil.twoHexFromInt(l.getElement(2)),
+                                StringUtil.twoHexFromInt(l.getElement(3)),
+                                StringUtil.twoHexFromInt(l.getElement(4)),
+                                StringUtil.twoHexFromInt(l.getElement(5)),
+                                StringUtil.twoHexFromInt(l.getElement(6)),
+                                StringUtil.twoHexFromInt(l.getElement(7)),
+                                StringUtil.twoHexFromInt(l.getElement(8)),
+                                StringUtil.twoHexFromInt(l.getElement(9)),
+                                StringUtil.twoHexFromInt(l.getElement(10))
+                                );
+                        log.warn("   NMRA packet: {} {} {} {} {}",
+                                StringUtil.twoHexFromInt(packetInt[0]),
+                                StringUtil.twoHexFromInt(packetInt[1]),
+                                StringUtil.twoHexFromInt(packetInt[2]),
+                                StringUtil.twoHexFromInt(packetInt[3]),
+                                StringUtil.twoHexFromInt(packetInt[4])
+                                );
+                        log.warn("***************");
+                        
+                        if ((packetInt[2] & 0xF0) == 0xF0) {
+                            /*
+                            * 2.3.7.2 Configuration Variable Access Instruction - Short Form
+                            * This instruction has the format of:
+                            * {instruction bytes} = 1111GGGG 0 DDDDDDDD 0 DDDDDDDD
+                            * The 8 bit data DDDDDDDD is placed in the configuration 
+                            * variable identified by GGGG according
+                            */
+                            log.warn("***************");
+                            log.warn("Is an Short-form Extended Accessory Ops-mode CV access");
+                            log.warn("***************");
+                        }
+                        if ((packetInt[2] & 0xf0) == 0xe0) {
+                            /*
+                            * 2.3.7.3 Configuration Variable Access Instruction - Long Form
+                            * The long form allows the direct manipulation of all CVs8. This 
+                            * instruction is valid both when the Digital Decoder has its 
+                            * long address active and short address active. Digital Decoders 
+                            * shall not act on this instruction if sent to its consist 
+                            * address. 
+                            *
+                            * The format of the instructions using Direct CV 
+                            * addressing is:
+                            *   {instruction bytes}= 1110GGVV 0 VVVVVVVV 0 DDDDDDDD
+                            *
+                            * The actual Configuration Variable desired is selected 
+                            * via the 10-bit address with the 2-bit address (VV) in 
+                            * the first data byte being the most significant bits of 
+                            * the address. The Configuration variable being addressed 
+                            * is the provided 10-bit address plus 1. For example, to 
+                            * address CV1 the 10 bit address is “00 00000000”.
+                            *
+                            * The defined values for Instruction type (CC) are:
+                            *       GG=00 Reserved for future use
+                            *       GG=01 Verify byte 505
+                            *       GG=11 Write byte
+                            *       GG=10 Bit manipulation
+                            * */
+                            log.warn("***************");
+                            int addr = 1 + ((packetInt[0] & 0x3F) << 2) + 
+                                    ((( ~ packetInt[1]) & 0x70) << 4)
+                                    + ((packetInt[1] & 0x06) >> 1);
+                            log.warn("Long-format Extended Accessory Ops-mode CV access: Extended Acceccory Address {}", addr);
+                            int cvnum = 1 + ((packetInt[2] & 0x03) << 2) + (packetInt[3] & 0xff);
+                            switch (packetInt[2] & 0x0C) {
+                                case 0x04:
+                                    //  GG=01 Verify byte
+                                    /*
+                                     * Type = "01" VERIFY BYTE
+                                     *
+                                     * The contents of the Configuration Variable as indicated 
+                                     * by the 10-bit address are compared with the data byte 
+                                     * (DDDDDDDD). If the decoder successfully receives this 
+                                     * packet and the values are identical, the Digital 
+                                     * Decoder shall respond with the contents of the CV as 
+                                     * the Decoder Response Transmission, if enabled.
+                                    */
+                                    log.warn("CV # {}, Verify Byte: {}", cvnum, packetInt[4]);
+                                    log.warn("CV # {}, Write Byte: {}", cvnum, packetInt[4]);
+                                    return "Extended Accessory Decoder CV 'Verify': Address "
+                                            + addr +  " CV " + cvnum + ", check if it is " +
+                                            packetInt[4] + ".";
+                                case 0x08:
+                                    // GG=10 Bit manipulation
+                                    /*
+                                     * Type = "10" BIT MANIPULATION.
+                                     *
+                                     * The bit manipulation instructions use a special 
+                                     * format for the data byte (DDDDDDDD): 111FDBBB, where 
+                                     * BBB represents the bit position within the CV, 
+                                     * D contains the value of the bit to be verified 
+                                     * or written, and F describes whether the 
+                                     * operation is a verify bit or a write bit 
+                                     * operation.
+                                     * 
+                                     * F = "1" : WRITE BIT
+                                     * F = "0" : VERIFY BIT
+                                     * The VERIFY BIT and WRITE BIT instructions operate 
+                                     * in a manner similar to the VERIFY BYTE and WRITE 
+                                     * BYTE instructions (but operates on a single bit). 
+                                     * Using the same criteria as the VERIFY BYTE 
+                                     * instruction, an operations mode acknowledgment 
+                                     * will be generated in response to a VERIFY BIT 
+                                     * instruction if appropriate. Using the same 
+                                     * criteria as the WRITE BYTE instruction, a 
+                                     * configuration variable access acknowledgment 
+                                     * will be generated in response to the second 
+                                     * identical WRITE BIT instruction if appropriate.
+                                     */
+                                    log.warn("CV # {}, Bit Manipulation: {} {} (of bits 0-7) with {}", 
+                                            cvnum, (packetInt[4] & 0x10) == 0x10 ? "Write bit" : "Verify bit",
+                                            (packetInt[4] & 0x7),
+                                            (packetInt[4] >>4) & 0x1);
+                                    return "Extended Accessory Decoder CV Bit " +
+                                            ((packetInt[4] & 0x10) == 0x10 ? "Write bit" : "Verify bit") +
+                                            " Address CV # " + 
+                                            cvnum + 
+                                            ", " +
+                                            (packetInt[4] & 0x7) +
+                                            "(of bits 0-7) with " +
+                                            ((packetInt[4] >>4) & 0x1);
+                                case 0x0c:
+                                    // GG=11 Write byte
+                                    /*
+                                     * Type = "11" WRITE BYTE
+                                     *
+                                     * The contents of the Configuration Variable as indicated by the 10-bit
+                                     * address are replaced by the data byte (DDDDDDDD). Two identical 
+                                     * packets are needed before the decoder shall modify a 
+                                     * configuration variable. These two packets need not be back
+                                     * to back on the track. However any other packet to the same 
+                                     * decoder will invalidate the write operation. (This includes 
+                                     * broadcast packets.) If the decoder successfully receives 
+                                     * this second identical packet, it shall respond with a 
+                                     * configuration variable access acknowledgment.
+                                     */
+                                    log.warn("CV # {}, Write Byte: {}", cvnum, packetInt[4]);
+                                    return "Extended Accessory Decoder CV Write: Address "
+                                            + addr +  " CV " + cvnum + " with " + packetInt[4] + ".";
+                                case 0x0:
+                                default:
+                                    // GG=00 Reserved for future use
+                                    log.warn("CV # {}, Reserved (GG=0); {}", cvnum, packetInt[4]);    
+                                    break;
+                            }
+                            log.warn("***************");
+                        }
+                    }
                     return Bundle.getMessage("LN_MSG_OPC_IMM_PKT_GENERIC",
                             ((reps & 0x70) >> 4),
                             (reps & 0x07),
@@ -4151,6 +4318,8 @@ public class LocoNetMessageInterpret {
         return ""; // not an understood message.
     }
 
+    
+    
     private static String interpretOpcPr3Mode(LocoNetMessage l) {
         /*
          * Sets the operating mode of the PR3 device, if present.

--- a/java/src/jmri/jmrix/loconet/messageinterp/LocoNetMessageInterpret.java
+++ b/java/src/jmri/jmrix/loconet/messageinterp/LocoNetMessageInterpret.java
@@ -4192,9 +4192,8 @@ public class LocoNetMessageInterpret {
                                     */
                                     log.warn("CV # {}, Verify Byte: {}", cvnum, packetInt[4]);
                                     log.warn("CV # {}, Write Byte: {}", cvnum, packetInt[4]);
-                                    return "Extended Accessory Decoder CV 'Verify': Address "
-                                            + addr +  " CV " + cvnum + ", check if it is " +
-                                            packetInt[4] + ".\n";
+                                    return Bundle.getMessage("LN_MSG_EXTEND_ACCY_CV_VERIFY",
+                                            addr, cvnum, packetInt[4] );
                                 case 0x08:
                                     // GG=10 Bit manipulation
                                     /*
@@ -4251,8 +4250,8 @@ public class LocoNetMessageInterpret {
                                      * configuration variable access acknowledgment.
                                      */
                                     log.warn("CV # {}, Write Byte: {}", cvnum, packetInt[4]);
-                                    return "Extended Accessory Decoder CV Write: Address "
-                                            + addr +  " CV " + cvnum + " with " + packetInt[4] + ".\n";
+                                    return Bundle.getMessage("LN_MSG_EXTEND_ACCY_CV_WRITE",
+                                            addr, cvnum, packetInt[4] );
                                 case 0x0:
                                 default:
                                     // GG=00 Reserved for future use

--- a/java/src/jmri/jmrix/loconet/messageinterp/MessageInterpretation.properties
+++ b/java/src/jmri/jmrix/loconet/messageinterp/MessageInterpretation.properties
@@ -1553,3 +1553,6 @@ LN_MSG_OPC_EXP_SPECIALSTATUS_FLAGS = Rsync Max {0} USB Connected {1} Other Flags
 LN_MSG_ON  = On
 LN_MSG_OFF = Off
 LN_MSG_COMMAND_STATION = (CS)
+
+LN_MSG_EXTEND_ACCY_CV_WRITE = Extended Accessory Decoder CV Write: Address {0} CV {1} with {2}.\n
+LN_MSG_EXTEND_ACCY_CV_VERIFY  = Extended Accessory Decoder CV Verify: Address {0} CV {1}, check if it is {2}.\n

--- a/java/src/jmri/jmrix/loconet/messageinterp/MessageInterpretation.properties
+++ b/java/src/jmri/jmrix/loconet/messageinterp/MessageInterpretation.properties
@@ -1556,3 +1556,4 @@ LN_MSG_COMMAND_STATION = (CS)
 
 LN_MSG_EXTEND_ACCY_CV_WRITE = Extended Accessory Decoder CV Write: Address {0} CV {1} with {2}.\n
 LN_MSG_EXTEND_ACCY_CV_VERIFY  = Extended Accessory Decoder CV Verify: Address {0} CV {1}, check if it is {2}.\n
+LN_MSG_EXTEND_ACCY_CV_BIT_ACCESS  = Extended Accessory Decoder CV Bit {} bit, Address {}, CV {}, bit # {} (of bits 0-7) with value {}.\n

--- a/java/src/jmri/jmrix/loconet/messageinterp/MessageInterpretation.properties
+++ b/java/src/jmri/jmrix/loconet/messageinterp/MessageInterpretation.properties
@@ -1556,4 +1556,4 @@ LN_MSG_COMMAND_STATION = (CS)
 
 LN_MSG_EXTEND_ACCY_CV_WRITE = Extended Accessory Decoder CV Write: Address {0} CV {1} with {2}.\n
 LN_MSG_EXTEND_ACCY_CV_VERIFY  = Extended Accessory Decoder CV Verify: Address {0} CV {1}, check if it is {2}.\n
-LN_MSG_EXTEND_ACCY_CV_BIT_ACCESS  = Extended Accessory Decoder CV Bit {} bit, Address {}, CV {}, bit # {} (of bits 0-7) with value {}.\n
+LN_MSG_EXTEND_ACCY_CV_BIT_ACCESS  = Extended Accessory Decoder CV Bit {0} bit, Address {1}, CV {2}, bit # {3} (of bits 0-7) with value {4}.\n

--- a/java/test/jmri/jmrix/loconet/messageinterp/LocoNetMessageInterpretTest.java
+++ b/java/test/jmri/jmrix/loconet/messageinterp/LocoNetMessageInterpretTest.java
@@ -6723,9 +6723,92 @@ public class LocoNetMessageInterpretTest {
     @Test
     public void testLocoReset() {
         LocoNetMessage l = new LocoNetMessage(new int[] {0x8a, 0x75});
-        Assert.assertEquals("check LocoReset", "Loco Reset mechanism triggered.\n", LocoNetMessageInterpret.interpretMessage(l, "LT", "LS", "LR"));
+        Assert.assertEquals("check LocoReset", "Loco Reset mechanism triggered.\n", 
+                LocoNetMessageInterpret.interpretMessage(l, "LT", "LS", "LR"));
     }
 
+    @Test
+    public void testExpendedAccyReads() {
+        //[ED 0B 7F 54 07 00 78 64 0A 00 23]  Extended Accessory Decoder CV 'Verify': Address 1 CV 11, check if it is 0.
+        LocoNetMessage l = new LocoNetMessage(new int[] {0xED, 0x0B, 0x7F, 0x54, 
+            0x07, 0x00, 0x78, 0x64, 0x0A, 0x00, 0x23});
+        Assert.assertEquals("read 1 Ext Accy Addr 1 CV 11", ""
+                + "Extended Accessory Decoder CV 'Verify': Address 1 CV 11, check if it is 0.\n",
+                LocoNetMessageInterpret.interpretMessage(l, "LT", "LS", "LR"));
+
+        //[ED 0B 7F 54 07 00 78 64 0B 00 22]  Extended Accessory Decoder CV 'Verify': Address 1 CV 12, check if it is 0.
+        l = new LocoNetMessage(new int[] {0xED, 0x0B, 0x7F, 0x54, 
+            0x07, 0x00, 0x78, 0x64, 0x0b, 0x00, 0x22});
+        
+        Assert.assertEquals("read 2 Ext Accy Addr 1 CV 12", ""
+                + "Extended Accessory Decoder CV 'Verify': Address 1 CV 12, check if it is 0.\n",
+                LocoNetMessageInterpret.interpretMessage(l, "LT", "LS", "LR"));
+
+        // [ED 0B 7F 54 07 00 78 64 18 00 31] Extended Accessory Decoder CV 'Verify': Address 1 CV 25, check if it is 0.
+        l = new LocoNetMessage(new int[] {0xED, 0x0B, 0x7F, 0x54, 
+            0x07, 0x00, 0x78, 0x64, 0x18, 0x00, 0x31});
+        
+        Assert.assertEquals("read 3 Ext Accy Addr 1 CV 25", ""
+                + "Extended Accessory Decoder CV 'Verify': Address 1 CV 25, check if it is 0.\n",
+                LocoNetMessageInterpret.interpretMessage(l, "LT", "LS", "LR"));
+        
+        // [ED 0B 7F 54 07 00 7A 64 19 00 32] Extended Accessory Decoder CV 'Verify': Address 2 CV 26, check if it is 0.
+        l = new LocoNetMessage(new int[] {0xED, 0x0B, 0x7F, 0x54, 
+            0x07, 0x00, 0x7A, 0x64, 0x19, 0x00, 0x32});
+        
+        Assert.assertEquals("read 4 Ext Accy Addr 2 CV 26", ""
+                + "Extended Accessory Decoder CV 'Verify': Address 2 CV 26, check if it is 0.\n",
+                LocoNetMessageInterpret.interpretMessage(l, "LT", "LS", "LR"));
+        
+        // [ED 0B 7F 54 07 00 7A 64 1A 00 31] Extended Accessory Decoder CV 'Verify': Address 2 CV 27, check if it is 0.
+        l = new LocoNetMessage(new int[] {0xED, 0x0B, 0x7F, 0x54, 
+            0x07, 0x00, 0x7A, 0x64, 0x1A, 0x00, 0x31});
+        
+        Assert.assertEquals("read 5 Ext Accy Addr 2 CV 27", ""
+                + "Extended Accessory Decoder CV 'Verify': Address 2 CV 27, check if it is 0.\n",
+                LocoNetMessageInterpret.interpretMessage(l, "LT", "LS", "LR"));
+        
+        // [ED 0B 7F 54 07 01 7E 64 1B 00 35] Extended Accessory Decoder CV 'Verify': Address 8 CV 28, check if it is 0.
+        l = new LocoNetMessage(new int[] {0xED, 0x0B, 0x7F, 0x54, 
+            0x07, 0x01, 0x7E, 0x64, 0x1B, 0x00, 0x35});
+        
+        Assert.assertEquals("read 6 Ext Accy Addr 8 CV 28", ""
+                + "Extended Accessory Decoder CV 'Verify': Address 8 CV 28, check if it is 0.\n",
+                LocoNetMessageInterpret.interpretMessage(l, "LT", "LS", "LR"));
+    }
+    
+
+    @Test
+    public void testExpendedAccyWrites() {
+        // [ED 0B 7F 54 07 01 7E 6C 1B 7D 40]  Extended Accessory Decoder CV 'Write': Address 8 CV 28, write 125.
+        LocoNetMessage l = new LocoNetMessage(new int[] {0xED, 0x0B, 0x7F, 0x54, 
+            0x07, 0x01, 0x7E, 0x6C, 0x1B, 0x7D, 0x40});
+        Assert.assertEquals("write 1: Ext Accy Addr 8 CV 28 to 125", ""
+                + "Extended Accessory Decoder CV Write: Address 8 CV 28 with 125.\n",
+                LocoNetMessageInterpret.interpretMessage(l, "LT", "LS", "LR"));
+        
+        // [ED 0B 7F 54 07 01 7E 6C 18 0A 34] Extended Accessory Decoder CV 'Write': Address 7 CV 25, write 10.
+        l = new LocoNetMessage(new int[] {0xED, 0x0B, 0x7F, 0x54, 
+            0x07, 0x01, 0x7E, 0x6C, 0x18, 0x0A, 0x34});
+        Assert.assertEquals("write 2: Ext Accy Addr 8 CV 25 to 10", ""
+                + "Extended Accessory Decoder CV Write: Address 8 CV 25 with 10.\n",
+                LocoNetMessageInterpret.interpretMessage(l, "LT", "LS", "LR"));
+        
+        // [ED 0B 7F 54 07 01 7A 6C 1A 7D 45] Extended Accessory Decoder CV 'Write': Address 5 CV 27, write 125.
+        l = new LocoNetMessage(new int[] {0xED, 0x0B, 0x7F, 0x54, 
+            0x07, 0x01, 0x7A, 0x6C, 0x1A, 0x7D, 0x45});
+        Assert.assertEquals("write 3: Ext Accy Addr 5 CV 27 to 125", ""
+                + "Extended Accessory Decoder CV Write: Address 6 CV 27 with 125.\n",
+                LocoNetMessageInterpret.interpretMessage(l, "LT", "LS", "LR"));
+        
+        // [ED 0B 7F 54 07 00 78 6C 0B 00 2A] Extended Accessory Decoder CV 'Write': Address 1 CV 12, write 0.
+        l = new LocoNetMessage(new int[] {0xED, 0x0B, 0x7F, 0x54, 
+            0x07, 0x00, 0x78, 0x6C, 0x0B, 0x00, 0x45});
+        Assert.assertEquals("write 4: Ext Accy Addr 1 CV 12 to 0", ""
+                + "Extended Accessory Decoder CV Write: Address 1 CV 12 with 0.\n",
+                LocoNetMessageInterpret.interpretMessage(l, "LT", "LS", "LR"));
+        
+    }    
     @BeforeEach
     public void setUp() {
         JUnitUtil.setUp();

--- a/java/test/jmri/jmrix/loconet/messageinterp/LocoNetMessageInterpretTest.java
+++ b/java/test/jmri/jmrix/loconet/messageinterp/LocoNetMessageInterpretTest.java
@@ -6937,40 +6937,41 @@ public class LocoNetMessageInterpretTest {
             0x07, 0x00, 0x78, 0x68, 0x0B, 0x0f, 0x00} );
         Assert.assertEquals("verify 17: Ext Accy Addr 1 CV 12 bit 7 verify as 1",
                 "Send packet immediate: 5 bytes, repeat count 4(84)\n" +
-                "	DHI=0x07, IM1=0x00, IM2=0x78, IM3=0x68, IM4=0x0B, IM5=0x0F\n" +
-                "	packet: 80 F8 E8 0B 0F .\n",
+                "\tDHI=0x07, IM1=0x00, IM2=0x78, IM3=0x68, IM4=0x0B, IM5=0x0F\n" +
+                "\tpacket: 80 F8 E8 0B 0F .\n",
                 LocoNetMessageInterpret.interpretMessage(m, "LT", "LS", "LR"));
 
         m = new LocoNetMessage(new int[] {0xED, 0x0B, 0x7F, 0x54, 
             0x07, 0x00, 0x78, 0x68, 0x0B, 0x37, 0x00} );
         Assert.assertEquals("write 18: Ext Accy Addr 1 CV 12 bit 7 verify as 0",
                "Send packet immediate: 5 bytes, repeat count 4(84)\n" +
-                "	DHI=0x07, IM1=0x00, IM2=0x78, IM3=0x68, IM4=0x0B, IM5=0x37\n" +
-                "	packet: 80 F8 E8 0B 37 .\n",
+                "\tDHI=0x07, IM1=0x00, IM2=0x78, IM3=0x68, IM4=0x0B, IM5=0x37\n" +
+                "\tpacket: 80 F8 E8 0B 37 .\n",
                 LocoNetMessageInterpret.interpretMessage(m, "LT", "LS", "LR"));
         
         m = new LocoNetMessage(new int[] {0xED, 0x0B, 0x7F, 0x54, 
             0x07, 0x00, 0x78, 0x68, 0x0B, 0x4f, 0x00} );
         Assert.assertEquals("verify 19: Ext Accy Addr 1 CV 12 bit 7 verify as 1",
                "Send packet immediate: 5 bytes, repeat count 4(84)\n" +
-                "	DHI=0x07, IM1=0x00, IM2=0x78, IM3=0x68, IM4=0x0B, IM5=0x4F\n" +
-                "	packet: 80 F8 E8 0B 4F .\n",
+                "\tDHI=0x07, IM1=0x00, IM2=0x78, IM3=0x68, IM4=0x0B, IM5=0x4F\n" +
+                "\tpacket: 80 F8 E8 0B 4F .\n",
                 LocoNetMessageInterpret.interpretMessage(m, "LT", "LS", "LR"));
 
         m = new LocoNetMessage(new int[] {0xED, 0x0B, 0x7F, 0x54, 
             0x07, 0x00, 0x78, 0x68, 0x0B, 0x57, 0x00} );
         Assert.assertEquals("write 20: Ext Accy Addr 1 CV 12 bit 7 verify as 0",
                "Send packet immediate: 5 bytes, repeat count 4(84)\n" +
-                "	DHI=0x07, IM1=0x00, IM2=0x78, IM3=0x68, IM4=0x0B, IM5=0x57\n" +
-                "	packet: 80 F8 E8 0B 57 .\n",
+                "\tDHI=0x07, IM1=0x00, IM2=0x78, IM3=0x68, IM4=0x0B, IM5=0x57\n" +
+                "\tpacket: 80 F8 E8 0B 57 .\n",
                 LocoNetMessageInterpret.interpretMessage(m, "LT", "LS", "LR"));
-        
+
+
         m = new LocoNetMessage(new int[] {0xED, 0x0B, 0x7F, 0x54, 
             0x07, 0x00, 0x78, 0x68, 0x0B, 0x6f, 0x00} );
         Assert.assertEquals("verify 21: Ext Accy Addr 1 CV 12 bit 7 verify as 1",
                "Send packet immediate: 5 bytes, repeat count 4(84)\n" +
-                "	DHI=0x07, IM1=0x00, IM2=0x78, IM3=0x68, IM4=0x0B, IM5=0x6F\n" +
-                "	packet: 80 F8 E8 0B 6F .\n",
+                "\tDHI=0x07, IM1=0x00, IM2=0x78, IM3=0x68, IM4=0x0B, IM5=0x6F\n" +
+                "\tpacket: 80 F8 E8 0B 6F .\n",
                 LocoNetMessageInterpret.interpretMessage(m, "LT", "LS", "LR"));
 
     }

--- a/java/test/jmri/jmrix/loconet/messageinterp/LocoNetMessageInterpretTest.java
+++ b/java/test/jmri/jmrix/loconet/messageinterp/LocoNetMessageInterpretTest.java
@@ -6807,8 +6807,174 @@ public class LocoNetMessageInterpretTest {
         Assert.assertEquals("write 4: Ext Accy Addr 1 CV 12 to 0", ""
                 + "Extended Accessory Decoder CV Write: Address 1 CV 12 with 0.\n",
                 LocoNetMessageInterpret.interpretMessage(l, "LT", "LS", "LR"));
-        
     }    
+    
+    @Test
+    public void testExpendedAccyBitReadsQQQQ() {
+        // GG=10 Bit manipulation
+        /*
+         * Type = "10" BIT MANIPULATION.
+         *
+         * The bit manipulation instructions use a special 
+         * format for the data byte (DDDDDDDD): 111FDBBB, where 
+         * BBB represents the bit position within the CV, 
+         * D contains the value of the bit to be verified 
+         * or written, and F describes whether the 
+         * operation is a verify bit or a write bit 
+         * operation.
+         * 
+         * F = "1" : WRITE BIT
+         * F = "0" : VERIFY BIT
+         * The VERIFY BIT and WRITE BIT instructions operate 
+         * in a manner similar to the VERIFY BYTE and WRITE 
+         * BYTE instructions (but operates on a single bit). 
+         * Using the same criteria as the VERIFY BYTE 
+         * instruction, an operations mode acknowledgment 
+         * will be generated in response to a VERIFY BIT 
+         * instruction if appropriate. Using the same 
+         * criteria as the WRITE BYTE instruction, a 
+         * configuration variable access acknowledgment 
+         * will be generated in response to the second 
+         * identical WRITE BIT instruction if appropriate.
+         */
+        LocoNetMessage m = new LocoNetMessage(new int[] {0xED, 0x0B, 0x7F, 0x54, 
+            0x07, 0x00, 0x78, 0x68, 0x0B, 0xe1, 0x00} );
+        Assert.assertEquals("Verify 1: Ext Accy Addr 1 CV 12 bit 1 verify as 0",
+                "Extended Accessory Decoder CV Bit Verify bit, Address 1, CV 12, bit # 1 (of bits 0-7) with value 0.\n",
+                LocoNetMessageInterpret.interpretMessage(m, "LT", "LS", "LR"));
+
+        m = new LocoNetMessage(new int[] {0xED, 0x0B, 0x7F, 0x54, 
+            0x07, 0x00, 0x78, 0x68, 0x0B, 0xF9, 0x00} );
+        Assert.assertEquals("write 2: Ext Accy Addr 1 CV 12 bit 1 verify as 1",
+                "Extended Accessory Decoder CV Bit Write bit, Address 1, CV 12, bit # 1 (of bits 0-7) with value 1.\n",
+                LocoNetMessageInterpret.interpretMessage(m, "LT", "LS", "LR"));
+        
+        m = new LocoNetMessage(new int[] {0xED, 0x0B, 0x7F, 0x54, 
+            0x07, 0x00, 0x78, 0x68, 0x0B, 0xE0, 0x00} );
+        Assert.assertEquals("verify 3: Ext Accy Addr 1 CV 12 bit 0 verify as 0",
+                "Extended Accessory Decoder CV Bit Verify bit, Address 1, CV 12, bit # 0 (of bits 0-7) with value 0.\n",
+                LocoNetMessageInterpret.interpretMessage(m, "LT", "LS", "LR"));
+
+        m = new LocoNetMessage(new int[] {0xED, 0x0B, 0x7F, 0x54, 
+            0x07, 0x00, 0x78, 0x68, 0x0B, 0xF8, 0x00} );
+        Assert.assertEquals("write 4: Ext Accy Addr 1 CV 12 bit 0 verify as 1",
+                "Extended Accessory Decoder CV Bit Write bit, Address 1, CV 12, bit # 0 (of bits 0-7) with value 1.\n",
+                LocoNetMessageInterpret.interpretMessage(m, "LT", "LS", "LR"));
+        
+        m = new LocoNetMessage(new int[] {0xED, 0x0B, 0x7F, 0x54, 
+            0x07, 0x00, 0x78, 0x68, 0x0B, 0xE2, 0x00} );
+        Assert.assertEquals("verify 5: Ext Accy Addr 1 CV 12 bit 2 verify as 0",
+                "Extended Accessory Decoder CV Bit Verify bit, Address 1, CV 12, bit # 2 (of bits 0-7) with value 0.\n",
+                LocoNetMessageInterpret.interpretMessage(m, "LT", "LS", "LR"));
+
+        m = new LocoNetMessage(new int[] {0xED, 0x0B, 0x7F, 0x54, 
+            0x07, 0x00, 0x78, 0x68, 0x0B, 0xFA, 0x00} );
+        Assert.assertEquals("write 6: Ext Accy Addr 1 CV 12 bit 2 verify as 1",
+                "Extended Accessory Decoder CV Bit Write bit, Address 1, CV 12, bit # 2 (of bits 0-7) with value 1.\n",
+                LocoNetMessageInterpret.interpretMessage(m, "LT", "LS", "LR"));
+
+        m = new LocoNetMessage(new int[] {0xED, 0x0B, 0x7F, 0x54, 
+            0x07, 0x00, 0x78, 0x68, 0x0B, 0xeb, 0x00} );
+        Assert.assertEquals("verify 7: Ext Accy Addr 1 CV 12 bit 3 verify as 1",
+                "Extended Accessory Decoder CV Bit Verify bit, Address 1, CV 12, bit # 3 (of bits 0-7) with value 1.\n",
+                LocoNetMessageInterpret.interpretMessage(m, "LT", "LS", "LR"));
+
+        m = new LocoNetMessage(new int[] {0xED, 0x0B, 0x7F, 0x54, 
+            0x07, 0x00, 0x78, 0x68, 0x0B, 0xf3, 0x00} );
+        Assert.assertEquals("write 8: Ext Accy Addr 1 CV 12 bit 3 verify as 0",
+                "Extended Accessory Decoder CV Bit Write bit, Address 1, CV 12, bit # 3 (of bits 0-7) with value 0.\n",
+                LocoNetMessageInterpret.interpretMessage(m, "LT", "LS", "LR"));
+        
+        m = new LocoNetMessage(new int[] {0xED, 0x0B, 0x7F, 0x54, 
+            0x07, 0x00, 0x78, 0x68, 0x0B, 0xe4, 0x00} );
+        Assert.assertEquals("verify 9: Ext Accy Addr 1 CV 12 bit 4 verify as 0",
+                "Extended Accessory Decoder CV Bit Verify bit, Address 1, CV 12, bit # 4 (of bits 0-7) with value 0.\n",
+                LocoNetMessageInterpret.interpretMessage(m, "LT", "LS", "LR"));
+
+        m = new LocoNetMessage(new int[] {0xED, 0x0B, 0x7F, 0x54, 
+            0x07, 0x00, 0x78, 0x68, 0x0B, 0xf4, 0x00} );
+        Assert.assertEquals("write 10: Ext Accy Addr 1 CV 12 bit 4 verify as 0",
+                "Extended Accessory Decoder CV Bit Write bit, Address 1, CV 12, bit # 4 (of bits 0-7) with value 0.\n",
+                LocoNetMessageInterpret.interpretMessage(m, "LT", "LS", "LR"));
+
+        m = new LocoNetMessage(new int[] {0xED, 0x0B, 0x7F, 0x54, 
+            0x07, 0x00, 0x78, 0x68, 0x0B, 0xed, 0x00} );
+        Assert.assertEquals("verify 11: Ext Accy Addr 1 CV 12 bit 5 verify as 1",
+                "Extended Accessory Decoder CV Bit Verify bit, Address 1, CV 12, bit # 5 (of bits 0-7) with value 1.\n",
+                LocoNetMessageInterpret.interpretMessage(m, "LT", "LS", "LR"));
+
+        m = new LocoNetMessage(new int[] {0xED, 0x0B, 0x7F, 0x54, 
+            0x07, 0x00, 0x78, 0x68, 0x0B, 0xfd, 0x00} );
+        Assert.assertEquals("write 10: Ext Accy Addr 1 CV 12 bit 5 verify as 1",
+                "Extended Accessory Decoder CV Bit Write bit, Address 1, CV 12, bit # 5 (of bits 0-7) with value 1.\n",
+                LocoNetMessageInterpret.interpretMessage(m, "LT", "LS", "LR"));
+        
+        m = new LocoNetMessage(new int[] {0xED, 0x0B, 0x7F, 0x54, 
+            0x07, 0x00, 0x78, 0x68, 0x0B, 0xe6, 0x00} );
+        Assert.assertEquals("verify 13: Ext Accy Addr 1 CV 12 bit 6 verify as 0",
+                "Extended Accessory Decoder CV Bit Verify bit, Address 1, CV 12, bit # 6 (of bits 0-7) with value 0.\n",
+                LocoNetMessageInterpret.interpretMessage(m, "LT", "LS", "LR"));
+
+        m = new LocoNetMessage(new int[] {0xED, 0x0B, 0x7F, 0x54, 
+            0x07, 0x00, 0x78, 0x68, 0x0B, 0xfe, 0x00} );
+        Assert.assertEquals("write 14: Ext Accy Addr 1 CV 12 bit 6 verify as 1",
+                "Extended Accessory Decoder CV Bit Write bit, Address 1, CV 12, bit # 6 (of bits 0-7) with value 1.\n",
+                LocoNetMessageInterpret.interpretMessage(m, "LT", "LS", "LR"));
+        
+        m = new LocoNetMessage(new int[] {0xED, 0x0B, 0x7F, 0x54, 
+            0x07, 0x00, 0x78, 0x68, 0x0B, 0xef, 0x00} );
+        Assert.assertEquals("verify 15: Ext Accy Addr 1 CV 12 bit 7 verify as 1",
+                "Extended Accessory Decoder CV Bit Verify bit, Address 1, CV 12, bit # 7 (of bits 0-7) with value 1.\n",
+                LocoNetMessageInterpret.interpretMessage(m, "LT", "LS", "LR"));
+
+        m = new LocoNetMessage(new int[] {0xED, 0x0B, 0x7F, 0x54, 
+            0x07, 0x00, 0x78, 0x68, 0x0B, 0xf7, 0x00} );
+        Assert.assertEquals("write 16: Ext Accy Addr 1 CV 12 bit 7 verify as 0",
+                "Extended Accessory Decoder CV Bit Write bit, Address 1, CV 12, bit # 7 (of bits 0-7) with value 0.\n",
+                LocoNetMessageInterpret.interpretMessage(m, "LT", "LS", "LR"));
+        
+        m = new LocoNetMessage(new int[] {0xED, 0x0B, 0x7F, 0x54, 
+            0x07, 0x00, 0x78, 0x68, 0x0B, 0x0f, 0x00} );
+        Assert.assertEquals("verify 17: Ext Accy Addr 1 CV 12 bit 7 verify as 1",
+                "Send packet immediate: 5 bytes, repeat count 4(84)\n" +
+                "	DHI=0x07, IM1=0x00, IM2=0x78, IM3=0x68, IM4=0x0B, IM5=0x0F\n" +
+                "	packet: 80 F8 E8 0B 0F .\n",
+                LocoNetMessageInterpret.interpretMessage(m, "LT", "LS", "LR"));
+
+        m = new LocoNetMessage(new int[] {0xED, 0x0B, 0x7F, 0x54, 
+            0x07, 0x00, 0x78, 0x68, 0x0B, 0x37, 0x00} );
+        Assert.assertEquals("write 18: Ext Accy Addr 1 CV 12 bit 7 verify as 0",
+               "Send packet immediate: 5 bytes, repeat count 4(84)\n" +
+                "	DHI=0x07, IM1=0x00, IM2=0x78, IM3=0x68, IM4=0x0B, IM5=0x37\n" +
+                "	packet: 80 F8 E8 0B 37 .\n",
+                LocoNetMessageInterpret.interpretMessage(m, "LT", "LS", "LR"));
+        
+        m = new LocoNetMessage(new int[] {0xED, 0x0B, 0x7F, 0x54, 
+            0x07, 0x00, 0x78, 0x68, 0x0B, 0x4f, 0x00} );
+        Assert.assertEquals("verify 19: Ext Accy Addr 1 CV 12 bit 7 verify as 1",
+               "Send packet immediate: 5 bytes, repeat count 4(84)\n" +
+                "	DHI=0x07, IM1=0x00, IM2=0x78, IM3=0x68, IM4=0x0B, IM5=0x4F\n" +
+                "	packet: 80 F8 E8 0B 4F .\n",
+                LocoNetMessageInterpret.interpretMessage(m, "LT", "LS", "LR"));
+
+        m = new LocoNetMessage(new int[] {0xED, 0x0B, 0x7F, 0x54, 
+            0x07, 0x00, 0x78, 0x68, 0x0B, 0x57, 0x00} );
+        Assert.assertEquals("write 20: Ext Accy Addr 1 CV 12 bit 7 verify as 0",
+               "Send packet immediate: 5 bytes, repeat count 4(84)\n" +
+                "	DHI=0x07, IM1=0x00, IM2=0x78, IM3=0x68, IM4=0x0B, IM5=0x57\n" +
+                "	packet: 80 F8 E8 0B 57 .\n",
+                LocoNetMessageInterpret.interpretMessage(m, "LT", "LS", "LR"));
+        
+        m = new LocoNetMessage(new int[] {0xED, 0x0B, 0x7F, 0x54, 
+            0x07, 0x00, 0x78, 0x68, 0x0B, 0x6f, 0x00} );
+        Assert.assertEquals("verify 21: Ext Accy Addr 1 CV 12 bit 7 verify as 1",
+               "Send packet immediate: 5 bytes, repeat count 4(84)\n" +
+                "	DHI=0x07, IM1=0x00, IM2=0x78, IM3=0x68, IM4=0x0B, IM5=0x6F\n" +
+                "	packet: 80 F8 E8 0B 6F .\n",
+                LocoNetMessageInterpret.interpretMessage(m, "LT", "LS", "LR"));
+
+    }
+
     @BeforeEach
     public void setUp() {
         JUnitUtil.setUp();

--- a/java/test/jmri/jmrix/loconet/messageinterp/LocoNetMessageInterpretTest.java
+++ b/java/test/jmri/jmrix/loconet/messageinterp/LocoNetMessageInterpretTest.java
@@ -6733,7 +6733,7 @@ public class LocoNetMessageInterpretTest {
         LocoNetMessage l = new LocoNetMessage(new int[] {0xED, 0x0B, 0x7F, 0x54, 
             0x07, 0x00, 0x78, 0x64, 0x0A, 0x00, 0x23});
         Assert.assertEquals("read 1 Ext Accy Addr 1 CV 11", ""
-                + "Extended Accessory Decoder CV 'Verify': Address 1 CV 11, check if it is 0.\n",
+                + "Extended Accessory Decoder CV Verify: Address 1 CV 11, check if it is 0.\n",
                 LocoNetMessageInterpret.interpretMessage(l, "LT", "LS", "LR"));
 
         //[ED 0B 7F 54 07 00 78 64 0B 00 22]  Extended Accessory Decoder CV 'Verify': Address 1 CV 12, check if it is 0.
@@ -6741,7 +6741,7 @@ public class LocoNetMessageInterpretTest {
             0x07, 0x00, 0x78, 0x64, 0x0b, 0x00, 0x22});
         
         Assert.assertEquals("read 2 Ext Accy Addr 1 CV 12", ""
-                + "Extended Accessory Decoder CV 'Verify': Address 1 CV 12, check if it is 0.\n",
+                + "Extended Accessory Decoder CV Verify: Address 1 CV 12, check if it is 0.\n",
                 LocoNetMessageInterpret.interpretMessage(l, "LT", "LS", "LR"));
 
         // [ED 0B 7F 54 07 00 78 64 18 00 31] Extended Accessory Decoder CV 'Verify': Address 1 CV 25, check if it is 0.
@@ -6749,7 +6749,7 @@ public class LocoNetMessageInterpretTest {
             0x07, 0x00, 0x78, 0x64, 0x18, 0x00, 0x31});
         
         Assert.assertEquals("read 3 Ext Accy Addr 1 CV 25", ""
-                + "Extended Accessory Decoder CV 'Verify': Address 1 CV 25, check if it is 0.\n",
+                + "Extended Accessory Decoder CV Verify: Address 1 CV 25, check if it is 0.\n",
                 LocoNetMessageInterpret.interpretMessage(l, "LT", "LS", "LR"));
         
         // [ED 0B 7F 54 07 00 7A 64 19 00 32] Extended Accessory Decoder CV 'Verify': Address 2 CV 26, check if it is 0.
@@ -6757,7 +6757,7 @@ public class LocoNetMessageInterpretTest {
             0x07, 0x00, 0x7A, 0x64, 0x19, 0x00, 0x32});
         
         Assert.assertEquals("read 4 Ext Accy Addr 2 CV 26", ""
-                + "Extended Accessory Decoder CV 'Verify': Address 2 CV 26, check if it is 0.\n",
+                + "Extended Accessory Decoder CV Verify: Address 2 CV 26, check if it is 0.\n",
                 LocoNetMessageInterpret.interpretMessage(l, "LT", "LS", "LR"));
         
         // [ED 0B 7F 54 07 00 7A 64 1A 00 31] Extended Accessory Decoder CV 'Verify': Address 2 CV 27, check if it is 0.
@@ -6765,7 +6765,7 @@ public class LocoNetMessageInterpretTest {
             0x07, 0x00, 0x7A, 0x64, 0x1A, 0x00, 0x31});
         
         Assert.assertEquals("read 5 Ext Accy Addr 2 CV 27", ""
-                + "Extended Accessory Decoder CV 'Verify': Address 2 CV 27, check if it is 0.\n",
+                + "Extended Accessory Decoder CV Verify: Address 2 CV 27, check if it is 0.\n",
                 LocoNetMessageInterpret.interpretMessage(l, "LT", "LS", "LR"));
         
         // [ED 0B 7F 54 07 01 7E 64 1B 00 35] Extended Accessory Decoder CV 'Verify': Address 8 CV 28, check if it is 0.
@@ -6773,7 +6773,7 @@ public class LocoNetMessageInterpretTest {
             0x07, 0x01, 0x7E, 0x64, 0x1B, 0x00, 0x35});
         
         Assert.assertEquals("read 6 Ext Accy Addr 8 CV 28", ""
-                + "Extended Accessory Decoder CV 'Verify': Address 8 CV 28, check if it is 0.\n",
+                + "Extended Accessory Decoder CV Verify: Address 8 CV 28, check if it is 0.\n",
                 LocoNetMessageInterpret.interpretMessage(l, "LT", "LS", "LR"));
     }
     


### PR DESCRIPTION
Adds Extended Accy "long form" CV write and "verify", as needed for Digitrax "Seventh-generation" accessory devices. 