### PR TITLE
Improve LogixNG Entry/Exit action

### DIFF
--- a/java/src/jmri/jmrit/logixng/actions/ActionBundle.properties
+++ b/java/src/jmri/jmrit/logixng/actions/ActionBundle.properties
@@ -106,6 +106,7 @@ ActionEntryExit_SetNXPairInactive   = Set NX Pair Inactive
 ActionEntryExit_SetNXPairActive     = Set NX Pair Active
 ActionEntryExit_SetNXPairReversed   = Set NX Pair Reversed
 ActionEntryExit_DestinationPointsInUseVeto  = Destination points is in use by Set Entry/Exit action "{0}"
+ActionEntryExit_SetReversedError    = "{0}" is not enabled for reversed (Both Way) activation
 
 
 ActionFindTableRowOrColumn_Short    = Find table row or column

--- a/java/src/jmri/jmrit/logixng/actions/ActionEntryExit.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionEntryExit.java
@@ -100,6 +100,11 @@ public class ActionEntryExit extends AbstractDigitalAction
                     }
                     break;
                 case SetNXPairReversed:
+                    if (entryExit.isUniDirection()) {
+                        throw new IllegalArgumentException("\"" + entryExit.getDisplayName() +
+                                "\" is not enabled for reversed activation (Both Way)");
+                    }
+
                     if (!entryExit.isActive()) {
                         jmri.InstanceManager.getDefault(jmri.jmrit.entryexit.EntryExitPairs.class).
                                 setReversedRoute(entryExit.getSystemName());

--- a/java/src/jmri/jmrit/logixng/actions/swing/ActionEntryExitSwing.java
+++ b/java/src/jmri/jmrit/logixng/actions/swing/ActionEntryExitSwing.java
@@ -74,6 +74,12 @@ public class ActionEntryExitSwing extends AbstractDigitalActionSwing {
         _selectNamedBeanSwing.validate(action.getSelectNamedBean(), errorMessages);
         _selectOperationSwing.validate(action.getSelectEnum(), errorMessages);
 
+        DestinationPoints dp = _selectNamedBeanSwing.getBean();
+        boolean isReverse = _selectOperationSwing.getEnum() == Operation.SetNXPairReversed;
+        if (dp != null && isReverse && dp.isUniDirection()) {
+            errorMessages.add(Bundle.getMessage("ActionEntryExit_SetReversedError", dp.getDisplayName()));
+        }
+
         return errorMessages.isEmpty();
     }
 

--- a/java/src/jmri/jmrit/logixng/actions/swing/ActionEntryExitSwing.java
+++ b/java/src/jmri/jmrit/logixng/actions/swing/ActionEntryExitSwing.java
@@ -74,10 +74,13 @@ public class ActionEntryExitSwing extends AbstractDigitalActionSwing {
         _selectNamedBeanSwing.validate(action.getSelectNamedBean(), errorMessages);
         _selectOperationSwing.validate(action.getSelectEnum(), errorMessages);
 
-        DestinationPoints dp = _selectNamedBeanSwing.getBean();
-        boolean isReverse = _selectOperationSwing.getEnum() == Operation.SetNXPairReversed;
-        if (dp != null && isReverse && dp.isUniDirection()) {
-            errorMessages.add(Bundle.getMessage("ActionEntryExit_SetReversedError", dp.getDisplayName()));
+        if (_selectNamedBeanSwing.getAddressing() == NamedBeanAddressing.Direct &&
+                 _selectOperationSwing.getAddressing() == NamedBeanAddressing.Direct) {
+            DestinationPoints dp = _selectNamedBeanSwing.getBean();
+            boolean isReverse = _selectOperationSwing.getEnum() == Operation.SetNXPairReversed;
+            if (dp != null && isReverse && dp.isUniDirection()) {
+                errorMessages.add(Bundle.getMessage("ActionEntryExit_SetReversedError", dp.getDisplayName()));
+            }
         }
 
         return errorMessages.isEmpty();


### PR DESCRIPTION
- Verify that the Both Way option is enabled when selecting the reverse route option.  A dialog is displayed if needed.
- Verify that the Both Way option is still enabled when activating a reverse route.  An "IllegalArgumentException" exception is thrown if the Entry/Exit pair no longer has the Both Way option.
