### PR TITLE
Play sound infinite if audio source is configured that way

### DIFF
--- a/java/src/jmri/jmrit/audio/AbstractAudioSource.java
+++ b/java/src/jmri/jmrit/audio/AbstractAudioSource.java
@@ -465,6 +465,11 @@ public abstract class AbstractAudioSource extends AbstractAudio implements Audio
         return this.numLoops;
     }
 
+    @Override
+    public int getLastNumLoops() {
+        return this.numLoops;
+    }
+
 //    public void setMinLoopDelay(int loopDelay) {
 //        if (this.maxLoopDelay < loopDelay) {
 //            this.maxLoopDelay = loopDelay;

--- a/java/src/jmri/jmrit/audio/AudioSource.java
+++ b/java/src/jmri/jmrit/audio/AudioSource.java
@@ -580,7 +580,7 @@ public interface AudioSource extends Audio {
     int getNumLoops();
 
     /**
-     * Get the last value returned by {@link getNumLoops() }
+     * Get the last value returned by {@link #getNumLoops() }
      * @return the number of loops
      */
     int getLastNumLoops();

--- a/java/src/jmri/jmrit/audio/AudioSource.java
+++ b/java/src/jmri/jmrit/audio/AudioSource.java
@@ -579,6 +579,12 @@ public interface AudioSource extends Audio {
      */
     int getNumLoops();
 
+    /**
+     * Get the last value returned by {@link getNumLoops() }
+     * @return the number of loops
+     */
+    int getLastNumLoops();
+
 //    /**
 //     * Set the minimum length of time in milliseconds to wait before
 //     * playing a subsequent loop of this source.

--- a/java/src/jmri/jmrit/display/AudioIcon.java
+++ b/java/src/jmri/jmrit/display/AudioIcon.java
@@ -91,6 +91,19 @@ public class AudioIcon extends PositionableLabel {
         return Bundle.getMessage("PositionableType_AudioIcon");
     }
 
+    @Override
+    @Nonnull
+    public String getNameString() {
+        String name;
+        if (_namedAudio == null) {
+            name = Bundle.getMessage("NotConnected");
+        } else {
+            name = _namedAudio.getBean().getDisplayName(
+                    NamedBean.DisplayOptions.USERNAME_SYSTEMNAME);
+        }
+        return name;
+    }
+
     public int getIdentity() {
         return _identity;
     }

--- a/java/src/jmri/server/json/JSON.java
+++ b/java/src/jmri/server/json/JSON.java
@@ -689,6 +689,10 @@ public final class JSON {
      */
     public static final String AUDIO_COMMAND_PLAY = "Play";
     /**
+     * {@value #AUDIO_COMMAND_PLAY_NUM_LOOPS}
+     */
+    public static final String AUDIO_COMMAND_PLAY_NUM_LOOPS = "playNumLoops";
+    /**
      * {@value #AUDIO_COMMAND_STOP}
      */
     public static final String AUDIO_COMMAND_STOP = "Stop";

--- a/java/src/jmri/server/json/audio/JsonAudioHttpService.java
+++ b/java/src/jmri/server/json/audio/JsonAudioHttpService.java
@@ -34,11 +34,16 @@ public class JsonAudioHttpService extends JsonNamedBeanHttpService<Audio> {
 
     @Override
     public ObjectNode doGet(Audio audio, String name, String type, JsonRequest request) throws JsonException {
+        if (audio.getSubType() != Audio.SOURCE || (!(audio instanceof AudioSource))) {
+            throw new JsonException(400, Bundle.getMessage(request.locale, "ErrorAudioNotSource", AUDIO, audio.getSubType()), request.id);
+        }
+        AudioSource audioSource = (AudioSource) audio;
         ObjectNode root = this.getNamedBean(audio, name, getType(), request); // throws JsonException if audio == null
         ObjectNode data = root.with(JSON.DATA);
         switch (audio.getState()) {
             case Audio.STATE_PLAYING:
                 data.put(JSON.STATE, JSON.AUDIO_PLAYING);
+                data.put(JSON.AUDIO_COMMAND_PLAY_NUM_LOOPS, audioSource.getLastNumLoops());
                 break;
             case Audio.STATE_STOPPED:
                 data.put(JSON.STATE, JSON.AUDIO_STOPPED);

--- a/web/js/jquery.jmri.js
+++ b/web/js/jquery.jmri.js
@@ -112,7 +112,7 @@
             };
             jmri.audios = function (data) {
             };
-            jmri.audioicon = function (identity, command) {
+            jmri.audioicon = function (identity, command, playNumLoops) {
             };
             jmri.block = function (name, value, data) {
             };
@@ -235,7 +235,7 @@
                     jmri.socket.send("audio", { name: name });
                 } else {
                     $.getJSON(jmri.url + "audio/" + name, function (json) {
-                        jmri.audio(json.data.name, json.data.identity, json.data.command);
+                        jmri.audio(json.data.name, json.data.state, json.data);
                     });
                 }
             };
@@ -260,7 +260,7 @@
                     jmri.socket.send("audioicon", { identity: identity });
                 } else {
                     $.getJSON(jmri.url + "audioicon/" + identity, function (json) {
-                        jmri.audioicon(json.data.identity, json.data.command);
+                        jmri.audioicon(json.data.identity, json.data.command, json.data.playNumLoops);
                     });
                 }
             };
@@ -878,7 +878,7 @@
                     jmri.audio(e.data.name, e.data.state, e.data);
                 },
                 audioicon: function (e) {
-                    jmri.audioicon(e.data.identity, e.data.command);
+                    jmri.audioicon(e.data.identity, e.data.command, e.data.playNumLoops);
                 },
                 block: function (e) {
                     jmri.block(e.data.name, e.data.value, e.data);

--- a/web/js/panel.js
+++ b/web/js/panel.js
@@ -1488,6 +1488,8 @@ function $handleClick(e) {
         switch ($widget['onClickOperation']) {
             case "PlaySoundLocally":
                 if ($widget['audio_widget'].paused) {   // Sound is stopped
+                    $widget['audio_widget'].loop = false;
+//                    $widget['audio_widget'].loop = (playNumLoops == -1);
                     $widget['audio_widget'].play();
                 } else {                                // Sound is playing
                     $widget['audio_widget'].pause();
@@ -2502,13 +2504,15 @@ $(document).ready(function() {
                         $widget['audio_widget'].currentTime = 0;
                     } else if (state == 17 && $widget['playSoundWhenJmriPlays']) {  // Sound is playing
                         $widget['audio_widget'].currentTime = 0;
+                        $widget['audio_widget'].loop = (data.playNumLoops == -1);
                         $widget['audio_widget'].play();
                     }
                 });
             },
-            audioicon: function(identity, command) {
+            audioicon: function(identity, command, playNumLoops) {
                 $widget = audioIconIDs['audioicon:'+identity];
                 if (command == "Play") {
+                    $widget['audio_widget'].loop = (playNumLoops == -1);
                     $widget['audio_widget'].play();
                 } else if (command == "Stop") {
                     $widget['audio_widget'].pause();


### PR DESCRIPTION
If the audio source is configured to play sound infinite, the audio icon on a web panel will play sound infinity. This applies both to when the audio source is played in JMRI and when the LogixNG action AudioIcon tells the audio icon to play the sound on the web panel.