### PR TITLE
Select an icon below another icon on Panel Editor

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -498,6 +498,12 @@
    <h3>Panel Editor</h3>
         <a id="PE" name="PE"></a>
         <ul>
+            <li>It's now possible to select an icon below another icon. Right-click on
+            the icon to open the popup menu of the icon. If there are any icons at the
+            mouse position below this icon, the sub menu <strong>Icons below</strong>
+            will appear at the end of the popup menu. The sub menu will contain all
+            the icons below this icon. These menu items will open the popup menu for
+            for its icon.</li>
             <li>A new <strong>Audio</strong> icon has been added to Panel Editor.
             It can be used to play audio on a web panel, or let the user start
             playing sound in JMRI by clicking on the Audio icon. When editing the

--- a/java/src/jmri/jmrit/display/AnalogClock2Display.java
+++ b/java/src/jmri/jmrit/display/AnalogClock2Display.java
@@ -13,6 +13,7 @@ import java.awt.event.ActionListener;
 import java.awt.geom.AffineTransform;
 import java.util.Date;
 
+import javax.annotation.Nonnull;
 import javax.swing.ButtonGroup;
 import javax.swing.JMenu;
 import javax.swing.JMenuItem;
@@ -187,6 +188,12 @@ public class AnalogClock2Display extends PositionableJComponent implements Linki
         popup.add(colorMenuItem);
 
         return true;
+    }
+
+    @Override
+    @Nonnull
+    public String getTypeString() {
+        return Bundle.getMessage("PositionableType_");
     }
 
     @Override

--- a/java/src/jmri/jmrit/display/AudioIcon.java
+++ b/java/src/jmri/jmrit/display/AudioIcon.java
@@ -85,6 +85,12 @@ public class AudioIcon extends PositionableLabel {
         return super.finishClone(pos);
     }
 
+    @Override
+    @Nonnull
+    public String getTypeString() {
+        return Bundle.getMessage("PositionableType_AudioIcon");
+    }
+
     public int getIdentity() {
         return _identity;
     }

--- a/java/src/jmri/jmrit/display/BlockContentsIcon.java
+++ b/java/src/jmri/jmrit/display/BlockContentsIcon.java
@@ -129,6 +129,12 @@ public class BlockContentsIcon extends MemoryIcon {
 
     @Override
     @Nonnull
+    public String getTypeString() {
+        return Bundle.getMessage("PositionableType_BlockContentsIcon");
+    }
+
+    @Override
+    @Nonnull
     public String getNameString() {
         String name;
         if (namedBlock == null) {
@@ -296,11 +302,11 @@ public class BlockContentsIcon extends MemoryIcon {
     }
 
     protected void editBlockValue() {
-    
+
         String reval = (String)JmriJOptionPane.showInputDialog(this,
                                      Bundle.getMessage("EditCurrentBlockValue", namedBlock.getName()),
                                      getBlock().getValue());
-    
+
         setValue(reval);
         updateSize();
     }

--- a/java/src/jmri/jmrit/display/DisplayBundle.properties
+++ b/java/src/jmri/jmrit/display/DisplayBundle.properties
@@ -42,6 +42,7 @@ MenuItemDuplicate   = Duplicate
 MenuItemAddItem     = Add Item
 MenuItemItemPalette = Item Palette
 MenuItemTableList   = Item Tables
+MenuItemIconsBelow  = Icons below
 
 MenuItemNoPanels = (No Panels Available)
 
@@ -550,3 +551,32 @@ AudioIcon_WebPanelMenu_PlaySoundWhenJmriPlays   = Play sound on web panel when J
 AudioIcon_WebPanelMenu_StopSoundWhenJmriStops   = Stop sound on web panel when JMRI stops the sound
 
 LogixNGIcon_Text    = LogixNG
+
+PositionableTypeAndName                     = {0}: {1}
+
+PositionableType_AudioIcon                  = Audio
+PositionableType_BlockContentsIcon          = Block
+PositionableType_GlobalVariableComboIcon    = Global variable, combobox
+PositionableType_GlobalVariableIcon         = Global variable
+PositionableType_GlobalVariableInputIcon    = Global variable, input
+PositionableType_GlobalVariableSpinnerIcon  = Global variable, spinner
+PositionableType_IndicatorTrackIcon         = Indicator track
+PositionableType_IndicatorTurnoutIcon       = Indicator turnout
+PositionableType_LightIcon                  = Light
+PositionableType_LogixNGIcon                = LogixNG
+PositionableType_MemoryComboIcon            = Memory, combobox
+PositionableType_MemoryIcon                 = Memory
+PositionableType_MemoryInputIcon            = Memory, input
+PositionableType_MemorySpinnerIcon          = Memory, spinner
+PositionableType_MultiSensorIcon            = Multi sensor
+PositionableType_PortalIcon                 = Portal
+PositionableType_PositionableJComponent     = Icon
+PositionableType_PositionableJPanel         = Icon
+PositionableType_PositionableLabel          = Icon or label
+PositionableType_ReporterIcon               = Reporter
+PositionableType_RpsPositionIcon            = RPS position
+PositionableType_SensorIcon                 = Sensor
+PositionableType_SignalHead                 = Signal head
+PositionableType_SignalMastIcon             = Signal mast
+PositionableType_SlipTurnoutIcon            = Slip turnout
+PositionableType_TurnoutIcon                = Turnout

--- a/java/src/jmri/jmrit/display/DisplayBundle.properties
+++ b/java/src/jmri/jmrit/display/DisplayBundle.properties
@@ -43,6 +43,7 @@ MenuItemAddItem     = Add Item
 MenuItemItemPalette = Item Palette
 MenuItemTableList   = Item Tables
 MenuItemIconsBelow  = Icons below
+MenuItemIconsBelow_InfoNotInOrder   = List is not in Z-order
 
 MenuItemNoPanels = (No Panels Available)
 
@@ -552,6 +553,7 @@ AudioIcon_WebPanelMenu_StopSoundWhenJmriStops   = Stop sound on web panel when J
 
 LogixNGIcon_Text    = LogixNG
 
+LayoutTrackTypeAndName                      = {0}: {1}
 PositionableTypeAndName                     = {0}: {1}
 
 PositionableType_AudioIcon                  = Audio

--- a/java/src/jmri/jmrit/display/Editor.java
+++ b/java/src/jmri/jmrit/display/Editor.java
@@ -3570,15 +3570,6 @@ abstract public class Editor extends JmriJFrame implements JmriMouseListener, Jm
     abstract protected void setNextLocation(Positionable obj);
 
     /**
-     * Editor Views should make calls to this class (Editor) to set popup menu
-     * items. See 'Popup Item Methods' above for the calls.
-     *
-     * @param p     the item containing or requiring the context menu
-     * @param event the event triggering the menu
-     */
-    abstract protected void showPopUp(Positionable p, JmriMouseEvent event);
-
-    /**
      * After construction, initialize all the widgets to their saved config
      * settings.
      */

--- a/java/src/jmri/jmrit/display/GlobalVariableComboIcon.java
+++ b/java/src/jmri/jmrit/display/GlobalVariableComboIcon.java
@@ -3,6 +3,7 @@ package jmri.jmrit.display;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 
+import javax.annotation.Nonnull;
 import javax.swing.AbstractButton;
 import javax.swing.DefaultListModel;
 import javax.swing.JButton;
@@ -156,6 +157,12 @@ public class GlobalVariableComboIcon extends MemoryOrGVComboIcon
         if (e.getPropertyName().equals("value")) {
             displayState();
         }
+    }
+
+    @Override
+    @Nonnull
+    public String getTypeString() {
+        return Bundle.getMessage("PositionableType_GlobalVariableComboIcon");
     }
 
     @Override

--- a/java/src/jmri/jmrit/display/GlobalVariableIcon.java
+++ b/java/src/jmri/jmrit/display/GlobalVariableIcon.java
@@ -5,6 +5,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.Map;
 
+import javax.annotation.Nonnull;
 import javax.swing.AbstractAction;
 import javax.swing.JPopupMenu;
 import javax.swing.JSeparator;
@@ -175,6 +176,12 @@ public class GlobalVariableIcon extends MemoryOrGVIcon implements java.beans.Pro
                 }
             }
         }
