### PR TITLE
Clean up decoder identify process

### DIFF
--- a/java/src/jmri/jmrit/decoderdefn/IdentifyDecoder.java
+++ b/java/src/jmri/jmrit/decoderdefn/IdentifyDecoder.java
@@ -14,10 +14,15 @@ import org.slf4j.LoggerFactory;
  * <p>
  * Contains manufacturer-specific code to generate a 3rd "productID" identifier,
  * in addition to the manufacturer ID and model ID:<ul>
- * <li>QSI: (mfgID == 113) write {@literal 254=>CV49}, write {@literal 4=>CV50},
- * then CV56 is high byte, write {@literal 5=>CV50}, then CV56 is low byte of
- * ID</li>
- * <li>Harman: (mfgID = 98) CV112 is high byte, CV113 is low byte of ID</li>
+ * <li>Dietz (mfgID == 115) CV128 is ID</li>
+ * <li>DIY: (mfgID == 13) CV47 is the highest byte, CV48 is high byte, CV49 is
+ *  low byte, CV50 is the lowest byte; (CV47 == 1) is reserved for the Czech
+ *  Republic</li>
+ * <li>Doehler &amp; Haass: (mfgID == 97) CV261 is ID from 2020 firmwares</li>
+ * <li>ESU: (mfgID == 151, modelID == 255) use RailCom&reg; Product ID CVs;
+ *  write {@literal 0=>CV31}, write {@literal 255=>CV32}, then CVs 261 (lowest)
+ *  to 264 (highest) are a four byte ID</li>
+ * <li>Harman: (mfgID == 98) CV112 is high byte, CV113 is low byte of ID</li>
  * <li>Hornby: (mfgID == 48) <ul>
  *     <li>If CV7 = 254, this is a HN7000 series decoder. The ID is in 
  *         CV47(MSB), CV48, CV49 (LSB)
