### PR TITLE
Help updates for 5.5.7

### DIFF
--- a/help/en/JmriHelp_enIndex.xml
+++ b/help/en/JmriHelp_enIndex.xml
@@ -156,6 +156,8 @@
  </indexitem>
  <indexitem text="DCC Specialties - Hardware, Connection, Tools " target="html.hardware.misc.DccSpecialties"/>
 
+ <indexitem text="DCC-EX EX-CommandStation Hardware, Connection, Tools " target="html.hardware.dcc-ex.index"/>
+
  <indexitem text="DCC++ Hardware, Connection, Tools " target="html.hardware.dccpp.index"/>
 
  <indexitem text="Debug Menu " target="html.apps.PanelPro.DebugMenu"/>

--- a/help/en/JmriHelp_enTOC.xml
+++ b/help/en/JmriHelp_enTOC.xml
@@ -47,6 +47,8 @@
 
   <tocitem text="CVP EasyDCC " target="html.hardware.easydcc.EasyDCC"/>
 
+  <tocitem text="DCC-EX EX-CommandStation " target="html.hardware.dcc-ex.index"/>
+
   <tocitem text="DCC++ " target="html.hardware.dccpp.index"/>
 
   <tocitem text="DCC4PC Railcom Reader " target="html.hardware.dcc4pc.index"/>

--- a/help/en/format.xsl
+++ b/help/en/format.xsl
@@ -42,6 +42,7 @@
     <xsl:comment>=====================================================================</xsl:comment>
 
     <xsl:comment>#include virtual="/help/en/parts/Style.shtml" </xsl:comment>
+    <script src="/js/help.js"></script>
     </head>
 
     <body>
@@ -98,6 +99,7 @@
     <xsl:comment>=====================================================================</xsl:comment>
 
     <xsl:comment>#include virtual="/help/en/parts/Style.shtml" </xsl:comment>
+    <script src="/js/help.js"></script>
     </head>
 
     <body>

--- a/help/en/local/index.html
+++ b/help/en/local/index.html
@@ -386,14 +386,14 @@ Format: full-word | starts-with* | *ends-with');
                       ">CVP EasyDCC </a>
             <ul></ul>
         </li>
-
+          
         <li>
             <a id="html.hardware.dcc-ex.index"></a><a onclick="
                         openLink('../html/hardware/dcc-ex/index.shtml')
                       ">DCC-EX EX-CommandStation </a>
             <ul></ul>
         </li>
-
+          
         <li>
             <a id="html.hardware.dccpp.index"></a><a onclick="
                         openLink('../html/hardware/dccpp/index.shtml')
@@ -4261,8 +4261,8 @@ Format: full-word | starts-with* | *ends-with');
     <ul></ul>
 </li>
 
-<li>
-    <a id="html.hardware.dcc_ex.index"></a><a onclick="
+ <li>
+    <a id="html.hardware.dcc-ex.index"></a><a onclick="
                         openLink('../html/hardware/dcc-ex/index.shtml')
                       ">DCC-EX EX-CommandStation Hardware, Connection, Tools </a>
     <ul></ul>

--- a/help/en/local/jmri_map.xml
+++ b/help/en/local/jmri_map.xml
@@ -79,8 +79,8 @@
 <mapID target="html.hardware.can.index" url="html/hardware/can/index.shtml"/>
 <mapID target="html.hardware.cmri.CMRI" url="html/hardware/cmri/CMRI.shtml"/>
 <mapID target="html.hardware.cmri.Signals" url="html/hardware/cmri/Signals.shtml"/>
+<mapID target="html.hardware.dcc-ex.index" url="html/hardware/dcc-ex/index.shtml"/>
 <mapID target="html.hardware.dcc4pc.index" url="html/hardware/dcc4pc/index.shtml"/>
-<mapID target="html.hardware.dcc_ex.index" url="html/hardware/dcc-ex/index.shtml"/>
 <mapID target="html.hardware.dccpp.index" url="html/hardware/dccpp/index.shtml"/>
 <mapID target="html.hardware.digirails.index" url="html/hardware/digirails/index.shtml"/>
 <mapID target="html.hardware.easydcc.EasyDCC" url="html/hardware/easydcc/EasyDCC.shtml"/>

