### PR TITLE
Improve LogixNG expression Entry/Exit

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -424,7 +424,8 @@
     <h3>LogixNG</h3>
         <a id="LogixNG" name="LogixNG"></a>
         <ul>
-          <li></li>
+          <li>The expression <strong>Entry/exit</strong> can now check if a
+          entry/exit is reverse or bidirectional.</li>
         </ul>
 
     <h3>Meters and MeterFrames</h3>

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -425,7 +425,7 @@
         <a id="LogixNG" name="LogixNG"></a>
         <ul>
           <li>The expression <strong>Entry/exit</strong> can now check if a
-          entry/exit is reverse or bidirectional.</li>
+          entry/exit is reversed or bidirectional.</li>
         </ul>
 
     <h3>Meters and MeterFrames</h3>

--- a/java/src/jmri/jmrit/entryexit/DestinationPoints.java
+++ b/java/src/jmri/jmrit/entryexit/DestinationPoints.java
@@ -45,6 +45,7 @@ public class DestinationPoints extends jmri.implementation.AbstractNamedBean {
     int entryExitType = EntryExitPairs.SETUPTURNOUTSONLY;//SETUPSIGNALMASTLOGIC;
     boolean enabled = true;
     boolean activeEntryExit = false;
+    boolean activeEntryExitReverse = false;
     List<LayoutBlock> routeDetails = new ArrayList<>();
     LayoutBlock destination;
     boolean disposed = false;
@@ -1211,7 +1212,7 @@ public class DestinationPoints extends jmri.implementation.AbstractNamedBean {
                 }
 
                 if (getEntryExitType() == EntryExitPairs.FULLINTERLOCK) {
-                    setActiveEntryExit(true);
+                    setActiveEntryExit(true, reverseDirection);
                 }
                 setRoute(true);
             }
@@ -1297,13 +1298,26 @@ public class DestinationPoints extends jmri.implementation.AbstractNamedBean {
         return activeEntryExit;
     }
 
+    public boolean isReverse() {
+        return activeEntryExitReverse;
+    }
+
+    public boolean isUniDirection() {
+        return uniDirection;
+    }
+
     @Override
     public void setState(int state) {
     }
 
     protected void setActiveEntryExit(boolean boo) {
+        setActiveEntryExit(boo, false);
+    }
+
+    protected void setActiveEntryExit(boolean boo, boolean reverse) {
         int oldvalue = getState();
         activeEntryExit = boo;
+        activeEntryExitReverse = reverse;
         src.setMenuEnabled(boo);
         firePropertyChange("active", oldvalue, getState());  // NOI18N
     }