+    }
+
+    @Override
+    @Nonnull
+    public String getTypeString() {
+        return Bundle.getMessage("PositionableType_GlobalVariableIcon");
     }
 
     @Override
@@ -459,11 +466,11 @@ public class GlobalVariableIcon extends MemoryOrGVIcon implements java.beans.Pro
     }
 
     protected void editGlobalVariableValue() {
-    
+
         String reval = (String)JmriJOptionPane.showInputDialog(this,
                                      Bundle.getMessage("EditCurrentGlobalVariableValue", namedGlobalVariable.getName()),
                                      getGlobalVariable().getValue());
-    
+
         setValue(reval);
         updateSize();
     }

--- a/java/src/jmri/jmrit/display/GlobalVariableInputIcon.java
+++ b/java/src/jmri/jmrit/display/GlobalVariableInputIcon.java
@@ -5,6 +5,7 @@ import java.awt.event.ActionListener;
 import java.awt.event.KeyAdapter;
 import java.awt.event.KeyEvent;
 
+import javax.annotation.Nonnull;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
@@ -150,6 +151,12 @@ public class GlobalVariableInputIcon extends PositionableJPanel implements java.
         if (e.getPropertyName().equals("value")) {
             displayState();
         }
+    }
+
+    @Override
+    @Nonnull
+    public String getTypeString() {
+        return Bundle.getMessage("PositionableType_GlobalVariableInputIcon");
     }
 
     @Override

--- a/java/src/jmri/jmrit/display/GlobalVariableSpinnerIcon.java
+++ b/java/src/jmri/jmrit/display/GlobalVariableSpinnerIcon.java
@@ -5,6 +5,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.beans.PropertyChangeListener;
 
+import javax.annotation.Nonnull;
 import javax.swing.AbstractAction;
 import javax.swing.JSpinner;
 import javax.swing.SpinnerNumberModel;
@@ -145,6 +146,12 @@ public class GlobalVariableSpinnerIcon extends PositionableJPanel implements Cha
     @Override
     public void stateChanged(ChangeEvent e) {
         spinnerUpdated();
+    }
+
+    @Override
+    @Nonnull
+    public String getTypeString() {
+        return Bundle.getMessage("PositionableType_GlobalVariableSpinnerIcon");
     }
 
     @Override

