### PR TITLE
NCE popup notes

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -117,6 +117,9 @@
         <h4>NCE</h4>
             <ul>
                 <li>NCE serial connections have been updated to use a new serial library.</li>
+                <li>Clock, Macro, and Consist added and improved error notification to user
+                	when invalid inputs entered. Prior these were silently ignored or only
+                	logged to the console.</li>
             </ul>
 
         <h4>Oak Tree</h4>


### PR DESCRIPTION
Forgot to add this file within the prior commit. Document the changes in Consist, Macro, and Clock