### PR TITLE
Upgrade PanelPro file history

### DIFF
--- a/help/en/html/apps/DataManagement.shtml
+++ b/help/en/html/apps/DataManagement.shtml
@@ -357,7 +357,7 @@
           </td>
           <td class="who">UC/US</td>
           <td class="cmd">Tools &rArr; Speedometer, Hit "Save as default"</td>
-          <td class="store">In PanelProSpeedometer.xml in User Files location. NOTE: <em>"Save as default" 
+          <td class="store">In PanelProSpeedometer.xml in User Files location. NOTE: <em>"Save as default"
           causes sensors to be created if they do not already exist.  These must then be saved in a panel file.</em></td>
           <td>
           </td>
@@ -439,11 +439,11 @@
         <tr>
           <td class="type">Other</td>
           <td class="data">Backup panels</td>
-          <td class="where">Whenever panels or tables are stored</td>
+          <td class="where">Whenever tables and panels are stored with the same file name.</td>
           <td class="who"><strong>AC/AS</strong>
           </td>
           <td class="cmd">NA</td>
-          <td class="store">In backupPanels/ in Profile location</td>
+          <td class="store">In backupPanels/ in User Files location</td>
           <td>&#10004;</td>
         </tr>
 

--- a/help/en/html/apps/LoadStoreWork.shtml
+++ b/help/en/html/apps/LoadStoreWork.shtml
@@ -360,7 +360,7 @@
         "Store Only table content (No Panels)... {Store configuration}" rather than "Store ALL
         table content and panels... {Store configuration and panels}" and overwrote an existing
         panel file. Don't panic - the backup copy (in the directory "backupPanels" in the <a href=
-        "../doc/Technical/ProfileFileStructure.shtml">Profile Location</a>) is there. Best practice
+        "../doc/Technical/ProfileFileStructure.shtml">User Files Location</a>) is there. Best practice
         in working with PanelPro is to almost always use <strong>"Store ALL table content and
         panels...</strong> {<em>Old: <strong>Store configuration and panels</strong></em>}" or
         <strong>"Store ALL table content and panels...</strong> {<em>Old: <strong>Store

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -444,6 +444,19 @@
             <li></li>
         </ul>
 
+    <h3>PanelPro</h3>
+        <a id="PanelPro" name="PanelPro"></a>
+        <ul>
+            <li>The path for the <strong>backupPanels</strong> directory has been fixed so that it
+            now refers to the user files location instead of the profile location.  This only affects
+            the backup files location when user data is shared by multiple profiles.</li>
+
+            <li>The <strong>File &rArr; Show file history</strong> content has been enhanced.  The
+            <strong>app</strong> entries show the JMRI version.  The <strong>Store</strong> entries
+            show the name of the file that was created.
+            <li>
+        </ul>
+
    <h3>Panel Editor</h3>
         <a id="PE" name="PE"></a>
         <ul>
@@ -606,7 +619,7 @@
     <h3>Miscellaneous</h3>
         <a id="Misc" name="Misc"></a>
         <ul>
-            <li>Added an 
+            <li>Added a
                 <a href="https://www.jmri.org/help/en/html/doc/Technical/plugins.shtml">SPI mechanism</a>
                 for extending the Tools menu.</li>
             <li>The Linux and macOS application launchers and the Ant build process
@@ -614,6 +627,6 @@
                 directory. This gives creators of JMRI plug-ins a way to distribute
                 their code separate from JMRI.</li>
             <li>The Windows application launcher has been updated to allow access to
-                jar files in the settings:lib/ directory. This gives creators of JMRI 
+                jar files in the settings:lib/ directory. This gives creators of JMRI
                 plug-ins a way to distribute their code separate from JMRI.</li>
         </ul>

--- a/java/src/apps/Apps.java
+++ b/java/src/apps/Apps.java
@@ -137,7 +137,8 @@ public class Apps extends JPanel implements PropertyChangeListener, WindowListen
         ConfigureManager cm = InstanceManager.setDefault(ConfigureManager.class, new AppsConfigurationManager());
 
         // record startup
-        InstanceManager.getDefault(FileHistory.class).addOperation("app", nameString, null);
+        String appString = String.format("%s (v%s)", jmri.Application.getApplicationName(), Version.getCanonicalVersion());
+        InstanceManager.getDefault(FileHistory.class).addOperation("app", appString, null);
 
         // Install abstractActionModel
         InstanceManager.store(new apps.CreateButtonModel(), apps.CreateButtonModel.class);

--- a/java/src/apps/AppsBase.java
+++ b/java/src/apps/AppsBase.java
@@ -198,7 +198,8 @@ public abstract class AppsBase {
 
     protected void installManagers() {
         // record startup
-        InstanceManager.getDefault(FileHistory.class).addOperation("app", Application.getApplicationName(), null);
+        String appString = String.format("%s (v%s)", Application.getApplicationName(), Version.getCanonicalVersion());
+        InstanceManager.getDefault(FileHistory.class).addOperation("app", appString, null);
 
         // install the abstract action model that allows items to be added to the, both
         // CreateButton and Perform Action Model use a common Abstract class

--- a/java/src/jmri/configurexml/ConfigXmlManager.java
+++ b/java/src/jmri/configurexml/ConfigXmlManager.java
@@ -327,10 +327,11 @@ public class ConfigXmlManager extends jmri.jmrit.XmlFile
         }
     }
 