--- a/java/src/jmri/jmrit/entryexit/DestinationPoints.java
+++ b/java/src/jmri/jmrit/entryexit/DestinationPoints.java
@@ -45,7 +45,7 @@ public class DestinationPoints extends jmri.implementation.AbstractNamedBean {
     int entryExitType = EntryExitPairs.SETUPTURNOUTSONLY;//SETUPSIGNALMASTLOGIC;
     boolean enabled = true;
     boolean activeEntryExit = false;
-    boolean activeEntryExitReverse = false;
+    boolean activeEntryExitReversed = false;
     List<LayoutBlock> routeDetails = new ArrayList<>();
     LayoutBlock destination;
     boolean disposed = false;
@@ -1298,8 +1298,8 @@ public class DestinationPoints extends jmri.implementation.AbstractNamedBean {
         return activeEntryExit;
     }
 
-    public boolean isReverse() {
-        return activeEntryExitReverse;
+    public boolean isReversed() {
+        return activeEntryExitReversed;
     }
 
     public boolean isUniDirection() {
@@ -1317,7 +1317,7 @@ public class DestinationPoints extends jmri.implementation.AbstractNamedBean {
     protected void setActiveEntryExit(boolean boo, boolean reverse) {
         int oldvalue = getState();
         activeEntryExit = boo;
-        activeEntryExitReverse = reverse;
+        activeEntryExitReversed = reverse;
         src.setMenuEnabled(boo);
         firePropertyChange("active", oldvalue, getState());  // NOI18N
     }

--- a/java/src/jmri/jmrit/entryexit/DestinationPoints.java
+++ b/java/src/jmri/jmrit/entryexit/DestinationPoints.java
@@ -1314,10 +1314,10 @@ public class DestinationPoints extends jmri.implementation.AbstractNamedBean {
         setActiveEntryExit(boo, false);
     }
 
-    protected void setActiveEntryExit(boolean boo, boolean reverse) {
+    protected void setActiveEntryExit(boolean boo, boolean reversed) {
         int oldvalue = getState();
         activeEntryExit = boo;
-        activeEntryExitReversed = reverse;
+        activeEntryExitReversed = reversed;
         src.setMenuEnabled(boo);
         firePropertyChange("active", oldvalue, getState());  // NOI18N
     }

--- a/java/src/jmri/jmrit/logixng/Base.java
+++ b/java/src/jmri/jmrit/logixng/Base.java
@@ -21,6 +21,13 @@ import org.apache.commons.lang3.mutable.MutableInt;
 public interface Base extends PropertyChangeProvider {
 
     /**
+     * Separator returned by enums toString() methods to get a separator
+     * in JComboBoxes. See {@link jmri.jmrit.logixng.expressions.ExpressionEntryExit.EntryExitState}
+     * for an example.
+     */
+    String SEPARATOR = "---------------";
+
+    /**
      * The name of the property child count.
      * To get the number of children, use the method getChildCount().
      * This constant is used in calls to firePropertyChange().

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionBundle.properties
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionBundle.properties
@@ -108,6 +108,8 @@ EntryExit_Long          = Entry/exit "{0}" {1} {2}
 EntryExitStateInactive  = Inactive
 EntryExitStateActive    = Active
 EntryExitOtherStatus    = Other
+EntryExitIsReverse      = Is reverse
+EntryExitIsBiDirection  = Is bidrectional
 EntryExit_DestinationPointsInUseEntryExitExpressionVeto = DestinationPoints is in use by EntryExit expression "{0}"
 
 False_Short           = Always false

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionBundle.properties
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionBundle.properties
@@ -108,7 +108,7 @@ EntryExit_Long          = Entry/exit "{0}" {1} {2}
 EntryExitStateInactive  = Inactive
 EntryExitStateActive    = Active
 EntryExitOtherStatus    = Other
-EntryExitReverse        = Reversed
+EntryExitReversed       = Reversed
 EntryExitBiDirection    = Bidirectional
 EntryExit_DestinationPointsInUseEntryExitExpressionVeto = DestinationPoints is in use by EntryExit expression "{0}"
 

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionBundle.properties
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionBundle.properties
@@ -108,7 +108,7 @@ EntryExit_Long          = Entry/exit "{0}" {1} {2}
 EntryExitStateInactive  = Inactive
 EntryExitStateActive    = Active
 EntryExitOtherStatus    = Other
-EntryExitReverse        = Reverse
+EntryExitReverse        = Reversed
 EntryExitBiDirection    = Bidirectional
 EntryExit_DestinationPointsInUseEntryExitExpressionVeto = DestinationPoints is in use by EntryExit expression "{0}"
 

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionBundle.properties
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionBundle.properties
@@ -108,8 +108,8 @@ EntryExit_Long          = Entry/exit "{0}" {1} {2}
 EntryExitStateInactive  = Inactive
 EntryExitStateActive    = Active
 EntryExitOtherStatus    = Other
-EntryExitIsReverse      = Reverse
-EntryExitIsBiDirection  = Bidirectional
+EntryExitReverse        = Reverse
+EntryExitBiDirection    = Bidirectional
 EntryExit_DestinationPointsInUseEntryExitExpressionVeto = DestinationPoints is in use by EntryExit expression "{0}"
 
 False_Short           = Always false

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionBundle.properties
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionBundle.properties
@@ -108,8 +108,8 @@ EntryExit_Long          = Entry/exit "{0}" {1} {2}
 EntryExitStateInactive  = Inactive
 EntryExitStateActive    = Active
 EntryExitOtherStatus    = Other
-EntryExitIsReverse      = Is reverse
-EntryExitIsBiDirection  = Is bidrectional
+EntryExitIsReverse      = Reverse
+EntryExitIsBiDirection  = Bidirectional
 EntryExit_DestinationPointsInUseEntryExitExpressionVeto = DestinationPoints is in use by EntryExit expression "{0}"
 
 False_Short           = Always false

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionEntryExit.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionEntryExit.java
@@ -283,7 +283,9 @@ public class ExpressionEntryExit extends AbstractDigitalExpression
         Inactive(0x04, Bundle.getMessage("EntryExitStateInactive")),
         Active(0x02, Bundle.getMessage("EntryExitStateActive")),
         Other(-1, Bundle.getMessage("EntryExitOtherStatus")),
+        Separator1(-1, null),
         IsReverse(-1, Bundle.getMessage("EntryExitIsReverse")),
+        Separator2(-1, null),
         IsBiDirection(-1, Bundle.getMessage("EntryExitIsBiDirection"));
 
         private final int _id;

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionEntryExit.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionEntryExit.java
@@ -283,9 +283,9 @@ public class ExpressionEntryExit extends AbstractDigitalExpression
         Inactive(0x04, Bundle.getMessage("EntryExitStateInactive")),
         Active(0x02, Bundle.getMessage("EntryExitStateActive")),
         Other(-1, Bundle.getMessage("EntryExitOtherStatus")),
-        Separator1(-1, null),
+        Separator1(-1, Base.SEPARATOR),
         Reverse(-1, Bundle.getMessage("EntryExitReverse")),
-        Separator2(-1, null),
+        Separator2(-1, Base.SEPARATOR),
         BiDirection(-1, Bundle.getMessage("EntryExitBiDirection"));
 
         private final int _id;

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionEntryExit.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionEntryExit.java
@@ -183,9 +183,9 @@ public class ExpressionEntryExit extends AbstractDigitalExpression
                 }
             case Reversed:
                 if (_is_IsNot == Is_IsNot_Enum.Is) {
-                    return destinationPoints.isReverse();
+                    return destinationPoints.isReversed();
                 } else {
-                    return !destinationPoints.isReverse();
+                    return !destinationPoints.isReversed();
                 }
             case BiDirection:
                 if (_is_IsNot == Is_IsNot_Enum.Is) {

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionEntryExit.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionEntryExit.java
@@ -181,7 +181,7 @@ public class ExpressionEntryExit extends AbstractDigitalExpression
                 } else {
                     return currentEntryExitState != checkEntryExitState;
                 }
-            case Reverse:
+            case Reversed:
                 if (_is_IsNot == Is_IsNot_Enum.Is) {
                     return destinationPoints.isReverse();
                 } else {
@@ -284,7 +284,7 @@ public class ExpressionEntryExit extends AbstractDigitalExpression
         Active(0x02, Bundle.getMessage("EntryExitStateActive")),
         Other(-1, Bundle.getMessage("EntryExitOtherStatus")),
         Separator1(-1, Base.SEPARATOR),
-        Reverse(-1, Bundle.getMessage("EntryExitReverse")),
+        Reversed(-1, Bundle.getMessage("EntryExitReversed")),
         Separator2(-1, Base.SEPARATOR),
         BiDirection(-1, Bundle.getMessage("EntryExitBiDirection"));
 

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionEntryExit.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionEntryExit.java
@@ -171,11 +171,30 @@ public class ExpressionEntryExit extends AbstractDigitalExpression
             checkEntryExitState = EntryExitState.valueOf(getNewState());
         }
 
-        EntryExitState currentEntryExitState = EntryExitState.get(destinationPoints.getState());
-        if (_is_IsNot == Is_IsNot_Enum.Is) {
-            return currentEntryExitState == checkEntryExitState;
-        } else {
-            return currentEntryExitState != checkEntryExitState;
+        switch (checkEntryExitState) {
+            case Inactive:
+            case Active:
+            case Other:
+                EntryExitState currentEntryExitState = EntryExitState.get(destinationPoints.getState());
+                if (_is_IsNot == Is_IsNot_Enum.Is) {
+                    return currentEntryExitState == checkEntryExitState;
+                } else {
+                    return currentEntryExitState != checkEntryExitState;
+                }
+            case IsReverse:
+                if (_is_IsNot == Is_IsNot_Enum.Is) {
+                    return destinationPoints.isReverse();
+                } else {
+                    return !destinationPoints.isReverse();
+                }
+            case IsBiDirection:
+                if (_is_IsNot == Is_IsNot_Enum.Is) {
+                    return !destinationPoints.isUniDirection();
+                } else {
+                    return destinationPoints.isUniDirection();
+                }
+            default:
+                throw new IllegalArgumentException("checkEntryExitState has unknown value: "+checkEntryExitState.name());
         }
     }
 
@@ -263,7 +282,9 @@ public class ExpressionEntryExit extends AbstractDigitalExpression
     public enum EntryExitState {
         Inactive(0x04, Bundle.getMessage("EntryExitStateInactive")),
         Active(0x02, Bundle.getMessage("EntryExitStateActive")),
-        Other(-1, Bundle.getMessage("EntryExitOtherStatus"));
+        Other(-1, Bundle.getMessage("EntryExitOtherStatus")),
+        IsReverse(-1, Bundle.getMessage("EntryExitIsReverse")),
+        IsBiDirection(-1, Bundle.getMessage("EntryExitIsBiDirection"));
 
         private final int _id;
         private final String _text;

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionEntryExit.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionEntryExit.java
@@ -181,13 +181,13 @@ public class ExpressionEntryExit extends AbstractDigitalExpression
                 } else {
                     return currentEntryExitState != checkEntryExitState;
                 }
-            case IsReverse:
+            case Reverse:
                 if (_is_IsNot == Is_IsNot_Enum.Is) {
                     return destinationPoints.isReverse();
                 } else {
                     return !destinationPoints.isReverse();
                 }
-            case IsBiDirection:
+            case BiDirection:
                 if (_is_IsNot == Is_IsNot_Enum.Is) {
                     return !destinationPoints.isUniDirection();
                 } else {
@@ -284,9 +284,9 @@ public class ExpressionEntryExit extends AbstractDigitalExpression
         Active(0x02, Bundle.getMessage("EntryExitStateActive")),
         Other(-1, Bundle.getMessage("EntryExitOtherStatus")),
         Separator1(-1, null),
-        IsReverse(-1, Bundle.getMessage("EntryExitIsReverse")),
+        Reverse(-1, Bundle.getMessage("EntryExitReverse")),
         Separator2(-1, null),
-        IsBiDirection(-1, Bundle.getMessage("EntryExitIsBiDirection"));
+        BiDirection(-1, Bundle.getMessage("EntryExitBiDirection"));
 
         private final int _id;
         private final String _text;

--- a/java/src/jmri/jmrit/logixng/expressions/swing/ExpressionEntryExitSwing.java
+++ b/java/src/jmri/jmrit/logixng/expressions/swing/ExpressionEntryExitSwing.java
@@ -205,9 +205,9 @@ public class ExpressionEntryExitSwing extends AbstractDigitalExpressionSwing {
     private static class ComboBoxRenderer<EntryExitState> extends JLabel implements ListCellRenderer<EntryExitState> {
 
         private final JSeparator _separator = new JSeparator(JSeparator.HORIZONTAL);
-        private final ListCellRenderer<Object> _old;
+        private final ListCellRenderer<EntryExitState> _old;
 
-        private ComboBoxRenderer(ListCellRenderer<Object> old) {
+        private ComboBoxRenderer(ListCellRenderer<EntryExitState> old) {
             this._old = old;
         }
 

--- a/java/src/jmri/jmrit/logixng/expressions/swing/ExpressionEntryExitSwing.java
+++ b/java/src/jmri/jmrit/logixng/expressions/swing/ExpressionEntryExitSwing.java
@@ -214,7 +214,7 @@ public class ExpressionEntryExitSwing extends AbstractDigitalExpressionSwing {
         @Override
         public Component getListCellRendererComponent(JList<? extends E> list,
                 E value, int index, boolean isSelected, boolean cellHasFocus) {
-            if (value.toString() == null) {
+            if (Base.SEPARATOR.equals(value.toString())) {
                 return _separator;
             } else {
                 return _old.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);

--- a/java/src/jmri/jmrit/logixng/expressions/swing/ExpressionEntryExitSwing.java
+++ b/java/src/jmri/jmrit/logixng/expressions/swing/ExpressionEntryExitSwing.java
@@ -1,5 +1,6 @@
 package jmri.jmrit.logixng.expressions.swing;
 
+import java.awt.Component;
 import java.util.List;
 
 import javax.annotation.CheckForNull;
@@ -79,6 +80,8 @@ public class ExpressionEntryExitSwing extends AbstractDigitalExpressionSwing {
             _stateComboBox.addItem(e);
         }
         JComboBoxUtil.setupComboBoxMaxRows(_stateComboBox);
+
+        _stateComboBox.setRenderer(new ComboBoxRenderer(_stateComboBox.getRenderer()));
 
         _panelEntryExitStateDirect.add(_stateComboBox);
 
@@ -198,6 +201,26 @@ public class ExpressionEntryExitSwing extends AbstractDigitalExpressionSwing {
     public void dispose() {
     }
 
+
+    private static class ComboBoxRenderer<EntryExitState> extends JLabel implements ListCellRenderer<EntryExitState> {
+
+        private final JSeparator _separator = new JSeparator(JSeparator.HORIZONTAL);
+        private final ListCellRenderer<Object> _old;
+
+        private ComboBoxRenderer(ListCellRenderer<Object> old) {
+            this._old = old;
+        }
+
+        @Override
+        public Component getListCellRendererComponent(JList<? extends EntryExitState> list,
+                EntryExitState value, int index, boolean isSelected, boolean cellHasFocus) {
+            if (value.toString() == null) {
+                return _separator;
+            } else {
+                return _old.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
+            }
+        }
+    }
 
 //    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ExpressionEntryExitSwing.class);
 

--- a/java/src/jmri/jmrit/logixng/expressions/swing/ExpressionEntryExitSwing.java
+++ b/java/src/jmri/jmrit/logixng/expressions/swing/ExpressionEntryExitSwing.java
@@ -81,7 +81,7 @@ public class ExpressionEntryExitSwing extends AbstractDigitalExpressionSwing {
         }
         JComboBoxUtil.setupComboBoxMaxRows(_stateComboBox);
 
-        _stateComboBox.setRenderer(new ComboBoxRenderer(_stateComboBox.getRenderer()));
+        _stateComboBox.setRenderer(new ComboBoxRenderer<>(_stateComboBox.getRenderer()));
 
         _panelEntryExitStateDirect.add(_stateComboBox);
 
@@ -202,18 +202,18 @@ public class ExpressionEntryExitSwing extends AbstractDigitalExpressionSwing {
     }
 
 
-    private static class ComboBoxRenderer<EntryExitState> extends JLabel implements ListCellRenderer<EntryExitState> {
+    private static class ComboBoxRenderer<E> extends JLabel implements ListCellRenderer<E> {
 
         private final JSeparator _separator = new JSeparator(JSeparator.HORIZONTAL);
-        private final ListCellRenderer<EntryExitState> _old;
+        private final ListCellRenderer<E> _old;
 
-        private ComboBoxRenderer(ListCellRenderer<EntryExitState> old) {
+        private ComboBoxRenderer(ListCellRenderer<E> old) {
             this._old = old;
         }
 
         @Override
-        public Component getListCellRendererComponent(JList<? extends EntryExitState> list,
-                EntryExitState value, int index, boolean isSelected, boolean cellHasFocus) {
+        public Component getListCellRendererComponent(JList<? extends E> list,
+                E value, int index, boolean isSelected, boolean cellHasFocus) {
             if (value.toString() == null) {
                 return _separator;
             } else {

--- a/java/test/jmri/jmrit/logixng/CreateLogixNGTreeScaffold.java
+++ b/java/test/jmri/jmrit/logixng/CreateLogixNGTreeScaffold.java
@@ -3678,7 +3678,7 @@ public class CreateLogixNGTreeScaffold {
 
         expressionEntryExit = new ExpressionEntryExit(digitalExpressionManager.getAutoSystemName(), null);
         expressionEntryExit.setComment("A comment");
-        expressionEntryExit.setBeanState(ExpressionEntryExit.EntryExitState.Inactive);
+        expressionEntryExit.setBeanState(ExpressionEntryExit.EntryExitState.Active);
         expressionEntryExit.getSelectNamedBean().setNamedBean(dp2);
         expressionEntryExit.getSelectNamedBean().setAddressing(NamedBeanAddressing.LocalVariable);
         expressionEntryExit.getSelectNamedBean().setFormula("\"IT\"+index");
@@ -3694,7 +3694,7 @@ public class CreateLogixNGTreeScaffold {
 
         expressionEntryExit = new ExpressionEntryExit(digitalExpressionManager.getAutoSystemName(), null);
         expressionEntryExit.setComment("A comment");
-        expressionEntryExit.setBeanState(ExpressionEntryExit.EntryExitState.Inactive);
+        expressionEntryExit.setBeanState(ExpressionEntryExit.EntryExitState.Other);
         expressionEntryExit.getSelectNamedBean().setAddressing(NamedBeanAddressing.Formula);
         expressionEntryExit.getSelectNamedBean().setFormula("\"IT\"+index");
         expressionEntryExit.getSelectNamedBean().setLocalVariable("index");
@@ -3709,7 +3709,7 @@ public class CreateLogixNGTreeScaffold {
 
         expressionEntryExit = new ExpressionEntryExit(digitalExpressionManager.getAutoSystemName(), null);
         expressionEntryExit.setComment("A comment");
-        expressionEntryExit.setBeanState(ExpressionEntryExit.EntryExitState.Inactive);
+        expressionEntryExit.setBeanState(ExpressionEntryExit.EntryExitState.Reverse);
         expressionEntryExit.getSelectNamedBean().setAddressing(NamedBeanAddressing.Reference);
         expressionEntryExit.getSelectNamedBean().setFormula("\"IT\"+index");
         expressionEntryExit.getSelectNamedBean().setLocalVariable("index");
@@ -3719,6 +3719,12 @@ public class CreateLogixNGTreeScaffold {
         expressionEntryExit.setStateFormula("\"IT\"+index2");
         expressionEntryExit.setStateLocalVariable("index2");
         expressionEntryExit.setStateReference("{IM2}");
+        maleSocket = digitalExpressionManager.registerExpression(expressionEntryExit);
+        and.getChild(indexExpr++).connect(maleSocket);
+
+        expressionEntryExit = new ExpressionEntryExit(digitalExpressionManager.getAutoSystemName(), null);
+        expressionEntryExit.setComment("A comment");
+        expressionEntryExit.setBeanState(ExpressionEntryExit.EntryExitState.BiDirection);
         maleSocket = digitalExpressionManager.registerExpression(expressionEntryExit);
         and.getChild(indexExpr++).connect(maleSocket);
 

--- a/java/test/jmri/jmrit/logixng/CreateLogixNGTreeScaffold.java
+++ b/java/test/jmri/jmrit/logixng/CreateLogixNGTreeScaffold.java
@@ -3709,7 +3709,7 @@ public class CreateLogixNGTreeScaffold {
 
         expressionEntryExit = new ExpressionEntryExit(digitalExpressionManager.getAutoSystemName(), null);
         expressionEntryExit.setComment("A comment");
-        expressionEntryExit.setBeanState(ExpressionEntryExit.EntryExitState.Reverse);
+        expressionEntryExit.setBeanState(ExpressionEntryExit.EntryExitState.Reversed);
         expressionEntryExit.getSelectNamedBean().setAddressing(NamedBeanAddressing.Reference);
         expressionEntryExit.getSelectNamedBean().setFormula("\"IT\"+index");
         expressionEntryExit.getSelectNamedBean().setLocalVariable("index");

--- a/xml/schema/logixng/digital-expressions/expression-entryexit-4.23.1.xsd
+++ b/xml/schema/logixng/digital-expressions/expression-entryexit-4.23.1.xsd
@@ -62,7 +62,7 @@
                     <xs:enumeration value="Inactive"/>
                     <xs:enumeration value="Active"/>
                     <xs:enumeration value="Other"/>
-                    <xs:enumeration value="Reverse"/>
+                    <xs:enumeration value="Reversed"/>
                     <xs:enumeration value="BiDirection"/>
                   </xs:restriction>
                 </xs:simpleType>

--- a/xml/schema/logixng/digital-expressions/expression-entryexit-4.23.1.xsd
+++ b/xml/schema/logixng/digital-expressions/expression-entryexit-4.23.1.xsd
@@ -62,6 +62,8 @@
                     <xs:enumeration value="Inactive"/>
                     <xs:enumeration value="Active"/>
                     <xs:enumeration value="Other"/>
+                    <xs:enumeration value="Reverse"/>
+                    <xs:enumeration value="BiDirection"/>
                   </xs:restriction>
                 </xs:simpleType>
               </xs:element>


### PR DESCRIPTION
The LogixNG expression `Entry/exit` can now check if a entry/exit is reverse or bidirectional.

![Skärmklipp 2023-11-12 12 23 21](https://github.com/JMRI/JMRI/assets/20255317/029386dc-4d21-42e3-b046-666c7393db77)
