### PR TITLE
Remove unused bundle item

### DIFF
--- a/java/src/jmri/jmrix/loconet/LocoNetBundle_ca.properties
+++ b/java/src/jmri/jmrix/loconet/LocoNetBundle_ca.properties
@@ -15,7 +15,6 @@ MenuItemSE8cProgrammer      = Configura SE8C
 MenuItemDS64Programmer      = Configura DS64
 MenuItemThrottleMessages    = Envia Missatges al Regulador
 MenuItemClockMon            = Monitor del Rellotge
-MenuItemStartLocoNetServer  = Arranca Servidor LocoNet
 MenuItemLocoNetOverTCPServer = Arranca Servidor LocoNetOverTCP
 MenuItemLocoStats           = Monitor d'Estat LocoNet
 MenuItemCmdStnConfig        = Configura la Central

--- a/java/src/jmri/jmrix/loconet/LocoNetBundle_cs.properties
+++ b/java/src/jmri/jmrix/loconet/LocoNetBundle_cs.properties
@@ -14,7 +14,6 @@ MenuItemSE8cProgrammer      = Konfigurovat SE8C
 MenuItemDS64Programmer      = Konfigurovat DS64
 MenuItemThrottleMessages    = Odeslat zpr\u00e1vu ovlada\u010de 
 MenuItemClockMon            = Monitor hodin
-MenuItemStartLocoNetServer  = Start LocoNet server
 MenuItemLocoNetOverTCPServer = Start LocoNetOverTCP server
 MenuItemLocoStats           = Monitor LocoNet stavu
 MenuItemCmdStnConfig        = Konfigurovat centr\u00e1lu

--- a/java/src/jmri/jmrix/loconet/LocoNetBundle_da.properties
+++ b/java/src/jmri/jmrix/loconet/LocoNetBundle_da.properties
@@ -14,7 +14,6 @@ MenuItemSE8cProgrammer      = Konfigurer SE8C
 MenuItemDS64Programmer      = Konfigurer DS64
 MenuItemThrottleMessages    = Send K\u00f8rekontrol Meddelelser
 MenuItemClockMon            = UR Monitor
-MenuItemStartLocoNetServer  = Start LocoNet Server
 MenuItemLocoNetOverTCPServer = Start LocoNet Over TCP Server
 MenuItemLocoStats           = LocoNet Statistik Monitor
 MenuItemCmdStnConfig        = Konfigurer Kommando Station

--- a/java/src/jmri/jmrix/loconet/LocoNetBundle_de.properties
+++ b/java/src/jmri/jmrix/loconet/LocoNetBundle_de.properties
@@ -15,7 +15,6 @@ MenuItemSE8cProgrammer      = SE8C Konfigurator
 MenuItemDS64Programmer      = DS64 Konfigurator
 MenuItemThrottleMessages    = Meldungen der Fahrregler
 MenuItemClockMon            = Uhr Monitor
-MenuItemStartLocoNetServer  = Starte LocoNet Server
 MenuItemLocoNetOverTCPServer = LocoNetOverTCP Server
 MenuItemLocoStats           = LocoBuffer Statistikmonitor
 MenuItemCmdStnConfig        = Zentraleinheitskonfigurator

--- a/java/src/jmri/jmrix/loconet/LocoNetBundle_es.properties
+++ b/java/src/jmri/jmrix/loconet/LocoNetBundle_es.properties
@@ -15,7 +15,6 @@ MenuItemSE8cProgrammer      = Programador de SE8C
 MenuItemDS64Programmer      = Configure DS64
 MenuItemThrottleMessages    = Mensajes del mando
 MenuItemClockMon            = Monitor de reloj
-MenuItemStartLocoNetServer  = Arrancar servidor LocoNet
 MenuItemLocoNetOverTCPServer = Start LocoNetOverTCP Server
 MenuItemLocoStats           = Monitor de estadísticas LocoBuffer
 MenuItemCmdStnConfig        = Programador de opciones de la estación de comados

