### PR TITLE
YAAT: Add random wait times to the Wait for n seconds command

### DIFF
--- a/help/en/html/scripthelp/yaat/YAAT.shtml
+++ b/help/en/html/scripthelp/yaat/YAAT.shtml
@@ -215,9 +215,9 @@
 
         <dt>Set direction to &lt;forward | reverse&gt;</dt>
 
-        <dt>Set function key &lt;0 to 28&gt; &lt;on | off&gt;[, wait &lt;n&gt; seconds]</dt>
+        <dt>Set function key &lt;0 to 68&gt; &lt;on | off&gt;[, wait &lt;n&gt; seconds]</dt>
 
-        <dd>Set the function key on or off. The number can be from 0 to 28. If seconds is greater
+        <dd>Set the function key on or off. The number can be from 0 to 68. If seconds is greater
         than zero, the opposite action will be performed after the number of seconds has
         passed.</dd>
 
@@ -262,9 +262,12 @@
         sequence of actions again. If the Stop action is missing, the script will run forever,
         until the script thread is killed, or JMRI is stopped.</dd>
 
-        <dt>Wait for &lt;n&gt; seconds</dt>
+        <dt>Wait for &lt;n&gt; [to &lt;n&gt;] seconds</dt>
 
         <dd>Wait until the time has expired. Normally used for station stops.</dd>
+
+        <dd>The optional second number is used to provide a random wait time between the two
+        values.<span class="since">since YAAT 3.1</span></dd>
 
         <dt>Wait for block &lt;block name&gt; to become &lt;occupied | unoccupied | reserved |
         free&gt;</dt>

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -498,7 +498,8 @@
     <h3>Scripting</h3>
         <a id="Scripting" name="Scripting"></a>
         <ul>
-            <li></li>
+            <li>YAAT: Change function number limit from 28 to 68.</li>
+            <li>YAAT: Add a random delay time: <strong>Wait for &lt;n&gt; [to &lt;n&gt;] seconds</strong></li>
         </ul>
 
     <h3>Signals</h3>


### PR DESCRIPTION
- Change the "wait for" command to support random wait times:  `Wait for <n> [to <n>] seconds`
- Change the limit for function key numbers from 28 to 68.