@@ -27,22 +32,17 @@ import org.slf4j.LoggerFactory;
  *         {@link #setOptionalCv(boolean flag) setOptionalCv()} and
  *         {@link #isOptionalCv() isOptionalCv()} as documented below.)</li>
  *      </ul>
- * <li>TCS: (mfgID == 153) CV249 is physical hardware id, V5 and above use
- * CV248, CV110 and CV111 to identify specific sound sets and
- * features. New productID process triggers if (CV249 &gt; 128).</li>
- * <li>Zimo: (mfgID == 145) CV250 is ID</li>
+ * <li>QSI: (mfgID == 113) write {@literal 254=>CV49}, write {@literal 4=>CV50},
+ *  then CV56 is high byte, write {@literal 5=>CV50}, then CV56 is low byte of
+ *  ID</li>
  * <li>SoundTraxx: (mfgID == 141, modelID == 70, 71 or 72) CV253 is high byte, CV256
- * is low byte of ID</li>
- * <li>ESU: (mfgID == 151, modelID == 255) use RailCom&reg; Product ID CVs;
- * write {@literal 0=>CV31}, write {@literal 255=>CV32}, then CVs 261 (lowest)
- * to 264 (highest) are a four byte ID</li>
- * <li>DIY: (mfgID == 13) CV47 is the highest byte, CV48 is high byte, CV49 is
- * low byte, CV50 is the lowest byte; (CV47 == 1) is reserved for the Czech
- * Republic</li>
- * <li>Doehler &amp; Haass: (mfgID == 97) CV261 is ID from 2020 firmwares</li>
- * <li>Dietz (mfgID == 115) CV128 is ID</li>
+ *  is low byte of ID</li>
+ * <li>TCS: (mfgID == 153) CV249 is physical hardware id, V5 and above use
+ *  CV248, CV110 and CV111 to identify specific sound sets and
+ *  features. New productID process triggers if (CV249 &gt; 128).</li>
  * <li>Train-O-Matic: (mfgID == 78) CV508 lowest byte,
- * CV509 low byte and CV510 high byte</li>
+ *  CV509 low byte and CV510 high byte</li>
+ * <li>Zimo: (mfgID == 145) CV250 is ID</li>
  * </ul>
  * <dl>
  * <dt>Optional CVs:</dt>
@@ -84,13 +84,47 @@ public abstract class IdentifyDecoder extends jmri.jmrit.AbstractIdentify {
         super(programmer);
     }
 
-    int mfgID = -1;  // cv8
+    Manufacturer mfgID = null;  // cv8
+    int intMfg = -1;  // needed to hold mfg number in cases that don't match enum
     int modelID = -1; // cv7
     int productIDhigh = -1;
     int productIDlow = -1;
     int productIDhighest = -1;
     int productIDlowest = -1;
     int productID = -1;
+    
+    /**
+     * Represents specific CV8 values.  We don't do
+     * product ID for anything not defined here.
+    */
+    enum Manufacturer {
+        DIETZ(115),
+        DIY(13),
+        DOEHLER(97),
+        ESU(151),
+        HARMAN(98),
+        HORNBY(48),
+        QSI(113),
+        SOUNDTRAXX(141),
+        TCS(153),
+        TRAINOMATIC(78),
+        ZIMO(145);
+
+        public int value;
+
+        private Manufacturer(int value) {
+            this.value = value;
+        }
+        
+        public static Manufacturer forValue(int value) {
+            for (var e : values()) {
+                if (e.value == value) {
+                    return e;
+                }
+            }
+            return null;
+        }
+    }
 
     // steps of the identification state machine
     @Override
@@ -103,7 +137,8 @@ public abstract class IdentifyDecoder extends jmri.jmrit.AbstractIdentify {
 
     @Override
     public boolean test2(int value) {
-        mfgID = value;
+        mfgID = Manufacturer.forValue(value);
+        intMfg = value;
         statusUpdate("Read MFG version - CV 7");
         readCV("7");
         return false;
@@ -112,15 +147,17 @@ public abstract class IdentifyDecoder extends jmri.jmrit.AbstractIdentify {
     @Override
     public boolean test3(int value) {
         modelID = value;
-        if (mfgID == 113) {  // QSI
+        if (mfgID == null) return true; // done
+        switch (mfgID) {
+        case QSI:
             statusUpdate("Set PI for Read Product ID High Byte");
             writeCV("49", 254);
             return false;
-        } else if (mfgID == 153) {  // TCS
+        case TCS:
             statusUpdate("Read decoder ID CV 249");
             readCV("249");
             return false;
-        } else if (mfgID == 48) {  // Hornby
+        case HORNBY:
             if (modelID == 254) { // HN7000
                 statusUpdate("Read decoder ID CV 47");
                 readCV("47");
@@ -131,50 +168,56 @@ public abstract class IdentifyDecoder extends jmri.jmrit.AbstractIdentify {
                 readCV("159");
                 return false;
             }
-        } else if (mfgID == 145) {  // Zimo
+        case ZIMO:
             statusUpdate("Read decoder ID CV 250");
             readCV("250");
             return false;
-        } else if (mfgID == 141 && (modelID >= 70 && modelID <= 72)) {  // SoundTraxx Econami, Tsunami2 and Blunami
-            statusUpdate("Read productID high CV253");
-            readCV("253");
-            return false;
-        } else if (mfgID == 98) {  // Harman
+        case SOUNDTRAXX:
+            if (modelID >= 70 && modelID <= 72) {  // SoundTraxx Econami, Tsunami2 and Blunami
+                statusUpdate("Read productID high CV253");
+                readCV("253");
+                return false;
+            } else return true;
+        case HARMAN:
             statusUpdate("Read decoder ID high CV 112");
             readCV("112");
             return false;
-        } else if (mfgID == 151 && modelID == 255) {  // ESU recent
-            statusUpdate("Set PI for Read productID");
-            writeCV("31", 0);
-            return false;
-        } else if (mfgID == 13) {  // DIY
+        case ESU:
+            if (modelID == 255) {  // ESU recent
+                statusUpdate("Set PI for Read productID");
+                writeCV("31", 0);
+                return false;
+            } else return true;
+        case DIY:
             statusUpdate("Read decoder product ID #1 CV 47");
             readCV("47");
             return false;
-        } else if (mfgID == 97) {  // Doehler and Haass
+        case DOEHLER:
             statusUpdate("Read optional decoder ID CV 261");
             setOptionalCv(true);
             readCV("261");
             return false;
-        } else if (mfgID == 78) {  // Train-O-Matic
+        case TRAINOMATIC:
             statusUpdate("Read productID #1 CV 510");
             readCV("510");
             return false;
-        } else if (mfgID == 115) {  // Dietz
+        case DIETZ:
             statusUpdate("Read productID CV 128");
             readCV("128");
             return false;
+        default:
+            return true;
         }
-        return true;
     }
 
     @Override
     public boolean test4(int value) {
-        if (mfgID == 113) {  // QSI
+        switch (mfgID) {
+        case QSI:
             statusUpdate("Set SI for Read Product ID High Byte");
             writeCV("50", 4);
             return false;
-        } else if (mfgID == 153) {  // TCS
+        case TCS:
             if(value < 129){ //check for mobile decoders
                 productID = value;
                 return true;
@@ -185,7 +228,7 @@ public abstract class IdentifyDecoder extends jmri.jmrit.AbstractIdentify {
                 readCV("248");
                 return false;
             }
-        } else if (mfgID == 48) {  // Hornby
+        case HORNBY:
             if (modelID == 254) { // HN7000
                 productIDhighest = value;
                 statusUpdate("Read decoder ID CV 48");
@@ -205,54 +248,58 @@ public abstract class IdentifyDecoder extends jmri.jmrit.AbstractIdentify {
                     return true;
                 }
             }
-        } else if (mfgID == 145) {  // Zimo
+        case ZIMO:
             productID = value;
             return true;
-        } else if (mfgID == 141 && (modelID >= 70 && modelID <= 72)) {  // SoundTraxx Econami, Tsunami2 and Blunami
-            productIDhigh = value;
-            statusUpdate("Read decoder productID low CV256");
-            readCV("256");
-            return false;
-        } else if (mfgID == 98) {  // Harman
+        case SOUNDTRAXX:
+            if (modelID >= 70 && modelID <= 72) {  // SoundTraxx Econami, Tsunami2 and Blunami
+                productIDhigh = value;
+                statusUpdate("Read decoder productID low CV256");
+                readCV("256");
+                return false;
+            } else return true;
+        case HARMAN:
             productIDhigh = value;
             statusUpdate("Read decoder ID low CV 113");
             readCV("113");
             return false;
-        } else if (mfgID == 151) {  // ESU
+        case ESU:
             statusUpdate("Set SI for Read productID");
             writeCV("32", 255);
             return false;
-        } else if (mfgID == 13) {  // DIY
+        case DIY:
             productIDhighest = value;
             statusUpdate("Read decoder product ID #2 CV 48");
             readCV("48");
             return false;
-        } else if (mfgID == 97) {  // Doehler and Haass
+        case DOEHLER:
             if (isOptionalCv()) {
                 return true;
             }
             productID = value;
             return true;
-        } else if (mfgID == 78) {  // Train-O-Matic
+        case TRAINOMATIC:
             productIDhigh = value;
             statusUpdate("Read productID #2 CV 509");
             readCV("509");
             return false;
-        } else if (mfgID == 115) {  // Dietz
+        case DIETZ:
             productID = value;
             return true;
+        default:
+            log.error("unexpected step 4 reached with value: {}", value);
+            return true;
         }
-        log.error("unexpected step 4 reached with value: {}", value);
-        return true;
     }
 
     @Override
     public boolean test5(int value) {
-        if (mfgID == 113) {  // QSI
+        switch (mfgID) {
+        case QSI:
             statusUpdate("Read Product ID High Byte");
             readCV("56");
             return false;
-        } else if (mfgID == 48) {  // Hornby
+        case HORNBY:
             if (modelID == 254) { // HN7000
                 productIDhigh = value;
                 statusUpdate("Read decoder ID CV 49");
@@ -263,88 +310,94 @@ public abstract class IdentifyDecoder extends jmri.jmrit.AbstractIdentify {
                 productID = (productIDhigh << 8) | productIDlow;
                 return true;
             }
-        } else if (mfgID == 141 && (modelID >= 70 && modelID <= 72)) {  // SoundTraxx Econami, Tsunami2 and Blunami
+        case SOUNDTRAXX:
+            if (modelID >= 70 && modelID <= 72) {  // SoundTraxx Econami, Tsunami2 and Blunami
+                productIDlow = value;
+                productID = (productIDhigh << 8) | productIDlow;
+                return true;
+            } else return true;
+        case HARMAN:
             productIDlow = value;
             productID = (productIDhigh << 8) | productIDlow;
             return true;
-        } else if (mfgID == 98) {  // Harman
-            productIDlow = value;
-            productID = (productIDhigh << 8) | productIDlow;
-            return true;
-        } else if (mfgID == 151) {  // ESU
+        case ESU:
             statusUpdate("Read productID Byte 1");
             readCV("261");
             return false;
-        } else if (mfgID == 13) {  // DIY
+        case DIY:
             productIDhigh = value;
             statusUpdate("Read decoder product ID #3 CV 49");
             readCV("49");
             return false;
-        } else if (mfgID == 153) {  // TCS
+        case TCS:
             productIDlow = value;
             statusUpdate("Read decoder extended Version ID Low Byte");
             readCV("111");
             return false;
-        } else if (mfgID == 78) {  // Train-O-Matic
+        case TRAINOMATIC:
             productIDlow = value;
             statusUpdate("Read productID #3 CV 508");
             readCV("508");
             return false;
+        default:
+            log.error("unexpected step 5 reached with value: {}", value);
+            return true;
         }
-        log.error("unexpected step 5 reached with value: {}", value);
-        return true;
     }
 
     @Override
     public boolean test6(int value) {
-        if (mfgID == 113) {  // QSI
+        switch (mfgID) {
+        case QSI:
             productIDhigh = value;
             statusUpdate("Set SI for Read Product ID Low Byte");
             writeCV("50", 5);
             return false;
-        } else if (mfgID == 48) {  // Hornby
+        case HORNBY:
             // HN7000 reaches here
             productID = value + (productIDhigh * 256) + (productIDhighest * 256 * 256);
             return true;
-        } else if (mfgID == 151) {  // ESU
+        case ESU:
             productID = value;
             statusUpdate("Read productID Byte 2");
             readCV("262");
             return false;
-        } else if (mfgID == 13) {  // DIY
+        case DIY:
             productIDlow = value;
             statusUpdate("Read decoder product ID #4 CV 50");
             readCV("50");
             return false;
-        } else if (mfgID == 153) {  // TCS
+        case TCS:
             productIDhigh = value;
             statusUpdate("Read decoder extended Version ID High Byte");
             readCV("110");
             return false;
-        } else if (mfgID == 78) {  // Train-O-Matic
+        case TRAINOMATIC:
             productID = value + (productIDlow * 256) + (productIDhigh * 256 * 256);
             return true;
+        default:
+            log.error("unexpected step 6 reached with value: {}", value);
+            return true;
         }
-        log.error("unexpected step 6 reached with value: {}", value);
-        return true;
     }
 
     @Override
     public boolean test7(int value) {
-        if (mfgID == 113) {  // QSI
+        switch (mfgID) {
+        case QSI:
             statusUpdate("Read Product ID Low Byte");
             readCV("56");
             return false;
-        } else if (mfgID == 151) {  // ESU
+        case ESU:
             productID = productID + (value * 256);
             statusUpdate("Read productID Byte 3");
             readCV("263");
             return false;
-        } else if (mfgID == 13) {  // DIY
+        case DIY:
             productIDlowest = value;
             productID = (((((productIDhighest << 8) | productIDhigh) << 8) | productIDlow) << 8) | productIDlowest;
             return true;
-        } else if (mfgID == 153) {  // TCS
+        case TCS:
             productIDhighest = value;
             if (((productIDlowest >= 129 && productIDlowest <= 135) && (productIDlow == 5))||(modelID >= 5)){
                 if ((productIDlowest == 180) && (modelID == 5)) {
@@ -358,30 +411,33 @@ public abstract class IdentifyDecoder extends jmri.jmrit.AbstractIdentify {
                 productID = productIDlowest;
             }
             return true;
+        default:
+            log.error("unexpected step 7 reached with value: {}", value);
+            return true;
         }
-        log.error("unexpected step 7 reached with value: {}", value);
-        return true;
     }
 
     @Override
     public boolean test8(int value) {
-        if (mfgID == 113) {  // QSI
+        switch (mfgID) {
+        case QSI:
             productIDlow = value;
             productID = (productIDhigh * 256) + productIDlow;
             return true;
-        } else if (mfgID == 151) {  // ESU
+        case ESU:
             productID = productID + (value * 256 * 256);
             statusUpdate("Read productID Byte 4");
             readCV("264");
             return false;
+        default:
+            log.error("unexpected step 8 reached with value: {}", value);
+            return true;
         }
-        log.error("unexpected step 8 reached with value: {}", value);
-        return true;
     }
 
     @Override
     public boolean test9(int value) {
-        if (mfgID == 151) {  // ESU
+        if (mfgID == Manufacturer.ESU) {
             productID = productID + (value * 256 * 256 * 256);
             return true;
         }
@@ -393,8 +449,8 @@ public abstract class IdentifyDecoder extends jmri.jmrit.AbstractIdentify {
     protected void statusUpdate(String s) {
         message(s);
         if (s.equals("Done")) {
-            done(mfgID, modelID, productID);
-            log.info("Decoder returns mfgID:{};modelID:{};productID:{}", mfgID, modelID, productID);
+            done(intMfg, modelID, productID);
+            log.info("Decoder returns mfgID:{};modelID:{};productID:{}", intMfg, modelID, productID);
         } else if (log.isDebugEnabled()) {
             log.debug("received status: {}", s);
         }

--- a/java/test/jmri/jmrit/decoderdefn/IdentifyDecoderTest.java
+++ b/java/test/jmri/jmrit/decoderdefn/IdentifyDecoderTest.java
@@ -20,6 +20,16 @@ public class IdentifyDecoderTest {
     private int cvRead = -1;
     private ProgDebugger p;
 
+
+    /** 
+     * Test enum search routine
+     */
+    @Test
+    public void testEnum() {
+        var here = IdentifyDecoder.Manufacturer.DIETZ;
+        var found = IdentifyDecoder.Manufacturer.forValue(115);
+        Assert.assertEquals("found proper value", here, found);
+    }
     /**
      * Test standard decoder without productID.
      */
@@ -52,7 +62,8 @@ public class IdentifyDecoderTest {
         // simulate CV read complete, ending check
         i.programmingOpReply(123, 0);
         Assert.assertEquals("running after 2 ", false, i.isRunning());
-        Assert.assertEquals("found mfg ID ", 0x12, i.mfgID);
+        Assert.assertEquals("found mfg int ID ", 0x12, i.intMfg);
+        Assert.assertEquals("found mfg ID ", null, i.mfgID);
         Assert.assertEquals("found model ID ", 123, i.modelID);
         Assert.assertEquals("found product ID ", -1, i.productID);
 
@@ -101,7 +112,7 @@ public class IdentifyDecoderTest {
         i.programmingOpReply(0xCD, 0);
         Assert.assertEquals("running after 5 ", false, i.isRunning());
 
-        Assert.assertEquals("found mfg ID ", 98, i.mfgID);
+        Assert.assertEquals("found mfg ID ", 98, i.mfgID.value);
         Assert.assertEquals("found model ID ", 123, i.modelID);
         Assert.assertEquals("found product ID ", 0xABCD, i.productID);
 
@@ -150,7 +161,7 @@ public class IdentifyDecoderTest {
         i.programmingOpReply(29, 0);
         Assert.assertEquals("running after 5 ", false, i.isRunning());
 
-        Assert.assertEquals("found mfg ID ", 141, i.mfgID);
+        Assert.assertEquals("found mfg ID ", 141, i.mfgID.value);
         Assert.assertEquals("found model ID ", 71, i.modelID);
         Assert.assertEquals("found product ID ", 285, i.productID);
 
@@ -199,7 +210,7 @@ public class IdentifyDecoderTest {
         i.programmingOpReply(29, 0);
         Assert.assertEquals("running after 5 ", false, i.isRunning());
 
-        Assert.assertEquals("found mfg ID ", 141, i.mfgID);
+        Assert.assertEquals("found mfg ID ", 141, i.mfgID.value);
         Assert.assertEquals("found model ID ", 72, i.modelID);
         Assert.assertEquals("found product ID ", 285, i.productID);
 
@@ -249,7 +260,7 @@ public class IdentifyDecoderTest {
         i.programmingOpReply(2, 0);
         Assert.assertEquals("running after 5 ", false, i.isRunning());
 
-        Assert.assertEquals("found mfg ID ", 48, i.mfgID);
+        Assert.assertEquals("found mfg ID ", 48, i.mfgID.value);
         Assert.assertEquals("found model ID ", 4, i.modelID);
         Assert.assertEquals("found product ID ", (2 * 256) + 143, i.productID);
     }
@@ -301,7 +312,7 @@ public class IdentifyDecoderTest {
         i.programmingOpReply(3, 0);
         Assert.assertEquals("running after 6 ", false, i.isRunning());
 
-        Assert.assertEquals("found mfg ID ", 48, i.mfgID);
+        Assert.assertEquals("found mfg ID ", 48, i.mfgID.value);
         Assert.assertEquals("found model ID ", 254, i.modelID);
         Assert.assertEquals("found product ID ", 1*256*256 + 2*256 + 3, i.productID);
     }
@@ -344,7 +355,7 @@ public class IdentifyDecoderTest {
         i.programmingOpReply(142, 0);
         Assert.assertEquals("running after 4 ", false, i.isRunning());
 
-        Assert.assertEquals("found mfg ID ", 48, i.mfgID);
+        Assert.assertEquals("found mfg ID ", 48, i.mfgID.value);
         Assert.assertEquals("found model ID ", 77, i.modelID);
         Assert.assertEquals("found product ID ", 142, i.productID);
     }
@@ -387,7 +398,7 @@ public class IdentifyDecoderTest {
         i.programmingOpReply(144, 0);
         Assert.assertEquals("running after 4 ", false, i.isRunning());
 
-        Assert.assertEquals("found mfg ID ", 48, i.mfgID);
+        Assert.assertEquals("found mfg ID ", 48, i.mfgID.value);
         Assert.assertEquals("found model ID ", 88, i.modelID);
         Assert.assertEquals("found product ID ", 144, i.productID);
     }
@@ -413,7 +424,7 @@ public class IdentifyDecoderTest {
             }
         };
 
-        Assert.assertEquals("found mfg ID ", -1, i.mfgID);
+        Assert.assertEquals("found mfg ID ", null, i.mfgID);
         Assert.assertEquals("found model ID ", -1, i.modelID);
         Assert.assertEquals("found product ID ", -1, i.productID);
         Assert.assertEquals("Test isOptionalCv() before start", i.isOptionalCv(), false);
@@ -436,7 +447,7 @@ public class IdentifyDecoderTest {
         Assert.assertEquals("Test isOptionalCv() after 2", i.isOptionalCv(), false);
         Assert.assertEquals("Programming mode after 2", ProgrammingMode.PAGEMODE, p.getMode());
 
-        Assert.assertEquals("found mfg ID ", 48, i.mfgID);
+        Assert.assertEquals("found mfg ID ", IdentifyDecoder.Manufacturer.HORNBY, i.mfgID);
         Assert.assertEquals("found model ID ", -1, i.modelID);
         Assert.assertEquals("found product ID ", -1, i.productID);
 
@@ -449,7 +460,7 @@ public class IdentifyDecoderTest {
         Assert.assertEquals("Test isOptionalCv() after 3", i.isOptionalCv(), true);
         Assert.assertEquals("Programming mode after 3", ProgrammingMode.PAGEMODE, p.getMode());
 
-        Assert.assertEquals("found mfg ID ", 48, i.mfgID);
+        Assert.assertEquals("found mfg ID ", 48, i.mfgID.value);
         Assert.assertEquals("found model ID ", 88, i.modelID);
         Assert.assertEquals("found product ID ", -1, i.productID);
 
@@ -461,7 +472,7 @@ public class IdentifyDecoderTest {
         Assert.assertEquals("Test isOptionalCv() after 4", i.isOptionalCv(), true);
         Assert.assertEquals("Programming mode after 4", ProgrammingMode.DIRECTMODE, p.getMode());
 
-        Assert.assertEquals("found mfg ID ", 48, i.mfgID);
+        Assert.assertEquals("found mfg ID ", 48, i.mfgID.value);
         Assert.assertEquals("found model ID ", 88, i.modelID);
         Assert.assertEquals("found product ID ", -1, i.productID);
 
@@ -491,7 +502,7 @@ public class IdentifyDecoderTest {
             }
         };
 
-        Assert.assertEquals("found mfg ID ", -1, i.mfgID);
+        Assert.assertEquals("found mfg ID ", null, i.mfgID);
         Assert.assertEquals("found model ID ", -1, i.modelID);
         Assert.assertEquals("found product ID ", -1, i.productID);
         Assert.assertEquals("Test isOptionalCv() before start", i.isOptionalCv(), false);
@@ -511,7 +522,7 @@ public class IdentifyDecoderTest {
         Assert.assertEquals("Test isOptionalCv() after 2", i.isOptionalCv(), false);
         Assert.assertEquals("Programming mode after 2", ProgrammingMode.DIRECTMODE, p.getMode());
 
-        Assert.assertEquals("found mfg ID ", 48, i.mfgID);
+        Assert.assertEquals("found mfg ID ", IdentifyDecoder.Manufacturer.HORNBY, i.mfgID);
         Assert.assertEquals("found model ID ", -1, i.modelID);
         Assert.assertEquals("found product ID ", -1, i.productID);
 
@@ -523,7 +534,7 @@ public class IdentifyDecoderTest {
         Assert.assertEquals("running after 2 ", false, i.isRunning());
         Assert.assertEquals("Programming mode after 3", ProgrammingMode.DIRECTMODE, p.getMode());
 
-        Assert.assertEquals("found mfg ID ", 48, i.mfgID);
+        Assert.assertEquals("found mfg ID ", 48, i.mfgID.value);
         Assert.assertEquals("found model ID ", -1, i.modelID);
         Assert.assertEquals("found product ID ", -1, i.productID);
 
@@ -569,7 +580,7 @@ public class IdentifyDecoderTest {
         i.programmingOpReply(123, 0);
         Assert.assertEquals("running after 4 ", false, i.isRunning());
 
-        Assert.assertEquals("found mfg ID ", 115, i.mfgID);
+        Assert.assertEquals("found mfg ID ", 115, i.mfgID.value);
         Assert.assertEquals("found model ID ", 88, i.modelID);
         Assert.assertEquals("found product ID ", 123, i.productID);
     }
@@ -628,7 +639,7 @@ public class IdentifyDecoderTest {
         // simulate CV read complete on CV110, start end
         i.programmingOpReply(2, 0);
 
-        Assert.assertEquals("found mfg ID ", 153, i.mfgID);
+        Assert.assertEquals("found mfg ID ", 153, i.mfgID.value);
         Assert.assertEquals("found model ID ", 5, i.modelID);
         Assert.assertEquals("found product ID ", 33620400, i.productID);
     }
@@ -686,7 +697,7 @@ public class IdentifyDecoderTest {
         // simulate CV read complete on CV110, start end
         i.programmingOpReply(2, 0);
 
-        Assert.assertEquals("found mfg ID ", 153, i.mfgID);
+        Assert.assertEquals("found mfg ID ", 153, i.mfgID.value);
         Assert.assertEquals("found model ID ", 4, i.modelID);
         Assert.assertEquals("found product ID ", 176, i.productID);
     }
@@ -729,7 +740,7 @@ public class IdentifyDecoderTest {
         // simulate CV read complete on CV249, end
         i.programmingOpReply(80, 0);
 
-        Assert.assertEquals("found mfg ID ", 153, i.mfgID);
+        Assert.assertEquals("found mfg ID ", 153, i.mfgID.value);
         Assert.assertEquals("found model ID ", 4, i.modelID);
         Assert.assertEquals("found product ID ", 80, i.productID);
     }


### PR DESCRIPTION
This is a refactoring and clean up of the decoder ID process in IdentifyDecoder.java.  Functionally remains the same. Users should not see any difference.

This is a precursor to updating for a new decoder manufacturer.

