### PR TITLE
Fix bugs in Audio table

### DIFF
--- a/java/src/jmri/jmrit/audio/swing/AudioSourceFrame.java
+++ b/java/src/jmri/jmrit/audio/swing/AudioSourceFrame.java
@@ -258,8 +258,9 @@ public class AudioSourceFrame extends AbstractAudioFrame {
         JButton ok;
         p.add(ok = new JButton(Bundle.getMessage("ButtonOK")));
         ok.addActionListener((ActionEvent e) -> {
-            applyPressed(e);
-            frame.dispose();
+            if (applyPressed(e)) {
+                frame.dispose();
+            }
         });
         JButton cancel;
         p.add(cancel = new JButton(Bundle.getMessage("ButtonCancel")));
@@ -352,10 +353,10 @@ public class AudioSourceFrame extends AbstractAudioFrame {
         });
     }
 
-    private void applyPressed(ActionEvent e) {
+    private boolean applyPressed(ActionEvent e) {
         String sName = sysName.getText();
         if (entryError(sName, PREFIX, "" + counter)) {
-            return;
+            return false;
         }
         String user = userName.getText();
         if (user.equals("")) {
@@ -364,17 +365,20 @@ public class AudioSourceFrame extends AbstractAudioFrame {
         AudioSource s;
         try {
             AudioManager am = InstanceManager.getDefault(jmri.AudioManager.class);
+            if (newSource && am.getBySystemName(sName) != null) {
+                throw new AudioException(Bundle.getMessage("DuplicateSystemName"));
+            }
             try {
                 s = (AudioSource) am.provideAudio(sName);
             } catch (IllegalArgumentException ex) {
-                throw new AudioException("Problem creating source");
+                throw new AudioException(Bundle.getMessage("ProblemCreatingSource"));
             }
             if ((user != null) && (newSource) && (am.getByUserName(user) != null)) {
                 am.deregister(s);
                 synchronized (lock) {
                     prevCounter();
                 }
-                throw new AudioException("Duplicate user name - please modify");
+                throw new AudioException(Bundle.getMessage("DuplicateUserName"));
             }
             s.setUserName(user);
             if (assignedBuffer.getSelectedIndex() > 0) {
@@ -406,7 +410,10 @@ public class AudioSourceFrame extends AbstractAudioFrame {
         } catch (AudioException ex) {
             JmriJOptionPane.showMessageDialog(this, ex.getMessage(),
                 Bundle.getMessage("AudioCreateErrorTitle"), JmriJOptionPane.ERROR_MESSAGE);
+            return false;
         }
+        newSource = false;  // If the user presses Apply, the dialog stays visible.
+        return true;
     }
 
     private static int nextCounter() {

--- a/java/src/jmri/jmrit/audio/swing/AudioTableBundle.properties
+++ b/java/src/jmri/jmrit/audio/swing/AudioTableBundle.properties
@@ -66,3 +66,8 @@ LabelFadeIn = Fade-in
 LabelFadeOut = Fade-out
 LabelPositionRelative = Relative position
 SelectBufferFromList = Select buffer from list
+
+DuplicateSystemName     = Duplicate system name - please modify
+DuplicateUserName       = Duplicate user name - please modify
+ProblemCreatingBuffer   = Problem creating buffer
+ProblemCreatingSource   = Problem creating source


### PR DESCRIPTION
While I was working with Audio, I discovered several bugs in the Audio table in the dialogs "Add Buffer" and "Add Source".

- The suggested system name does often already exists.
- If the system name already exists, the existing bean was changed instead of giving an error message.
- If I click "Ok" and an error message is shown, the dialog was closed anyway.
- The error messages was not I18N.

This PR:
- Gives an error message if the user enters an existent system name.
- Doesn't close the dialog on "Ok" if an error message is present.
- Moves the error messages to the property file.