### PR TITLE
WIP - Add support for SVG images to NamedIcon

### DIFF
--- a/java/src/jmri/CatalogTreeManager.java
+++ b/java/src/jmri/CatalogTreeManager.java
@@ -104,7 +104,7 @@ public interface CatalogTreeManager extends Manager<CatalogTree> {
 
     @SuppressFBWarnings(value = "MS_MUTABLE_ARRAY",
             justification = "with existing code structure, just have to accept these exposed arrays. Someday...")
-    String[] IMAGE_FILTER = {"gif", "jpg", "jpeg", "png"};
+    String[] IMAGE_FILTER = {"gif", "jpg", "jpeg", "png", "svg"};
 
     @SuppressFBWarnings(value = "MS_OOI_PKGPROTECT",
             justification = "with existing code structure, just have to accept these exposed arrays. Someday...")

--- a/java/test/jmri/jmrit/display/panelEditor/LoadAndStoreTest.java
+++ b/java/test/jmri/jmrit/display/panelEditor/LoadAndStoreTest.java
@@ -167,7 +167,8 @@ public class LoadAndStoreTest extends jmri.configurexml.LoadAndStoreTestBase {
     @BeforeEach
     @Override
     public void setUp(@TempDir java.io.File tempDir) throws IOException  {
-        super.setUp(tempDir);
+//        super.setUp(tempDir);
+        super.setUp(FileUtil.getFile(FileUtil.SETTINGS));  // Temporary disable tempDir to get the screenshots
         JUnitUtil.initLayoutBlockManager();
     }
 


### PR DESCRIPTION
First step to solve issue #12416.

Rotation and scaling are still pixel based, not vector based. Maybe this document has the solution for that:
https://core.ac.uk/download/pdf/70407874.pdf

Even if this PR doesn't solve issue #12416 completely, it's still useful since users with svg images can use them with JMRI without needing to convert them to gif, png or jpg.