### PR TITLE
Jmri generic plugin management

### DIFF
--- a/java/src/jmri/Plugin.java
+++ b/java/src/jmri/Plugin.java
@@ -1,0 +1,16 @@
+package jmri;
+
+/**
+ * Plugin to JMRI.
+ * <P>
+ * A class that implements the Plugin interface must have one constructor with
+ * no parameters. When the plugin JAR file is loaded, the class which implements
+ * the Plugin interface is initialized and the {@link #init()} method is called.
+ *
+ * @author Daniel Bergqvist (C) 2023
+ */
+public interface Plugin {
+
+    public void init();
+
+}

--- a/java/src/jmri/Plugin.java
+++ b/java/src/jmri/Plugin.java
@@ -1,5 +1,7 @@
 package jmri;
 
+import javax.swing.JMenu;
+
 /**
  * Plugin to JMRI.
  * <P>
@@ -11,6 +13,17 @@ package jmri;
  */
 public interface Plugin {
 
-    public void init();
+    /**
+     * Initialize this plugin.
+     */
+    public default void init() {
+    }
+
+    /**
+     * Add menu items to the Tools menu if desired.
+     * @param menu the Tools menu
+     */
+    public default void addToolsMenu(JMenu menu) {
+    }
 
 }

--- a/java/src/jmri/PluginManager.java
+++ b/java/src/jmri/PluginManager.java
@@ -1,0 +1,24 @@
+package jmri;
+
+import java.util.*;
+
+/**
+ * Manages plugins
+ *
+ * @author Daniel Bergqvist (C) 2023
+ */
+public interface PluginManager {
+
+    /**
+     * Add a plugin.
+     * @param p the plugin
+     */
+    public void addPlugin(Plugin p);
+
+    /**
+     * Get a list of the plugins.
+     * @return the list
+     */
+    public List<Plugin> getPlugins();
+
+}

--- a/java/src/jmri/jmrit/ToolsMenu.java
+++ b/java/src/jmri/jmrit/ToolsMenu.java
@@ -8,6 +8,8 @@ import javax.swing.JSeparator;
 import javax.annotation.CheckForNull;
 
 import jmri.InstanceManager;
+import jmri.Plugin;
+import jmri.PluginManager;
 import jmri.jmrit.throttle.ThrottleCreationAction;
 import jmri.util.gui.GuiLafPreferencesManager;
 import jmri.AddressedProgrammerManager;
