### PR TITLE
Improve LocoNet transmit queuing

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -86,7 +86,9 @@
 
         <h4>LocoNet</h4>
             <ul>
-                <li></li>
+                <li>Improved the internal queuing mechanism for transmitted messages.
+                    This will prevent messages being delayed occasionally.
+                </li>
             </ul>
 
         <h4>Maple</h4>

--- a/java/src/jmri/jmrix/loconet/LnPacketizer.java
+++ b/java/src/jmri/jmrix/loconet/LnPacketizer.java
@@ -2,8 +2,7 @@ package jmri.jmrix.loconet;
 
 import java.io.DataInputStream;
 import java.io.OutputStream;
-import java.util.LinkedList;
-import java.util.NoSuchElementException;
+import java.util.concurrent.LinkedTransferQueue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -61,7 +60,7 @@ public class LnPacketizer extends LnTrafficController {
     /**
      * Synchronized list used as a transmit queue.
      */
-    protected LinkedList<byte[]> xmtList = new LinkedList<>();
+    protected LinkedTransferQueue<byte[]> xmtList = new LinkedTransferQueue<>();
 
     /**
      * XmtHandler (a local class) object to implement the transmit thread.
@@ -106,10 +105,7 @@ public class LnPacketizer extends LnTrafficController {
         // But the thread might not be running, in which case the request is just
         // queued up.
         try {
-            synchronized (xmtHandler) {
-                xmtList.addLast(msg);
-                xmtHandler.notifyAll();
-            }
+            xmtList.add(msg);
         } catch (RuntimeException e) {
             log.warn("passing to xmit: unexpected exception: ", e);
         }
@@ -365,12 +361,10 @@ public class LnPacketizer extends LnTrafficController {
             while (!threadStopRequest) {   // loop until asked to stop
                 // any input?
                 try {
-                    // get content; failure is a NoSuchElementException
+                    // get content; blocks until preset
                     log.trace("check for input"); // NOI18N
-                    byte msg[] = null;
-                    synchronized (this) {
-                        msg = xmtList.removeFirst();
-                    }
+
+                    byte msg[] = xmtList.take();
 
                     // input - now send
                     try {
@@ -392,13 +386,10 @@ public class LnPacketizer extends LnTrafficController {
                     } catch (java.io.IOException e) {
                         log.warn("sendLocoNetMessage: IOException: {}", e.toString()); // NOI18N
                     }
-                } catch (NoSuchElementException e) {
-                    // message queue was empty, wait for input
-                    log.trace("start wait"); // NOI18N
-
-                    new jmri.util.WaitHandler(this); // handle synchronization, spurious wake, interruption
-
-                    log.trace("end wait"); // NOI18N
+                } catch (InterruptedException ie) {
+                    return; // ending the thread
+                } catch (RuntimeException rt) {
+                    log.error("Exception on take() call", rt);
                 }
             }
         }

--- a/java/src/jmri/jmrix/loconet/LnPacketizer.java
+++ b/java/src/jmri/jmrix/loconet/LnPacketizer.java
@@ -361,7 +361,7 @@ public class LnPacketizer extends LnTrafficController {
             while (!threadStopRequest) {   // loop until asked to stop
                 // any input?
                 try {
-                    // get content; blocks until preset
+                    // get content; blocks until present
                     log.trace("check for input"); // NOI18N
 
                     byte msg[] = xmtList.take();

--- a/java/src/jmri/jmrix/loconet/LnPacketizerStrict.java
+++ b/java/src/jmri/jmrix/loconet/LnPacketizerStrict.java
@@ -1,6 +1,5 @@
 package jmri.jmrix.loconet;
 
-import java.util.NoSuchElementException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -235,12 +234,11 @@ public class LnPacketizerStrict extends LnPacketizer {
             while (true) { // loop permanently
                 // any input?
                 try {
-                    // get content; failure is a NoSuchElementException
+                    // get content; blocks until present
                     log.trace("check for input"); // NOI18N
-                    byte msg[] = null;
-                    synchronized (this) {
-                        msg = xmtList.removeFirst();
-                    }
+
+                    byte msg[] = xmtList.take();
+
                     // input - now send
                     try {
                         if (ostream != null) {
@@ -340,11 +338,8 @@ public class LnPacketizerStrict extends LnPacketizer {
                     } catch (java.io.IOException e) {
                         log.warn("sendLocoNetMessage: IOException: {}", e.toString()); // NOI18N
                     }
-                } catch (NoSuchElementException e) {
-                    // message queue was empty, wait for input
-                    log.trace("start wait"); // NOI18N
-                    new jmri.util.WaitHandler(this); // handle synchronization, spurious wake, interruption
-                    log.trace("end wait"); // NOI18N
+                } catch (InterruptedException ie) {
+                    return; // ending the thread
                 }
             }
         }

--- a/java/src/jmri/jmrix/loconet/streamport/LnStreamPortPacketizer.java
+++ b/java/src/jmri/jmrix/loconet/streamport/LnStreamPortPacketizer.java
@@ -1,6 +1,5 @@
 package jmri.jmrix.loconet.streamport;
 
-import java.util.NoSuchElementException;
 import jmri.jmrix.loconet.LnPacketizer;
 import jmri.jmrix.loconet.LocoNetSystemConnectionMemo;
 import org.slf4j.Logger;
@@ -86,12 +85,10 @@ public class LnStreamPortPacketizer extends LnPacketizer {
             while (!threadStopRequest) {   // loop until asked to stop
                 // any input?
                 try {
-                    // get content; failure is a NoSuchElementException
+                    // get content; blocks until present
                     log.trace("check for input"); // NOI18N
-                    byte msg[] = null;
-                    synchronized (this) {
-                        msg = xmtList.removeFirst();
-                    }
+
+                    byte msg[] = xmtList.take();
 
                     // input - now send
                     try {
@@ -115,13 +112,8 @@ public class LnStreamPortPacketizer extends LnPacketizer {
                     } catch (java.io.IOException e) {
                         log.warn("sendLocoNetMessage: IOException: {}", e.toString()); // NOI18N
                     }
-                } catch (NoSuchElementException e) {
-                    // message queue was empty, wait for input
-                    log.trace("start wait"); // NOI18N
-
-                    new jmri.util.WaitHandler(this);  // handle synchronization, spurious wake, interruption
-
-                    log.trace("end wait"); // NOI18N
+                } catch (InterruptedException ie) {
+                    return; // ending the thread
                 }
             }
         }

--- a/java/src/jmri/jmrix/loconet/uhlenbrock/UhlenbrockPacketizer.java
+++ b/java/src/jmri/jmrix/loconet/uhlenbrock/UhlenbrockPacketizer.java
@@ -75,7 +75,7 @@ public class UhlenbrockPacketizer extends LnPacketizer {
         if (log.isDebugEnabled()) {
             log.debug("queue LocoNet packet: {}", m.toString());
         }
-        // in an atomic operation, queue the request and wake the xmit thread
+        // queue the request
         try {
             xmtLocoNetList.addLast(m);
             xmtList.add(msg);


### PR DESCRIPTION
This switches the internal implementation of the LocoNet transmit queuing from notify/wait to use of a BlockingQueue.  

The previous implementation would occasionally cause delays in the transmission of messages, so this should be an improvement in consistency.