### PR TITLE
Add support for including help files in plugins

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -616,4 +616,8 @@
             <li>The Windows application launcher has been updated to allow access to
                 jar files in the settings:lib/ directory. This gives creators of JMRI 
                 plug-ins a way to distribute their code separate from JMRI.</li>
+            <li>Plugins can now have help files, including images and css files, withing
+                the JAR file. See <a href="https://github.com/JMRI/JMRI/pull/12705">PR #12705</a> and
+                <a href="https://github.com/danielb987/JmriPlugin">JmriPlugin</a> for example and
+                documentation.</li>
         </ul>

--- a/java/src/jmri/util/HelpUtilPreferences.java
+++ b/java/src/jmri/util/HelpUtilPreferences.java
@@ -34,35 +34,6 @@ public final class HelpUtilPreferences extends PreferencesBean implements Instan
         _openHelpOnline = sharedPreferences.getBoolean(OPEN_HELP_ONLINE, _openHelpOnline);
         _openHelpOnFile = sharedPreferences.getBoolean(OPEN_HELP_ON_FILE, _openHelpOnFile);
         _openHelpOnJMRIWebServer = sharedPreferences.getBoolean(OPEN_HELP_ON_JMRI_WEB_SERVER, _openHelpOnJMRIWebServer);
-
-/*
-        this.allowRemoteConfig = sharedPreferences.getBoolean(ALLOW_REMOTE_CONFIG, this.allowRemoteConfig);
-        this.clickDelay = sharedPreferences.getInt(CLICK_DELAY, this.clickDelay);
-        this.simple = sharedPreferences.getBoolean(SIMPLE, this.simple);
-        this.railroadName = sharedPreferences.get(RAILROAD_NAME, this.railroadName);
-        this.readonlyPower = sharedPreferences.getBoolean(READONLY_POWER, this.readonlyPower);
-        this.refreshDelay = sharedPreferences.getInt(REFRESH_DELAY, this.refreshDelay);
-        this.useAjax = sharedPreferences.getBoolean(USE_AJAX, this.useAjax);
-        this.disableFrames = sharedPreferences.getBoolean(DISABLE_FRAME_SERVER, this.disableFrames);
-        this.redirectFramesToPanels = sharedPreferences.getBoolean(REDIRECT_FRAMES, this.redirectFramesToPanels);
-        try {
-            Preferences frames = sharedPreferences.node(DISALLOWED_FRAMES);
-            if (frames.keys().length != 0) {
-                this.disallowedFrames.clear();
-                for (String key : frames.keys()) { // throws BackingStoreException
-                    String frame = frames.get(key, null);
-                    if (frame != null && !frame.trim().isEmpty()) {
-                        this.disallowedFrames.add(frame);
-                    }
-                }
-            }
-        } catch (BackingStoreException ex) {
-            // this is expected if sharedPreferences have not been written previously,
-            // so do nothing.
-        }
-        this.port = sharedPreferences.getInt(PORT, this.port);
-        this.useZeroConf = sharedPreferences.getBoolean(USE_ZERO_CONF, this.useZeroConf);
-*/
         setIsDirty(false);
     }
 

--- a/java/src/jmri/util/UtilBundle.properties
+++ b/java/src/jmri/util/UtilBundle.properties
@@ -40,7 +40,7 @@ Help_LabelOpenHelpOnline                    = Open help pages online
 Help_ToolTipLabelOpenHelpOnline             = This requires Internet access
 Help_LabelOpenHelpOnFile                    = Open help pages locally
 Help_ToolTipLabelOpenHelpOnFile             = This works without an Internet connection
-Help_LabelOpenHelpOnJMRIWebServer           = Open help pages using the web server in JMRI (Experimental. Not recommended)
+Help_LabelOpenHelpOnJMRIWebServer           = Open help pages using the web server in JMRI
 Help_ToolTipLabelOpenHelpOnJMRIWebServer    = This option is for developers only.
 
 HelpError_Title                             = Help file not found

