### PR TITLE
Web server will display index.shtml file if present

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -591,7 +591,7 @@
    <h3>Web Server</h3>
         <a id="server" name="server"></a>
         <ul>
-            <li></li>
+            <li>Now displays "index.shtml" files if present in a directory.</li>
         </ul>
 
    <h3>Virtual Sound Decoder</h3>

--- a/java/src/jmri/web/servlet/directory/DirectoryHandler.java
+++ b/java/src/jmri/web/servlet/directory/DirectoryHandler.java
@@ -20,7 +20,7 @@ public class DirectoryHandler extends ResourceHandler {
     public DirectoryHandler(@Nonnull String resourceBase) {
         super(new DirectoryService());
         super.setDirectoriesListed(true);
-        super.setWelcomeFiles(new String[]{"index.html"}); // NOI18N
+        super.setWelcomeFiles(new String[]{"index.shtml", "index.html"}); // NOI18N
         super.setResourceBase(resourceBase);
     }
 }

--- a/java/test/jmri/web/servlet/directory/DirectoryHandlerTest.java
+++ b/java/test/jmri/web/servlet/directory/DirectoryHandlerTest.java
@@ -27,7 +27,7 @@ public class DirectoryHandlerTest {
         // `new File("foo").toURL().toURI()` does, compare paths of Files from URIs
         assertThat(new File(new URI(t.getResourceBase())).getCanonicalPath()).isEqualTo((new File("foo")).getCanonicalPath());
         assertThat(t.isDirectoriesListed()).isTrue();
-        assertThat(t.getWelcomeFiles()).containsExactly("index.html");
+        assertThat(t.getWelcomeFiles()).containsExactly("index.shtml", "index.html");
     }
 
     @BeforeEach


### PR DESCRIPTION
Previously, when you navigate the JMRI web server to a directory, if that directory contained an image.html file, that file would be displayed.

This PR adds the ability to display the index.shtml file if present. These are used e.g. in our signaling definitions.