### PR TITLE
Cleanup; Supporting fredi v2.2 updated lnsv

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -326,7 +326,7 @@
 
         <h4>Public Domain and DIY decoders</h4>
             <ul>
-                <li></li>
+                <li>Cleanup; Removed obsolete (leftover) settings from one of the sub-files</li>
             </ul>
 
         <h4>QSI</h4>

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -326,7 +326,7 @@
 
         <h4>Public Domain and DIY decoders</h4>
             <ul>
-                <li>Cleanup; Removed obsolete (leftover) settings from one of the sub-files</li>
+                <li>FREDi - Cleanup; Removed obsolete (leftover) settings from one of the sub-files</li>
             </ul>
 
         <h4>QSI</h4>

--- a/xml/decoders/public_domain/pane-FREDiFunctionMap.xml
+++ b/xml/decoders/public_domain/pane-FREDiFunctionMap.xml
@@ -86,14 +86,6 @@
             </label>
         </griditem>
 
-        <griditem gridx="0" gridy="12">
-            <display item="CV44:Enable OPC-IMM for high functions" />
-        </griditem>
-
-        <griditem gridx="0" gridy="14">
-            <display item="SV43:Break Function active" />
-        </griditem>
-
         <griditem gridx="1" gridy="0">
             <label>
                 <text>&#x0020;&#x0020;&#x0020;&#x0020;&#x0020;&#x0020;&#x0020;&#x0020;</text>


### PR DESCRIPTION
Removed a leftover obsolete settings, which in practice makes no functional problem, except looks contradictory compared to the correct settings in the main file Public_Domain_FREDi_LNSV2.xml