--- a/java/src/jmri/jmrix/loconet/LocoNetBundle_fr.properties
+++ b/java/src/jmri/jmrix/loconet/LocoNetBundle_fr.properties
@@ -16,7 +16,6 @@ MenuItemDS64Programmer      = Configurer DS64
 MenuItemLncvProg            = Configurer par LNCV
 MenuItemThrottleMessages    = Envoyer des Messages de R\u00e9gulateur
 MenuItemClockMon            = Moniteur Horloge
-MenuItemStartLocoNetServer  = D\u00e9marrer Serveur LocoNet
 MenuItemLocoNetOverTCPServer = D\u00e9marrer Serveur LocoNetOverTCP
 MenuItemLocoStats           = Moniteur Statistiques LocoNet
 MenuItemCmdStnConfig        = Configurer la Centrale de Commande

--- a/java/src/jmri/jmrix/loconet/LocoNetBundle_it.properties
+++ b/java/src/jmri/jmrix/loconet/LocoNetBundle_it.properties
@@ -15,7 +15,6 @@ MenuItemSE8cProgrammer      = Configura SE8C
 MenuItemDS64Programmer      = Configura DS64
 MenuItemThrottleMessages    = Invio messaggi a Throttle
 MenuItemClockMon            = Monitor orologio
-MenuItemStartLocoNetServer  = Lancia Server LocoNet
 MenuItemLocoNetOverTCPServer = Lancia Server LocoNetOverTCP
 MenuItemLocoStats           = Monitor Statistiche LocoNet
 MenuItemCmdStnConfig        = Configura Command Station

--- a/java/src/jmri/jmrix/loconet/LocoNetBundle_ja_JP.properties
+++ b/java/src/jmri/jmrix/loconet/LocoNetBundle_ja_JP.properties
@@ -14,7 +14,6 @@ MenuItemSE8cProgrammer = SE8C\u8a2d\u5b9a
 MenuItemDS64Programmer = DS64\u306e\u8abf\u6574
 MenuItemThrottleMessages = \u30b9\u30ed\u30c3\u30c8\u30eb\u30e1\u30c3\u30bb\u30fc\u30b8\u9001\u4fe1
 MenuItemClockMon = \u30e2\u30cb\u30bf\u30fc\u30af\u30ed\u30c3\u30af
-MenuItemStartLocoNetServer = LocoNet\u2122 \u30b5\u30fc\u30d0\u30fc\u958b\u59cb
 MenuItemLocoNetOverTCPServer = LocoNet\u2122OverTCP\u30b5\u30fc\u30d0\u30fc\u958b\u59cb
 MenuItemLocoStats = LocoNet\u2122 \u7d71\u8a08\u30e2\u30cb\u30bf\u30fc
 MenuItemCmdStnConfig = \u30b3\u30de\u30f3\u30c9\u30b9\u30c6\u30fc\u30b7\u30e7\u30f3\u306e\u8a2d\u5b9a

--- a/java/src/jmri/jmrix/loconet/LocoNetBundle_nl.properties
+++ b/java/src/jmri/jmrix/loconet/LocoNetBundle_nl.properties
@@ -14,7 +14,6 @@ MenuItemSE8cProgrammer      = Configureer SE8C
 MenuItemDS64Programmer      = Configureer DS64
 MenuItemThrottleMessages    = Verstuur Rijregelaar-berichten
 MenuItemClockMon            = Tijd-monitor
-MenuItemStartLocoNetServer  = Start LocoNet Server
 MenuItemLocoNetOverTCPServer = Start LocoNetOverTCP Server
 MenuItemLocoStats           = LocoNet Stats-monitor
 MenuItemCmdStnConfig        = Configureer Centrale


### PR DESCRIPTION
This removes the unused "MenuItemStartLocoNetServer" bundle item from translated property files. The reference to it was removed in an earlier PR.