### PR TITLE
Olcb HubPane Test - add headless check

### DIFF
--- a/java/test/jmri/jmrix/openlcb/swing/hub/HubPaneTest.java
+++ b/java/test/jmri/jmrix/openlcb/swing/hub/HubPaneTest.java
@@ -1,15 +1,16 @@
 package jmri.jmrix.openlcb.swing.hub;
 
 import jmri.jmrix.can.CanSystemConnectionMemo;
+import jmri.jmrix.can.TestTrafficController;
 import jmri.util.JUnitUtil;
 
 import org.junit.jupiter.api.*;
-
-import jmri.jmrix.can.TestTrafficController;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 /**
  * @author Bob Jacobsen Copyright 2013
  */
+@DisabledIfSystemProperty(named = "java.awt.headless", matches = "true")
 public class HubPaneTest {
 
     HubPane hub = null;


### PR DESCRIPTION
Prevents HeadlessException

```
     [java]     MethodSource [className = 'jmri.jmrix.openlcb.swing.hub.HubPaneTest', methodName = 'testCtor', methodParameterTypes = '']
     [java]     => java.awt.HeadlessException
     [java]        java.desktop/java.awt.GraphicsEnvironment.checkHeadless(GraphicsEnvironment.java:208)
     [java]        java.desktop/java.awt.TextComponent.<init>(TextComponent.java:134)
     [java]        java.desktop/java.awt.TextArea.<init>(TextArea.java:258)
     [java]        java.desktop/java.awt.TextArea.<init>(TextArea.java:162)
     [java]        jmri.jmrix.openlcb.swing.hub.HubPane.<init>(HubPane.java:61)
```