### PR TITLE
support leading/trailing spaces in DCC-EX LCD message text

### DIFF
--- a/java/src/jmri/jmrix/dccpp/DCCppConstants.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppConstants.java
@@ -274,6 +274,6 @@ public final class DCCppConstants {
     public static final char   LCD_TEXT_CMD         = '@'; //request that LCD messages be sent to this instance of JMRI
     public static final String LCD_TEXT_CMD_REGEX   = "@";
     public static final char   LCD_TEXT_REPLY       = '@';
-    public static final String LCD_TEXT_REPLY_REGEX = "^\\s*@\\s*(\\d+)\\s+(\\d+)\\s*([\\S\\s]*)$"; //<@ 0 3 message text> where 0 is display# and 3 is line#  
+    public static final String LCD_TEXT_REPLY_REGEX = "^\\s*@\\s*(\\d+)\\s+(\\d+)\\s+\\\"(.*)\\\"$"; //<@ 0 3 "message text"> where 0 is display# and 3 is line#  
 
 }

--- a/java/src/jmri/jmrix/dccpp/DCCppReply.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppReply.java
@@ -1620,7 +1620,7 @@ public class DCCppReply extends jmri.jmrix.AbstractMRReply {
         return (Integer.parseInt(this.getClockRateString()));
     }
 
-    // <@ 123 123 message text>
+    // <@ 0 8 "message text">
     public boolean isLCDTextReply() {
         return (this.matches(DCCppConstants.LCD_TEXT_REPLY_REGEX));
     }   

--- a/java/src/jmri/jmrix/dccpp/simulator/DCCppSimulatorAdapter.java
+++ b/java/src/jmri/jmrix/dccpp/simulator/DCCppSimulatorAdapter.java
@@ -626,13 +626,15 @@ public class DCCppSimulatorAdapter extends DCCppSimulatorPortController implemen
                 DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss a");
                 LocalDateTime now = LocalDateTime.now();
                 String dateTimeString = now.format(formatter);
-                reply = DCCppReply.parseDCCppReply("@ 0 0 Welcome to DCC-EX -- " + dateTimeString);
+                reply = DCCppReply.parseDCCppReply("@ 0 0 \"Welcome to DCC-EX -- " + dateTimeString + "\"" );
                 writeReply(reply);
-                reply = DCCppReply.parseDCCppReply("@ 0 1 LCD Line 1");
+                reply = DCCppReply.parseDCCppReply("@ 0 1 \"LCD Line 1\"");
                 writeReply(reply);
-                reply = DCCppReply.parseDCCppReply("@ 0 2 LCD Line 2");
+                reply = DCCppReply.parseDCCppReply("@ 0 2 \"LCD Line 2\"");
                 writeReply(reply);
-                reply = DCCppReply.parseDCCppReply("@ 0 3 1234567890123456789012345678901234567890");
+                reply = DCCppReply.parseDCCppReply("@ 0 3 \"     LCD Line 3 with spaces   \"");
+                writeReply(reply);
+                reply = DCCppReply.parseDCCppReply("@ 0 4 \"1234567890123456789012345678901234567890\"");
                 break;
 
             case DCCppConstants.READ_CS_STATUS:

--- a/java/src/jmri/jmrix/dccpp/swing/virtuallcd/VirtualLCDFrame.java
+++ b/java/src/jmri/jmrix/dccpp/swing/virtuallcd/VirtualLCDFrame.java
@@ -44,15 +44,19 @@ public class VirtualLCDFrame extends JmriJFrame implements DCCppListener  {
      */
     @Override
     public void message(DCCppReply msg) {
-        if (msg.isLCDTextReply()) {
-            int lineNumber = msg.getLCDLineNumInt();
-            if (lineNumber < TOTALLINES) {
-                lines.get(lineNumber).setText(msg.getLCDTextString()+"   "); // padding for appearance
-                pack(); 
-            } else {
-                log.warn("Received LCD message for line {}, but configured for TOTALLINES limit of {}", 
-                            lineNumber, TOTALLINES-1);
-            }
+        if (msg.isLCDTextReply()) { // <@ display# line# "message text">
+            int displayNumber = msg.getLCDDisplayNumInt();
+            if (displayNumber == 0) {  //TODO: add support for multiple LCD displays
+                int lineNumber = msg.getLCDLineNumInt();
+                if (lineNumber < TOTALLINES) {
+                    lines.get(lineNumber).setText(msg.getLCDTextString()+"   "); // padding for appearance
+                    pack(); 
+                } else {
+                    log.warn("Received LCD message for line {}, but configured for TOTALLINES limit of {}", 
+                                lineNumber, TOTALLINES-1);
+                }
+                log.debug("Received LCD message for display# {}, only display 0 supported at this time.", displayNumber);
+            } 
         }
     }
     

--- a/java/test/jmri/jmrix/dccpp/DCCppReplyTest.java
+++ b/java/test/jmri/jmrix/dccpp/DCCppReplyTest.java
@@ -380,18 +380,23 @@ public class DCCppReplyTest extends jmri.jmrix.AbstractMessageTestBase {
         Assert.assertEquals("Monitor string", "TrackManager:= B PROG 123", r.toMonitorString());
 
         //LCD message
-        r = DCCppReply.parseDCCppReply("@ 0 12 this is a test lcd message 12345");
+        r = DCCppReply.parseDCCppReply("@ 0 12 \"this is a test lcd message 12345\"");
         Assert.assertTrue(r.isLCDTextReply());
         Assert.assertEquals("this is a test lcd message 12345", r.getLCDTextString());
         Assert.assertEquals(0, r.getLCDDisplayNumInt());
         Assert.assertEquals(12, r.getLCDLineNumInt());
-        r = DCCppReply.parseDCCppReply("@ 12 this is not, missing display#");
+        r = DCCppReply.parseDCCppReply("@ 12 \"this is not, missing display#\"");
         Assert.assertFalse(r.isLCDTextReply());
-        r = DCCppReply.parseDCCppReply("@ 0 4 123 456.789.001 test initial digits");
+        r = DCCppReply.parseDCCppReply("@ 0 4 \"123 456.789.001 test initial digits\"");
         Assert.assertTrue(r.isLCDTextReply());
         Assert.assertEquals("123 456.789.001 test initial digits", r.getLCDTextString());
         Assert.assertEquals(0, r.getLCDDisplayNumInt());
         Assert.assertEquals(4, r.getLCDLineNumInt());
+        r = DCCppReply.parseDCCppReply("@ 0 4 test without quotes");
+        Assert.assertFalse(r.isLCDTextReply());
+        r = DCCppReply.parseDCCppReply("@ 0 4 \"    test leading and trailing spaces   \"");
+        Assert.assertTrue(r.isLCDTextReply());
+        Assert.assertEquals("    test leading and trailing spaces   ", r.getLCDTextString());
 
     }
 


### PR DESCRIPTION
Also, ignore all displays except 0 (for now)