@@ -32,10 +34,10 @@ public class ToolsMenu extends JMenu {
 
     ConnectionConfig serModeProCon = null;
     ConnectionConfig opsModeProCon = null;
-    
+
     AbstractAction serviceAction = new jmri.jmrit.symbolicprog.tabbedframe.PaneProgAction(Bundle.getMessage("MenuItemDecoderProServiceProgrammer"));
     AbstractAction opsAction = new jmri.jmrit.symbolicprog.tabbedframe.PaneOpsProgAction(Bundle.getMessage("MenuItemDecoderProOpsModeProgrammer"));
-        
+
     public ToolsMenu(String name) {
         this();
         setText(name);
@@ -46,7 +48,7 @@ public class ToolsMenu extends JMenu {
         super();
 
         setText(Bundle.getMessage("MenuTools"));
-        
+
         JMenu programmerMenu = new JMenu(Bundle.getMessage("MenuProgrammers"));
         programmerMenu.add(new jmri.jmrit.simpleprog.SimpleProgAction());
         programmerMenu.add(serviceAction);
@@ -217,6 +219,10 @@ public class ToolsMenu extends JMenu {
                     updateProgrammerStatus(evt);
                 });
         InstanceManager.getList(GlobalProgrammerManager.class).forEach(m -> m.addPropertyChangeListener(this::updateProgrammerStatus));
+
+        for (Plugin p : InstanceManager.getDefault(PluginManager.class).getPlugins()) {
+            p.addToolsMenu(this);
+        }
     }
 
     /**
@@ -224,7 +230,7 @@ public class ToolsMenu extends JMenu {
      * available.
      *
      * Adapted from similar named function in @link jmri.jmrit.roster.swing.RosterFrame.java
-     * 
+     *
      * @param evt the triggering event; if not null and if a removal of a
      *            ProgrammerManager, care will be taken not to trigger the
      *            automatic creation of a new ProgrammerManager
@@ -317,5 +323,5 @@ public class ToolsMenu extends JMenu {
     }
 
     private final static Logger log = LoggerFactory.getLogger(jmri.jmrit.ToolsMenu.class);
-    
+
 }

--- a/java/src/jmri/managers/DefaultInstanceInitializer.java
+++ b/java/src/jmri/managers/DefaultInstanceInitializer.java
@@ -85,6 +85,10 @@ public class DefaultInstanceInitializer extends AbstractInstanceInitializer {
             return new ProxyMeterManager();
         }
 
+        if (type == PluginManager.class) {
+            return new DefaultPluginManager();
+        }
+
         if (type == RailComManager.class) {
             return new DefaultRailComManager();
         }
@@ -172,6 +176,7 @@ public class DefaultInstanceInitializer extends AbstractInstanceInitializer {
                 LogixManager.class,
                 MemoryManager.class,
                 MeterManager.class,
+                PluginManager.class,
                 RailComManager.class,
                 ReporterManager.class,
                 RouteManager.class,

--- a/java/src/jmri/managers/DefaultPluginManager.java
+++ b/java/src/jmri/managers/DefaultPluginManager.java
@@ -1,0 +1,28 @@
+package jmri.managers;
+
+import java.util.*;
+
+import jmri.Plugin;
+import jmri.PluginManager;
+
+/**
+ * Default implementation of PluginManager.
+ *
+ * @author Daniel Bergqvist (C) 2023
+ */
+public class DefaultPluginManager implements PluginManager {
+
+    private final List<Plugin> _plugins = new ArrayList<>();
+
+    /** {@inheritDoc} */
+    @Override
+    public void addPlugin(Plugin p) {
+        _plugins.add(p);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public List<Plugin> getPlugins() {
+        return Collections.unmodifiableList(_plugins);
+    }
+}

--- a/java/src/jmri/util/plugin/Bundle.java
+++ b/java/src/jmri/util/plugin/Bundle.java
@@ -1,0 +1,99 @@
+package jmri.util.plugin;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+import java.util.Locale;
+
+import javax.annotation.CheckReturnValue;
+import javax.annotation.CheckForNull;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
+@CheckReturnValue
+@SuppressFBWarnings(value = "NM_SAME_SIMPLE_NAME_AS_SUPERCLASS", justification = "Desired pattern is repeated class names with package-level access to members")
+
+@javax.annotation.concurrent.Immutable
+
+/**
+ * Provides standard access for resource bundles in a package.
+ *
+ * Convention is to provide a subclass of this name in each package, working off
+ * the local resource bundle name.
+ *
+ * @author Bob Jacobsen Copyright (C) 2012
+ * @since 3.3.1
+ */
+public class Bundle extends jmri.util.Bundle {
+
+    @CheckForNull
+    private static final String name = "jmri.util.plugin.Bundle"; // NOI18N
+
+    //
+    // below here is boilerplate to be copied exactly
+    //
+    /**
+     * Provides a translated string for a given key from the package resource
+     * bundle or parent.
+     * <p>
+     * Note that this is intentionally package-local access.
+     *
+     * @param key Bundle key to be translated
+     * @return Internationalized text
+     */
+    static String getMessage(String key) {
+        return getBundle().handleGetMessage(key);
+    }
+
+    /**
+     * Merges user data with a translated string for a given key from the
+     * package resource bundle or parent.
+     * <p>
+     * Uses the transformation conventions of the Java MessageFormat utility.
+     * <p>
+     * Note that this is intentionally package-local access.
+     *
+     * @see java.text.MessageFormat
+     * @param key  Bundle key to be translated
+     * @param subs One or more objects to be inserted into the message
+     * @return Internationalized text
+     */
+    static String getMessage(String key, Object... subs) {
+        return getBundle().handleGetMessage(key, subs);
+    }
+
+    /**
+     * Merges user data with a translated string for a given key in a given
+     * locale from the package resource bundle or parent.
+     * <p>
+     * Uses the transformation conventions of the Java MessageFormat utility.
+     * <p>
+     * Note that this is intentionally package-local access.
+     *
+     * @see java.text.MessageFormat
+     * @param locale The locale to be used
+     * @param key    Bundle key to be translated
+     * @param subs   One or more objects to be inserted into the message
+     * @return Internationalized text
+     */
+    static String getMessage(Locale locale, String key, Object... subs) {
+        return getBundle().handleGetMessage(locale, key, subs);
+    }
+
+    private final static Bundle b = new Bundle();
+
+    @Override
+    @CheckForNull
+    protected String bundleName() {
+        return name;
+    }
+
+    protected static jmri.Bundle getBundle() {
+        return b;
+    }
+
+    @Override
+    protected String retry(Locale locale, String key) {
+        return super.getBundle().handleGetMessage(locale,key);
+    }
+
+}

--- a/java/src/jmri/util/plugin/Bundle.properties
+++ b/java/src/jmri/util/plugin/Bundle.properties
@@ -1,5 +1,5 @@
 jmri.util.plugin.LoadPluginModel    = Load plugin
 
-CannotLoadPlugin    = Cannot load plugin {}. {}
+CannotLoadPlugin    = Cannot load plugin {0}. {1}
 
 allPlugins          = All Plugin Files

--- a/java/src/jmri/util/plugin/Bundle.properties
+++ b/java/src/jmri/util/plugin/Bundle.properties
@@ -1,0 +1,5 @@
+jmri.util.plugin.LoadPluginModel    = Load plugin
+
+CannotLoadPlugin    = Cannot load plugin {}. {}
+
+allPlugins          = All Plugin Files

--- a/java/src/jmri/util/plugin/LoadPluginModel.java
+++ b/java/src/jmri/util/plugin/LoadPluginModel.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 
 import jmri.JmriException;
-import jmri.jmrix.sprog.sprogslotmon.Bundle;
 import jmri.util.startup.AbstractStartupModel;
 
 /**
@@ -33,7 +32,7 @@ public class LoadPluginModel extends AbstractStartupModel {
         } catch (IOException | ClassNotFoundException | IllegalAccessException
                 | InstantiationException | NoSuchMethodException
                 | InvocationTargetException ex) {
-            throw new JmriException(Bundle.formatMessage("CannotLoadPlugin",
+            throw new JmriException(Bundle.getMessage("CannotLoadPlugin",
                     this.getFileName(), ex.getLocalizedMessage()));
         }
     }

--- a/java/src/jmri/util/plugin/LoadPluginModel.java
+++ b/java/src/jmri/util/plugin/LoadPluginModel.java
@@ -1,0 +1,42 @@
+package jmri.util.plugin;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+
+import jmri.JmriException;
+import jmri.jmrix.sprog.sprogslotmon.Bundle;
+import jmri.util.startup.AbstractStartupModel;
+
+/**
+ * A LoadPluginModel object loads a plugin when the program is started.
+ *
+ * @author Bob Jacobsen Copyright 2003
+ * @author Randall Wood (c) 2016
+ * @author Daniel Bergqvist (C) 2023
+ * @see jmri.util.plugin.LoadPluginModelFactory
+ */
+public class LoadPluginModel extends AbstractStartupModel {
+
+    public String getFileName() {
+        return this.getName();
+    }
+
+    public void setFileName(String n) {
+        this.setName(n);
+    }
+
+    @Override
+    public void performAction() throws JmriException {
+        log.info("Load plugin {}", this.getFileName());
+        try {
+            PluginLoader.loadJarFile(this.getFileName());
+        } catch (IOException | ClassNotFoundException | IllegalAccessException
+                | InstantiationException | NoSuchMethodException
+                | InvocationTargetException ex) {
+            throw new JmriException(Bundle.formatMessage("CannotLoadPlugin",
+                    this.getFileName(), ex.getLocalizedMessage()));
+        }
+    }
+
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LoadPluginModel.class);
+}

--- a/java/src/jmri/util/plugin/LoadPluginModelFactory.java
+++ b/java/src/jmri/util/plugin/LoadPluginModelFactory.java
@@ -1,0 +1,42 @@
+package jmri.util.plugin;
+
+import javax.swing.JFileChooser;
+
+import jmri.util.startup.AbstractFileModelFactory;
+import jmri.util.startup.StartupModel;
+import jmri.util.startup.StartupModelFactory;
+
+import org.openide.util.lookup.ServiceProvider;
+
+/**
+ * Factory for LoadPluginModel.
+ *
+ * @author Randall Wood (C) 2016
+ * @author Daniel Bergqvist (C) 2023
+ */
+@ServiceProvider(service = StartupModelFactory.class)
+public class LoadPluginModelFactory extends AbstractFileModelFactory {
+
+    public LoadPluginModelFactory() {
+    }
+
+    @Override
+    public Class<? extends StartupModel> getModelClass() {
+        return LoadPluginModel.class;
+    }
+
+    @Override
+    public LoadPluginModel newModel() {
+        return new LoadPluginModel();
+    }
+
+    @Override
+    protected JFileChooser setFileChooser() {
+        return new PluginFileChooser();
+    }
+
+    @Override
+    public String getDescription() {
+        return Bundle.getMessage(this.getModelClass().getCanonicalName());
+    }
+}

--- a/java/src/jmri/util/plugin/PluginFileChooser.java
+++ b/java/src/jmri/util/plugin/PluginFileChooser.java
@@ -1,0 +1,45 @@
+package jmri.util.plugin;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.swing.JFileChooser;
+import javax.swing.filechooser.FileFilter;
+import javax.swing.filechooser.FileNameExtensionFilter;
+
+import jmri.util.FileUtil;
+
+/**
+ * File chooser for plugins.
+ *
+ * @author Daniel Bergqvist (C) 2023
+ */
+public class PluginFileChooser extends jmri.util.swing.JmriJFileChooser {
+
+    public PluginFileChooser() {
+        super(FileUtil.getPreferencesPath());
+        this.init();
+    }
+
+    public PluginFileChooser(String path) {
+        super(path);
+        this.init();
+    }
+
+    public PluginFileChooser(File dir) {
+        super(dir);
+        this.init();
+    }
+
+    private void init() {
+        List<String> allExtensions = new ArrayList<>();
+        allExtensions.add("JAR");
+        FileFilter allPlugins = new FileNameExtensionFilter(Bundle.getMessage("allPlugins"), allExtensions.toArray(new String[allExtensions.size()]));
+        this.addChoosableFileFilter(allPlugins);
+        this.setFileFilter(allPlugins);
+        this.setFileSelectionMode(JFileChooser.FILES_ONLY);
+    }
+
+    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(PluginFileChooser.class);
+}

--- a/java/src/jmri/util/plugin/PluginFileChooser.java
+++ b/java/src/jmri/util/plugin/PluginFileChooser.java
@@ -41,5 +41,5 @@ public class PluginFileChooser extends jmri.util.swing.JmriJFileChooser {
         this.setFileSelectionMode(JFileChooser.FILES_ONLY);
     }
 
-    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(PluginFileChooser.class);
+//    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(PluginFileChooser.class);
 }

