### PR TITLE
Programmer test tweaks / Suppress Bidib Warning

### DIFF
--- a/java/test/jmri/AddressedProgrammerTestBase.java
+++ b/java/test/jmri/AddressedProgrammerTestBase.java
@@ -1,7 +1,6 @@
 package jmri;
 
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.jupiter.api.*;
 
 /**
@@ -18,7 +17,7 @@ abstract public class AddressedProgrammerTestBase extends ProgrammerTestBase {
     @Test
     @Override
     public void testDefault() {
-        Assume.assumeTrue(programmer instanceof AddressedProgrammer);
+        Assumptions.assumeTrue(programmer instanceof AddressedProgrammer);
         Assert.assertEquals("Check Default", ProgrammingMode.OPSBYTEMODE,
                 programmer.getMode());        
     }
@@ -26,32 +25,32 @@ abstract public class AddressedProgrammerTestBase extends ProgrammerTestBase {
     @Test
     @Override
     public void testGetCanRead() {
-        Assume.assumeTrue(programmer instanceof AddressedProgrammer);
+        Assumptions.assumeTrue(programmer instanceof AddressedProgrammer);
         Assert.assertFalse("can read", programmer.getCanRead());
     }
     
     @Test
     @Override
     public void testSetGetMode() {
-        Assume.assumeTrue(programmer instanceof AddressedProgrammer);
+        Assumptions.assumeTrue(programmer instanceof AddressedProgrammer);
         Assert.assertThrows(IllegalArgumentException.class, () -> programmer.setMode(ProgrammingMode.REGISTERMODE));
     }
 
     @Test
     public void testGetLongAddress(){
-        Assume.assumeTrue(programmer instanceof AddressedProgrammer);
+        Assumptions.assumeTrue(programmer instanceof AddressedProgrammer);
         Assert.assertNotNull("long/short address boolean",((AddressedProgrammer)programmer).getLongAddress());
     }
 
     @Test
     public void testGetAddressNumber(){
-        Assume.assumeTrue(programmer instanceof AddressedProgrammer);
+        Assumptions.assumeTrue(programmer instanceof AddressedProgrammer);
         Assert.assertNotNull("Numeric Address",((AddressedProgrammer)programmer).getAddressNumber());
     }
 
     @Test
     public void testGetAddress(){
-        Assume.assumeTrue(programmer instanceof AddressedProgrammer);
+        Assumptions.assumeTrue(programmer instanceof AddressedProgrammer);
         Assert.assertNotNull("String Address",((AddressedProgrammer)programmer).getAddress());
     }
 

--- a/java/test/jmri/ProgrammerTestBase.java
+++ b/java/test/jmri/ProgrammerTestBase.java
@@ -1,6 +1,5 @@
 package jmri;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.*;
 
 /**
@@ -16,59 +15,59 @@ abstract public class ProgrammerTestBase {
 
     @Test
     public void testCtor() {
-        Assert.assertNotNull(programmer);
+        Assertions.assertNotNull(programmer);
     }
 
     @Test
     public void testDefault() {
-        Assert.assertEquals("Check Default", ProgrammingMode.DIRECTMODE,
-                programmer.getMode());        
+        Assertions.assertEquals( ProgrammingMode.DIRECTMODE,
+            programmer.getMode(), "Check Default");
     }
 
     @Test
     public void testGetCanRead() {
-        Assert.assertTrue("can read", programmer.getCanRead());
+        Assertions.assertTrue( programmer.getCanRead(), "can read");
     }
 
     @Test
     public void testGetCanWrite() {
-        Assert.assertTrue("can write", programmer.getCanWrite());
+        Assertions.assertTrue( programmer.getCanWrite(), "can write");
     }
 
     @Test
     public void testGetCanReadAddress() {
-        Assert.assertFalse("can read address", programmer.getCanRead("1234"));
+        Assertions.assertFalse( programmer.getCanRead("1234"), "can read address");
     }
 
     @Test
     public void testGetCanWriteAddress() {
-        Assert.assertTrue("can write address", programmer.getCanWrite("1234"));
-    }   
+        Assertions.assertTrue( programmer.getCanWrite("1234"), "can write address");
+    }
  
     @Test
     public void testSetGetMode() {
         programmer.setMode(ProgrammingMode.REGISTERMODE);
-        Assert.assertEquals("Check mode matches set", ProgrammingMode.REGISTERMODE,
-                programmer.getMode());        
+        Assertions.assertEquals( ProgrammingMode.REGISTERMODE,
+            programmer.getMode(), "Check mode matches set");
     }
-    
+
     @Test
     public void testSetModeNull() {
-        Throwable throwable = Assert.assertThrows(IllegalArgumentException.class, () -> programmer.setMode(null));
+        Throwable throwable = Assertions.assertThrows(IllegalArgumentException.class, () -> programmer.setMode(null));
         Assertions.assertNotNull(throwable.getMessage());
     }
 
     @Test
     public void testGetWriteConfirmMode(){
-        Assert.assertEquals("Write Confirm Mode",Programmer.WriteConfirmMode.NotVerified,
-                programmer.getWriteConfirmMode("1234"));
+        Assertions.assertEquals( Programmer.WriteConfirmMode.NotVerified,
+            programmer.getWriteConfirmMode("1234"), "Write Confirm Mode");
     }
 
     @Test
     public void testWriteCVNullListener() throws jmri.ProgrammerException {
-                programmer.writeCV("1",42,null);
+        programmer.writeCV("1",42,null);
     }
-    
+
     abstract public void setUp();
 
     abstract public void tearDown();

--- a/java/test/jmri/jmrix/AbstractOpsModeProgrammerTestBase.java
+++ b/java/test/jmri/jmrix/AbstractOpsModeProgrammerTestBase.java
@@ -2,7 +2,6 @@ package jmri.jmrix;
 
 import jmri.ProgrammingMode;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.*;
 
 /**
@@ -18,20 +17,23 @@ abstract public class AbstractOpsModeProgrammerTestBase extends jmri.AddressedPr
 
     @Test
     public void testDefaultViaBestMode() {
-        Assert.assertEquals("Check Default", ProgrammingMode.OPSBYTEMODE,
-                ((AbstractProgrammer)programmer).getBestMode());        
+        Assertions.assertEquals( ProgrammingMode.OPSBYTEMODE,
+            ((AbstractProgrammer)programmer).getBestMode(),"Check Default");        
     }
 
     @Override
     @Test
     public void testGetCanRead() {
-        Assert.assertFalse("can read", programmer.getCanRead());
+        Assertions.assertFalse( programmer.getCanRead(),"can read");
     }
     
     @Override
     @Test
     public void testSetGetMode() {
-        Assert.assertThrows(IllegalArgumentException.class, () -> programmer.setMode(ProgrammingMode.REGISTERMODE));
+        IllegalArgumentException iae = Assertions.assertThrows(
+            IllegalArgumentException.class, () ->
+                programmer.setMode(ProgrammingMode.REGISTERMODE));
+        Assertions.assertNotNull(iae);
     }
     
     // must set the value of programmer in setUp.

--- a/java/test/jmri/jmrix/bidib/BiDiBOpsModeProgrammerTest.java
+++ b/java/test/jmri/jmrix/bidib/BiDiBOpsModeProgrammerTest.java
@@ -1,5 +1,7 @@
 package jmri.jmrix.bidib;
 
+import jmri.util.JUnitAppender;
+
 import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.AfterEach;
@@ -33,7 +35,16 @@ public class BiDiBOpsModeProgrammerTest extends jmri.jmrix.AbstractOpsModeProgra
     @Test
     public void testGetCanWriteAddress() {
         //Assert.assertTrue("can write address", programmer.getCanWrite("1234"));
-    }   
+    }
+
+    @Test
+    @Override
+    public void testWriteCVNullListener() throws jmri.ProgrammerException {
+        super.testWriteCVNullListener();
+        // test may require further setup?
+        JUnitAppender.suppressWarnMessageStartsWith(
+            "The node is no longer registered. Skip send message to node:");
+    }
 
     @Override
     @BeforeEach
@@ -49,6 +60,8 @@ public class BiDiBOpsModeProgrammerTest extends jmri.jmrix.AbstractOpsModeProgra
     @AfterEach
     public void tearDown() {
         programmer = null;
+        memo.dispose();
+        memo.getBiDiBTrafficController().terminate();
         //JUnitUtil.resetWindows(false,false);
         //JUnitUtil.clearShutDownManager(); // put in place because AbstractMRTrafficController implementing subclass was not terminated properly
         JUnitUtil.tearDown();


### PR DESCRIPTION
Programmer Tests - minor tweaks to assertions.

BiDiBOpsModeProgrammerTest - suppress Warn Message
`The node is no longer registered. Skip send message`