--- a/java/src/jmri/jmrit/display/IndicatorTrackIcon.java
+++ b/java/src/jmri/jmrit/display/IndicatorTrackIcon.java
@@ -221,7 +221,7 @@ public class IndicatorTrackIcon extends PositionableIcon
         log.debug("set \"{}\" icon= {}", name, icon);
         _iconMap.put(name, icon);
         if (_status.equals(name)) {
-            setIcon(icon);            
+            setIcon(icon);
         }
     }
 
@@ -299,6 +299,12 @@ public class IndicatorTrackIcon extends PositionableIcon
 
     @Override
     @Nonnull
+    public String getTypeString() {
+        return Bundle.getMessage("PositionableType_IndicatorTrackIcon");
+    }
+
+    @Override
+    @Nonnull
     public String getNameString() {
         String str = "";
         if (namedOccBlock != null) {
@@ -328,7 +334,7 @@ public class IndicatorTrackIcon extends PositionableIcon
         }
         updateSize();
     }
-    
+
     @Override
     public void rotate(int deg) {
         super.rotate(deg);

--- a/java/src/jmri/jmrit/display/IndicatorTurnoutIcon.java
+++ b/java/src/jmri/jmrit/display/IndicatorTurnoutIcon.java
@@ -4,6 +4,9 @@ import java.awt.event.ActionListener;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map.Entry;
+
+import javax.annotation.Nonnull;
+
 import jmri.InstanceManager;
 import jmri.NamedBeanHandle;
 import jmri.NamedBeanHandleManager;
@@ -371,6 +374,12 @@ public class IndicatorTurnoutIcon extends TurnoutIcon implements IndicatorTrack 
     }
 
     @Override
+    @Nonnull
+    public String getTypeString() {
+        return Bundle.getMessage("PositionableType_IndicatorTurnoutIcon");
+    }
+
+    @Override
     public String getNameString() {
         String str = "";
         if (namedOccBlock != null) {
@@ -455,7 +464,7 @@ public class IndicatorTurnoutIcon extends TurnoutIcon implements IndicatorTrack 
             }
         }
         _itemPanel.initUpdate(updateAction, iconMaps);
-        
+
         if (namedOccSensor != null) {
             _itemPanel.setOccDetector(namedOccSensor.getBean().getDisplayName());
         }
@@ -465,7 +474,7 @@ public class IndicatorTurnoutIcon extends TurnoutIcon implements IndicatorTrack 
         _itemPanel.setShowTrainName(_pathUtil.showTrain());
         _itemPanel.setPaths(_pathUtil.getPaths());
         _itemPanel.setSelection(getTurnout());  // do after all other params set - calls resize()
-        
+
         initPaletteFrame(_paletteFrame, _itemPanel);
     }
 

--- a/java/src/jmri/jmrit/display/LightIcon.java
+++ b/java/src/jmri/jmrit/display/LightIcon.java
@@ -3,6 +3,8 @@ package jmri.jmrit.display;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 
+import javax.annotation.Nonnull;
+
 import jmri.InstanceManager;
 import jmri.Light;
 import jmri.NamedBean.DisplayOptions;
@@ -172,6 +174,12 @@ public class LightIcon extends PositionableLabel implements java.beans.PropertyC
             int now = ((Integer) e.getNewValue());
             displayState(now);
         }
+    }
+
+    @Override
+    @Nonnull
+    public String getTypeString() {
+        return Bundle.getMessage("PositionableType_LightIcon");
     }
 
     @Override

--- a/java/src/jmri/jmrit/display/LogixNGIcon.java
+++ b/java/src/jmri/jmrit/display/LogixNGIcon.java
@@ -53,6 +53,12 @@ public class LogixNGIcon extends PositionableLabel {
         // createLogixNGIconImage();
     }
 
+    @Override
+    @Nonnull
+    public String getTypeString() {
+        return Bundle.getMessage("PositionableType_LogixNGIcon");
+    }
+
     public int getIdentity() {
         return _identity;
     }

--- a/java/src/jmri/jmrit/display/MemoryComboIcon.java
+++ b/java/src/jmri/jmrit/display/MemoryComboIcon.java
@@ -3,6 +3,7 @@ package jmri.jmrit.display;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 
+import javax.annotation.Nonnull;
 import javax.swing.AbstractButton;
 import javax.swing.BoxLayout;
 import javax.swing.DefaultListModel;
@@ -155,6 +156,12 @@ public class MemoryComboIcon extends MemoryOrGVComboIcon
         if (e.getPropertyName().equals("value")) {
             displayState();
         }
+    }
+
+    @Override
+    @Nonnull
+    public String getTypeString() {
+        return Bundle.getMessage("PositionableType_MemoryComboIcon");
     }
 
     @Override

--- a/java/src/jmri/jmrit/display/MemoryIcon.java
+++ b/java/src/jmri/jmrit/display/MemoryIcon.java
@@ -8,6 +8,7 @@ import java.awt.event.ActionListener;
 import java.util.ArrayList;
 import java.util.Map;
 
+import javax.annotation.Nonnull;
 import javax.swing.AbstractAction;
 import javax.swing.JComponent;
 import javax.swing.JPopupMenu;
