### PR TITLE
Dispatcher fixes

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -415,7 +415,8 @@
    <h3>Dispatcher</h3>
         <a id="Dispatcher" name="Dispatcher"></a>
         <ul>
-             <li></li>
+             <li>Check each section against reserved sections for conflicting blocks.</li>
+             <li>Do not turn off block alternate colour when it has already be reallocated.</li>
         </ul>
 
     <h3>Dispatcher System</h3>

--- a/java/src/jmri/jmrit/dispatcher/ActiveTrain.java
+++ b/java/src/jmri/jmrit/dispatcher/ActiveTrain.java
@@ -16,6 +16,8 @@ import jmri.Section;
 import jmri.Sensor;
 import jmri.Transit;
 import jmri.beans.PropertyChangeProvider;
+import jmri.jmrit.display.layoutEditor.LayoutBlock;
+import jmri.jmrit.display.layoutEditor.LayoutBlockManager;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -791,7 +793,17 @@ public class ActiveTrain implements PropertyChangeProvider {
             as.getSection().clearNameInUnoccupiedBlocks();
             as.getSection().suppressNameUpdate(false);
         }
-        as.getSection().setAlternateColor(false);
+        for (Block b: as.getSection().getBlockList()) {
+            if (!InstanceManager.getDefault(DispatcherFrame.class).checkForBlockInAllocatedSection(b, as.getSection())) {
+                String userName = b.getUserName();
+                if (userName != null) {
+                    LayoutBlock lb = InstanceManager.getDefault(LayoutBlockManager.class).getByUserName(userName);
+                    if (lb != null) {
+                        lb.setUseExtraColor(false);
+                    }
+                }
+            }
+        }
         refreshPanel();
         if (as.getSection() == mLastAllocatedSection) {
             mLastAllocatedSection = null;
@@ -827,7 +839,7 @@ public class ActiveTrain implements PropertyChangeProvider {
         resetAllAllocatedSections();
         clearAllocations();
         setAllocationReversed(false);
-        // wait for autoallocate to do its stuffbefore continuing
+        // wait for AutoAllocate to do complete.
         InstanceManager.getDefault(DispatcherFrame.class).queueWaitForEmpty();
         if (mAutoRun) {
             mAutoActiveTrain.allocateAFresh();

--- a/java/src/jmri/jmrit/dispatcher/AutoAllocate.java
+++ b/java/src/jmri/jmrit/dispatcher/AutoAllocate.java
@@ -297,10 +297,10 @@ public class AutoAllocate implements Runnable {
                                                 trainName, sS.getUserName(),
                                                 _dispatcher.checkBlocksNotInAllocatedSection(sS, ar));
                                         areForwardsFree = false;
-                                    } else if (checkBlocksNotInReservedSection(activeTrain, ar) != null) {
+                                    } else if (checkBlocksNotInReservedSection(activeTrain, sS) != null) {
                                         log.debug("{}: Forward section [{}] is in conflict with [{}]",
                                                 trainName, sS.getDisplayName(),
-                                                checkBlocksNotInReservedSection(activeTrain, ar).getDisplayName());
+                                                checkBlocksNotInReservedSection(activeTrain, sS).getDisplayName());
                                         areForwardsFree = false;
 
                                     } else if (reservedSections.get(sS.getSystemName()) != null &&
@@ -484,9 +484,9 @@ public class AutoAllocate implements Runnable {
     /*
      * Check conflicting blocks acros reserved sections.
      */
-    protected Section checkBlocksNotInReservedSection(ActiveTrain at, AllocationRequest ar) {
+    protected Section checkBlocksNotInReservedSection(ActiveTrain at, Section sectionToCheck) {
         String trainName = at.getTrainName();
-        List<Block> lb = ar.getSection().getBlockList();
+        List<Block> lb = sectionToCheck.getBlockList();
         Iterator<Entry<String, String>> iterRS = reservedSections.entrySet().iterator();
         while (iterRS.hasNext()) {
             Map.Entry<String, String> pair = iterRS.next();

--- a/java/src/jmri/jmrit/dispatcher/DispatcherFrame.java
+++ b/java/src/jmri/jmrit/dispatcher/DispatcherFrame.java
@@ -2198,6 +2198,23 @@ public class DispatcherFrame extends jmri.util.JmriJFrame implements InstanceMan
         return _levelXingList;
     }
 
+    /**
+     * Checks for a block in allocated section, except one
+     * @param b - The Block
+     * @param ignoreSection - ignore this section, can be null
+     * @return true is The Block is being used in a section.
+     */
+    protected boolean checkForBlockInAllocatedSection ( Block b, Section ignoreSection ) {
+        for ( AllocatedSection as : allocatedSections) {
+            if (ignoreSection == null || as.getSection() != ignoreSection) {
+                if (as.getSection().getBlockList().contains(b)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
     /*
      * This is used to determine if the blocks in a section we want to allocate are already allocated to a section, or if they are now free.
      */


### PR DESCRIPTION
Check each section as required not just the one in the request.
When releaseing a section, only change the alternate colour, which triggers other events, on the blocks in the section that have not already been reallocated.