--- a/java/src/jmri/util/plugin/PluginLoader.java
+++ b/java/src/jmri/util/plugin/PluginLoader.java
@@ -12,7 +12,9 @@ import java.util.List;
 import java.util.jar.JarEntry;
 import java.util.jar.JarInputStream;
 
+import jmri.InstanceManager;
 import jmri.Plugin;
+import jmri.PluginManager;
 
 /**
  * Loads a plugin JAR file.
@@ -39,6 +41,7 @@ public class PluginLoader {
                     if (o instanceof Plugin) {
                         Plugin p = (Plugin)o;
                         p.init();
+                        InstanceManager.getDefault(PluginManager.class).addPlugin(p);
                     } else {
                         throw new IllegalArgumentException("Class is not a jmri.Plugin");
                     }

--- a/java/src/jmri/util/plugin/PluginLoader.java
+++ b/java/src/jmri/util/plugin/PluginLoader.java
@@ -35,7 +35,7 @@ public class PluginLoader {
 
         try (URLClassLoader cl = new URLClassLoader(urls)) {
             for (String className : classNameList) {
-                Class cls = cl.loadClass(className);
+                Class<?> cls = cl.loadClass(className);
                 if (Plugin.class.isAssignableFrom(cls)) {
                     Object o = cls.getDeclaredConstructor().newInstance();
                     if (o instanceof Plugin) {

--- a/java/src/jmri/util/plugin/PluginLoader.java
+++ b/java/src/jmri/util/plugin/PluginLoader.java
@@ -1,0 +1,77 @@
+package jmri.util.plugin;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.jar.JarEntry;
+import java.util.jar.JarInputStream;
+
+import jmri.Plugin;
+
+/**
+ * Loads a plugin JAR file.
+ *
+ * @author Daniel Bergqvist (C) 2023
+ */
+public class PluginLoader {
+
+    private static void loadClassesInJarFile(String filename, List<String> classNameList)
+            throws IOException, ClassNotFoundException,
+            InstantiationException, IllegalAccessException,
+            NoSuchMethodException, InvocationTargetException {
+
+        File file = new File(filename);
+
+        URL url = file.toURI().toURL();
+        URL[] urls = new URL[]{url};
+
+        try (URLClassLoader cl = new URLClassLoader(urls)) {
+            for (String className : classNameList) {
+                Class cls = cl.loadClass(className);
+                if (Plugin.class.isAssignableFrom(cls)) {
+                    Object o = cls.getDeclaredConstructor().newInstance();
+                    if (o instanceof Plugin) {
+                        Plugin p = (Plugin)o;
+                        p.init();
+                    } else {
+                        throw new IllegalArgumentException("Class is not a jmri.Plugin");
+                    }
+                }
+            }
+            cl.close();
+        }
+    }
+
+    public static void loadJarFile(String filename)
+            throws FileNotFoundException, IOException, ClassNotFoundException,
+            InstantiationException, IllegalAccessException,
+            NoSuchMethodException, InvocationTargetException {
+
+        List<String> classNameList = new ArrayList<>();
+
+        try (JarInputStream jarFile = new JarInputStream(new FileInputStream(filename))) {
+            JarEntry jarEntry;
+
+            while (true) {
+                jarEntry = jarFile.getNextJarEntry();
+                if (jarEntry == null) {
+                    break;
+                }
+                if ((jarEntry.getName().endsWith(".class"))) {
+                    String className = jarEntry.getName().replaceAll("/", "\\.");
+                    String myClass = className.substring(0, className.lastIndexOf('.'));
+                    classNameList.add(myClass);
+                }
+            }
+        }
+
+        loadClassesInJarFile(filename, classNameList);
+    }
+
+}

