### PR TITLE
OpenLCB Signal Mast Add/Edit Pane enhancements

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -140,7 +140,9 @@
                             to not open for certain nodes, including the DCC-LCC Gateway.
                     </ul>
                 </li>
-                <li>Added Window and Help menus to the Configure Node window.
+                <li>Added Window and Help menus to the Configure Node window.</li>
+                <li>Added support for multiple OpenLCB connections in Signal Masts add/edit dialog.</li>
+                <li>Added GUI Icons for OpenLCB signal masts in the add/edit dialog.</li>
             </ul>
 
         <h4>Powerline</h4>

--- a/java/src/jmri/jmrix/openlcb/OlcbSignalMast.java
+++ b/java/src/jmri/jmrix/openlcb/OlcbSignalMast.java
@@ -105,7 +105,6 @@ public class OlcbSignalMast extends AbstractSignalMast {
             java.util.List<SystemConnectionMemo> memoList = jmri.InstanceManager.getList(SystemConnectionMemo.class);
 
             for (SystemConnectionMemo memo : memoList) {
-                System.out.println("memo: " + memo);
                 if (memo.getSystemPrefix().equals(systemPrefix)) {
                     if (memo instanceof jmri.jmrix.can.CanSystemConnectionMemo) {
                         systemMemo = (jmri.jmrix.can.CanSystemConnectionMemo) memo;

--- a/java/src/jmri/jmrix/openlcb/OlcbSignalMast.java
+++ b/java/src/jmri/jmrix/openlcb/OlcbSignalMast.java
@@ -81,6 +81,11 @@ public class OlcbSignalMast extends AbstractSignalMast {
 
     NodeID node;
     Connection connection;
+    String systemPrefix;
+
+    public String getSystemPrefix() {
+        return systemPrefix;
+    }
 
     // not sure why this is a CanSystemConnectionMemo in simulator, but it is
     jmri.jmrix.can.CanSystemConnectionMemo systemMemo;
@@ -93,12 +98,14 @@ public class OlcbSignalMast extends AbstractSignalMast {
             throw new IllegalArgumentException("System name needs at least three parts: " + systemName);
         }
         if (!parts[0].endsWith(mastType)) {
+            systemPrefix = null;
             log.warn("First part of SignalMast system name is incorrect {} : {}",systemName,mastType);
         } else {
-            String systemPrefix = parts[0].substring(0, parts[0].indexOf('$') - 1);
+            systemPrefix = parts[0].substring(0, parts[0].indexOf('$') - 1);
             java.util.List<SystemConnectionMemo> memoList = jmri.InstanceManager.getList(SystemConnectionMemo.class);
 
             for (SystemConnectionMemo memo : memoList) {
+                System.out.println("memo: " + memo);
                 if (memo.getSystemPrefix().equals(systemPrefix)) {
                     if (memo instanceof jmri.jmrix.can.CanSystemConnectionMemo) {
                         systemMemo = (jmri.jmrix.can.CanSystemConnectionMemo) memo;

--- a/java/src/jmri/jmrix/openlcb/swing/Bundle.properties
+++ b/java/src/jmri/jmrix/openlcb/swing/Bundle.properties
@@ -16,6 +16,7 @@ AllowUnLitLabel = This Mast can be unlit
 EnterAspectsLabel = Aspects
 DisableAspect = Disable Aspect
 
+OlcbConnection = OpenLCB Connection
 OlcbSignalMastPane = OpenLCB Event Mast
 LitLabel = Lit:
 NotLitLabel = Not Lit:

--- a/java/src/jmri/jmrix/openlcb/swing/OlcbSignalMastAddPane.java
+++ b/java/src/jmri/jmrix/openlcb/swing/OlcbSignalMastAddPane.java
@@ -135,8 +135,8 @@ public class OlcbSignalMastAddPane extends SignalMastAddPane {
 
     // This used to be called "disabledAspects", but that's misleading: it's actually a map of
     // ALL aspects' "disabled" checkboxes, regardless of their enabled/disabled state.
-    LinkedHashMap<String, JCheckBox> allAspectsCheckBoxes = new LinkedHashMap<String, JCheckBox>(NOTIONAL_ASPECT_COUNT);
-    final LinkedHashMap<String, EventIdTextField> aspectEventIDs = new LinkedHashMap<String, EventIdTextField>(NOTIONAL_ASPECT_COUNT);
+    LinkedHashMap<String, JCheckBox> allAspectsCheckBoxes = new LinkedHashMap<>(NOTIONAL_ASPECT_COUNT);
+    final LinkedHashMap<String, EventIdTextField> aspectEventIDs = new LinkedHashMap<>(NOTIONAL_ASPECT_COUNT);
     final JPanel allAspectsPanel = new JPanel();
     final EventIdTextField litEventID = new EventIdTextField();
     final EventIdTextField notLitEventID = new EventIdTextField();
@@ -155,7 +155,7 @@ public class OlcbSignalMastAddPane extends SignalMastAddPane {
     public void setAspectNames(@Nonnull SignalAppearanceMap map, @Nonnull SignalSystem sigSystem) {
         Enumeration<String> aspectNames = map.getAspects();
         // update immediately
-        allAspectsCheckBoxes = new LinkedHashMap<String, JCheckBox>(NOTIONAL_ASPECT_COUNT);
+        allAspectsCheckBoxes = new LinkedHashMap<>(NOTIONAL_ASPECT_COUNT);
         allAspectsPanel.removeAll();
         while (aspectNames.hasMoreElements()) {
             String aspectName = aspectNames.nextElement();

--- a/java/src/jmri/jmrix/openlcb/swing/OlcbSignalMastAddPane.java
+++ b/java/src/jmri/jmrix/openlcb/swing/OlcbSignalMastAddPane.java
@@ -220,7 +220,7 @@ public class OlcbSignalMastAddPane extends SignalMastAddPane {
 
     /*
      * Populate the list of valid OpenLCB connection names.
-     * Only connections that have "OpenLCB" as their manufacturer are added.
+     * Only connections that have "OpenLCB" or "LCC" as their manufacturer are added.
      */
     private void getOlcbConnections() {
         olcbConnections = null;
@@ -239,11 +239,11 @@ public class OlcbSignalMastAddPane extends SignalMastAddPane {
             log.debug("conns[{}]: name={} info={} adapter={} conn={}  man={}",
                       x, cc.name(), cc.getInfo(), cc.getAdapter(),
                       cc.getConnectionName(), cc.getManufacturer());
-            /* As this is the Olcb signal mast add pane, only show OpenLCB connections */
+            /* As this is the Olcb signal mast add pane, only show OpenLCB/LCC connections */
             String man = cc.getManufacturer();
             String name = cc.getConnectionName();
-            /* TODO: are there other strings than "OpenLCB" for manufacturer? */
-            if (man != null && man.equals("OpenLCB") && name != null && !name.isEmpty()) {
+            if (man != null && name != null && !name.isEmpty() &&
+                (man.equals("OpenLCB") || man.equals("LCC"))) {
                 if (olcbConnections == null) {
                     olcbConnections = new ArrayList<String>();
                 }

--- a/java/src/jmri/jmrix/openlcb/swing/OlcbSignalMastAddPane.java
+++ b/java/src/jmri/jmrix/openlcb/swing/OlcbSignalMastAddPane.java
@@ -188,7 +188,7 @@ public class OlcbSignalMastAddPane extends SignalMastAddPane {
                     n = new NamedIcon(iconLink, iconLink);
                     log.debug("Loaded icon {}", iconLink);
                 } catch (Exception e) {
-                    log.debug("Got exception trying to load icon link {}: {}", iconLink, e);
+                    log.debug("Got exception trying to load icon link {}: {}", iconLink, e.getMessage());
                 }
                 // display icon
                 if (n != null) {

--- a/java/src/jmri/jmrix/openlcb/swing/OlcbSignalMastAddPane.java
+++ b/java/src/jmri/jmrix/openlcb/swing/OlcbSignalMastAddPane.java
@@ -2,13 +2,18 @@ package jmri.jmrix.openlcb.swing;
 
 import jmri.*;
 import jmri.jmrit.beantable.signalmast.SignalMastAddPane;
+import jmri.jmrit.catalog.NamedIcon;
 import jmri.SystemConnectionMemo;
+import jmri.util.ConnectionNameFromSystemName;
 
 import jmri.jmrix.openlcb.*;
+import jmri.jmrix.ConnectionConfig;
+import jmri.jmrix.ConnectionConfigManager;
 
 import java.awt.*;
 import java.text.DecimalFormat;
 import java.util.*;
+import java.util.ArrayList;
 import java.util.List;
 
 import javax.swing.*;
@@ -35,6 +40,23 @@ public class OlcbSignalMastAddPane extends SignalMastAddPane {
         heldEventID.setText("00.00.00.00.00.00.00.00");
         notHeldEventID.setText("00.00.00.00.00.00.00.00");
 
+        // populate the OpenLCB connections list before creating GUI components.
+        getOlcbConnections();
+
+        // If the connections list has less than 2 items, don't show a selector.
+        // This maintains backward compatibility with previous versions.
+        if (olcbConnections != null && olcbConnections.size() > 1) {
+            // Connection selector
+            JPanel p = new JPanel();
+            TitledBorder border = BorderFactory.createTitledBorder(BorderFactory.createLineBorder(Color.black));
+            border.setTitle(Bundle.getMessage("OlcbConnection"));
+            p.setBorder(border);
+            p.setLayout(new jmri.util.javaworld.GridLayout2(3, 1));
+
+            p.add(connSelectionBox);
+            add(p);
+        }
+
         // lit/unlit controls
         JPanel p = new JPanel();
         p.setLayout(new BoxLayout(p, BoxLayout.X_AXIS));
@@ -44,11 +66,11 @@ public class OlcbSignalMastAddPane extends SignalMastAddPane {
         add(p);
         
         // aspects controls
-        TitledBorder disableborder = BorderFactory.createTitledBorder(BorderFactory.createLineBorder(Color.black));
-        disableborder.setTitle(Bundle.getMessage("EnterAspectsLabel"));
-        JScrollPane disabledAspectsScroll = new JScrollPane(disabledAspectsPanel);
-        disabledAspectsScroll.setBorder(disableborder);
-        add(disabledAspectsScroll);
+        TitledBorder aspectsBorder = BorderFactory.createTitledBorder(BorderFactory.createLineBorder(Color.black));
+        aspectsBorder.setTitle(Bundle.getMessage("EnterAspectsLabel"));
+        JScrollPane allAspectsScroll = new JScrollPane(allAspectsPanel);
+        allAspectsScroll.setBorder(aspectsBorder);
+        add(allAspectsScroll);
         
         JPanel p5;
 
@@ -98,6 +120,9 @@ public class OlcbSignalMastAddPane extends SignalMastAddPane {
         
         add(pHeld);
 
+        // set up selection of connections, if needed
+        populateConnSelectionBox();
+
     }
 
     /** {@inheritDoc} */
@@ -106,54 +131,156 @@ public class OlcbSignalMastAddPane extends SignalMastAddPane {
         return Bundle.getMessage("OlcbSignalMastPane");
     }
 
-
     final JCheckBox allowUnLit = new JCheckBox();
 
-    LinkedHashMap<String, JCheckBox> disabledAspects = new LinkedHashMap<>(NOTIONAL_ASPECT_COUNT);
-    final LinkedHashMap<String, EventIdTextField> aspectEventIDs = new LinkedHashMap<>(NOTIONAL_ASPECT_COUNT);
-    final JPanel disabledAspectsPanel = new JPanel();
+    // This used to be called "disabledAspects", but that's misleading: it's actually a map of
+    // ALL aspects' "disabled" checkboxes, regardless of their enabled/disabled state.
+    LinkedHashMap<String, JCheckBox> allAspectsCheckBoxes = new LinkedHashMap<String, JCheckBox>(NOTIONAL_ASPECT_COUNT);
+    final LinkedHashMap<String, EventIdTextField> aspectEventIDs = new LinkedHashMap<String, EventIdTextField>(NOTIONAL_ASPECT_COUNT);
+    final JPanel allAspectsPanel = new JPanel();
     final EventIdTextField litEventID = new EventIdTextField();
     final EventIdTextField notLitEventID = new EventIdTextField();
     final EventIdTextField heldEventID = new EventIdTextField();
     final EventIdTextField notHeldEventID = new EventIdTextField();
 
+    JComboBox<String> connSelectionBox = new JComboBox<String>();
+
     OlcbSignalMast currentMast = null;
+
+    // Support for multiple OpenLCB connections with different prefixes
+    ArrayList<String> olcbConnections = null;
 
     /** {@inheritDoc} */
     @Override
     public void setAspectNames(@Nonnull SignalAppearanceMap map, @Nonnull SignalSystem sigSystem) {
-        Enumeration<String> aspects = map.getAspects();
+        Enumeration<String> aspectNames = map.getAspects();
         // update immediately
-        disabledAspects = new LinkedHashMap<>(NOTIONAL_ASPECT_COUNT);
-        disabledAspectsPanel.removeAll();
-        while (aspects.hasMoreElements()) {
-            String aspect = aspects.nextElement();
-            JCheckBox disabled = new JCheckBox(aspect);
-            disabledAspects.put(aspect, disabled);
+        allAspectsCheckBoxes = new LinkedHashMap<String, JCheckBox>(NOTIONAL_ASPECT_COUNT);
+        allAspectsPanel.removeAll();
+        while (aspectNames.hasMoreElements()) {
+            String aspectName = aspectNames.nextElement();
+            JCheckBox disabled = new JCheckBox(aspectName);
+            allAspectsCheckBoxes.put(aspectName, disabled);
             EventIdTextField eventID = new EventIdTextField();
             eventID.setText("00.00.00.00.00.00.00.00");
-            aspectEventIDs.put(aspect, eventID);
+            aspectEventIDs.put(aspectName, eventID);
         }
-        disabledAspectsPanel.setLayout(new BoxLayout(disabledAspectsPanel, BoxLayout.Y_AXIS));
-        for (Map.Entry<String, JCheckBox> entry : disabledAspects.entrySet()) {
+        allAspectsPanel.setLayout(new BoxLayout(allAspectsPanel, BoxLayout.Y_AXIS));
+        for (Map.Entry<String, JCheckBox> entry : allAspectsCheckBoxes.entrySet()) {
             JPanel p1 = new JPanel();
             TitledBorder p1border = BorderFactory.createTitledBorder(BorderFactory.createLineBorder(Color.black));
-            p1border.setTitle(entry.getKey());
+            p1border.setTitle(entry.getKey()); // Note this is not I18N'd: as-is from xml file
             p1.setBorder(p1border);
-            p1.setLayout(new BoxLayout(p1, BoxLayout.Y_AXIS));
-            p1.add(aspectEventIDs.get(entry.getKey()));
-            p1.add(entry.getValue());
+            p1.setLayout(new BoxLayout(p1, BoxLayout.X_AXIS));
+
+            // Attempt to load an icon for display
+            String iconLink = map.getImageLink(entry.getKey(), "default");
+            if (iconLink == null || iconLink.isEmpty()) {
+                log.debug("Got empty image link for {}", entry.getKey());
+            } else {
+                log.debug("Image link for {} is {}", entry.getKey(), iconLink);
+                if (!iconLink.contains("preference:")) {
+                    // This logic copied from SignalMastItemPanel.java
+                    iconLink = iconLink.substring(iconLink.indexOf("resources"));
+                }
+                NamedIcon n = null;
+                try {
+                    n = new NamedIcon(iconLink, iconLink);
+                    log.debug("Loaded icon {}", iconLink);
+                } catch (Exception e) {
+                    log.debug("Got exception trying to load icon link {}: {}", iconLink, e);
+                }
+                // display icon
+                if (n != null) {
+                    p1.add(new JLabel(n));
+                }
+            }
+
+            JPanel p2 = new JPanel();
+            p2.setLayout(new BoxLayout(p2, BoxLayout.Y_AXIS));
+            // event ID text box
+            p2.add(aspectEventIDs.get(entry.getKey()));
+            // "Disable" checkbox
+            p2.add(entry.getValue());
             entry.getValue().setName(entry.getKey());
             entry.getValue().setText(Bundle.getMessage("DisableAspect"));
-            disabledAspectsPanel.add(p1);
+            p1.add(p2);
+            allAspectsPanel.add(p1);
         }
+
+        populateConnSelectionBox();
 
         litEventID.setText("00.00.00.00.00.00.00.00");
         notLitEventID.setText("00.00.00.00.00.00.00.00");
         heldEventID.setText("00.00.00.00.00.00.00.00");
         notHeldEventID.setText("00.00.00.00.00.00.00.00");
 
-        disabledAspectsPanel.revalidate();
+        allAspectsPanel.revalidate();
+    }
+
+    /*
+     * Populate the list of valid OpenLCB connection names.
+     * Only connections that have "OpenLCB" as their manufacturer are added.
+     */
+    private void getOlcbConnections() {
+        olcbConnections = null;
+        ConnectionConfig[] conns = null;
+        try {
+            conns = InstanceManager.getDefault(ConnectionConfigManager.class).getConnections();
+        } catch (Exception e) {
+            log.info("No ConnectionConfigManager installed: Using default Olcb Connections");
+        }
+        if (conns == null || conns.length == 0) {
+            log.debug("Found null or empty connections list");
+            return;
+        }
+        for (int x = 0; x < conns.length; x++) {
+            ConnectionConfig cc = conns[x];
+            log.debug("conns[" + x + "]: name=" + cc.name() + " info=" + cc.getInfo() +
+                      " adapter=" + cc.getAdapter() + " conn=" + cc.getConnectionName() +
+                      " man=" + cc.getManufacturer());
+            /* As this is the Olcb signal mast add pane, only show OpenLCB connections */
+            String man = cc.getManufacturer();
+            String name = cc.getConnectionName();
+            /* TODO: are there other strings than "OpenLCB" for manufacturer? */
+            if (man != null && man.equals("OpenLCB") && name != null && !name.isEmpty()) {
+                if (olcbConnections == null) {
+                    olcbConnections = new ArrayList<String>();
+                }
+                olcbConnections.add(name);
+            }
+        }
+    }
+
+    /*
+     * Populate the GUI connection selection box, if there are
+     * multiple OpenLCB connections.
+     */
+    private void populateConnSelectionBox() {
+        connSelectionBox.removeAllItems();
+        if (olcbConnections == null || olcbConnections.size() < 2) {
+            return;
+        }
+        for (String conn : olcbConnections) {
+            connSelectionBox.addItem(conn);
+        }
+        if (currentMast == null) {
+            connSelectionBox.setEnabled(true);
+            return;
+        }
+        // set the selected connection based on the current mast
+        String mastPrefix = currentMast.getSystemPrefix();
+        if (mastPrefix != null) {
+            for (String conn : olcbConnections) {
+                String connectionPrefix = ConnectionNameFromSystemName.getPrefixFromName(conn);
+                if (connectionPrefix.equals(mastPrefix)) {
+                    connSelectionBox.setSelectedItem(conn);
+                    break;
+                }
+            }
+        }
+        // Can't change connection on existing masts
+        connSelectionBox.setEnabled(false);
     }
 
     /** {@inheritDoc} */
@@ -167,6 +294,8 @@ public class OlcbSignalMastAddPane extends SignalMastAddPane {
     public void setMast(SignalMast mast) { 
         if (mast == null) { 
             currentMast = null; 
+            // re-enable connection selector
+            populateConnSelectionBox();
             return; 
         }
         
@@ -176,11 +305,11 @@ public class OlcbSignalMastAddPane extends SignalMastAddPane {
         }
 
         currentMast = (OlcbSignalMast) mast;
-        List<String> disabled = currentMast.getDisabledAspects();
-        if (disabled != null) {
-            for (String aspect : disabled) {
-                if (disabledAspects.containsKey(aspect)) {
-                    disabledAspects.get(aspect).setSelected(true);
+        List<String> disabledList = currentMast.getDisabledAspects();
+        if (disabledList != null) {
+            for (String aspect : disabledList) {
+                if (allAspectsCheckBoxes.containsKey(aspect)) {
+                    allAspectsCheckBoxes.get(aspect).setSelected(true);
                 }
             }
          }
@@ -204,6 +333,9 @@ public class OlcbSignalMastAddPane extends SignalMastAddPane {
 
         allowUnLit.setSelected(currentMast.allowUnLit());
 
+        // show current connection in selector
+        populateConnSelectionBox();
+
         log.debug("setMast({})", mast);
     }
 
@@ -216,9 +348,18 @@ public class OlcbSignalMastAddPane extends SignalMastAddPane {
                               @Nonnull String username) {
         if (currentMast == null) {
             // create a mast
+            String selItem = (String)connSelectionBox.getSelectedItem();
+            String connectionPrefix = ConnectionNameFromSystemName.getPrefixFromName(selItem);
+            log.debug("selected name=" + selItem + ", prefix=" + connectionPrefix);
+            // if prefix is null, use default
+            if (connectionPrefix == null || connectionPrefix.isEmpty()) {
+                connectionPrefix = "M";
+            }
+
             String type = mastname.substring(11, mastname.length() - 4);
-            String name = "MF$olm:" + sigsysname + ":" + type;
+            String name = connectionPrefix + "F$olm:" + sigsysname + ":" + type;
             name += "($" + (paddedNumber.format(OlcbSignalMast.getLastRef() + 1)) + ")";
+            log.debug("Creating mast: " + name);
             currentMast = new OlcbSignalMast(name);
             if (!username.equals("")) {
                 currentMast.setUserName(username);
@@ -228,7 +369,7 @@ public class OlcbSignalMastAddPane extends SignalMastAddPane {
         }
         
         // load a new or existing mast
-        for (Map.Entry<String, JCheckBox> entry : disabledAspects.entrySet()) {
+        for (Map.Entry<String, JCheckBox> entry : allAspectsCheckBoxes.entrySet()) {
             if (entry.getValue().isSelected()) {
                 currentMast.setAspectDisabled(entry.getKey());
             } else {

--- a/java/src/jmri/jmrix/openlcb/swing/OlcbSignalMastAddPane.java
+++ b/java/src/jmri/jmrix/openlcb/swing/OlcbSignalMastAddPane.java
@@ -236,9 +236,9 @@ public class OlcbSignalMastAddPane extends SignalMastAddPane {
         }
         for (int x = 0; x < conns.length; x++) {
             ConnectionConfig cc = conns[x];
-            log.debug("conns[" + x + "]: name=" + cc.name() + " info=" + cc.getInfo() +
-                      " adapter=" + cc.getAdapter() + " conn=" + cc.getConnectionName() +
-                      " man=" + cc.getManufacturer());
+            log.debug("conns[{}]: name={} info={} adapter={} conn={}  man={}",
+                      x, cc.name(), cc.getInfo(), cc.getAdapter(),
+                      cc.getConnectionName(), cc.getManufacturer());
             /* As this is the Olcb signal mast add pane, only show OpenLCB connections */
             String man = cc.getManufacturer();
             String name = cc.getConnectionName();
@@ -273,7 +273,7 @@ public class OlcbSignalMastAddPane extends SignalMastAddPane {
         if (mastPrefix != null) {
             for (String conn : olcbConnections) {
                 String connectionPrefix = ConnectionNameFromSystemName.getPrefixFromName(conn);
-                if (connectionPrefix.equals(mastPrefix)) {
+                if (connectionPrefix != null && connectionPrefix.equals(mastPrefix)) {
                     connSelectionBox.setSelectedItem(conn);
                     break;
                 }
@@ -350,7 +350,7 @@ public class OlcbSignalMastAddPane extends SignalMastAddPane {
             // create a mast
             String selItem = (String)connSelectionBox.getSelectedItem();
             String connectionPrefix = ConnectionNameFromSystemName.getPrefixFromName(selItem);
-            log.debug("selected name=" + selItem + ", prefix=" + connectionPrefix);
+            log.debug("selected name={}, prefix={}", selItem, connectionPrefix);
             // if prefix is null, use default
             if (connectionPrefix == null || connectionPrefix.isEmpty()) {
                 connectionPrefix = "M";
@@ -359,7 +359,7 @@ public class OlcbSignalMastAddPane extends SignalMastAddPane {
             String type = mastname.substring(11, mastname.length() - 4);
             String name = connectionPrefix + "F$olm:" + sigsysname + ":" + type;
             name += "($" + (paddedNumber.format(OlcbSignalMast.getLastRef() + 1)) + ")";
-            log.debug("Creating mast: " + name);
+            log.debug("Creating mast: {}", name);
             currentMast = new OlcbSignalMast(name);
             if (!username.equals("")) {
                 currentMast.setUserName(username);

--- a/java/test/jmri/jmrix/openlcb/OlcbSystemConnectionMemoScaffold.java
+++ b/java/test/jmri/jmrix/openlcb/OlcbSystemConnectionMemoScaffold.java
@@ -25,6 +25,12 @@ public class OlcbSystemConnectionMemoScaffold extends jmri.jmrix.can.CanSystemCo
         InstanceManager.store(this, OlcbSystemConnectionMemoScaffold.class); // also register as specific type
     }
 
+    public OlcbSystemConnectionMemoScaffold(String prefix) {
+        super(prefix);
+        register(); // registers general type
+        InstanceManager.store(this, OlcbSystemConnectionMemoScaffold.class); // also register as specific type
+    }
+
     final jmri.jmrix.swing.ComponentFactory cf = null;
 
     /**

--- a/java/test/jmri/jmrix/openlcb/swing/OlcbSignalMastAddPaneTest.java
+++ b/java/test/jmri/jmrix/openlcb/swing/OlcbSignalMastAddPaneTest.java
@@ -29,11 +29,17 @@ public class OlcbSignalMastAddPaneTest extends AbstractSignalMastAddPaneTestBase
     @Test
     public void testSetMast() {
         OlcbSignalMast s1 = new OlcbSignalMast("MF$olm:basic:one-searchlight($0001)", "user name");
+        // TODO: Enable multiple OpenLCB connections for tests
+        //OlcbSignalMast s2 = new OlcbSignalMast("SF$olm:basic:one-low($0002)", "user name");
+        //OlcbSignalMast s3 = new OlcbSignalMast("M3F$olm:basic:two-searchlight($0003)", "user name");
         MatrixSignalMast m1 = new MatrixSignalMast("IF$xsm:basic:one-low($0001)-3t", "user");
 
         OlcbSignalMastAddPane vp = new OlcbSignalMastAddPane();
 
         Assert.assertTrue(vp.canHandleMast(s1));
+        // TODO: Enable multiple OpenLCB connections for tests
+        //Assert.assertTrue(vp.canHandleMast(s2));
+        //Assert.assertTrue(vp.canHandleMast(s3));
         Assert.assertFalse(vp.canHandleMast(m1));
 
         vp.setMast(null);
@@ -45,6 +51,11 @@ public class OlcbSignalMastAddPaneTest extends AbstractSignalMastAddPaneTestBase
 
         vp.setAspectNames(s1.getAppearanceMap(), ss );
         vp.setMast(s1);
+        // TODO: Enable multiple OpenLCB connections for tests
+        //vp.setAspectNames(s2.getAppearanceMap(), ss );
+        //vp.setMast(s2);
+        //vp.setAspectNames(s3.getAppearanceMap(), ss );
+        //vp.setMast(s3);
 
         vp.setAspectNames(m1.getAppearanceMap(), ss );
         vp.setMast(m1);
@@ -121,7 +132,7 @@ public class OlcbSignalMastAddPaneTest extends AbstractSignalMastAddPaneTestBase
         // disable Approach Medim, change some of the event IDs
         // then build the mast, all on Swing thread
         ThreadingUtil.runOnGUI(() -> {
-            var approachMed = vp.disabledAspects.get("Approach Medium");
+            var approachMed = vp.allAspectsCheckBoxes.get("Approach Medium");
             Assert.assertNotNull(approachMed);
             approachMed.setSelected(true);
 
@@ -207,11 +218,11 @@ public class OlcbSignalMastAddPaneTest extends AbstractSignalMastAddPaneTestBase
         // disable Approach, change some of the event IDs
         // then build the mast, all on Swing thread
         ThreadingUtil.runOnGUI(() -> {
-            var approach = vp.disabledAspects.get("Approach");
+            var approach = vp.allAspectsCheckBoxes.get("Approach");
             Assert.assertNotNull(approach);
             approach.setSelected(true);
             
-            var unlit = vp.disabledAspects.get("Unlit");
+            var unlit = vp.allAspectsCheckBoxes.get("Unlit");
             Assert.assertNotNull(unlit);
             unlit.setSelected(false);
 
@@ -248,6 +259,7 @@ public class OlcbSignalMastAddPaneTest extends AbstractSignalMastAddPaneTestBase
         ThreadingUtil.runOnGUI(frame::dispose);
     }
 
+    // TODO: GUI test of icons in Add/Edit pane
 
     // from here down is testing infrastructure
     private static OlcbSystemConnectionMemoScaffold memo;
@@ -283,6 +295,10 @@ public class OlcbSignalMastAddPaneTest extends AbstractSignalMastAddPaneTestBase
                 messages.add(msg);
             }
         };
+
+        // TODO: Enable multiple OpenLCB connections for tests. Not sure how to
+        // do this, because OlcbSystemConnectionMemoScaffold defaults to a connection
+        // with prefix 'M' (from the default constructor in CanSystemConnectionMemo).
 
         memo = new OlcbSystemConnectionMemoScaffold(); // this self-registers as 'M'
         memo.setProtocol(jmri.jmrix.can.ConfigurationManager.OPENLCB);

--- a/java/test/jmri/jmrix/openlcb/swing/OlcbSignalMastAddPaneTest.java
+++ b/java/test/jmri/jmrix/openlcb/swing/OlcbSignalMastAddPaneTest.java
@@ -29,17 +29,15 @@ public class OlcbSignalMastAddPaneTest extends AbstractSignalMastAddPaneTestBase
     @Test
     public void testSetMast() {
         OlcbSignalMast s1 = new OlcbSignalMast("MF$olm:basic:one-searchlight($0001)", "user name");
-        // TODO: Enable multiple OpenLCB connections for tests
-        //OlcbSignalMast s2 = new OlcbSignalMast("SF$olm:basic:one-low($0002)", "user name");
-        //OlcbSignalMast s3 = new OlcbSignalMast("M3F$olm:basic:two-searchlight($0003)", "user name");
+        OlcbSignalMast s2 = new OlcbSignalMast("SF$olm:basic:one-low($0002)", "user name");
+        OlcbSignalMast s3 = new OlcbSignalMast("M3F$olm:basic:two-searchlight($0003)", "user name");
         MatrixSignalMast m1 = new MatrixSignalMast("IF$xsm:basic:one-low($0001)-3t", "user");
 
         OlcbSignalMastAddPane vp = new OlcbSignalMastAddPane();
 
         Assert.assertTrue(vp.canHandleMast(s1));
-        // TODO: Enable multiple OpenLCB connections for tests
-        //Assert.assertTrue(vp.canHandleMast(s2));
-        //Assert.assertTrue(vp.canHandleMast(s3));
+        Assert.assertTrue(vp.canHandleMast(s2));
+        Assert.assertTrue(vp.canHandleMast(s3));
         Assert.assertFalse(vp.canHandleMast(m1));
 
         vp.setMast(null);
@@ -51,11 +49,10 @@ public class OlcbSignalMastAddPaneTest extends AbstractSignalMastAddPaneTestBase
 
         vp.setAspectNames(s1.getAppearanceMap(), ss );
         vp.setMast(s1);
-        // TODO: Enable multiple OpenLCB connections for tests
-        //vp.setAspectNames(s2.getAppearanceMap(), ss );
-        //vp.setMast(s2);
-        //vp.setAspectNames(s3.getAppearanceMap(), ss );
-        //vp.setMast(s3);
+        vp.setAspectNames(s2.getAppearanceMap(), ss );
+        vp.setMast(s2);
+        vp.setAspectNames(s3.getAppearanceMap(), ss );
+        vp.setMast(s3);
 
         vp.setAspectNames(m1.getAppearanceMap(), ss );
         vp.setMast(m1);
@@ -263,8 +260,12 @@ public class OlcbSignalMastAddPaneTest extends AbstractSignalMastAddPaneTestBase
 
     // from here down is testing infrastructure
     private static OlcbSystemConnectionMemoScaffold memo;
+    private static OlcbSystemConnectionMemoScaffold memo1;
+    private static OlcbSystemConnectionMemoScaffold memo2;
     static Connection connection;
     static NodeID nodeID = new NodeID(new byte[]{1, 0, 0, 0, 0, 0});
+    static NodeID nodeID1 = new NodeID(new byte[]{2, 0, 0, 0, 0, 0});
+    static NodeID nodeID2 = new NodeID(new byte[]{3, 0, 0, 0, 0, 0});
     static java.util.ArrayList<Message> messages;
 
     private static void resetMessages(){
@@ -287,6 +288,8 @@ public class OlcbSignalMastAddPaneTest extends AbstractSignalMastAddPaneTestBase
         JUnitUtil.resetProfileManager();
         JUnitUtil.initInternalTurnoutManager();
         nodeID = new NodeID(new byte[]{1, 0, 0, 0, 0, 0});
+        nodeID1 = new NodeID(new byte[]{2, 0, 0, 0, 0, 0});
+        nodeID2 = new NodeID(new byte[]{3, 0, 0, 0, 0, 0});
 
         messages = new java.util.ArrayList<>();
         connection = new AbstractConnection() {
@@ -296,13 +299,26 @@ public class OlcbSignalMastAddPaneTest extends AbstractSignalMastAddPaneTestBase
             }
         };
 
-        // TODO: Enable multiple OpenLCB connections for tests. Not sure how to
-        // do this, because OlcbSystemConnectionMemoScaffold defaults to a connection
-        // with prefix 'M' (from the default constructor in CanSystemConnectionMemo).
-
+        // Enable multiple OpenLCB connections for tests.
         memo = new OlcbSystemConnectionMemoScaffold(); // this self-registers as 'M'
         memo.setProtocol(jmri.jmrix.can.ConfigurationManager.OPENLCB);
         memo.setInterface(new OlcbInterface(nodeID, connection) {
+            @Override
+            public Connection getOutputConnection() {
+                return connection;
+            }
+        });
+        memo1 = new OlcbSystemConnectionMemoScaffold("S");
+        memo1.setProtocol(jmri.jmrix.can.ConfigurationManager.OPENLCB);
+        memo1.setInterface(new OlcbInterface(nodeID1, connection) {
+            @Override
+            public Connection getOutputConnection() {
+                return connection;
+            }
+        });
+        memo2 = new OlcbSystemConnectionMemoScaffold("M3");
+        memo2.setProtocol(jmri.jmrix.can.ConfigurationManager.OPENLCB);
+        memo2.setInterface(new OlcbInterface(nodeID2, connection) {
             @Override
             public Connection getOutputConnection() {
                 return connection;
@@ -322,9 +338,19 @@ public class OlcbSignalMastAddPaneTest extends AbstractSignalMastAddPaneTestBase
         if(memo != null && memo.getInterface() !=null ) {
            memo.getInterface().dispose();
         }
+        if(memo1 != null && memo1.getInterface() !=null ) {
+           memo1.getInterface().dispose();
+        }
+        if(memo2 != null && memo2.getInterface() !=null ) {
+           memo2.getInterface().dispose();
+        }
         memo = null;
+        memo1 = null;
+        memo2 = null;
         connection = null;
         nodeID = null;
+        nodeID1 = null;
+        nodeID2 = null;
         JUnitUtil.tearDown();
     }
 }


### PR DESCRIPTION
1) Support for multiple OpenLCB connections using different prefixes
   than the default "M" prefix. The Add/Edit pane will show a combobox
   selector if there are multiple OpenLCB connections present.
2) Added GUI icons for each signal mast in the Add/Edit signal mast
   pane. This makes it far easier to correlate with the names of the
   signal masts in the signals xml files.

Also changed a few variable names in OlcbSignalMastAddPane.java to be
clearer. This forced a change in the SignalMastAddPaneTest since it uses
the internal object variable names.