### PR TITLE
Update aspects.xml

### DIFF
--- a/xml/signals/SBB-1989/aspects.xml
+++ b/xml/signals/SBB-1989/aspects.xml
@@ -55,7 +55,6 @@
         <name>Spento</name>
         <indication>Stop</indication>
 	  <description>no light</description>
-	  <description></description>
 	  <comment>Fermata</comment>
         <speed>Stop</speed>
         <speed2>Stop</speed2>
@@ -113,7 +112,6 @@
       <name>Arancione 70km/h</name>
       <indication>Proceed at 70km/h from next signal</indication>
 	  <description>One orange light with next speed limit</description>
-	  <description></description>
 	  <comment>segnale aperto</comment>
       <speed>Slow</speed>
       <speed2>Slow</speed2>


### PR DESCRIPTION
@bobjacobsen 
Headless CI currently fails on this file. `<description></description>` becomes `<description />`. I don't see this error when I run the test locally so I'm not sure why it happens. But there are two descriptions after each other so my question is if both are needed? If not, I suggest merging this PR early without waiting 24 hours, to get Headless CI work again.