### PR TITLE
Add (some) support for new LokSound 5 firmware 5.9.159

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -226,7 +226,7 @@
 
         <h4>ESU</h4>
             <ul>
-                <li></li>
+                <li>Added support for "Tone Control" for LokSound 5 (requires firmware 5.9.159 or higher).</li>
             </ul>
 
         <h4>Hornby</h4>

--- a/java/src/jmri/jmrit/symbolicprog/FnMapPanelESU.java
+++ b/java/src/jmri/jmrit/symbolicprog/FnMapPanelESU.java
@@ -388,9 +388,6 @@ public final class FnMapPanelESU extends JPanel {
                         if (outBlockNum == 1 && item >= thisOutBlockStart + numOutsFromDefinition && item < thisOutBlockStart + numOuts) {
                             log.debug("Skipping previous item because function output AUX {} does not exist on this decoder", item - thisOutBlockStart - 2 + 1);
                         }
-                        else if (outBlockNum == 1 && item >= thisOutBlockStart + numOutsFromDefinition && Integer.parseInt(model.getAttribute("productID").getValue()) == 16777432) {
-                            log.debug("Skipping previous item because [2] function outputs cannot be programmed on ESU 58751 as of 2023-11-12");
-                        }
                         else {
                             // create a JDOM tree with some elements to add to varModel
                             Element root = new Element("decoder-config");

--- a/xml/decoders/esu/v4soundPane.xml
+++ b/xml/decoders/esu/v4soundPane.xml
@@ -319,11 +319,23 @@
             <label>
                 <text> </text>
             </label>
-            <label>
-                <text>Requires decoder firmware version 5.9.159 or greater.</text>
-                <text>You may need to re-read the info pane for DecoderPro to correctly see your firmware version.</text>
-                <text> </text>
-            </label>
+            <group>
+                <qualifier>
+                    <variableref>Firmware Full Version</variableref>
+                    <relation>lt</relation>
+                    <!-- 5.9.159 -> 0x509009f -> 84476063 -->
+                    <value>84476063</value>
+                </qualifier>
+                <label>
+                    <text>Requires decoder firmware version 5.9.159 or greater.</text>
+                </label>
+                <label>
+                    <text>You may need to re-read the info pane for DecoderPro to correctly see your firmware version.</text>
+                </label>
+                <label>
+                    <text> </text>
+                </label>
+            </group>
             <grid gridx="0" gridy="NEXT" ipady="10" anchor="LINE_END">
                 <griditem>
                     <display item="Bass setting"/>

--- a/xml/decoders/esu/v4soundPane.xml
+++ b/xml/decoders/esu/v4soundPane.xml
@@ -309,7 +309,31 @@
                     <display item="SoundCV16" format="hslider" label=""/>
                 </griditem>
             </grid>
+            <label>
+                <text> </text>
+            </label>
+            <separator/>
+            <label>
+                <text>ESU Tone Control</text>
+            </label>
+            <label>
+                <text> </text>
+            </label>
+            <label>
+                <text>Requires decoder firmware version 5.9.159 or greater.</text>
+                <text>You may need to re-read the info pane for DecoderPro to correctly see your firmware version.</text>
+                <text> </text>
+            </label>
+            <grid gridx="0" gridy="NEXT" ipady="10" anchor="LINE_END">
+                <griditem>
+                    <display item="Bass setting"/>
+                    <display item="Bass setting" format="hslider" label=""/>
+                </griditem>
+                <griditem>
+                    <display item="Treble setting"/>
+                    <display item="Treble setting" format="hslider" label=""/>
+                </griditem>
+            </grid>
         </column>
     </group>
-
 </pane>

--- a/xml/decoders/esu/v5readMePane.xml
+++ b/xml/decoders/esu/v5readMePane.xml
@@ -548,16 +548,16 @@
             <text>regardless of the value attempted to write. This is true for "CV programming" with ESU LokProgrammer</text>
         </label>
         <label>
-            <text>as well, and it occurs at least up to firmware version 5.8.156 (current as of the time of this writing).</text>
+            <text>as well, and it occurs at least up to firmware version 5.9.159 (current as of the time of this writing).</text>
         </label>
         <label>
             <text> </text>
         </label>
         <label>
-            <text>To avoid destroying someones [2]-output configuration, JMRI does not read or write those CVs.</text>
+            <text>To avoid destroying someones [2]-output configuration, JMRI does not read or write CVs to configure [2] outputs.</text>
         </label>
         <label>
-            <text>This is true for both the Function Outputs and the Function Map panes.</text>
+            <text>Some firmware versions also break Function Map of [2] outputs, though they work with 5.9.159.</text>
         </label>
         <label>
             <text> </text>

--- a/xml/decoders/esu/v5soundCVs.xml
+++ b/xml/decoders/esu/v5soundCVs.xml
@@ -141,8 +141,8 @@
             <relation>ge</relation>
             <value>159</value>
         </qualifier>
-        <tooltip>0 = -10dB, 16 = 0dB, 32 = +10dB</tooltip>
         <decVal min="0" max="32"/>
+        <tooltip>0 = -10dB, 16 = 0dB, 32 = +10dB</tooltip>
     </variable>
     <variable CV="197" default="16" item="Treble setting">
         <qualifier>
@@ -160,8 +160,8 @@
             <relation>ge</relation>
             <value>159</value>
         </qualifier>
-        <tooltip>0 = -10dB, 16 = 0dB, 32 = +10dB</tooltip>
         <decVal min="0" max="32"/>
+        <tooltip>0 = -10dB, 16 = 0dB, 32 = +10dB</tooltip>
     </variable>
     <!-- Indexed variables -->
     <variable CV="16.1.259" default="128" item="Sound Volume 1">

--- a/xml/decoders/esu/v5soundCVs.xml
+++ b/xml/decoders/esu/v5soundCVs.xml
@@ -125,44 +125,22 @@
         <decVal/>
         <label>Sound CV16</label>
     </variable>
-    <variable CV="196" default="16" item="Bass setting">
+    <variables>
         <qualifier>
-            <variableref>Firmware Major Version</variableref>
+            <variableref>Firmware Full Version</variableref>
             <relation>ge</relation>
-            <value>5</value>
+            <!-- 5.9.159 -> 0x509009f -> 84476063 -->
+            <value>84476063</value>
         </qualifier>
-        <qualifier>
-            <variableref>Firmware Minor Version</variableref>
-            <relation>ge</relation>
-            <value>9</value>
-        </qualifier>
-        <qualifier>
-            <variableref>Firmware Build Number</variableref>
-            <relation>ge</relation>
-            <value>159</value>
-        </qualifier>
-        <decVal min="0" max="32"/>
-        <tooltip>0 = -10dB, 16 = 0dB, 32 = +10dB</tooltip>
-    </variable>
-    <variable CV="197" default="16" item="Treble setting">
-        <qualifier>
-            <variableref>Firmware Major Version</variableref>
-            <relation>ge</relation>
-            <value>5</value>
-        </qualifier>
-        <qualifier>
-            <variableref>Firmware Minor Version</variableref>
-            <relation>ge</relation>
-            <value>9</value>
-        </qualifier>
-        <qualifier>
-            <variableref>Firmware Build Number</variableref>
-            <relation>ge</relation>
-            <value>159</value>
-        </qualifier>
-        <decVal min="0" max="32"/>
-        <tooltip>0 = -10dB, 16 = 0dB, 32 = +10dB</tooltip>
-    </variable>
+        <variable CV="196" default="16" item="Bass setting">
+            <decVal min="0" max="32"/>
+            <tooltip>0 = -10dB, 16 = 0dB, 32 = +10dB</tooltip>
+        </variable>
+        <variable CV="197" default="16" item="Treble setting">
+            <decVal min="0" max="32"/>
+            <tooltip>0 = -10dB, 16 = 0dB, 32 = +10dB</tooltip>
+        </variable>
+    </variables>
     <!-- Indexed variables -->
     <variable CV="16.1.259" default="128" item="Sound Volume 1">
         <decVal/>

--- a/xml/decoders/esu/v5soundCVs.xml
+++ b/xml/decoders/esu/v5soundCVs.xml
@@ -125,6 +125,44 @@
         <decVal/>
         <label>Sound CV16</label>
     </variable>
+    <variable CV="196" default="16" item="Bass setting">
+        <qualifier>
+            <variableref>Firmware Major Version</variableref>
+            <relation>ge</relation>
+            <value>5</value>
+        </qualifier>
+        <qualifier>
+            <variableref>Firmware Minor Version</variableref>
+            <relation>ge</relation>
+            <value>9</value>
+        </qualifier>
+        <qualifier>
+            <variableref>Firmware Build Number</variableref>
+            <relation>ge</relation>
+            <value>159</value>
+        </qualifier>
+        <tooltip>0 = -10dB, 16 = 0dB, 32 = +10dB</tooltip>
+        <decVal min="0" max="32"/>
+    </variable>
+    <variable CV="197" default="16" item="Treble setting">
+        <qualifier>
+            <variableref>Firmware Major Version</variableref>
+            <relation>ge</relation>
+            <value>5</value>
+        </qualifier>
+        <qualifier>
+            <variableref>Firmware Minor Version</variableref>
+            <relation>ge</relation>
+            <value>9</value>
+        </qualifier>
+        <qualifier>
+            <variableref>Firmware Build Number</variableref>
+            <relation>ge</relation>
+            <value>159</value>
+        </qualifier>
+        <tooltip>0 = -10dB, 16 = 0dB, 32 = +10dB</tooltip>
+        <decVal min="0" max="32"/>
+    </variable>
     <!-- Indexed variables -->
     <variable CV="16.1.259" default="128" item="Sound Volume 1">
         <decVal/>

--- a/xml/decoders/esu/v5standardCVs.xml
+++ b/xml/decoders/esu/v5standardCVs.xml
@@ -1043,6 +1043,11 @@
         <decVal/>
         <label>Firmware Major Version</label>
     </variable>
+    <variable CV="0.255.285:4" readOnly="yes" item="Firmware Full Version">
+        <splitHexVal/>
+        <label>Firmware Full Version</label>
+        <tooltip>A machine-comparable value calculated from the different parts of the Firmware Version</tooltip>
+    </variable>
     <xi:include href="http://jmri.org/xml/decoders/esu/v4decoderInfoCVs.xml"/>
     <variables exclude="Essential Sound Unit">
         <xi:include href="http://jmri.org/xml/decoders/esu/v4projectInfoCVs.xml"/>


### PR DESCRIPTION
Just three days after #11682, ESU released a new firmware for those decoder (and all the LokSound / LokPilot 5s). They add new features and fix bugs...

This PR proposes two changes:

. Simplified the firmware bug workaround from #11682 since half the bug has been fixed
. Added Tone Control: https://www.esu.eu/en/support/tips-tricks/lokprogrammer-software-50x/tone-control/

Question on qualifiers: I see the CVs get added to the roster file even when the qualifier is not matched. Is that correct  behavior?

And another question/note on ESU firmware version numbering:

New ESU firmware usually has a greater or equal major version, a greater or equal minor version _and_ a greater build number than an older firmware. For example: 5.6.144 -> 5.6.147 -> 5.7.151 -> 5.8.156 -> 5.9.159 , but not 5.8.156 -> 5.9.152. That's why the qualifier I added on the variables should work.

However: Can I add a variable calculated from multiple CVs that are already covered by other variables?

I.e. lets say there already are variables "Firmware Major Version" CV 288 and "Firmware Minor Version" CV 287.

Can I add another variable, call it "Firmware Full Version" and have DecoderPro calculate it as 1000 * CV 288 + CV 287? Probably something like SplitVal(CV="0.255.288,0.255.287" factor="1000,1") ?

That would make version comparison more stable, but I'm not sure two variables can refer to the same CVs.

Heiko