### PR TITLE
Power control - view multiple connections

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -639,6 +639,12 @@
             <li></li>
         </ul>
 
+   <h3>Other Tools</h3>
+        <a id="Tools" name="Tools"></a>
+        <ul>
+            <li>The Power Control now defaults to display all connections.</li>
+        </ul>
+
     <h3>Miscellaneous</h3>
         <a id="Misc" name="Misc"></a>
         <ul>

--- a/java/src/jmri/NamedBeanBundle.properties
+++ b/java/src/jmri/NamedBeanBundle.properties
@@ -531,3 +531,5 @@ FeedbackModeLayout      = Layout
 
 # Shared by jmri.configurexml.LoadXmlConfigAction and jmri.jmrit.display.EditorManager.
 DuplicateLoadSkip  = Skip the Duplicate Load Dialog
+
+AllConnections = All Connections

--- a/java/src/jmri/jmrit/powerpanel/PowerPane.java
+++ b/java/src/jmri/jmrit/powerpanel/PowerPane.java
@@ -1,20 +1,51 @@
 package jmri.jmrit.powerpanel;
 
+import java.awt.Color;
 import java.util.List;
-import javax.swing.JButton;
-import javax.swing.JLabel;
-import javax.swing.JMenu;
-import jmri.JmriException;
-import jmri.PowerManager;
+
+import javax.annotation.Nonnull;
+import javax.swing.*;
+
+import jmri.*;
 import jmri.jmrit.catalog.NamedIcon;
+import jmri.swing.PowerManagerMenu;
 
 /**
  * Pane for power control
  *
  * @author Bob Jacobsen Copyright (C) 2001, 2010
  */