--- a/help/en/webindex.shtml
+++ b/help/en/webindex.shtml
@@ -10,7 +10,7 @@
         <!--Do not edit it directly-->
         <!--=====================================================================-->
         <!--#include virtual="/help/en/parts/Style.shtml" -->
-        <script src="/js/help.js"></script>       
+        <script src="/js/help.js"></script>
     </head>
     <body>
         <!--#include virtual="/help/en/parts/Header.shtml" -->
@@ -428,6 +428,11 @@
              
             <li>
                 <a href="html/hardware/misc/DccSpecialties.shtml">DCC Specialties - Hardware, Connection, Tools </a>
+                <ul></ul>
+            </li>
+             
+            <li>
+                <a href="html/hardware/dcc-ex/index.shtml">DCC-EX EX-CommandStation Hardware, Connection, Tools </a>
                 <ul></ul>
             </li>
              

--- a/help/en/webtoc.shtml
+++ b/help/en/webtoc.shtml
@@ -11,7 +11,6 @@
         <!--=====================================================================-->
         <!--#include virtual="/help/en/parts/Style.shtml" -->
         <script src="/js/help.js"></script>
-        
     </head>
     <body>
         <!--#include virtual="/help/en/parts/Header.shtml" -->
@@ -136,6 +135,11 @@
                       
                     <li>
                         <a href="html/hardware/easydcc/EasyDCC.shtml">CVP EasyDCC </a>
+                        <ul></ul>
+                    </li>
+                      
+                    <li>
+                        <a href="html/hardware/dcc-ex/index.shtml">DCC-EX EX-CommandStation </a>
                         <ul></ul>
                     </li>
                       

--- a/help/fr/format.xsl
+++ b/help/fr/format.xsl
@@ -45,13 +45,13 @@
     </HEAD>
 
     <BODY>
-    <xsl:comment>#include virtual="/Header_fr.shtml" </xsl:comment>
+    <xsl:comment>#include virtual="/help/fr/parts/Header_fr.shtml" </xsl:comment>
     <xsl:comment>#include virtual="indexheader" </xsl:comment>
     <ul>
         <xsl:apply-templates/>
     </ul>
 
-    <xsl:comment>#include virtual="/Footer_fr.shtml" </xsl:comment>
+    <xsl:comment>#include virtual="/help/fr/parts/Footer_fr.shtml" </xsl:comment>
     </BODY>
     </HTML>
 </xsl:template>
@@ -100,13 +100,13 @@
     </HEAD>
 
     <BODY>
-    <xsl:comment>#include virtual="/Header_fr.shtml" </xsl:comment>
+    <xsl:comment>#include virtual="/help/fr/parts/Header_fr.shtml" </xsl:comment>
     <xsl:comment>#include virtual="tocheader" </xsl:comment>
     <ul>
         <xsl:apply-templates/>
     </ul>
 
-    <xsl:comment>#include virtual="/Footer_fr.shtml" </xsl:comment>
+    <xsl:comment>#include virtual="/help/fr/parts/Footer_fr.shtml" </xsl:comment>
     </BODY>
     </HTML>
 </xsl:template>

--- a/xml/decoderIndex.xml
+++ b/xml/decoderIndex.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet href="/xml/XSLT/DecoderID.xsl" type="text/xsl"?>
 <decoderIndex-config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
-  <!--Written by JMRI version 5.5.6plus+jake+20231122T1355Z+R642f5d9106 on Wed Nov 22 08:55:15 EST 2023-->
-  <decoderIndex version="9">
+  <!--Written by JMRI version 5.5.6plus+jake+20231128T1936Z+Rec83b4b38c on Tue Nov 28 14:36:34 EST 2023-->
+  <decoderIndex version="11">
     <!--The manufacturer list is from the nmra_mfg_list.xml file-->
     <mfgList nmraListDate="2021-03-06" updated="2023-01-25" lastadd="169">
       <manufacturer mfg="NMRA" mfgID="999" />


### PR DESCRIPTION
1) Make sure DCC-EX entries persist by putting them in the original files (i.e. not just having them in files that are recreated by `ant build help`
2) Update `format.xsl` in English and French help to properly build indexes for new SSI support
3) and use those changes to update index files for test release 5.5.7
