### PR TITLE
Require @Override and removal of unused imports

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -600,6 +600,7 @@
     <h3>Miscellaneous</h3>
         <a id="Misc" name="Misc"></a>
         <ul>
-            <li></li>
+            <li>(For developers) Our CI process has been updated to require the
+            @Override annocation on overriding methods and removal of unused import statements.</li>
         </ul>
 

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -601,6 +601,6 @@
         <a id="Misc" name="Misc"></a>
         <ul>
             <li>(For developers) Our CI process has been updated to require the
-            @Override annocation on overriding methods and removal of unused import statements.</li>
+            @Override annotation on overriding methods and removal of unused import statements.</li>
         </ul>
 

--- a/java/ecj.warning.options-ci
+++ b/java/ecj.warning.options-ci
@@ -56,8 +56,8 @@
 -err:-unusedAllocation
   # cases of the `catch (FooException ex)` and then not using `ex`
 -err:-unusedExceptionParam
-  # allow unused imports as a convenience
--err:-unusedImport
+  # unused imports removed Oct 2023
+-err:+unusedImport
 -err:+unusedLabel
 -err:+unusedLocal
   # our APIs routinely have "may need in future" parameters
@@ -117,7 +117,6 @@
 -err:+semicolon
 -err:+specialParamHiding
 -err:+switchDefault
--err:+syncOverride
 -err:+unavoidableGenericProblems
 -err:+unchecked
 -err:+uselessTypeCheck

--- a/java/ecj.warning.options-test-ci
+++ b/java/ecj.warning.options-test-ci
@@ -23,16 +23,10 @@
 # Enforce missing synch in synchronized method override
 -err:+syncOverride
 
-
-
 # Allowing 55 un-annotated deprecations
 -err:-dep-ann
 -err:-deprecation
 -err:-allDeprecation
-
-# 176 missing @Override annotations
--err:-allOver-ann
--err:-over-ann
 
 # 179 generic raw types
 -err:-raw


### PR DESCRIPTION
Updates the control files for `ant warnings` etc to 
 - require `@Override` on all relevant methods
 - require that all `import` statements be necessary, i.e. unused ones must be removed.

No functional changes.