### PR TITLE
WIP: Change order of subelements in Block schema to properly handle Reporter

### DIFF
--- a/xml/schema/types/blocks-2-9-6.xsd
+++ b/xml/schema/types/blocks-2-9-6.xsd
@@ -92,12 +92,7 @@
                   <xs:attribute name="systemName" type="beanNameType" /><!-- This will now store either a user or system name -->
                 </xs:complexType>
               </xs:element>
-              <xs:element name="reporter" minOccurs="0" maxOccurs="1" >
-                <xs:complexType>
-                <xs:attribute name="systemName" type="systemNameType" />
-                <xs:attribute name="useCurrent" type="yesNoType" />
-                </xs:complexType>
-              </xs:element>
+
               <xs:element name="deniedBlocks" minOccurs="0" maxOccurs="1" >
                 <xs:complexType>
                     <xs:sequence>
@@ -106,6 +101,13 @@
                 </xs:complexType>
               </xs:element>
               
+              <xs:element name="reporter" minOccurs="0" maxOccurs="1" >
+                <xs:complexType>
+                <xs:attribute name="systemName" type="systemNameType" />
+                <xs:attribute name="useCurrent" type="yesNoType" />
+                </xs:complexType>
+              </xs:element>
+
               <xs:element name="path" minOccurs="0" maxOccurs="unbounded" >
                 <xs:complexType>
                     <xs:sequence>


### PR DESCRIPTION
Reporter references that have been added to Blocks are properly being written to and read back from ConfigureXML files.  But the schema had some subelements in the wrong order with respect to the way these are written.  This fixes that.

I'd like this to be considered for the 5.7.8 test release hence 5.6

