### PR TITLE
Prepend railroad name to MQTT clientId

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -106,7 +106,9 @@
 
         <h4>MQTT</h4>
             <ul>
-                <li></li>
+                <li>JMRI will now use the railroad name from the preferences
+                    when creating the client ID.  This will make it easier to 
+                    identify the JMRI connection in the MQTT broker logs.</li>
             </ul>
 
         <h4>MRC</h4>

--- a/java/src/jmri/jmrix/mqtt/MqttAdapter.java
+++ b/java/src/jmri/jmrix/mqtt/MqttAdapter.java
@@ -161,8 +161,9 @@ public class MqttAdapter extends jmri.jmrix.AbstractNetworkPortController implem
             }
 
             // generate a unique client ID based on the network ID and the system prefix of the MQTT connection.
-            String clientID = jmri.util.node.NodeIdentity.networkIdentity() + getSystemPrefix();
-
+            String clientID = jmri.InstanceManager.getDefault(jmri.web.server.WebServerPreferences.class).getRailroadName() + " "
+                                + getSystemPrefix() + " " + jmri.util.node.NodeIdentity.networkIdentity();
+            
             // ensure that only valid characters are included in the client ID
             clientID = clientID.replaceAll("[^A-Za-z0-9]", "");
             //ensure the length of the client ID doesn't exceed the guaranteed acceptable length of 23

--- a/java/src/jmri/jmrix/mqtt/MqttAdapter.java
+++ b/java/src/jmri/jmrix/mqtt/MqttAdapter.java
@@ -161,15 +161,18 @@ public class MqttAdapter extends jmri.jmrix.AbstractNetworkPortController implem
             }
 
             // generate a unique client ID based on the network ID and the system prefix of the MQTT connection.
-            String clientID = jmri.InstanceManager.getDefault(jmri.web.server.WebServerPreferences.class).getRailroadName() + " "
-                                + getSystemPrefix() + " " + jmri.util.node.NodeIdentity.networkIdentity();
+            String clientID = jmri.InstanceManager.getDefault(jmri.web.server.WebServerPreferences.class).getRailroadName()
+                                + getSystemPrefix() + jmri.util.node.NodeIdentity.networkIdentity();
             
-            // ensure that only valid characters are included in the client ID
+            // ensure that only guaranteed valid characters are included in the client ID
             clientID = clientID.replaceAll("[^A-Za-z0-9]", "");
-            //ensure the length of the client ID doesn't exceed the guaranteed acceptable length of 23
+            
+            // ensure the length of the client ID doesn't exceed the guaranteed acceptable length of 23
             if (clientID.length() > 23) {
-                clientID = clientID.substring(clientID.length() - 23);
+                clientID = clientID.substring(0, 23);
             }
+            log.info("Connection {} is using a clientID of \"{}\"", getSystemPrefix(), clientID);
+            
             String tempdirName = jmri.util.FileUtil.getExternalFilename(jmri.util.FileUtil.PROFILE);
             log.debug("will use {} as temporary directory", tempdirName);
 


### PR DESCRIPTION
This makes it easier to identify the JMRI instance in the MQTT broker log.