--- a/java/src/jmri/web/servlet/help/HelpSSIServlet.java
+++ b/java/src/jmri/web/servlet/help/HelpSSIServlet.java
@@ -1,8 +1,6 @@
 package jmri.web.servlet.help;
 
 import java.io.*;
-import java.net.*;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;

--- a/java/src/jmri/web/servlet/help/HelpSSIServlet.java
+++ b/java/src/jmri/web/servlet/help/HelpSSIServlet.java
@@ -125,14 +125,15 @@ public class HelpSSIServlet extends HttpServlet {
                 String resourceName = fileName.substring("/plugin/".length());
                 try (InputStream is = this.getClass().getClassLoader().getResourceAsStream(resourceName)) {
                     if (is != null) {
-                        BufferedReader reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
+                        try (BufferedReader reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8))) {
 
-                        StringBuilder sb = new StringBuilder();
-                        String line;
-                        while ((line = reader.readLine()) != null) {
-                            sb.append(line);
+                            StringBuilder sb = new StringBuilder();
+                            String line;
+                            while ((line = reader.readLine()) != null) {
+                                sb.append(line);
+                            }
+                            content = sb.toString();
                         }
-                        content = sb.toString();
                     } else {
                         content = String.format("%n<br>%nERROR: Plugin resource \"%s\" couldn't be found%n<br>%n", resourceName);
                         log.warn("Plugin resource \"{}\" couldn't be found", resourceName);

--- a/java/src/jmri/web/servlet/help/HelpSSIServlet.java
+++ b/java/src/jmri/web/servlet/help/HelpSSIServlet.java
@@ -123,19 +123,20 @@ public class HelpSSIServlet extends HttpServlet {
         try {
             if (fileName.startsWith("/plugin/")) {
                 String resourceName = fileName.substring("/plugin/".length());
-                InputStream is = this.getClass().getClassLoader().getResourceAsStream(resourceName);
-                if (is != null) {
-                    BufferedReader reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
+                try (InputStream is = this.getClass().getClassLoader().getResourceAsStream(resourceName)) {
+                    if (is != null) {
+                        BufferedReader reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
 
-                    StringBuilder sb = new StringBuilder();
-                    String line;
-                    while ((line = reader.readLine()) != null) {
-                        sb.append(line);
+                        StringBuilder sb = new StringBuilder();
+                        String line;
+                        while ((line = reader.readLine()) != null) {
+                            sb.append(line);
+                        }
+                        content = sb.toString();
+                    } else {
+                        content = String.format("%n<br>%nERROR: Plugin resource \"%s\" couldn't be found%n<br>%n", resourceName);
+                        log.warn("Plugin resource \"{}\" couldn't be found", resourceName);
                     }
-                    content = sb.toString();
-                } else {
-                    content = String.format("%n<br>%nERROR: Plugin resource \"%s\" couldn't be found%n<br>%n", resourceName);
-                    log.warn("Plugin resource \"{}\" couldn't be found", resourceName);
                 }
             } else {
                 content = new String(Files.readAllBytes(Paths.get(fileName)));


### PR DESCRIPTION
This PR adds support for help files in a plugin. See https://github.com/danielb987/JmriPlugin for an example plugin.

To use this feature, the JMRI web server must be running.

Local help pages are accessed by the path `/help/`, for example:
http://localhost:12080/help/en/html/tools/logixng/LogixNG.shtml

Help pages within a plugin are accessed by the path `/plugin/`, for example:
http://localhost:12080/plugin/se/bergqvist/jmri/LogixNG.shtml

In the plugin https://github.com/danielb987/JmriPlugin, the help pages are in the source package `se.bergqvist.jmri` and the images are in the source package `se.bergqvist.jmri.images`. Help pages in the plugin can link to, and include, JMRI help pages if the path starts with `/help/`.