### PR TITLE
VSD thread exception handling in Diesel3Sound.java

### DIFF
--- a/java/src/jmri/jmrit/vsdecoder/Diesel3Sound.java
+++ b/java/src/jmri/jmrit/vsdecoder/Diesel3Sound.java
@@ -665,7 +665,6 @@ class Diesel3Sound extends EngineSound {
             } catch (InterruptedException ie) {
                 // kill thread
                 log.debug("thread interrupted");
-                return;
             }
         }
 

--- a/java/src/jmri/jmrit/vsdecoder/Diesel3Sound.java
+++ b/java/src/jmri/jmrit/vsdecoder/Diesel3Sound.java
@@ -663,7 +663,9 @@ class Diesel3Sound extends EngineSound {
                 }
                 _sound.stop();
             } catch (InterruptedException ie) {
-                log.error("execption", ie);
+                // kill thread
+                log.debug("thread interrupted");
+                return;
             }
         }
 

--- a/java/src/jmri/jmrit/vsdecoder/Steam1Sound.java
+++ b/java/src/jmri/jmrit/vsdecoder/Steam1Sound.java
@@ -1008,7 +1008,6 @@ class Steam1Sound extends EngineSound {
             } catch (InterruptedException ie) {
                 // kill thread
                 log.debug("thread interrupted");
-                return;
             }
         }
 


### PR DESCRIPTION
```Diesel3Sound.java``` has a similar thread case to ```Steam1Sound.java```, see https://github.com/JMRI/JMRI/blob/master/java/src/jmri/jmrit/vsdecoder/Steam1Sound.java#L1009 .
That has lead me to change it accordingly here as well.