@@ -184,6 +185,12 @@ public class MemoryIcon extends MemoryOrGVIcon implements java.beans.PropertyCha
                 }
             }
         }
+    }
+
+    @Override
+    @Nonnull
+    public String getTypeString() {
+        return Bundle.getMessage("PositionableType_MemoryIcon");
     }
 
     @Override
@@ -573,11 +580,11 @@ public class MemoryIcon extends MemoryOrGVIcon implements java.beans.PropertyCha
     }
 
     protected void editMemoryValue() {
-    
+
         String reval = (String)JmriJOptionPane.showInputDialog(this,
                                      Bundle.getMessage("EditCurrentMemoryValue", namedMemory.getName()),
                                      getMemory().getValue());
-    
+
         setValue(reval);
         updateSize();
     }

--- a/java/src/jmri/jmrit/display/MemoryInputIcon.java
+++ b/java/src/jmri/jmrit/display/MemoryInputIcon.java
@@ -5,6 +5,7 @@ import java.awt.event.ActionListener;
 import java.awt.event.KeyAdapter;
 import java.awt.event.KeyEvent;
 
+import javax.annotation.Nonnull;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
@@ -149,6 +150,12 @@ public class MemoryInputIcon extends PositionableJPanel implements java.beans.Pr
         if (e.getPropertyName().equals("value")) {
             displayState();
         }
+    }
+
+    @Override
+    @Nonnull
+    public String getTypeString() {
+        return Bundle.getMessage("PositionableType_MemoryInputIcon");
     }
 
     @Override

--- a/java/src/jmri/jmrit/display/MemorySpinnerIcon.java
+++ b/java/src/jmri/jmrit/display/MemorySpinnerIcon.java
@@ -5,6 +5,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.beans.PropertyChangeListener;
 
+import javax.annotation.Nonnull;
 import javax.swing.AbstractAction;
 import javax.swing.JSpinner;
 import javax.swing.SpinnerNumberModel;
@@ -143,6 +144,12 @@ public class MemorySpinnerIcon extends PositionableJPanel implements ChangeListe
     @Override
     public void stateChanged(ChangeEvent e) {
         spinnerUpdated();
+    }
+
+    @Override
+    @Nonnull
+    public String getTypeString() {
+        return Bundle.getMessage("PositionableType_MemorySpinnerIcon");
     }
 
     @Override

--- a/java/src/jmri/jmrit/display/MultiSensorIcon.java
+++ b/java/src/jmri/jmrit/display/MultiSensorIcon.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
+import javax.annotation.Nonnull;
 import javax.swing.AbstractAction;
 import javax.swing.JPopupMenu;
 
@@ -174,6 +175,12 @@ public class MultiSensorIcon extends PositionableLabel implements java.beans.Pro
             displayState();
             _editor.repaint();
         }
+    }
+
+    @Override
+    @Nonnull
+    public String getTypeString() {
+        return Bundle.getMessage("PositionableType_MultiSensorIcon");
     }
 
     @Override

