### PR TITLE
Add warning about backwards compability issue with PR #11623

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -465,6 +465,10 @@
     <h3>LogixNG</h3>
         <a id="LogixNG" name="LogixNG"></a>
         <ul>
+          <li><strong>Note:</strong> If tables and panels are stored with this JMRI version, the file
+          might not load in a previous version of JMRI if it includes LogixNG. This is because JMRI
+          now stores some LogixNG data in a different way than before.</li>
+
           <li>The expression <strong>Timer</strong> has been added. It returns <strong>False</strong>
           until some time has passed. It then returns <strong>True</strong> once and the timer starts
           again. This expression is intended to be used together with the action <strong>Sequence</strong></li>.


### PR DESCRIPTION
If tables and panels are stored with this JMRI version, the file might not load in a previous version of JMRI if it includes LogixNG. This is because JMRI now stores some LogixNG data in a different way than before.