### PR TITLE
Change format of CSV file written by Event Table

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -138,6 +138,8 @@
                 </li>
                 <li>Fix a problem that would sometimes leave the node list improperly sorted</li>
                 <li>Reduced the start up delay when opening the OpenLCB hub.</li>
+                <li>Changed the formatting of the CSV file written by the Event Table so that
+                    multiple paths are broken out into multiple columns</li>
             </ul>
 
         <h4>Powerline</h4>

--- a/java/src/jmri/jmrix/openlcb/swing/eventtable/EventTablePane.java
+++ b/java/src/jmri/jmrix/openlcb/swing/eventtable/EventTablePane.java
@@ -267,16 +267,20 @@ public class EventTablePane extends jmri.util.swing.JmriPanel
                 str.printRecord("Event ID", "Event Name", "Producer Node", "Producer Node Name",
                                 "Consumer Node", "Consumer Node Name", "Paths");
                 for (int i = 0; i < model.getRowCount(); i++) {
-                    String contextInfo = model.getValueAt(i, EventTableDataModel.COL_CONTEXT_INFO).toString().replace("\n", " / "); // multi-line cell
 
-                    str.printRecord(model.getValueAt(i, EventTableDataModel.COL_EVENTID),
-                                    model.getValueAt(i, EventTableDataModel.COL_EVENTNAME),
-                                    model.getValueAt(i, EventTableDataModel.COL_PRODUCER_NODE),
-                                    model.getValueAt(i, EventTableDataModel.COL_PRODUCER_NAME),
-                                    model.getValueAt(i, EventTableDataModel.COL_CONSUMER_NODE),
-                                    model.getValueAt(i, EventTableDataModel.COL_CONSUMER_NAME),
-                                    contextInfo
-                            );
+                    str.print(model.getValueAt(i, EventTableDataModel.COL_EVENTID));
+                    str.print(model.getValueAt(i, EventTableDataModel.COL_EVENTNAME));
+                    str.print(model.getValueAt(i, EventTableDataModel.COL_PRODUCER_NODE));
+                    str.print(model.getValueAt(i, EventTableDataModel.COL_PRODUCER_NAME));
+                    str.print(model.getValueAt(i, EventTableDataModel.COL_CONSUMER_NODE));
+                    str.print(model.getValueAt(i, EventTableDataModel.COL_CONSUMER_NAME));
+
+                    String[] contexts = model.getValueAt(i, EventTableDataModel.COL_CONTEXT_INFO).toString().split("\n"); // multi-line cell
+                    for (String context : contexts) {
+                        str.print(context);
+                    }
+                    
+                    str.println();
                 }
                 str.flush();
             } catch (IOException ex) {


### PR DESCRIPTION
Previously, the 'path' column in the Event Table's CSV output file would contain all the relevant configuration paths in one cell.  This PR changes that to putting them into separate, additional columns.