--- a/java/src/jmri/jmrit/display/Positionable.java
+++ b/java/src/jmri/jmrit/display/Positionable.java
@@ -151,6 +151,13 @@ public interface Positionable extends Cloneable, InlineLogixNG {
     Positionable deepClone();
 
     /**
+     * Get the type of the positional as a String.
+     *
+     * @return the type to display
+     */
+    String getTypeString();
+
+    /**
      * Get the name of the positional as a String. This is often the display
      * name of the NamedBean being positioned.
      *

--- a/java/src/jmri/jmrit/display/PositionableJComponent.java
+++ b/java/src/jmri/jmrit/display/PositionableJComponent.java
@@ -4,6 +4,7 @@ import java.util.Objects;
 import java.util.HashSet;
 import java.util.Set;
 
+import javax.annotation.Nonnull;
 import javax.swing.JCheckBoxMenuItem;
 import javax.swing.JComponent;
 import javax.swing.JMenuItem;
@@ -256,6 +257,12 @@ public class PositionableJComponent extends JComponent implements Positionable {
     @Override
     public int getDegrees() {
         return 0;
+    }
+
+    @Override
+    @Nonnull
+    public String getTypeString() {
+        return Bundle.getMessage("PositionableType_PositionableJComponent");
     }
 
     @Override

--- a/java/src/jmri/jmrit/display/PositionableJPanel.java
+++ b/java/src/jmri/jmrit/display/PositionableJPanel.java
@@ -264,6 +264,12 @@ public class PositionableJPanel extends JPanel implements Positionable, JmriMous
     }
 
     @Override
+    @Nonnull
+    public String getTypeString() {
+        return Bundle.getMessage("PositionableType_PositionableJPanel");
+    }
+
+    @Override
     public String getNameString() {
         return getName();
     }

--- a/java/src/jmri/jmrit/display/PositionableLabel.java
+++ b/java/src/jmri/jmrit/display/PositionableLabel.java
@@ -290,6 +290,12 @@ public class PositionableLabel extends JLabel implements Positionable {
 
     @Override
     @Nonnull
+    public String getTypeString() {
+        return Bundle.getMessage("PositionableType_PositionableLabel");
+    }
+
+    @Override
+    @Nonnull
     public  String getNameString() {
         if (_icon && _displayLevel > Editor.BKG) {
             return "Icon";

--- a/java/src/jmri/jmrit/display/ReporterIcon.java
+++ b/java/src/jmri/jmrit/display/ReporterIcon.java
@@ -1,7 +1,10 @@
 package jmri.jmrit.display;
 
 import java.awt.event.ActionListener;
+
+import javax.annotation.Nonnull;
 import javax.swing.JPopupMenu;
+
 import jmri.InstanceManager;
 import jmri.Reporter;
 import jmri.NamedBean.DisplayOptions;
@@ -97,6 +100,12 @@ public class ReporterIcon extends PositionableLabel implements java.beans.Proper
             log.debug("property change: {} is now {}", e.getPropertyName(), e.getNewValue());
         }
         displayState();
+    }
+
+    @Override
+    @Nonnull
+    public String getTypeString() {
+        return Bundle.getMessage("PositionableType_ReporterIcon");
     }
 
     @Override

--- a/java/src/jmri/jmrit/display/RpsPositionIcon.java
+++ b/java/src/jmri/jmrit/display/RpsPositionIcon.java
@@ -2,6 +2,7 @@ package jmri.jmrit.display;
 
 import java.awt.event.ActionEvent;
 
+import javax.annotation.Nonnull;
 import javax.swing.AbstractAction;
 import javax.swing.JCheckBoxMenuItem;
 import javax.swing.JMenuItem;
@@ -60,6 +61,12 @@ public class RpsPositionIcon extends PositionableLabel implements MeasurementLis
     public void setErrorIcon(NamedIcon i) {
         error = i;
         displayState();
+    }
+
+    @Override
+    @Nonnull
+    public String getTypeString() {
+        return Bundle.getMessage("PositionableType_RpsPositionIcon");
     }
 
     @Override
@@ -264,7 +271,7 @@ public class RpsPositionIcon extends PositionableLabel implements MeasurementLis
         }
 
         // remember this measurement for last position, e.g. for
-        // alignment    
+        // alignment
         lastMeasurement = m;
 
         // update state based on if valid measurement, fiducial volume

--- a/java/src/jmri/jmrit/display/SensorIcon.java
+++ b/java/src/jmri/jmrit/display/SensorIcon.java
@@ -305,6 +305,12 @@ public class SensorIcon extends PositionableIcon implements java.beans.PropertyC
 
     @Override
     @Nonnull
+    public String getTypeString() {
+        return Bundle.getMessage("PositionableType_SensorIcon");
+    }
+
+    @Override
+    @Nonnull
     public String getNameString() {
         String name;
         if (namedSensor == null) {

--- a/java/src/jmri/jmrit/display/SignalHeadIcon.java
+++ b/java/src/jmri/jmrit/display/SignalHeadIcon.java
@@ -171,6 +171,12 @@ public class SignalHeadIcon extends PositionableIcon implements java.beans.Prope
     }
 
     @Override
+    @Nonnull
+    public String getTypeString() {
+        return Bundle.getMessage("PositionableType_SignalHead");
+    }
+
+    @Override
     public @Nonnull
     String getNameString() {
         if (namedHead == null) {

--- a/java/src/jmri/jmrit/display/SignalMastIcon.java
+++ b/java/src/jmri/jmrit/display/SignalMastIcon.java
@@ -3,6 +3,7 @@ package jmri.jmrit.display;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 
+import javax.annotation.Nonnull;
 import javax.swing.AbstractAction;
 import javax.swing.ButtonGroup;
 import javax.swing.JMenu;
@@ -179,6 +180,12 @@ public class SignalMastIcon extends PositionableIcon implements java.beans.Prope
         log.debug("property change: {} current state: {}", e.getPropertyName(), mastState());
         displayState(mastState());
         _editor.getTargetPanel().repaint();
+    }
+
+    @Override
+    @Nonnull
+    public String getTypeString() {
+        return Bundle.getMessage("PositionableType_SignalMastIcon");
     }
 
 //    public String getPName() { return namedMast.getName(); }

--- a/java/src/jmri/jmrit/display/SlipTurnoutIcon.java
+++ b/java/src/jmri/jmrit/display/SlipTurnoutIcon.java
@@ -495,6 +495,12 @@ public class SlipTurnoutIcon extends PositionableLabel implements java.beans.Pro
 
     @Override
     @Nonnull
+    public String getTypeString() {
+        return Bundle.getMessage("PositionableType_SlipTurnoutIcon");
+    }
+
+    @Override
+    @Nonnull
     public String getNameString() {
         String name;
         if (namedTurnoutWest == null) {

--- a/java/src/jmri/jmrit/display/TurnoutIcon.java
+++ b/java/src/jmri/jmrit/display/TurnoutIcon.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.Map.Entry;
 
+import javax.annotation.Nonnull;
 import javax.swing.JCheckBoxMenuItem;
 import javax.swing.JPopupMenu;
 
@@ -213,6 +214,12 @@ public class TurnoutIcon extends PositionableIcon implements java.beans.Property
     public String getStateName(int state) {
         return _state2nameMap.get(state);
 
+    }
+
+    @Override
+    @Nonnull
+    public String getTypeString() {
+        return Bundle.getMessage("PositionableType_TurnoutIcon");
     }
 
     @Override

--- a/java/src/jmri/jmrit/display/controlPanelEditor/ControlPanelEditor.java
+++ b/java/src/jmri/jmrit/display/controlPanelEditor/ControlPanelEditor.java
@@ -1569,8 +1569,10 @@ public class ControlPanelEditor extends Editor implements DropTargetListener, Cl
      * Create popup for a Positionable object. Popup items common to all
      * positionable objects are done before and after the items that pertain
      * only to specific Positionable types.
+     *
+     * @param p     the item containing or requiring the context menu
+     * @param event the event triggering the menu
      */
-    @Override
     protected void showPopUp(Positionable p, JmriMouseEvent event) {
         if (!((JComponent) p).isVisible()) {
             return;     // component must be showing on the screen to determine its location

--- a/java/src/jmri/jmrit/display/controlPanelEditor/PortalIcon.java
+++ b/java/src/jmri/jmrit/display/controlPanelEditor/PortalIcon.java
@@ -243,6 +243,12 @@ public class PortalIcon extends PositionableIcon implements PropertyChangeListen
 
     @Override
     @Nonnull
+    public String getTypeString() {
+        return Bundle.getMessage("PositionableType_PortalIcon");
+    }
+
+    @Override
+    @Nonnull
     public String getNameString() {
         Portal p = getPortal();
         if (p == null) return "No Portal Defined";

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
@@ -3826,8 +3826,9 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
 
     /**
      * Select the menu items to display for the Positionable's popup.
+     * @param p     the item containing or requiring the context menu
+     * @param event the event triggering the menu
      */
-    @Override
     public void showPopUp(@Nonnull Positionable p, @Nonnull JmriMouseEvent event) {
         assert p != null;
 

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
@@ -3742,6 +3742,52 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
         requestFocusInWindow();
     }   // mouseReleased
 
+    public void addPopupItems(@Nonnull JPopupMenu popup, @Nonnull JmriMouseEvent event) {
+
+        List<LayoutTrack> tracks = getLayoutTracks().stream().filter(layoutTrack -> {  // != means can't (yet) loop over Views
+            HitPointType hitPointType = getLayoutTrackView(layoutTrack).findHitPointType(dLoc, false, false);
+            return (HitPointType.NONE != hitPointType);
+        }).collect(Collectors.toList());
+
+        List<Positionable> selections = getSelectedItems(event);
+
+        if ((tracks.size() > 1) || (selections.size() > 1)) {
+            JMenu iconsBelowMenu = new JMenu(Bundle.getMessage("MenuItemIconsBelow"));
+
+            JMenuItem mi = new JMenuItem(Bundle.getMessage("MenuItemIconsBelow_InfoNotInOrder"));
+            mi.setEnabled(false);
+            iconsBelowMenu.add(mi);
+
+            if (tracks.size() > 1) {
+                for (int i=0; i < tracks.size(); i++) {
+                    LayoutTrack t = tracks.get(i);
+                    iconsBelowMenu.add(new AbstractAction(Bundle.getMessage(
+                            "LayoutTrackTypeAndName", t.getTypeName(), t.getName())) {
+                        @Override
+                        public void actionPerformed(ActionEvent e) {
+                            LayoutTrackView ltv = getLayoutTrackView(t);
+                            ltv.showPopup(event);
+                        }
+                    });
+                }
+            }
+            if (selections.size() > 1) {
+                for (int i=0; i < selections.size(); i++) {
+                    Positionable pos = selections.get(i);
+                    iconsBelowMenu.add(new AbstractAction(Bundle.getMessage(
+                            "PositionableTypeAndName", pos.getTypeString(), pos.getNameString())) {
+                        @Override
+                        public void actionPerformed(ActionEvent e) {
+                            showPopUp(pos, event, new ArrayList<>());
+                        }
+                    });
+                }
+            }
+            popup.addSeparator();
+            popup.add(iconsBelowMenu);
+        }
+    }
+
     private void showEditPopUps(@Nonnull JmriMouseEvent event) {
         if (findLayoutTracksHitPoint(dLoc)) {
             if (HitPointType.isBezierHitType(foundHitPointType)) {
@@ -3922,6 +3968,9 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
                 util.setAdditionalViewPopUpMenu(popup);
             }
         }
+
+        addPopupItems(popup, event);
+
         popup.show((Component) p, p.getWidth() / 2 + (int) ((getZoom() - 1.0) * p.getX()),
                 p.getHeight() / 2 + (int) ((getZoom() - 1.0) * p.getY()));
 

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutTrackView.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutTrackView.java
@@ -489,6 +489,7 @@ abstract public class LayoutTrackView implements InlineLogixNG {
     protected void addCommonPopupItems(@Nonnull JmriMouseEvent mouseEvent, @Nonnull JPopupMenu popup) {
         popup.addSeparator();
         setLogixNGPositionableMenu(popup);
+        layoutEditor.addPopupItems(popup, mouseEvent);
     }
 
     @Override

--- a/java/src/jmri/jmrit/display/panelEditor/PanelEditor.java
+++ b/java/src/jmri/jmrit/display/panelEditor/PanelEditor.java
@@ -594,9 +594,12 @@ public class PanelEditor extends Editor implements ItemListener {
      * Create popup for a Positionable object. Popup items common to all
      * positionable objects are done before and after the items that pertain
      * only to specific Positionable types.
+     *
+     * @param p           the item containing or requiring the context menu
+     * @param event       the event triggering the menu
+     * @param selections  the list of all Positionables at this position
      */
-    @Override
-    protected void showPopUp(Positionable p, JmriMouseEvent event) {
+    protected void showPopUp(Positionable p, JmriMouseEvent event, List<Positionable> selections) {
         if (!((JComponent) p).isVisible()) {
             return;     // component must be showing on the screen to determine its location
         }
@@ -664,6 +667,28 @@ public class PanelEditor extends Editor implements ItemListener {
                 util.setAdditionalViewPopUpMenu(popup);
             }
         }
+
+        if (selections.size() > 1) {
+            boolean found = false;
+            JMenu iconsBelowMenu = new JMenu(Bundle.getMessage("MenuItemIconsBelow"));
+            for (int i=0; i < selections.size(); i++) {
+                Positionable pos = selections.get(i);
+                if (found) {
+                    iconsBelowMenu.add(new AbstractAction(Bundle.getMessage(
+                            "PositionableTypeAndName", pos.getTypeString(), pos.getNameString())) {
+                        @Override
+                        public void actionPerformed(ActionEvent e) {
+                            showPopUp(pos, event, new ArrayList<>());
+                        }
+                    });
+                } else {
+                    if (p == pos) found = true;
+                }
+            }
+            popup.addSeparator();
+            popup.add(iconsBelowMenu);
+        }
+
         popup.show((Component) p, p.getWidth() / 2, p.getHeight() / 2);
     }
 
@@ -703,7 +728,7 @@ public class PanelEditor extends Editor implements ItemListener {
                         //Will show the copy option only
                         showMultiSelectPopUp(event, _currentSelection);
                     } else {
-                        showPopUp(_currentSelection, event);
+                        showPopUp(_currentSelection, event, selections);
                     }
                 }
             } else if (!event.isControlDown()) {
@@ -790,7 +815,7 @@ public class PanelEditor extends Editor implements ItemListener {
                 showMultiSelectPopUp(event, _currentSelection);
 
             } else {
-                showPopUp(_currentSelection, event);
+                showPopUp(_currentSelection, event, selections);
             }
         } else {
             if (_currentSelection != null && !_dragging && !event.isControlDown()) {
@@ -930,7 +955,7 @@ public class PanelEditor extends Editor implements ItemListener {
             if (_selectionGroup != null) {
                 showMultiSelectPopUp(event, _currentSelection);
             } else {
-                showPopUp(_currentSelection, event);
+                showPopUp(_currentSelection, event, selections);
             }
             // _selectionGroup = null; // Show popup only works for a single item
 

--- a/java/src/jmri/jmrit/display/switchboardEditor/BeanSwitch.java
+++ b/java/src/jmri/jmrit/display/switchboardEditor/BeanSwitch.java
@@ -23,11 +23,9 @@ import jmri.NamedBeanHandle;
 import jmri.Sensor;
 import jmri.Turnout;
 import jmri.jmrit.beantable.AddNewDevicePanel;
-import jmri.jmrit.display.Positionable;
 import jmri.util.JmriJFrame;
 import jmri.util.SystemType;
 import jmri.util.swing.JmriJOptionPane;
-import jmri.util.swing.JmriMouseEvent;
 
 /**
  * Class for a switchboard interface object.

--- a/java/src/jmri/jmrit/display/switchboardEditor/BeanSwitch.java
+++ b/java/src/jmri/jmrit/display/switchboardEditor/BeanSwitch.java
@@ -303,33 +303,33 @@ public class BeanSwitch extends JPanel implements java.beans.PropertyChangeListe
         log.debug("Created switch {}", index);
     }
 
-    static final AffineTransform affinetransform = new AffineTransform();     
-    static final FontRenderContext frc = new FontRenderContext(affinetransform,true,true);    
+    static final AffineTransform affinetransform = new AffineTransform();
+    static final FontRenderContext frc = new FontRenderContext(affinetransform,true,true);
 
     int getLabelFontSize(int radius, String text) {
         int fontSize = Math.max(12, radius/4);
         // see if that fits using font metrics
         if (text != null) {
-            Font font = new Font(Font.SANS_SERIF, Font.BOLD, fontSize); 
+            Font font = new Font(Font.SANS_SERIF, Font.BOLD, fontSize);
             int textwidth = (int)(font.getStringBounds(text, frc).getWidth());
             fontSize = Math.min(fontSize, fontSize*2*radius*9/textwidth/10); // integer arithmetic: fit in 90% of radius*2
             log.trace("calculate fontsize {} from radius {} and textwidth {} for string \"{}\"", fontSize, radius, textwidth, text);
         }
         return Math.max(fontSize, 5); // but go no smaller than 6 point
     }
-    
+
     int getSubLabelFontSize(int radius, String text) {
         int fontSize = Math.max(9, radius/5);
         // see if text fits using font metrics, if not correct it with a smaller font size
         if (text != null) {
-            Font font = new Font(Font.SANS_SERIF, Font.BOLD, fontSize); 
+            Font font = new Font(Font.SANS_SERIF, Font.BOLD, fontSize);
             int textwidth = (int)(font.getStringBounds(text, frc).getWidth());
             fontSize = Math.min(fontSize, fontSize*2*radius*9/textwidth/10); // integer arithmetic: fit in 90% of radius*2
             log.trace("calculate fontsize {} from radius {} and textwidth {} for string \"{}\"", fontSize, radius, textwidth, text);
         }
         return Math.max(fontSize, 5); // but go no smaller than 6 point
     }
-    
+
     public NamedBean getNamedBean() {
         return _bname;
     }
@@ -617,8 +617,7 @@ public class BeanSwitch extends JPanel implements java.beans.PropertyChangeListe
 
     /**
      * Show pop-up on a switch with its unique attributes including the
-     * (un)connected bean. Derived from
-     * {@link jmri.jmrit.display.switchboardEditor.SwitchboardEditor#showPopUp(Positionable, JmriMouseEvent)}
+     * (un)connected bean.
      *
      * @param e unused because we now our own location
      * @return true when pop up displayed

--- a/java/src/jmri/jmrit/display/switchboardEditor/SwitchboardEditor.java
+++ b/java/src/jmri/jmrit/display/switchboardEditor/SwitchboardEditor.java
@@ -899,7 +899,7 @@ public class SwitchboardEditor extends Editor {
                 // if new defaultTextColor matches bgColor, ask user as labels will become unreadable
                 if (desiredColor.equals(defaultBackgroundColor)) {
                     int retval = JmriJOptionPane.showOptionDialog(this,
-                    Bundle.getMessage("ColorIdenticalWarningF"), Bundle.getMessage("WarningTitle"), 
+                    Bundle.getMessage("ColorIdenticalWarningF"), Bundle.getMessage("WarningTitle"),
                 JmriJOptionPane.DEFAULT_OPTION, JmriJOptionPane.INFORMATION_MESSAGE, null,
                     new Object[]{Bundle.getMessage("ButtonOK"), Bundle.getMessage("ButtonInvert"),
                     Bundle.getMessage("ButtonCancel")}, Bundle.getMessage("ButtonCancel"));
@@ -927,7 +927,7 @@ public class SwitchboardEditor extends Editor {
                 // if new bgColor matches the defaultTextColor, ask user as labels will become unreadable
                 if (desiredColor.equals(defaultTextColor)) {
                     int retval = JmriJOptionPane.showOptionDialog(this,
-                        Bundle.getMessage("ColorIdenticalWarningR"), Bundle.getMessage("WarningTitle"), 
+                        Bundle.getMessage("ColorIdenticalWarningR"), Bundle.getMessage("WarningTitle"),
                         JmriJOptionPane.YES_NO_OPTION, JmriJOptionPane.INFORMATION_MESSAGE, null,
                         new Object[]{Bundle.getMessage("ButtonOK"), Bundle.getMessage("ButtonInvert"), Bundle.getMessage("ButtonCancel")},
                         Bundle.getMessage("ButtonCancel"));
@@ -982,7 +982,7 @@ public class SwitchboardEditor extends Editor {
                 // if new InactiveColor matches ActiveColor, ask user as state will become unreadable
                 if (desiredColor.equals(defaultInactiveColor)) {
                     int retval = JmriJOptionPane.showOptionDialog(this,
-                        Bundle.getMessage("ColorIdenticalWarningF"), Bundle.getMessage("WarningTitle"), 
+                        Bundle.getMessage("ColorIdenticalWarningF"), Bundle.getMessage("WarningTitle"),
                         JmriJOptionPane.DEFAULT_OPTION, JmriJOptionPane.INFORMATION_MESSAGE, null,
                         new Object[]{Bundle.getMessage("ButtonOK"), Bundle.getMessage("ButtonInvert"), Bundle.getMessage("ButtonCancel")}, Bundle.getMessage("ButtonCancel"));
                     if (retval == 1) { // array position 1 invert the other color
@@ -1803,18 +1803,6 @@ public class SwitchboardEditor extends Editor {
      */
     @Override
     public void setNextLocation(Positionable obj) {
-    }
-
-    /**
-     * Create popup for a Positionable object.
-     * <p>
-     * Not used on switchboards but has to override Editor.
-     *
-     * @param p     the item on the Panel
-     * @param event JmriMouseEvent heard
-     */
-    @Override
-    protected void showPopUp(Positionable p, JmriMouseEvent event) {
     }
 
     protected ArrayList<Positionable> getSelectionGroup() {

--- a/java/test/jmri/jmrit/display/EditorScaffold.java
+++ b/java/test/jmri/jmrit/display/EditorScaffold.java
@@ -95,15 +95,6 @@ public class EditorScaffold extends Editor {
     }
 
     /**
-     * Editor Views should make calls to this class (Editor) to set popup menu
-     * items. See 'Popup Item Methods' above for the calls.
-     *
-     */
-    @Override
-    protected void showPopUp(Positionable p, JmriMouseEvent event){
-    }
-
-    /**
      * After construction, initialize all the widgets to their saved config
      * settings.
      */


### PR DESCRIPTION
This PR makes it possible to select an icon below another icon in Panel Editor. Right-click on the icon to open the popup menu of the icon. If there are any icons at the mouse position below this icon, the sub menu `Icons below` will appear at the end of the popup menu. The sub menu will contain all the icons below this icon. These menu items will open the popup menu for for its icon.