-public class PowerPane extends jmri.util.swing.JmriPanel
-        implements java.beans.PropertyChangeListener {
+public class PowerPane extends jmri.util.swing.JmriPanel {
+
+    final jmri.swing.PowerManagerMenu selectMenu;
+    final JPanel contentP;
+    final List<SinglePowerPane> mgrList = new java.util.ArrayList<>();
+
+    /**
+     * Constructor for PowerPane.
+     */
+    public PowerPane() {
+        this(null);
+    }
+
+    public PowerPane(PowerManager initialMgr){
+        contentP = new JPanel();
+        selectMenu = new PowerManagerMenuImpl(initialMgr);
+        contentP.setLayout(new BoxLayout(contentP, BoxLayout.Y_AXIS));
+        add(contentP);
+        PowerPane.this.managerChanged();
+    }
+
+    /**
+     * Add Connection menu to choose which to turn on/off.
+     * @return List of menu items (all active connections)
+     */
+    @Override
+    public List<JMenu> getMenus() {
+        List<JMenu> list = new java.util.ArrayList<>();
+        list.add(selectMenu);
+        return list;
+    }
 
     @Override
     public String getHelpTarget() {
@@ -23,248 +54,225 @@ public class PowerPane extends jmri.util.swing.JmriPanel
 
     @Override
     public String getTitle() {
-        return Bundle.getMessage("TitlePowerPanel");
-    }
-
-    // GUI member declarations
-    JLabel onOffStatus = new JLabel(Bundle.getMessage("LabelUnknown"));
-    JLabel connLabel = new JLabel(Bundle.getMessage("LabelLayoutPower"));
-    JButton onButton = new JButton(Bundle.getMessage("ButtonOn"));
-    JButton offButton = new JButton(Bundle.getMessage("ButtonOff"));
-    JButton idleButton = new JButton(Bundle.getMessage("ButtonIdle"));
-
-    NamedIcon onIcon = new NamedIcon("resources/icons/throttles/power_green.png", "resources/icons/throttles/power_green.png") ;
-    NamedIcon offIcon = new NamedIcon("resources/icons/throttles/power_red.png", "resources/icons/throttles/power_red.png") ;
-    NamedIcon unknownIcon = new NamedIcon("resources/icons/throttles/power_yellow.png", "resources/icons/throttles/power_yellow.png") ;
-
-    jmri.swing.PowerManagerMenu selectMenu;
-
-    /**
-     * Add Connection menu to choose which to turn on/off.
-     * @return List of menu items (all active connections)
-     */
-    @Override
-    public List<JMenu> getMenus() {
-        java.util.ArrayList<JMenu> list = new java.util.ArrayList<>();
-        list.add(selectMenu);
-        return list;
-    }
-
-    PowerManager listening = null;
-
-    /**
-     * Constructor for PowerPane.
-     */
-    public PowerPane() {
-        init();
-    }
-
-    private void init() {
-        selectMenu = new jmri.swing.PowerManagerMenu() {
-            @Override
-            protected void choiceChanged() {
-                managerChanged();
-            }
-        };
-
-        // add listeners to buttons
-        onButton.addActionListener(e -> onButtonPushed());
-        offButton.addActionListener(e -> offButtonPushed());
-        idleButton.addActionListener(e -> idleButtonPushed());
-
-        if ((selectMenu != null) && (selectMenu.getManager() != null)) {
-            idleButton.setVisible(selectMenu.getManager().implementsIdle());
-        } else {
-            // assume IDLE not supported if no manager or selectMenu
-            idleButton.setVisible(false);
-        }
-        idleButton.setToolTipText(Bundle.getMessage("ToolTipIdleButton"));
-
-        // general GUI config
-        setLayout(new java.awt.GridLayout(3, 2, 3, 5)); // r, c, hgap , vgap
-
-        // Add margin around the panel
-        setBorder(javax.swing.BorderFactory.createEmptyBorder(5, 5, 5, 5)); // top, left, btm, right
-
-        // set minimum size ( for all 6 cells in the layout ) to prevent twitching
-        onOffStatus.setMinimumSize(new java.awt.Dimension(getLabelMinimumWidth(), onOffStatus.getPreferredSize().height));
-
-        // install items in GUI
-        add(connLabel);
-        add(onButton);
-        add(onOffStatus); // on row 2
-        add(offButton);
-        add(new JLabel("")); // on row 3
-        add(idleButton);
-
-        setStatus();
-    }
-
-    /**
-     * Display status changes from PowerManager in PowerPane.
-     */
-    void setStatus() {
-        // Check to see if the Power Manager has a current status
-        if (mgrOK()) {
-            switch (listening.getPower()) {
-                case PowerManager.ON:
-                    onOffStatus.setText(Bundle.getMessage("StatusOn"));
-                    onOffStatus.setIcon(onIcon);
-                    break;
-                case PowerManager.OFF:
-                    onOffStatus.setText(Bundle.getMessage("StatusOff"));
-                    onOffStatus.setIcon(offIcon);
-                    break;
-                case PowerManager.IDLE:
-                    onOffStatus.setText(Bundle.getMessage("StatusIdle"));
-                    onOffStatus.setIcon(unknownIcon);
-                    break;
-                case PowerManager.UNKNOWN:
-                    onOffStatus.setText(Bundle.getMessage("StatusUnknown"));
-                    onOffStatus.setIcon(unknownIcon);
-                    break;
-                default:
-                    onOffStatus.setText(Bundle.getMessage("StatusUnknown"));
-                    onOffStatus.setIcon(unknownIcon);
-                    log.error("Unexpected state value: {}", selectMenu.getManager().getPower());
-                    break;
-            }
-        }
+        var mgr = selectMenu.getManager();
+        return Bundle.getMessage("TitlePowerPanel") + " : " +
+           ( mgr== null ? Bundle.getMessage("AllConnections") : mgr.getUserName());
     }
 
     /**
      * Reset listener and update status.
      */
     void managerChanged() {
-        if (listening != null) {
-            listening.removePropertyChangeListener(this);
-        }
-        listening = null;
-        setStatus();
-    }
+        log.debug("manager changed to {}", selectMenu.getManager() );
 
-    /**
-     * Check for presence of PowerManager.
-     * @return True if one is available, false if not
-     */
-    private boolean mgrOK() {
-        if (listening == null) {
-            listening = selectMenu.getManager();
-            log.debug("Manager = {}", listening);
-            if (listening == null) {
-                log.debug("No power manager instance found, panel not active");
-                return false;
-            } else {
-                listening.addPropertyChangeListener(this);
-            }
-            idleButton.setVisible(listening.implementsIdle());
-            connLabel.setText(getConnectionLabelString());
-        }
-        return true;
-    }
-
-    /**
-     * Respond to Power On button pressed.
-     */
-    public void onButtonPushed() {
-        if (mgrOK()) {
-            try {
-                selectMenu.getManager().setPower(PowerManager.ON);
-            } catch (JmriException e) {
-                log.error("Exception trying to turn power on", e);
+        mgrList.forEach( SinglePowerPane::dispose);
+        mgrList.clear();
+        contentP.removeAll();
+        var mgr = selectMenu.getManager();
+        if ( mgr != null ){
+            mgrList.add(new SinglePowerPane(mgr));
+        } else {
+            List<PowerManager> managers = InstanceManager.getList(PowerManager.class);
+            for (PowerManager pm : managers) {
+                mgrList.add(new SinglePowerPane(pm));
             }
         }
-    }
-
-    /**
-     * Respond to Power Off button pressed.
-     */
-    public void offButtonPushed() {
-        if (mgrOK()) {
-            try {
-                selectMenu.getManager().setPower(PowerManager.OFF);
-            } catch (JmriException e) {
-                log.error("Exception trying to turn power off", e);
-            }
+        for ( SinglePowerPane spp: mgrList){
+            contentP.add(spp);
         }
-    }
 
-    /**
-     * Respond to Power Idle button pressed.
-     */
-    public void idleButtonPushed() {
-        if (mgrOK()) {
-            if (!listening.implementsIdle()) {
-                return;
-            }
-            try {
-                selectMenu.getManager().setPower(PowerManager.IDLE);
-            } catch (JmriException e) {
-                log.error("Exception trying to set power to idle", e);
-            }
-        }
-    }
-
-    /**
-     * Get Minimum width for the current power status JLabel.
-     * @return minimum width
-     */
-    private int getLabelMinimumWidth (){
-        String[] bundleStrings = {"StatusIdle", "StatusOn", "StatusOff", "StatusUnknown"};
-        JLabel tmp = new JLabel(Bundle.getMessage("LabelLayoutPower"));
-        int a=tmp.getWidth();
-        tmp.setIcon(onIcon);
-        for ( String bs : bundleStrings ) {
-            tmp.setText(Bundle.getMessage(bs));
-            a = Math.max(a, tmp.getWidth());
-        }
-        return a+2;
-    }
-
-    private String getConnectionLabelString(){
-        StringBuilder s = new StringBuilder("<html>");
-        if (listening != null && selectMenu.getItemCount()>1 ) {
-            s.append( listening.getUserName()).append("<br>");
-        }
-        s.append(Bundle.getMessage("LabelLayoutPower")).append("</html>");
-        return s.toString();
-    }
-
-    @Override
-    public void propertyChange(java.beans.PropertyChangeEvent ev) {
-        log.debug("PropertyChange received ");
-        switch (listening.getPower()) {
-            case PowerManager.ON:
-                onOffStatus.setText(Bundle.getMessage("StatusOn"));
-                onOffStatus.setIcon(onIcon);
-                break;
-            case PowerManager.OFF:
-                onOffStatus.setText(Bundle.getMessage("StatusOff"));
-                onOffStatus.setIcon(offIcon);
-                break;
-            case PowerManager.IDLE:
-                onOffStatus.setText(Bundle.getMessage("StatusIdle"));
-                onOffStatus.setIcon(unknownIcon);
-                break;
-            case PowerManager.UNKNOWN:
-                onOffStatus.setText(Bundle.getMessage("StatusUnknown"));
-                onOffStatus.setIcon(unknownIcon);
-                break;
-            default:
-                onOffStatus.setText(Bundle.getMessage("StatusUnknown"));
-                onOffStatus.setIcon(unknownIcon);
-                log.error("Unexpected state value: {}", listening.getPower());
-                break;
+        JFrame f = (JFrame)javax.swing.SwingUtilities.windowForComponent(this);
+        if ( f != null ) {
+            f.pack();
+            f.setTitle(this.getTitle());
         }
     }
 
     @Override
     public void dispose() {
-        if (listening != null) {
-            listening.removePropertyChangeListener(this);
+        mgrList.forEach( SinglePowerPane::dispose);
+    }
+
+    private static final NamedIcon onIcon = new NamedIcon("resources/icons/throttles/power_green.png", "resources/icons/throttles/power_green.png") ;
+    private static final NamedIcon offIcon = new NamedIcon("resources/icons/throttles/power_red.png", "resources/icons/throttles/power_red.png") ;
+    private static final NamedIcon unknownIcon = new NamedIcon("resources/icons/throttles/power_yellow.png", "resources/icons/throttles/power_yellow.png") ;
+
+    class SinglePowerPane extends javax.swing.JPanel implements java.beans.PropertyChangeListener {
+
+        private final PowerManager powerMgr;
+
+        // GUI member declarations
+        private final JLabel onOffStatus = new JLabel(Bundle.getMessage("LabelUnknown"));
+        private final JLabel connLabel = new JLabel(Bundle.getMessage("LabelLayoutPower"));
+        private final JButton onButton = new JButton(Bundle.getMessage("ButtonOn"));
+        private final JButton offButton = new JButton(Bundle.getMessage("ButtonOff"));
+        private final JButton idleButton = new JButton(Bundle.getMessage("ButtonIdle"));
+
+        SinglePowerPane(@Nonnull PowerManager powerManager){
+        
+            super();
+            powerMgr = powerManager;
+
+            // add listeners to buttons
+            onButton.addActionListener(e -> onButtonPushed());
+            offButton.addActionListener(e -> offButtonPushed());
+            idleButton.addActionListener(e -> idleButtonPushed());
+            idleButton.setToolTipText(Bundle.getMessage("ToolTipIdleButton"));
+
+            // general GUI config
+            setLayout(new java.awt.GridLayout((powerMgr.implementsIdle() ? 3 : 2), 2, 3, 5)); // r, c, hgap , vgap
+            var border = BorderFactory.createLineBorder(Color.BLACK, 1);
+
+            String title = powerMgr.getUserName();
+            if ( InstanceManager.getDefault(PowerManager.class) == powerMgr ) {
+                title += " ( " + Bundle.getMessage("optionDefault") + " ) ";
+            }
+            setBorder(BorderFactory.createTitledBorder(border, title));
+
+            // set minimum size ( for all 6 cells in the layout ) to prevent twitching
+            onOffStatus.setPreferredSize(new java.awt.Dimension(getLabelMinimumWidth(onOffStatus), onButton.getPreferredSize().height+10 ));
+
+            // install items in GUI
+            add(connLabel);
+            add(onButton);
+            add(onOffStatus); // on row 2
+            add(offButton);
+            
+            if ( powerMgr.implementsIdle()) {
+                add(new JLabel("")); // on row 3
+                add(idleButton);
+            }
+            powerMgr.addPropertyChangeListener(SinglePowerPane.this);
+            setStatus();
+        }
+
+        /**
+         * Respond to Power On button pressed.
+         */
+        private void onButtonPushed() {
+            if (mgrOK()) {
+                try {
+                    powerMgr.setPower(PowerManager.ON);
+                } catch (JmriException e) {
+                    couldNotSetPower("Exception trying to turn power on", e);
+                }
+            }
+        }
+
+        /**
+         * Respond to Power Off button pressed.
+         */
+        private void offButtonPushed() {
+            if (mgrOK()) {
+                try {
+                    powerMgr.setPower(PowerManager.OFF);
+                } catch (JmriException e) {
+                    couldNotSetPower("Exception trying to turn power off", e);
+                }
+            }
+        }
+
+        /**
+         * Respond to Power Idle button pressed.
+         */
+        private void idleButtonPushed() {
+            if ( mgrOK() && powerMgr.implementsIdle() ) {
+                try {
+                    powerMgr.setPower(PowerManager.IDLE);
+                } catch (JmriException e) {
+                    couldNotSetPower("Exception trying to set power to idle", e);
+                }
+            }
+        }
+
+        private void couldNotSetPower( String action, JmriException e){
+            log.error("PowerPane {}", action, e);
+            jmri.util.swing.JmriJOptionPane.showMessageDialog(this,
+                powerMgr.getUserName() + System.lineSeparator() +
+                action + System.lineSeparator() + e.getMessage(),
+                action,
+                jmri.util.swing.JmriJOptionPane.ERROR_MESSAGE);
+        }
+
+        /**
+         * Get Minimum width for the current power status JLabel.
+         * @return minimum width
+         */
+        private int getLabelMinimumWidth (JLabel label){
+            String[] bundleStrings = {"StatusIdle", "StatusOn", "StatusOff", "StatusUnknown"};
+            int a= 10;
+            for ( String bs : bundleStrings ) {
+                java.awt.FontMetrics fm = label.getFontMetrics(label.getFont());
+                int wi = fm.stringWidth(Bundle.getMessage(bs))
+                    + onIcon.getIconWidth() + 5;
+                a = Math.max(a, wi);
+            }
+            return a;
+        }
+
+        /**
+         * Display status changes from PowerManager in PowerPane.
+         */
+        private void setStatus() {
+            // Check to see if the Power Manager has a current status
+            if (mgrOK()) {
+                switch (powerMgr.getPower()) {
+                    case PowerManager.ON:
+                        onOffStatus.setText(Bundle.getMessage("StatusOn"));
+                        onOffStatus.setIcon(onIcon);
+                        break;
+                    case PowerManager.OFF:
+                        onOffStatus.setText(Bundle.getMessage("StatusOff"));
+                        onOffStatus.setIcon(offIcon);
+                        break;
+                    case PowerManager.IDLE:
+                        onOffStatus.setText(Bundle.getMessage("StatusIdle"));
+                        onOffStatus.setIcon(unknownIcon);
+                        break;
+                    case PowerManager.UNKNOWN:
+                        onOffStatus.setText(Bundle.getMessage("StatusUnknown"));
+                        onOffStatus.setIcon(unknownIcon);
+                        break;
+                    default:
+                        onOffStatus.setText(Bundle.getMessage("StatusUnknown"));
+                        onOffStatus.setIcon(unknownIcon);
+                        log.error("Unexpected state value: {}", selectMenu.getManager());
+                        break;
+                }
+            }
+        }
+
+        /**
+         * Check for presence of PowerManager.
+         * @return True if one is available, false if not
+         */
+        private boolean mgrOK() {
+            return InstanceManager.getList(PowerManager.class).contains(powerMgr);
+        }
+    
+        @Override
+        public void propertyChange(java.beans.PropertyChangeEvent ev) {
+            setStatus();
+        }
+
+        void dispose() {
+            powerMgr.removePropertyChangeListener(this);
+        }
+        
+    }
+
+    class PowerManagerMenuImpl extends PowerManagerMenu {
+
+        PowerManagerMenuImpl(PowerManager mgr) {
+            super(true, mgr);
+        }
+
+        @Override
+        protected void choiceChanged() {
+            managerChanged();
         }
     }
 
-    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(PowerPane.class);
+    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(PowerPane.class);
 
 }

--- a/java/src/jmri/jmrit/powerpanel/PowerPane.java
+++ b/java/src/jmri/jmrit/powerpanel/PowerPane.java
@@ -122,12 +122,8 @@ public class PowerPane extends jmri.util.swing.JmriPanel {
             // general GUI config
             setLayout(new java.awt.GridLayout((powerMgr.implementsIdle() ? 3 : 2), 2, 3, 5)); // r, c, hgap , vgap
             var border = BorderFactory.createLineBorder(Color.BLACK, 1);
-
-            String title = powerMgr.getUserName();
-            if ( InstanceManager.getDefault(PowerManager.class) == powerMgr ) {
-                title += " ( " + Bundle.getMessage("optionDefault") + " ) ";
-            }
-            setBorder(BorderFactory.createTitledBorder(border, title));
+            setBorder(BorderFactory.createTitledBorder(border,
+                PowerManagerMenu.getManagerNameIncludeIfDefault(powerMgr)));
 
             // set minimum size ( for all 6 cells in the layout ) to prevent twitching
             onOffStatus.setPreferredSize(new java.awt.Dimension(getLabelMinimumWidth(onOffStatus), onButton.getPreferredSize().height+10 ));

--- a/java/src/jmri/jmrit/powerpanel/README
+++ b/java/src/jmri/jmrit/powerpanel/README
@@ -1,5 +1,0 @@
-The jmrit.pwerpanel Java package provides a GUI panel for controlling
-layout power.
-	
-
-The JMRI web page is located at http://jmri.org/

--- a/java/src/jmri/jmrit/powerpanel/package-info.java
+++ b/java/src/jmri/jmrit/powerpanel/package-info.java
@@ -1,0 +1,9 @@
+/**
+ * The jmrit.powerpanel Java package provides a GUI panel for controlling
+ * layout power.
+*/
+
+//@annotations for the entire package go here
+// include empty DefaultAnnotation to avoid excessive recompilation
+@edu.umd.cs.findbugs.annotations.DefaultAnnotation(value={})
+package jmri.jmrit.powerpanel;

--- a/java/src/jmri/swing/Bundle.properties
+++ b/java/src/jmri/swing/Bundle.properties
@@ -9,3 +9,4 @@ SystemNameValidatorRequired    = <html>A system name is required.<br><br>{0}</ht
 SystemNameValidatorInvalid     = <html>{0}<br><br>{1}</html>
 
 MenuConnection = Connection
+DefaultConnection = {0} (Default)

--- a/java/src/jmri/swing/PowerManagerMenu.java
+++ b/java/src/jmri/swing/PowerManagerMenu.java
@@ -33,8 +33,8 @@ public abstract class PowerManagerMenu extends JMenu {
 
     /**
      * Create a PowerManager menu.
-     * @param includeAllConns
-     * @param defaultPwrMgr
+     * @param includeAllConns true to include all connections
+     * @param defaultPwrMgr specify a PowerManager to be selected on Menu startup.
      */
     public PowerManagerMenu(boolean includeAllConns, PowerManager defaultPwrMgr) {
         super();

--- a/java/src/jmri/swing/PowerManagerMenu.java
+++ b/java/src/jmri/swing/PowerManagerMenu.java
@@ -3,6 +3,7 @@ package jmri.swing;
 import java.util.List;
 
 import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
 import javax.swing.ButtonGroup;
 import javax.swing.JMenu;
 import javax.swing.JMenuItem;
@@ -56,7 +57,8 @@ public abstract class PowerManagerMenu extends JMenu {
         List<PowerManager> managers = InstanceManager.getList(PowerManager.class);
         for (PowerManager mgr : managers) {
             if (mgr != null) {
-                JMenuItem item = new JRadioButtonMenuItem(mgr.getUserName());
+                JMenuItem item = new JRadioButtonMenuItem(getManagerNameIncludeIfDefault(mgr));
+                item.setActionCommand(mgr.getUserName());
                 add(item);
                 group.add(item);
                 menuItems.add(item);
@@ -108,6 +110,15 @@ public abstract class PowerManagerMenu extends JMenu {
             }
         }
         return null;
+    }
+
+    @Nonnull
+    public static String getManagerNameIncludeIfDefault(@Nonnull PowerManager mgr){
+        String mgrName = mgr.getUserName();
+        if ( mgr == InstanceManager.getDefault(PowerManager.class) ) {
+            mgrName = Bundle.getMessage("DefaultConnection",mgr.getUserName());
+        }
+        return mgrName;
     }
 
 }

--- a/java/src/jmri/swing/PowerManagerMenu.java
+++ b/java/src/jmri/swing/PowerManagerMenu.java
@@ -1,10 +1,13 @@
 package jmri.swing;
 
 import java.util.List;
+
+import javax.annotation.CheckForNull;
 import javax.swing.ButtonGroup;
 import javax.swing.JMenu;
 import javax.swing.JMenuItem;
 import javax.swing.JRadioButtonMenuItem;
+
 import jmri.InstanceManager;
 import jmri.PowerManager;
 
@@ -14,30 +17,40 @@ import jmri.PowerManager;
  * @author Bob Jacobsen Copyright 2010
  * @since 2.9.5
  */
-abstract public class PowerManagerMenu extends JMenu {
+public abstract class PowerManagerMenu extends JMenu {
 
-    /**
-     * Get the currently selected manager.
-     *
-     * @return null unless overridden by subclass
-     */
-    // should this be abstract?
-    public PowerManager get() {
-        return null;
-    }
+    JMenuItem allConnsItem = new JRadioButtonMenuItem(Bundle.getMessage("AllConnections"));
+    private final List<JMenuItem> menuItems = new java.util.ArrayList<>();
 
-    abstract protected void choiceChanged();
+    protected abstract void choiceChanged();
 
     /**
      * Create a PowerManager menu.
      */
     public PowerManagerMenu() {
+        this(false, null);
+    }
+
+    /**
+     * Create a PowerManager menu.
+     * @param includeAllConns
+     * @param defaultPwrMgr
+     */
+    public PowerManagerMenu(boolean includeAllConns, PowerManager defaultPwrMgr) {
         super();
 
         ButtonGroup group = new ButtonGroup();
 
         // label this menu
         setText(Bundle.getMessage("MenuConnection")) ;
+
+        if (includeAllConns) {
+            add(allConnsItem);
+            group.add(allConnsItem);
+            menuItems.add(allConnsItem);
+            allConnsItem.addActionListener((java.awt.event.ActionEvent e) -> 
+                choiceChanged());
+        }
 
         // now add an item for each available manager
         List<PowerManager> managers = InstanceManager.getList(PowerManager.class);
@@ -46,42 +59,39 @@ abstract public class PowerManagerMenu extends JMenu {
                 JMenuItem item = new JRadioButtonMenuItem(mgr.getUserName());
                 add(item);
                 group.add(item);
-                items.add(item);
-                item.addActionListener((java.awt.event.ActionEvent e) -> {
-                    choiceChanged();
-                });
+                menuItems.add(item);
+                item.addActionListener((java.awt.event.ActionEvent e) -> 
+                    choiceChanged());
             }
         }
 
-        setDefault();
+        PowerManagerMenu.this.setManager(defaultPwrMgr);
     }
 
-    List<JMenuItem> items = new java.util.ArrayList<>();
-
-    void setDefault() {
-        // name of default
-        PowerManager manager = InstanceManager.getNullableDefault(jmri.PowerManager.class);
-        if (manager == null) {
+    public void setManager(@CheckForNull PowerManager suppliedMgr) {
+        if (InstanceManager.getNullableDefault(jmri.PowerManager.class) == null) {
             return;
         }
-        String defaultMgr = manager.getUserName();
-        for (JMenuItem item : items) {
-            if (defaultMgr.equals(item.getActionCommand())) {
+        String searchMgr = ( suppliedMgr != null ? suppliedMgr.getUserName() : "");
+        for (JMenuItem item : menuItems) {
+            if (searchMgr.equals(item.getActionCommand())) {
                 item.setSelected(true);
+                return;
             }
         }
+        allConnsItem.setSelected(true);
     }
 
+    /**
+     * Get the selected PowerManager.
+     * @return null if All Connections option selected.
+     */
+    @CheckForNull
     public PowerManager getManager() {
-        // start with default
-        PowerManager manager = InstanceManager.getNullableDefault(jmri.PowerManager.class);
-        if (manager == null) {
-            return null;
-        }
-        String name = manager.getUserName();
 
+        String name="";
         // find active name
-        for (JMenuItem item : items) {
+        for (JMenuItem item : menuItems) {
             if (item.isSelected()) {
                 name = item.getActionCommand();
                 break;
@@ -89,12 +99,15 @@ abstract public class PowerManagerMenu extends JMenu {
         }
         // find PowerManager and return
         List<PowerManager> managers = InstanceManager.getList(PowerManager.class);
+        if (managers.size()==1){
+            return managers.get(0);
+        }
         for (PowerManager mgr : managers) {
             if (name.equals(mgr.getUserName())) {
                 return mgr;
             }
         }
-        // should not happen
         return null;
     }
+
 }

--- a/java/test/jmri/jmrit/powerpanel/PowerPaneTest.java
+++ b/java/test/jmri/jmrit/powerpanel/PowerPaneTest.java
@@ -1,60 +1,111 @@
 package jmri.jmrit.powerpanel;
 
+import javax.swing.JFrame;
+
+import jmri.InstanceManager;
+import jmri.PowerManager;
+import jmri.jmrix.lenz.*;
 import jmri.util.JUnitUtil;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.netbeans.jemmy.operators.*;
 
 /**
  * Tests for the Jmrit PowerPanel
  *
  * @author Bob Jacobsen
  */
+@DisabledIfSystemProperty(named = "java.awt.headless", matches = "true")
 public class PowerPaneTest extends jmri.util.swing.JmriPanelTest {
+
+    private void createPowerFrame(String frameName){
+        JFrame f = new JFrame(frameName);
+        f.getContentPane().add(panel);
+        f.pack();
+        jmri.util.ThreadingUtil.runOnGUI(() -> f.setVisible(true));
+    }
+
+    // test on button routine
+    @Test
+    public void testPushOn() {
+        createPowerFrame("testPushOn");
+        JFrameOperator jfo = new JFrameOperator("testPushOn");
+
+        Assertions.assertEquals(PowerManager.UNKNOWN, InstanceManager.getDefault(PowerManager.class).getPower());
+        Assertions.assertEquals(Bundle.getMessage("StatusUnknown"), new JLabelOperator(jfo, 1).getText());
+
+        new JButtonOperator(jfo,Bundle.getMessage("ButtonOn")).doClick();
+        JUnitUtil.waitFor(() -> InstanceManager.getDefault(PowerManager.class).getPower()== PowerManager.ON,"power on");
+        JUnitUtil.waitFor(() -> Bundle.getMessage("StatusOn").equals( new JLabelOperator(jfo, 1).getText()),"Status not changed on");
+
+        jfo.requestClose();
+        jfo.waitClosed();
+    }
+
+    // test off button routine
+    @Test
+    public void testPushOff() {
+        createPowerFrame("testPushOff");
+        JFrameOperator jfo = new JFrameOperator("testPushOff");
+
+        Assertions.assertEquals(PowerManager.UNKNOWN, InstanceManager.getDefault(PowerManager.class).getPower());
+        Assertions.assertEquals(Bundle.getMessage("StatusUnknown"), new JLabelOperator(jfo, 1).getText());
+
+        new JButtonOperator(jfo,Bundle.getMessage("ButtonOff")).doClick();
+        JUnitUtil.waitFor(() -> InstanceManager.getDefault(PowerManager.class).getPower()== PowerManager.OFF,"power off");
+        JUnitUtil.waitFor(() -> Bundle.getMessage("StatusOff").equals( new JLabelOperator(jfo, 1).getText()),"Status not changed off");
+
+        jfo.requestClose();
+        jfo.waitClosed();
+    }
+
+    @Test
+    public void testPowerPanelMultiConn(){
+
+        XNetInterfaceScaffold tc = new XNetInterfaceScaffold(new LenzCommandStation());
+        PowerManager pm = new XNetPowerManager(tc.getSystemConnectionMemo());
+        InstanceManager.setDefault(PowerManager.class, pm);
+
+        jmri.util.ThreadingUtil.runOnGUI( () ->
+            new PowerPanelAction().actionPerformed(null));
+
+        JFrameOperator jfo = new JFrameOperator(Bundle.getMessage("TitlePowerPanel")
+                + " : " + Bundle.getMessage("AllConnections"));
+        new JMenuBarOperator(jfo).getMenu(0).doClick();
+        JPopupMenuOperator jpo = new JPopupMenuOperator(jfo);
+        Assertions.assertEquals(3, jpo.getComponentCount());
+
+        new JMenuItemOperator(jpo, 2).doClick(); // select xnet
+        jfo.getQueueTool().waitEmpty();
+        Assertions.assertEquals(Bundle.getMessage("TitlePowerPanel")
+                + " : " + pm.getUserName(), jfo.getTitle());
+
+        int framesBefore = tc.outbound.size();
+        new JButtonOperator(jfo,Bundle.getMessage("ButtonIdle")).doClick();
+        Assertions.assertTrue( tc.outbound.size() > framesBefore);
+
+        new JMenuItemOperator(jpo, 0).doClick(); // select all connections
+        jfo.getQueueTool().waitEmpty();
+        Assertions.assertEquals(Bundle.getMessage("TitlePowerPanel")
+                + " : " + Bundle.getMessage("AllConnections"), jfo.getTitle());
+
+        tc.terminateThreads();
+        jfo.requestClose();
+        jfo.waitClosed();
+
+    }
 
     // setup a default PowerManager interface
     @BeforeEach
     @Override
     public void setUp() {
         JUnitUtil.setUp();
+        JUnitUtil.resetInstanceManager();
         JUnitUtil.initDebugPowerManager();
         panel = new PowerPane();
         helpTarget="package.jmri.jmrit.powerpanel.PowerPanelFrame";
-        title=Bundle.getMessage("TitlePowerPanel");
+        title=Bundle.getMessage("TitlePowerPanel") + " : Internal";
     }
-    @AfterEach
-    @Override
-    public void tearDown() {
-        JUnitUtil.tearDown();
-    }
-
-    // test on button routine
-    @Test
-    public void testPushOn() {
-        ((PowerPane) panel).onButtonPushed();
-        Assert.assertEquals("Testing shown on/off", "On", ((PowerPane) panel).onOffStatus.getText());
-    }
-
-    // test off button routine
-    @Test
-    public void testPushOff() {
-        ((PowerPane) panel).offButtonPushed();
-        Assert.assertEquals("Testing shown on/off", "Off", ((PowerPane) panel).onOffStatus.getText());
-    }
-
-    // click on button
-    @Test
-    public void testOnClicked() {
-        ((PowerPane) panel).onButton.doClick();
-        Assert.assertEquals("Testing shown on/off", "On", ((PowerPane) panel).onOffStatus.getText());
-    }
-
-    // click off button
-    @Test
-    public void testOffClicked() {
-        ((PowerPane) panel).offButton.doClick();
-        Assert.assertEquals("Testing shown on/off", "Off", ((PowerPane) panel).onOffStatus.getText());
-    }
-
 
 }


### PR DESCRIPTION
PowerPane.java 

Move panel display to SinglePowerPane
if PowerManager returned from PowerManagerMenuImpl is null, display all PowerManagers.

PowerManagerMenu.java 

Add All Connections option.
When this option is selected, getManager returns null, or if there is only 1 connection, the connection.

![image](https://github.com/JMRI/JMRI/assets/39652002/643f79a8-66e9-41dc-b5a0-bfc198eb0aea)
