### PR TITLE
Keep LogixNG socket names constant

### DIFF
--- a/java/test/jmri/jmrit/logixng/CreateLogixNGTreeScaffold.java
+++ b/java/test/jmri/jmrit/logixng/CreateLogixNGTreeScaffold.java
@@ -5271,7 +5271,7 @@ public class CreateLogixNGTreeScaffold {
 
 
     private static final PrimitiveIterator.OfInt iterator =
-            JUnitUtil.getRandom().ints('a', 'z'+10).iterator();
+            JUnitUtil.getRandomConstantSeed().ints('a', 'z'+10).iterator();
 
     private static String getRandomString(int count) {
         StringBuilder s = new StringBuilder();

--- a/java/test/jmri/jmrit/logixng/configurexml/load/LogixNG.xml
+++ b/java/test/jmri/jmrit/logixng/configurexml/load/LogixNG.xml
@@ -18,7 +18,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
   <jmriversion>
     <major>5</major>
     <minor>5</minor>
-    <test>5</test>
+    <test>6</test>
     <modifier>plus</modifier>
   </jmriversion>
   <sensors class="jmri.jmrix.internal.configurexml.InternalSensorManagerXml">
@@ -85,7 +85,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
     <memory>
       <systemName>IM3</systemName>
     </memory>
-    <memory value="9:30 AM">
+    <memory value="4:50 PM">
       <systemName>IMCURRENTTIME</systemName>
     </memory>
     <memory value="1.0">
@@ -176,7 +176,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <userName>First conditional</userName>
     </conditional>
   </conditionals>
-  <timebase class="jmri.jmrit.simpleclock.configurexml.SimpleTimebaseXml" time="Wed Nov 01 09:30:01 CET 2023" rate="1.0" startrate="1.0" run="yes" master="yes" sync="no" correct="no" display="no" startstopped="no" startrunning="yes" startsettime="no" startclockoption="0" showbutton="no" startsetrate="yes" />
+  <timebase class="jmri.jmrit.simpleclock.configurexml.SimpleTimebaseXml" time="Tue Nov 14 16:49:29 CET 2023" rate="1.0" startrate="1.0" run="yes" master="yes" sync="no" correct="no" display="no" startstopped="no" startrunning="yes" startsettime="no" startclockoption="0" showbutton="no" startsetrate="yes" />
   <LogixNGs class="jmri.jmrit.logixng.implementation.configurexml.DefaultLogixNGManagerXml">
     <Thread>
       <id>0</id>
@@ -344,7 +344,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <userName>Yet another conditionalNG</userName>
       <thread>0</thread>
       <Socket>
-        <socketName>fmdwlia8gl</socketName>
+        <socketName>fxecz3qb9j</socketName>
         <systemName>IQDA:AUTO:0001</systemName>
       </Socket>
     </ConditionalNG>
@@ -361,7 +361,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <systemName>IQDE:AUTO:0001</systemName>
       <Expressions>
         <Socket>
-          <socketName>bk892lbma3</socketName>
+          <socketName>j95yvzl25f</socketName>
         </Socket>
       </Expressions>
       <MaleSocket>
@@ -441,7 +441,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <comment>Start expression</comment>
       <Expressions>
         <Socket>
-          <socketName>to5rtkksod</socketName>
+          <socketName>xxpi22ye9k</socketName>
         </Socket>
       </Expressions>
       <MaleSocket>
@@ -521,7 +521,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <comment>Stop expression</comment>
       <Expressions>
         <Socket>
-          <socketName>p63l3wonmq</socketName>
+          <socketName>wyooijoslv</socketName>
         </Socket>
       </Expressions>
       <MaleSocket>
@@ -601,7 +601,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <comment>Start expression</comment>
       <Expressions>
         <Socket>
-          <socketName>rzrmsqw2v9</socketName>
+          <socketName>udtp8cpuxh</socketName>
         </Socket>
       </Expressions>
       <MaleSocket>
@@ -681,7 +681,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <comment>Stop expression</comment>
       <Expressions>
         <Socket>
-          <socketName>xaizs9igmt</socketName>
+          <socketName>fl3l156ozr</socketName>
         </Socket>
       </Expressions>
       <MaleSocket>
@@ -761,7 +761,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <comment>Reset expression</comment>
       <Expressions>
         <Socket>
-          <socketName>b2qypqq4gk</socketName>
+          <socketName>sakwkoxfxi</socketName>
         </Socket>
       </Expressions>
       <MaleSocket>
@@ -841,7 +841,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <comment>Expression socket 1</comment>
       <Expressions>
         <Socket>
-          <socketName>xwtofp9eds</socketName>
+          <socketName>wnpu87n68p</socketName>
         </Socket>
       </Expressions>
       <MaleSocket>
@@ -921,7 +921,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <comment>Expression socket 2</comment>
       <Expressions>
         <Socket>
-          <socketName>o7nllcrj5r</socketName>
+          <socketName>kgtz349yaq</socketName>
         </Socket>
       </Expressions>
       <MaleSocket>
@@ -1000,7 +1000,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <systemName>IQDE:AUTO:0009</systemName>
       <Expressions>
         <Socket>
-          <socketName>vuoidwex8f</socketName>
+          <socketName>nfutemk393</socketName>
         </Socket>
       </Expressions>
       <MaleSocket>
@@ -1279,11 +1279,11 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <systemName>IQDE:AUTO:0012</systemName>
       <Expressions>
         <Socket>
-          <socketName>y94l2wvtkp</socketName>
+          <socketName>d21exwa4si</socketName>
           <systemName>IQDE:AUTO:0013</systemName>
         </Socket>
         <Socket>
-          <socketName>fcdwl564xe</socketName>
+          <socketName>ud11he2obp</socketName>
         </Socket>
       </Expressions>
       <MaleSocket>
@@ -1363,595 +1363,599 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <comment>A comment</comment>
       <Expressions>
         <Socket>
-          <socketName>ejm1h9cahm</socketName>
+          <socketName>sgwjs6fb79</socketName>
           <systemName>IQDE:AUTO:0014</systemName>
         </Socket>
         <Socket>
-          <socketName>wfo4z5tjb1</socketName>
+          <socketName>f7ympjufvd</socketName>
           <systemName>IQDE:AUTO:0015</systemName>
         </Socket>
         <Socket>
-          <socketName>otzhefpqg3</socketName>
+          <socketName>i3dklol6qb</socketName>
           <systemName>IQDE:AUTO:0016</systemName>
         </Socket>
         <Socket>
-          <socketName>xma2jdlnyv</socketName>
+          <socketName>htoijvvdpu</socketName>
           <systemName>IQDE:AUTO:0017</systemName>
         </Socket>
         <Socket>
-          <socketName>nyepf1e6yw</socketName>
+          <socketName>r978uixdgc</socketName>
           <systemName>IQDE:AUTO:0018</systemName>
         </Socket>
         <Socket>
-          <socketName>vhe9ghnrcb</socketName>
+          <socketName>yhs8xm7lrb</socketName>
           <systemName>IQDE:AUTO:0019</systemName>
         </Socket>
         <Socket>
-          <socketName>wiwkt6s85f</socketName>
+          <socketName>tuv85jlel5</socketName>
           <systemName>IQDE:AUTO:0020</systemName>
         </Socket>
         <Socket>
-          <socketName>zi1b4pv71f</socketName>
+          <socketName>mgmcj2it71</socketName>
           <systemName>IQDE:AUTO:0021</systemName>
         </Socket>
         <Socket>
-          <socketName>tefibmwmyy</socketName>
+          <socketName>ykn8w9csa8</socketName>
           <systemName>IQDE:AUTO:0022</systemName>
         </Socket>
         <Socket>
-          <socketName>xtpfixe5ae</socketName>
+          <socketName>s2ja1chjqh</socketName>
           <systemName>IQDE:AUTO:0023</systemName>
         </Socket>
         <Socket>
-          <socketName>u3poer2i42</socketName>
+          <socketName>tcbc9aasij</socketName>
           <systemName>IQDE:AUTO:0024</systemName>
         </Socket>
         <Socket>
-          <socketName>tzjdo8xaus</socketName>
+          <socketName>jm56oxg2l4</socketName>
           <systemName>IQDE:AUTO:0025</systemName>
         </Socket>
         <Socket>
-          <socketName>egakuwidz9</socketName>
+          <socketName>pzeswbb2xn</socketName>
           <systemName>IQDE:AUTO:0026</systemName>
         </Socket>
         <Socket>
-          <socketName>r4j22e7ecq</socketName>
+          <socketName>fnfssstegg</socketName>
           <systemName>IQDE:AUTO:0027</systemName>
         </Socket>
         <Socket>
-          <socketName>xom7y362yv</socketName>
+          <socketName>kaesgm6ia8</socketName>
           <systemName>IQDE:AUTO:0028</systemName>
         </Socket>
         <Socket>
-          <socketName>ikqsvoibwp</socketName>
+          <socketName>xtiiihe6qf</socketName>
           <systemName>IQDE:AUTO:0029</systemName>
         </Socket>
         <Socket>
-          <socketName>f75ctvoqhz</socketName>
+          <socketName>dcu2tio1t3</socketName>
           <systemName>IQDE:AUTO:0030</systemName>
         </Socket>
         <Socket>
-          <socketName>px4yknu4bg</socketName>
+          <socketName>rdn2drhr36</socketName>
           <systemName>IQDE:AUTO:0031</systemName>
         </Socket>
         <Socket>
-          <socketName>urleg6z1ds</socketName>
+          <socketName>nt8rsqu32c</socketName>
           <systemName>IQDE:AUTO:0032</systemName>
         </Socket>
         <Socket>
-          <socketName>kogxi987no</socketName>
+          <socketName>s7xbqylno3</socketName>
           <systemName>IQDE:AUTO:0033</systemName>
         </Socket>
         <Socket>
-          <socketName>yn7qj4vupd</socketName>
+          <socketName>uq5djvmbfs</socketName>
           <systemName>IQDE:AUTO:0034</systemName>
         </Socket>
         <Socket>
-          <socketName>i7145zv7sv</socketName>
+          <socketName>fpphi7hb23</socketName>
           <systemName>IQDE:AUTO:0035</systemName>
         </Socket>
         <Socket>
-          <socketName>wzqtjctz3c</socketName>
+          <socketName>nn9ylotnj4</socketName>
           <systemName>IQDE:AUTO:0036</systemName>
         </Socket>
         <Socket>
-          <socketName>cvx117ics9</socketName>
+          <socketName>c1ptrgsavf</socketName>
           <systemName>IQDE:AUTO:0037</systemName>
         </Socket>
         <Socket>
-          <socketName>i2n3fhem9h</socketName>
+          <socketName>gv6u2zcp6e</socketName>
           <systemName>IQDE:AUTO:0038</systemName>
         </Socket>
         <Socket>
-          <socketName>ohwgi1w96o</socketName>
+          <socketName>zu82lrq34a</socketName>
           <systemName>IQDE:AUTO:0039</systemName>
         </Socket>
         <Socket>
-          <socketName>rqksiiiwky</socketName>
+          <socketName>vkrtde9k74</socketName>
           <systemName>IQDE:AUTO:0040</systemName>
         </Socket>
         <Socket>
-          <socketName>rzqcqjix3s</socketName>
+          <socketName>ygdh9hgftr</socketName>
           <systemName>IQDE:AUTO:0041</systemName>
         </Socket>
         <Socket>
-          <socketName>dhv9bctqjh</socketName>
+          <socketName>ni53qu192d</socketName>
           <systemName>IQDE:AUTO:0042</systemName>
         </Socket>
         <Socket>
-          <socketName>cvs143jgts</socketName>
+          <socketName>l1g9qgy68s</socketName>
           <systemName>IQDE:AUTO:0043</systemName>
         </Socket>
         <Socket>
-          <socketName>mkzpdewpe5</socketName>
+          <socketName>gci6nx3xl1</socketName>
           <systemName>IQDE:AUTO:0044</systemName>
         </Socket>
         <Socket>
-          <socketName>tpt3vlz8s9</socketName>
+          <socketName>nme8yfy7aa</socketName>
           <systemName>IQDE:AUTO:0045</systemName>
         </Socket>
         <Socket>
-          <socketName>k7tkpuv8ic</socketName>
+          <socketName>hrxgm6evrp</socketName>
           <systemName>IQDE:AUTO:0046</systemName>
         </Socket>
         <Socket>
-          <socketName>j91n5z3j17</socketName>
+          <socketName>ai3zlj4dzp</socketName>
           <systemName>IQDE:AUTO:0047</systemName>
         </Socket>
         <Socket>
-          <socketName>v4zgqzffxu</socketName>
+          <socketName>hidixg9g2b</socketName>
           <systemName>IQDE:AUTO:0048</systemName>
         </Socket>
         <Socket>
-          <socketName>btymbdedpx</socketName>
+          <socketName>hwxlh6vndi</socketName>
           <systemName>IQDE:AUTO:0049</systemName>
         </Socket>
         <Socket>
-          <socketName>hlhl8r8bf7</socketName>
+          <socketName>adp61xwf3w</socketName>
           <systemName>IQDE:AUTO:0050</systemName>
         </Socket>
         <Socket>
-          <socketName>j8jpgerb79</socketName>
+          <socketName>nvn98wn4ps</socketName>
           <systemName>IQDE:AUTO:0051</systemName>
         </Socket>
         <Socket>
-          <socketName>y956auxewh</socketName>
+          <socketName>tkj6rlauvb</socketName>
           <systemName>IQDE:AUTO:0052</systemName>
         </Socket>
         <Socket>
-          <socketName>yeb9uol8wi</socketName>
+          <socketName>szl3bf5qo7</socketName>
           <systemName>IQDE:AUTO:0053</systemName>
         </Socket>
         <Socket>
-          <socketName>ayqplnkmot</socketName>
+          <socketName>ug7t21hll3</socketName>
           <systemName>IQDE:AUTO:0054</systemName>
         </Socket>
         <Socket>
-          <socketName>abmrvygqy5</socketName>
+          <socketName>dnq1il8sd4</socketName>
           <systemName>IQDE:AUTO:0055</systemName>
         </Socket>
         <Socket>
-          <socketName>ie7hvuoako</socketName>
+          <socketName>eby7n5mu4l</socketName>
           <systemName>IQDE:AUTO:0056</systemName>
         </Socket>
         <Socket>
-          <socketName>qsxkhf1edq</socketName>
+          <socketName>qs3crv8xkx</socketName>
           <systemName>IQDE:AUTO:0057</systemName>
         </Socket>
         <Socket>
-          <socketName>vmdwym7fjx</socketName>
+          <socketName>u9accnurcx</socketName>
           <systemName>IQDE:AUTO:0058</systemName>
         </Socket>
         <Socket>
-          <socketName>ebjqco36hf</socketName>
+          <socketName>ve9yh1c8ad</socketName>
           <systemName>IQDE:AUTO:0059</systemName>
         </Socket>
         <Socket>
-          <socketName>gf5c7nl62p</socketName>
+          <socketName>attsywgeql</socketName>
           <systemName>IQDE:AUTO:0060</systemName>
         </Socket>
         <Socket>
-          <socketName>o1nux9fps2</socketName>
+          <socketName>ntrqq346l8</socketName>
           <systemName>IQDE:AUTO:0061</systemName>
         </Socket>
         <Socket>
-          <socketName>aermptvzak</socketName>
+          <socketName>xucakxn3wz</socketName>
           <systemName>IQDE:AUTO:0062</systemName>
         </Socket>
         <Socket>
-          <socketName>wrr7a12jra</socketName>
+          <socketName>sy46acj8ke</socketName>
           <systemName>IQDE:AUTO:0063</systemName>
         </Socket>
         <Socket>
-          <socketName>fzjqogjyjr</socketName>
+          <socketName>quqylymh8b</socketName>
           <systemName>IQDE:AUTO:0064</systemName>
         </Socket>
         <Socket>
-          <socketName>f9pmh22rvr</socketName>
+          <socketName>fzdq1244oi</socketName>
           <systemName>IQDE:AUTO:0065</systemName>
         </Socket>
         <Socket>
-          <socketName>auxgyp82q5</socketName>
+          <socketName>tbbn7vddqh</socketName>
           <systemName>IQDE:AUTO:0066</systemName>
         </Socket>
         <Socket>
-          <socketName>wpokbopkr9</socketName>
+          <socketName>qxsg2me8s2</socketName>
           <systemName>IQDE:AUTO:0067</systemName>
         </Socket>
         <Socket>
-          <socketName>rdjjruc9k9</socketName>
+          <socketName>hucvtz9uu1</socketName>
           <systemName>IQDE:AUTO:0068</systemName>
         </Socket>
         <Socket>
-          <socketName>wz633crecs</socketName>
+          <socketName>i9qy7tnicn</socketName>
           <systemName>IQDE:AUTO:0069</systemName>
         </Socket>
         <Socket>
-          <socketName>xmgid4d6wj</socketName>
+          <socketName>t4a3inccjt</socketName>
           <systemName>IQDE:AUTO:0070</systemName>
         </Socket>
         <Socket>
-          <socketName>bfofbfv3mp</socketName>
+          <socketName>rmf8u3x9af</socketName>
           <systemName>IQDE:AUTO:0071</systemName>
         </Socket>
         <Socket>
-          <socketName>x6gah7vyot</socketName>
+          <socketName>d51cthqx4m</socketName>
           <systemName>IQDE:AUTO:0072</systemName>
         </Socket>
         <Socket>
-          <socketName>qj1amndd6j</socketName>
+          <socketName>q4kfdajznb</socketName>
           <systemName>IQDE:AUTO:0073</systemName>
         </Socket>
         <Socket>
-          <socketName>gghvhnux8j</socketName>
+          <socketName>pioauj6jc3</socketName>
           <systemName>IQDE:AUTO:0074</systemName>
         </Socket>
         <Socket>
-          <socketName>rvs1sfpbu4</socketName>
+          <socketName>wyvm3bvgae</socketName>
           <systemName>IQDE:AUTO:0075</systemName>
         </Socket>
         <Socket>
-          <socketName>omsmvg71mp</socketName>
+          <socketName>u7kyvzwjv2</socketName>
           <systemName>IQDE:AUTO:0076</systemName>
         </Socket>
         <Socket>
-          <socketName>yhjspnfq7y</socketName>
+          <socketName>ssnqg1n5wd</socketName>
           <systemName>IQDE:AUTO:0077</systemName>
         </Socket>
         <Socket>
-          <socketName>xfznqxkvdr</socketName>
+          <socketName>mf3ksjwbqt</socketName>
           <systemName>IQDE:AUTO:0078</systemName>
         </Socket>
         <Socket>
-          <socketName>yka4ccru5o</socketName>
+          <socketName>wjtg3zh9t9</socketName>
           <systemName>IQDE:AUTO:0079</systemName>
         </Socket>
         <Socket>
-          <socketName>yzck6zchw6</socketName>
+          <socketName>q3hd6stoqt</socketName>
           <systemName>IQDE:AUTO:0080</systemName>
         </Socket>
         <Socket>
-          <socketName>sz31z12qjd</socketName>
+          <socketName>pan861zyq4</socketName>
           <systemName>IQDE:AUTO:0081</systemName>
         </Socket>
         <Socket>
-          <socketName>njzl4b9tcp</socketName>
+          <socketName>kmg5sys5zt</socketName>
           <systemName>IQDE:AUTO:0082</systemName>
         </Socket>
         <Socket>
-          <socketName>xz6vn5n4ga</socketName>
+          <socketName>lrj88tquba</socketName>
           <systemName>IQDE:AUTO:0083</systemName>
         </Socket>
         <Socket>
-          <socketName>x95wumxzw3</socketName>
+          <socketName>tueg2j7icw</socketName>
           <systemName>IQDE:AUTO:0084</systemName>
         </Socket>
         <Socket>
-          <socketName>z4h5vrodab</socketName>
+          <socketName>lut98dddzz</socketName>
           <systemName>IQDE:AUTO:0085</systemName>
         </Socket>
         <Socket>
-          <socketName>bw2e4q9k2u</socketName>
+          <socketName>bfgvqc8dmf</socketName>
           <systemName>IQDE:AUTO:0086</systemName>
         </Socket>
         <Socket>
-          <socketName>jhp86rt5f8</socketName>
+          <socketName>trlq75q4jv</socketName>
           <systemName>IQDE:AUTO:0087</systemName>
         </Socket>
         <Socket>
-          <socketName>gh6arzpgnm</socketName>
+          <socketName>vcuuvn8l8x</socketName>
           <systemName>IQDE:AUTO:0088</systemName>
         </Socket>
         <Socket>
-          <socketName>kf3fjovf2u</socketName>
+          <socketName>yibvpauc4i</socketName>
           <systemName>IQDE:AUTO:0089</systemName>
         </Socket>
         <Socket>
-          <socketName>occrbeas3s</socketName>
+          <socketName>ut4gbrpw2u</socketName>
           <systemName>IQDE:AUTO:0090</systemName>
         </Socket>
         <Socket>
-          <socketName>yshlnosyej</socketName>
+          <socketName>dgteu629lx</socketName>
           <systemName>IQDE:AUTO:0091</systemName>
         </Socket>
         <Socket>
-          <socketName>q67nmhjvpy</socketName>
+          <socketName>yzzvaanhji</socketName>
           <systemName>IQDE:AUTO:0092</systemName>
         </Socket>
         <Socket>
-          <socketName>qz662rx4ld</socketName>
+          <socketName>liooxoomiy</socketName>
           <systemName>IQDE:AUTO:0093</systemName>
         </Socket>
         <Socket>
-          <socketName>wwntcit3gv</socketName>
+          <socketName>sys5qy8tnk</socketName>
           <systemName>IQDE:AUTO:0094</systemName>
         </Socket>
         <Socket>
-          <socketName>fb74u33292</socketName>
+          <socketName>jfddztfqkm</socketName>
           <systemName>IQDE:AUTO:0095</systemName>
         </Socket>
         <Socket>
-          <socketName>u517snupup</socketName>
+          <socketName>don3qkw7wh</socketName>
           <systemName>IQDE:AUTO:0096</systemName>
         </Socket>
         <Socket>
-          <socketName>um7mftzsho</socketName>
+          <socketName>alvwggbkup</socketName>
           <systemName>IQDE:AUTO:0097</systemName>
         </Socket>
         <Socket>
-          <socketName>x7onglsviq</socketName>
+          <socketName>s9ydimm634</socketName>
           <systemName>IQDE:AUTO:0098</systemName>
         </Socket>
         <Socket>
-          <socketName>em6z44o69k</socketName>
+          <socketName>l7fh91vagy</socketName>
           <systemName>IQDE:AUTO:0099</systemName>
         </Socket>
         <Socket>
-          <socketName>capo3xqb3q</socketName>
+          <socketName>v3dqvrfl81</socketName>
           <systemName>IQDE:AUTO:0100</systemName>
         </Socket>
         <Socket>
-          <socketName>y99cio4245</socketName>
+          <socketName>mh5hoxzu9f</socketName>
           <systemName>IQDE:AUTO:0101</systemName>
         </Socket>
         <Socket>
-          <socketName>nhzlqya7ex</socketName>
+          <socketName>i287pof65a</socketName>
           <systemName>IQDE:AUTO:0102</systemName>
         </Socket>
         <Socket>
-          <socketName>k1ybt5s9x7</socketName>
+          <socketName>yvymxur2x7</socketName>
           <systemName>IQDE:AUTO:0103</systemName>
         </Socket>
         <Socket>
-          <socketName>d13uln64m5</socketName>
+          <socketName>tak595hfi6</socketName>
           <systemName>IQDE:AUTO:0104</systemName>
         </Socket>
         <Socket>
-          <socketName>tfhoq744uv</socketName>
+          <socketName>g3ugbgxavk</socketName>
           <systemName>IQDE:AUTO:0105</systemName>
         </Socket>
         <Socket>
-          <socketName>mtk8zudid1</socketName>
+          <socketName>xm9sy9fs1r</socketName>
           <systemName>IQDE:AUTO:0106</systemName>
         </Socket>
         <Socket>
-          <socketName>t4cl3cw6ey</socketName>
+          <socketName>v38c2tah9s</socketName>
           <systemName>IQDE:AUTO:0107</systemName>
         </Socket>
         <Socket>
-          <socketName>cswc4euy3g</socketName>
+          <socketName>gay6w1msey</socketName>
           <systemName>IQDE:AUTO:0108</systemName>
         </Socket>
         <Socket>
-          <socketName>tsksbry952</socketName>
+          <socketName>c8oqjno6rk</socketName>
           <systemName>IQDE:AUTO:0109</systemName>
         </Socket>
         <Socket>
-          <socketName>f166bqvaki</socketName>
+          <socketName>ugap5jmru2</socketName>
           <systemName>IQDE:AUTO:0110</systemName>
         </Socket>
         <Socket>
-          <socketName>cbsh66icu6</socketName>
+          <socketName>maumcj878o</socketName>
           <systemName>IQDE:AUTO:0111</systemName>
         </Socket>
         <Socket>
-          <socketName>bddvry1b5w</socketName>
+          <socketName>ypbdadjbr7</socketName>
           <systemName>IQDE:AUTO:0112</systemName>
         </Socket>
         <Socket>
-          <socketName>p11dr4kiv1</socketName>
+          <socketName>t531zgr9tj</socketName>
           <systemName>IQDE:AUTO:0113</systemName>
         </Socket>
         <Socket>
-          <socketName>hhdcq6d7z7</socketName>
+          <socketName>uatsmchemk</socketName>
           <systemName>IQDE:AUTO:0114</systemName>
         </Socket>
         <Socket>
-          <socketName>yk3ondm13g</socketName>
+          <socketName>f7begznyq4</socketName>
           <systemName>IQDE:AUTO:0115</systemName>
         </Socket>
         <Socket>
-          <socketName>ay14udmsbu</socketName>
+          <socketName>m1sdvthtw2</socketName>
           <systemName>IQDE:AUTO:0116</systemName>
         </Socket>
         <Socket>
-          <socketName>jdy319nb1d</socketName>
+          <socketName>t8lxnwuljl</socketName>
           <systemName>IQDE:AUTO:0117</systemName>
         </Socket>
         <Socket>
-          <socketName>ixwufwz7s2</socketName>
+          <socketName>b3bolhi9gd</socketName>
           <systemName>IQDE:AUTO:0118</systemName>
         </Socket>
         <Socket>
-          <socketName>q9s4sxe3q2</socketName>
+          <socketName>nua5ivcxqn</socketName>
           <systemName>IQDE:AUTO:0119</systemName>
         </Socket>
         <Socket>
-          <socketName>ycye5xx7zy</socketName>
+          <socketName>uq2leafg9h</socketName>
           <systemName>IQDE:AUTO:0120</systemName>
         </Socket>
         <Socket>
-          <socketName>sqt9zgs9cv</socketName>
+          <socketName>uwmmtijp8t</socketName>
           <systemName>IQDE:AUTO:0121</systemName>
         </Socket>
         <Socket>
-          <socketName>r1ln8cp2le</socketName>
+          <socketName>jsz8f9k2pp</socketName>
           <systemName>IQDE:AUTO:0122</systemName>
         </Socket>
         <Socket>
-          <socketName>fxkkuuqy5l</socketName>
+          <socketName>sle9afweuu</socketName>
           <systemName>IQDE:AUTO:0123</systemName>
         </Socket>
         <Socket>
-          <socketName>sac82ewmnf</socketName>
+          <socketName>uvccqodr8w</socketName>
           <systemName>IQDE:AUTO:0124</systemName>
         </Socket>
         <Socket>
-          <socketName>v2v2f7zxad</socketName>
+          <socketName>ywjzv12dod</socketName>
           <systemName>IQDE:AUTO:0125</systemName>
         </Socket>
         <Socket>
-          <socketName>dmi6qxmi3o</socketName>
+          <socketName>ylzsvkbadp</socketName>
           <systemName>IQDE:AUTO:0126</systemName>
         </Socket>
         <Socket>
-          <socketName>xyem912hgg</socketName>
+          <socketName>l4mz42rwxv</socketName>
           <systemName>IQDE:AUTO:0127</systemName>
         </Socket>
         <Socket>
-          <socketName>yqrlsbl62f</socketName>
+          <socketName>f3xp1r7vew</socketName>
           <systemName>IQDE:AUTO:0128</systemName>
         </Socket>
         <Socket>
-          <socketName>t1y3b3nxi8</socketName>
+          <socketName>n1ej5yjlkg</socketName>
           <systemName>IQDE:AUTO:0129</systemName>
         </Socket>
         <Socket>
-          <socketName>qk6ouiluuj</socketName>
+          <socketName>v98werwf3l</socketName>
           <systemName>IQDE:AUTO:0130</systemName>
         </Socket>
         <Socket>
-          <socketName>fgwmytmzm8</socketName>
+          <socketName>eogr2y25mm</socketName>
           <systemName>IQDE:AUTO:0131</systemName>
         </Socket>
         <Socket>
-          <socketName>tr7qt4cbgn</socketName>
+          <socketName>r5eu33k2w8</socketName>
           <systemName>IQDE:AUTO:0132</systemName>
         </Socket>
         <Socket>
-          <socketName>lurum632d8</socketName>
+          <socketName>j4m4ljdink</socketName>
           <systemName>IQDE:AUTO:0133</systemName>
         </Socket>
         <Socket>
-          <socketName>hzal3eimta</socketName>
+          <socketName>uehibmaeo1</socketName>
           <systemName>IQDE:AUTO:0134</systemName>
         </Socket>
         <Socket>
-          <socketName>rsehaxdunw</socketName>
+          <socketName>hcj4hvo31x</socketName>
           <systemName>IQDE:AUTO:0135</systemName>
         </Socket>
         <Socket>
-          <socketName>s6e7oxau3k</socketName>
+          <socketName>vpgy1yhwpv</socketName>
           <systemName>IQDE:AUTO:0136</systemName>
         </Socket>
         <Socket>
-          <socketName>f33t9g6xdc</socketName>
+          <socketName>ckbfvt9b4m</socketName>
           <systemName>IQDE:AUTO:0137</systemName>
         </Socket>
         <Socket>
-          <socketName>q8anc9zoif</socketName>
+          <socketName>svq6p57e3w</socketName>
           <systemName>IQDE:AUTO:0138</systemName>
         </Socket>
         <Socket>
-          <socketName>ik9ew1dvih</socketName>
+          <socketName>qx6r2n6ih7</socketName>
           <systemName>IQDE:AUTO:0139</systemName>
         </Socket>
         <Socket>
-          <socketName>wbz5ld2iaa</socketName>
+          <socketName>g49wcf8eg2</socketName>
           <systemName>IQDE:AUTO:0140</systemName>
         </Socket>
         <Socket>
-          <socketName>vid9mrcrty</socketName>
+          <socketName>lgdgjqj4ok</socketName>
           <systemName>IQDE:AUTO:0141</systemName>
         </Socket>
         <Socket>
-          <socketName>sq6rqwdewl</socketName>
+          <socketName>hmdkcevbox</socketName>
           <systemName>IQDE:AUTO:0142</systemName>
         </Socket>
         <Socket>
-          <socketName>yabuijpjz2</socketName>
+          <socketName>lb6rju95p4</socketName>
           <systemName>IQDE:AUTO:0143</systemName>
         </Socket>
         <Socket>
-          <socketName>oywwa12aug</socketName>
+          <socketName>yae51gnd8i</socketName>
           <systemName>IQDE:AUTO:0144</systemName>
         </Socket>
         <Socket>
-          <socketName>qgnpj7cfp1</socketName>
+          <socketName>nemk3igaex</socketName>
           <systemName>IQDE:AUTO:0145</systemName>
         </Socket>
         <Socket>
-          <socketName>t16xgfstiz</socketName>
+          <socketName>hxm1h21ohd</socketName>
           <systemName>IQDE:AUTO:0146</systemName>
         </Socket>
         <Socket>
-          <socketName>poaygu4sgw</socketName>
+          <socketName>sh1w4z8zxh</socketName>
           <systemName>IQDE:AUTO:0147</systemName>
         </Socket>
         <Socket>
-          <socketName>bhnvngm6iy</socketName>
+          <socketName>dm9zzrbwe2</socketName>
           <systemName>IQDE:AUTO:0148</systemName>
         </Socket>
         <Socket>
-          <socketName>kxhys41ns7</socketName>
+          <socketName>jmcdwjwbre</socketName>
           <systemName>IQDE:AUTO:0149</systemName>
         </Socket>
         <Socket>
-          <socketName>kir8n1p6p1</socketName>
+          <socketName>bea2cq7md7</socketName>
           <systemName>IQDE:AUTO:0150</systemName>
         </Socket>
         <Socket>
-          <socketName>r7ehfz32vs</socketName>
+          <socketName>l8i7ljg9f1</socketName>
           <systemName>IQDE:AUTO:0151</systemName>
         </Socket>
         <Socket>
-          <socketName>mjevpbkju8</socketName>
+          <socketName>pvtuotfvel</socketName>
           <systemName>IQDE:AUTO:0152</systemName>
         </Socket>
         <Socket>
-          <socketName>jiy3shnc7m</socketName>
+          <socketName>wdttrqy5c2</socketName>
           <systemName>IQDE:AUTO:0153</systemName>
         </Socket>
         <Socket>
-          <socketName>fd1y84wgcq</socketName>
+          <socketName>wxdflkerqp</socketName>
           <systemName>IQDE:AUTO:0154</systemName>
         </Socket>
         <Socket>
-          <socketName>yxalhke53u</socketName>
+          <socketName>aqigmdtofw</socketName>
           <systemName>IQDE:AUTO:0155</systemName>
         </Socket>
         <Socket>
-          <socketName>rlp4t6pk2r</socketName>
+          <socketName>qblsrs8i3b</socketName>
           <systemName>IQDE:AUTO:0156</systemName>
         </Socket>
         <Socket>
-          <socketName>z9fnmwvbne</socketName>
+          <socketName>uw2i5uh7gf</socketName>
           <systemName>IQDE:AUTO:0157</systemName>
         </Socket>
         <Socket>
-          <socketName>frupxwwgy9</socketName>
+          <socketName>swapgiccl2</socketName>
           <systemName>IQDE:AUTO:0158</systemName>
         </Socket>
         <Socket>
-          <socketName>z5jlt3mwel</socketName>
+          <socketName>t3m415np1g</socketName>
           <systemName>IQDE:AUTO:0159</systemName>
         </Socket>
         <Socket>
-          <socketName>w4qveddor1</socketName>
+          <socketName>kxc17cppf1</socketName>
           <systemName>IQDE:AUTO:0160</systemName>
         </Socket>
         <Socket>
-          <socketName>lj2bmpwkbp</socketName>
+          <socketName>u2pqjbox29</socketName>
+          <systemName>IQDE:AUTO:0161</systemName>
+        </Socket>
+        <Socket>
+          <socketName>rhfw2hirjt</socketName>
         </Socket>
       </Expressions>
       <MaleSocket>
@@ -2031,7 +2035,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <antecedent />
       <Expressions>
         <Socket>
-          <socketName>gk5nlr4efd</socketName>
+          <socketName>callmx7cd1</socketName>
         </Socket>
       </Expressions>
       <MaleSocket>
@@ -2111,7 +2115,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <antecedent />
       <Expressions>
         <Socket>
-          <socketName>y3caxy7339</socketName>
+          <socketName>xjco1rsiks</socketName>
         </Socket>
       </Expressions>
       <MaleSocket>
@@ -2192,7 +2196,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <antecedent>R1 or R2</antecedent>
       <Expressions>
         <Socket>
-          <socketName>u33l1h23ns</socketName>
+          <socketName>hmmo87rscc</socketName>
         </Socket>
       </Expressions>
       <MaleSocket>
@@ -2272,7 +2276,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <antecedent />
       <Expressions>
         <Socket>
-          <socketName>qxysbudju7</socketName>
+          <socketName>d3sj3m7d46</socketName>
         </Socket>
       </Expressions>
       <MaleSocket>
@@ -2352,7 +2356,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <antecedent />
       <Expressions>
         <Socket>
-          <socketName>unnlck8p7x</socketName>
+          <socketName>s2lpm93de5</socketName>
         </Socket>
       </Expressions>
       <MaleSocket>
@@ -2432,7 +2436,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <antecedent />
       <Expressions>
         <Socket>
-          <socketName>rir9arcvmd</socketName>
+          <socketName>uq5k3su5ou</socketName>
         </Socket>
       </Expressions>
       <MaleSocket>
@@ -5638,7 +5642,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </namedBean>
       <is_isNot>Is</is_isNot>
       <stateAddressing>Formula</stateAddressing>
-      <entryExitState>Inactive</entryExitState>
+      <entryExitState>Active</entryExitState>
       <stateReference>{IM2}</stateReference>
       <stateLocalVariable>index2</stateLocalVariable>
       <stateFormula>"IT"+index2</stateFormula>
@@ -5726,7 +5730,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </namedBean>
       <is_isNot>IsNot</is_isNot>
       <stateAddressing>Reference</stateAddressing>
-      <entryExitState>Inactive</entryExitState>
+      <entryExitState>Other</entryExitState>
       <stateReference>{IM2}</stateReference>
       <stateLocalVariable>index2</stateLocalVariable>
       <stateFormula>"IT"+index2</stateFormula>
@@ -5814,7 +5818,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </namedBean>
       <is_isNot>Is</is_isNot>
       <stateAddressing>Direct</stateAddressing>
-      <entryExitState>Inactive</entryExitState>
+      <entryExitState>Reversed</entryExitState>
       <stateReference>{IM2}</stateReference>
       <stateLocalVariable>index2</stateLocalVariable>
       <stateFormula>"IT"+index2</stateFormula>
@@ -5890,8 +5894,93 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
         </AbstractMaleSocket>
       </MaleSocket>
     </ExpressionEntryExit>
-    <ExpressionLight class="jmri.jmrit.logixng.expressions.configurexml.ExpressionLightXml">
+    <ExpressionEntryExit class="jmri.jmrit.logixng.expressions.configurexml.ExpressionEntryExitXml">
       <systemName>IQDE:AUTO:0059</systemName>
+      <comment>A comment</comment>
+      <namedBean>
+        <addressing>Direct</addressing>
+        <listenToMemory>no</listenToMemory>
+      </namedBean>
+      <is_isNot>Is</is_isNot>
+      <stateAddressing>Direct</stateAddressing>
+      <entryExitState>BiDirection</entryExitState>
+      <stateReference />
+      <stateLocalVariable />
+      <stateFormula />
+      <MaleSocket>
+        <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
+        <AbstractMaleSocket enabled="yes" locked="no" system="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
+          <errorHandling>Default</errorHandling>
+          <LocalVariable>
+            <name>A1</name>
+            <type>None</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A2</name>
+            <type>Integer</type>
+            <data>32</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A3</name>
+            <type>FloatingNumber</type>
+            <data>41.429</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A4</name>
+            <type>String</type>
+            <data>My string</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A5</name>
+            <type>Array</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A6</name>
+            <type>Map</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A7</name>
+            <type>LocalVariable</type>
+            <data>index</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A8</name>
+            <type>Memory</type>
+            <data>IM2</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A9</name>
+            <type>Reference</type>
+            <data>{IM3}</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A10</name>
+            <type>Formula</type>
+            <data>index * 2</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A11</name>
+            <type>ScriptExpression</type>
+            <data>sensors.provide("mySensor)"</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A12</name>
+            <type>ScriptFile</type>
+            <data>scripts:InitLogixNGVariable</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A13</name>
+            <type>LogixNG_Table</type>
+            <data>MyTable</data>
+          </LocalVariable>
+        </AbstractMaleSocket>
+      </MaleSocket>
+    </ExpressionEntryExit>
+    <ExpressionLight class="jmri.jmrit.logixng.expressions.configurexml.ExpressionLightXml">
+      <systemName>IQDE:AUTO:0060</systemName>
       <namedBean>
         <addressing>Direct</addressing>
         <listenToMemory>no</listenToMemory>
@@ -5975,7 +6064,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExpressionLight>
     <ExpressionLight class="jmri.jmrit.logixng.expressions.configurexml.ExpressionLightXml">
-      <systemName>IQDE:AUTO:0060</systemName>
+      <systemName>IQDE:AUTO:0061</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>Direct</addressing>
@@ -6064,7 +6153,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExpressionLight>
     <ExpressionLight class="jmri.jmrit.logixng.expressions.configurexml.ExpressionLightXml">
-      <systemName>IQDE:AUTO:0061</systemName>
+      <systemName>IQDE:AUTO:0062</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>LocalVariable</addressing>
@@ -6153,7 +6242,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExpressionLight>
     <ExpressionLight class="jmri.jmrit.logixng.expressions.configurexml.ExpressionLightXml">
-      <systemName>IQDE:AUTO:0062</systemName>
+      <systemName>IQDE:AUTO:0063</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>Formula</addressing>
@@ -6242,7 +6331,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExpressionLight>
     <ExpressionLight class="jmri.jmrit.logixng.expressions.configurexml.ExpressionLightXml">
-      <systemName>IQDE:AUTO:0063</systemName>
+      <systemName>IQDE:AUTO:0064</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>Reference</addressing>
@@ -6331,7 +6420,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExpressionLight>
     <ExpressionLocalVariable class="jmri.jmrit.logixng.expressions.configurexml.ExpressionLocalVariableXml">
-      <systemName>IQDE:AUTO:0064</systemName>
+      <systemName>IQDE:AUTO:0065</systemName>
       <otherVariable />
       <memoryNamedBean>
         <addressing>Direct</addressing>
@@ -6427,7 +6516,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExpressionLocalVariable>
     <ExpressionLocalVariable class="jmri.jmrit.logixng.expressions.configurexml.ExpressionLocalVariableXml">
-      <systemName>IQDE:AUTO:0065</systemName>
+      <systemName>IQDE:AUTO:0066</systemName>
       <comment>A comment</comment>
       <otherVariable />
       <memoryNamedBean>
@@ -6524,7 +6613,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExpressionLocalVariable>
     <ExpressionLocalVariable class="jmri.jmrit.logixng.expressions.configurexml.ExpressionLocalVariableXml">
-      <systemName>IQDE:AUTO:0066</systemName>
+      <systemName>IQDE:AUTO:0067</systemName>
       <comment>A comment</comment>
       <variable>MyVar</variable>
       <otherVariable />
@@ -6635,7 +6724,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExpressionLocalVariable>
     <ExpressionLocalVariable class="jmri.jmrit.logixng.expressions.configurexml.ExpressionLocalVariableXml">
-      <systemName>IQDE:AUTO:0067</systemName>
+      <systemName>IQDE:AUTO:0068</systemName>
       <comment>A comment</comment>
       <variable>MyVar</variable>
       <otherVariable>MyOtherVar</otherVariable>
@@ -6746,7 +6835,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExpressionLocalVariable>
     <ExpressionLocalVariable class="jmri.jmrit.logixng.expressions.configurexml.ExpressionLocalVariableXml">
-      <systemName>IQDE:AUTO:0068</systemName>
+      <systemName>IQDE:AUTO:0069</systemName>
       <comment>A comment</comment>
       <variable>MyVar</variable>
       <otherVariable>MyOtherVar</otherVariable>
@@ -6778,117 +6867,6 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
         </row>
         <column>
           <addressing>Memory</addressing>
-          <name>The column</name>
-          <reference>{columnRef}</reference>
-          <localVariable>columnVariable</localVariable>
-          <formula>"Column "+str(index)</formula>
-        </column>
-      </table>
-      <MaleSocket>
-        <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="yes" locked="no" system="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
-          <errorHandling>Default</errorHandling>
-          <LocalVariable>
-            <name>A1</name>
-            <type>None</type>
-            <data />
-          </LocalVariable>
-          <LocalVariable>
-            <name>A2</name>
-            <type>Integer</type>
-            <data>32</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A3</name>
-            <type>FloatingNumber</type>
-            <data>41.429</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A4</name>
-            <type>String</type>
-            <data>My string</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A5</name>
-            <type>Array</type>
-            <data />
-          </LocalVariable>
-          <LocalVariable>
-            <name>A6</name>
-            <type>Map</type>
-            <data />
-          </LocalVariable>
-          <LocalVariable>
-            <name>A7</name>
-            <type>LocalVariable</type>
-            <data>index</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A8</name>
-            <type>Memory</type>
-            <data>IM2</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A9</name>
-            <type>Reference</type>
-            <data>{IM3}</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A10</name>
-            <type>Formula</type>
-            <data>index * 2</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A11</name>
-            <type>ScriptExpression</type>
-            <data>sensors.provide("mySensor)"</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A12</name>
-            <type>ScriptFile</type>
-            <data>scripts:InitLogixNGVariable</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A13</name>
-            <type>LogixNG_Table</type>
-            <data>MyTable</data>
-          </LocalVariable>
-        </AbstractMaleSocket>
-      </MaleSocket>
-    </ExpressionLocalVariable>
-    <ExpressionLocalVariable class="jmri.jmrit.logixng.expressions.configurexml.ExpressionLocalVariableXml">
-      <systemName>IQDE:AUTO:0069</systemName>
-      <comment>A comment</comment>
-      <variable>MyVar</variable>
-      <otherVariable>MyOtherVar</otherVariable>
-      <memoryNamedBean>
-        <addressing>Direct</addressing>
-        <name>Some memory</name>
-        <listenToMemory>no</listenToMemory>
-      </memoryNamedBean>
-      <compareTo>Table</compareTo>
-      <variableOperation>LessThan</variableOperation>
-      <compareType>NumberOrString</compareType>
-      <caseInsensitive>no</caseInsensitive>
-      <constant />
-      <regEx />
-      <table>
-        <tableName>
-          <addressing>Formula</addressing>
-          <name>IQT1</name>
-          <reference>{tableRef}</reference>
-          <localVariable>tableVariable</localVariable>
-          <formula>"IT"+str(index)</formula>
-        </tableName>
-        <row>
-          <addressing>Direct</addressing>
-          <name>The row</name>
-          <reference>{rowRef}</reference>
-          <localVariable>rowVariable</localVariable>
-          <formula>"Row "+str(index)</formula>
-        </row>
-        <column>
-          <addressing>Reference</addressing>
           <name>The column</name>
           <reference>{columnRef}</reference>
           <localVariable>columnVariable</localVariable>
@@ -6985,6 +6963,117 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <regEx />
       <table>
         <tableName>
+          <addressing>Formula</addressing>
+          <name>IQT1</name>
+          <reference>{tableRef}</reference>
+          <localVariable>tableVariable</localVariable>
+          <formula>"IT"+str(index)</formula>
+        </tableName>
+        <row>
+          <addressing>Direct</addressing>
+          <name>The row</name>
+          <reference>{rowRef}</reference>
+          <localVariable>rowVariable</localVariable>
+          <formula>"Row "+str(index)</formula>
+        </row>
+        <column>
+          <addressing>Reference</addressing>
+          <name>The column</name>
+          <reference>{columnRef}</reference>
+          <localVariable>columnVariable</localVariable>
+          <formula>"Column "+str(index)</formula>
+        </column>
+      </table>
+      <MaleSocket>
+        <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
+        <AbstractMaleSocket enabled="yes" locked="no" system="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
+          <errorHandling>Default</errorHandling>
+          <LocalVariable>
+            <name>A1</name>
+            <type>None</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A2</name>
+            <type>Integer</type>
+            <data>32</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A3</name>
+            <type>FloatingNumber</type>
+            <data>41.429</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A4</name>
+            <type>String</type>
+            <data>My string</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A5</name>
+            <type>Array</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A6</name>
+            <type>Map</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A7</name>
+            <type>LocalVariable</type>
+            <data>index</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A8</name>
+            <type>Memory</type>
+            <data>IM2</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A9</name>
+            <type>Reference</type>
+            <data>{IM3}</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A10</name>
+            <type>Formula</type>
+            <data>index * 2</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A11</name>
+            <type>ScriptExpression</type>
+            <data>sensors.provide("mySensor)"</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A12</name>
+            <type>ScriptFile</type>
+            <data>scripts:InitLogixNGVariable</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A13</name>
+            <type>LogixNG_Table</type>
+            <data>MyTable</data>
+          </LocalVariable>
+        </AbstractMaleSocket>
+      </MaleSocket>
+    </ExpressionLocalVariable>
+    <ExpressionLocalVariable class="jmri.jmrit.logixng.expressions.configurexml.ExpressionLocalVariableXml">
+      <systemName>IQDE:AUTO:0071</systemName>
+      <comment>A comment</comment>
+      <variable>MyVar</variable>
+      <otherVariable>MyOtherVar</otherVariable>
+      <memoryNamedBean>
+        <addressing>Direct</addressing>
+        <name>Some memory</name>
+        <listenToMemory>no</listenToMemory>
+      </memoryNamedBean>
+      <compareTo>Table</compareTo>
+      <variableOperation>LessThan</variableOperation>
+      <compareType>NumberOrString</compareType>
+      <caseInsensitive>no</caseInsensitive>
+      <constant />
+      <regEx />
+      <table>
+        <tableName>
           <addressing>LocalVariable</addressing>
           <name>IQT1</name>
           <reference>{tableRef}</reference>
@@ -7079,7 +7168,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExpressionLocalVariable>
     <ExpressionLocalVariable class="jmri.jmrit.logixng.expressions.configurexml.ExpressionLocalVariableXml">
-      <systemName>IQDE:AUTO:0071</systemName>
+      <systemName>IQDE:AUTO:0072</systemName>
       <comment>A comment</comment>
       <variable>MyVar</variable>
       <otherVariable>MyOtherVar</otherVariable>
@@ -7190,7 +7279,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExpressionLocalVariable>
     <ExpressionLocalVariable class="jmri.jmrit.logixng.expressions.configurexml.ExpressionLocalVariableXml">
-      <systemName>IQDE:AUTO:0072</systemName>
+      <systemName>IQDE:AUTO:0073</systemName>
       <comment>A comment</comment>
       <variable>MyVar</variable>
       <otherVariable />
@@ -7301,7 +7390,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExpressionLocalVariable>
     <ExpressionMemory class="jmri.jmrit.logixng.expressions.configurexml.ExpressionMemoryXml">
-      <systemName>IQDE:AUTO:0073</systemName>
+      <systemName>IQDE:AUTO:0074</systemName>
       <namedBean>
         <addressing>Direct</addressing>
         <listenToMemory>no</listenToMemory>
@@ -7401,7 +7490,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExpressionMemory>
     <ExpressionMemory class="jmri.jmrit.logixng.expressions.configurexml.ExpressionMemoryXml">
-      <systemName>IQDE:AUTO:0074</systemName>
+      <systemName>IQDE:AUTO:0075</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>Direct</addressing>
@@ -7503,7 +7592,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExpressionMemory>
     <ExpressionMemory class="jmri.jmrit.logixng.expressions.configurexml.ExpressionMemoryXml">
-      <systemName>IQDE:AUTO:0075</systemName>
+      <systemName>IQDE:AUTO:0076</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>Direct</addressing>
@@ -7618,7 +7707,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExpressionMemory>
     <ExpressionMemory class="jmri.jmrit.logixng.expressions.configurexml.ExpressionMemoryXml">
-      <systemName>IQDE:AUTO:0076</systemName>
+      <systemName>IQDE:AUTO:0077</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>Direct</addressing>
@@ -7733,7 +7822,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExpressionMemory>
     <ExpressionMemory class="jmri.jmrit.logixng.expressions.configurexml.ExpressionMemoryXml">
-      <systemName>IQDE:AUTO:0077</systemName>
+      <systemName>IQDE:AUTO:0078</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>Direct</addressing>
@@ -7848,7 +7937,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExpressionMemory>
     <ExpressionMemory class="jmri.jmrit.logixng.expressions.configurexml.ExpressionMemoryXml">
-      <systemName>IQDE:AUTO:0078</systemName>
+      <systemName>IQDE:AUTO:0079</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>Direct</addressing>
@@ -7963,7 +8052,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExpressionMemory>
     <ExpressionOBlock class="jmri.jmrit.logixng.expressions.configurexml.ExpressionOBlockXml">
-      <systemName>IQDE:AUTO:0079</systemName>
+      <systemName>IQDE:AUTO:0080</systemName>
       <namedBean>
         <addressing>Direct</addressing>
         <listenToMemory>no</listenToMemory>
@@ -8047,7 +8136,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExpressionOBlock>
     <ExpressionOBlock class="jmri.jmrit.logixng.expressions.configurexml.ExpressionOBlockXml">
-      <systemName>IQDE:AUTO:0080</systemName>
+      <systemName>IQDE:AUTO:0081</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>Direct</addressing>
@@ -8136,7 +8225,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExpressionOBlock>
     <ExpressionOBlock class="jmri.jmrit.logixng.expressions.configurexml.ExpressionOBlockXml">
-      <systemName>IQDE:AUTO:0081</systemName>
+      <systemName>IQDE:AUTO:0082</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>LocalVariable</addressing>
@@ -8225,7 +8314,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExpressionOBlock>
     <ExpressionOBlock class="jmri.jmrit.logixng.expressions.configurexml.ExpressionOBlockXml">
-      <systemName>IQDE:AUTO:0082</systemName>
+      <systemName>IQDE:AUTO:0083</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>Formula</addressing>
@@ -8314,7 +8403,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExpressionOBlock>
     <ExpressionOBlock class="jmri.jmrit.logixng.expressions.configurexml.ExpressionOBlockXml">
-      <systemName>IQDE:AUTO:0083</systemName>
+      <systemName>IQDE:AUTO:0084</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>Reference</addressing>
@@ -8403,7 +8492,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExpressionOBlock>
     <ExpressionPower class="jmri.jmrit.logixng.expressions.configurexml.ExpressionPowerXml">
-      <systemName>IQDE:AUTO:0084</systemName>
+      <systemName>IQDE:AUTO:0085</systemName>
       <is_isNot>Is</is_isNot>
       <powerState>On</powerState>
       <ignoreUnknownState>yes</ignoreUnknownState>
@@ -8480,7 +8569,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExpressionPower>
     <ExpressionPower class="jmri.jmrit.logixng.expressions.configurexml.ExpressionPowerXml">
-      <systemName>IQDE:AUTO:0085</systemName>
+      <systemName>IQDE:AUTO:0086</systemName>
       <comment>A comment</comment>
       <is_isNot>IsNot</is_isNot>
       <powerState>Off</powerState>
@@ -8558,7 +8647,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExpressionPower>
     <ExpressionPower class="jmri.jmrit.logixng.expressions.configurexml.ExpressionPowerXml">
-      <systemName>IQDE:AUTO:0086</systemName>
+      <systemName>IQDE:AUTO:0087</systemName>
       <comment>A comment</comment>
       <is_isNot>IsNot</is_isNot>
       <powerState>On</powerState>
@@ -8636,7 +8725,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExpressionPower>
     <ExpressionPower class="jmri.jmrit.logixng.expressions.configurexml.ExpressionPowerXml">
-      <systemName>IQDE:AUTO:0087</systemName>
+      <systemName>IQDE:AUTO:0088</systemName>
       <comment>A comment</comment>
       <is_isNot>IsNot</is_isNot>
       <powerState>Idle</powerState>
@@ -8714,7 +8803,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExpressionPower>
     <ExpressionPower class="jmri.jmrit.logixng.expressions.configurexml.ExpressionPowerXml">
-      <systemName>IQDE:AUTO:0088</systemName>
+      <systemName>IQDE:AUTO:0089</systemName>
       <comment>A comment</comment>
       <is_isNot>Is</is_isNot>
       <powerState>Unknown</powerState>
@@ -8792,7 +8881,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExpressionPower>
     <ExpressionPower class="jmri.jmrit.logixng.expressions.configurexml.ExpressionPowerXml">
-      <systemName>IQDE:AUTO:0089</systemName>
+      <systemName>IQDE:AUTO:0090</systemName>
       <comment>A comment</comment>
       <is_isNot>IsNot</is_isNot>
       <powerState>OnOrOff</powerState>
@@ -8870,7 +8959,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExpressionPower>
     <ExpressionReference class="jmri.jmrit.logixng.expressions.configurexml.ExpressionReferenceXml">
-      <systemName>IQDE:AUTO:0090</systemName>
+      <systemName>IQDE:AUTO:0091</systemName>
       <reference />
       <is_isNot>Is</is_isNot>
       <pointsTo>LogixNGTable</pointsTo>
@@ -8947,7 +9036,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExpressionReference>
     <ExpressionReference class="jmri.jmrit.logixng.expressions.configurexml.ExpressionReferenceXml">
-      <systemName>IQDE:AUTO:0091</systemName>
+      <systemName>IQDE:AUTO:0092</systemName>
       <comment>A comment</comment>
       <reference>IL1</reference>
       <is_isNot>IsNot</is_isNot>
@@ -9025,7 +9114,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExpressionReference>
     <ExpressionReporter class="jmri.jmrit.logixng.expressions.configurexml.ExpressionReporterXml">
-      <systemName>IQDE:AUTO:0092</systemName>
+      <systemName>IQDE:AUTO:0093</systemName>
       <namedBean>
         <addressing>Direct</addressing>
         <listenToMemory>no</listenToMemory>
@@ -9114,7 +9203,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExpressionReporter>
     <ExpressionScript class="jmri.jmrit.logixng.expressions.configurexml.ExpressionScriptXml">
-      <systemName>IQDE:AUTO:0093</systemName>
+      <systemName>IQDE:AUTO:0094</systemName>
       <operationAddressing>Direct</operationAddressing>
       <operationType>SingleLineCommand</operationType>
       <operationReference />
@@ -9203,7 +9292,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExpressionScript>
     <ExpressionScript class="jmri.jmrit.logixng.expressions.configurexml.ExpressionScriptXml">
-      <systemName>IQDE:AUTO:0094</systemName>
+      <systemName>IQDE:AUTO:0095</systemName>
       <comment>A comment</comment>
       <operationAddressing>Direct</operationAddressing>
       <operationType>RunScript</operationType>
@@ -9293,7 +9382,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExpressionScript>
     <ExpressionScript class="jmri.jmrit.logixng.expressions.configurexml.ExpressionScriptXml">
-      <systemName>IQDE:AUTO:0095</systemName>
+      <systemName>IQDE:AUTO:0096</systemName>
       <comment>A comment</comment>
       <operationAddressing>Direct</operationAddressing>
       <operationType>SingleLineCommand</operationType>
@@ -9383,7 +9472,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExpressionScript>
     <ExpressionSection class="jmri.jmrit.logixng.expressions.configurexml.ExpressionSectionXml">
-      <systemName>IQDE:AUTO:0096</systemName>
+      <systemName>IQDE:AUTO:0097</systemName>
       <namedBean>
         <addressing>Direct</addressing>
         <listenToMemory>no</listenToMemory>
@@ -9467,7 +9556,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExpressionSection>
     <ExpressionSection class="jmri.jmrit.logixng.expressions.configurexml.ExpressionSectionXml">
-      <systemName>IQDE:AUTO:0097</systemName>
+      <systemName>IQDE:AUTO:0098</systemName>
       <comment>Direct / Direct :: Free</comment>
       <namedBean>
         <addressing>Direct</addressing>
@@ -9553,7 +9642,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExpressionSection>
     <ExpressionSection class="jmri.jmrit.logixng.expressions.configurexml.ExpressionSectionXml">
-      <systemName>IQDE:AUTO:0098</systemName>
+      <systemName>IQDE:AUTO:0099</systemName>
       <comment>Reference / Direct :: Forwar</comment>
       <namedBean>
         <addressing>Reference</addressing>
@@ -9639,7 +9728,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExpressionSection>
     <ExpressionSensor class="jmri.jmrit.logixng.expressions.configurexml.ExpressionSensorXml">
-      <systemName>IQDE:AUTO:0099</systemName>
+      <systemName>IQDE:AUTO:0100</systemName>
       <namedBean>
         <addressing>Direct</addressing>
         <listenToMemory>no</listenToMemory>
@@ -9723,7 +9812,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExpressionSensor>
     <ExpressionSensor class="jmri.jmrit.logixng.expressions.configurexml.ExpressionSensorXml">
-      <systemName>IQDE:AUTO:0100</systemName>
+      <systemName>IQDE:AUTO:0101</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>Direct</addressing>
@@ -9736,98 +9825,6 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <is_isNot>IsNot</is_isNot>
       <state>
         <addressing>LocalVariable</addressing>
-        <enum>Inactive</enum>
-        <reference>{IM2}</reference>
-        <listenToMemory>no</listenToMemory>
-        <localVariable>index2</localVariable>
-        <formula>"IT"+index2</formula>
-      </state>
-      <MaleSocket>
-        <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="yes" locked="no" system="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
-          <errorHandling>Default</errorHandling>
-          <LocalVariable>
-            <name>A1</name>
-            <type>None</type>
-            <data />
-          </LocalVariable>
-          <LocalVariable>
-            <name>A2</name>
-            <type>Integer</type>
-            <data>32</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A3</name>
-            <type>FloatingNumber</type>
-            <data>41.429</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A4</name>
-            <type>String</type>
-            <data>My string</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A5</name>
-            <type>Array</type>
-            <data />
-          </LocalVariable>
-          <LocalVariable>
-            <name>A6</name>
-            <type>Map</type>
-            <data />
-          </LocalVariable>
-          <LocalVariable>
-            <name>A7</name>
-            <type>LocalVariable</type>
-            <data>index</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A8</name>
-            <type>Memory</type>
-            <data>IM2</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A9</name>
-            <type>Reference</type>
-            <data>{IM3}</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A10</name>
-            <type>Formula</type>
-            <data>index * 2</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A11</name>
-            <type>ScriptExpression</type>
-            <data>sensors.provide("mySensor)"</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A12</name>
-            <type>ScriptFile</type>
-            <data>scripts:InitLogixNGVariable</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A13</name>
-            <type>LogixNG_Table</type>
-            <data>MyTable</data>
-          </LocalVariable>
-        </AbstractMaleSocket>
-      </MaleSocket>
-    </ExpressionSensor>
-    <ExpressionSensor class="jmri.jmrit.logixng.expressions.configurexml.ExpressionSensorXml">
-      <systemName>IQDE:AUTO:0101</systemName>
-      <comment>A comment</comment>
-      <namedBean>
-        <addressing>LocalVariable</addressing>
-        <name>IS1</name>
-        <reference>{IM1}</reference>
-        <listenToMemory>no</listenToMemory>
-        <localVariable>index</localVariable>
-        <formula>"IT"+index</formula>
-      </namedBean>
-      <is_isNot>Is</is_isNot>
-      <state>
-        <addressing>Formula</addressing>
         <enum>Inactive</enum>
         <reference>{IM2}</reference>
         <listenToMemory>no</listenToMemory>
@@ -9910,6 +9907,98 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <systemName>IQDE:AUTO:0102</systemName>
       <comment>A comment</comment>
       <namedBean>
+        <addressing>LocalVariable</addressing>
+        <name>IS1</name>
+        <reference>{IM1}</reference>
+        <listenToMemory>no</listenToMemory>
+        <localVariable>index</localVariable>
+        <formula>"IT"+index</formula>
+      </namedBean>
+      <is_isNot>Is</is_isNot>
+      <state>
+        <addressing>Formula</addressing>
+        <enum>Inactive</enum>
+        <reference>{IM2}</reference>
+        <listenToMemory>no</listenToMemory>
+        <localVariable>index2</localVariable>
+        <formula>"IT"+index2</formula>
+      </state>
+      <MaleSocket>
+        <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
+        <AbstractMaleSocket enabled="yes" locked="no" system="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
+          <errorHandling>Default</errorHandling>
+          <LocalVariable>
+            <name>A1</name>
+            <type>None</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A2</name>
+            <type>Integer</type>
+            <data>32</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A3</name>
+            <type>FloatingNumber</type>
+            <data>41.429</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A4</name>
+            <type>String</type>
+            <data>My string</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A5</name>
+            <type>Array</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A6</name>
+            <type>Map</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A7</name>
+            <type>LocalVariable</type>
+            <data>index</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A8</name>
+            <type>Memory</type>
+            <data>IM2</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A9</name>
+            <type>Reference</type>
+            <data>{IM3}</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A10</name>
+            <type>Formula</type>
+            <data>index * 2</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A11</name>
+            <type>ScriptExpression</type>
+            <data>sensors.provide("mySensor)"</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A12</name>
+            <type>ScriptFile</type>
+            <data>scripts:InitLogixNGVariable</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A13</name>
+            <type>LogixNG_Table</type>
+            <data>MyTable</data>
+          </LocalVariable>
+        </AbstractMaleSocket>
+      </MaleSocket>
+    </ExpressionSensor>
+    <ExpressionSensor class="jmri.jmrit.logixng.expressions.configurexml.ExpressionSensorXml">
+      <systemName>IQDE:AUTO:0103</systemName>
+      <comment>A comment</comment>
+      <namedBean>
         <addressing>Formula</addressing>
         <name>IS1</name>
         <reference>{IM1}</reference>
@@ -9999,7 +10088,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExpressionSensor>
     <ExpressionSensor class="jmri.jmrit.logixng.expressions.configurexml.ExpressionSensorXml">
-      <systemName>IQDE:AUTO:0103</systemName>
+      <systemName>IQDE:AUTO:0104</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>Reference</addressing>
@@ -10091,7 +10180,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExpressionSensor>
     <ExpressionSensorEdge class="jmri.jmrit.logixng.expressions.configurexml.ExpressionSensorEdgeXml">
-      <systemName>IQDE:AUTO:0104</systemName>
+      <systemName>IQDE:AUTO:0105</systemName>
       <namedBean>
         <addressing>Direct</addressing>
         <listenToMemory>no</listenToMemory>
@@ -10180,7 +10269,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExpressionSensorEdge>
     <ExpressionSensorEdge class="jmri.jmrit.logixng.expressions.configurexml.ExpressionSensorEdgeXml">
-      <systemName>IQDE:AUTO:0105</systemName>
+      <systemName>IQDE:AUTO:0106</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>Direct</addressing>
@@ -10277,7 +10366,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExpressionSensorEdge>
     <ExpressionSensorEdge class="jmri.jmrit.logixng.expressions.configurexml.ExpressionSensorEdgeXml">
-      <systemName>IQDE:AUTO:0106</systemName>
+      <systemName>IQDE:AUTO:0107</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>LocalVariable</addressing>
@@ -10377,7 +10466,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExpressionSensorEdge>
     <ExpressionSensorEdge class="jmri.jmrit.logixng.expressions.configurexml.ExpressionSensorEdgeXml">
-      <systemName>IQDE:AUTO:0107</systemName>
+      <systemName>IQDE:AUTO:0108</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>Formula</addressing>
@@ -10474,7 +10563,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExpressionSensorEdge>
     <ExpressionSensorEdge class="jmri.jmrit.logixng.expressions.configurexml.ExpressionSensorEdgeXml">
-      <systemName>IQDE:AUTO:0108</systemName>
+      <systemName>IQDE:AUTO:0109</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>Reference</addressing>
@@ -10571,7 +10660,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExpressionSensorEdge>
     <ExpressionSignalHead class="jmri.jmrit.logixng.expressions.configurexml.ExpressionSignalHeadXml">
-      <systemName>IQDE:AUTO:0109</systemName>
+      <systemName>IQDE:AUTO:0110</systemName>
       <namedBean>
         <addressing>Direct</addressing>
         <listenToMemory>no</listenToMemory>
@@ -10663,7 +10752,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExpressionSignalHead>
     <ExpressionSignalHead class="jmri.jmrit.logixng.expressions.configurexml.ExpressionSignalHeadXml">
-      <systemName>IQDE:AUTO:0110</systemName>
+      <systemName>IQDE:AUTO:0111</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>Direct</addressing>
@@ -10761,7 +10850,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExpressionSignalHead>
     <ExpressionSignalHead class="jmri.jmrit.logixng.expressions.configurexml.ExpressionSignalHeadXml">
-      <systemName>IQDE:AUTO:0111</systemName>
+      <systemName>IQDE:AUTO:0112</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>LocalVariable</addressing>
@@ -10858,7 +10947,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExpressionSignalHead>
     <ExpressionSignalHead class="jmri.jmrit.logixng.expressions.configurexml.ExpressionSignalHeadXml">
-      <systemName>IQDE:AUTO:0112</systemName>
+      <systemName>IQDE:AUTO:0113</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>Formula</addressing>
@@ -10955,7 +11044,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExpressionSignalHead>
     <ExpressionSignalHead class="jmri.jmrit.logixng.expressions.configurexml.ExpressionSignalHeadXml">
-      <systemName>IQDE:AUTO:0113</systemName>
+      <systemName>IQDE:AUTO:0114</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>Reference</addressing>
@@ -11052,7 +11141,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExpressionSignalHead>
     <ExpressionSignalMast class="jmri.jmrit.logixng.expressions.configurexml.ExpressionSignalMastXml">
-      <systemName>IQDE:AUTO:0114</systemName>
+      <systemName>IQDE:AUTO:0115</systemName>
       <namedBean>
         <addressing>Direct</addressing>
         <listenToMemory>no</listenToMemory>
@@ -11144,7 +11233,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExpressionSignalMast>
     <ExpressionSignalMast class="jmri.jmrit.logixng.expressions.configurexml.ExpressionSignalMastXml">
-      <systemName>IQDE:AUTO:0115</systemName>
+      <systemName>IQDE:AUTO:0116</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>Direct</addressing>
@@ -11242,7 +11331,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExpressionSignalMast>
     <ExpressionSignalMast class="jmri.jmrit.logixng.expressions.configurexml.ExpressionSignalMastXml">
-      <systemName>IQDE:AUTO:0116</systemName>
+      <systemName>IQDE:AUTO:0117</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>LocalVariable</addressing>
@@ -11339,7 +11428,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExpressionSignalMast>
     <ExpressionSignalMast class="jmri.jmrit.logixng.expressions.configurexml.ExpressionSignalMastXml">
-      <systemName>IQDE:AUTO:0117</systemName>
+      <systemName>IQDE:AUTO:0118</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>Formula</addressing>
@@ -11436,7 +11525,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExpressionSignalMast>
     <ExpressionSignalMast class="jmri.jmrit.logixng.expressions.configurexml.ExpressionSignalMastXml">
-      <systemName>IQDE:AUTO:0118</systemName>
+      <systemName>IQDE:AUTO:0119</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>Reference</addressing>
@@ -11533,7 +11622,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExpressionSignalMast>
     <Timer class="jmri.jmrit.logixng.expressions.configurexml.TimerXml">
-      <systemName>IQDE:AUTO:0119</systemName>
+      <systemName>IQDE:AUTO:0120</systemName>
       <delayAddressing>Direct</delayAddressing>
       <delay>0</delay>
       <delayReference />
@@ -11613,7 +11702,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </Timer>
     <Timer class="jmri.jmrit.logixng.expressions.configurexml.TimerXml">
-      <systemName>IQDE:AUTO:0120</systemName>
+      <systemName>IQDE:AUTO:0121</systemName>
       <comment>A comment</comment>
       <delayAddressing>Direct</delayAddressing>
       <delay>100</delay>
@@ -11694,7 +11783,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </Timer>
     <Timer class="jmri.jmrit.logixng.expressions.configurexml.TimerXml">
-      <systemName>IQDE:AUTO:0121</systemName>
+      <systemName>IQDE:AUTO:0122</systemName>
       <comment>A comment</comment>
       <delayAddressing>LocalVariable</delayAddressing>
       <delay>0</delay>
@@ -11775,7 +11864,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </Timer>
     <Timer class="jmri.jmrit.logixng.expressions.configurexml.TimerXml">
-      <systemName>IQDE:AUTO:0122</systemName>
+      <systemName>IQDE:AUTO:0123</systemName>
       <comment>A comment</comment>
       <delayAddressing>Reference</delayAddressing>
       <delay>0</delay>
@@ -11856,7 +11945,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </Timer>
     <Timer class="jmri.jmrit.logixng.expressions.configurexml.TimerXml">
-      <systemName>IQDE:AUTO:0123</systemName>
+      <systemName>IQDE:AUTO:0124</systemName>
       <comment>A comment</comment>
       <delayAddressing>Formula</delayAddressing>
       <delay>0</delay>
@@ -11937,7 +12026,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </Timer>
     <ExpressionTransit class="jmri.jmrit.logixng.expressions.configurexml.ExpressionTransitXml">
-      <systemName>IQDE:AUTO:0124</systemName>
+      <systemName>IQDE:AUTO:0125</systemName>
       <namedBean>
         <addressing>Direct</addressing>
         <listenToMemory>no</listenToMemory>
@@ -12021,7 +12110,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExpressionTransit>
     <ExpressionTransit class="jmri.jmrit.logixng.expressions.configurexml.ExpressionTransitXml">
-      <systemName>IQDE:AUTO:0125</systemName>
+      <systemName>IQDE:AUTO:0126</systemName>
       <comment>Direct / Direct :: Idle</comment>
       <namedBean>
         <addressing>Direct</addressing>
@@ -12107,7 +12196,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExpressionTransit>
     <ExpressionTransit class="jmri.jmrit.logixng.expressions.configurexml.ExpressionTransitXml">
-      <systemName>IQDE:AUTO:0126</systemName>
+      <systemName>IQDE:AUTO:0127</systemName>
       <comment>Reference / Direct :: Assigned</comment>
       <namedBean>
         <addressing>Reference</addressing>
@@ -12193,7 +12282,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExpressionTransit>
     <ExpressionTurnout class="jmri.jmrit.logixng.expressions.configurexml.ExpressionTurnoutXml">
-      <systemName>IQDE:AUTO:0127</systemName>
+      <systemName>IQDE:AUTO:0128</systemName>
       <namedBean>
         <addressing>Direct</addressing>
         <listenToMemory>no</listenToMemory>
@@ -12277,7 +12366,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExpressionTurnout>
     <ExpressionTurnout class="jmri.jmrit.logixng.expressions.configurexml.ExpressionTurnoutXml">
-      <systemName>IQDE:AUTO:0128</systemName>
+      <systemName>IQDE:AUTO:0129</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>Direct</addressing>
@@ -12366,7 +12455,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExpressionTurnout>
     <ExpressionTurnout class="jmri.jmrit.logixng.expressions.configurexml.ExpressionTurnoutXml">
-      <systemName>IQDE:AUTO:0129</systemName>
+      <systemName>IQDE:AUTO:0130</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>LocalVariable</addressing>
@@ -12455,7 +12544,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExpressionTurnout>
     <ExpressionTurnout class="jmri.jmrit.logixng.expressions.configurexml.ExpressionTurnoutXml">
-      <systemName>IQDE:AUTO:0130</systemName>
+      <systemName>IQDE:AUTO:0131</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>Formula</addressing>
@@ -12544,7 +12633,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExpressionTurnout>
     <ExpressionTurnout class="jmri.jmrit.logixng.expressions.configurexml.ExpressionTurnoutXml">
-      <systemName>IQDE:AUTO:0131</systemName>
+      <systemName>IQDE:AUTO:0132</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>Reference</addressing>
@@ -12633,7 +12722,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExpressionTurnout>
     <ExpressionWarrant class="jmri.jmrit.logixng.expressions.configurexml.ExpressionWarrantXml">
-      <systemName>IQDE:AUTO:0132</systemName>
+      <systemName>IQDE:AUTO:0133</systemName>
       <namedBean>
         <addressing>Direct</addressing>
         <listenToMemory>no</listenToMemory>
@@ -12717,7 +12806,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExpressionWarrant>
     <ExpressionWarrant class="jmri.jmrit.logixng.expressions.configurexml.ExpressionWarrantXml">
-      <systemName>IQDE:AUTO:0133</systemName>
+      <systemName>IQDE:AUTO:0134</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>Direct</addressing>
@@ -12806,7 +12895,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExpressionWarrant>
     <ExpressionWarrant class="jmri.jmrit.logixng.expressions.configurexml.ExpressionWarrantXml">
-      <systemName>IQDE:AUTO:0134</systemName>
+      <systemName>IQDE:AUTO:0135</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>LocalVariable</addressing>
@@ -12895,7 +12984,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExpressionWarrant>
     <ExpressionWarrant class="jmri.jmrit.logixng.expressions.configurexml.ExpressionWarrantXml">
-      <systemName>IQDE:AUTO:0135</systemName>
+      <systemName>IQDE:AUTO:0136</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>Formula</addressing>
@@ -12984,7 +13073,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExpressionWarrant>
     <ExpressionWarrant class="jmri.jmrit.logixng.expressions.configurexml.ExpressionWarrantXml">
-      <systemName>IQDE:AUTO:0136</systemName>
+      <systemName>IQDE:AUTO:0137</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>Reference</addressing>
@@ -13073,7 +13162,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExpressionWarrant>
     <False class="jmri.jmrit.logixng.expressions.configurexml.FalseXml">
-      <systemName>IQDE:AUTO:0137</systemName>
+      <systemName>IQDE:AUTO:0138</systemName>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
         <AbstractMaleSocket enabled="no" locked="no" system="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
@@ -13147,7 +13236,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </False>
     <False class="jmri.jmrit.logixng.expressions.configurexml.FalseXml">
-      <systemName>IQDE:AUTO:0138</systemName>
+      <systemName>IQDE:AUTO:0139</systemName>
       <comment>A comment</comment>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
@@ -13222,7 +13311,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </False>
     <FileAsFlag class="jmri.jmrit.logixng.expressions.configurexml.FileAsFlagXml">
-      <systemName>IQDE:AUTO:0139</systemName>
+      <systemName>IQDE:AUTO:0140</systemName>
       <filename>
         <addressing>Direct</addressing>
         <listenToMemory>no</listenToMemory>
@@ -13305,7 +13394,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </FileAsFlag>
     <FileAsFlag class="jmri.jmrit.logixng.expressions.configurexml.FileAsFlagXml">
-      <systemName>IQDE:AUTO:0140</systemName>
+      <systemName>IQDE:AUTO:0141</systemName>
       <comment>A comment</comment>
       <filename>
         <addressing>Direct</addressing>
@@ -13396,10 +13485,10 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </FileAsFlag>
     <DigitalFormula class="jmri.jmrit.logixng.expressions.configurexml.DigitalFormulaXml">
-      <systemName>IQDE:AUTO:0141</systemName>
+      <systemName>IQDE:AUTO:0142</systemName>
       <Expressions>
         <Socket>
-          <socketName>ophzqm7pmt</socketName>
+          <socketName>a2fbhpjre6</socketName>
         </Socket>
       </Expressions>
       <formula />
@@ -13476,11 +13565,11 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </DigitalFormula>
     <DigitalFormula class="jmri.jmrit.logixng.expressions.configurexml.DigitalFormulaXml">
-      <systemName>IQDE:AUTO:0142</systemName>
+      <systemName>IQDE:AUTO:0143</systemName>
       <comment>A comment</comment>
       <Expressions>
         <Socket>
-          <socketName>y73opar5cx</socketName>
+          <socketName>uoke12ornl</socketName>
         </Socket>
       </Expressions>
       <formula>n + 1</formula>
@@ -13557,12 +13646,12 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </DigitalFormula>
     <Hold class="jmri.jmrit.logixng.expressions.configurexml.HoldXml">
-      <systemName>IQDE:AUTO:0143</systemName>
+      <systemName>IQDE:AUTO:0144</systemName>
       <TriggerSocket>
-        <socketName>iul8ouu6ji</socketName>
+        <socketName>b4axr5iwev</socketName>
       </TriggerSocket>
       <HoldSocket>
-        <socketName>qx92ly25i8</socketName>
+        <socketName>pqanimw81q</socketName>
       </HoldSocket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
@@ -13637,14 +13726,14 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </Hold>
     <Hold class="jmri.jmrit.logixng.expressions.configurexml.HoldXml">
-      <systemName>IQDE:AUTO:0144</systemName>
+      <systemName>IQDE:AUTO:0145</systemName>
       <userName>A hold expression</userName>
       <comment>A comment</comment>
       <TriggerSocket>
-        <socketName>trtlwmlhxz</socketName>
+        <socketName>u85rpcmh2h</socketName>
       </TriggerSocket>
       <HoldSocket>
-        <socketName>r7ycn39r59</socketName>
+        <socketName>d6y5x6v3r3</socketName>
       </HoldSocket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
@@ -13719,7 +13808,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </Hold>
     <LastResultOfDigitalExpression class="jmri.jmrit.logixng.expressions.configurexml.LastResultOfDigitalExpressionXml">
-      <systemName>IQDE:AUTO:0145</systemName>
+      <systemName>IQDE:AUTO:0146</systemName>
       <namedBean>
         <addressing>Direct</addressing>
         <listenToMemory>no</listenToMemory>
@@ -13797,7 +13886,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </LastResultOfDigitalExpression>
     <LastResultOfDigitalExpression class="jmri.jmrit.logixng.expressions.configurexml.LastResultOfDigitalExpressionXml">
-      <systemName>IQDE:AUTO:0146</systemName>
+      <systemName>IQDE:AUTO:0147</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>Direct</addressing>
@@ -13877,7 +13966,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </LastResultOfDigitalExpression>
     <LogData class="jmri.jmrit.logixng.expressions.configurexml.LogDataXml">
-      <systemName>IQDE:AUTO:0147</systemName>
+      <systemName>IQDE:AUTO:0148</systemName>
       <result>no</result>
       <logToLog>yes</logToLog>
       <logToScriptOutput>no</logToScriptOutput>
@@ -13957,7 +14046,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </LogData>
     <LogData class="jmri.jmrit.logixng.expressions.configurexml.LogDataXml">
-      <systemName>IQDE:AUTO:0148</systemName>
+      <systemName>IQDE:AUTO:0149</systemName>
       <comment>A comment</comment>
       <result>no</result>
       <logToLog>yes</logToLog>
@@ -14043,7 +14132,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </LogData>
     <LogData class="jmri.jmrit.logixng.expressions.configurexml.LogDataXml">
-      <systemName>IQDE:AUTO:0149</systemName>
+      <systemName>IQDE:AUTO:0150</systemName>
       <comment>A comment</comment>
       <result>no</result>
       <logToLog>yes</logToLog>
@@ -14129,7 +14218,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </LogData>
     <LogData class="jmri.jmrit.logixng.expressions.configurexml.LogDataXml">
-      <systemName>IQDE:AUTO:0150</systemName>
+      <systemName>IQDE:AUTO:0151</systemName>
       <comment>A comment</comment>
       <result>no</result>
       <logToLog>yes</logToLog>
@@ -14215,7 +14304,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </LogData>
     <LogData class="jmri.jmrit.logixng.expressions.configurexml.LogDataXml">
-      <systemName>IQDE:AUTO:0151</systemName>
+      <systemName>IQDE:AUTO:0152</systemName>
       <comment>A comment</comment>
       <result>no</result>
       <logToLog>yes</logToLog>
@@ -14313,9 +14402,9 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </LogData>
     <Not class="jmri.jmrit.logixng.expressions.configurexml.NotXml">
-      <systemName>IQDE:AUTO:0152</systemName>
+      <systemName>IQDE:AUTO:0153</systemName>
       <Socket>
-        <socketName>ig444r3j4f</socketName>
+        <socketName>jj28zm95l9</socketName>
       </Socket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
@@ -14390,10 +14479,10 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </Not>
     <Not class="jmri.jmrit.logixng.expressions.configurexml.NotXml">
-      <systemName>IQDE:AUTO:0153</systemName>
+      <systemName>IQDE:AUTO:0154</systemName>
       <comment>A comment</comment>
       <Socket>
-        <socketName>u34zy4ve65</socketName>
+        <socketName>u94ukiph8o</socketName>
       </Socket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
@@ -14468,10 +14557,10 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </Not>
     <Or class="jmri.jmrit.logixng.expressions.configurexml.OrXml" type="EvaluateAll">
-      <systemName>IQDE:AUTO:0154</systemName>
+      <systemName>IQDE:AUTO:0155</systemName>
       <Expressions>
         <Socket>
-          <socketName>qm7rzr32n9</socketName>
+          <socketName>e22f7z9sne</socketName>
         </Socket>
       </Expressions>
       <MaleSocket>
@@ -14547,11 +14636,11 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </Or>
     <Or class="jmri.jmrit.logixng.expressions.configurexml.OrXml" type="EvaluateNeeded">
-      <systemName>IQDE:AUTO:0155</systemName>
+      <systemName>IQDE:AUTO:0156</systemName>
       <comment>A comment</comment>
       <Expressions>
         <Socket>
-          <socketName>v4cwe8pt1i</socketName>
+          <socketName>skkyhhz34h</socketName>
         </Socket>
       </Expressions>
       <MaleSocket>
@@ -14627,9 +14716,9 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </Or>
     <TriggerOnce class="jmri.jmrit.logixng.expressions.configurexml.TriggerOnceXml">
-      <systemName>IQDE:AUTO:0156</systemName>
+      <systemName>IQDE:AUTO:0157</systemName>
       <Socket>
-        <socketName>egl7c8zgj5</socketName>
+        <socketName>c86f5w9yhf</socketName>
       </Socket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
@@ -14704,10 +14793,10 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </TriggerOnce>
     <TriggerOnce class="jmri.jmrit.logixng.expressions.configurexml.TriggerOnceXml">
-      <systemName>IQDE:AUTO:0157</systemName>
+      <systemName>IQDE:AUTO:0158</systemName>
       <comment>A comment</comment>
       <Socket>
-        <socketName>ocpenquub8</socketName>
+        <socketName>i61yfkfdoh</socketName>
       </Socket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
@@ -14782,7 +14871,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </TriggerOnce>
     <True class="jmri.jmrit.logixng.expressions.configurexml.TrueXml">
-      <systemName>IQDE:AUTO:0158</systemName>
+      <systemName>IQDE:AUTO:0159</systemName>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
         <AbstractMaleSocket enabled="no" locked="no" system="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
@@ -14856,7 +14945,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </True>
     <True class="jmri.jmrit.logixng.expressions.configurexml.TrueXml">
-      <systemName>IQDE:AUTO:0159</systemName>
+      <systemName>IQDE:AUTO:0160</systemName>
       <comment>A comment</comment>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
@@ -14931,7 +15020,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </True>
     <ExpressionLoconetSlotUsage class="jmri.jmrix.loconet.logixng.configurexml.ExpressionSlotUsageXml">
-      <systemName>IQDE:AUTO:0160</systemName>
+      <systemName>IQDE:AUTO:0161</systemName>
       <systemConnection>L</systemConnection>
       <advanced>no</advanced>
       <has_hasNot>Has</has_hasNot>
@@ -15033,1235 +15122,1247 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <systemName>IQDA:AUTO:0001</systemName>
       <Actions>
         <Socket>
-          <socketName>xy2cgdc9jc</socketName>
+          <socketName>wc3czoyaga</socketName>
           <systemName>IQDA:AUTO:0002</systemName>
         </Socket>
         <Socket>
-          <socketName>y5rsnf5ee4</socketName>
+          <socketName>idy7c5nmcn</socketName>
           <systemName>IQDA:AUTO:0003</systemName>
         </Socket>
         <Socket>
-          <socketName>hup8fvt6fw</socketName>
+          <socketName>akch7rk3dp</socketName>
           <systemName>IQDA:AUTO:0004</systemName>
         </Socket>
         <Socket>
-          <socketName>wuh3a61f3j</socketName>
+          <socketName>afkanbtv2h</socketName>
           <systemName>IQDA:AUTO:0005</systemName>
         </Socket>
         <Socket>
-          <socketName>n31f38lyit</socketName>
+          <socketName>o2g176d7xc</socketName>
           <systemName>IQDA:AUTO:0006</systemName>
         </Socket>
         <Socket>
-          <socketName>ir76fb5gpg</socketName>
+          <socketName>h8un82g8dd</socketName>
           <systemName>IQDA:AUTO:0012</systemName>
         </Socket>
         <Socket>
-          <socketName>huiswqvuik</socketName>
+          <socketName>dh26qu7rak</socketName>
           <systemName>IQDA:AUTO:0013</systemName>
         </Socket>
         <Socket>
-          <socketName>sj2j4qi4wf</socketName>
+          <socketName>mnc4f7j3gl</socketName>
           <systemName>IQDA:AUTO:0014</systemName>
         </Socket>
         <Socket>
-          <socketName>a1jmqfl8oa</socketName>
+          <socketName>dunjv32ruq</socketName>
           <systemName>IQDA:AUTO:0015</systemName>
         </Socket>
         <Socket>
-          <socketName>ubqrh7t8yb</socketName>
+          <socketName>b59d2rg7xd</socketName>
           <systemName>IQDA:AUTO:0016</systemName>
         </Socket>
         <Socket>
-          <socketName>hitiznj683</socketName>
+          <socketName>zzn1ccbbuv</socketName>
           <systemName>IQDA:AUTO:0017</systemName>
         </Socket>
         <Socket>
-          <socketName>w8mi3zm58y</socketName>
+          <socketName>vjfkv4e72z</socketName>
           <systemName>IQDA:AUTO:0018</systemName>
         </Socket>
         <Socket>
-          <socketName>kfu8i361k2</socketName>
+          <socketName>x8tklkur49</socketName>
           <systemName>IQDA:AUTO:0019</systemName>
         </Socket>
         <Socket>
-          <socketName>nwoygxdsq7</socketName>
+          <socketName>r1l37xqqk1</socketName>
           <systemName>IQDA:AUTO:0020</systemName>
         </Socket>
         <Socket>
-          <socketName>xleo8k6t7s</socketName>
+          <socketName>gsn2831iap</socketName>
           <systemName>IQDA:AUTO:0021</systemName>
         </Socket>
         <Socket>
-          <socketName>qhhcqyex3s</socketName>
+          <socketName>zuxez5nugg</socketName>
           <systemName>IQDA:AUTO:0022</systemName>
         </Socket>
         <Socket>
-          <socketName>rytyeb5sa2</socketName>
+          <socketName>xr8b7eebmq</socketName>
           <systemName>IQDA:AUTO:0023</systemName>
         </Socket>
         <Socket>
-          <socketName>dwgzqbufro</socketName>
+          <socketName>cqdlodtrzs</socketName>
           <systemName>IQDA:AUTO:0024</systemName>
         </Socket>
         <Socket>
-          <socketName>y958z2p6vn</socketName>
+          <socketName>mf8bicf4ji</socketName>
           <systemName>IQDA:AUTO:0025</systemName>
         </Socket>
         <Socket>
-          <socketName>i18k1fy2ee</socketName>
+          <socketName>u7oidu56dc</socketName>
           <systemName>IQDA:AUTO:0026</systemName>
         </Socket>
         <Socket>
-          <socketName>tpmmjx37s8</socketName>
+          <socketName>yohijceypu</socketName>
           <systemName>IQDA:AUTO:0027</systemName>
         </Socket>
         <Socket>
-          <socketName>yx7a12v89b</socketName>
+          <socketName>nfwp7rz8o7</socketName>
           <systemName>IQDA:AUTO:0028</systemName>
         </Socket>
         <Socket>
-          <socketName>qs9kr1xpqj</socketName>
+          <socketName>a67ka3xx75</socketName>
           <systemName>IQDA:AUTO:0029</systemName>
         </Socket>
         <Socket>
-          <socketName>r5kmjm36ey</socketName>
+          <socketName>qcz19xc2up</socketName>
           <systemName>IQDA:AUTO:0030</systemName>
         </Socket>
         <Socket>
-          <socketName>abb28ybphm</socketName>
+          <socketName>tb4xtsxu16</socketName>
           <systemName>IQDA:AUTO:0031</systemName>
         </Socket>
         <Socket>
-          <socketName>r2f5jh9f27</socketName>
+          <socketName>hj943x37bo</socketName>
           <systemName>IQDA:AUTO:0032</systemName>
         </Socket>
         <Socket>
-          <socketName>jyhkixlmgo</socketName>
+          <socketName>k9zlvm47ho</socketName>
           <systemName>IQDA:AUTO:0033</systemName>
         </Socket>
         <Socket>
-          <socketName>y7jeomooo2</socketName>
+          <socketName>eca8uc1fq8</socketName>
           <systemName>IQDA:AUTO:0034</systemName>
         </Socket>
         <Socket>
-          <socketName>it662ewka7</socketName>
+          <socketName>jb1wzow18h</socketName>
           <systemName>IQDA:AUTO:0035</systemName>
         </Socket>
         <Socket>
-          <socketName>p5578k8gvh</socketName>
+          <socketName>zrd1gg2sds</socketName>
           <systemName>IQDA:AUTO:0036</systemName>
         </Socket>
         <Socket>
-          <socketName>wha7edpvnq</socketName>
+          <socketName>znen65jh15</socketName>
           <systemName>IQDA:AUTO:0037</systemName>
         </Socket>
         <Socket>
-          <socketName>k43ixog2e9</socketName>
+          <socketName>rk5b1e1aa6</socketName>
           <systemName>IQDA:AUTO:0038</systemName>
         </Socket>
         <Socket>
-          <socketName>r4it3hynjn</socketName>
+          <socketName>f92u8rmgmy</socketName>
           <systemName>IQDA:AUTO:0039</systemName>
         </Socket>
         <Socket>
-          <socketName>upngxarcrw</socketName>
+          <socketName>x98811pbtx</socketName>
           <systemName>IQDA:AUTO:0040</systemName>
         </Socket>
         <Socket>
-          <socketName>cj6pbrj3rh</socketName>
+          <socketName>rbdmmjy7wh</socketName>
           <systemName>IQDA:AUTO:0041</systemName>
         </Socket>
         <Socket>
-          <socketName>qxskbg2353</socketName>
+          <socketName>xdmjuvfxo4</socketName>
           <systemName>IQDA:AUTO:0042</systemName>
         </Socket>
         <Socket>
-          <socketName>cyzhlxw2jg</socketName>
+          <socketName>x2wldj6ve1</socketName>
           <systemName>IQDA:AUTO:0043</systemName>
         </Socket>
         <Socket>
-          <socketName>pcpfsyodjt</socketName>
+          <socketName>znbxlz6cgi</socketName>
           <systemName>IQDA:AUTO:0044</systemName>
         </Socket>
         <Socket>
-          <socketName>sn6w1xb8q6</socketName>
+          <socketName>qaqry2ivuk</socketName>
           <systemName>IQDA:AUTO:0045</systemName>
         </Socket>
         <Socket>
-          <socketName>iyo1pcg1tz</socketName>
+          <socketName>x2comkwm43</socketName>
           <systemName>IQDA:AUTO:0046</systemName>
         </Socket>
         <Socket>
-          <socketName>sbc21a1bbu</socketName>
+          <socketName>neozhbrblg</socketName>
           <systemName>IQDA:AUTO:0047</systemName>
         </Socket>
         <Socket>
-          <socketName>ya22ij7yy4</socketName>
+          <socketName>gxg7cl93d9</socketName>
           <systemName>IQDA:AUTO:0048</systemName>
         </Socket>
         <Socket>
-          <socketName>vu38g6iia1</socketName>
+          <socketName>i6rfnkc6dz</socketName>
           <systemName>IQDA:AUTO:0049</systemName>
         </Socket>
         <Socket>
-          <socketName>x42e6f98bp</socketName>
+          <socketName>rgy5914uee</socketName>
           <systemName>IQDA:AUTO:0050</systemName>
         </Socket>
         <Socket>
-          <socketName>wg2j7xtssk</socketName>
+          <socketName>pm2xcw4tcq</socketName>
           <systemName>IQDA:AUTO:0051</systemName>
         </Socket>
         <Socket>
-          <socketName>qbgtftl327</socketName>
+          <socketName>c5d4a9k7ub</socketName>
           <systemName>IQDA:AUTO:0052</systemName>
         </Socket>
         <Socket>
-          <socketName>m9fnwhzlwy</socketName>
+          <socketName>tl72hd9hmz</socketName>
           <systemName>IQDA:AUTO:0053</systemName>
         </Socket>
         <Socket>
-          <socketName>fsxfnr4hbg</socketName>
+          <socketName>s63ujlvcvu</socketName>
           <systemName>IQDA:AUTO:0054</systemName>
         </Socket>
         <Socket>
-          <socketName>z41k228epn</socketName>
+          <socketName>wlkaeey2hz</socketName>
           <systemName>IQDA:AUTO:0055</systemName>
         </Socket>
         <Socket>
-          <socketName>xvqkrh6e1b</socketName>
+          <socketName>tedugatae4</socketName>
           <systemName>IQDA:AUTO:0056</systemName>
         </Socket>
         <Socket>
-          <socketName>aeytdywi8f</socketName>
+          <socketName>x1nch1ja57</socketName>
           <systemName>IQDA:AUTO:0057</systemName>
         </Socket>
         <Socket>
-          <socketName>xj61pqksxx</socketName>
+          <socketName>exb3ny75gr</socketName>
           <systemName>IQDA:AUTO:0058</systemName>
         </Socket>
         <Socket>
-          <socketName>wkuwbs8fxh</socketName>
+          <socketName>kj3acmijjf</socketName>
           <systemName>IQDA:AUTO:0059</systemName>
         </Socket>
         <Socket>
-          <socketName>tf8by28otv</socketName>
+          <socketName>xeklm2zh3p</socketName>
           <systemName>IQDA:AUTO:0060</systemName>
         </Socket>
         <Socket>
-          <socketName>xm9jpu4sui</socketName>
+          <socketName>fsmamnn46z</socketName>
           <systemName>IQDA:AUTO:0061</systemName>
         </Socket>
         <Socket>
-          <socketName>gijlm6tbk9</socketName>
+          <socketName>d1avdaw6jg</socketName>
           <systemName>IQDA:AUTO:0062</systemName>
         </Socket>
         <Socket>
-          <socketName>ujkrm3vrhj</socketName>
+          <socketName>gb3yv1dxr9</socketName>
           <systemName>IQDA:AUTO:0063</systemName>
         </Socket>
         <Socket>
-          <socketName>q68ork57jk</socketName>
+          <socketName>xpy3i77nhs</socketName>
           <systemName>IQDA:AUTO:0064</systemName>
         </Socket>
         <Socket>
-          <socketName>pnd7b1apw2</socketName>
+          <socketName>qup555wttd</socketName>
           <systemName>IQDA:AUTO:0065</systemName>
         </Socket>
         <Socket>
-          <socketName>meosazl1zb</socketName>
+          <socketName>wuigw1ds5v</socketName>
           <systemName>IQDA:AUTO:0066</systemName>
         </Socket>
         <Socket>
-          <socketName>vk3foxvoqh</socketName>
+          <socketName>xfleqct6kw</socketName>
           <systemName>IQDA:AUTO:0067</systemName>
         </Socket>
         <Socket>
-          <socketName>lped5aeb7a</socketName>
+          <socketName>vlv59vo5a4</socketName>
           <systemName>IQDA:AUTO:0068</systemName>
         </Socket>
         <Socket>
-          <socketName>ucsjsu45p6</socketName>
+          <socketName>q9gds87p2a</socketName>
           <systemName>IQDA:AUTO:0069</systemName>
         </Socket>
         <Socket>
-          <socketName>rvhe2k2jz8</socketName>
+          <socketName>hccitho1kb</socketName>
           <systemName>IQDA:AUTO:0070</systemName>
         </Socket>
         <Socket>
-          <socketName>t29pdaqfg8</socketName>
+          <socketName>vvk5l9lt33</socketName>
           <systemName>IQDA:AUTO:0071</systemName>
         </Socket>
         <Socket>
-          <socketName>qie3valq6p</socketName>
+          <socketName>xhoc59azoz</socketName>
           <systemName>IQDA:AUTO:0072</systemName>
         </Socket>
         <Socket>
-          <socketName>akrvn9l45g</socketName>
+          <socketName>xqc34jgbk1</socketName>
           <systemName>IQDA:AUTO:0073</systemName>
         </Socket>
         <Socket>
-          <socketName>ia9zjjwtef</socketName>
+          <socketName>ow1z4sgq1q</socketName>
           <systemName>IQDA:AUTO:0074</systemName>
         </Socket>
         <Socket>
-          <socketName>q7jxav7dm2</socketName>
+          <socketName>g6nibt5mb6</socketName>
           <systemName>IQDA:AUTO:0075</systemName>
         </Socket>
         <Socket>
-          <socketName>ekaritkiuz</socketName>
+          <socketName>kgi4x37scl</socketName>
           <systemName>IQDA:AUTO:0076</systemName>
         </Socket>
         <Socket>
-          <socketName>tii1f22i5f</socketName>
+          <socketName>gsug8ix6fh</socketName>
           <systemName>IQDA:AUTO:0077</systemName>
         </Socket>
         <Socket>
-          <socketName>e2aqrdv1xp</socketName>
+          <socketName>svhcqkigcn</socketName>
           <systemName>IQDA:AUTO:0078</systemName>
         </Socket>
         <Socket>
-          <socketName>ub7trdez3h</socketName>
+          <socketName>yy21lll1ia</socketName>
           <systemName>IQDA:AUTO:0079</systemName>
         </Socket>
         <Socket>
-          <socketName>ppdxoisfq1</socketName>
+          <socketName>g5wwqcdccj</socketName>
           <systemName>IQDA:AUTO:0080</systemName>
         </Socket>
         <Socket>
-          <socketName>t9plehjitq</socketName>
+          <socketName>xwmshwrr9b</socketName>
           <systemName>IQDA:AUTO:0081</systemName>
         </Socket>
         <Socket>
-          <socketName>qshrux8tx3</socketName>
+          <socketName>l6g2m1wqfv</socketName>
           <systemName>IQDA:AUTO:0082</systemName>
         </Socket>
         <Socket>
-          <socketName>vncamrim7g</socketName>
+          <socketName>tb8b4ne3tw</socketName>
           <systemName>IQDA:AUTO:0083</systemName>
         </Socket>
         <Socket>
-          <socketName>wjmv2refrt</socketName>
+          <socketName>vlyeaq9epy</socketName>
+          <systemName>IQDA:AUTO:0084</systemName>
+        </Socket>
+        <Socket>
+          <socketName>gdrxp66zmm</socketName>
           <systemName>IQDA:AUTO:0085</systemName>
         </Socket>
         <Socket>
-          <socketName>brnzqd8lxy</socketName>
+          <socketName>fobteyzsp2</socketName>
           <systemName>IQDA:AUTO:0086</systemName>
         </Socket>
         <Socket>
-          <socketName>edutq4hjy3</socketName>
-          <systemName>IQDA:AUTO:0087</systemName>
-        </Socket>
-        <Socket>
-          <socketName>x9effuzxhd</socketName>
+          <socketName>ckrboppfn3</socketName>
           <systemName>IQDA:AUTO:0088</systemName>
         </Socket>
         <Socket>
-          <socketName>z4uehlac68</socketName>
+          <socketName>em2rrycd3d</socketName>
           <systemName>IQDA:AUTO:0089</systemName>
         </Socket>
         <Socket>
-          <socketName>yccrhx59nh</socketName>
+          <socketName>xogx1br96m</socketName>
           <systemName>IQDA:AUTO:0090</systemName>
         </Socket>
         <Socket>
-          <socketName>w156i8oqhj</socketName>
+          <socketName>xhnkogin27</socketName>
           <systemName>IQDA:AUTO:0091</systemName>
         </Socket>
         <Socket>
-          <socketName>xgrstp9xfv</socketName>
+          <socketName>cdpvimisvf</socketName>
           <systemName>IQDA:AUTO:0092</systemName>
         </Socket>
         <Socket>
-          <socketName>wkvz361zh2</socketName>
+          <socketName>aoma97e7zh</socketName>
           <systemName>IQDA:AUTO:0093</systemName>
         </Socket>
         <Socket>
-          <socketName>go7r79b3bi</socketName>
+          <socketName>u1ko9hu32s</socketName>
           <systemName>IQDA:AUTO:0094</systemName>
         </Socket>
         <Socket>
-          <socketName>wxaeklomui</socketName>
+          <socketName>ule75ghomu</socketName>
           <systemName>IQDA:AUTO:0095</systemName>
         </Socket>
         <Socket>
-          <socketName>ppngjvt7xw</socketName>
+          <socketName>go6sk76lfo</socketName>
           <systemName>IQDA:AUTO:0096</systemName>
         </Socket>
         <Socket>
-          <socketName>uct97l499m</socketName>
+          <socketName>mtlogicwnb</socketName>
           <systemName>IQDA:AUTO:0097</systemName>
         </Socket>
         <Socket>
-          <socketName>wjec8tobgj</socketName>
+          <socketName>yhhkloxles</socketName>
           <systemName>IQDA:AUTO:0098</systemName>
         </Socket>
         <Socket>
-          <socketName>xdof1dw2cs</socketName>
+          <socketName>us6ilqzmag</socketName>
           <systemName>IQDA:AUTO:0099</systemName>
         </Socket>
         <Socket>
-          <socketName>bbcx3bhfkn</socketName>
+          <socketName>vvz9oitk9x</socketName>
           <systemName>IQDA:AUTO:0100</systemName>
         </Socket>
         <Socket>
-          <socketName>xtdsdlb2dz</socketName>
+          <socketName>tz6lef5ozj</socketName>
           <systemName>IQDA:AUTO:0101</systemName>
         </Socket>
         <Socket>
-          <socketName>roa5tjz9t8</socketName>
+          <socketName>j777aynqwe</socketName>
           <systemName>IQDA:AUTO:0102</systemName>
         </Socket>
         <Socket>
-          <socketName>m8rh1z7tln</socketName>
+          <socketName>na7j3b3ygg</socketName>
           <systemName>IQDA:AUTO:0103</systemName>
         </Socket>
         <Socket>
-          <socketName>p7x7iptlyy</socketName>
+          <socketName>jqxfoz86m6</socketName>
           <systemName>IQDA:AUTO:0104</systemName>
         </Socket>
         <Socket>
-          <socketName>u6apgupdp5</socketName>
+          <socketName>zj4slr1bce</socketName>
           <systemName>IQDA:AUTO:0105</systemName>
         </Socket>
         <Socket>
-          <socketName>xmlyrbthds</socketName>
+          <socketName>rsc5i2v21q</socketName>
           <systemName>IQDA:AUTO:0106</systemName>
         </Socket>
         <Socket>
-          <socketName>ve9w2t1zen</socketName>
+          <socketName>f5hu8kimmy</socketName>
           <systemName>IQDA:AUTO:0107</systemName>
         </Socket>
         <Socket>
-          <socketName>ci6e5rmcp2</socketName>
+          <socketName>hsgtdg8cju</socketName>
           <systemName>IQDA:AUTO:0108</systemName>
         </Socket>
         <Socket>
-          <socketName>tid83rc68t</socketName>
+          <socketName>m1fhhdzcdh</socketName>
           <systemName>IQDA:AUTO:0109</systemName>
         </Socket>
         <Socket>
-          <socketName>iayl9ybu1j</socketName>
+          <socketName>q34jilu47q</socketName>
           <systemName>IQDA:AUTO:0110</systemName>
         </Socket>
         <Socket>
-          <socketName>ww9yvxxtah</socketName>
+          <socketName>ayoqcqtdqy</socketName>
           <systemName>IQDA:AUTO:0111</systemName>
         </Socket>
         <Socket>
-          <socketName>gbvg9l5zj4</socketName>
+          <socketName>dl1chyc49x</socketName>
           <systemName>IQDA:AUTO:0112</systemName>
         </Socket>
         <Socket>
-          <socketName>vzg3uc9i6z</socketName>
+          <socketName>jiyvo9xjc1</socketName>
           <systemName>IQDA:AUTO:0113</systemName>
         </Socket>
         <Socket>
-          <socketName>y9cvy1j4ak</socketName>
+          <socketName>vna3bkaq1m</socketName>
           <systemName>IQDA:AUTO:0114</systemName>
         </Socket>
         <Socket>
-          <socketName>w1pvfjebsv</socketName>
+          <socketName>qljkcrjbxo</socketName>
           <systemName>IQDA:AUTO:0115</systemName>
         </Socket>
         <Socket>
-          <socketName>whwguktmnz</socketName>
+          <socketName>o1b4klwmkz</socketName>
           <systemName>IQDA:AUTO:0116</systemName>
         </Socket>
         <Socket>
-          <socketName>ji73ukdcht</socketName>
+          <socketName>kcnhu8v8rm</socketName>
           <systemName>IQDA:AUTO:0117</systemName>
         </Socket>
         <Socket>
-          <socketName>ecdvhb7hma</socketName>
+          <socketName>v1wss2bkh3</socketName>
           <systemName>IQDA:AUTO:0118</systemName>
         </Socket>
         <Socket>
-          <socketName>uj4wjh5nax</socketName>
+          <socketName>vxlfauzimd</socketName>
           <systemName>IQDA:AUTO:0119</systemName>
         </Socket>
         <Socket>
-          <socketName>xptycpuxbf</socketName>
+          <socketName>c2x5g2xu4n</socketName>
           <systemName>IQDA:AUTO:0120</systemName>
         </Socket>
         <Socket>
-          <socketName>hvtj9trg2i</socketName>
+          <socketName>wyyuidvu37</socketName>
           <systemName>IQDA:AUTO:0121</systemName>
         </Socket>
         <Socket>
-          <socketName>sqtogvi3zr</socketName>
+          <socketName>dzrzst29td</socketName>
           <systemName>IQDA:AUTO:0122</systemName>
         </Socket>
         <Socket>
-          <socketName>d7rravfam7</socketName>
+          <socketName>eulaj897a4</socketName>
           <systemName>IQDA:AUTO:0123</systemName>
         </Socket>
         <Socket>
-          <socketName>x4mo5368l6</socketName>
+          <socketName>qgjtnojqtp</socketName>
           <systemName>IQDA:AUTO:0124</systemName>
         </Socket>
         <Socket>
-          <socketName>uok6qftpbx</socketName>
+          <socketName>d2o8bwlrjq</socketName>
           <systemName>IQDA:AUTO:0125</systemName>
         </Socket>
         <Socket>
-          <socketName>vjgx9wvykq</socketName>
+          <socketName>oubw9234sc</socketName>
           <systemName>IQDA:AUTO:0126</systemName>
         </Socket>
         <Socket>
-          <socketName>n91sl4an9c</socketName>
+          <socketName>qnzv72w9px</socketName>
           <systemName>IQDA:AUTO:0127</systemName>
         </Socket>
         <Socket>
-          <socketName>vca9nbenov</socketName>
+          <socketName>bd9brl1gqx</socketName>
           <systemName>IQDA:AUTO:0128</systemName>
         </Socket>
         <Socket>
-          <socketName>bp5g71kcvc</socketName>
+          <socketName>nabq1gv48q</socketName>
           <systemName>IQDA:AUTO:0129</systemName>
         </Socket>
         <Socket>
-          <socketName>jv9oce97da</socketName>
+          <socketName>jm443d8d3h</socketName>
           <systemName>IQDA:AUTO:0130</systemName>
         </Socket>
         <Socket>
-          <socketName>m1qzwdvm94</socketName>
+          <socketName>o9388elqr3</socketName>
           <systemName>IQDA:AUTO:0131</systemName>
         </Socket>
         <Socket>
-          <socketName>gj8o3okntw</socketName>
+          <socketName>alpj3x1mxa</socketName>
           <systemName>IQDA:AUTO:0132</systemName>
         </Socket>
         <Socket>
-          <socketName>t42wm4h5tv</socketName>
+          <socketName>q3z9bic5ci</socketName>
           <systemName>IQDA:AUTO:0133</systemName>
         </Socket>
         <Socket>
-          <socketName>hvghw2st4b</socketName>
+          <socketName>vjbjtddq6s</socketName>
+          <systemName>IQDA:AUTO:0134</systemName>
+        </Socket>
+        <Socket>
+          <socketName>t4lbfa9pzo</socketName>
           <systemName>IQDA:AUTO:0135</systemName>
         </Socket>
         <Socket>
-          <socketName>wjfjo295d8</socketName>
+          <socketName>jnhe3mvgge</socketName>
           <systemName>IQDA:AUTO:0136</systemName>
         </Socket>
         <Socket>
-          <socketName>s5m99sh4ad</socketName>
-          <systemName>IQDA:AUTO:0137</systemName>
-        </Socket>
-        <Socket>
-          <socketName>ukw9uxfbr8</socketName>
+          <socketName>m12fiz8tbw</socketName>
           <systemName>IQDA:AUTO:0138</systemName>
         </Socket>
         <Socket>
-          <socketName>smm1j973ym</socketName>
+          <socketName>ddpqz35fz2</socketName>
           <systemName>IQDA:AUTO:0139</systemName>
         </Socket>
         <Socket>
-          <socketName>inudvr5vk7</socketName>
+          <socketName>egmeefplvd</socketName>
           <systemName>IQDA:AUTO:0140</systemName>
         </Socket>
         <Socket>
-          <socketName>ww7gk6jr84</socketName>
+          <socketName>ed1q2yz22a</socketName>
           <systemName>IQDA:AUTO:0141</systemName>
         </Socket>
         <Socket>
-          <socketName>sgu6xj9boy</socketName>
+          <socketName>wrx1w6ml8o</socketName>
           <systemName>IQDA:AUTO:0142</systemName>
         </Socket>
         <Socket>
-          <socketName>z8wb7s44fn</socketName>
+          <socketName>uqozcfs8yl</socketName>
           <systemName>IQDA:AUTO:0143</systemName>
         </Socket>
         <Socket>
-          <socketName>rq2mmw4xop</socketName>
+          <socketName>ll339gkrpn</socketName>
           <systemName>IQDA:AUTO:0144</systemName>
         </Socket>
         <Socket>
-          <socketName>rz49y4pb95</socketName>
+          <socketName>wenznyot94</socketName>
           <systemName>IQDA:AUTO:0145</systemName>
         </Socket>
         <Socket>
-          <socketName>s4uyz8sm4q</socketName>
+          <socketName>dtorbakkob</socketName>
           <systemName>IQDA:AUTO:0146</systemName>
         </Socket>
         <Socket>
-          <socketName>p9tuo5ggkl</socketName>
+          <socketName>x2c1hz1kll</socketName>
           <systemName>IQDA:AUTO:0147</systemName>
         </Socket>
         <Socket>
-          <socketName>rl1zxzm3ee</socketName>
+          <socketName>n77p4zh11p</socketName>
           <systemName>IQDA:AUTO:0148</systemName>
         </Socket>
         <Socket>
-          <socketName>rfu3novgqb</socketName>
+          <socketName>dbzbtaz1vi</socketName>
           <systemName>IQDA:AUTO:0149</systemName>
         </Socket>
         <Socket>
-          <socketName>sn9pjmqrvu</socketName>
+          <socketName>jskzl2pf1g</socketName>
           <systemName>IQDA:AUTO:0150</systemName>
         </Socket>
         <Socket>
-          <socketName>wctdw6jzsx</socketName>
+          <socketName>cx7wgvo9pr</socketName>
           <systemName>IQDA:AUTO:0151</systemName>
         </Socket>
         <Socket>
-          <socketName>rsu9k6de1t</socketName>
+          <socketName>sbhaacoyec</socketName>
           <systemName>IQDA:AUTO:0152</systemName>
         </Socket>
         <Socket>
-          <socketName>afovhmrhlv</socketName>
+          <socketName>sllvc3w3ji</socketName>
           <systemName>IQDA:AUTO:0153</systemName>
         </Socket>
         <Socket>
-          <socketName>uurj4ryoxh</socketName>
+          <socketName>qfvn37uuk6</socketName>
           <systemName>IQDA:AUTO:0154</systemName>
         </Socket>
         <Socket>
-          <socketName>q1jatvquq5</socketName>
+          <socketName>mdc8s3jfns</socketName>
           <systemName>IQDA:AUTO:0155</systemName>
         </Socket>
         <Socket>
-          <socketName>qkif127xb9</socketName>
+          <socketName>m426soywjf</socketName>
           <systemName>IQDA:AUTO:0156</systemName>
         </Socket>
         <Socket>
-          <socketName>tdyepz7buc</socketName>
+          <socketName>j6jaxckiku</socketName>
           <systemName>IQDA:AUTO:0157</systemName>
         </Socket>
         <Socket>
-          <socketName>elqy5io417</socketName>
+          <socketName>y3dk66gp5w</socketName>
           <systemName>IQDA:AUTO:0158</systemName>
         </Socket>
         <Socket>
-          <socketName>ox42t9g1ie</socketName>
+          <socketName>q684ntg68z</socketName>
           <systemName>IQDA:AUTO:0159</systemName>
         </Socket>
         <Socket>
-          <socketName>obk66mg5c2</socketName>
+          <socketName>om4iajqjju</socketName>
+          <systemName>IQDA:AUTO:0160</systemName>
+        </Socket>
+        <Socket>
+          <socketName>xismowodg1</socketName>
+          <systemName>IQDA:AUTO:0161</systemName>
+        </Socket>
+        <Socket>
+          <socketName>sh9bfl62k6</socketName>
           <systemName>IQDA:AUTO:0162</systemName>
         </Socket>
         <Socket>
-          <socketName>jtpo1xdfiy</socketName>
-          <systemName>IQDA:AUTO:0163</systemName>
-        </Socket>
-        <Socket>
-          <socketName>qpfwgi498q</socketName>
-          <systemName>IQDA:AUTO:0164</systemName>
-        </Socket>
-        <Socket>
-          <socketName>uu9ngic1d8</socketName>
+          <socketName>rr2bh4b3y2</socketName>
           <systemName>IQDA:AUTO:0165</systemName>
         </Socket>
         <Socket>
-          <socketName>ut3li24q1f</socketName>
+          <socketName>s5yrurb2pr</socketName>
           <systemName>IQDA:AUTO:0166</systemName>
         </Socket>
         <Socket>
-          <socketName>i33rj4eing</socketName>
+          <socketName>ke2ghbiv81</socketName>
           <systemName>IQDA:AUTO:0167</systemName>
         </Socket>
         <Socket>
-          <socketName>z58wkfvge5</socketName>
+          <socketName>hn85fkq3mu</socketName>
           <systemName>IQDA:AUTO:0168</systemName>
         </Socket>
         <Socket>
-          <socketName>rky12gcajt</socketName>
+          <socketName>q6g3b321ae</socketName>
           <systemName>IQDA:AUTO:0169</systemName>
         </Socket>
         <Socket>
-          <socketName>ozynj1gfbe</socketName>
+          <socketName>tvaz6i1cqp</socketName>
           <systemName>IQDA:AUTO:0170</systemName>
         </Socket>
         <Socket>
-          <socketName>h5ofe8mq2q</socketName>
+          <socketName>mnttgd2fyw</socketName>
           <systemName>IQDA:AUTO:0171</systemName>
         </Socket>
         <Socket>
-          <socketName>rsn6in84l5</socketName>
+          <socketName>ut261pc86w</socketName>
           <systemName>IQDA:AUTO:0172</systemName>
         </Socket>
         <Socket>
-          <socketName>rgvri5ict2</socketName>
+          <socketName>vsf3c8ehah</socketName>
           <systemName>IQDA:AUTO:0173</systemName>
         </Socket>
         <Socket>
-          <socketName>xoz291rsd7</socketName>
+          <socketName>x3re5wwleb</socketName>
           <systemName>IQDA:AUTO:0174</systemName>
         </Socket>
         <Socket>
-          <socketName>ttzobgiajl</socketName>
+          <socketName>rkpcy9uqzh</socketName>
           <systemName>IQDA:AUTO:0175</systemName>
         </Socket>
         <Socket>
-          <socketName>xhf95dcr8l</socketName>
+          <socketName>poico1m7zn</socketName>
           <systemName>IQDA:AUTO:0176</systemName>
         </Socket>
         <Socket>
-          <socketName>vg59lyan93</socketName>
+          <socketName>tnm4y4ehqv</socketName>
           <systemName>IQDA:AUTO:0177</systemName>
         </Socket>
         <Socket>
-          <socketName>aa3c9kk9qg</socketName>
+          <socketName>bthyduqz8i</socketName>
           <systemName>IQDA:AUTO:0178</systemName>
         </Socket>
         <Socket>
-          <socketName>hqxq1mh5rm</socketName>
+          <socketName>ybfidw39oo</socketName>
           <systemName>IQDA:AUTO:0179</systemName>
         </Socket>
         <Socket>
-          <socketName>q1xs2jaxjn</socketName>
+          <socketName>ljkrvrqaxt</socketName>
           <systemName>IQDA:AUTO:0180</systemName>
         </Socket>
         <Socket>
-          <socketName>ym5k5w116c</socketName>
+          <socketName>no5ksx91qw</socketName>
           <systemName>IQDA:AUTO:0181</systemName>
         </Socket>
         <Socket>
-          <socketName>wj5hii8yto</socketName>
+          <socketName>cok6o3u9d9</socketName>
           <systemName>IQDA:AUTO:0182</systemName>
         </Socket>
         <Socket>
-          <socketName>hsq3qhuh2c</socketName>
+          <socketName>fscz8rt6go</socketName>
           <systemName>IQDA:AUTO:0183</systemName>
         </Socket>
         <Socket>
-          <socketName>wika5xmgdv</socketName>
+          <socketName>ubf1nwjtyy</socketName>
           <systemName>IQDA:AUTO:0184</systemName>
         </Socket>
         <Socket>
-          <socketName>jd8u9oysz1</socketName>
+          <socketName>l858p35jj8</socketName>
           <systemName>IQDA:AUTO:0185</systemName>
         </Socket>
         <Socket>
-          <socketName>qn9d28s3gj</socketName>
+          <socketName>sepqxf8i3b</socketName>
           <systemName>IQDA:AUTO:0186</systemName>
         </Socket>
         <Socket>
-          <socketName>uyl35b26qm</socketName>
+          <socketName>mseaghafv9</socketName>
           <systemName>IQDA:AUTO:0187</systemName>
         </Socket>
         <Socket>
-          <socketName>ybz9pqa557</socketName>
+          <socketName>wfpvj5vw33</socketName>
           <systemName>IQDA:AUTO:0188</systemName>
         </Socket>
         <Socket>
-          <socketName>pklaf37zja</socketName>
+          <socketName>ik89p74366</socketName>
           <systemName>IQDA:AUTO:0189</systemName>
         </Socket>
         <Socket>
-          <socketName>xxbcc6pqtr</socketName>
+          <socketName>upawpe5w3t</socketName>
           <systemName>IQDA:AUTO:0190</systemName>
         </Socket>
         <Socket>
-          <socketName>t1u2633pe5</socketName>
+          <socketName>w22tisghjl</socketName>
           <systemName>IQDA:AUTO:0191</systemName>
         </Socket>
         <Socket>
-          <socketName>aqz6mhatqh</socketName>
+          <socketName>h57fnwwht9</socketName>
           <systemName>IQDA:AUTO:0192</systemName>
         </Socket>
         <Socket>
-          <socketName>y81f99mly5</socketName>
+          <socketName>mla6f7jys1</socketName>
           <systemName>IQDA:AUTO:0193</systemName>
         </Socket>
         <Socket>
-          <socketName>rmsxc251if</socketName>
+          <socketName>xoa26n599p</socketName>
           <systemName>IQDA:AUTO:0194</systemName>
         </Socket>
         <Socket>
-          <socketName>dz3gkvbqwt</socketName>
+          <socketName>v33rofa258</socketName>
           <systemName>IQDA:AUTO:0195</systemName>
         </Socket>
         <Socket>
-          <socketName>d7stnukfom</socketName>
+          <socketName>s9zbh7ue5d</socketName>
           <systemName>IQDA:AUTO:0196</systemName>
         </Socket>
         <Socket>
-          <socketName>ve9xbd88ft</socketName>
+          <socketName>cohv8qbbfp</socketName>
           <systemName>IQDA:AUTO:0197</systemName>
         </Socket>
         <Socket>
-          <socketName>moo4zsoejv</socketName>
+          <socketName>xhk7tcmzks</socketName>
           <systemName>IQDA:AUTO:0198</systemName>
         </Socket>
         <Socket>
-          <socketName>a2t3yw4hjo</socketName>
+          <socketName>njs4e719nu</socketName>
           <systemName>IQDA:AUTO:0199</systemName>
         </Socket>
         <Socket>
-          <socketName>w8c4gw533s</socketName>
+          <socketName>nv8bfbhp6g</socketName>
           <systemName>IQDA:AUTO:0200</systemName>
         </Socket>
         <Socket>
-          <socketName>hyleblazfb</socketName>
+          <socketName>bdovakpsun</socketName>
           <systemName>IQDA:AUTO:0201</systemName>
         </Socket>
         <Socket>
-          <socketName>k1xu5f5hew</socketName>
+          <socketName>y58fy4117r</socketName>
           <systemName>IQDA:AUTO:0202</systemName>
         </Socket>
         <Socket>
-          <socketName>a7tqqymuxi</socketName>
+          <socketName>wwgz1qnc5y</socketName>
           <systemName>IQDA:AUTO:0203</systemName>
         </Socket>
         <Socket>
-          <socketName>jlma74rsfk</socketName>
+          <socketName>mfurzc69ng</socketName>
           <systemName>IQDA:AUTO:0204</systemName>
         </Socket>
         <Socket>
-          <socketName>ledhd2jp1g</socketName>
+          <socketName>c6ysl8eknz</socketName>
           <systemName>IQDA:AUTO:0205</systemName>
         </Socket>
         <Socket>
-          <socketName>odcmcvrmec</socketName>
+          <socketName>sed58o4rb3</socketName>
           <systemName>IQDA:AUTO:0206</systemName>
         </Socket>
         <Socket>
-          <socketName>t7mlhqvrfk</socketName>
+          <socketName>sixurbc5w8</socketName>
           <systemName>IQDA:AUTO:0207</systemName>
         </Socket>
         <Socket>
-          <socketName>xby4wlgqsu</socketName>
+          <socketName>ussxqvjfkt</socketName>
           <systemName>IQDA:AUTO:0208</systemName>
         </Socket>
         <Socket>
-          <socketName>v9whofq5st</socketName>
+          <socketName>n31myn5t6k</socketName>
           <systemName>IQDA:AUTO:0209</systemName>
         </Socket>
         <Socket>
-          <socketName>xh1q6ua5o5</socketName>
+          <socketName>wkbf576tby</socketName>
           <systemName>IQDA:AUTO:0210</systemName>
         </Socket>
         <Socket>
-          <socketName>xafre572oo</socketName>
+          <socketName>h5w28psula</socketName>
           <systemName>IQDA:AUTO:0211</systemName>
         </Socket>
         <Socket>
-          <socketName>dihj1tg2nf</socketName>
+          <socketName>ap5beeeplz</socketName>
           <systemName>IQDA:AUTO:0212</systemName>
         </Socket>
         <Socket>
-          <socketName>s794w4l8g5</socketName>
+          <socketName>uyvtbrdb6p</socketName>
           <systemName>IQDA:AUTO:0213</systemName>
         </Socket>
         <Socket>
-          <socketName>avbnxmgxj6</socketName>
+          <socketName>ybdz4sq5my</socketName>
           <systemName>IQDA:AUTO:0214</systemName>
         </Socket>
         <Socket>
-          <socketName>sbff5w1tj9</socketName>
+          <socketName>rv2vhlehf5</socketName>
           <systemName>IQDA:AUTO:0215</systemName>
         </Socket>
         <Socket>
-          <socketName>izqn79772t</socketName>
+          <socketName>vt7o3wbguk</socketName>
           <systemName>IQDA:AUTO:0216</systemName>
         </Socket>
         <Socket>
-          <socketName>u375jydlv7</socketName>
+          <socketName>z7ykjh6syj</socketName>
           <systemName>IQDA:AUTO:0217</systemName>
         </Socket>
         <Socket>
-          <socketName>xwlplh7xhi</socketName>
+          <socketName>thp1mbe54a</socketName>
           <systemName>IQDA:AUTO:0218</systemName>
         </Socket>
         <Socket>
-          <socketName>osl13wczsn</socketName>
+          <socketName>y6rmi1w4ro</socketName>
           <systemName>IQDA:AUTO:0219</systemName>
         </Socket>
         <Socket>
-          <socketName>ua7wt4s3hm</socketName>
+          <socketName>k95a8cp9yb</socketName>
           <systemName>IQDA:AUTO:0220</systemName>
         </Socket>
         <Socket>
-          <socketName>e3p9inc2k9</socketName>
+          <socketName>xribeapv4h</socketName>
           <systemName>IQDA:AUTO:0221</systemName>
         </Socket>
         <Socket>
-          <socketName>z8k5hdr6g3</socketName>
+          <socketName>dx5ut2h1ph</socketName>
           <systemName>IQDA:AUTO:0222</systemName>
         </Socket>
         <Socket>
-          <socketName>vy6li2pd2z</socketName>
+          <socketName>tdsjxu8v3w</socketName>
           <systemName>IQDA:AUTO:0223</systemName>
         </Socket>
         <Socket>
-          <socketName>ld8ij1zmhd</socketName>
+          <socketName>vucnq54u4w</socketName>
           <systemName>IQDA:AUTO:0224</systemName>
         </Socket>
         <Socket>
-          <socketName>tsoeizbonx</socketName>
+          <socketName>ztssn58q86</socketName>
           <systemName>IQDA:AUTO:0225</systemName>
         </Socket>
         <Socket>
-          <socketName>qaokzgm5to</socketName>
+          <socketName>qxxeg95a9z</socketName>
           <systemName>IQDA:AUTO:0226</systemName>
         </Socket>
         <Socket>
-          <socketName>m274xqkjcm</socketName>
+          <socketName>sfmfeo7fup</socketName>
           <systemName>IQDA:AUTO:0227</systemName>
         </Socket>
         <Socket>
-          <socketName>szz83opf3h</socketName>
+          <socketName>q2wojm7med</socketName>
           <systemName>IQDA:AUTO:0228</systemName>
         </Socket>
         <Socket>
-          <socketName>l5xt2zegxl</socketName>
+          <socketName>jyy3bix7wu</socketName>
           <systemName>IQDA:AUTO:0229</systemName>
         </Socket>
         <Socket>
-          <socketName>j2koojb2aj</socketName>
+          <socketName>c81e1kei24</socketName>
           <systemName>IQDA:AUTO:0230</systemName>
         </Socket>
         <Socket>
-          <socketName>u71xit6d2t</socketName>
+          <socketName>avazikrevg</socketName>
           <systemName>IQDA:AUTO:0231</systemName>
         </Socket>
         <Socket>
-          <socketName>x1uvhysp59</socketName>
+          <socketName>qhg56abewk</socketName>
           <systemName>IQDA:AUTO:0232</systemName>
         </Socket>
         <Socket>
-          <socketName>l6vj5b7rlq</socketName>
+          <socketName>g3nqf73sal</socketName>
           <systemName>IQDA:AUTO:0233</systemName>
         </Socket>
         <Socket>
-          <socketName>vgt2fnbfmo</socketName>
+          <socketName>v3817e59en</socketName>
           <systemName>IQDA:AUTO:0234</systemName>
         </Socket>
         <Socket>
-          <socketName>l7ti6c6dtl</socketName>
+          <socketName>uk5jh8r7ly</socketName>
           <systemName>IQDA:AUTO:0235</systemName>
         </Socket>
         <Socket>
-          <socketName>xyrq41nmx2</socketName>
+          <socketName>qtvddsl3ad</socketName>
           <systemName>IQDA:AUTO:0236</systemName>
         </Socket>
         <Socket>
-          <socketName>twup3ewnrj</socketName>
+          <socketName>vcrpdlbdru</socketName>
           <systemName>IQDA:AUTO:0237</systemName>
         </Socket>
         <Socket>
-          <socketName>qzyrp426md</socketName>
+          <socketName>tu6bq5y562</socketName>
           <systemName>IQDA:AUTO:0238</systemName>
         </Socket>
         <Socket>
-          <socketName>uogy2clatd</socketName>
+          <socketName>lqv3ac1jkp</socketName>
           <systemName>IQDA:AUTO:0239</systemName>
         </Socket>
         <Socket>
-          <socketName>jhaocuzjdo</socketName>
+          <socketName>uwus6lhytn</socketName>
           <systemName>IQDA:AUTO:0240</systemName>
         </Socket>
         <Socket>
-          <socketName>dojz2zf84e</socketName>
+          <socketName>lm9f7p7vmr</socketName>
           <systemName>IQDA:AUTO:0241</systemName>
         </Socket>
         <Socket>
-          <socketName>igqjv7jhv8</socketName>
+          <socketName>wj6tzmxzrx</socketName>
           <systemName>IQDA:AUTO:0242</systemName>
         </Socket>
         <Socket>
-          <socketName>sfkcj7jl75</socketName>
+          <socketName>talb4ieoh1</socketName>
           <systemName>IQDA:AUTO:0243</systemName>
         </Socket>
         <Socket>
-          <socketName>uy2ukvb1u4</socketName>
+          <socketName>hgc9mqpdpk</socketName>
           <systemName>IQDA:AUTO:0244</systemName>
         </Socket>
         <Socket>
-          <socketName>x9a2sfq1cg</socketName>
+          <socketName>qxri56ycfb</socketName>
           <systemName>IQDA:AUTO:0245</systemName>
         </Socket>
         <Socket>
-          <socketName>ev2m8mgxxj</socketName>
+          <socketName>ru68hiofz4</socketName>
           <systemName>IQDA:AUTO:0246</systemName>
         </Socket>
         <Socket>
-          <socketName>s9bxq6884a</socketName>
+          <socketName>wjsbose9ni</socketName>
           <systemName>IQDA:AUTO:0247</systemName>
         </Socket>
         <Socket>
-          <socketName>wasunn3m7s</socketName>
+          <socketName>u8eb6w6svz</socketName>
           <systemName>IQDA:AUTO:0248</systemName>
         </Socket>
         <Socket>
-          <socketName>n8vpvpkxqi</socketName>
+          <socketName>i5r732z79w</socketName>
           <systemName>IQDA:AUTO:0249</systemName>
         </Socket>
         <Socket>
-          <socketName>q484cb9gq1</socketName>
+          <socketName>xxo3bwu4tb</socketName>
           <systemName>IQDA:AUTO:0250</systemName>
         </Socket>
         <Socket>
-          <socketName>uyekktofmf</socketName>
+          <socketName>s4np58jivd</socketName>
           <systemName>IQDA:AUTO:0251</systemName>
         </Socket>
         <Socket>
-          <socketName>y13ywcpsk2</socketName>
+          <socketName>vx4695avvl</socketName>
           <systemName>IQDA:AUTO:0252</systemName>
         </Socket>
         <Socket>
-          <socketName>zvel474lya</socketName>
+          <socketName>ckso1hajam</socketName>
           <systemName>IQDA:AUTO:0253</systemName>
         </Socket>
         <Socket>
-          <socketName>ntc6weayn9</socketName>
+          <socketName>mtle2ohqax</socketName>
           <systemName>IQDA:AUTO:0254</systemName>
         </Socket>
         <Socket>
-          <socketName>eo5osveihi</socketName>
+          <socketName>xuh75srz1b</socketName>
           <systemName>IQDA:AUTO:0255</systemName>
         </Socket>
         <Socket>
-          <socketName>mqhceoa1ok</socketName>
+          <socketName>shug1r7lm6</socketName>
           <systemName>IQDA:AUTO:0256</systemName>
         </Socket>
         <Socket>
-          <socketName>poeav59s4t</socketName>
+          <socketName>a61jjzq9kh</socketName>
           <systemName>IQDA:AUTO:0257</systemName>
         </Socket>
         <Socket>
-          <socketName>wzo5nneens</socketName>
+          <socketName>h4gz4ig1bo</socketName>
           <systemName>IQDA:AUTO:0258</systemName>
         </Socket>
         <Socket>
-          <socketName>c9i798wsdb</socketName>
+          <socketName>wo8cpupd6r</socketName>
           <systemName>IQDA:AUTO:0259</systemName>
         </Socket>
         <Socket>
-          <socketName>sofzdz9uuz</socketName>
+          <socketName>ewo8rqgsbz</socketName>
           <systemName>IQDA:AUTO:0260</systemName>
         </Socket>
         <Socket>
-          <socketName>wfjzq2ekud</socketName>
+          <socketName>c2narrjnm3</socketName>
           <systemName>IQDA:AUTO:0261</systemName>
         </Socket>
         <Socket>
-          <socketName>qa9jkl1796</socketName>
+          <socketName>zb6x8pake7</socketName>
           <systemName>IQDA:AUTO:0262</systemName>
         </Socket>
         <Socket>
-          <socketName>mtc6svx2t2</socketName>
+          <socketName>lr4ij1u56y</socketName>
           <systemName>IQDA:AUTO:0263</systemName>
         </Socket>
         <Socket>
-          <socketName>fpqvgmpr6h</socketName>
+          <socketName>hw4dfb4ms6</socketName>
           <systemName>IQDA:AUTO:0264</systemName>
         </Socket>
         <Socket>
-          <socketName>r776pkvv2a</socketName>
+          <socketName>b378gkyhva</socketName>
           <systemName>IQDA:AUTO:0265</systemName>
         </Socket>
         <Socket>
-          <socketName>aoyiitfxub</socketName>
+          <socketName>t13vt7pj7l</socketName>
           <systemName>IQDA:AUTO:0266</systemName>
         </Socket>
         <Socket>
-          <socketName>vq9nwg13y2</socketName>
+          <socketName>bts4p8dtye</socketName>
           <systemName>IQDA:AUTO:0267</systemName>
         </Socket>
         <Socket>
-          <socketName>ukyoji8fj8</socketName>
+          <socketName>qzwopn3sbr</socketName>
           <systemName>IQDA:AUTO:0268</systemName>
         </Socket>
         <Socket>
-          <socketName>gwiq4l5vc5</socketName>
+          <socketName>b6kiqdscy7</socketName>
           <systemName>IQDA:AUTO:0269</systemName>
         </Socket>
         <Socket>
-          <socketName>zrspjitoy8</socketName>
+          <socketName>vuc9pu2ef6</socketName>
           <systemName>IQDA:AUTO:0270</systemName>
         </Socket>
         <Socket>
-          <socketName>qgqyaf1lh8</socketName>
+          <socketName>dl4keuixr9</socketName>
           <systemName>IQDA:AUTO:0271</systemName>
         </Socket>
         <Socket>
-          <socketName>jpagiwt4eb</socketName>
+          <socketName>d53gstzmi3</socketName>
           <systemName>IQDA:AUTO:0272</systemName>
         </Socket>
         <Socket>
-          <socketName>jckjujxov6</socketName>
+          <socketName>xjsl8fpzgz</socketName>
           <systemName>IQDA:AUTO:0273</systemName>
         </Socket>
         <Socket>
-          <socketName>wnoz2xu2x1</socketName>
+          <socketName>hmzha6j2b3</socketName>
           <systemName>IQDA:AUTO:0274</systemName>
         </Socket>
         <Socket>
-          <socketName>ae8824w3b9</socketName>
+          <socketName>f3m9deay7o</socketName>
           <systemName>IQDA:AUTO:0275</systemName>
         </Socket>
         <Socket>
-          <socketName>l57b48ud9o</socketName>
+          <socketName>eoze3kv8ok</socketName>
+          <systemName>IQDA:AUTO:0276</systemName>
+        </Socket>
+        <Socket>
+          <socketName>qbrwls7qy8</socketName>
           <systemName>IQDA:AUTO:0277</systemName>
         </Socket>
         <Socket>
-          <socketName>sfwfes3xmy</socketName>
+          <socketName>dxfmbz4kbi</socketName>
           <systemName>IQDA:AUTO:0278</systemName>
         </Socket>
         <Socket>
-          <socketName>xguw18812o</socketName>
+          <socketName>yeoxdhuf8d</socketName>
+          <systemName>IQDA:AUTO:0280</systemName>
+        </Socket>
+        <Socket>
+          <socketName>uw158l32gq</socketName>
           <systemName>IQDA:AUTO:0281</systemName>
         </Socket>
         <Socket>
-          <socketName>ef1uei3jts</socketName>
-          <systemName>IQDA:AUTO:0282</systemName>
-        </Socket>
-        <Socket>
-          <socketName>rmbwhrq7kk</socketName>
+          <socketName>srf99x2a35</socketName>
           <systemName>IQDA:AUTO:0284</systemName>
         </Socket>
         <Socket>
-          <socketName>hvx3x5qqfc</socketName>
+          <socketName>mlnc4k6qn4</socketName>
           <systemName>IQDA:AUTO:0285</systemName>
         </Socket>
         <Socket>
-          <socketName>tsf69fftgh</socketName>
-          <systemName>IQDA:AUTO:0286</systemName>
-        </Socket>
-        <Socket>
-          <socketName>enu8dyttxg</socketName>
+          <socketName>fbutbqurtm</socketName>
           <systemName>IQDA:AUTO:0287</systemName>
         </Socket>
         <Socket>
-          <socketName>watnmyjc18</socketName>
+          <socketName>ue1sp3epkv</socketName>
           <systemName>IQDA:AUTO:0288</systemName>
         </Socket>
         <Socket>
-          <socketName>y8nmi9anqx</socketName>
+          <socketName>yc9ce89f3q</socketName>
           <systemName>IQDA:AUTO:0289</systemName>
         </Socket>
         <Socket>
-          <socketName>uphnlsva8r</socketName>
+          <socketName>yn8jc934ui</socketName>
           <systemName>IQDA:AUTO:0290</systemName>
         </Socket>
         <Socket>
-          <socketName>kxuwd7lhnl</socketName>
+          <socketName>uifr65z46p</socketName>
           <systemName>IQDA:AUTO:0291</systemName>
         </Socket>
         <Socket>
-          <socketName>q1ycjjkkvl</socketName>
+          <socketName>xfj7cgvxud</socketName>
           <systemName>IQDA:AUTO:0292</systemName>
         </Socket>
         <Socket>
-          <socketName>tb39962z6z</socketName>
+          <socketName>jd37fbq7r6</socketName>
           <systemName>IQDA:AUTO:0293</systemName>
         </Socket>
         <Socket>
-          <socketName>rm6cv9vp7x</socketName>
+          <socketName>hybf4lq97w</socketName>
           <systemName>IQDA:AUTO:0294</systemName>
         </Socket>
         <Socket>
-          <socketName>h1cwtbco2p</socketName>
+          <socketName>qw2295xlf4</socketName>
           <systemName>IQDA:AUTO:0295</systemName>
         </Socket>
         <Socket>
-          <socketName>wqfya6p1nf</socketName>
+          <socketName>v7eb4hjqlh</socketName>
+          <systemName>IQDA:AUTO:0296</systemName>
+        </Socket>
+        <Socket>
+          <socketName>seb9z2saox</socketName>
           <systemName>IQDA:AUTO:0297</systemName>
         </Socket>
         <Socket>
-          <socketName>wjqrl1owgi</socketName>
-          <systemName>IQDA:AUTO:0299</systemName>
+          <socketName>tnyp972s83</socketName>
+          <systemName>IQDA:AUTO:0298</systemName>
         </Socket>
         <Socket>
-          <socketName>wcqtnj3umh</socketName>
+          <socketName>t5py3v44q1</socketName>
           <systemName>IQDA:AUTO:0300</systemName>
         </Socket>
         <Socket>
-          <socketName>rkt186tey5</socketName>
-          <systemName>IQDA:AUTO:0301</systemName>
-        </Socket>
-        <Socket>
-          <socketName>fz4ckosp52</socketName>
+          <socketName>jusfcdq3al</socketName>
           <systemName>IQDA:AUTO:0302</systemName>
         </Socket>
         <Socket>
-          <socketName>rdbaz1y5xn</socketName>
+          <socketName>wa9aa3g946</socketName>
           <systemName>IQDA:AUTO:0303</systemName>
         </Socket>
         <Socket>
-          <socketName>prcpios5gx</socketName>
+          <socketName>k46amjh2pb</socketName>
           <systemName>IQDA:AUTO:0304</systemName>
         </Socket>
         <Socket>
-          <socketName>m7a7rjmy15</socketName>
+          <socketName>fsdt3wsk4g</socketName>
           <systemName>IQDA:AUTO:0305</systemName>
         </Socket>
         <Socket>
-          <socketName>em8ral5431</socketName>
+          <socketName>tntw1l2jv1</socketName>
           <systemName>IQDA:AUTO:0306</systemName>
         </Socket>
         <Socket>
-          <socketName>fmuf1m85pp</socketName>
+          <socketName>y93os8mwqf</socketName>
           <systemName>IQDA:AUTO:0307</systemName>
         </Socket>
         <Socket>
-          <socketName>ogxx6lf12u</socketName>
+          <socketName>ahox88rf5o</socketName>
           <systemName>IQDA:AUTO:0308</systemName>
         </Socket>
         <Socket>
-          <socketName>x3fkkd47dt</socketName>
+          <socketName>ac6zbsi1ng</socketName>
           <systemName>IQDA:AUTO:0309</systemName>
         </Socket>
         <Socket>
-          <socketName>ctoy7zlctz</socketName>
+          <socketName>esopgdv22x</socketName>
           <systemName>IQDA:AUTO:0310</systemName>
         </Socket>
         <Socket>
-          <socketName>mqdrva4bs6</socketName>
+          <socketName>cy6vy3p439</socketName>
           <systemName>IQDA:AUTO:0311</systemName>
         </Socket>
         <Socket>
-          <socketName>hne2wqa65s</socketName>
+          <socketName>qfsxsok3u4</socketName>
           <systemName>IQDA:AUTO:0312</systemName>
         </Socket>
         <Socket>
-          <socketName>mmps9nrsw7</socketName>
+          <socketName>y9bf7ze6yv</socketName>
           <systemName>IQDA:AUTO:0313</systemName>
         </Socket>
         <Socket>
-          <socketName>cekva2cath</socketName>
+          <socketName>cp2drth5nk</socketName>
           <systemName>IQDA:AUTO:0314</systemName>
         </Socket>
         <Socket>
-          <socketName>zgjjd162rn</socketName>
+          <socketName>jfxmp8vzxn</socketName>
           <systemName>IQDA:AUTO:0315</systemName>
         </Socket>
         <Socket>
-          <socketName>it91feeiil</socketName>
+          <socketName>cw87f5ki23</socketName>
           <systemName>IQDA:AUTO:0316</systemName>
         </Socket>
         <Socket>
-          <socketName>cjggu1zqqv</socketName>
+          <socketName>vdw8jfs99a</socketName>
           <systemName>IQDA:AUTO:0317</systemName>
         </Socket>
         <Socket>
-          <socketName>fd1abyr558</socketName>
+          <socketName>bwfj4v7kz8</socketName>
           <systemName>IQDA:AUTO:0318</systemName>
         </Socket>
         <Socket>
-          <socketName>kzsi1xnrp1</socketName>
+          <socketName>q639p5r8wl</socketName>
           <systemName>IQDA:AUTO:0319</systemName>
         </Socket>
         <Socket>
-          <socketName>ra12m98igx</socketName>
+          <socketName>ybtbna95yj</socketName>
           <systemName>IQDA:AUTO:0320</systemName>
         </Socket>
         <Socket>
-          <socketName>vbk28rn3ik</socketName>
+          <socketName>u1hydxw8zi</socketName>
           <systemName>IQDA:AUTO:0321</systemName>
         </Socket>
         <Socket>
-          <socketName>wf8qazotj1</socketName>
+          <socketName>w837xvzouo</socketName>
           <systemName>IQDA:AUTO:0322</systemName>
         </Socket>
         <Socket>
-          <socketName>yl3w3icqow</socketName>
+          <socketName>m4e8ks5plt</socketName>
           <systemName>IQDA:AUTO:0323</systemName>
         </Socket>
         <Socket>
-          <socketName>hidkpek2o3</socketName>
+          <socketName>phpml9dn8m</socketName>
+          <systemName>IQDA:AUTO:0324</systemName>
+        </Socket>
+        <Socket>
+          <socketName>zbtn5tzui4</socketName>
+          <systemName>IQDA:AUTO:0325</systemName>
+        </Socket>
+        <Socket>
+          <socketName>fsh3o87fc4</socketName>
+          <systemName>IQDA:AUTO:0326</systemName>
+        </Socket>
+        <Socket>
+          <socketName>l1lsgtizz4</socketName>
         </Socket>
       </Actions>
       <MaleSocket>
@@ -19019,8 +19120,281 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
         </AbstractMaleSocket>
       </MaleSocket>
     </ActionDispatcher>
-    <ActionFindTableRowOrColumn class="jmri.jmrit.logixng.actions.configurexml.ActionFindTableRowOrColumnXml" includeCellsWithoutHeader="no">
+    <ActionDispatcher class="jmri.jmrit.logixng.actions.configurexml.ActionDispatcherXml">
       <systemName>IQDA:AUTO:0038</systemName>
+      <trainInfoFileName>MyTrainInfo.xml</trainInfoFileName>
+      <addressing>Direct</addressing>
+      <reference>{IM1}</reference>
+      <localVariable>MyVar</localVariable>
+      <formula>a+b</formula>
+      <operation>
+        <addressing>Direct</addressing>
+        <enum>TrainPriority</enum>
+        <listenToMemory>no</listenToMemory>
+      </operation>
+      <dataAddressing>Direct</dataAddressing>
+      <dataReference>{IM3}</dataReference>
+      <dataLocalVariable>SomeVar</dataLocalVariable>
+      <dataFormula>x+y</dataFormula>
+      <resetOption>false</resetOption>
+      <terminateOption>false</terminateOption>
+      <trainPriority>2</trainPriority>
+      <MaleSocket>
+        <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
+        <AbstractMaleSocket enabled="no" locked="no" system="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
+          <errorHandling>Default</errorHandling>
+          <LocalVariable>
+            <name>A1</name>
+            <type>None</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A2</name>
+            <type>Integer</type>
+            <data>32</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A3</name>
+            <type>FloatingNumber</type>
+            <data>41.429</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A4</name>
+            <type>String</type>
+            <data>My string</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A5</name>
+            <type>Array</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A6</name>
+            <type>Map</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A7</name>
+            <type>LocalVariable</type>
+            <data>index</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A8</name>
+            <type>Memory</type>
+            <data>IM2</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A9</name>
+            <type>Reference</type>
+            <data>{IM3}</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A10</name>
+            <type>Formula</type>
+            <data>index * 2</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A11</name>
+            <type>ScriptExpression</type>
+            <data>sensors.provide("mySensor)"</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A12</name>
+            <type>ScriptFile</type>
+            <data>scripts:InitLogixNGVariable</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A13</name>
+            <type>LogixNG_Table</type>
+            <data>MyTable</data>
+          </LocalVariable>
+        </AbstractMaleSocket>
+      </MaleSocket>
+    </ActionDispatcher>
+    <ActionDispatcher class="jmri.jmrit.logixng.actions.configurexml.ActionDispatcherXml">
+      <systemName>IQDA:AUTO:0039</systemName>
+      <trainInfoFileName>MyOtherTrainInfo.xml</trainInfoFileName>
+      <addressing>LocalVariable</addressing>
+      <reference>{IM2}</reference>
+      <localVariable>MyOtherVar</localVariable>
+      <formula>a+b+c</formula>
+      <operation>
+        <addressing>Direct</addressing>
+        <enum>TrainPriority</enum>
+        <listenToMemory>no</listenToMemory>
+      </operation>
+      <dataAddressing>Direct</dataAddressing>
+      <dataReference>{IM5}</dataReference>
+      <dataLocalVariable>SomeOtherVar</dataLocalVariable>
+      <dataFormula>x+y+z</dataFormula>
+      <resetOption>false</resetOption>
+      <terminateOption>true</terminateOption>
+      <trainPriority>4</trainPriority>
+      <MaleSocket>
+        <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
+        <AbstractMaleSocket enabled="no" locked="no" system="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
+          <errorHandling>Default</errorHandling>
+          <LocalVariable>
+            <name>A1</name>
+            <type>None</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A2</name>
+            <type>Integer</type>
+            <data>32</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A3</name>
+            <type>FloatingNumber</type>
+            <data>41.429</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A4</name>
+            <type>String</type>
+            <data>My string</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A5</name>
+            <type>Array</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A6</name>
+            <type>Map</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A7</name>
+            <type>LocalVariable</type>
+            <data>index</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A8</name>
+            <type>Memory</type>
+            <data>IM2</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A9</name>
+            <type>Reference</type>
+            <data>{IM3}</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A10</name>
+            <type>Formula</type>
+            <data>index * 2</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A11</name>
+            <type>ScriptExpression</type>
+            <data>sensors.provide("mySensor)"</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A12</name>
+            <type>ScriptFile</type>
+            <data>scripts:InitLogixNGVariable</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A13</name>
+            <type>LogixNG_Table</type>
+            <data>MyTable</data>
+          </LocalVariable>
+        </AbstractMaleSocket>
+      </MaleSocket>
+    </ActionDispatcher>
+    <ActionDispatcher class="jmri.jmrit.logixng.actions.configurexml.ActionDispatcherXml">
+      <systemName>IQDA:AUTO:0040</systemName>
+      <trainInfoFileName>MyOtherTrainInfo.xml</trainInfoFileName>
+      <addressing>LocalVariable</addressing>
+      <reference>{IM8}</reference>
+      <localVariable>MyOtherVar</localVariable>
+      <formula>a+c</formula>
+      <operation>
+        <addressing>Direct</addressing>
+        <enum>TrainPriority</enum>
+        <listenToMemory>no</listenToMemory>
+      </operation>
+      <dataAddressing>Direct</dataAddressing>
+      <dataReference>{IM7}</dataReference>
+      <dataLocalVariable>SomeOtherVar</dataLocalVariable>
+      <dataFormula>x+z</dataFormula>
+      <resetOption>true</resetOption>
+      <terminateOption>false</terminateOption>
+      <trainPriority>8</trainPriority>
+      <MaleSocket>
+        <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
+        <AbstractMaleSocket enabled="no" locked="no" system="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
+          <errorHandling>Default</errorHandling>
+          <LocalVariable>
+            <name>A1</name>
+            <type>None</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A2</name>
+            <type>Integer</type>
+            <data>32</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A3</name>
+            <type>FloatingNumber</type>
+            <data>41.429</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A4</name>
+            <type>String</type>
+            <data>My string</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A5</name>
+            <type>Array</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A6</name>
+            <type>Map</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A7</name>
+            <type>LocalVariable</type>
+            <data>index</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A8</name>
+            <type>Memory</type>
+            <data>IM2</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A9</name>
+            <type>Reference</type>
+            <data>{IM3}</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A10</name>
+            <type>Formula</type>
+            <data>index * 2</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A11</name>
+            <type>ScriptExpression</type>
+            <data>sensors.provide("mySensor)"</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A12</name>
+            <type>ScriptFile</type>
+            <data>scripts:InitLogixNGVariable</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A13</name>
+            <type>LogixNG_Table</type>
+            <data>MyTable</data>
+          </LocalVariable>
+        </AbstractMaleSocket>
+      </MaleSocket>
+    </ActionDispatcher>
+    <ActionFindTableRowOrColumn class="jmri.jmrit.logixng.actions.configurexml.ActionFindTableRowOrColumnXml" includeCellsWithoutHeader="no">
+      <systemName>IQDA:AUTO:0041</systemName>
       <namedBean>
         <addressing>Direct</addressing>
         <listenToMemory>no</listenToMemory>
@@ -19102,258 +19476,6 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionFindTableRowOrColumn>
     <ActionFindTableRowOrColumn class="jmri.jmrit.logixng.actions.configurexml.ActionFindTableRowOrColumnXml" includeCellsWithoutHeader="no">
-      <systemName>IQDA:AUTO:0039</systemName>
-      <comment>A comment</comment>
-      <namedBean>
-        <addressing>Direct</addressing>
-        <name>IQT1</name>
-        <listenToMemory>no</listenToMemory>
-      </namedBean>
-      <rowOrColumnName />
-      <tableRowOrColumn>Row</tableRowOrColumn>
-      <localVariableNamedBean />
-      <localVariableRow />
-      <MaleSocket>
-        <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
-        <AbstractMaleSocket enabled="yes" locked="no" system="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>Default</errorHandling>
-          <LocalVariable>
-            <name>A1</name>
-            <type>None</type>
-            <data />
-          </LocalVariable>
-          <LocalVariable>
-            <name>A2</name>
-            <type>Integer</type>
-            <data>32</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A3</name>
-            <type>FloatingNumber</type>
-            <data>41.429</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A4</name>
-            <type>String</type>
-            <data>My string</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A5</name>
-            <type>Array</type>
-            <data />
-          </LocalVariable>
-          <LocalVariable>
-            <name>A6</name>
-            <type>Map</type>
-            <data />
-          </LocalVariable>
-          <LocalVariable>
-            <name>A7</name>
-            <type>LocalVariable</type>
-            <data>index</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A8</name>
-            <type>Memory</type>
-            <data>IM2</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A9</name>
-            <type>Reference</type>
-            <data>{IM3}</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A10</name>
-            <type>Formula</type>
-            <data>index * 2</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A11</name>
-            <type>ScriptExpression</type>
-            <data>sensors.provide("mySensor)"</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A12</name>
-            <type>ScriptFile</type>
-            <data>scripts:InitLogixNGVariable</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A13</name>
-            <type>LogixNG_Table</type>
-            <data>MyTable</data>
-          </LocalVariable>
-        </AbstractMaleSocket>
-      </MaleSocket>
-    </ActionFindTableRowOrColumn>
-    <ActionFindTableRowOrColumn class="jmri.jmrit.logixng.actions.configurexml.ActionFindTableRowOrColumnXml" includeCellsWithoutHeader="no">
-      <systemName>IQDA:AUTO:0040</systemName>
-      <comment>A comment</comment>
-      <namedBean>
-        <addressing>Direct</addressing>
-        <name>IQT1</name>
-        <listenToMemory>no</listenToMemory>
-      </namedBean>
-      <rowOrColumnName>Signal before</rowOrColumnName>
-      <tableRowOrColumn>Row</tableRowOrColumn>
-      <localVariableNamedBean>variableNamedBean</localVariableNamedBean>
-      <localVariableRow>variableRow</localVariableRow>
-      <MaleSocket>
-        <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
-        <AbstractMaleSocket enabled="yes" locked="no" system="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>Default</errorHandling>
-          <LocalVariable>
-            <name>A1</name>
-            <type>None</type>
-            <data />
-          </LocalVariable>
-          <LocalVariable>
-            <name>A2</name>
-            <type>Integer</type>
-            <data>32</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A3</name>
-            <type>FloatingNumber</type>
-            <data>41.429</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A4</name>
-            <type>String</type>
-            <data>My string</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A5</name>
-            <type>Array</type>
-            <data />
-          </LocalVariable>
-          <LocalVariable>
-            <name>A6</name>
-            <type>Map</type>
-            <data />
-          </LocalVariable>
-          <LocalVariable>
-            <name>A7</name>
-            <type>LocalVariable</type>
-            <data>index</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A8</name>
-            <type>Memory</type>
-            <data>IM2</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A9</name>
-            <type>Reference</type>
-            <data>{IM3}</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A10</name>
-            <type>Formula</type>
-            <data>index * 2</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A11</name>
-            <type>ScriptExpression</type>
-            <data>sensors.provide("mySensor)"</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A12</name>
-            <type>ScriptFile</type>
-            <data>scripts:InitLogixNGVariable</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A13</name>
-            <type>LogixNG_Table</type>
-            <data>MyTable</data>
-          </LocalVariable>
-        </AbstractMaleSocket>
-      </MaleSocket>
-    </ActionFindTableRowOrColumn>
-    <ActionFindTableRowOrColumn class="jmri.jmrit.logixng.actions.configurexml.ActionFindTableRowOrColumnXml" includeCellsWithoutHeader="no">
-      <systemName>IQDA:AUTO:0041</systemName>
-      <comment>A comment</comment>
-      <namedBean>
-        <addressing>Direct</addressing>
-        <name>IQT1</name>
-        <listenToMemory>no</listenToMemory>
-      </namedBean>
-      <rowOrColumnName>2</rowOrColumnName>
-      <tableRowOrColumn>Column</tableRowOrColumn>
-      <localVariableNamedBean />
-      <localVariableRow />
-      <MaleSocket>
-        <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
-        <AbstractMaleSocket enabled="yes" locked="no" system="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>Default</errorHandling>
-          <LocalVariable>
-            <name>A1</name>
-            <type>None</type>
-            <data />
-          </LocalVariable>
-          <LocalVariable>
-            <name>A2</name>
-            <type>Integer</type>
-            <data>32</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A3</name>
-            <type>FloatingNumber</type>
-            <data>41.429</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A4</name>
-            <type>String</type>
-            <data>My string</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A5</name>
-            <type>Array</type>
-            <data />
-          </LocalVariable>
-          <LocalVariable>
-            <name>A6</name>
-            <type>Map</type>
-            <data />
-          </LocalVariable>
-          <LocalVariable>
-            <name>A7</name>
-            <type>LocalVariable</type>
-            <data>index</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A8</name>
-            <type>Memory</type>
-            <data>IM2</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A9</name>
-            <type>Reference</type>
-            <data>{IM3}</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A10</name>
-            <type>Formula</type>
-            <data>index * 2</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A11</name>
-            <type>ScriptExpression</type>
-            <data>sensors.provide("mySensor)"</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A12</name>
-            <type>ScriptFile</type>
-            <data>scripts:InitLogixNGVariable</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A13</name>
-            <type>LogixNG_Table</type>
-            <data>MyTable</data>
-          </LocalVariable>
-        </AbstractMaleSocket>
-      </MaleSocket>
-    </ActionFindTableRowOrColumn>
-    <ActionFindTableRowOrColumn class="jmri.jmrit.logixng.actions.configurexml.ActionFindTableRowOrColumnXml" includeCellsWithoutHeader="yes">
       <systemName>IQDA:AUTO:0042</systemName>
       <comment>A comment</comment>
       <namedBean>
@@ -19437,8 +19559,260 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
         </AbstractMaleSocket>
       </MaleSocket>
     </ActionFindTableRowOrColumn>
-    <ActionFindTableRowOrColumn class="jmri.jmrit.logixng.actions.configurexml.ActionFindTableRowOrColumnXml" includeCellsWithoutHeader="yes">
+    <ActionFindTableRowOrColumn class="jmri.jmrit.logixng.actions.configurexml.ActionFindTableRowOrColumnXml" includeCellsWithoutHeader="no">
       <systemName>IQDA:AUTO:0043</systemName>
+      <comment>A comment</comment>
+      <namedBean>
+        <addressing>Direct</addressing>
+        <name>IQT1</name>
+        <listenToMemory>no</listenToMemory>
+      </namedBean>
+      <rowOrColumnName>Signal before</rowOrColumnName>
+      <tableRowOrColumn>Row</tableRowOrColumn>
+      <localVariableNamedBean>variableNamedBean</localVariableNamedBean>
+      <localVariableRow>variableRow</localVariableRow>
+      <MaleSocket>
+        <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
+        <AbstractMaleSocket enabled="yes" locked="no" system="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
+          <errorHandling>Default</errorHandling>
+          <LocalVariable>
+            <name>A1</name>
+            <type>None</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A2</name>
+            <type>Integer</type>
+            <data>32</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A3</name>
+            <type>FloatingNumber</type>
+            <data>41.429</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A4</name>
+            <type>String</type>
+            <data>My string</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A5</name>
+            <type>Array</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A6</name>
+            <type>Map</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A7</name>
+            <type>LocalVariable</type>
+            <data>index</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A8</name>
+            <type>Memory</type>
+            <data>IM2</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A9</name>
+            <type>Reference</type>
+            <data>{IM3}</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A10</name>
+            <type>Formula</type>
+            <data>index * 2</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A11</name>
+            <type>ScriptExpression</type>
+            <data>sensors.provide("mySensor)"</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A12</name>
+            <type>ScriptFile</type>
+            <data>scripts:InitLogixNGVariable</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A13</name>
+            <type>LogixNG_Table</type>
+            <data>MyTable</data>
+          </LocalVariable>
+        </AbstractMaleSocket>
+      </MaleSocket>
+    </ActionFindTableRowOrColumn>
+    <ActionFindTableRowOrColumn class="jmri.jmrit.logixng.actions.configurexml.ActionFindTableRowOrColumnXml" includeCellsWithoutHeader="no">
+      <systemName>IQDA:AUTO:0044</systemName>
+      <comment>A comment</comment>
+      <namedBean>
+        <addressing>Direct</addressing>
+        <name>IQT1</name>
+        <listenToMemory>no</listenToMemory>
+      </namedBean>
+      <rowOrColumnName>2</rowOrColumnName>
+      <tableRowOrColumn>Column</tableRowOrColumn>
+      <localVariableNamedBean />
+      <localVariableRow />
+      <MaleSocket>
+        <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
+        <AbstractMaleSocket enabled="yes" locked="no" system="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
+          <errorHandling>Default</errorHandling>
+          <LocalVariable>
+            <name>A1</name>
+            <type>None</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A2</name>
+            <type>Integer</type>
+            <data>32</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A3</name>
+            <type>FloatingNumber</type>
+            <data>41.429</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A4</name>
+            <type>String</type>
+            <data>My string</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A5</name>
+            <type>Array</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A6</name>
+            <type>Map</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A7</name>
+            <type>LocalVariable</type>
+            <data>index</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A8</name>
+            <type>Memory</type>
+            <data>IM2</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A9</name>
+            <type>Reference</type>
+            <data>{IM3}</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A10</name>
+            <type>Formula</type>
+            <data>index * 2</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A11</name>
+            <type>ScriptExpression</type>
+            <data>sensors.provide("mySensor)"</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A12</name>
+            <type>ScriptFile</type>
+            <data>scripts:InitLogixNGVariable</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A13</name>
+            <type>LogixNG_Table</type>
+            <data>MyTable</data>
+          </LocalVariable>
+        </AbstractMaleSocket>
+      </MaleSocket>
+    </ActionFindTableRowOrColumn>
+    <ActionFindTableRowOrColumn class="jmri.jmrit.logixng.actions.configurexml.ActionFindTableRowOrColumnXml" includeCellsWithoutHeader="yes">
+      <systemName>IQDA:AUTO:0045</systemName>
+      <comment>A comment</comment>
+      <namedBean>
+        <addressing>Direct</addressing>
+        <name>IQT1</name>
+        <listenToMemory>no</listenToMemory>
+      </namedBean>
+      <rowOrColumnName />
+      <tableRowOrColumn>Row</tableRowOrColumn>
+      <localVariableNamedBean />
+      <localVariableRow />
+      <MaleSocket>
+        <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
+        <AbstractMaleSocket enabled="yes" locked="no" system="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
+          <errorHandling>Default</errorHandling>
+          <LocalVariable>
+            <name>A1</name>
+            <type>None</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A2</name>
+            <type>Integer</type>
+            <data>32</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A3</name>
+            <type>FloatingNumber</type>
+            <data>41.429</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A4</name>
+            <type>String</type>
+            <data>My string</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A5</name>
+            <type>Array</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A6</name>
+            <type>Map</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A7</name>
+            <type>LocalVariable</type>
+            <data>index</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A8</name>
+            <type>Memory</type>
+            <data>IM2</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A9</name>
+            <type>Reference</type>
+            <data>{IM3}</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A10</name>
+            <type>Formula</type>
+            <data>index * 2</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A11</name>
+            <type>ScriptExpression</type>
+            <data>sensors.provide("mySensor)"</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A12</name>
+            <type>ScriptFile</type>
+            <data>scripts:InitLogixNGVariable</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A13</name>
+            <type>LogixNG_Table</type>
+            <data>MyTable</data>
+          </LocalVariable>
+        </AbstractMaleSocket>
+      </MaleSocket>
+    </ActionFindTableRowOrColumn>
+    <ActionFindTableRowOrColumn class="jmri.jmrit.logixng.actions.configurexml.ActionFindTableRowOrColumnXml" includeCellsWithoutHeader="yes">
+      <systemName>IQDA:AUTO:0046</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>Direct</addressing>
@@ -19522,7 +19896,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionFindTableRowOrColumn>
     <ActionLight class="jmri.jmrit.logixng.actions.configurexml.ActionLightXml">
-      <systemName>IQDA:AUTO:0044</systemName>
+      <systemName>IQDA:AUTO:0047</systemName>
       <namedBean>
         <addressing>Direct</addressing>
         <listenToMemory>no</listenToMemory>
@@ -19609,7 +19983,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionLight>
     <ActionLight class="jmri.jmrit.logixng.actions.configurexml.ActionLightXml">
-      <systemName>IQDA:AUTO:0045</systemName>
+      <systemName>IQDA:AUTO:0048</systemName>
       <namedBean>
         <addressing>Direct</addressing>
         <listenToMemory>no</listenToMemory>
@@ -19696,7 +20070,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionLight>
     <ActionLight class="jmri.jmrit.logixng.actions.configurexml.ActionLightXml">
-      <systemName>IQDA:AUTO:0046</systemName>
+      <systemName>IQDA:AUTO:0049</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>Direct</addressing>
@@ -19715,9 +20089,10 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
         <formula>"IT"+index2</formula>
       </state>
       <dataAddressing>Direct</dataAddressing>
-      <dataReference />
-      <dataLocalVariable />
-      <dataFormula />
+      <dataReference>{MyRef}</dataReference>
+      <dataLocalVariable>MyLocalVariable</dataLocalVariable>
+      <dataFormula>a+b-c</dataFormula>
+      <lightValue>10</lightValue>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
         <AbstractMaleSocket enabled="yes" locked="no" system="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
@@ -19791,7 +20166,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionLight>
     <ActionLight class="jmri.jmrit.logixng.actions.configurexml.ActionLightXml">
-      <systemName>IQDA:AUTO:0047</systemName>
+      <systemName>IQDA:AUTO:0050</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>LocalVariable</addressing>
@@ -19809,10 +20184,11 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
         <localVariable>index2</localVariable>
         <formula>"IT"+index2</formula>
       </state>
-      <dataAddressing>Direct</dataAddressing>
-      <dataReference />
-      <dataLocalVariable />
-      <dataFormula />
+      <dataAddressing>Formula</dataAddressing>
+      <dataReference>{MyOtherRef}</dataReference>
+      <dataLocalVariable>MyOtherLocalVariable</dataLocalVariable>
+      <dataFormula>a+b*c</dataFormula>
+      <lightValue>15</lightValue>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
         <AbstractMaleSocket enabled="yes" locked="no" system="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
@@ -19886,7 +20262,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionLight>
     <ActionLight class="jmri.jmrit.logixng.actions.configurexml.ActionLightXml">
-      <systemName>IQDA:AUTO:0048</systemName>
+      <systemName>IQDA:AUTO:0051</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>Formula</addressing>
@@ -19981,7 +20357,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionLight>
     <ActionLight class="jmri.jmrit.logixng.actions.configurexml.ActionLightXml">
-      <systemName>IQDA:AUTO:0049</systemName>
+      <systemName>IQDA:AUTO:0052</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>Reference</addressing>
@@ -20076,7 +20452,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionLight>
     <ActionLight class="jmri.jmrit.logixng.actions.configurexml.ActionLightXml">
-      <systemName>IQDA:AUTO:0050</systemName>
+      <systemName>IQDA:AUTO:0053</systemName>
       <namedBean>
         <addressing>Direct</addressing>
         <name>IL1</name>
@@ -20164,7 +20540,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionLight>
     <ActionLight class="jmri.jmrit.logixng.actions.configurexml.ActionLightXml">
-      <systemName>IQDA:AUTO:0051</systemName>
+      <systemName>IQDA:AUTO:0054</systemName>
       <namedBean>
         <addressing>Direct</addressing>
         <name>IL1</name>
@@ -20252,7 +20628,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionLight>
     <ActionLight class="jmri.jmrit.logixng.actions.configurexml.ActionLightXml">
-      <systemName>IQDA:AUTO:0052</systemName>
+      <systemName>IQDA:AUTO:0055</systemName>
       <namedBean>
         <addressing>Direct</addressing>
         <name>IL1</name>
@@ -20340,7 +20716,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionLight>
     <ActionLight class="jmri.jmrit.logixng.actions.configurexml.ActionLightXml">
-      <systemName>IQDA:AUTO:0053</systemName>
+      <systemName>IQDA:AUTO:0056</systemName>
       <namedBean>
         <addressing>Direct</addressing>
         <listenToMemory>no</listenToMemory>
@@ -20427,13 +20803,13 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionLight>
     <ActionLightIntensity class="jmri.jmrit.logixng.actions.configurexml.ActionLightIntensityXml">
-      <systemName>IQDA:AUTO:0054</systemName>
+      <systemName>IQDA:AUTO:0057</systemName>
       <namedBean>
         <addressing>Direct</addressing>
         <listenToMemory>no</listenToMemory>
       </namedBean>
       <IntensitySocket>
-        <socketName>vphjnkcb2a</socketName>
+        <socketName>qu8rnombfj</socketName>
       </IntensitySocket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -20508,13 +20884,13 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionLightIntensity>
     <ActionLightIntensity class="jmri.jmrit.logixng.actions.configurexml.ActionLightIntensityXml">
-      <systemName>IQDA:AUTO:0055</systemName>
+      <systemName>IQDA:AUTO:0058</systemName>
       <namedBean>
         <addressing>Direct</addressing>
         <listenToMemory>no</listenToMemory>
       </namedBean>
       <IntensitySocket>
-        <socketName>swycd6ayxu</socketName>
+        <socketName>gg9bjuff9v</socketName>
       </IntensitySocket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -20589,7 +20965,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionLightIntensity>
     <ActionLightIntensity class="jmri.jmrit.logixng.actions.configurexml.ActionLightIntensityXml">
-      <systemName>IQDA:AUTO:0056</systemName>
+      <systemName>IQDA:AUTO:0059</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>Direct</addressing>
@@ -20600,7 +20976,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
         <formula>"IT"+index</formula>
       </namedBean>
       <IntensitySocket>
-        <socketName>c5uyqzslv3</socketName>
+        <socketName>t4kxnplymm</socketName>
       </IntensitySocket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -20675,7 +21051,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionLightIntensity>
     <ActionLightIntensity class="jmri.jmrit.logixng.actions.configurexml.ActionLightIntensityXml">
-      <systemName>IQDA:AUTO:0057</systemName>
+      <systemName>IQDA:AUTO:0060</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>LocalVariable</addressing>
@@ -20686,7 +21062,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
         <formula>"IT"+index</formula>
       </namedBean>
       <IntensitySocket>
-        <socketName>vlwi7vx4dg</socketName>
+        <socketName>xbj36aynf1</socketName>
       </IntensitySocket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -20761,7 +21137,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionLightIntensity>
     <ActionLightIntensity class="jmri.jmrit.logixng.actions.configurexml.ActionLightIntensityXml">
-      <systemName>IQDA:AUTO:0058</systemName>
+      <systemName>IQDA:AUTO:0061</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>Formula</addressing>
@@ -20772,7 +21148,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
         <formula>"IT"+index</formula>
       </namedBean>
       <IntensitySocket>
-        <socketName>zdx36q6prp</socketName>
+        <socketName>stdsivnqur</socketName>
       </IntensitySocket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -20847,7 +21223,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionLightIntensity>
     <ActionLightIntensity class="jmri.jmrit.logixng.actions.configurexml.ActionLightIntensityXml">
-      <systemName>IQDA:AUTO:0059</systemName>
+      <systemName>IQDA:AUTO:0062</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>Reference</addressing>
@@ -20858,7 +21234,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
         <formula>"IT"+index</formula>
       </namedBean>
       <IntensitySocket>
-        <socketName>pc4o44a6v3</socketName>
+        <socketName>ggo8sppel2</socketName>
       </IntensitySocket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -20933,7 +21309,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionLightIntensity>
     <ActionListenOnBeans class="jmri.jmrit.logixng.actions.configurexml.ActionListenOnBeansXml">
-      <systemName>IQDA:AUTO:0060</systemName>
+      <systemName>IQDA:AUTO:0063</systemName>
       <References />
       <localVariableNamedBean />
       <localVariableEvent />
@@ -21011,7 +21387,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionListenOnBeans>
     <ActionListenOnBeans class="jmri.jmrit.logixng.actions.configurexml.ActionListenOnBeansXml">
-      <systemName>IQDA:AUTO:0061</systemName>
+      <systemName>IQDA:AUTO:0064</systemName>
       <comment>A comment</comment>
       <References>
         <Reference>
@@ -21096,7 +21472,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionListenOnBeans>
     <ActionListenOnBeans class="jmri.jmrit.logixng.actions.configurexml.ActionListenOnBeansXml">
-      <systemName>IQDA:AUTO:0062</systemName>
+      <systemName>IQDA:AUTO:0065</systemName>
       <comment>A comment</comment>
       <References>
         <Reference>
@@ -21181,7 +21557,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionListenOnBeans>
     <ActionListenOnBeans class="jmri.jmrit.logixng.actions.configurexml.ActionListenOnBeansXml">
-      <systemName>IQDA:AUTO:0063</systemName>
+      <systemName>IQDA:AUTO:0066</systemName>
       <comment>A comment</comment>
       <References>
         <Reference>
@@ -21266,7 +21642,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionListenOnBeans>
     <ActionListenOnBeans class="jmri.jmrit.logixng.actions.configurexml.ActionListenOnBeansXml">
-      <systemName>IQDA:AUTO:0064</systemName>
+      <systemName>IQDA:AUTO:0067</systemName>
       <comment>A comment</comment>
       <References>
         <Reference>
@@ -21351,7 +21727,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionListenOnBeans>
     <ActionListenOnBeans class="jmri.jmrit.logixng.actions.configurexml.ActionListenOnBeansXml">
-      <systemName>IQDA:AUTO:0065</systemName>
+      <systemName>IQDA:AUTO:0068</systemName>
       <comment>A comment</comment>
       <References>
         <Reference>
@@ -21436,7 +21812,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionListenOnBeans>
     <ActionListenOnBeans class="jmri.jmrit.logixng.actions.configurexml.ActionListenOnBeansXml">
-      <systemName>IQDA:AUTO:0066</systemName>
+      <systemName>IQDA:AUTO:0069</systemName>
       <comment>A comment</comment>
       <References>
         <Reference>
@@ -21521,7 +21897,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionListenOnBeans>
     <ActionListenOnBeans class="jmri.jmrit.logixng.actions.configurexml.ActionListenOnBeansXml">
-      <systemName>IQDA:AUTO:0067</systemName>
+      <systemName>IQDA:AUTO:0070</systemName>
       <comment>A comment</comment>
       <References>
         <Reference>
@@ -21606,7 +21982,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionListenOnBeans>
     <ActionListenOnBeans class="jmri.jmrit.logixng.actions.configurexml.ActionListenOnBeansXml">
-      <systemName>IQDA:AUTO:0068</systemName>
+      <systemName>IQDA:AUTO:0071</systemName>
       <comment>A comment</comment>
       <References>
         <Reference>
@@ -21691,7 +22067,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionListenOnBeans>
     <ActionListenOnBeans class="jmri.jmrit.logixng.actions.configurexml.ActionListenOnBeansXml">
-      <systemName>IQDA:AUTO:0069</systemName>
+      <systemName>IQDA:AUTO:0072</systemName>
       <comment>A comment</comment>
       <References>
         <Reference>
@@ -21776,7 +22152,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionListenOnBeans>
     <ActionListenOnBeans class="jmri.jmrit.logixng.actions.configurexml.ActionListenOnBeansXml">
-      <systemName>IQDA:AUTO:0070</systemName>
+      <systemName>IQDA:AUTO:0073</systemName>
       <comment>A comment</comment>
       <References>
         <Reference>
@@ -21861,7 +22237,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionListenOnBeans>
     <ActionListenOnBeans class="jmri.jmrit.logixng.actions.configurexml.ActionListenOnBeansXml">
-      <systemName>IQDA:AUTO:0071</systemName>
+      <systemName>IQDA:AUTO:0074</systemName>
       <comment>A comment</comment>
       <References>
         <Reference>
@@ -21946,7 +22322,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionListenOnBeans>
     <ActionListenOnBeans class="jmri.jmrit.logixng.actions.configurexml.ActionListenOnBeansXml">
-      <systemName>IQDA:AUTO:0072</systemName>
+      <systemName>IQDA:AUTO:0075</systemName>
       <comment>A comment</comment>
       <References>
         <Reference>
@@ -22031,7 +22407,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionListenOnBeans>
     <ActionListenOnBeans class="jmri.jmrit.logixng.actions.configurexml.ActionListenOnBeansXml">
-      <systemName>IQDA:AUTO:0073</systemName>
+      <systemName>IQDA:AUTO:0076</systemName>
       <comment>A comment</comment>
       <References>
         <Reference>
@@ -22116,7 +22492,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionListenOnBeans>
     <ActionListenOnBeans class="jmri.jmrit.logixng.actions.configurexml.ActionListenOnBeansXml">
-      <systemName>IQDA:AUTO:0074</systemName>
+      <systemName>IQDA:AUTO:0077</systemName>
       <comment>A comment</comment>
       <References>
         <Reference>
@@ -22201,7 +22577,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionListenOnBeans>
     <ActionListenOnBeans class="jmri.jmrit.logixng.actions.configurexml.ActionListenOnBeansXml">
-      <systemName>IQDA:AUTO:0075</systemName>
+      <systemName>IQDA:AUTO:0078</systemName>
       <comment>A comment</comment>
       <References>
         <Reference>
@@ -22286,7 +22662,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionListenOnBeans>
     <ActionListenOnBeans class="jmri.jmrit.logixng.actions.configurexml.ActionListenOnBeansXml">
-      <systemName>IQDA:AUTO:0076</systemName>
+      <systemName>IQDA:AUTO:0079</systemName>
       <comment>A comment</comment>
       <References>
         <Reference>
@@ -22371,7 +22747,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionListenOnBeans>
     <ActionListenOnBeans class="jmri.jmrit.logixng.actions.configurexml.ActionListenOnBeansXml">
-      <systemName>IQDA:AUTO:0077</systemName>
+      <systemName>IQDA:AUTO:0080</systemName>
       <comment>A comment</comment>
       <References>
         <Reference>
@@ -22456,7 +22832,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionListenOnBeans>
     <ActionListenOnBeans class="jmri.jmrit.logixng.actions.configurexml.ActionListenOnBeansXml">
-      <systemName>IQDA:AUTO:0078</systemName>
+      <systemName>IQDA:AUTO:0081</systemName>
       <comment>A comment</comment>
       <References>
         <Reference>
@@ -22541,7 +22917,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionListenOnBeans>
     <ActionListenOnBeans class="jmri.jmrit.logixng.actions.configurexml.ActionListenOnBeansXml">
-      <systemName>IQDA:AUTO:0079</systemName>
+      <systemName>IQDA:AUTO:0082</systemName>
       <comment>A comment</comment>
       <References>
         <Reference>
@@ -22626,7 +23002,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionListenOnBeans>
     <ActionListenOnBeans class="jmri.jmrit.logixng.actions.configurexml.ActionListenOnBeansXml">
-      <systemName>IQDA:AUTO:0080</systemName>
+      <systemName>IQDA:AUTO:0083</systemName>
       <comment>A comment</comment>
       <References>
         <Reference>
@@ -22711,7 +23087,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionListenOnBeans>
     <ActionListenOnBeans class="jmri.jmrit.logixng.actions.configurexml.ActionListenOnBeansXml">
-      <systemName>IQDA:AUTO:0081</systemName>
+      <systemName>IQDA:AUTO:0084</systemName>
       <comment>A comment</comment>
       <References>
         <Reference>
@@ -22796,14 +23172,14 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionListenOnBeans>
     <ActionListenOnBeansLocalVariable class="jmri.jmrit.logixng.actions.configurexml.ActionListenOnBeansLocalVariableXml" listenOnAllProperties="no">
-      <systemName>IQDA:AUTO:0082</systemName>
+      <systemName>IQDA:AUTO:0085</systemName>
       <namedBeanType>Light</namedBeanType>
       <localVariableBeanToListenOn />
       <localVariableNamedBean />
       <localVariableEvent />
       <localVariableNewValue />
       <Socket>
-        <socketName>qzsih3t3v5</socketName>
+        <socketName>qbeaa7nxcf</socketName>
       </Socket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -22878,7 +23254,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionListenOnBeansLocalVariable>
     <ActionListenOnBeansLocalVariable class="jmri.jmrit.logixng.actions.configurexml.ActionListenOnBeansLocalVariableXml" listenOnAllProperties="yes">
-      <systemName>IQDA:AUTO:0083</systemName>
+      <systemName>IQDA:AUTO:0086</systemName>
       <comment>A comment</comment>
       <namedBeanType>Turnout</namedBeanType>
       <localVariableBeanToListenOn>beanToListenOn</localVariableBeanToListenOn>
@@ -22886,8 +23262,8 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <localVariableEvent>event</localVariableEvent>
       <localVariableNewValue>value</localVariableNewValue>
       <Socket>
-        <socketName>j46h7wgy3k</socketName>
-        <systemName>IQDA:AUTO:0084</systemName>
+        <socketName>xb846k9i9i</socketName>
+        <systemName>IQDA:AUTO:0087</systemName>
       </Socket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -22962,11 +23338,11 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionListenOnBeansLocalVariable>
     <DigitalMany class="jmri.jmrit.logixng.actions.configurexml.DigitalManyXml">
-      <systemName>IQDA:AUTO:0084</systemName>
+      <systemName>IQDA:AUTO:0087</systemName>
       <comment>Action socket 1</comment>
       <Actions>
         <Socket>
-          <socketName>ugp9kd953w</socketName>
+          <socketName>zjwjbqb5um</socketName>
         </Socket>
       </Actions>
       <MaleSocket>
@@ -23042,7 +23418,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </DigitalMany>
     <ActionListenOnBeansTable class="jmri.jmrit.logixng.actions.configurexml.ActionListenOnBeansTableXml" includeCellsWithoutHeader="no" listenOnAllProperties="no">
-      <systemName>IQDA:AUTO:0085</systemName>
+      <systemName>IQDA:AUTO:0088</systemName>
       <namedBean>
         <addressing>Direct</addressing>
         <listenToMemory>no</listenToMemory>
@@ -23126,264 +23502,6 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionListenOnBeansTable>
     <ActionListenOnBeansTable class="jmri.jmrit.logixng.actions.configurexml.ActionListenOnBeansTableXml" includeCellsWithoutHeader="no" listenOnAllProperties="no">
-      <systemName>IQDA:AUTO:0086</systemName>
-      <comment>A comment</comment>
-      <namedBean>
-        <addressing>Direct</addressing>
-        <name>IQT1</name>
-        <listenToMemory>no</listenToMemory>
-      </namedBean>
-      <rowOrColumnName />
-      <tableRowOrColumn>Row</tableRowOrColumn>
-      <namedBeanType>Light</namedBeanType>
-      <localVariableNamedBean />
-      <localVariableEvent />
-      <localVariableNewValue />
-      <MaleSocket>
-        <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
-        <AbstractMaleSocket enabled="yes" locked="no" system="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>Default</errorHandling>
-          <LocalVariable>
-            <name>A1</name>
-            <type>None</type>
-            <data />
-          </LocalVariable>
-          <LocalVariable>
-            <name>A2</name>
-            <type>Integer</type>
-            <data>32</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A3</name>
-            <type>FloatingNumber</type>
-            <data>41.429</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A4</name>
-            <type>String</type>
-            <data>My string</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A5</name>
-            <type>Array</type>
-            <data />
-          </LocalVariable>
-          <LocalVariable>
-            <name>A6</name>
-            <type>Map</type>
-            <data />
-          </LocalVariable>
-          <LocalVariable>
-            <name>A7</name>
-            <type>LocalVariable</type>
-            <data>index</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A8</name>
-            <type>Memory</type>
-            <data>IM2</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A9</name>
-            <type>Reference</type>
-            <data>{IM3}</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A10</name>
-            <type>Formula</type>
-            <data>index * 2</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A11</name>
-            <type>ScriptExpression</type>
-            <data>sensors.provide("mySensor)"</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A12</name>
-            <type>ScriptFile</type>
-            <data>scripts:InitLogixNGVariable</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A13</name>
-            <type>LogixNG_Table</type>
-            <data>MyTable</data>
-          </LocalVariable>
-        </AbstractMaleSocket>
-      </MaleSocket>
-    </ActionListenOnBeansTable>
-    <ActionListenOnBeansTable class="jmri.jmrit.logixng.actions.configurexml.ActionListenOnBeansTableXml" includeCellsWithoutHeader="no" listenOnAllProperties="no">
-      <systemName>IQDA:AUTO:0087</systemName>
-      <comment>A comment</comment>
-      <namedBean>
-        <addressing>Direct</addressing>
-        <name>IQT1</name>
-        <listenToMemory>no</listenToMemory>
-      </namedBean>
-      <rowOrColumnName>Signal before</rowOrColumnName>
-      <tableRowOrColumn>Row</tableRowOrColumn>
-      <namedBeanType>Light</namedBeanType>
-      <localVariableNamedBean>variableNamedBean</localVariableNamedBean>
-      <localVariableEvent>variableEvent</localVariableEvent>
-      <localVariableNewValue>variableNewValue</localVariableNewValue>
-      <MaleSocket>
-        <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
-        <AbstractMaleSocket enabled="yes" locked="no" system="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>Default</errorHandling>
-          <LocalVariable>
-            <name>A1</name>
-            <type>None</type>
-            <data />
-          </LocalVariable>
-          <LocalVariable>
-            <name>A2</name>
-            <type>Integer</type>
-            <data>32</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A3</name>
-            <type>FloatingNumber</type>
-            <data>41.429</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A4</name>
-            <type>String</type>
-            <data>My string</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A5</name>
-            <type>Array</type>
-            <data />
-          </LocalVariable>
-          <LocalVariable>
-            <name>A6</name>
-            <type>Map</type>
-            <data />
-          </LocalVariable>
-          <LocalVariable>
-            <name>A7</name>
-            <type>LocalVariable</type>
-            <data>index</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A8</name>
-            <type>Memory</type>
-            <data>IM2</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A9</name>
-            <type>Reference</type>
-            <data>{IM3}</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A10</name>
-            <type>Formula</type>
-            <data>index * 2</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A11</name>
-            <type>ScriptExpression</type>
-            <data>sensors.provide("mySensor)"</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A12</name>
-            <type>ScriptFile</type>
-            <data>scripts:InitLogixNGVariable</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A13</name>
-            <type>LogixNG_Table</type>
-            <data>MyTable</data>
-          </LocalVariable>
-        </AbstractMaleSocket>
-      </MaleSocket>
-    </ActionListenOnBeansTable>
-    <ActionListenOnBeansTable class="jmri.jmrit.logixng.actions.configurexml.ActionListenOnBeansTableXml" includeCellsWithoutHeader="no" listenOnAllProperties="yes">
-      <systemName>IQDA:AUTO:0088</systemName>
-      <comment>A comment</comment>
-      <namedBean>
-        <addressing>Direct</addressing>
-        <name>IQT1</name>
-        <listenToMemory>no</listenToMemory>
-      </namedBean>
-      <rowOrColumnName>2</rowOrColumnName>
-      <tableRowOrColumn>Column</tableRowOrColumn>
-      <namedBeanType>Light</namedBeanType>
-      <localVariableNamedBean />
-      <localVariableEvent />
-      <localVariableNewValue />
-      <MaleSocket>
-        <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
-        <AbstractMaleSocket enabled="yes" locked="no" system="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>Default</errorHandling>
-          <LocalVariable>
-            <name>A1</name>
-            <type>None</type>
-            <data />
-          </LocalVariable>
-          <LocalVariable>
-            <name>A2</name>
-            <type>Integer</type>
-            <data>32</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A3</name>
-            <type>FloatingNumber</type>
-            <data>41.429</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A4</name>
-            <type>String</type>
-            <data>My string</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A5</name>
-            <type>Array</type>
-            <data />
-          </LocalVariable>
-          <LocalVariable>
-            <name>A6</name>
-            <type>Map</type>
-            <data />
-          </LocalVariable>
-          <LocalVariable>
-            <name>A7</name>
-            <type>LocalVariable</type>
-            <data>index</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A8</name>
-            <type>Memory</type>
-            <data>IM2</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A9</name>
-            <type>Reference</type>
-            <data>{IM3}</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A10</name>
-            <type>Formula</type>
-            <data>index * 2</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A11</name>
-            <type>ScriptExpression</type>
-            <data>sensors.provide("mySensor)"</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A12</name>
-            <type>ScriptFile</type>
-            <data>scripts:InitLogixNGVariable</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A13</name>
-            <type>LogixNG_Table</type>
-            <data>MyTable</data>
-          </LocalVariable>
-        </AbstractMaleSocket>
-      </MaleSocket>
-    </ActionListenOnBeansTable>
-    <ActionListenOnBeansTable class="jmri.jmrit.logixng.actions.configurexml.ActionListenOnBeansTableXml" includeCellsWithoutHeader="yes" listenOnAllProperties="no">
       <systemName>IQDA:AUTO:0089</systemName>
       <comment>A comment</comment>
       <namedBean>
@@ -23469,8 +23587,266 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
         </AbstractMaleSocket>
       </MaleSocket>
     </ActionListenOnBeansTable>
-    <ActionListenOnBeansTable class="jmri.jmrit.logixng.actions.configurexml.ActionListenOnBeansTableXml" includeCellsWithoutHeader="yes" listenOnAllProperties="yes">
+    <ActionListenOnBeansTable class="jmri.jmrit.logixng.actions.configurexml.ActionListenOnBeansTableXml" includeCellsWithoutHeader="no" listenOnAllProperties="no">
       <systemName>IQDA:AUTO:0090</systemName>
+      <comment>A comment</comment>
+      <namedBean>
+        <addressing>Direct</addressing>
+        <name>IQT1</name>
+        <listenToMemory>no</listenToMemory>
+      </namedBean>
+      <rowOrColumnName>Signal before</rowOrColumnName>
+      <tableRowOrColumn>Row</tableRowOrColumn>
+      <namedBeanType>Light</namedBeanType>
+      <localVariableNamedBean>variableNamedBean</localVariableNamedBean>
+      <localVariableEvent>variableEvent</localVariableEvent>
+      <localVariableNewValue>variableNewValue</localVariableNewValue>
+      <MaleSocket>
+        <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
+        <AbstractMaleSocket enabled="yes" locked="no" system="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
+          <errorHandling>Default</errorHandling>
+          <LocalVariable>
+            <name>A1</name>
+            <type>None</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A2</name>
+            <type>Integer</type>
+            <data>32</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A3</name>
+            <type>FloatingNumber</type>
+            <data>41.429</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A4</name>
+            <type>String</type>
+            <data>My string</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A5</name>
+            <type>Array</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A6</name>
+            <type>Map</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A7</name>
+            <type>LocalVariable</type>
+            <data>index</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A8</name>
+            <type>Memory</type>
+            <data>IM2</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A9</name>
+            <type>Reference</type>
+            <data>{IM3}</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A10</name>
+            <type>Formula</type>
+            <data>index * 2</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A11</name>
+            <type>ScriptExpression</type>
+            <data>sensors.provide("mySensor)"</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A12</name>
+            <type>ScriptFile</type>
+            <data>scripts:InitLogixNGVariable</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A13</name>
+            <type>LogixNG_Table</type>
+            <data>MyTable</data>
+          </LocalVariable>
+        </AbstractMaleSocket>
+      </MaleSocket>
+    </ActionListenOnBeansTable>
+    <ActionListenOnBeansTable class="jmri.jmrit.logixng.actions.configurexml.ActionListenOnBeansTableXml" includeCellsWithoutHeader="no" listenOnAllProperties="yes">
+      <systemName>IQDA:AUTO:0091</systemName>
+      <comment>A comment</comment>
+      <namedBean>
+        <addressing>Direct</addressing>
+        <name>IQT1</name>
+        <listenToMemory>no</listenToMemory>
+      </namedBean>
+      <rowOrColumnName>2</rowOrColumnName>
+      <tableRowOrColumn>Column</tableRowOrColumn>
+      <namedBeanType>Light</namedBeanType>
+      <localVariableNamedBean />
+      <localVariableEvent />
+      <localVariableNewValue />
+      <MaleSocket>
+        <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
+        <AbstractMaleSocket enabled="yes" locked="no" system="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
+          <errorHandling>Default</errorHandling>
+          <LocalVariable>
+            <name>A1</name>
+            <type>None</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A2</name>
+            <type>Integer</type>
+            <data>32</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A3</name>
+            <type>FloatingNumber</type>
+            <data>41.429</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A4</name>
+            <type>String</type>
+            <data>My string</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A5</name>
+            <type>Array</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A6</name>
+            <type>Map</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A7</name>
+            <type>LocalVariable</type>
+            <data>index</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A8</name>
+            <type>Memory</type>
+            <data>IM2</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A9</name>
+            <type>Reference</type>
+            <data>{IM3}</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A10</name>
+            <type>Formula</type>
+            <data>index * 2</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A11</name>
+            <type>ScriptExpression</type>
+            <data>sensors.provide("mySensor)"</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A12</name>
+            <type>ScriptFile</type>
+            <data>scripts:InitLogixNGVariable</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A13</name>
+            <type>LogixNG_Table</type>
+            <data>MyTable</data>
+          </LocalVariable>
+        </AbstractMaleSocket>
+      </MaleSocket>
+    </ActionListenOnBeansTable>
+    <ActionListenOnBeansTable class="jmri.jmrit.logixng.actions.configurexml.ActionListenOnBeansTableXml" includeCellsWithoutHeader="yes" listenOnAllProperties="no">
+      <systemName>IQDA:AUTO:0092</systemName>
+      <comment>A comment</comment>
+      <namedBean>
+        <addressing>Direct</addressing>
+        <name>IQT1</name>
+        <listenToMemory>no</listenToMemory>
+      </namedBean>
+      <rowOrColumnName />
+      <tableRowOrColumn>Row</tableRowOrColumn>
+      <namedBeanType>Light</namedBeanType>
+      <localVariableNamedBean />
+      <localVariableEvent />
+      <localVariableNewValue />
+      <MaleSocket>
+        <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
+        <AbstractMaleSocket enabled="yes" locked="no" system="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
+          <errorHandling>Default</errorHandling>
+          <LocalVariable>
+            <name>A1</name>
+            <type>None</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A2</name>
+            <type>Integer</type>
+            <data>32</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A3</name>
+            <type>FloatingNumber</type>
+            <data>41.429</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A4</name>
+            <type>String</type>
+            <data>My string</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A5</name>
+            <type>Array</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A6</name>
+            <type>Map</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A7</name>
+            <type>LocalVariable</type>
+            <data>index</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A8</name>
+            <type>Memory</type>
+            <data>IM2</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A9</name>
+            <type>Reference</type>
+            <data>{IM3}</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A10</name>
+            <type>Formula</type>
+            <data>index * 2</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A11</name>
+            <type>ScriptExpression</type>
+            <data>sensors.provide("mySensor)"</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A12</name>
+            <type>ScriptFile</type>
+            <data>scripts:InitLogixNGVariable</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A13</name>
+            <type>LogixNG_Table</type>
+            <data>MyTable</data>
+          </LocalVariable>
+        </AbstractMaleSocket>
+      </MaleSocket>
+    </ActionListenOnBeansTable>
+    <ActionListenOnBeansTable class="jmri.jmrit.logixng.actions.configurexml.ActionListenOnBeansTableXml" includeCellsWithoutHeader="yes" listenOnAllProperties="yes">
+      <systemName>IQDA:AUTO:0093</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>Direct</addressing>
@@ -23556,7 +23932,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionListenOnBeansTable>
     <ActionLocalVariable class="jmri.jmrit.logixng.actions.configurexml.ActionLocalVariableXml">
-      <systemName>IQDA:AUTO:0091</systemName>
+      <systemName>IQDA:AUTO:0094</systemName>
       <memoryNamedBean>
         <addressing>Direct</addressing>
         <listenToMemory>no</listenToMemory>
@@ -23661,7 +24037,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionLocalVariable>
     <ActionLocalVariable class="jmri.jmrit.logixng.actions.configurexml.ActionLocalVariableXml">
-      <systemName>IQDA:AUTO:0092</systemName>
+      <systemName>IQDA:AUTO:0095</systemName>
       <comment>A comment</comment>
       <variable>result</variable>
       <memoryNamedBean>
@@ -23769,7 +24145,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionLocalVariable>
     <ActionLocalVariable class="jmri.jmrit.logixng.actions.configurexml.ActionLocalVariableXml">
-      <systemName>IQDA:AUTO:0093</systemName>
+      <systemName>IQDA:AUTO:0096</systemName>
       <comment>A comment</comment>
       <variable>result</variable>
       <memoryNamedBean>
@@ -23877,7 +24253,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionLocalVariable>
     <ActionLocalVariable class="jmri.jmrit.logixng.actions.configurexml.ActionLocalVariableXml">
-      <systemName>IQDA:AUTO:0094</systemName>
+      <systemName>IQDA:AUTO:0097</systemName>
       <comment>A comment</comment>
       <variable>result</variable>
       <memoryNamedBean>
@@ -23987,7 +24363,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionLocalVariable>
     <ActionLocalVariable class="jmri.jmrit.logixng.actions.configurexml.ActionLocalVariableXml">
-      <systemName>IQDA:AUTO:0095</systemName>
+      <systemName>IQDA:AUTO:0098</systemName>
       <comment>A comment</comment>
       <variable>result</variable>
       <memoryNamedBean>
@@ -24097,7 +24473,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionLocalVariable>
     <ActionLocalVariable class="jmri.jmrit.logixng.actions.configurexml.ActionLocalVariableXml">
-      <systemName>IQDA:AUTO:0096</systemName>
+      <systemName>IQDA:AUTO:0099</systemName>
       <comment>A comment</comment>
       <variable>result</variable>
       <memoryNamedBean>
@@ -24207,7 +24583,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionLocalVariable>
     <ActionLocalVariable class="jmri.jmrit.logixng.actions.configurexml.ActionLocalVariableXml">
-      <systemName>IQDA:AUTO:0097</systemName>
+      <systemName>IQDA:AUTO:0100</systemName>
       <comment>A comment</comment>
       <variable>result</variable>
       <memoryNamedBean>
@@ -24327,7 +24703,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionLocalVariable>
     <ActionLocalVariable class="jmri.jmrit.logixng.actions.configurexml.ActionLocalVariableXml">
-      <systemName>IQDA:AUTO:0098</systemName>
+      <systemName>IQDA:AUTO:0101</systemName>
       <comment>A comment</comment>
       <variable>result</variable>
       <memoryNamedBean>
@@ -24449,7 +24825,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionLocalVariable>
     <ActionLocalVariable class="jmri.jmrit.logixng.actions.configurexml.ActionLocalVariableXml">
-      <systemName>IQDA:AUTO:0099</systemName>
+      <systemName>IQDA:AUTO:0102</systemName>
       <comment>A comment</comment>
       <variable>result</variable>
       <memoryNamedBean>
@@ -24569,7 +24945,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionLocalVariable>
     <ActionLocalVariable class="jmri.jmrit.logixng.actions.configurexml.ActionLocalVariableXml">
-      <systemName>IQDA:AUTO:0100</systemName>
+      <systemName>IQDA:AUTO:0103</systemName>
       <comment>A comment</comment>
       <variable>result</variable>
       <memoryNamedBean>
@@ -24689,7 +25065,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionLocalVariable>
     <ActionMemory class="jmri.jmrit.logixng.actions.configurexml.ActionMemoryXml">
-      <systemName>IQDA:AUTO:0101</systemName>
+      <systemName>IQDA:AUTO:0104</systemName>
       <namedBean>
         <addressing>Direct</addressing>
         <listenToMemory>no</listenToMemory>
@@ -24786,7 +25162,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionMemory>
     <ActionMemory class="jmri.jmrit.logixng.actions.configurexml.ActionMemoryXml">
-      <systemName>IQDA:AUTO:0102</systemName>
+      <systemName>IQDA:AUTO:0105</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>Direct</addressing>
@@ -24889,7 +25265,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionMemory>
     <ActionMemory class="jmri.jmrit.logixng.actions.configurexml.ActionMemoryXml">
-      <systemName>IQDA:AUTO:0103</systemName>
+      <systemName>IQDA:AUTO:0106</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>Formula</addressing>
@@ -24992,7 +25368,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionMemory>
     <ActionMemory class="jmri.jmrit.logixng.actions.configurexml.ActionMemoryXml">
-      <systemName>IQDA:AUTO:0104</systemName>
+      <systemName>IQDA:AUTO:0107</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>LocalVariable</addressing>
@@ -25107,7 +25483,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionMemory>
     <ActionMemory class="jmri.jmrit.logixng.actions.configurexml.ActionMemoryXml">
-      <systemName>IQDA:AUTO:0105</systemName>
+      <systemName>IQDA:AUTO:0108</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>LocalVariable</addressing>
@@ -25222,7 +25598,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionMemory>
     <ActionMemory class="jmri.jmrit.logixng.actions.configurexml.ActionMemoryXml">
-      <systemName>IQDA:AUTO:0106</systemName>
+      <systemName>IQDA:AUTO:0109</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>Reference</addressing>
@@ -25337,7 +25713,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionMemory>
     <ActionMemory class="jmri.jmrit.logixng.actions.configurexml.ActionMemoryXml">
-      <systemName>IQDA:AUTO:0107</systemName>
+      <systemName>IQDA:AUTO:0110</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>Direct</addressing>
@@ -25452,7 +25828,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionMemory>
     <ActionOBlock class="jmri.jmrit.logixng.actions.configurexml.ActionOBlockXml">
-      <systemName>IQDA:AUTO:0108</systemName>
+      <systemName>IQDA:AUTO:0111</systemName>
       <namedBean>
         <addressing>Direct</addressing>
         <listenToMemory>no</listenToMemory>
@@ -25544,7 +25920,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionOBlock>
     <ActionOBlock class="jmri.jmrit.logixng.actions.configurexml.ActionOBlockXml">
-      <systemName>IQDA:AUTO:0109</systemName>
+      <systemName>IQDA:AUTO:0112</systemName>
       <namedBean>
         <addressing>Direct</addressing>
         <listenToMemory>no</listenToMemory>
@@ -25636,7 +26012,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionOBlock>
     <ActionOBlock class="jmri.jmrit.logixng.actions.configurexml.ActionOBlockXml">
-      <systemName>IQDA:AUTO:0110</systemName>
+      <systemName>IQDA:AUTO:0113</systemName>
       <namedBean>
         <addressing>Direct</addressing>
         <listenToMemory>no</listenToMemory>
@@ -25728,7 +26104,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionOBlock>
     <ActionOBlock class="jmri.jmrit.logixng.actions.configurexml.ActionOBlockXml">
-      <systemName>IQDA:AUTO:0111</systemName>
+      <systemName>IQDA:AUTO:0114</systemName>
       <comment>Direct / Direct / Direct :: SetValue</comment>
       <namedBean>
         <addressing>Direct</addressing>
@@ -25822,7 +26198,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionOBlock>
     <ActionOBlock class="jmri.jmrit.logixng.actions.configurexml.ActionOBlockXml">
-      <systemName>IQDA:AUTO:0112</systemName>
+      <systemName>IQDA:AUTO:0115</systemName>
       <comment>Direct / Direct :: ClearError</comment>
       <namedBean>
         <addressing>Direct</addressing>
@@ -25916,7 +26292,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionOBlock>
     <ActionOBlock class="jmri.jmrit.logixng.actions.configurexml.ActionOBlockXml">
-      <systemName>IQDA:AUTO:0113</systemName>
+      <systemName>IQDA:AUTO:0116</systemName>
       <comment>Direct / LocalVariable</comment>
       <namedBean>
         <addressing>Direct</addressing>
@@ -26011,7 +26387,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionOBlock>
     <ActionOBlock class="jmri.jmrit.logixng.actions.configurexml.ActionOBlockXml">
-      <systemName>IQDA:AUTO:0114</systemName>
+      <systemName>IQDA:AUTO:0117</systemName>
       <comment>LocalVariable / Formula</comment>
       <namedBean>
         <addressing>LocalVariable</addressing>
@@ -26106,7 +26482,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionOBlock>
     <ActionOBlock class="jmri.jmrit.logixng.actions.configurexml.ActionOBlockXml">
-      <systemName>IQDA:AUTO:0115</systemName>
+      <systemName>IQDA:AUTO:0118</systemName>
       <comment>Formula / Reference</comment>
       <namedBean>
         <addressing>Formula</addressing>
@@ -26201,7 +26577,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionOBlock>
     <ActionOBlock class="jmri.jmrit.logixng.actions.configurexml.ActionOBlockXml">
-      <systemName>IQDA:AUTO:0116</systemName>
+      <systemName>IQDA:AUTO:0119</systemName>
       <comment>Reference / Direct :: SetOutOfService</comment>
       <namedBean>
         <addressing>Reference</addressing>
@@ -26295,7 +26671,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionOBlock>
     <ActionPower class="jmri.jmrit.logixng.actions.configurexml.ActionPowerXml">
-      <systemName>IQDA:AUTO:0117</systemName>
+      <systemName>IQDA:AUTO:0120</systemName>
       <state>
         <addressing>Direct</addressing>
         <enum>On</enum>
@@ -26374,7 +26750,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionPower>
     <ActionPower class="jmri.jmrit.logixng.actions.configurexml.ActionPowerXml">
-      <systemName>IQDA:AUTO:0118</systemName>
+      <systemName>IQDA:AUTO:0121</systemName>
       <comment>A comment</comment>
       <state>
         <addressing>Direct</addressing>
@@ -26454,7 +26830,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionPower>
     <ActionPower class="jmri.jmrit.logixng.actions.configurexml.ActionPowerXml">
-      <systemName>IQDA:AUTO:0119</systemName>
+      <systemName>IQDA:AUTO:0122</systemName>
       <comment>A comment</comment>
       <state>
         <addressing>Direct</addressing>
@@ -26534,7 +26910,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionPower>
     <ActionReporter class="jmri.jmrit.logixng.actions.configurexml.ActionReporterXml">
-      <systemName>IQDA:AUTO:0120</systemName>
+      <systemName>IQDA:AUTO:0123</systemName>
       <namedBean>
         <addressing>Direct</addressing>
         <listenToMemory>no</listenToMemory>
@@ -26621,7 +26997,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionReporter>
     <ActionScript class="jmri.jmrit.logixng.actions.configurexml.ActionScriptXml">
-      <systemName>IQDA:AUTO:0121</systemName>
+      <systemName>IQDA:AUTO:0124</systemName>
       <operationAddressing>Direct</operationAddressing>
       <operationType>SingleLineCommand</operationType>
       <operationReference />
@@ -26708,7 +27084,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionScript>
     <ActionScript class="jmri.jmrit.logixng.actions.configurexml.ActionScriptXml">
-      <systemName>IQDA:AUTO:0122</systemName>
+      <systemName>IQDA:AUTO:0125</systemName>
       <comment>A comment</comment>
       <operationAddressing>Direct</operationAddressing>
       <operationType>SingleLineCommand</operationType>
@@ -26797,7 +27173,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionScript>
     <ActionScript class="jmri.jmrit.logixng.actions.configurexml.ActionScriptXml">
-      <systemName>IQDA:AUTO:0123</systemName>
+      <systemName>IQDA:AUTO:0126</systemName>
       <comment>A comment</comment>
       <operationAddressing>Formula</operationAddressing>
       <operationType>SingleLineCommand</operationType>
@@ -26885,7 +27261,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionScript>
     <ActionScript class="jmri.jmrit.logixng.actions.configurexml.ActionScriptXml">
-      <systemName>IQDA:AUTO:0124</systemName>
+      <systemName>IQDA:AUTO:0127</systemName>
       <comment>A comment</comment>
       <operationAddressing>LocalVariable</operationAddressing>
       <operationType>SingleLineCommand</operationType>
@@ -26974,7 +27350,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionScript>
     <ActionScript class="jmri.jmrit.logixng.actions.configurexml.ActionScriptXml">
-      <systemName>IQDA:AUTO:0125</systemName>
+      <systemName>IQDA:AUTO:0128</systemName>
       <comment>A comment</comment>
       <operationAddressing>Reference</operationAddressing>
       <operationType>SingleLineCommand</operationType>
@@ -27063,7 +27439,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionScript>
     <ActionSensor class="jmri.jmrit.logixng.actions.configurexml.ActionSensorXml">
-      <systemName>IQDA:AUTO:0126</systemName>
+      <systemName>IQDA:AUTO:0129</systemName>
       <namedBean>
         <addressing>Direct</addressing>
         <listenToMemory>no</listenToMemory>
@@ -27146,7 +27522,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionSensor>
     <ActionSensor class="jmri.jmrit.logixng.actions.configurexml.ActionSensorXml">
-      <systemName>IQDA:AUTO:0127</systemName>
+      <systemName>IQDA:AUTO:0130</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>Direct</addressing>
@@ -27237,7 +27613,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionSensor>
     <ActionSensor class="jmri.jmrit.logixng.actions.configurexml.ActionSensorXml">
-      <systemName>IQDA:AUTO:0128</systemName>
+      <systemName>IQDA:AUTO:0131</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>LocalVariable</addressing>
@@ -27328,7 +27704,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionSensor>
     <ActionSensor class="jmri.jmrit.logixng.actions.configurexml.ActionSensorXml">
-      <systemName>IQDA:AUTO:0129</systemName>
+      <systemName>IQDA:AUTO:0132</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>Formula</addressing>
@@ -27419,7 +27795,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionSensor>
     <ActionSensor class="jmri.jmrit.logixng.actions.configurexml.ActionSensorXml">
-      <systemName>IQDA:AUTO:0130</systemName>
+      <systemName>IQDA:AUTO:0133</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>Reference</addressing>
@@ -27510,7 +27886,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionSensor>
     <ActionSensor class="jmri.jmrit.logixng.actions.configurexml.ActionSensorXml">
-      <systemName>IQDA:AUTO:0131</systemName>
+      <systemName>IQDA:AUTO:0134</systemName>
       <namedBean>
         <addressing>Direct</addressing>
         <name>IS1</name>
@@ -27594,12 +27970,12 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionSensor>
     <ActionShutDownTask class="jmri.jmrit.logixng.actions.configurexml.ActionShutDownTaskXml">
-      <systemName>IQDA:AUTO:0132</systemName>
+      <systemName>IQDA:AUTO:0135</systemName>
       <CallSocket>
-        <socketName>sne9srcyu5</socketName>
+        <socketName>slnsiclvqe</socketName>
       </CallSocket>
       <RunSocket>
-        <socketName>quzwk4pwmt</socketName>
+        <socketName>rgslcfc9me</socketName>
       </RunSocket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -27674,14 +28050,14 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionShutDownTask>
     <ActionShutDownTask class="jmri.jmrit.logixng.actions.configurexml.ActionShutDownTaskXml">
-      <systemName>IQDA:AUTO:0133</systemName>
+      <systemName>IQDA:AUTO:0136</systemName>
       <CallSocket>
-        <socketName>wdgcsyaj1d</socketName>
+        <socketName>wh6sdz6fnw</socketName>
         <systemName>IQDE:AUTO:0001</systemName>
       </CallSocket>
       <RunSocket>
-        <socketName>q11n22dglv</socketName>
-        <systemName>IQDA:AUTO:0134</systemName>
+        <socketName>rjabjlf3mq</socketName>
+        <systemName>IQDA:AUTO:0137</systemName>
       </RunSocket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -27756,10 +28132,10 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionShutDownTask>
     <DigitalMany class="jmri.jmrit.logixng.actions.configurexml.DigitalManyXml">
-      <systemName>IQDA:AUTO:0134</systemName>
+      <systemName>IQDA:AUTO:0137</systemName>
       <Actions>
         <Socket>
-          <socketName>ned7swszxa</socketName>
+          <socketName>d7ug6wvrnt</socketName>
         </Socket>
       </Actions>
       <MaleSocket>
@@ -27835,7 +28211,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </DigitalMany>
     <ActionSignalHead class="jmri.jmrit.logixng.actions.configurexml.ActionSignalHeadXml">
-      <systemName>IQDA:AUTO:0135</systemName>
+      <systemName>IQDA:AUTO:0138</systemName>
       <namedBean>
         <addressing>Direct</addressing>
         <listenToMemory>no</listenToMemory>
@@ -27927,7 +28303,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionSignalHead>
     <ActionSignalHead class="jmri.jmrit.logixng.actions.configurexml.ActionSignalHeadXml">
-      <systemName>IQDA:AUTO:0136</systemName>
+      <systemName>IQDA:AUTO:0139</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>Direct</addressing>
@@ -28025,7 +28401,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionSignalHead>
     <ActionSignalHead class="jmri.jmrit.logixng.actions.configurexml.ActionSignalHeadXml">
-      <systemName>IQDA:AUTO:0137</systemName>
+      <systemName>IQDA:AUTO:0140</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>LocalVariable</addressing>
@@ -28122,7 +28498,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionSignalHead>
     <ActionSignalHead class="jmri.jmrit.logixng.actions.configurexml.ActionSignalHeadXml">
-      <systemName>IQDA:AUTO:0138</systemName>
+      <systemName>IQDA:AUTO:0141</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>Formula</addressing>
@@ -28219,7 +28595,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionSignalHead>
     <ActionSignalHead class="jmri.jmrit.logixng.actions.configurexml.ActionSignalHeadXml">
-      <systemName>IQDA:AUTO:0139</systemName>
+      <systemName>IQDA:AUTO:0142</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>Reference</addressing>
@@ -28316,7 +28692,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionSignalHead>
     <ActionSignalMast class="jmri.jmrit.logixng.actions.configurexml.ActionSignalMastXml">
-      <systemName>IQDA:AUTO:0140</systemName>
+      <systemName>IQDA:AUTO:0143</systemName>
       <namedBean>
         <addressing>Direct</addressing>
         <listenToMemory>no</listenToMemory>
@@ -28408,7 +28784,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionSignalMast>
     <ActionSignalMast class="jmri.jmrit.logixng.actions.configurexml.ActionSignalMastXml">
-      <systemName>IQDA:AUTO:0141</systemName>
+      <systemName>IQDA:AUTO:0144</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>Direct</addressing>
@@ -28506,7 +28882,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionSignalMast>
     <ActionSignalMast class="jmri.jmrit.logixng.actions.configurexml.ActionSignalMastXml">
-      <systemName>IQDA:AUTO:0142</systemName>
+      <systemName>IQDA:AUTO:0145</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>LocalVariable</addressing>
@@ -28603,7 +28979,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionSignalMast>
     <ActionSignalMast class="jmri.jmrit.logixng.actions.configurexml.ActionSignalMastXml">
-      <systemName>IQDA:AUTO:0143</systemName>
+      <systemName>IQDA:AUTO:0146</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>Formula</addressing>
@@ -28700,7 +29076,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionSignalMast>
     <ActionSignalMast class="jmri.jmrit.logixng.actions.configurexml.ActionSignalMastXml">
-      <systemName>IQDA:AUTO:0144</systemName>
+      <systemName>IQDA:AUTO:0147</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>Reference</addressing>
@@ -28797,7 +29173,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionSignalMast>
     <ActionSound class="jmri.jmrit.logixng.actions.configurexml.ActionSoundXml">
-      <systemName>IQDA:AUTO:0145</systemName>
+      <systemName>IQDA:AUTO:0148</systemName>
       <operation>
         <addressing>Direct</addressing>
         <enum>Play</enum>
@@ -28881,7 +29257,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionSound>
     <ActionSound class="jmri.jmrit.logixng.actions.configurexml.ActionSoundXml">
-      <systemName>IQDA:AUTO:0146</systemName>
+      <systemName>IQDA:AUTO:0149</systemName>
       <comment>A comment</comment>
       <operation>
         <addressing>Direct</addressing>
@@ -28970,7 +29346,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionSound>
     <ActionSound class="jmri.jmrit.logixng.actions.configurexml.ActionSoundXml">
-      <systemName>IQDA:AUTO:0147</systemName>
+      <systemName>IQDA:AUTO:0150</systemName>
       <comment>A comment</comment>
       <operation>
         <addressing>Formula</addressing>
@@ -29059,7 +29435,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionSound>
     <ActionSound class="jmri.jmrit.logixng.actions.configurexml.ActionSoundXml">
-      <systemName>IQDA:AUTO:0148</systemName>
+      <systemName>IQDA:AUTO:0151</systemName>
       <comment>A comment</comment>
       <operation>
         <addressing>LocalVariable</addressing>
@@ -29148,7 +29524,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionSound>
     <ActionSound class="jmri.jmrit.logixng.actions.configurexml.ActionSoundXml">
-      <systemName>IQDA:AUTO:0149</systemName>
+      <systemName>IQDA:AUTO:0152</systemName>
       <comment>A comment</comment>
       <operation>
         <addressing>Reference</addressing>
@@ -29237,21 +29613,21 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionSound>
     <Throttle class="jmri.jmrit.logixng.actions.configurexml.ActionThrottleXml">
-      <systemName>IQDA:AUTO:0150</systemName>
+      <systemName>IQDA:AUTO:0153</systemName>
       <LocoAddressSocket>
-        <socketName>s1p8vu2ru9</socketName>
+        <socketName>tbta76ffqn</socketName>
       </LocoAddressSocket>
       <LocoSpeedSocket>
-        <socketName>yux1ar39ry</socketName>
+        <socketName>d7twykn8af</socketName>
       </LocoSpeedSocket>
       <LocoDirectionSocket>
-        <socketName>vudbh814n4</socketName>
+        <socketName>mkvt215o6j</socketName>
       </LocoDirectionSocket>
       <LocoFunctionSocket>
-        <socketName>iuvzdx9ufi</socketName>
+        <socketName>n2f3116v3y</socketName>
       </LocoFunctionSocket>
       <LocoFunctionOnOffSocket>
-        <socketName>sj5co5mk7b</socketName>
+        <socketName>tmvu2idg4m</socketName>
       </LocoFunctionOnOffSocket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -29326,22 +29702,22 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </Throttle>
     <Throttle class="jmri.jmrit.logixng.actions.configurexml.ActionThrottleXml">
-      <systemName>IQDA:AUTO:0151</systemName>
+      <systemName>IQDA:AUTO:0154</systemName>
       <comment>A comment</comment>
       <LocoAddressSocket>
-        <socketName>baeckzi8xl</socketName>
+        <socketName>p8e6wuy7zt</socketName>
       </LocoAddressSocket>
       <LocoSpeedSocket>
-        <socketName>lmzyr28xuj</socketName>
+        <socketName>fffdw58dk7</socketName>
       </LocoSpeedSocket>
       <LocoDirectionSocket>
-        <socketName>uh6u3vvt38</socketName>
+        <socketName>xqa53mrdha</socketName>
       </LocoDirectionSocket>
       <LocoFunctionSocket>
-        <socketName>xco9ioz2m3</socketName>
+        <socketName>viw3g1j4or</socketName>
       </LocoFunctionSocket>
       <LocoFunctionOnOffSocket>
-        <socketName>usjujxscab</socketName>
+        <socketName>d4u5owxfgg</socketName>
       </LocoFunctionOnOffSocket>
       <systemConnection>L</systemConnection>
       <MaleSocket>
@@ -29417,22 +29793,22 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </Throttle>
     <Throttle class="jmri.jmrit.logixng.actions.configurexml.ActionThrottleXml">
-      <systemName>IQDA:AUTO:0152</systemName>
+      <systemName>IQDA:AUTO:0155</systemName>
       <comment>A comment</comment>
       <LocoAddressSocket>
-        <socketName>dor4izultb</socketName>
+        <socketName>y2a1lkju7h</socketName>
       </LocoAddressSocket>
       <LocoSpeedSocket>
-        <socketName>ugikaxhjtm</socketName>
+        <socketName>yo3ioljh7y</socketName>
       </LocoSpeedSocket>
       <LocoDirectionSocket>
-        <socketName>wb2xqcmk64</socketName>
+        <socketName>scrfd59d2s</socketName>
       </LocoDirectionSocket>
       <LocoFunctionSocket>
-        <socketName>nooeqq9siu</socketName>
+        <socketName>fjylf46m2s</socketName>
       </LocoFunctionSocket>
       <LocoFunctionOnOffSocket>
-        <socketName>uu4b833rfm</socketName>
+        <socketName>poy1xhawvr</socketName>
       </LocoFunctionOnOffSocket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -29507,7 +29883,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </Throttle>
     <ThrottleFunction class="jmri.jmrit.logixng.actions.configurexml.ActionThrottleFunctionXml">
-      <systemName>IQDA:AUTO:0153</systemName>
+      <systemName>IQDA:AUTO:0156</systemName>
       <address>
         <addressing>Direct</addressing>
         <value>0</value>
@@ -29596,7 +29972,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ThrottleFunction>
     <ThrottleFunction class="jmri.jmrit.logixng.actions.configurexml.ActionThrottleFunctionXml">
-      <systemName>IQDA:AUTO:0154</systemName>
+      <systemName>IQDA:AUTO:0157</systemName>
       <comment>A comment</comment>
       <address>
         <addressing>Direct</addressing>
@@ -29687,7 +30063,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ThrottleFunction>
     <ThrottleFunction class="jmri.jmrit.logixng.actions.configurexml.ActionThrottleFunctionXml">
-      <systemName>IQDA:AUTO:0155</systemName>
+      <systemName>IQDA:AUTO:0158</systemName>
       <comment>A comment</comment>
       <address>
         <addressing>Direct</addressing>
@@ -29777,17 +30153,17 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ThrottleFunction>
     <ActionTimer class="jmri.jmrit.logixng.actions.configurexml.ActionTimerXml">
-      <systemName>IQDA:AUTO:0156</systemName>
+      <systemName>IQDA:AUTO:0159</systemName>
       <StartSocket>
-        <socketName>de9bsnbh9t</socketName>
+        <socketName>xfzar4lhws</socketName>
       </StartSocket>
       <StopSocket>
-        <socketName>uokg4zumxx</socketName>
+        <socketName>p5vl4jvd1o</socketName>
       </StopSocket>
       <Actions>
         <Socket>
           <delay>0</delay>
-          <socketName>hbk1hawzlh</socketName>
+          <socketName>b3wwocwzaq</socketName>
         </Socket>
       </Actions>
       <startImmediately>no</startImmediately>
@@ -29869,18 +30245,18 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionTimer>
     <ActionTimer class="jmri.jmrit.logixng.actions.configurexml.ActionTimerXml">
-      <systemName>IQDA:AUTO:0157</systemName>
+      <systemName>IQDA:AUTO:0160</systemName>
       <comment>A comment</comment>
       <StartSocket>
-        <socketName>gwjuvv1jvr</socketName>
+        <socketName>u8fb7flozz</socketName>
       </StartSocket>
       <StopSocket>
-        <socketName>jnmi784i5l</socketName>
+        <socketName>vyvisih39q</socketName>
       </StopSocket>
       <Actions>
         <Socket>
           <delay>100</delay>
-          <socketName>rlgxyb6f7z</socketName>
+          <socketName>l2q74sia2l</socketName>
         </Socket>
       </Actions>
       <startImmediately>no</startImmediately>
@@ -29962,22 +30338,22 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionTimer>
     <ActionTimer class="jmri.jmrit.logixng.actions.configurexml.ActionTimerXml">
-      <systemName>IQDA:AUTO:0158</systemName>
+      <systemName>IQDA:AUTO:0161</systemName>
       <comment>A comment</comment>
       <StartSocket>
-        <socketName>mdzwrum19r</socketName>
+        <socketName>fe851rfquz</socketName>
       </StartSocket>
       <StopSocket>
-        <socketName>nosvzeyjnr</socketName>
+        <socketName>j88z471k7l</socketName>
       </StopSocket>
       <Actions>
         <Socket>
           <delay>2400</delay>
-          <socketName>dupmilg3tu</socketName>
+          <socketName>c5smtfv7fw</socketName>
         </Socket>
         <Socket>
           <delay>10</delay>
-          <socketName>oyws5c4awm</socketName>
+          <socketName>uclpldpm9y</socketName>
         </Socket>
       </Actions>
       <startImmediately>yes</startImmediately>
@@ -30059,26 +30435,26 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionTimer>
     <ActionTimer class="jmri.jmrit.logixng.actions.configurexml.ActionTimerXml">
-      <systemName>IQDA:AUTO:0159</systemName>
+      <systemName>IQDA:AUTO:0162</systemName>
       <comment>A comment</comment>
       <StartSocket>
-        <socketName>r2yyahnis9</socketName>
+        <socketName>bof6zry1pp</socketName>
         <systemName>IQDE:AUTO:0002</systemName>
       </StartSocket>
       <StopSocket>
-        <socketName>y3qih8y76q</socketName>
+        <socketName>nzhp8pi4fe</socketName>
         <systemName>IQDE:AUTO:0003</systemName>
       </StopSocket>
       <Actions>
         <Socket>
           <delay>20</delay>
-          <socketName>u9e5r1ynpz</socketName>
-          <systemName>IQDA:AUTO:0160</systemName>
+          <socketName>jrxr194o3s</socketName>
+          <systemName>IQDA:AUTO:0163</systemName>
         </Socket>
         <Socket>
           <delay>100</delay>
-          <socketName>or9ctvq39c</socketName>
-          <systemName>IQDA:AUTO:0161</systemName>
+          <socketName>tk1o6iba1v</socketName>
+          <systemName>IQDA:AUTO:0164</systemName>
         </Socket>
       </Actions>
       <startImmediately>yes</startImmediately>
@@ -30160,11 +30536,11 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionTimer>
     <DigitalMany class="jmri.jmrit.logixng.actions.configurexml.DigitalManyXml">
-      <systemName>IQDA:AUTO:0160</systemName>
+      <systemName>IQDA:AUTO:0163</systemName>
       <comment>Action socket 1</comment>
       <Actions>
         <Socket>
-          <socketName>ynz3sgixgu</socketName>
+          <socketName>xnvwmnacye</socketName>
         </Socket>
       </Actions>
       <MaleSocket>
@@ -30240,11 +30616,11 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </DigitalMany>
     <DigitalMany class="jmri.jmrit.logixng.actions.configurexml.DigitalManyXml">
-      <systemName>IQDA:AUTO:0161</systemName>
+      <systemName>IQDA:AUTO:0164</systemName>
       <comment>Action socket 2</comment>
       <Actions>
         <Socket>
-          <socketName>qs4tq9npa5</socketName>
+          <socketName>e12uvvzcry</socketName>
         </Socket>
       </Actions>
       <MaleSocket>
@@ -30320,7 +30696,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </DigitalMany>
     <ActionTurnout class="jmri.jmrit.logixng.actions.configurexml.ActionTurnoutXml">
-      <systemName>IQDA:AUTO:0162</systemName>
+      <systemName>IQDA:AUTO:0165</systemName>
       <namedBean>
         <addressing>Direct</addressing>
         <listenToMemory>no</listenToMemory>
@@ -30403,7 +30779,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionTurnout>
     <ActionTurnout class="jmri.jmrit.logixng.actions.configurexml.ActionTurnoutXml">
-      <systemName>IQDA:AUTO:0163</systemName>
+      <systemName>IQDA:AUTO:0166</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>Direct</addressing>
@@ -30494,7 +30870,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionTurnout>
     <ActionTurnout class="jmri.jmrit.logixng.actions.configurexml.ActionTurnoutXml">
-      <systemName>IQDA:AUTO:0164</systemName>
+      <systemName>IQDA:AUTO:0167</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>LocalVariable</addressing>
@@ -30585,7 +30961,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionTurnout>
     <ActionTurnout class="jmri.jmrit.logixng.actions.configurexml.ActionTurnoutXml">
-      <systemName>IQDA:AUTO:0165</systemName>
+      <systemName>IQDA:AUTO:0168</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>Formula</addressing>
@@ -30676,7 +31052,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionTurnout>
     <ActionTurnout class="jmri.jmrit.logixng.actions.configurexml.ActionTurnoutXml">
-      <systemName>IQDA:AUTO:0166</systemName>
+      <systemName>IQDA:AUTO:0169</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>Memory</addressing>
@@ -30769,7 +31145,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionTurnout>
     <ActionTurnout class="jmri.jmrit.logixng.actions.configurexml.ActionTurnoutXml">
-      <systemName>IQDA:AUTO:0167</systemName>
+      <systemName>IQDA:AUTO:0170</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>Reference</addressing>
@@ -30860,7 +31236,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionTurnout>
     <ActionTurnout class="jmri.jmrit.logixng.actions.configurexml.ActionTurnoutXml">
-      <systemName>IQDA:AUTO:0168</systemName>
+      <systemName>IQDA:AUTO:0171</systemName>
       <namedBean>
         <addressing>Direct</addressing>
         <name>IT1</name>
@@ -30944,7 +31320,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionTurnout>
     <ActionTurnout class="jmri.jmrit.logixng.actions.configurexml.ActionTurnoutXml">
-      <systemName>IQDA:AUTO:0169</systemName>
+      <systemName>IQDA:AUTO:0172</systemName>
       <namedBean>
         <addressing>Direct</addressing>
         <name>IT2</name>
@@ -31028,7 +31404,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionTurnout>
     <ActionTurnout class="jmri.jmrit.logixng.actions.configurexml.ActionTurnoutXml">
-      <systemName>IQDA:AUTO:0170</systemName>
+      <systemName>IQDA:AUTO:0173</systemName>
       <namedBean>
         <addressing>Direct</addressing>
         <name>Some turnout</name>
@@ -31112,7 +31488,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionTurnout>
     <ActionTurnout class="jmri.jmrit.logixng.actions.configurexml.ActionTurnoutXml">
-      <systemName>IQDA:AUTO:0171</systemName>
+      <systemName>IQDA:AUTO:0174</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>Table</addressing>
@@ -31249,7 +31625,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionTurnout>
     <ActionTurnout class="jmri.jmrit.logixng.actions.configurexml.ActionTurnoutXml">
-      <systemName>IQDA:AUTO:0172</systemName>
+      <systemName>IQDA:AUTO:0175</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>Table</addressing>
@@ -31386,7 +31762,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionTurnout>
     <ActionTurnout class="jmri.jmrit.logixng.actions.configurexml.ActionTurnoutXml">
-      <systemName>IQDA:AUTO:0173</systemName>
+      <systemName>IQDA:AUTO:0176</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>Table</addressing>
@@ -31523,7 +31899,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionTurnout>
     <ActionTurnout class="jmri.jmrit.logixng.actions.configurexml.ActionTurnoutXml">
-      <systemName>IQDA:AUTO:0174</systemName>
+      <systemName>IQDA:AUTO:0177</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>Table</addressing>
@@ -31671,7 +32047,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionTurnout>
     <ActionTurnout class="jmri.jmrit.logixng.actions.configurexml.ActionTurnoutXml">
-      <systemName>IQDA:AUTO:0175</systemName>
+      <systemName>IQDA:AUTO:0178</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>Table</addressing>
@@ -31813,7 +32189,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionTurnout>
     <ActionTurnoutLock class="jmri.jmrit.logixng.actions.configurexml.ActionTurnoutLockXml">
-      <systemName>IQDA:AUTO:0176</systemName>
+      <systemName>IQDA:AUTO:0179</systemName>
       <namedBean>
         <addressing>Direct</addressing>
         <listenToMemory>no</listenToMemory>
@@ -31896,7 +32272,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionTurnoutLock>
     <ActionWarrant class="jmri.jmrit.logixng.actions.configurexml.ActionWarrantXml">
-      <systemName>IQDA:AUTO:0177</systemName>
+      <systemName>IQDA:AUTO:0180</systemName>
       <namedBean>
         <addressing>Direct</addressing>
         <listenToMemory>no</listenToMemory>
@@ -31989,7 +32365,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionWarrant>
     <ActionWarrant class="jmri.jmrit.logixng.actions.configurexml.ActionWarrantXml">
-      <systemName>IQDA:AUTO:0178</systemName>
+      <systemName>IQDA:AUTO:0181</systemName>
       <namedBean>
         <addressing>Direct</addressing>
         <listenToMemory>no</listenToMemory>
@@ -32082,7 +32458,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionWarrant>
     <ActionWarrant class="jmri.jmrit.logixng.actions.configurexml.ActionWarrantXml">
-      <systemName>IQDA:AUTO:0179</systemName>
+      <systemName>IQDA:AUTO:0182</systemName>
       <namedBean>
         <addressing>Direct</addressing>
         <listenToMemory>no</listenToMemory>
@@ -32175,7 +32551,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionWarrant>
     <ActionWarrant class="jmri.jmrit.logixng.actions.configurexml.ActionWarrantXml">
-      <systemName>IQDA:AUTO:0180</systemName>
+      <systemName>IQDA:AUTO:0183</systemName>
       <comment>Direct / Direct / Direct :: SetTrainName</comment>
       <namedBean>
         <addressing>Direct</addressing>
@@ -32270,7 +32646,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionWarrant>
     <ActionWarrant class="jmri.jmrit.logixng.actions.configurexml.ActionWarrantXml">
-      <systemName>IQDA:AUTO:0181</systemName>
+      <systemName>IQDA:AUTO:0184</systemName>
       <comment>Direct / Direct / Direct :: ControlAutoTrain - Resume</comment>
       <namedBean>
         <addressing>Direct</addressing>
@@ -32365,7 +32741,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionWarrant>
     <ActionWarrant class="jmri.jmrit.logixng.actions.configurexml.ActionWarrantXml">
-      <systemName>IQDA:AUTO:0182</systemName>
+      <systemName>IQDA:AUTO:0185</systemName>
       <comment>Direct / Direct :: AllocateWarrantRoute</comment>
       <namedBean>
         <addressing>Direct</addressing>
@@ -32460,7 +32836,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionWarrant>
     <ActionWarrant class="jmri.jmrit.logixng.actions.configurexml.ActionWarrantXml">
-      <systemName>IQDA:AUTO:0183</systemName>
+      <systemName>IQDA:AUTO:0186</systemName>
       <comment>Direct / LocalVariable</comment>
       <namedBean>
         <addressing>Direct</addressing>
@@ -32556,7 +32932,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionWarrant>
     <ActionWarrant class="jmri.jmrit.logixng.actions.configurexml.ActionWarrantXml">
-      <systemName>IQDA:AUTO:0184</systemName>
+      <systemName>IQDA:AUTO:0187</systemName>
       <comment>LocalVariable / Formula</comment>
       <namedBean>
         <addressing>LocalVariable</addressing>
@@ -32652,7 +33028,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionWarrant>
     <ActionWarrant class="jmri.jmrit.logixng.actions.configurexml.ActionWarrantXml">
-      <systemName>IQDA:AUTO:0185</systemName>
+      <systemName>IQDA:AUTO:0188</systemName>
       <comment>Formula / Reference</comment>
       <namedBean>
         <addressing>Formula</addressing>
@@ -32748,7 +33124,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionWarrant>
     <ActionWarrant class="jmri.jmrit.logixng.actions.configurexml.ActionWarrantXml">
-      <systemName>IQDA:AUTO:0186</systemName>
+      <systemName>IQDA:AUTO:0189</systemName>
       <comment>Reference / Direct :: DeallocateWarrant</comment>
       <namedBean>
         <addressing>Reference</addressing>
@@ -32843,9 +33219,9 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionWarrant>
     <WebBrowser class="jmri.jmrit.logixng.actions.configurexml.WebBrowserXml">
-      <systemName>IQDA:AUTO:0187</systemName>
+      <systemName>IQDA:AUTO:0190</systemName>
       <Socket>
-        <socketName>sip5q8c212</socketName>
+        <socketName>rarjyk1lzh</socketName>
       </Socket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -32920,9 +33296,9 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </WebBrowser>
     <WebRequest class="jmri.jmrit.logixng.actions.configurexml.WebRequestXml">
-      <systemName>IQDA:AUTO:0188</systemName>
+      <systemName>IQDA:AUTO:0191</systemName>
       <Socket>
-        <socketName>fc59wjfypj</socketName>
+        <socketName>l3r8kbnr4e</socketName>
       </Socket>
       <requestMethod>
         <addressing>Direct</addressing>
@@ -33015,9 +33391,9 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </WebRequest>
     <WebRequest class="jmri.jmrit.logixng.actions.configurexml.WebRequestXml">
-      <systemName>IQDA:AUTO:0189</systemName>
+      <systemName>IQDA:AUTO:0192</systemName>
       <Socket>
-        <socketName>x3as9ymqov</socketName>
+        <socketName>yyzu8avtqx</socketName>
       </Socket>
       <requestMethod>
         <addressing>Direct</addressing>
@@ -33111,9 +33487,9 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </WebRequest>
     <WebRequest class="jmri.jmrit.logixng.actions.configurexml.WebRequestXml">
-      <systemName>IQDA:AUTO:0190</systemName>
+      <systemName>IQDA:AUTO:0193</systemName>
       <Socket>
-        <socketName>j6a3iaobrb</socketName>
+        <socketName>uvoziancms</socketName>
       </Socket>
       <requestMethod>
         <addressing>Direct</addressing>
@@ -33218,7 +33594,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </WebRequest>
     <DisplayActionLayoutTurnout class="jmri.jmrit.display.logixng.configurexml.ActionLayoutTurnoutXml">
-      <systemName>IQDA:AUTO:0191</systemName>
+      <systemName>IQDA:AUTO:0194</systemName>
       <addressing>Direct</addressing>
       <reference />
       <localVariable />
@@ -33301,7 +33677,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </DisplayActionLayoutTurnout>
     <DisplayActionPositionable class="jmri.jmrit.display.logixng.configurexml.ActionPositionableXml">
-      <systemName>IQDA:AUTO:0192</systemName>
+      <systemName>IQDA:AUTO:0195</systemName>
       <addressing>Direct</addressing>
       <reference />
       <localVariable />
@@ -33384,7 +33760,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </DisplayActionPositionable>
     <DisplayActionPositionableByClass class="jmri.jmrit.display.logixng.configurexml.ActionPositionableByClassXml">
-      <systemName>IQDA:AUTO:0193</systemName>
+      <systemName>IQDA:AUTO:0196</systemName>
       <addressing>Direct</addressing>
       <reference />
       <localVariable />
@@ -33467,7 +33843,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </DisplayActionPositionableByClass>
     <DisplayActionPositionableByClass class="jmri.jmrit.display.logixng.configurexml.ActionPositionableByClassXml">
-      <systemName>IQDA:AUTO:0194</systemName>
+      <systemName>IQDA:AUTO:0197</systemName>
       <className>TheClass</className>
       <addressing>Direct</addressing>
       <reference />
@@ -33551,7 +33927,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </DisplayActionPositionableByClass>
     <DisplayActionAudioIcon class="jmri.jmrit.display.logixng.configurexml.ActionAudioIconXml">
-      <systemName>IQDA:AUTO:0195</systemName>
+      <systemName>IQDA:AUTO:0198</systemName>
       <addressing>Direct</addressing>
       <reference />
       <localVariable />
@@ -33634,7 +34010,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </DisplayActionAudioIcon>
     <DisplayActionAudioIcon class="jmri.jmrit.display.logixng.configurexml.ActionAudioIconXml">
-      <systemName>IQDA:AUTO:0196</systemName>
+      <systemName>IQDA:AUTO:0199</systemName>
       <addressing>Direct</addressing>
       <reference />
       <localVariable />
@@ -33717,7 +34093,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </DisplayActionAudioIcon>
     <DisplayActionAudioIcon class="jmri.jmrit.display.logixng.configurexml.ActionAudioIconXml">
-      <systemName>IQDA:AUTO:0197</systemName>
+      <systemName>IQDA:AUTO:0200</systemName>
       <addressing>Direct</addressing>
       <reference />
       <localVariable />
@@ -33800,230 +34176,6 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </DisplayActionAudioIcon>
     <ActionRequestUpdateAllSensors class="jmri.jmrit.logixng.actions.configurexml.ActionRequestUpdateAllSensorsXml">
-      <systemName>IQDA:AUTO:0198</systemName>
-      <systemConnection>L</systemConnection>
-      <MaleSocket>
-        <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
-        <AbstractMaleSocket enabled="no" locked="no" system="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>Default</errorHandling>
-          <LocalVariable>
-            <name>A1</name>
-            <type>None</type>
-            <data />
-          </LocalVariable>
-          <LocalVariable>
-            <name>A2</name>
-            <type>Integer</type>
-            <data>32</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A3</name>
-            <type>FloatingNumber</type>
-            <data>41.429</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A4</name>
-            <type>String</type>
-            <data>My string</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A5</name>
-            <type>Array</type>
-            <data />
-          </LocalVariable>
-          <LocalVariable>
-            <name>A6</name>
-            <type>Map</type>
-            <data />
-          </LocalVariable>
-          <LocalVariable>
-            <name>A7</name>
-            <type>LocalVariable</type>
-            <data>index</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A8</name>
-            <type>Memory</type>
-            <data>IM2</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A9</name>
-            <type>Reference</type>
-            <data>{IM3}</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A10</name>
-            <type>Formula</type>
-            <data>index * 2</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A11</name>
-            <type>ScriptExpression</type>
-            <data>sensors.provide("mySensor)"</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A12</name>
-            <type>ScriptFile</type>
-            <data>scripts:InitLogixNGVariable</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A13</name>
-            <type>LogixNG_Table</type>
-            <data>MyTable</data>
-          </LocalVariable>
-        </AbstractMaleSocket>
-      </MaleSocket>
-    </ActionRequestUpdateAllSensors>
-    <ActionRequestUpdateAllSensors class="jmri.jmrit.logixng.actions.configurexml.ActionRequestUpdateAllSensorsXml">
-      <systemName>IQDA:AUTO:0199</systemName>
-      <MaleSocket>
-        <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
-        <AbstractMaleSocket enabled="no" locked="no" system="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>Default</errorHandling>
-          <LocalVariable>
-            <name>A1</name>
-            <type>None</type>
-            <data />
-          </LocalVariable>
-          <LocalVariable>
-            <name>A2</name>
-            <type>Integer</type>
-            <data>32</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A3</name>
-            <type>FloatingNumber</type>
-            <data>41.429</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A4</name>
-            <type>String</type>
-            <data>My string</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A5</name>
-            <type>Array</type>
-            <data />
-          </LocalVariable>
-          <LocalVariable>
-            <name>A6</name>
-            <type>Map</type>
-            <data />
-          </LocalVariable>
-          <LocalVariable>
-            <name>A7</name>
-            <type>LocalVariable</type>
-            <data>index</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A8</name>
-            <type>Memory</type>
-            <data>IM2</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A9</name>
-            <type>Reference</type>
-            <data>{IM3}</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A10</name>
-            <type>Formula</type>
-            <data>index * 2</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A11</name>
-            <type>ScriptExpression</type>
-            <data>sensors.provide("mySensor)"</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A12</name>
-            <type>ScriptFile</type>
-            <data>scripts:InitLogixNGVariable</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A13</name>
-            <type>LogixNG_Table</type>
-            <data>MyTable</data>
-          </LocalVariable>
-        </AbstractMaleSocket>
-      </MaleSocket>
-    </ActionRequestUpdateAllSensors>
-    <ActionRequestUpdateAllSensors class="jmri.jmrit.logixng.actions.configurexml.ActionRequestUpdateAllSensorsXml">
-      <systemName>IQDA:AUTO:0200</systemName>
-      <systemConnection>M</systemConnection>
-      <MaleSocket>
-        <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
-        <AbstractMaleSocket enabled="no" locked="no" system="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>Default</errorHandling>
-          <LocalVariable>
-            <name>A1</name>
-            <type>None</type>
-            <data />
-          </LocalVariable>
-          <LocalVariable>
-            <name>A2</name>
-            <type>Integer</type>
-            <data>32</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A3</name>
-            <type>FloatingNumber</type>
-            <data>41.429</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A4</name>
-            <type>String</type>
-            <data>My string</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A5</name>
-            <type>Array</type>
-            <data />
-          </LocalVariable>
-          <LocalVariable>
-            <name>A6</name>
-            <type>Map</type>
-            <data />
-          </LocalVariable>
-          <LocalVariable>
-            <name>A7</name>
-            <type>LocalVariable</type>
-            <data>index</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A8</name>
-            <type>Memory</type>
-            <data>IM2</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A9</name>
-            <type>Reference</type>
-            <data>{IM3}</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A10</name>
-            <type>Formula</type>
-            <data>index * 2</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A11</name>
-            <type>ScriptExpression</type>
-            <data>sensors.provide("mySensor)"</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A12</name>
-            <type>ScriptFile</type>
-            <data>scripts:InitLogixNGVariable</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A13</name>
-            <type>LogixNG_Table</type>
-            <data>MyTable</data>
-          </LocalVariable>
-        </AbstractMaleSocket>
-      </MaleSocket>
-    </ActionRequestUpdateAllSensors>
-    <ActionRequestUpdateAllSensors class="jmri.jmrit.logixng.actions.configurexml.ActionRequestUpdateAllSensorsXml">
       <systemName>IQDA:AUTO:0201</systemName>
       <systemConnection>L</systemConnection>
       <MaleSocket>
@@ -34098,8 +34250,232 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
         </AbstractMaleSocket>
       </MaleSocket>
     </ActionRequestUpdateAllSensors>
-    <ActionLoconetClearSlots class="jmri.jmrix.loconet.logixng.configurexml.ActionClearSlotsXml">
+    <ActionRequestUpdateAllSensors class="jmri.jmrit.logixng.actions.configurexml.ActionRequestUpdateAllSensorsXml">
       <systemName>IQDA:AUTO:0202</systemName>
+      <MaleSocket>
+        <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
+        <AbstractMaleSocket enabled="no" locked="no" system="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
+          <errorHandling>Default</errorHandling>
+          <LocalVariable>
+            <name>A1</name>
+            <type>None</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A2</name>
+            <type>Integer</type>
+            <data>32</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A3</name>
+            <type>FloatingNumber</type>
+            <data>41.429</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A4</name>
+            <type>String</type>
+            <data>My string</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A5</name>
+            <type>Array</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A6</name>
+            <type>Map</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A7</name>
+            <type>LocalVariable</type>
+            <data>index</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A8</name>
+            <type>Memory</type>
+            <data>IM2</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A9</name>
+            <type>Reference</type>
+            <data>{IM3}</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A10</name>
+            <type>Formula</type>
+            <data>index * 2</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A11</name>
+            <type>ScriptExpression</type>
+            <data>sensors.provide("mySensor)"</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A12</name>
+            <type>ScriptFile</type>
+            <data>scripts:InitLogixNGVariable</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A13</name>
+            <type>LogixNG_Table</type>
+            <data>MyTable</data>
+          </LocalVariable>
+        </AbstractMaleSocket>
+      </MaleSocket>
+    </ActionRequestUpdateAllSensors>
+    <ActionRequestUpdateAllSensors class="jmri.jmrit.logixng.actions.configurexml.ActionRequestUpdateAllSensorsXml">
+      <systemName>IQDA:AUTO:0203</systemName>
+      <systemConnection>M</systemConnection>
+      <MaleSocket>
+        <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
+        <AbstractMaleSocket enabled="no" locked="no" system="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
+          <errorHandling>Default</errorHandling>
+          <LocalVariable>
+            <name>A1</name>
+            <type>None</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A2</name>
+            <type>Integer</type>
+            <data>32</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A3</name>
+            <type>FloatingNumber</type>
+            <data>41.429</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A4</name>
+            <type>String</type>
+            <data>My string</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A5</name>
+            <type>Array</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A6</name>
+            <type>Map</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A7</name>
+            <type>LocalVariable</type>
+            <data>index</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A8</name>
+            <type>Memory</type>
+            <data>IM2</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A9</name>
+            <type>Reference</type>
+            <data>{IM3}</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A10</name>
+            <type>Formula</type>
+            <data>index * 2</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A11</name>
+            <type>ScriptExpression</type>
+            <data>sensors.provide("mySensor)"</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A12</name>
+            <type>ScriptFile</type>
+            <data>scripts:InitLogixNGVariable</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A13</name>
+            <type>LogixNG_Table</type>
+            <data>MyTable</data>
+          </LocalVariable>
+        </AbstractMaleSocket>
+      </MaleSocket>
+    </ActionRequestUpdateAllSensors>
+    <ActionRequestUpdateAllSensors class="jmri.jmrit.logixng.actions.configurexml.ActionRequestUpdateAllSensorsXml">
+      <systemName>IQDA:AUTO:0204</systemName>
+      <systemConnection>L</systemConnection>
+      <MaleSocket>
+        <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
+        <AbstractMaleSocket enabled="no" locked="no" system="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
+          <errorHandling>Default</errorHandling>
+          <LocalVariable>
+            <name>A1</name>
+            <type>None</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A2</name>
+            <type>Integer</type>
+            <data>32</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A3</name>
+            <type>FloatingNumber</type>
+            <data>41.429</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A4</name>
+            <type>String</type>
+            <data>My string</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A5</name>
+            <type>Array</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A6</name>
+            <type>Map</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A7</name>
+            <type>LocalVariable</type>
+            <data>index</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A8</name>
+            <type>Memory</type>
+            <data>IM2</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A9</name>
+            <type>Reference</type>
+            <data>{IM3}</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A10</name>
+            <type>Formula</type>
+            <data>index * 2</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A11</name>
+            <type>ScriptExpression</type>
+            <data>sensors.provide("mySensor)"</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A12</name>
+            <type>ScriptFile</type>
+            <data>scripts:InitLogixNGVariable</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A13</name>
+            <type>LogixNG_Table</type>
+            <data>MyTable</data>
+          </LocalVariable>
+        </AbstractMaleSocket>
+      </MaleSocket>
+    </ActionRequestUpdateAllSensors>
+    <ActionLoconetClearSlots class="jmri.jmrix.loconet.logixng.configurexml.ActionClearSlotsXml">
+      <systemName>IQDA:AUTO:0205</systemName>
       <systemConnection>L</systemConnection>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -34174,7 +34550,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionLoconetClearSlots>
     <ActionLoconetUpdateSlots class="jmri.jmrix.loconet.logixng.configurexml.ActionUpdateSlotsXml">
-      <systemName>IQDA:AUTO:0203</systemName>
+      <systemName>IQDA:AUTO:0206</systemName>
       <systemConnection>L</systemConnection>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -34249,7 +34625,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionLoconetUpdateSlots>
     <ActionLoconetSetSpeedZero class="jmri.jmrix.loconet.logixng.configurexml.SetSpeedZeroXml">
-      <systemName>IQDA:AUTO:0204</systemName>
+      <systemName>IQDA:AUTO:0207</systemName>
       <systemConnection>L</systemConnection>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -34324,7 +34700,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionLoconetSetSpeedZero>
     <MQTTPublish class="jmri.jmrix.mqtt.logixng.configurexml.PublishXml">
-      <systemName>IQDA:AUTO:0205</systemName>
+      <systemName>IQDA:AUTO:0208</systemName>
       <systemConnection>M</systemConnection>
       <topic>
         <addressing>Direct</addressing>
@@ -34407,7 +34783,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </MQTTPublish>
     <MQTTPublish class="jmri.jmrix.mqtt.logixng.configurexml.PublishXml">
-      <systemName>IQDA:AUTO:0206</systemName>
+      <systemName>IQDA:AUTO:0209</systemName>
       <systemConnection>M</systemConnection>
       <topic>
         <addressing>Direct</addressing>
@@ -34492,7 +34868,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </MQTTPublish>
     <MQTTSubscribe class="jmri.jmrix.mqtt.logixng.configurexml.SubscribeXml">
-      <systemName>IQDA:AUTO:0207</systemName>
+      <systemName>IQDA:AUTO:0210</systemName>
       <systemConnection>M</systemConnection>
       <removeChannelFromLastTopic>no</removeChannelFromLastTopic>
       <MaleSocket>
@@ -34568,7 +34944,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </MQTTSubscribe>
     <MQTTSubscribe class="jmri.jmrix.mqtt.logixng.configurexml.SubscribeXml">
-      <systemName>IQDA:AUTO:0208</systemName>
+      <systemName>IQDA:AUTO:0211</systemName>
       <systemConnection>M</systemConnection>
       <subscribeToTopic>theTopic</subscribeToTopic>
       <lastTopicLocalVariable>topic</lastTopicLocalVariable>
@@ -34647,7 +35023,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </MQTTSubscribe>
     <CallModule class="jmri.jmrit.logixng.actions.configurexml.DigitalCallModuleXml">
-      <systemName>IQDA:AUTO:0209</systemName>
+      <systemName>IQDA:AUTO:0212</systemName>
       <namedBean>
         <addressing>Direct</addressing>
         <listenToMemory>no</listenToMemory>
@@ -34726,7 +35102,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </CallModule>
     <CallModule class="jmri.jmrit.logixng.actions.configurexml.DigitalCallModuleXml">
-      <systemName>IQDA:AUTO:0210</systemName>
+      <systemName>IQDA:AUTO:0213</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>Direct</addressing>
@@ -34864,10 +35240,10 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </CallModule>
     <DigitalFormula class="jmri.jmrit.logixng.actions.configurexml.DigitalFormulaXml">
-      <systemName>IQDA:AUTO:0211</systemName>
+      <systemName>IQDA:AUTO:0214</systemName>
       <Expressions>
         <Socket>
-          <socketName>fil9z4qg49</socketName>
+          <socketName>o5f5g19g1g</socketName>
         </Socket>
       </Expressions>
       <formula />
@@ -34944,11 +35320,11 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </DigitalFormula>
     <DigitalFormula class="jmri.jmrit.logixng.actions.configurexml.DigitalFormulaXml">
-      <systemName>IQDA:AUTO:0212</systemName>
+      <systemName>IQDA:AUTO:0215</systemName>
       <comment>A comment</comment>
       <Expressions>
         <Socket>
-          <socketName>ujd62o3r2o</socketName>
+          <socketName>b5l1bddpls</socketName>
         </Socket>
       </Expressions>
       <formula>n + 1</formula>
@@ -35025,12 +35401,12 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </DigitalFormula>
     <DoAnalogAction class="jmri.jmrit.logixng.actions.configurexml.DoAnalogActionXml">
-      <systemName>IQDA:AUTO:0213</systemName>
+      <systemName>IQDA:AUTO:0216</systemName>
       <ExpressionSocket>
-        <socketName>q43c3swurf</socketName>
+        <socketName>e9neod8rdk</socketName>
       </ExpressionSocket>
       <ActionSocket>
-        <socketName>wx8fbj1jih</socketName>
+        <socketName>xv7zz4qmih</socketName>
       </ActionSocket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -35105,13 +35481,13 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </DoAnalogAction>
     <DoAnalogAction class="jmri.jmrit.logixng.actions.configurexml.DoAnalogActionXml">
-      <systemName>IQDA:AUTO:0214</systemName>
+      <systemName>IQDA:AUTO:0217</systemName>
       <comment>A comment</comment>
       <ExpressionSocket>
-        <socketName>lj2qn1dxly</socketName>
+        <socketName>u78b4ftfhq</socketName>
       </ExpressionSocket>
       <ActionSocket>
-        <socketName>vlbwv5fcig</socketName>
+        <socketName>iueagy6j8w</socketName>
       </ActionSocket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -35186,12 +35562,12 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </DoAnalogAction>
     <DoStringAction class="jmri.jmrit.logixng.actions.configurexml.DoStringActionXml">
-      <systemName>IQDA:AUTO:0215</systemName>
+      <systemName>IQDA:AUTO:0218</systemName>
       <ExpressionSocket>
-        <socketName>s34s6hxjca</socketName>
+        <socketName>rqwfgbl43w</socketName>
       </ExpressionSocket>
       <ActionSocket>
-        <socketName>tn7j1gwxly</socketName>
+        <socketName>rw1p5j47v7</socketName>
       </ActionSocket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -35266,13 +35642,13 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </DoStringAction>
     <DoStringAction class="jmri.jmrit.logixng.actions.configurexml.DoStringActionXml">
-      <systemName>IQDA:AUTO:0216</systemName>
+      <systemName>IQDA:AUTO:0219</systemName>
       <comment>A comment</comment>
       <ExpressionSocket>
-        <socketName>tmrnhmhzcn</socketName>
+        <socketName>qmtrkb9ltg</socketName>
       </ExpressionSocket>
       <ActionSocket>
-        <socketName>qmbsq5walq</socketName>
+        <socketName>clzxj2sd1q</socketName>
       </ActionSocket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -35347,7 +35723,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </DoStringAction>
     <EnableLogix class="jmri.jmrit.logixng.actions.configurexml.EnableLogixXml">
-      <systemName>IQDA:AUTO:0217</systemName>
+      <systemName>IQDA:AUTO:0220</systemName>
       <namedBean>
         <addressing>Direct</addressing>
         <listenToMemory>no</listenToMemory>
@@ -35430,7 +35806,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </EnableLogix>
     <EnableLogix class="jmri.jmrit.logixng.actions.configurexml.EnableLogixXml">
-      <systemName>IQDA:AUTO:0218</systemName>
+      <systemName>IQDA:AUTO:0221</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>Direct</addressing>
@@ -35521,7 +35897,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </EnableLogix>
     <EnableLogix class="jmri.jmrit.logixng.actions.configurexml.EnableLogixXml">
-      <systemName>IQDA:AUTO:0219</systemName>
+      <systemName>IQDA:AUTO:0222</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>LocalVariable</addressing>
@@ -35612,7 +35988,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </EnableLogix>
     <EnableLogix class="jmri.jmrit.logixng.actions.configurexml.EnableLogixXml">
-      <systemName>IQDA:AUTO:0220</systemName>
+      <systemName>IQDA:AUTO:0223</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>Formula</addressing>
@@ -35703,7 +36079,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </EnableLogix>
     <EnableLogix class="jmri.jmrit.logixng.actions.configurexml.EnableLogixXml">
-      <systemName>IQDA:AUTO:0221</systemName>
+      <systemName>IQDA:AUTO:0224</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>Reference</addressing>
@@ -35794,7 +36170,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </EnableLogix>
     <ActionEntryExit class="jmri.jmrit.logixng.actions.configurexml.ActionEntryExitXml">
-      <systemName>IQDA:AUTO:0222</systemName>
+      <systemName>IQDA:AUTO:0225</systemName>
       <namedBean>
         <addressing>Direct</addressing>
         <listenToMemory>no</listenToMemory>
@@ -35877,7 +36253,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionEntryExit>
     <ActionEntryExit class="jmri.jmrit.logixng.actions.configurexml.ActionEntryExitXml">
-      <systemName>IQDA:AUTO:0223</systemName>
+      <systemName>IQDA:AUTO:0226</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>Direct</addressing>
@@ -35968,7 +36344,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionEntryExit>
     <ActionEntryExit class="jmri.jmrit.logixng.actions.configurexml.ActionEntryExitXml">
-      <systemName>IQDA:AUTO:0224</systemName>
+      <systemName>IQDA:AUTO:0227</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>LocalVariable</addressing>
@@ -36059,7 +36435,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionEntryExit>
     <ActionEntryExit class="jmri.jmrit.logixng.actions.configurexml.ActionEntryExitXml">
-      <systemName>IQDA:AUTO:0225</systemName>
+      <systemName>IQDA:AUTO:0228</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>Formula</addressing>
@@ -36149,7 +36525,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionEntryExit>
     <ActionEntryExit class="jmri.jmrit.logixng.actions.configurexml.ActionEntryExitXml">
-      <systemName>IQDA:AUTO:0226</systemName>
+      <systemName>IQDA:AUTO:0229</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>Reference</addressing>
@@ -36239,9 +36615,9 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ActionEntryExit>
     <ExecuteDelayed class="jmri.jmrit.logixng.actions.configurexml.ExecuteDelayedXml">
-      <systemName>IQDA:AUTO:0227</systemName>
+      <systemName>IQDA:AUTO:0230</systemName>
       <Socket>
-        <socketName>vfi8pp4gto</socketName>
+        <socketName>texf2wq7qb</socketName>
       </Socket>
       <delayAddressing>Direct</delayAddressing>
       <delay>0</delay>
@@ -36323,10 +36699,10 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExecuteDelayed>
     <ExecuteDelayed class="jmri.jmrit.logixng.actions.configurexml.ExecuteDelayedXml">
-      <systemName>IQDA:AUTO:0228</systemName>
+      <systemName>IQDA:AUTO:0231</systemName>
       <comment>A comment</comment>
       <Socket>
-        <socketName>teb199wg4h</socketName>
+        <socketName>ysf3vzaknl</socketName>
       </Socket>
       <delayAddressing>Direct</delayAddressing>
       <delay>100</delay>
@@ -36408,10 +36784,10 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExecuteDelayed>
     <ExecuteDelayed class="jmri.jmrit.logixng.actions.configurexml.ExecuteDelayedXml">
-      <systemName>IQDA:AUTO:0229</systemName>
+      <systemName>IQDA:AUTO:0232</systemName>
       <comment>A comment</comment>
       <Socket>
-        <socketName>g9o3n6ujmm</socketName>
+        <socketName>tcubjwq9rn</socketName>
       </Socket>
       <delayAddressing>LocalVariable</delayAddressing>
       <delay>0</delay>
@@ -36494,10 +36870,10 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExecuteDelayed>
     <ExecuteDelayed class="jmri.jmrit.logixng.actions.configurexml.ExecuteDelayedXml">
-      <systemName>IQDA:AUTO:0230</systemName>
+      <systemName>IQDA:AUTO:0233</systemName>
       <comment>A comment</comment>
       <Socket>
-        <socketName>le14wdd3gh</socketName>
+        <socketName>f1xjzwlp3a</socketName>
       </Socket>
       <delayAddressing>Reference</delayAddressing>
       <delay>0</delay>
@@ -36579,10 +36955,10 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExecuteDelayed>
     <ExecuteDelayed class="jmri.jmrit.logixng.actions.configurexml.ExecuteDelayedXml">
-      <systemName>IQDA:AUTO:0231</systemName>
+      <systemName>IQDA:AUTO:0234</systemName>
       <comment>A comment</comment>
       <Socket>
-        <socketName>uhjc4hj8c2</socketName>
+        <socketName>qfx7akkbsa</socketName>
       </Socket>
       <delayAddressing>Formula</delayAddressing>
       <delay>0</delay>
@@ -36664,18 +37040,18 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ExecuteDelayed>
     <For class="jmri.jmrit.logixng.actions.configurexml.ForXml">
-      <systemName>IQDA:AUTO:0232</systemName>
+      <systemName>IQDA:AUTO:0235</systemName>
       <InitSocket>
-        <socketName>t6s58sb1fd</socketName>
+        <socketName>txrilws2vz</socketName>
       </InitSocket>
       <WhileSocket>
-        <socketName>mstxzfavzy</socketName>
+        <socketName>nlys94drz5</socketName>
       </WhileSocket>
       <AfterEachSocket>
-        <socketName>yxuotv3fo4</socketName>
+        <socketName>hhuy84atvn</socketName>
       </AfterEachSocket>
       <DoSocket>
-        <socketName>skzy4laf5e</socketName>
+        <socketName>rhjo6onlgz</socketName>
       </DoSocket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -36750,19 +37126,19 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </For>
     <For class="jmri.jmrit.logixng.actions.configurexml.ForXml">
-      <systemName>IQDA:AUTO:0233</systemName>
+      <systemName>IQDA:AUTO:0236</systemName>
       <comment>A comment</comment>
       <InitSocket>
-        <socketName>yf67v5qdhn</socketName>
+        <socketName>ucm1rznt67</socketName>
       </InitSocket>
       <WhileSocket>
-        <socketName>xkl7cy47cy</socketName>
+        <socketName>k96p256n4p</socketName>
       </WhileSocket>
       <AfterEachSocket>
-        <socketName>kbcvuanpuh</socketName>
+        <socketName>s1opkb7t1d</socketName>
       </AfterEachSocket>
       <DoSocket>
-        <socketName>m9egeysya3</socketName>
+        <socketName>qtm7wqnf6e</socketName>
       </DoSocket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -36837,7 +37213,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </For>
     <ForEach class="jmri.jmrit.logixng.actions.configurexml.ForEachXml">
-      <systemName>IQDA:AUTO:0234</systemName>
+      <systemName>IQDA:AUTO:0237</systemName>
       <useCommonSource>yes</useCommonSource>
       <commonManager>Sensors</commonManager>
       <operation>Variable</operation>
@@ -36852,7 +37228,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <formula />
       <localVariable />
       <Socket>
-        <socketName>sirptf2l98</socketName>
+        <socketName>emtqvv4yw6</socketName>
       </Socket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -36927,283 +37303,10 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ForEach>
     <ForEach class="jmri.jmrit.logixng.actions.configurexml.ForEachXml">
-      <systemName>IQDA:AUTO:0235</systemName>
-      <comment>A comment</comment>
-      <useCommonSource>no</useCommonSource>
-      <commonManager>Turnouts</commonManager>
-      <operation>Variable</operation>
-      <otherVariable>
-        <addressing>Direct</addressing>
-        <listenToMemory>no</listenToMemory>
-      </otherVariable>
-      <memoryNamedBean>
-        <addressing>Direct</addressing>
-        <listenToMemory>no</listenToMemory>
-      </memoryNamedBean>
-      <formula>turnouts</formula>
-      <localVariable>myVar</localVariable>
-      <Socket>
-        <socketName>t7owtbpopa</socketName>
-      </Socket>
-      <MaleSocket>
-        <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
-        <AbstractMaleSocket enabled="yes" locked="no" system="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>Default</errorHandling>
-          <LocalVariable>
-            <name>A1</name>
-            <type>None</type>
-            <data />
-          </LocalVariable>
-          <LocalVariable>
-            <name>A2</name>
-            <type>Integer</type>
-            <data>32</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A3</name>
-            <type>FloatingNumber</type>
-            <data>41.429</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A4</name>
-            <type>String</type>
-            <data>My string</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A5</name>
-            <type>Array</type>
-            <data />
-          </LocalVariable>
-          <LocalVariable>
-            <name>A6</name>
-            <type>Map</type>
-            <data />
-          </LocalVariable>
-          <LocalVariable>
-            <name>A7</name>
-            <type>LocalVariable</type>
-            <data>index</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A8</name>
-            <type>Memory</type>
-            <data>IM2</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A9</name>
-            <type>Reference</type>
-            <data>{IM3}</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A10</name>
-            <type>Formula</type>
-            <data>index * 2</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A11</name>
-            <type>ScriptExpression</type>
-            <data>sensors.provide("mySensor)"</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A12</name>
-            <type>ScriptFile</type>
-            <data>scripts:InitLogixNGVariable</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A13</name>
-            <type>LogixNG_Table</type>
-            <data>MyTable</data>
-          </LocalVariable>
-        </AbstractMaleSocket>
-      </MaleSocket>
-    </ForEach>
-    <ForEach class="jmri.jmrit.logixng.actions.configurexml.ForEachXml">
-      <systemName>IQDA:AUTO:0236</systemName>
-      <comment>A comment</comment>
-      <useCommonSource>no</useCommonSource>
-      <commonManager>Turnouts</commonManager>
-      <operation>Memory</operation>
-      <otherVariable>
-        <addressing>Direct</addressing>
-        <listenToMemory>no</listenToMemory>
-      </otherVariable>
-      <memoryNamedBean>
-        <addressing>Direct</addressing>
-        <listenToMemory>no</listenToMemory>
-      </memoryNamedBean>
-      <formula>turnouts</formula>
-      <localVariable>myVar</localVariable>
-      <Socket>
-        <socketName>q9e9g2uhqc</socketName>
-      </Socket>
-      <MaleSocket>
-        <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
-        <AbstractMaleSocket enabled="yes" locked="no" system="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>Default</errorHandling>
-          <LocalVariable>
-            <name>A1</name>
-            <type>None</type>
-            <data />
-          </LocalVariable>
-          <LocalVariable>
-            <name>A2</name>
-            <type>Integer</type>
-            <data>32</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A3</name>
-            <type>FloatingNumber</type>
-            <data>41.429</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A4</name>
-            <type>String</type>
-            <data>My string</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A5</name>
-            <type>Array</type>
-            <data />
-          </LocalVariable>
-          <LocalVariable>
-            <name>A6</name>
-            <type>Map</type>
-            <data />
-          </LocalVariable>
-          <LocalVariable>
-            <name>A7</name>
-            <type>LocalVariable</type>
-            <data>index</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A8</name>
-            <type>Memory</type>
-            <data>IM2</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A9</name>
-            <type>Reference</type>
-            <data>{IM3}</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A10</name>
-            <type>Formula</type>
-            <data>index * 2</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A11</name>
-            <type>ScriptExpression</type>
-            <data>sensors.provide("mySensor)"</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A12</name>
-            <type>ScriptFile</type>
-            <data>scripts:InitLogixNGVariable</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A13</name>
-            <type>LogixNG_Table</type>
-            <data>MyTable</data>
-          </LocalVariable>
-        </AbstractMaleSocket>
-      </MaleSocket>
-    </ForEach>
-    <ForEach class="jmri.jmrit.logixng.actions.configurexml.ForEachXml">
-      <systemName>IQDA:AUTO:0237</systemName>
-      <comment>A comment</comment>
-      <useCommonSource>no</useCommonSource>
-      <commonManager>Turnouts</commonManager>
-      <operation>Formula</operation>
-      <otherVariable>
-        <addressing>Direct</addressing>
-        <listenToMemory>no</listenToMemory>
-      </otherVariable>
-      <memoryNamedBean>
-        <addressing>Direct</addressing>
-        <listenToMemory>no</listenToMemory>
-      </memoryNamedBean>
-      <formula>turnouts</formula>
-      <localVariable>myVar</localVariable>
-      <Socket>
-        <socketName>vpbz5hp2nj</socketName>
-      </Socket>
-      <MaleSocket>
-        <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
-        <AbstractMaleSocket enabled="yes" locked="no" system="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>Default</errorHandling>
-          <LocalVariable>
-            <name>A1</name>
-            <type>None</type>
-            <data />
-          </LocalVariable>
-          <LocalVariable>
-            <name>A2</name>
-            <type>Integer</type>
-            <data>32</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A3</name>
-            <type>FloatingNumber</type>
-            <data>41.429</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A4</name>
-            <type>String</type>
-            <data>My string</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A5</name>
-            <type>Array</type>
-            <data />
-          </LocalVariable>
-          <LocalVariable>
-            <name>A6</name>
-            <type>Map</type>
-            <data />
-          </LocalVariable>
-          <LocalVariable>
-            <name>A7</name>
-            <type>LocalVariable</type>
-            <data>index</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A8</name>
-            <type>Memory</type>
-            <data>IM2</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A9</name>
-            <type>Reference</type>
-            <data>{IM3}</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A10</name>
-            <type>Formula</type>
-            <data>index * 2</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A11</name>
-            <type>ScriptExpression</type>
-            <data>sensors.provide("mySensor)"</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A12</name>
-            <type>ScriptFile</type>
-            <data>scripts:InitLogixNGVariable</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A13</name>
-            <type>LogixNG_Table</type>
-            <data>MyTable</data>
-          </LocalVariable>
-        </AbstractMaleSocket>
-      </MaleSocket>
-    </ForEach>
-    <ForEach class="jmri.jmrit.logixng.actions.configurexml.ForEachXml">
       <systemName>IQDA:AUTO:0238</systemName>
       <comment>A comment</comment>
-      <useCommonSource>yes</useCommonSource>
-      <commonManager>Sensors</commonManager>
+      <useCommonSource>no</useCommonSource>
+      <commonManager>Turnouts</commonManager>
       <operation>Variable</operation>
       <otherVariable>
         <addressing>Direct</addressing>
@@ -37213,10 +37316,10 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
         <addressing>Direct</addressing>
         <listenToMemory>no</listenToMemory>
       </memoryNamedBean>
-      <formula />
-      <localVariable />
+      <formula>turnouts</formula>
+      <localVariable>myVar</localVariable>
       <Socket>
-        <socketName>j8qn9cdazw</socketName>
+        <socketName>xra1qtzyld</socketName>
       </Socket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -37293,9 +37396,9 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
     <ForEach class="jmri.jmrit.logixng.actions.configurexml.ForEachXml">
       <systemName>IQDA:AUTO:0239</systemName>
       <comment>A comment</comment>
-      <useCommonSource>yes</useCommonSource>
+      <useCommonSource>no</useCommonSource>
       <commonManager>Turnouts</commonManager>
-      <operation>Variable</operation>
+      <operation>Memory</operation>
       <otherVariable>
         <addressing>Direct</addressing>
         <listenToMemory>no</listenToMemory>
@@ -37304,10 +37407,10 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
         <addressing>Direct</addressing>
         <listenToMemory>no</listenToMemory>
       </memoryNamedBean>
-      <formula />
-      <localVariable />
+      <formula>turnouts</formula>
+      <localVariable>myVar</localVariable>
       <Socket>
-        <socketName>rj9hnrgf4i</socketName>
+        <socketName>sr3y28h9oq</socketName>
       </Socket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -37384,9 +37487,9 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
     <ForEach class="jmri.jmrit.logixng.actions.configurexml.ForEachXml">
       <systemName>IQDA:AUTO:0240</systemName>
       <comment>A comment</comment>
-      <useCommonSource>yes</useCommonSource>
-      <commonManager>Lights</commonManager>
-      <operation>Variable</operation>
+      <useCommonSource>no</useCommonSource>
+      <commonManager>Turnouts</commonManager>
+      <operation>Formula</operation>
       <otherVariable>
         <addressing>Direct</addressing>
         <listenToMemory>no</listenToMemory>
@@ -37395,10 +37498,10 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
         <addressing>Direct</addressing>
         <listenToMemory>no</listenToMemory>
       </memoryNamedBean>
-      <formula />
-      <localVariable />
+      <formula>turnouts</formula>
+      <localVariable>myVar</localVariable>
       <Socket>
-        <socketName>swa2rfq3vp</socketName>
+        <socketName>alqxhc4ktj</socketName>
       </Socket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -37476,7 +37579,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <systemName>IQDA:AUTO:0241</systemName>
       <comment>A comment</comment>
       <useCommonSource>yes</useCommonSource>
-      <commonManager>SignalHeads</commonManager>
+      <commonManager>Sensors</commonManager>
       <operation>Variable</operation>
       <otherVariable>
         <addressing>Direct</addressing>
@@ -37489,7 +37592,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <formula />
       <localVariable />
       <Socket>
-        <socketName>gxvj6jwdc9</socketName>
+        <socketName>ncxrp4hwbk</socketName>
       </Socket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -37567,7 +37670,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <systemName>IQDA:AUTO:0242</systemName>
       <comment>A comment</comment>
       <useCommonSource>yes</useCommonSource>
-      <commonManager>SignalMasts</commonManager>
+      <commonManager>Turnouts</commonManager>
       <operation>Variable</operation>
       <otherVariable>
         <addressing>Direct</addressing>
@@ -37580,7 +37683,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <formula />
       <localVariable />
       <Socket>
-        <socketName>wmyi6yqdfm</socketName>
+        <socketName>nedglqg9n5</socketName>
       </Socket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -37658,7 +37761,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <systemName>IQDA:AUTO:0243</systemName>
       <comment>A comment</comment>
       <useCommonSource>yes</useCommonSource>
-      <commonManager>Routes</commonManager>
+      <commonManager>Lights</commonManager>
       <operation>Variable</operation>
       <otherVariable>
         <addressing>Direct</addressing>
@@ -37671,7 +37774,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <formula />
       <localVariable />
       <Socket>
-        <socketName>velkctbzuz</socketName>
+        <socketName>vlj1htey4x</socketName>
       </Socket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -37749,7 +37852,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <systemName>IQDA:AUTO:0244</systemName>
       <comment>A comment</comment>
       <useCommonSource>yes</useCommonSource>
-      <commonManager>Blocks</commonManager>
+      <commonManager>SignalHeads</commonManager>
       <operation>Variable</operation>
       <otherVariable>
         <addressing>Direct</addressing>
@@ -37762,7 +37865,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <formula />
       <localVariable />
       <Socket>
-        <socketName>klnzd59ijd</socketName>
+        <socketName>xbw3y8phew</socketName>
       </Socket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -37840,7 +37943,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <systemName>IQDA:AUTO:0245</systemName>
       <comment>A comment</comment>
       <useCommonSource>yes</useCommonSource>
-      <commonManager>Reporters</commonManager>
+      <commonManager>SignalMasts</commonManager>
       <operation>Variable</operation>
       <otherVariable>
         <addressing>Direct</addressing>
@@ -37853,7 +37956,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <formula />
       <localVariable />
       <Socket>
-        <socketName>ap2ocw6z23</socketName>
+        <socketName>tbwjak3u8n</socketName>
       </Socket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -37931,7 +38034,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <systemName>IQDA:AUTO:0246</systemName>
       <comment>A comment</comment>
       <useCommonSource>yes</useCommonSource>
-      <commonManager>Memories</commonManager>
+      <commonManager>Routes</commonManager>
       <operation>Variable</operation>
       <otherVariable>
         <addressing>Direct</addressing>
@@ -37944,7 +38047,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <formula />
       <localVariable />
       <Socket>
-        <socketName>cq3xtagrn7</socketName>
+        <socketName>x9e2qy7hw3</socketName>
       </Socket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -38022,7 +38125,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <systemName>IQDA:AUTO:0247</systemName>
       <comment>A comment</comment>
       <useCommonSource>yes</useCommonSource>
-      <commonManager>Audio</commonManager>
+      <commonManager>Blocks</commonManager>
       <operation>Variable</operation>
       <otherVariable>
         <addressing>Direct</addressing>
@@ -38035,7 +38138,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <formula />
       <localVariable />
       <Socket>
-        <socketName>zy76zneluz</socketName>
+        <socketName>ume2nw4tiz</socketName>
       </Socket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -38113,7 +38216,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <systemName>IQDA:AUTO:0248</systemName>
       <comment>A comment</comment>
       <useCommonSource>yes</useCommonSource>
-      <commonManager>LayoutBlocks</commonManager>
+      <commonManager>Reporters</commonManager>
       <operation>Variable</operation>
       <otherVariable>
         <addressing>Direct</addressing>
@@ -38126,7 +38229,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <formula />
       <localVariable />
       <Socket>
-        <socketName>ldukwsgyi1</socketName>
+        <socketName>wkxuny1xhe</socketName>
       </Socket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -38204,7 +38307,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <systemName>IQDA:AUTO:0249</systemName>
       <comment>A comment</comment>
       <useCommonSource>yes</useCommonSource>
-      <commonManager>EntryExit</commonManager>
+      <commonManager>Memories</commonManager>
       <operation>Variable</operation>
       <otherVariable>
         <addressing>Direct</addressing>
@@ -38217,7 +38320,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <formula />
       <localVariable />
       <Socket>
-        <socketName>ofxhuzzkvr</socketName>
+        <socketName>sbudnvdnyy</socketName>
       </Socket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -38295,7 +38398,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <systemName>IQDA:AUTO:0250</systemName>
       <comment>A comment</comment>
       <useCommonSource>yes</useCommonSource>
-      <commonManager>Warrants</commonManager>
+      <commonManager>Audio</commonManager>
       <operation>Variable</operation>
       <otherVariable>
         <addressing>Direct</addressing>
@@ -38308,7 +38411,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <formula />
       <localVariable />
       <Socket>
-        <socketName>x81wk5lp3z</socketName>
+        <socketName>j29y9mu7fj</socketName>
       </Socket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -38386,7 +38489,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <systemName>IQDA:AUTO:0251</systemName>
       <comment>A comment</comment>
       <useCommonSource>yes</useCommonSource>
-      <commonManager>Sections</commonManager>
+      <commonManager>LayoutBlocks</commonManager>
       <operation>Variable</operation>
       <otherVariable>
         <addressing>Direct</addressing>
@@ -38399,7 +38502,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <formula />
       <localVariable />
       <Socket>
-        <socketName>hfz9w7aq15</socketName>
+        <socketName>fm5om3ueua</socketName>
       </Socket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -38477,6 +38580,279 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <systemName>IQDA:AUTO:0252</systemName>
       <comment>A comment</comment>
       <useCommonSource>yes</useCommonSource>
+      <commonManager>EntryExit</commonManager>
+      <operation>Variable</operation>
+      <otherVariable>
+        <addressing>Direct</addressing>
+        <listenToMemory>no</listenToMemory>
+      </otherVariable>
+      <memoryNamedBean>
+        <addressing>Direct</addressing>
+        <listenToMemory>no</listenToMemory>
+      </memoryNamedBean>
+      <formula />
+      <localVariable />
+      <Socket>
+        <socketName>do1gmz4efn</socketName>
+      </Socket>
+      <MaleSocket>
+        <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
+        <AbstractMaleSocket enabled="yes" locked="no" system="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
+          <errorHandling>Default</errorHandling>
+          <LocalVariable>
+            <name>A1</name>
+            <type>None</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A2</name>
+            <type>Integer</type>
+            <data>32</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A3</name>
+            <type>FloatingNumber</type>
+            <data>41.429</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A4</name>
+            <type>String</type>
+            <data>My string</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A5</name>
+            <type>Array</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A6</name>
+            <type>Map</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A7</name>
+            <type>LocalVariable</type>
+            <data>index</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A8</name>
+            <type>Memory</type>
+            <data>IM2</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A9</name>
+            <type>Reference</type>
+            <data>{IM3}</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A10</name>
+            <type>Formula</type>
+            <data>index * 2</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A11</name>
+            <type>ScriptExpression</type>
+            <data>sensors.provide("mySensor)"</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A12</name>
+            <type>ScriptFile</type>
+            <data>scripts:InitLogixNGVariable</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A13</name>
+            <type>LogixNG_Table</type>
+            <data>MyTable</data>
+          </LocalVariable>
+        </AbstractMaleSocket>
+      </MaleSocket>
+    </ForEach>
+    <ForEach class="jmri.jmrit.logixng.actions.configurexml.ForEachXml">
+      <systemName>IQDA:AUTO:0253</systemName>
+      <comment>A comment</comment>
+      <useCommonSource>yes</useCommonSource>
+      <commonManager>Warrants</commonManager>
+      <operation>Variable</operation>
+      <otherVariable>
+        <addressing>Direct</addressing>
+        <listenToMemory>no</listenToMemory>
+      </otherVariable>
+      <memoryNamedBean>
+        <addressing>Direct</addressing>
+        <listenToMemory>no</listenToMemory>
+      </memoryNamedBean>
+      <formula />
+      <localVariable />
+      <Socket>
+        <socketName>sjb2oi8wti</socketName>
+      </Socket>
+      <MaleSocket>
+        <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
+        <AbstractMaleSocket enabled="yes" locked="no" system="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
+          <errorHandling>Default</errorHandling>
+          <LocalVariable>
+            <name>A1</name>
+            <type>None</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A2</name>
+            <type>Integer</type>
+            <data>32</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A3</name>
+            <type>FloatingNumber</type>
+            <data>41.429</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A4</name>
+            <type>String</type>
+            <data>My string</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A5</name>
+            <type>Array</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A6</name>
+            <type>Map</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A7</name>
+            <type>LocalVariable</type>
+            <data>index</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A8</name>
+            <type>Memory</type>
+            <data>IM2</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A9</name>
+            <type>Reference</type>
+            <data>{IM3}</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A10</name>
+            <type>Formula</type>
+            <data>index * 2</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A11</name>
+            <type>ScriptExpression</type>
+            <data>sensors.provide("mySensor)"</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A12</name>
+            <type>ScriptFile</type>
+            <data>scripts:InitLogixNGVariable</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A13</name>
+            <type>LogixNG_Table</type>
+            <data>MyTable</data>
+          </LocalVariable>
+        </AbstractMaleSocket>
+      </MaleSocket>
+    </ForEach>
+    <ForEach class="jmri.jmrit.logixng.actions.configurexml.ForEachXml">
+      <systemName>IQDA:AUTO:0254</systemName>
+      <comment>A comment</comment>
+      <useCommonSource>yes</useCommonSource>
+      <commonManager>Sections</commonManager>
+      <operation>Variable</operation>
+      <otherVariable>
+        <addressing>Direct</addressing>
+        <listenToMemory>no</listenToMemory>
+      </otherVariable>
+      <memoryNamedBean>
+        <addressing>Direct</addressing>
+        <listenToMemory>no</listenToMemory>
+      </memoryNamedBean>
+      <formula />
+      <localVariable />
+      <Socket>
+        <socketName>vaxmvc5ty1</socketName>
+      </Socket>
+      <MaleSocket>
+        <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
+        <AbstractMaleSocket enabled="yes" locked="no" system="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
+          <errorHandling>Default</errorHandling>
+          <LocalVariable>
+            <name>A1</name>
+            <type>None</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A2</name>
+            <type>Integer</type>
+            <data>32</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A3</name>
+            <type>FloatingNumber</type>
+            <data>41.429</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A4</name>
+            <type>String</type>
+            <data>My string</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A5</name>
+            <type>Array</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A6</name>
+            <type>Map</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A7</name>
+            <type>LocalVariable</type>
+            <data>index</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A8</name>
+            <type>Memory</type>
+            <data>IM2</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A9</name>
+            <type>Reference</type>
+            <data>{IM3}</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A10</name>
+            <type>Formula</type>
+            <data>index * 2</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A11</name>
+            <type>ScriptExpression</type>
+            <data>sensors.provide("mySensor)"</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A12</name>
+            <type>ScriptFile</type>
+            <data>scripts:InitLogixNGVariable</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A13</name>
+            <type>LogixNG_Table</type>
+            <data>MyTable</data>
+          </LocalVariable>
+        </AbstractMaleSocket>
+      </MaleSocket>
+    </ForEach>
+    <ForEach class="jmri.jmrit.logixng.actions.configurexml.ForEachXml">
+      <systemName>IQDA:AUTO:0255</systemName>
+      <comment>A comment</comment>
+      <useCommonSource>yes</useCommonSource>
       <commonManager>Transits</commonManager>
       <operation>Variable</operation>
       <otherVariable>
@@ -38490,7 +38866,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <formula />
       <localVariable />
       <Socket>
-        <socketName>vhgawkd8eg</socketName>
+        <socketName>ywirvwrygt</socketName>
       </Socket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -38565,18 +38941,18 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ForEach>
     <IfThenElse class="jmri.jmrit.logixng.actions.configurexml.IfThenElseXml" executeType="ExecuteOnChange" evaluateType="EvaluateAll">
-      <systemName>IQDA:AUTO:0253</systemName>
+      <systemName>IQDA:AUTO:0256</systemName>
       <Expressions>
         <Socket>
-          <socketName>belqf2l655</socketName>
+          <socketName>vpjw34wg8e</socketName>
         </Socket>
       </Expressions>
       <Actions>
         <Socket>
-          <socketName>yiudueu5qu</socketName>
+          <socketName>ddx5jjasgl</socketName>
         </Socket>
         <Socket>
-          <socketName>de2iw8rpc2</socketName>
+          <socketName>veddzl7o3q</socketName>
         </Socket>
       </Actions>
       <MaleSocket>
@@ -38652,19 +39028,19 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </IfThenElse>
     <IfThenElse class="jmri.jmrit.logixng.actions.configurexml.IfThenElseXml" executeType="ExecuteOnChange" evaluateType="EvaluateAll">
-      <systemName>IQDA:AUTO:0254</systemName>
+      <systemName>IQDA:AUTO:0257</systemName>
       <comment>A comment</comment>
       <Expressions>
         <Socket>
-          <socketName>y9btfcadjh</socketName>
+          <socketName>z87rzevud4</socketName>
         </Socket>
       </Expressions>
       <Actions>
         <Socket>
-          <socketName>g5g8oytb1s</socketName>
+          <socketName>r37d175td5</socketName>
         </Socket>
         <Socket>
-          <socketName>uo4hllb3sh</socketName>
+          <socketName>m192rgnf1t</socketName>
         </Socket>
       </Actions>
       <MaleSocket>
@@ -38740,19 +39116,19 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </IfThenElse>
     <IfThenElse class="jmri.jmrit.logixng.actions.configurexml.IfThenElseXml" executeType="AlwaysExecute" evaluateType="EvaluateAll">
-      <systemName>IQDA:AUTO:0255</systemName>
+      <systemName>IQDA:AUTO:0258</systemName>
       <comment>A comment</comment>
       <Expressions>
         <Socket>
-          <socketName>vn7cct8tr3</socketName>
+          <socketName>vmyvze3i7y</socketName>
         </Socket>
       </Expressions>
       <Actions>
         <Socket>
-          <socketName>w9kon9p1r4</socketName>
+          <socketName>qkqfqgbt9i</socketName>
         </Socket>
         <Socket>
-          <socketName>sdvf2xk4rn</socketName>
+          <socketName>ryxhjrioea</socketName>
         </Socket>
       </Actions>
       <MaleSocket>
@@ -38828,12 +39204,12 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </IfThenElse>
     <Logix class="jmri.jmrit.logixng.actions.configurexml.LogixXml" executeType="ExecuteOnChange">
-      <systemName>IQDA:AUTO:0256</systemName>
+      <systemName>IQDA:AUTO:0259</systemName>
       <ExpressionSocket>
-        <socketName>gkvaqbk2zt</socketName>
+        <socketName>a79pjx2vpf</socketName>
       </ExpressionSocket>
       <ActionSocket>
-        <socketName>dtfnlmm94x</socketName>
+        <socketName>fbdd4m97mo</socketName>
       </ActionSocket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -38908,13 +39284,13 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </Logix>
     <Logix class="jmri.jmrit.logixng.actions.configurexml.LogixXml" executeType="ExecuteOnChange">
-      <systemName>IQDA:AUTO:0257</systemName>
+      <systemName>IQDA:AUTO:0260</systemName>
       <comment>A comment</comment>
       <ExpressionSocket>
-        <socketName>ojsz43wdgx</socketName>
+        <socketName>bx7k5zj6vx</socketName>
       </ExpressionSocket>
       <ActionSocket>
-        <socketName>x74bw6btdq</socketName>
+        <socketName>upbfb6ibly</socketName>
       </ActionSocket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -38989,13 +39365,13 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </Logix>
     <Logix class="jmri.jmrit.logixng.actions.configurexml.LogixXml" executeType="ExecuteAlways">
-      <systemName>IQDA:AUTO:0258</systemName>
+      <systemName>IQDA:AUTO:0261</systemName>
       <comment>A comment</comment>
       <ExpressionSocket>
-        <socketName>wyfhkrexp9</socketName>
+        <socketName>qyhwf3cavu</socketName>
       </ExpressionSocket>
       <ActionSocket>
-        <socketName>u1en9jvz3q</socketName>
+        <socketName>wz4xyshni2</socketName>
         <systemName>IQDB:AUTO:0001</systemName>
       </ActionSocket>
       <MaleSocket>
@@ -39071,7 +39447,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </Logix>
     <LogData class="jmri.jmrit.logixng.actions.configurexml.LogDataXml">
-      <systemName>IQDA:AUTO:0259</systemName>
+      <systemName>IQDA:AUTO:0262</systemName>
       <logToLog>yes</logToLog>
       <logToScriptOutput>no</logToScriptOutput>
       <formatType>OnlyText</formatType>
@@ -39150,7 +39526,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </LogData>
     <LogData class="jmri.jmrit.logixng.actions.configurexml.LogDataXml">
-      <systemName>IQDA:AUTO:0260</systemName>
+      <systemName>IQDA:AUTO:0263</systemName>
       <comment>A comment</comment>
       <logToLog>yes</logToLog>
       <logToScriptOutput>yes</logToScriptOutput>
@@ -39235,7 +39611,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </LogData>
     <LogData class="jmri.jmrit.logixng.actions.configurexml.LogDataXml">
-      <systemName>IQDA:AUTO:0261</systemName>
+      <systemName>IQDA:AUTO:0264</systemName>
       <comment>A comment</comment>
       <logToLog>yes</logToLog>
       <logToScriptOutput>yes</logToScriptOutput>
@@ -39320,7 +39696,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </LogData>
     <LogData class="jmri.jmrit.logixng.actions.configurexml.LogDataXml">
-      <systemName>IQDA:AUTO:0262</systemName>
+      <systemName>IQDA:AUTO:0265</systemName>
       <comment>A comment</comment>
       <logToLog>yes</logToLog>
       <logToScriptOutput>yes</logToScriptOutput>
@@ -39405,7 +39781,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </LogData>
     <LogData class="jmri.jmrit.logixng.actions.configurexml.LogDataXml">
-      <systemName>IQDA:AUTO:0263</systemName>
+      <systemName>IQDA:AUTO:0266</systemName>
       <comment>A comment</comment>
       <logToLog>yes</logToLog>
       <logToScriptOutput>yes</logToScriptOutput>
@@ -39502,7 +39878,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </LogData>
     <LogLocalVariables class="jmri.jmrit.logixng.actions.configurexml.LogLocalVariablesXml">
-      <systemName>IQDA:AUTO:0264</systemName>
+      <systemName>IQDA:AUTO:0267</systemName>
       <includeGlobalVariables>yes</includeGlobalVariables>
       <expandArraysAndMaps>no</expandArraysAndMaps>
       <MaleSocket>
@@ -39578,7 +39954,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </LogLocalVariables>
     <LogLocalVariables class="jmri.jmrit.logixng.actions.configurexml.LogLocalVariablesXml">
-      <systemName>IQDA:AUTO:0265</systemName>
+      <systemName>IQDA:AUTO:0268</systemName>
       <comment>A comment</comment>
       <includeGlobalVariables>yes</includeGlobalVariables>
       <expandArraysAndMaps>no</expandArraysAndMaps>
@@ -39655,7 +40031,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </LogLocalVariables>
     <LogLocalVariables class="jmri.jmrit.logixng.actions.configurexml.LogLocalVariablesXml">
-      <systemName>IQDA:AUTO:0266</systemName>
+      <systemName>IQDA:AUTO:0269</systemName>
       <comment>A comment</comment>
       <includeGlobalVariables>no</includeGlobalVariables>
       <expandArraysAndMaps>yes</expandArraysAndMaps>
@@ -39732,10 +40108,10 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </LogLocalVariables>
     <DigitalMany class="jmri.jmrit.logixng.actions.configurexml.DigitalManyXml">
-      <systemName>IQDA:AUTO:0267</systemName>
+      <systemName>IQDA:AUTO:0270</systemName>
       <Actions>
         <Socket>
-          <socketName>fbh6p3nyyv</socketName>
+          <socketName>dnqmrzinu4</socketName>
         </Socket>
       </Actions>
       <MaleSocket>
@@ -39811,11 +40187,11 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </DigitalMany>
     <DigitalMany class="jmri.jmrit.logixng.actions.configurexml.DigitalManyXml">
-      <systemName>IQDA:AUTO:0268</systemName>
+      <systemName>IQDA:AUTO:0271</systemName>
       <comment>A comment</comment>
       <Actions>
         <Socket>
-          <socketName>yrdqceojvk</socketName>
+          <socketName>rb5mxi3fhp</socketName>
         </Socket>
       </Actions>
       <MaleSocket>
@@ -39891,7 +40267,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </DigitalMany>
     <Break class="jmri.jmrit.logixng.actions.configurexml.BreakXml">
-      <systemName>IQDA:AUTO:0269</systemName>
+      <systemName>IQDA:AUTO:0272</systemName>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
         <AbstractMaleSocket enabled="no" locked="no" system="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
@@ -39965,7 +40341,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </Break>
     <Continue class="jmri.jmrit.logixng.actions.configurexml.ContinueXml">
-      <systemName>IQDA:AUTO:0270</systemName>
+      <systemName>IQDA:AUTO:0273</systemName>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
         <AbstractMaleSocket enabled="no" locked="no" system="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
@@ -40039,7 +40415,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </Continue>
     <Error class="jmri.jmrit.logixng.actions.configurexml.ErrorXml">
-      <systemName>IQDA:AUTO:0271</systemName>
+      <systemName>IQDA:AUTO:0274</systemName>
       <message />
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -40114,7 +40490,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </Error>
     <Error class="jmri.jmrit.logixng.actions.configurexml.ErrorXml">
-      <systemName>IQDA:AUTO:0272</systemName>
+      <systemName>IQDA:AUTO:0275</systemName>
       <message>Some error has occurred</message>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -40189,7 +40565,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </Error>
     <Exit class="jmri.jmrit.logixng.actions.configurexml.ExitXml">
-      <systemName>IQDA:AUTO:0273</systemName>
+      <systemName>IQDA:AUTO:0276</systemName>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
         <AbstractMaleSocket enabled="no" locked="no" system="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
@@ -40263,7 +40639,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </Exit>
     <Return class="jmri.jmrit.logixng.actions.configurexml.ReturnXml">
-      <systemName>IQDA:AUTO:0274</systemName>
+      <systemName>IQDA:AUTO:0277</systemName>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
         <AbstractMaleSocket enabled="no" locked="no" system="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
@@ -40337,10 +40713,10 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </Return>
     <RunOnce class="jmri.jmrit.logixng.actions.configurexml.RunOnceXml">
-      <systemName>IQDA:AUTO:0275</systemName>
+      <systemName>IQDA:AUTO:0278</systemName>
       <Socket>
-        <socketName>xjnaqfd7ko</socketName>
-        <systemName>IQDA:AUTO:0276</systemName>
+        <socketName>zjh7xsbbzl</socketName>
+        <systemName>IQDA:AUTO:0279</systemName>
       </Socket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -40415,7 +40791,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </RunOnce>
     <Return class="jmri.jmrit.logixng.actions.configurexml.ReturnXml">
-      <systemName>IQDA:AUTO:0276</systemName>
+      <systemName>IQDA:AUTO:0279</systemName>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
         <AbstractMaleSocket enabled="no" locked="no" system="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
@@ -40489,24 +40865,24 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </Return>
     <Sequence class="jmri.jmrit.logixng.actions.configurexml.SequenceXml">
-      <systemName>IQDA:AUTO:0277</systemName>
+      <systemName>IQDA:AUTO:0280</systemName>
       <StartSocket>
-        <socketName>ey4fo3g2cj</socketName>
+        <socketName>otkzxfcl2l</socketName>
       </StartSocket>
       <StopSocket>
-        <socketName>qwevbsl7z5</socketName>
+        <socketName>rkf6badn3e</socketName>
       </StopSocket>
       <ResetSocket>
-        <socketName>cob7xfzrbw</socketName>
+        <socketName>fq2ak8ykvq</socketName>
       </ResetSocket>
       <Expressions>
         <Socket>
-          <socketName>y8sm7pk63b</socketName>
+          <socketName>smzm6u6xgt</socketName>
         </Socket>
       </Expressions>
       <Actions>
         <Socket>
-          <socketName>iziuzy6asv</socketName>
+          <socketName>tu85ub78ih</socketName>
         </Socket>
       </Actions>
       <startImmediately>yes</startImmediately>
@@ -40584,38 +40960,38 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </Sequence>
     <Sequence class="jmri.jmrit.logixng.actions.configurexml.SequenceXml">
-      <systemName>IQDA:AUTO:0278</systemName>
+      <systemName>IQDA:AUTO:0281</systemName>
       <comment>A comment</comment>
       <StartSocket>
-        <socketName>z4r41yt4cd</socketName>
+        <socketName>yj863ny6fw</socketName>
         <systemName>IQDE:AUTO:0004</systemName>
       </StartSocket>
       <StopSocket>
-        <socketName>isz1qng35p</socketName>
+        <socketName>a41baql2dj</socketName>
         <systemName>IQDE:AUTO:0005</systemName>
       </StopSocket>
       <ResetSocket>
-        <socketName>w9ko8q8ijp</socketName>
+        <socketName>e23y1goloe</socketName>
         <systemName>IQDE:AUTO:0006</systemName>
       </ResetSocket>
       <Expressions>
         <Socket>
-          <socketName>oef9l72uhi</socketName>
+          <socketName>ccnk4hofns</socketName>
           <systemName>IQDE:AUTO:0007</systemName>
         </Socket>
         <Socket>
-          <socketName>ewzu34wkx7</socketName>
+          <socketName>g92bucbmew</socketName>
           <systemName>IQDE:AUTO:0008</systemName>
         </Socket>
       </Expressions>
       <Actions>
         <Socket>
-          <socketName>e8hpkcmie9</socketName>
-          <systemName>IQDA:AUTO:0279</systemName>
+          <socketName>vqurpmyd2z</socketName>
+          <systemName>IQDA:AUTO:0282</systemName>
         </Socket>
         <Socket>
-          <socketName>urphboj1cz</socketName>
-          <systemName>IQDA:AUTO:0280</systemName>
+          <socketName>yqceand1vg</socketName>
+          <systemName>IQDA:AUTO:0283</systemName>
         </Socket>
       </Actions>
       <startImmediately>no</startImmediately>
@@ -40693,11 +41069,11 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </Sequence>
     <DigitalMany class="jmri.jmrit.logixng.actions.configurexml.DigitalManyXml">
-      <systemName>IQDA:AUTO:0279</systemName>
+      <systemName>IQDA:AUTO:0282</systemName>
       <comment>Action socket 1</comment>
       <Actions>
         <Socket>
-          <socketName>yt7d7s6f6l</socketName>
+          <socketName>bg52ugittp</socketName>
         </Socket>
       </Actions>
       <MaleSocket>
@@ -40773,11 +41149,11 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </DigitalMany>
     <DigitalMany class="jmri.jmrit.logixng.actions.configurexml.DigitalManyXml">
-      <systemName>IQDA:AUTO:0280</systemName>
+      <systemName>IQDA:AUTO:0283</systemName>
       <comment>Action socket 2</comment>
       <Actions>
         <Socket>
-          <socketName>dwdyfupw2d</socketName>
+          <socketName>t8qqsd8by1</socketName>
         </Socket>
       </Actions>
       <MaleSocket>
@@ -40853,12 +41229,12 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </DigitalMany>
     <ShowDialog class="jmri.jmrit.logixng.actions.configurexml.ShowDialogXml">
-      <systemName>IQDA:AUTO:0281</systemName>
+      <systemName>IQDA:AUTO:0284</systemName>
       <ValidateSocket>
-        <socketName>ryko5zkx59</socketName>
+        <socketName>d7ojqr983e</socketName>
       </ValidateSocket>
       <ExecuteSocket>
-        <socketName>jpr4qrgngn</socketName>
+        <socketName>k73dnmnafm</socketName>
       </ExecuteSocket>
       <Buttons>
         <name>Ok</name>
@@ -40943,15 +41319,15 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ShowDialog>
     <ShowDialog class="jmri.jmrit.logixng.actions.configurexml.ShowDialogXml">
-      <systemName>IQDA:AUTO:0282</systemName>
+      <systemName>IQDA:AUTO:0285</systemName>
       <comment>A comment</comment>
       <ValidateSocket>
-        <socketName>x51x1vcn3u</socketName>
+        <socketName>s2vyghyycl</socketName>
         <systemName>IQDE:AUTO:0009</systemName>
       </ValidateSocket>
       <ExecuteSocket>
-        <socketName>t3hjpqi1hw</socketName>
-        <systemName>IQDA:AUTO:0283</systemName>
+        <socketName>b9x3cyzb9o</socketName>
+        <systemName>IQDA:AUTO:0286</systemName>
       </ExecuteSocket>
       <Buttons>
         <name>Ok</name>
@@ -41041,7 +41417,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ShowDialog>
     <LogLocalVariables class="jmri.jmrit.logixng.actions.configurexml.LogLocalVariablesXml">
-      <systemName>IQDA:AUTO:0283</systemName>
+      <systemName>IQDA:AUTO:0286</systemName>
       <includeGlobalVariables>yes</includeGlobalVariables>
       <expandArraysAndMaps>no</expandArraysAndMaps>
       <MaleSocket>
@@ -41117,13 +41493,13 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </LogLocalVariables>
     <ShowDialog class="jmri.jmrit.logixng.actions.configurexml.ShowDialogXml">
-      <systemName>IQDA:AUTO:0284</systemName>
+      <systemName>IQDA:AUTO:0287</systemName>
       <comment>A comment</comment>
       <ValidateSocket>
-        <socketName>sk7o7su545</socketName>
+        <socketName>ziez7n3z7c</socketName>
       </ValidateSocket>
       <ExecuteSocket>
-        <socketName>kl8uumqutw</socketName>
+        <socketName>q3awialude</socketName>
       </ExecuteSocket>
       <Buttons>
         <name>Cancel</name>
@@ -41215,13 +41591,13 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ShowDialog>
     <ShowDialog class="jmri.jmrit.logixng.actions.configurexml.ShowDialogXml">
-      <systemName>IQDA:AUTO:0285</systemName>
+      <systemName>IQDA:AUTO:0288</systemName>
       <comment>A comment</comment>
       <ValidateSocket>
-        <socketName>aftbjwaxlb</socketName>
+        <socketName>xjy9nflujx</socketName>
       </ValidateSocket>
       <ExecuteSocket>
-        <socketName>sre3fqr76b</socketName>
+        <socketName>xynxey9iq9</socketName>
       </ExecuteSocket>
       <Buttons>
         <name>No</name>
@@ -41311,13 +41687,13 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ShowDialog>
     <ShowDialog class="jmri.jmrit.logixng.actions.configurexml.ShowDialogXml">
-      <systemName>IQDA:AUTO:0286</systemName>
+      <systemName>IQDA:AUTO:0289</systemName>
       <comment>A comment</comment>
       <ValidateSocket>
-        <socketName>q2xsbdhrm9</socketName>
+        <socketName>ygh4wzcu33</socketName>
       </ValidateSocket>
       <ExecuteSocket>
-        <socketName>unw8vs2bik</socketName>
+        <socketName>ccgs9lcudi</socketName>
       </ExecuteSocket>
       <Buttons>
         <name>No</name>
@@ -41419,7 +41795,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ShowDialog>
     <ShutdownComputer class="jmri.jmrit.logixng.actions.configurexml.ShutdownComputerXml">
-      <systemName>IQDA:AUTO:0287</systemName>
+      <systemName>IQDA:AUTO:0290</systemName>
       <shutdownOperation>
         <addressing>Direct</addressing>
         <enum>ShutdownJMRI</enum>
@@ -41498,7 +41874,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ShutdownComputer>
     <ShutdownComputer class="jmri.jmrit.logixng.actions.configurexml.ShutdownComputerXml">
-      <systemName>IQDA:AUTO:0288</systemName>
+      <systemName>IQDA:AUTO:0291</systemName>
       <comment>A comment</comment>
       <shutdownOperation>
         <addressing>Direct</addressing>
@@ -41578,7 +41954,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ShutdownComputer>
     <ShutdownComputer class="jmri.jmrit.logixng.actions.configurexml.ShutdownComputerXml">
-      <systemName>IQDA:AUTO:0289</systemName>
+      <systemName>IQDA:AUTO:0292</systemName>
       <comment>A comment</comment>
       <shutdownOperation>
         <addressing>Direct</addressing>
@@ -41658,7 +42034,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ShutdownComputer>
     <ShutdownComputer class="jmri.jmrit.logixng.actions.configurexml.ShutdownComputerXml">
-      <systemName>IQDA:AUTO:0290</systemName>
+      <systemName>IQDA:AUTO:0293</systemName>
       <comment>A comment</comment>
       <shutdownOperation>
         <addressing>Direct</addressing>
@@ -41738,7 +42114,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ShutdownComputer>
     <ShutdownComputer class="jmri.jmrit.logixng.actions.configurexml.ShutdownComputerXml">
-      <systemName>IQDA:AUTO:0291</systemName>
+      <systemName>IQDA:AUTO:0294</systemName>
       <comment>A comment</comment>
       <shutdownOperation>
         <addressing>Direct</addressing>
@@ -41818,7 +42194,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </ShutdownComputer>
     <SimulateTurnoutFeedback class="jmri.jmrit.logixng.actions.configurexml.SimulateTurnoutFeedbackXml">
-      <systemName>IQDA:AUTO:0292</systemName>
+      <systemName>IQDA:AUTO:0295</systemName>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
         <AbstractMaleSocket enabled="no" locked="no" system="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
@@ -41892,7 +42268,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </SimulateTurnoutFeedback>
     <SimulateTurnoutFeedback class="jmri.jmrit.logixng.actions.configurexml.SimulateTurnoutFeedbackXml">
-      <systemName>IQDA:AUTO:0293</systemName>
+      <systemName>IQDA:AUTO:0296</systemName>
       <comment>A comment</comment>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -41967,7 +42343,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </SimulateTurnoutFeedback>
     <TableForEach class="jmri.jmrit.logixng.actions.configurexml.TableForEachXml">
-      <systemName>IQDA:AUTO:0294</systemName>
+      <systemName>IQDA:AUTO:0297</systemName>
       <localVariable />
       <namedBean>
         <addressing>Direct</addressing>
@@ -41980,7 +42356,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <rowOrColumnFormula />
       <tableRowOrColumn>Column</tableRowOrColumn>
       <Socket>
-        <socketName>ufkbeivmxe</socketName>
+        <socketName>yc8tvjjr22</socketName>
       </Socket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -42055,7 +42431,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </TableForEach>
     <TableForEach class="jmri.jmrit.logixng.actions.configurexml.TableForEachXml">
-      <systemName>IQDA:AUTO:0295</systemName>
+      <systemName>IQDA:AUTO:0298</systemName>
       <comment>A comment</comment>
       <localVariable>MyLocalVariable</localVariable>
       <namedBean>
@@ -42070,8 +42446,8 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <rowOrColumnFormula />
       <tableRowOrColumn>Row</tableRowOrColumn>
       <Socket>
-        <socketName>v2nbohjx34</socketName>
-        <systemName>IQDA:AUTO:0296</systemName>
+        <socketName>uzimirj9fo</socketName>
+        <systemName>IQDA:AUTO:0299</systemName>
       </Socket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -42146,10 +42522,10 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </TableForEach>
     <DigitalMany class="jmri.jmrit.logixng.actions.configurexml.DigitalManyXml">
-      <systemName>IQDA:AUTO:0296</systemName>
+      <systemName>IQDA:AUTO:0299</systemName>
       <Actions>
         <Socket>
-          <socketName>x4vy17ptx7</socketName>
+          <socketName>k7sxm14qkb</socketName>
         </Socket>
       </Actions>
       <MaleSocket>
@@ -42225,7 +42601,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </DigitalMany>
     <TableForEach class="jmri.jmrit.logixng.actions.configurexml.TableForEachXml">
-      <systemName>IQDA:AUTO:0297</systemName>
+      <systemName>IQDA:AUTO:0300</systemName>
       <comment>A comment</comment>
       <localVariable>MyLocalVariable</localVariable>
       <namedBean>
@@ -42243,8 +42619,8 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <rowOrColumnFormula>MyRowOrColumnFormula</rowOrColumnFormula>
       <tableRowOrColumn>Column</tableRowOrColumn>
       <Socket>
-        <socketName>stp35ql3uy</socketName>
-        <systemName>IQDA:AUTO:0298</systemName>
+        <socketName>xq3sff1kg7</socketName>
+        <systemName>IQDA:AUTO:0301</systemName>
       </Socket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -42319,10 +42695,10 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </TableForEach>
     <DigitalMany class="jmri.jmrit.logixng.actions.configurexml.DigitalManyXml">
-      <systemName>IQDA:AUTO:0298</systemName>
+      <systemName>IQDA:AUTO:0301</systemName>
       <Actions>
         <Socket>
-          <socketName>l25tf5v2pb</socketName>
+          <socketName>vjwtcenuvi</socketName>
         </Socket>
       </Actions>
       <MaleSocket>
@@ -42398,26 +42774,26 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </DigitalMany>
     <Throttle class="jmri.jmrit.logixng.actions.configurexml.ActionThrottleXml">
-      <systemName>IQDA:AUTO:0299</systemName>
+      <systemName>IQDA:AUTO:0302</systemName>
       <comment>A comment</comment>
       <LocoAddressSocket>
-        <socketName>tyihsdbr74</socketName>
+        <socketName>rdztuue7gk</socketName>
         <systemName>IQAE:AUTO:0001</systemName>
       </LocoAddressSocket>
       <LocoSpeedSocket>
-        <socketName>ymtfx3tra6</socketName>
+        <socketName>zkibqwfao6</socketName>
         <systemName>IQAE:AUTO:0002</systemName>
       </LocoSpeedSocket>
       <LocoDirectionSocket>
-        <socketName>w3b9rrpd5s</socketName>
+        <socketName>zpdrgnokhq</socketName>
         <systemName>IQDE:AUTO:0010</systemName>
       </LocoDirectionSocket>
       <LocoFunctionSocket>
-        <socketName>nss5x2khtx</socketName>
+        <socketName>gxcsrc56lf</socketName>
         <systemName>IQAE:AUTO:0003</systemName>
       </LocoFunctionSocket>
       <LocoFunctionOnOffSocket>
-        <socketName>qiusg2ot85</socketName>
+        <socketName>zrbrgn2t9j</socketName>
         <systemName>IQDE:AUTO:0011</systemName>
       </LocoFunctionOnOffSocket>
       <MaleSocket>
@@ -42493,12 +42869,12 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </Throttle>
     <Timeout class="jmri.jmrit.logixng.actions.configurexml.TimeoutXml">
-      <systemName>IQDA:AUTO:0300</systemName>
+      <systemName>IQDA:AUTO:0303</systemName>
       <ExpressionSocket>
-        <socketName>m8r9qdnhrl</socketName>
+        <socketName>g8nsifjgjf</socketName>
       </ExpressionSocket>
       <ActionSocket>
-        <socketName>tv8c18erbc</socketName>
+        <socketName>oeinidefpr</socketName>
       </ActionSocket>
       <timeToDelay>
         <addressing>Direct</addressing>
@@ -42583,13 +42959,13 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </Timeout>
     <Timeout class="jmri.jmrit.logixng.actions.configurexml.TimeoutXml">
-      <systemName>IQDA:AUTO:0301</systemName>
+      <systemName>IQDA:AUTO:0304</systemName>
       <comment>A comment</comment>
       <ExpressionSocket>
-        <socketName>kn4kgyboa3</socketName>
+        <socketName>qk6hxcqhq8</socketName>
       </ExpressionSocket>
       <ActionSocket>
-        <socketName>i6ffyujezw</socketName>
+        <socketName>iqgtburyjj</socketName>
       </ActionSocket>
       <timeToDelay>
         <addressing>Direct</addressing>
@@ -42674,13 +43050,13 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </Timeout>
     <Timeout class="jmri.jmrit.logixng.actions.configurexml.TimeoutXml">
-      <systemName>IQDA:AUTO:0302</systemName>
+      <systemName>IQDA:AUTO:0305</systemName>
       <comment>A comment</comment>
       <ExpressionSocket>
-        <socketName>umi9638zcb</socketName>
+        <socketName>b2oc62irci</socketName>
       </ExpressionSocket>
       <ActionSocket>
-        <socketName>rhkbwjs1su</socketName>
+        <socketName>kkpjpr8eaz</socketName>
       </ActionSocket>
       <timeToDelay>
         <addressing>Memory</addressing>
@@ -42766,13 +43142,13 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </Timeout>
     <Timeout class="jmri.jmrit.logixng.actions.configurexml.TimeoutXml">
-      <systemName>IQDA:AUTO:0303</systemName>
+      <systemName>IQDA:AUTO:0306</systemName>
       <comment>A comment</comment>
       <ExpressionSocket>
-        <socketName>ud8ulbier4</socketName>
+        <socketName>ktv8l1ugaj</socketName>
       </ExpressionSocket>
       <ActionSocket>
-        <socketName>xfoimkhfsx</socketName>
+        <socketName>y6zi3ip13v</socketName>
       </ActionSocket>
       <timeToDelay>
         <addressing>LocalVariable</addressing>
@@ -42858,13 +43234,13 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </Timeout>
     <Timeout class="jmri.jmrit.logixng.actions.configurexml.TimeoutXml">
-      <systemName>IQDA:AUTO:0304</systemName>
+      <systemName>IQDA:AUTO:0307</systemName>
       <comment>A comment</comment>
       <ExpressionSocket>
-        <socketName>f3hi6i7oyd</socketName>
+        <socketName>nvxnojjjzx</socketName>
       </ExpressionSocket>
       <ActionSocket>
-        <socketName>q8s7ddnqm2</socketName>
+        <socketName>wt6hyfcjvg</socketName>
       </ActionSocket>
       <timeToDelay>
         <addressing>Reference</addressing>
@@ -42950,13 +43326,13 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </Timeout>
     <Timeout class="jmri.jmrit.logixng.actions.configurexml.TimeoutXml">
-      <systemName>IQDA:AUTO:0305</systemName>
+      <systemName>IQDA:AUTO:0308</systemName>
       <comment>A comment</comment>
       <ExpressionSocket>
-        <socketName>wov9qi23i4</socketName>
+        <socketName>cx25bhw6mm</socketName>
       </ExpressionSocket>
       <ActionSocket>
-        <socketName>xrf9xizrgf</socketName>
+        <socketName>h4boynz6l1</socketName>
       </ActionSocket>
       <timeToDelay>
         <addressing>Formula</addressing>
@@ -43042,7 +43418,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </Timeout>
     <TriggerRoute class="jmri.jmrit.logixng.actions.configurexml.TriggerRouteXml">
-      <systemName>IQDA:AUTO:0306</systemName>
+      <systemName>IQDA:AUTO:0309</systemName>
       <namedBean>
         <addressing>Direct</addressing>
         <listenToMemory>no</listenToMemory>
@@ -43125,7 +43501,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </TriggerRoute>
     <TriggerRoute class="jmri.jmrit.logixng.actions.configurexml.TriggerRouteXml">
-      <systemName>IQDA:AUTO:0307</systemName>
+      <systemName>IQDA:AUTO:0310</systemName>
       <comment>A comment</comment>
       <namedBean>
         <addressing>Direct</addressing>
@@ -43209,20 +43585,20 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </TriggerRoute>
     <IfThenElse class="jmri.jmrit.logixng.actions.configurexml.IfThenElseXml" executeType="ExecuteOnChange" evaluateType="EvaluateAll">
-      <systemName>IQDA:AUTO:0308</systemName>
+      <systemName>IQDA:AUTO:0311</systemName>
       <comment>A comment</comment>
       <Expressions>
         <Socket>
-          <socketName>h93w7jxiu5</socketName>
+          <socketName>rh2pef4qfc</socketName>
           <systemName>IQDE:AUTO:0012</systemName>
         </Socket>
       </Expressions>
       <Actions>
         <Socket>
-          <socketName>y18jhp9q6x</socketName>
+          <socketName>cohxicnwse</socketName>
         </Socket>
         <Socket>
-          <socketName>o7geaoaps2</socketName>
+          <socketName>yqfivzhf2l</socketName>
         </Socket>
       </Actions>
       <MaleSocket>
@@ -43298,260 +43674,14 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </IfThenElse>
     <DoAnalogAction class="jmri.jmrit.logixng.actions.configurexml.DoAnalogActionXml">
-      <systemName>IQDA:AUTO:0309</systemName>
+      <systemName>IQDA:AUTO:0312</systemName>
       <ExpressionSocket>
-        <socketName>c6vj3bdgu8</socketName>
+        <socketName>plcigffg7z</socketName>
         <systemName>IQAE:AUTO:0004</systemName>
       </ExpressionSocket>
       <ActionSocket>
-        <socketName>fj33dcl8la</socketName>
+        <socketName>yaey5k6885</socketName>
         <systemName>IQAA:AUTO:0001</systemName>
-      </ActionSocket>
-      <MaleSocket>
-        <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
-        <AbstractMaleSocket enabled="no" locked="no" system="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>Default</errorHandling>
-          <LocalVariable>
-            <name>A1</name>
-            <type>None</type>
-            <data />
-          </LocalVariable>
-          <LocalVariable>
-            <name>A2</name>
-            <type>Integer</type>
-            <data>32</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A3</name>
-            <type>FloatingNumber</type>
-            <data>41.429</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A4</name>
-            <type>String</type>
-            <data>My string</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A5</name>
-            <type>Array</type>
-            <data />
-          </LocalVariable>
-          <LocalVariable>
-            <name>A6</name>
-            <type>Map</type>
-            <data />
-          </LocalVariable>
-          <LocalVariable>
-            <name>A7</name>
-            <type>LocalVariable</type>
-            <data>index</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A8</name>
-            <type>Memory</type>
-            <data>IM2</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A9</name>
-            <type>Reference</type>
-            <data>{IM3}</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A10</name>
-            <type>Formula</type>
-            <data>index * 2</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A11</name>
-            <type>ScriptExpression</type>
-            <data>sensors.provide("mySensor)"</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A12</name>
-            <type>ScriptFile</type>
-            <data>scripts:InitLogixNGVariable</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A13</name>
-            <type>LogixNG_Table</type>
-            <data>MyTable</data>
-          </LocalVariable>
-        </AbstractMaleSocket>
-      </MaleSocket>
-    </DoAnalogAction>
-    <DoAnalogAction class="jmri.jmrit.logixng.actions.configurexml.DoAnalogActionXml">
-      <systemName>IQDA:AUTO:0310</systemName>
-      <ExpressionSocket>
-        <socketName>u7iq4uv4km</socketName>
-        <systemName>IQAE:AUTO:0005</systemName>
-      </ExpressionSocket>
-      <ActionSocket>
-        <socketName>q8jsr9a3oo</socketName>
-        <systemName>IQAA:AUTO:0002</systemName>
-      </ActionSocket>
-      <MaleSocket>
-        <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
-        <AbstractMaleSocket enabled="no" locked="no" system="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>Default</errorHandling>
-          <LocalVariable>
-            <name>A1</name>
-            <type>None</type>
-            <data />
-          </LocalVariable>
-          <LocalVariable>
-            <name>A2</name>
-            <type>Integer</type>
-            <data>32</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A3</name>
-            <type>FloatingNumber</type>
-            <data>41.429</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A4</name>
-            <type>String</type>
-            <data>My string</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A5</name>
-            <type>Array</type>
-            <data />
-          </LocalVariable>
-          <LocalVariable>
-            <name>A6</name>
-            <type>Map</type>
-            <data />
-          </LocalVariable>
-          <LocalVariable>
-            <name>A7</name>
-            <type>LocalVariable</type>
-            <data>index</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A8</name>
-            <type>Memory</type>
-            <data>IM2</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A9</name>
-            <type>Reference</type>
-            <data>{IM3}</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A10</name>
-            <type>Formula</type>
-            <data>index * 2</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A11</name>
-            <type>ScriptExpression</type>
-            <data>sensors.provide("mySensor)"</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A12</name>
-            <type>ScriptFile</type>
-            <data>scripts:InitLogixNGVariable</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A13</name>
-            <type>LogixNG_Table</type>
-            <data>MyTable</data>
-          </LocalVariable>
-        </AbstractMaleSocket>
-      </MaleSocket>
-    </DoAnalogAction>
-    <DoAnalogAction class="jmri.jmrit.logixng.actions.configurexml.DoAnalogActionXml">
-      <systemName>IQDA:AUTO:0311</systemName>
-      <ExpressionSocket>
-        <socketName>ntvkieonrm</socketName>
-        <systemName>IQAE:AUTO:0006</systemName>
-      </ExpressionSocket>
-      <ActionSocket>
-        <socketName>uugy34q2s4</socketName>
-        <systemName>IQAA:AUTO:0003</systemName>
-      </ActionSocket>
-      <MaleSocket>
-        <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
-        <AbstractMaleSocket enabled="no" locked="no" system="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>Default</errorHandling>
-          <LocalVariable>
-            <name>A1</name>
-            <type>None</type>
-            <data />
-          </LocalVariable>
-          <LocalVariable>
-            <name>A2</name>
-            <type>Integer</type>
-            <data>32</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A3</name>
-            <type>FloatingNumber</type>
-            <data>41.429</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A4</name>
-            <type>String</type>
-            <data>My string</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A5</name>
-            <type>Array</type>
-            <data />
-          </LocalVariable>
-          <LocalVariable>
-            <name>A6</name>
-            <type>Map</type>
-            <data />
-          </LocalVariable>
-          <LocalVariable>
-            <name>A7</name>
-            <type>LocalVariable</type>
-            <data>index</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A8</name>
-            <type>Memory</type>
-            <data>IM2</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A9</name>
-            <type>Reference</type>
-            <data>{IM3}</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A10</name>
-            <type>Formula</type>
-            <data>index * 2</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A11</name>
-            <type>ScriptExpression</type>
-            <data>sensors.provide("mySensor)"</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A12</name>
-            <type>ScriptFile</type>
-            <data>scripts:InitLogixNGVariable</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A13</name>
-            <type>LogixNG_Table</type>
-            <data>MyTable</data>
-          </LocalVariable>
-        </AbstractMaleSocket>
-      </MaleSocket>
-    </DoAnalogAction>
-    <DoAnalogAction class="jmri.jmrit.logixng.actions.configurexml.DoAnalogActionXml">
-      <systemName>IQDA:AUTO:0312</systemName>
-      <ExpressionSocket>
-        <socketName>vwudg48bqd</socketName>
-        <systemName>IQAE:AUTO:0007</systemName>
-      </ExpressionSocket>
-      <ActionSocket>
-        <socketName>z5gh7cegt7</socketName>
-        <systemName>IQAA:AUTO:0004</systemName>
       </ActionSocket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -43628,12 +43758,12 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
     <DoAnalogAction class="jmri.jmrit.logixng.actions.configurexml.DoAnalogActionXml">
       <systemName>IQDA:AUTO:0313</systemName>
       <ExpressionSocket>
-        <socketName>dlju4xehtu</socketName>
-        <systemName>IQAE:AUTO:0008</systemName>
+        <socketName>bx98z6wxgj</socketName>
+        <systemName>IQAE:AUTO:0005</systemName>
       </ExpressionSocket>
       <ActionSocket>
-        <socketName>vhvbzq6ba7</socketName>
-        <systemName>IQAA:AUTO:0005</systemName>
+        <socketName>ba7wnpgapk</socketName>
+        <systemName>IQAA:AUTO:0002</systemName>
       </ActionSocket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -43710,11 +43840,12 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
     <DoAnalogAction class="jmri.jmrit.logixng.actions.configurexml.DoAnalogActionXml">
       <systemName>IQDA:AUTO:0314</systemName>
       <ExpressionSocket>
-        <socketName>xbyd4n82wo</socketName>
-        <systemName>IQAE:AUTO:0010</systemName>
+        <socketName>xamuwb2tbh</socketName>
+        <systemName>IQAE:AUTO:0006</systemName>
       </ExpressionSocket>
       <ActionSocket>
-        <socketName>s3358wm6wg</socketName>
+        <socketName>ufvp35cf7o</socketName>
+        <systemName>IQAA:AUTO:0003</systemName>
       </ActionSocket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -43791,11 +43922,12 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
     <DoAnalogAction class="jmri.jmrit.logixng.actions.configurexml.DoAnalogActionXml">
       <systemName>IQDA:AUTO:0315</systemName>
       <ExpressionSocket>
-        <socketName>iqlj7uuciy</socketName>
-        <systemName>IQAE:AUTO:0011</systemName>
+        <socketName>gci3xcisf9</socketName>
+        <systemName>IQAE:AUTO:0007</systemName>
       </ExpressionSocket>
       <ActionSocket>
-        <socketName>ngoyfft3yd</socketName>
+        <socketName>tut6wh8oxq</socketName>
+        <systemName>IQAA:AUTO:0004</systemName>
       </ActionSocket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -43872,11 +44004,12 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
     <DoAnalogAction class="jmri.jmrit.logixng.actions.configurexml.DoAnalogActionXml">
       <systemName>IQDA:AUTO:0316</systemName>
       <ExpressionSocket>
-        <socketName>qt8w32d276</socketName>
-        <systemName>IQAE:AUTO:0012</systemName>
+        <socketName>ziprth23bq</socketName>
+        <systemName>IQAE:AUTO:0008</systemName>
       </ExpressionSocket>
       <ActionSocket>
-        <socketName>xd2efqvso7</socketName>
+        <socketName>ubvnhl1f4x</socketName>
+        <systemName>IQAA:AUTO:0005</systemName>
       </ActionSocket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -43953,11 +44086,254 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
     <DoAnalogAction class="jmri.jmrit.logixng.actions.configurexml.DoAnalogActionXml">
       <systemName>IQDA:AUTO:0317</systemName>
       <ExpressionSocket>
-        <socketName>xfz4vq5dwi</socketName>
+        <socketName>yaqa1len7q</socketName>
+        <systemName>IQAE:AUTO:0010</systemName>
+      </ExpressionSocket>
+      <ActionSocket>
+        <socketName>tbsutktwqn</socketName>
+      </ActionSocket>
+      <MaleSocket>
+        <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
+        <AbstractMaleSocket enabled="no" locked="no" system="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
+          <errorHandling>Default</errorHandling>
+          <LocalVariable>
+            <name>A1</name>
+            <type>None</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A2</name>
+            <type>Integer</type>
+            <data>32</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A3</name>
+            <type>FloatingNumber</type>
+            <data>41.429</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A4</name>
+            <type>String</type>
+            <data>My string</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A5</name>
+            <type>Array</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A6</name>
+            <type>Map</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A7</name>
+            <type>LocalVariable</type>
+            <data>index</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A8</name>
+            <type>Memory</type>
+            <data>IM2</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A9</name>
+            <type>Reference</type>
+            <data>{IM3}</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A10</name>
+            <type>Formula</type>
+            <data>index * 2</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A11</name>
+            <type>ScriptExpression</type>
+            <data>sensors.provide("mySensor)"</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A12</name>
+            <type>ScriptFile</type>
+            <data>scripts:InitLogixNGVariable</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A13</name>
+            <type>LogixNG_Table</type>
+            <data>MyTable</data>
+          </LocalVariable>
+        </AbstractMaleSocket>
+      </MaleSocket>
+    </DoAnalogAction>
+    <DoAnalogAction class="jmri.jmrit.logixng.actions.configurexml.DoAnalogActionXml">
+      <systemName>IQDA:AUTO:0318</systemName>
+      <ExpressionSocket>
+        <socketName>dibco75oxn</socketName>
+        <systemName>IQAE:AUTO:0011</systemName>
+      </ExpressionSocket>
+      <ActionSocket>
+        <socketName>ewnmhcfesk</socketName>
+      </ActionSocket>
+      <MaleSocket>
+        <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
+        <AbstractMaleSocket enabled="no" locked="no" system="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
+          <errorHandling>Default</errorHandling>
+          <LocalVariable>
+            <name>A1</name>
+            <type>None</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A2</name>
+            <type>Integer</type>
+            <data>32</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A3</name>
+            <type>FloatingNumber</type>
+            <data>41.429</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A4</name>
+            <type>String</type>
+            <data>My string</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A5</name>
+            <type>Array</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A6</name>
+            <type>Map</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A7</name>
+            <type>LocalVariable</type>
+            <data>index</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A8</name>
+            <type>Memory</type>
+            <data>IM2</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A9</name>
+            <type>Reference</type>
+            <data>{IM3}</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A10</name>
+            <type>Formula</type>
+            <data>index * 2</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A11</name>
+            <type>ScriptExpression</type>
+            <data>sensors.provide("mySensor)"</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A12</name>
+            <type>ScriptFile</type>
+            <data>scripts:InitLogixNGVariable</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A13</name>
+            <type>LogixNG_Table</type>
+            <data>MyTable</data>
+          </LocalVariable>
+        </AbstractMaleSocket>
+      </MaleSocket>
+    </DoAnalogAction>
+    <DoAnalogAction class="jmri.jmrit.logixng.actions.configurexml.DoAnalogActionXml">
+      <systemName>IQDA:AUTO:0319</systemName>
+      <ExpressionSocket>
+        <socketName>j58mdrq1dk</socketName>
+        <systemName>IQAE:AUTO:0012</systemName>
+      </ExpressionSocket>
+      <ActionSocket>
+        <socketName>quyv9dqri9</socketName>
+      </ActionSocket>
+      <MaleSocket>
+        <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
+        <AbstractMaleSocket enabled="no" locked="no" system="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
+          <errorHandling>Default</errorHandling>
+          <LocalVariable>
+            <name>A1</name>
+            <type>None</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A2</name>
+            <type>Integer</type>
+            <data>32</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A3</name>
+            <type>FloatingNumber</type>
+            <data>41.429</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A4</name>
+            <type>String</type>
+            <data>My string</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A5</name>
+            <type>Array</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A6</name>
+            <type>Map</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A7</name>
+            <type>LocalVariable</type>
+            <data>index</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A8</name>
+            <type>Memory</type>
+            <data>IM2</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A9</name>
+            <type>Reference</type>
+            <data>{IM3}</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A10</name>
+            <type>Formula</type>
+            <data>index * 2</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A11</name>
+            <type>ScriptExpression</type>
+            <data>sensors.provide("mySensor)"</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A12</name>
+            <type>ScriptFile</type>
+            <data>scripts:InitLogixNGVariable</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A13</name>
+            <type>LogixNG_Table</type>
+            <data>MyTable</data>
+          </LocalVariable>
+        </AbstractMaleSocket>
+      </MaleSocket>
+    </DoAnalogAction>
+    <DoAnalogAction class="jmri.jmrit.logixng.actions.configurexml.DoAnalogActionXml">
+      <systemName>IQDA:AUTO:0320</systemName>
+      <ExpressionSocket>
+        <socketName>q5vx1u2q3z</socketName>
         <systemName>IQAE:AUTO:0013</systemName>
       </ExpressionSocket>
       <ActionSocket>
-        <socketName>sfnc4ghr5u</socketName>
+        <socketName>y59isr773k</socketName>
       </ActionSocket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -44032,260 +44408,14 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </DoAnalogAction>
     <DoStringAction class="jmri.jmrit.logixng.actions.configurexml.DoStringActionXml">
-      <systemName>IQDA:AUTO:0318</systemName>
+      <systemName>IQDA:AUTO:0321</systemName>
       <ExpressionSocket>
-        <socketName>csftodahwa</socketName>
+        <socketName>vdkuw2iioa</socketName>
         <systemName>IQSE:AUTO:0001</systemName>
       </ExpressionSocket>
       <ActionSocket>
-        <socketName>udam3illtw</socketName>
+        <socketName>mov51low6b</socketName>
         <systemName>IQSA:AUTO:0001</systemName>
-      </ActionSocket>
-      <MaleSocket>
-        <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
-        <AbstractMaleSocket enabled="no" locked="no" system="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>Default</errorHandling>
-          <LocalVariable>
-            <name>A1</name>
-            <type>None</type>
-            <data />
-          </LocalVariable>
-          <LocalVariable>
-            <name>A2</name>
-            <type>Integer</type>
-            <data>32</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A3</name>
-            <type>FloatingNumber</type>
-            <data>41.429</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A4</name>
-            <type>String</type>
-            <data>My string</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A5</name>
-            <type>Array</type>
-            <data />
-          </LocalVariable>
-          <LocalVariable>
-            <name>A6</name>
-            <type>Map</type>
-            <data />
-          </LocalVariable>
-          <LocalVariable>
-            <name>A7</name>
-            <type>LocalVariable</type>
-            <data>index</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A8</name>
-            <type>Memory</type>
-            <data>IM2</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A9</name>
-            <type>Reference</type>
-            <data>{IM3}</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A10</name>
-            <type>Formula</type>
-            <data>index * 2</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A11</name>
-            <type>ScriptExpression</type>
-            <data>sensors.provide("mySensor)"</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A12</name>
-            <type>ScriptFile</type>
-            <data>scripts:InitLogixNGVariable</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A13</name>
-            <type>LogixNG_Table</type>
-            <data>MyTable</data>
-          </LocalVariable>
-        </AbstractMaleSocket>
-      </MaleSocket>
-    </DoStringAction>
-    <DoStringAction class="jmri.jmrit.logixng.actions.configurexml.DoStringActionXml">
-      <systemName>IQDA:AUTO:0319</systemName>
-      <ExpressionSocket>
-        <socketName>lu1vbc6um4</socketName>
-        <systemName>IQSE:AUTO:0002</systemName>
-      </ExpressionSocket>
-      <ActionSocket>
-        <socketName>brkhkjmsc8</socketName>
-        <systemName>IQSA:AUTO:0002</systemName>
-      </ActionSocket>
-      <MaleSocket>
-        <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
-        <AbstractMaleSocket enabled="no" locked="no" system="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>Default</errorHandling>
-          <LocalVariable>
-            <name>A1</name>
-            <type>None</type>
-            <data />
-          </LocalVariable>
-          <LocalVariable>
-            <name>A2</name>
-            <type>Integer</type>
-            <data>32</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A3</name>
-            <type>FloatingNumber</type>
-            <data>41.429</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A4</name>
-            <type>String</type>
-            <data>My string</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A5</name>
-            <type>Array</type>
-            <data />
-          </LocalVariable>
-          <LocalVariable>
-            <name>A6</name>
-            <type>Map</type>
-            <data />
-          </LocalVariable>
-          <LocalVariable>
-            <name>A7</name>
-            <type>LocalVariable</type>
-            <data>index</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A8</name>
-            <type>Memory</type>
-            <data>IM2</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A9</name>
-            <type>Reference</type>
-            <data>{IM3}</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A10</name>
-            <type>Formula</type>
-            <data>index * 2</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A11</name>
-            <type>ScriptExpression</type>
-            <data>sensors.provide("mySensor)"</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A12</name>
-            <type>ScriptFile</type>
-            <data>scripts:InitLogixNGVariable</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A13</name>
-            <type>LogixNG_Table</type>
-            <data>MyTable</data>
-          </LocalVariable>
-        </AbstractMaleSocket>
-      </MaleSocket>
-    </DoStringAction>
-    <DoStringAction class="jmri.jmrit.logixng.actions.configurexml.DoStringActionXml">
-      <systemName>IQDA:AUTO:0320</systemName>
-      <ExpressionSocket>
-        <socketName>ube22yg7lw</socketName>
-        <systemName>IQSE:AUTO:0003</systemName>
-      </ExpressionSocket>
-      <ActionSocket>
-        <socketName>tbzlo8o7rt</socketName>
-        <systemName>IQSA:AUTO:0003</systemName>
-      </ActionSocket>
-      <MaleSocket>
-        <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
-        <AbstractMaleSocket enabled="no" locked="no" system="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>Default</errorHandling>
-          <LocalVariable>
-            <name>A1</name>
-            <type>None</type>
-            <data />
-          </LocalVariable>
-          <LocalVariable>
-            <name>A2</name>
-            <type>Integer</type>
-            <data>32</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A3</name>
-            <type>FloatingNumber</type>
-            <data>41.429</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A4</name>
-            <type>String</type>
-            <data>My string</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A5</name>
-            <type>Array</type>
-            <data />
-          </LocalVariable>
-          <LocalVariable>
-            <name>A6</name>
-            <type>Map</type>
-            <data />
-          </LocalVariable>
-          <LocalVariable>
-            <name>A7</name>
-            <type>LocalVariable</type>
-            <data>index</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A8</name>
-            <type>Memory</type>
-            <data>IM2</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A9</name>
-            <type>Reference</type>
-            <data>{IM3}</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A10</name>
-            <type>Formula</type>
-            <data>index * 2</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A11</name>
-            <type>ScriptExpression</type>
-            <data>sensors.provide("mySensor)"</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A12</name>
-            <type>ScriptFile</type>
-            <data>scripts:InitLogixNGVariable</data>
-          </LocalVariable>
-          <LocalVariable>
-            <name>A13</name>
-            <type>LogixNG_Table</type>
-            <data>MyTable</data>
-          </LocalVariable>
-        </AbstractMaleSocket>
-      </MaleSocket>
-    </DoStringAction>
-    <DoStringAction class="jmri.jmrit.logixng.actions.configurexml.DoStringActionXml">
-      <systemName>IQDA:AUTO:0321</systemName>
-      <ExpressionSocket>
-        <socketName>iujr5id99b</socketName>
-        <systemName>IQSE:AUTO:0004</systemName>
-      </ExpressionSocket>
-      <ActionSocket>
-        <socketName>td8m4dyhnp</socketName>
-        <systemName>IQSA:AUTO:0004</systemName>
       </ActionSocket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -44362,12 +44492,12 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
     <DoStringAction class="jmri.jmrit.logixng.actions.configurexml.DoStringActionXml">
       <systemName>IQDA:AUTO:0322</systemName>
       <ExpressionSocket>
-        <socketName>y6k25ea1w3</socketName>
-        <systemName>IQSE:AUTO:0005</systemName>
+        <socketName>anv579ri78</socketName>
+        <systemName>IQSE:AUTO:0002</systemName>
       </ExpressionSocket>
       <ActionSocket>
-        <socketName>ew1aihis1x</socketName>
-        <systemName>IQSA:AUTO:0005</systemName>
+        <socketName>dmkeg78hx8</socketName>
+        <systemName>IQSA:AUTO:0002</systemName>
       </ActionSocket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -44444,11 +44574,257 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
     <DoStringAction class="jmri.jmrit.logixng.actions.configurexml.DoStringActionXml">
       <systemName>IQDA:AUTO:0323</systemName>
       <ExpressionSocket>
-        <socketName>x6ezesu3y4</socketName>
+        <socketName>nzth1kizpl</socketName>
+        <systemName>IQSE:AUTO:0003</systemName>
+      </ExpressionSocket>
+      <ActionSocket>
+        <socketName>s861p5gid8</socketName>
+        <systemName>IQSA:AUTO:0003</systemName>
+      </ActionSocket>
+      <MaleSocket>
+        <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
+        <AbstractMaleSocket enabled="no" locked="no" system="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
+          <errorHandling>Default</errorHandling>
+          <LocalVariable>
+            <name>A1</name>
+            <type>None</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A2</name>
+            <type>Integer</type>
+            <data>32</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A3</name>
+            <type>FloatingNumber</type>
+            <data>41.429</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A4</name>
+            <type>String</type>
+            <data>My string</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A5</name>
+            <type>Array</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A6</name>
+            <type>Map</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A7</name>
+            <type>LocalVariable</type>
+            <data>index</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A8</name>
+            <type>Memory</type>
+            <data>IM2</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A9</name>
+            <type>Reference</type>
+            <data>{IM3}</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A10</name>
+            <type>Formula</type>
+            <data>index * 2</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A11</name>
+            <type>ScriptExpression</type>
+            <data>sensors.provide("mySensor)"</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A12</name>
+            <type>ScriptFile</type>
+            <data>scripts:InitLogixNGVariable</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A13</name>
+            <type>LogixNG_Table</type>
+            <data>MyTable</data>
+          </LocalVariable>
+        </AbstractMaleSocket>
+      </MaleSocket>
+    </DoStringAction>
+    <DoStringAction class="jmri.jmrit.logixng.actions.configurexml.DoStringActionXml">
+      <systemName>IQDA:AUTO:0324</systemName>
+      <ExpressionSocket>
+        <socketName>udofg18vwv</socketName>
+        <systemName>IQSE:AUTO:0004</systemName>
+      </ExpressionSocket>
+      <ActionSocket>
+        <socketName>no54ve1o34</socketName>
+        <systemName>IQSA:AUTO:0004</systemName>
+      </ActionSocket>
+      <MaleSocket>
+        <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
+        <AbstractMaleSocket enabled="no" locked="no" system="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
+          <errorHandling>Default</errorHandling>
+          <LocalVariable>
+            <name>A1</name>
+            <type>None</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A2</name>
+            <type>Integer</type>
+            <data>32</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A3</name>
+            <type>FloatingNumber</type>
+            <data>41.429</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A4</name>
+            <type>String</type>
+            <data>My string</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A5</name>
+            <type>Array</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A6</name>
+            <type>Map</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A7</name>
+            <type>LocalVariable</type>
+            <data>index</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A8</name>
+            <type>Memory</type>
+            <data>IM2</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A9</name>
+            <type>Reference</type>
+            <data>{IM3}</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A10</name>
+            <type>Formula</type>
+            <data>index * 2</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A11</name>
+            <type>ScriptExpression</type>
+            <data>sensors.provide("mySensor)"</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A12</name>
+            <type>ScriptFile</type>
+            <data>scripts:InitLogixNGVariable</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A13</name>
+            <type>LogixNG_Table</type>
+            <data>MyTable</data>
+          </LocalVariable>
+        </AbstractMaleSocket>
+      </MaleSocket>
+    </DoStringAction>
+    <DoStringAction class="jmri.jmrit.logixng.actions.configurexml.DoStringActionXml">
+      <systemName>IQDA:AUTO:0325</systemName>
+      <ExpressionSocket>
+        <socketName>rnmhb41pe6</socketName>
+        <systemName>IQSE:AUTO:0005</systemName>
+      </ExpressionSocket>
+      <ActionSocket>
+        <socketName>xbrm4ifu6b</socketName>
+        <systemName>IQSA:AUTO:0005</systemName>
+      </ActionSocket>
+      <MaleSocket>
+        <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
+        <AbstractMaleSocket enabled="no" locked="no" system="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
+          <errorHandling>Default</errorHandling>
+          <LocalVariable>
+            <name>A1</name>
+            <type>None</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A2</name>
+            <type>Integer</type>
+            <data>32</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A3</name>
+            <type>FloatingNumber</type>
+            <data>41.429</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A4</name>
+            <type>String</type>
+            <data>My string</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A5</name>
+            <type>Array</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A6</name>
+            <type>Map</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A7</name>
+            <type>LocalVariable</type>
+            <data>index</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A8</name>
+            <type>Memory</type>
+            <data>IM2</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A9</name>
+            <type>Reference</type>
+            <data>{IM3}</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A10</name>
+            <type>Formula</type>
+            <data>index * 2</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A11</name>
+            <type>ScriptExpression</type>
+            <data>sensors.provide("mySensor)"</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A12</name>
+            <type>ScriptFile</type>
+            <data>scripts:InitLogixNGVariable</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A13</name>
+            <type>LogixNG_Table</type>
+            <data>MyTable</data>
+          </LocalVariable>
+        </AbstractMaleSocket>
+      </MaleSocket>
+    </DoStringAction>
+    <DoStringAction class="jmri.jmrit.logixng.actions.configurexml.DoStringActionXml">
+      <systemName>IQDA:AUTO:0326</systemName>
+      <ExpressionSocket>
+        <socketName>ageu6w44ut</socketName>
         <systemName>IQSE:AUTO:0006</systemName>
       </ExpressionSocket>
       <ActionSocket>
-        <socketName>xwc2b28a9w</socketName>
+        <socketName>jo49in5gpb</socketName>
       </ActionSocket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -44528,23 +44904,23 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <systemName>IQDB:AUTO:0001</systemName>
       <Actions>
         <Socket>
-          <socketName>yimhju4vki</socketName>
+          <socketName>pjd6cjfpm9</socketName>
           <systemName>IQDB:AUTO:0002</systemName>
         </Socket>
         <Socket>
-          <socketName>xelmcas59v</socketName>
+          <socketName>h84cw8rel1</socketName>
           <systemName>IQDB:AUTO:0003</systemName>
         </Socket>
         <Socket>
-          <socketName>o5feczh3kf</socketName>
+          <socketName>wwjlb6zcgn</socketName>
           <systemName>IQDB:AUTO:0004</systemName>
         </Socket>
         <Socket>
-          <socketName>sm944su3vb</socketName>
+          <socketName>hda5655wyx</socketName>
           <systemName>IQDB:AUTO:0005</systemName>
         </Socket>
         <Socket>
-          <socketName>vo864sng35</socketName>
+          <socketName>g84vwr7fg5</socketName>
         </Socket>
       </Actions>
       <MaleSocket>
@@ -44624,7 +45000,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <comment>A comment</comment>
       <Actions>
         <Socket>
-          <socketName>w6xatbrr4n</socketName>
+          <socketName>mopdyy11bg</socketName>
         </Socket>
       </Actions>
       <MaleSocket>
@@ -44702,7 +45078,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
     <LogixAction class="jmri.jmrit.logixng.actions.configurexml.DigitalBooleanLogixActionXml" trigger="Either">
       <systemName>IQDB:AUTO:0003</systemName>
       <Socket>
-        <socketName>o2lwaoey5r</socketName>
+        <socketName>xonk2yn5uw</socketName>
       </Socket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalBooleanActionSocketXml" />
@@ -44780,7 +45156,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <systemName>IQDB:AUTO:0004</systemName>
       <comment>A comment</comment>
       <Socket>
-        <socketName>rzderamn2p</socketName>
+        <socketName>rfe571t6se</socketName>
       </Socket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalBooleanActionSocketXml" />
@@ -44858,7 +45234,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <systemName>IQDB:AUTO:0005</systemName>
       <comment>A comment</comment>
       <Socket>
-        <socketName>zozq8g42rb</socketName>
+        <socketName>iuw9gqeiw7</socketName>
       </Socket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalBooleanActionSocketXml" />
@@ -45481,12 +45857,12 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <systemName>IQAE:AUTO:0008</systemName>
       <Expressions>
         <Socket>
-          <socketName>ojpejdttfj</socketName>
+          <socketName>zz54qb847c</socketName>
           <systemName>IQAE:AUTO:0009</systemName>
           <manager>jmri.jmrit.logixng.implementation.DefaultAnalogExpressionManager</manager>
         </Socket>
         <Socket>
-          <socketName>shlnvnzhkh</socketName>
+          <socketName>x1cmt7fe8q</socketName>
         </Socket>
       </Expressions>
       <formula />
@@ -45645,7 +46021,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <comment>A comment</comment>
       <Expressions>
         <Socket>
-          <socketName>jnerydwzxp</socketName>
+          <socketName>y4jes8h8yw</socketName>
         </Socket>
       </Expressions>
       <formula>sin(a)*2 + 14</formula>
@@ -46114,7 +46490,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <systemName>IQAA:AUTO:0003</systemName>
       <Actions>
         <Socket>
-          <socketName>idh8e8tjyn</socketName>
+          <socketName>g1syg9znua</socketName>
         </Socket>
       </Actions>
       <MaleSocket>
@@ -46194,7 +46570,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <comment>A comment</comment>
       <Actions>
         <Socket>
-          <socketName>i9v3irmzpe</socketName>
+          <socketName>u67aic4ola</socketName>
         </Socket>
       </Actions>
       <MaleSocket>
@@ -46662,7 +47038,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <systemName>IQSE:AUTO:0005</systemName>
       <Expressions>
         <Socket>
-          <socketName>cc8s8nilua</socketName>
+          <socketName>tauagy93qg</socketName>
         </Socket>
       </Expressions>
       <formula />
@@ -46743,7 +47119,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <comment>A comment</comment>
       <Expressions>
         <Socket>
-          <socketName>gsedg5191w</socketName>
+          <socketName>xru3gk16zp</socketName>
         </Socket>
       </Expressions>
       <formula>sin(a)*2 + 14</formula>
@@ -46983,7 +47359,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <systemName>IQSA:AUTO:0003</systemName>
       <Actions>
         <Socket>
-          <socketName>vy48xztk5s</socketName>
+          <socketName>zxeiigj1iw</socketName>
         </Socket>
       </Actions>
       <MaleSocket>
@@ -47063,7 +47439,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <comment>A comment</comment>
       <Actions>
         <Socket>
-          <socketName>qwj9zejjix</socketName>
+          <socketName>yhv4pk3eum</socketName>
         </Socket>
       </Actions>
       <MaleSocket>
@@ -47220,9 +47596,9 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
   <filehistory>
     <operation>
       <type>Store</type>
-      <date>Wed Nov 01 09:30:20 CET 2023</date>
+      <date>Tue Nov 14 16:50:11 CET 2023</date>
       <filename />
     </operation>
   </filehistory>
-  <!--Written by JMRI version 5.5.5plus+daniel+2023-11-01T08:29:35Z+R86af30e on Wed Nov 01 09:30:20 CET 2023-->
+  <!--Written by JMRI version 5.5.6plus+daniel+2023-11-14T15:38:10Z+Re450e78 on Tue Nov 14 16:50:11 CET 2023-->
 </layout-config>

--- a/java/test/jmri/util/JUnitUtil.java
+++ b/java/test/jmri/util/JUnitUtil.java
@@ -1600,6 +1600,12 @@ public class JUnitUtil {
         return random;
     }
 
+    final private static Random randomConstantSeed = new Random(0);
+
+    public static Random getRandomConstantSeed(){
+        return randomConstantSeed;
+    }
+
     private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(JUnitUtil.class);
 
 }


### PR DESCRIPTION
Instead of a random seed, use a constant seed to keep LogixNG socket names from changing in the LogixNG.xml test file.