### PR TITLE
Move ESU decoder add message from "Hardware" to "Decoders"

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -51,7 +51,7 @@
 
         <h4>ESU</h4>
             <ul>
-                <li>Added "LokSound 5 micro DCC Direct Atlas Legacy".</li>
+                <li></li>
             </ul>
 
         <h4>Hornby</h4>
@@ -234,6 +234,7 @@
 
         <h4>ESU</h4>
             <ul>
+                <li>Added "LokSound 5 micro DCC Direct Atlas Legacy".</li>
                 <li>Added support for "Tone Control" for LokSound 5 (requires firmware 5.9.159 or higher).</li>
             </ul>
 


### PR DESCRIPTION
While working on #12618, I realized I had added the release note entry for #11682 under the wrong header.