--- a/java/src/jmri/util/plugin/configurexml/LoadPluginModelXml.java
+++ b/java/src/jmri/util/plugin/configurexml/LoadPluginModelXml.java
@@ -1,0 +1,77 @@
+package jmri.util.plugin.configurexml;
+
+import jmri.util.plugin.LoadPluginModel;
+
+import jmri.util.startup.StartupActionsManager;
+import jmri.InstanceManager;
+import jmri.util.FileUtil;
+
+import org.jdom2.Attribute;
+import org.jdom2.Element;
+
+/**
+ * Handle XML persistence of LoadPluginModel objects
+ *
+ * @author Bob Jacobsen Copyright: Copyright (c) 2003
+ * @author Ken Cameron Copyright: Copyright (c) 2014
+ * @author Daniel Bergqvist (C) 2023
+ * @see jmri.util.startup.LoadPluginModelFactory
+ */
+public class LoadPluginModelXml extends jmri.configurexml.AbstractXmlAdapter {
+
+    public LoadPluginModelXml() {
+    }
+
+    /**
+     * Default implementation for storing the model contents
+     *
+     * @param o Object to store, of type PerformActonModel
+     * @return Element containing the complete info
+     */
+    @Override
+    public Element store(Object o) {
+        Element e = new Element("perform");
+        LoadPluginModel g = (LoadPluginModel) o;
+
+        e.setAttribute("name", FileUtil.getPortableFilename(g.getFileName()));
+        e.setAttribute("type", "PluginFile");
+        e.setAttribute("enabled", g.isEnabled() ? "yes" : "no");
+        e.setAttribute("class", this.getClass().getName());
+        return e;
+    }
+
+    /**
+     * Object should be loaded after basic GUI constructed
+     *
+     * @return true to defer loading
+     * @see jmri.configurexml.AbstractXmlAdapter#loadDeferred()
+     * @see jmri.configurexml.XmlAdapter#loadDeferred()
+     */
+    @Override
+    public boolean loadDeferred() {
+        return true;
+    }
+
+    @Override
+    public boolean load(Element shared, Element perNode) {
+        boolean result = true;
+        String fileName = shared.getAttribute("name").getValue();
+        fileName = FileUtil.getAbsoluteFilename(fileName);
+        LoadPluginModel m = new LoadPluginModel();
+
+        Attribute enabled = shared.getAttribute("enabled");
+        if (enabled != null) {
+            m.setEnabled("yes".equals(enabled.getValue()));
+        } else {
+            m.setEnabled(true);
+        }
+
+        m.setFileName(fileName);
+        InstanceManager.getDefault(StartupActionsManager.class).addAction(m);
+        return result;
+    }
+
+    // initialize logging
+//    private final static Logger log = LoggerFactory.getLogger(LoadPluginModelXml.class);
+
+}