-    protected void includeHistory(Element root) {
+    protected void includeHistory(Element root, File file) {
         // add history to end of document
         if (InstanceManager.getNullableDefault(FileHistory.class) != null) {
-            root.addContent(jmri.jmrit.revhistory.configurexml.FileHistoryXml.storeDirectly(InstanceManager.getDefault(FileHistory.class)));
+            root.addContent(jmri.jmrit.revhistory.configurexml.FileHistoryXml.storeDirectly(
+                    InstanceManager.getDefault(FileHistory.class), file.getPath()));
         }
     }
 
@@ -412,7 +413,7 @@ public class ConfigXmlManager extends jmri.jmrit.XmlFile
         if (!addConfigStore(root)) {
             result = false;
         }
-        includeHistory(root);
+        includeHistory(root, file);
         if (!finalStore(root, file)) {
             result = false;
         }
@@ -430,7 +431,7 @@ public class ConfigXmlManager extends jmri.jmrit.XmlFile
         if (!addUserStore(root)) {
             result = false;
         }
-        includeHistory(root);
+        includeHistory(root, file);
         if (!finalStore(root, file)) {
             result = false;
         }
@@ -440,10 +441,8 @@ public class ConfigXmlManager extends jmri.jmrit.XmlFile
     /** {@inheritDoc} */
     @Override
     public boolean makeBackup(File file) {
-        return makeBackupFile(defaultBackupDirectory, file);
+        return makeBackupFile(FileUtil.getUserFilesPath() + "backupPanels", file);
     }
-
-    String defaultBackupDirectory = FileUtil.getUserFilesPath() + "backupPanels";
 
     /**
      *
@@ -698,7 +697,8 @@ public class ConfigXmlManager extends jmri.jmrit.XmlFile
                     included = jmri.jmrit.revhistory.configurexml.FileHistoryXml.loadFileHistory(filehistory);
                 }
             }
-            r.addOperation((result ? "Load OK" : "Load with errors"), url.getFile(), included);
+            String friendlyName = url.getFile().replaceAll("%20", " ");
+            r.addOperation((result ? "Load OK" : "Load with errors"), friendlyName, included);
         } else {
             log.info("Not recording file history");
         }

--- a/java/src/jmri/jmrit/revhistory/configurexml/FileHistoryXml.java
+++ b/java/src/jmri/jmrit/revhistory/configurexml/FileHistoryXml.java
@@ -1,6 +1,5 @@
 package jmri.jmrit.revhistory.configurexml;
 
-import java.io.File;
 import java.util.ArrayList;
 import jmri.jmrit.revhistory.FileHistory;
 import org.jdom2.Element;

--- a/java/src/jmri/jmrit/revhistory/configurexml/FileHistoryXml.java
+++ b/java/src/jmri/jmrit/revhistory/configurexml/FileHistoryXml.java
@@ -1,5 +1,6 @@
 package jmri.jmrit.revhistory.configurexml;
 
+import java.io.File;
 import java.util.ArrayList;
 import jmri.jmrit.revhistory.FileHistory;
 import org.jdom2.Element;
@@ -114,12 +115,12 @@ public class FileHistoryXml extends jmri.configurexml.AbstractXmlAdapter {
      */
     @Override
     public Element store(Object o) {
-        return storeDirectly(o);
+        return storeDirectly(o, "");
     }
 
     static int defaultDepth = 5;
 
-    static public Element storeDirectly(Object o) {
+    static public Element storeDirectly(Object o, String fileName) {
         final FileHistory r = (FileHistory) o;
         if (r == null) {
             return null;  // no file history object, not recording
@@ -127,12 +128,13 @@ public class FileHistoryXml extends jmri.configurexml.AbstractXmlAdapter {
         Element e = historyElement(r, defaultDepth);
 
         // add one more element for this store
+        String name = fileName == null ? "" : fileName;
         FileHistory.OperationMemo rev
                 = r.new OperationMemo() {
                     {
                         type = "Store";
                         date = (new java.util.Date()).toString();
-                        filename = "";
+                        filename = name;
                         history = null;
                     }
                 };


### PR DESCRIPTION
- Fix the backup panels location.  Due to timing issues, it was defaulting to the _profile location_ instead of the _user files location_.
- Add the JMRI version to the **app** file history item.
- Add the file path and name for the new file to the **Store** file history item.  

Here is a sample output from **File &rArr; Show file history**.
```
Wed Dec 13 22:15:53 CST 2023: app PanelPro (v5.5.8)
Wed Dec 13 22:16:04 CST 2023: Load OK /Users/das/JMRI/_Configs/H&D-E14/test history.xml
    Wed Dec 13 22:13:23 CST 2023: app PanelPro (v5.5.8)
    Wed Dec 13 22:13:34 CST 2023: Load OK /Users/das/JMRI/_Configs/H&D-E14/test history.xml
        Wed Dec 13 22:09:47 CST 2023: app PanelPro (v5.5.8)
        Wed Dec 13 22:11:37 CST 2023: Store /Users/das/JMRI/_Configs/H&D-E14/test history.xml
    Wed Dec 13 22:14:16 CST 2023: Store /Users/das/JMRI/_Configs/H&D-E14/test history.xml
```