--- a/java/src/jmri/util/plugin/configurexml/LoadPluginModelXml.java
+++ b/java/src/jmri/util/plugin/configurexml/LoadPluginModelXml.java
@@ -15,7 +15,7 @@ import org.jdom2.Element;
  * @author Bob Jacobsen Copyright: Copyright (c) 2003
  * @author Ken Cameron Copyright: Copyright (c) 2014
  * @author Daniel Bergqvist (C) 2023
- * @see jmri.util.startup.LoadPluginModelFactory
+ * @see jmri.util.plugin.LoadPluginModelFactory
  */
 public class LoadPluginModelXml extends jmri.configurexml.AbstractXmlAdapter {
 


### PR DESCRIPTION
This PR adds an easy way to add plugins to JMRI. The plugin is a JAR file that can be located anywhere, for example in the user's preference folder. The plugin is loaded by the startup action `Load plugin`.

If the plugin has one or more classes that implements the `jmri.Plugin` interface, the method `init()` is called when the plugin is loaded. And the method `addToolsMenu(JMenu)` is called when the ToolsMenu is created to allow the plugin to add more items to the tools menu.

An example plugin is in the repository https://github.com/danielb987/JmriPlugin. To compile the plugin, copy the `jmri.jar` to the `lib` folder of the plugin. The example plugin adds a menu item to the Tools menu.

One question for this PR is if it would work in a headless environment. I don't know how to run `ant jmriheadless` with the `--profile=aaaa` parameter so I haven't been able to test that.

The branch for this PR is created from the `release-5.5.7` if we would include it in JMRI 5.6. But I have no problem waiting for after the next production release.