### PR TITLE
Last serial system updates

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -6,7 +6,7 @@
 
         <h4>Acela CTI</h4>
             <ul>
-                <li></li>
+                <li>Acela CTI serial connections have been updated to use a new serial library.</li>  
             </ul>
 
         <h4>Anyma DMX512</h4>
@@ -46,7 +46,7 @@
 
         <h4>Direct</h4>
             <ul>
-                <li></li>
+                <li>Direct DCC serial connections have been updated to use a new serial library.</li>  
             </ul>
 
         <h4>ESU</h4>
@@ -91,7 +91,7 @@
 
         <h4>Maple</h4>
             <ul>
-                <li></li>
+                <li>Maple serial connections have been updated to use a new serial library.</li>  
             </ul>
 
         <h4>Marklin CS2</h4>
@@ -121,7 +121,7 @@
 
         <h4>Oak Tree</h4>
             <ul>
-                <li></li>
+                <li>Oak Tree serial connections have been updated to use a new serial library.</li>  
             </ul>
 
         <h4><a href="http://openlcb.org">OpenLCB</a> / LCC</h4>
@@ -146,7 +146,7 @@
 
         <h4>Secsi</h4>
             <ul>
-                <li></li>
+                <li>SECSI serial connections have been updated to use a new serial library.</li>  
             </ul>
 
         <h4>SPROG</h4>
@@ -156,7 +156,7 @@
 
         <h4>TAMS</h4>
             <ul>
-                <li></li>
+                <li>TAMS serial connections have been updated to use a new serial library.</li>  
             </ul>
 
         <h4>TMCC</h4>

--- a/java/src/jmri/jmrix/AbstractMRTrafficController.java
+++ b/java/src/jmri/jmrix/AbstractMRTrafficController.java
@@ -969,8 +969,7 @@ public abstract class AbstractMRTrafficController {
     /**
      * Read a single byte, protecting against various timeouts, etc.
      * <p>
-     * When a port is set to have a receive timeout (via the
-     * {@link purejavacomm.SerialPort#enableReceiveTimeout(int)} method), some will return
+     * When a port is set to have a receive timeout, some will return
      * zero bytes or an EOFException at the end of the timeout. In that case, the read
      * should be repeated to get the next real character.
      *

--- a/java/src/jmri/jmrix/AbstractPortController.java
+++ b/java/src/jmri/jmrix/AbstractPortController.java
@@ -560,16 +560,12 @@ abstract public class AbstractPortController implements PortAdapter {
      * @param serialStream input data
      */
      @SuppressFBWarnings(value = "SR_NOT_CHECKED", justification = "skipping all, don't care what skip() returns")
-     protected void purgeStream(@Nonnull java.io.InputStream serialStream) {
-        try {
-            int count = serialStream.available();
-            log.debug("input stream shows {} bytes available", count);
-            while (count > 0) {
-                serialStream.skip(count);
-                count = serialStream.available();
-            }
-        } catch (IOException e) {
-            log.error("cause exception while trying to purge stream from port", e);
+     protected void purgeStream(@Nonnull java.io.InputStream serialStream) throws IOException {
+        int count = serialStream.available();
+        log.debug("input stream shows {} bytes available", count);
+        while (count > 0) {
+            serialStream.skip(count);
+            count = serialStream.available();
         }
     }
     

--- a/java/src/jmri/jmrix/AbstractPortController.java
+++ b/java/src/jmri/jmrix/AbstractPortController.java
@@ -558,6 +558,7 @@ abstract public class AbstractPortController implements PortAdapter {
      * Service method to purge a stream of initial contents
      * while opening the connection.
      * @param serialStream input data
+     * @throws IOException if the stream is e.g. closed due to failure to open the port completely
      */
      @SuppressFBWarnings(value = "SR_NOT_CHECKED", justification = "skipping all, don't care what skip() returns")
      protected void purgeStream(@Nonnull java.io.InputStream serialStream) throws IOException {

--- a/java/src/jmri/jmrix/AbstractSerialPortController.java
+++ b/java/src/jmri/jmrix/AbstractSerialPortController.java
@@ -47,7 +47,7 @@ abstract public class AbstractSerialPortController extends AbstractPortControlle
     }
 
     /**
-     * Standard error handling for purejavacomm port-not-found case.
+     * Specific error handling for purejavacomm port-not-found case.
      * @param p no such port exception.
      * @param portName port name.
      * @param log system log.
@@ -61,9 +61,10 @@ abstract public class AbstractSerialPortController extends AbstractPortControlle
     }
 
     /**
-     * Standard error handling for purejavacomm port-not-found case.
+     * Standard error handling for the port-not-found case.
      * @param portName port name.
      * @param log system log, passed so logging comes from bottom level class
+     * @param ex Underlying Exception that caused this failure
      * @return human readable string with error detail.
      */
     //@Deprecated(forRemoval=true) // Removed with PureJavaComm

--- a/java/src/jmri/jmrix/AbstractSerialPortController.java
+++ b/java/src/jmri/jmrix/AbstractSerialPortController.java
@@ -143,6 +143,7 @@ abstract public class AbstractSerialPortController extends AbstractPortControlle
             // IOException includes 
             //      com.fazecast.jSerialComm.SerialPortIOException
             handlePortNotFound(portName, log, ex);
+            return null;
         }
         return serialPort;
     }

--- a/java/src/jmri/jmrix/AbstractSerialPortController.java
+++ b/java/src/jmri/jmrix/AbstractSerialPortController.java
@@ -67,8 +67,8 @@ abstract public class AbstractSerialPortController extends AbstractPortControlle
      * @return human readable string with error detail.
      */
     //@Deprecated(forRemoval=true) // Removed with PureJavaComm
-    public String handlePortNotFound(String portName, org.slf4j.Logger log) {
-        log.error("Serial port {} not found", portName);
+    public String handlePortNotFound(String portName, org.slf4j.Logger log, Exception ex) {
+        log.error("Serial port {} not found: {}", portName, ex.getMessage());
         ConnectionStatus.instance().setConnectionState(this.getSystemPrefix(), portName, ConnectionStatus.CONNECTION_DOWN);
         return Bundle.getMessage("SerialPortNotFound", portName);
     }
@@ -138,8 +138,10 @@ abstract public class AbstractSerialPortController extends AbstractPortControlle
             serialPort.setNumStopBits(stop_bits_code);
             serialPort.setParity(com.fazecast.jSerialComm.SerialPort.NO_PARITY);
             purgeStream(serialPort.getInputStream());
-        } catch (com.fazecast.jSerialComm.SerialPortInvalidPortException ePE) {
-            handlePortNotFound(portName, log);
+        } catch (java.io.IOException | com.fazecast.jSerialComm.SerialPortInvalidPortException ex) {
+            // IOException includes 
+            //      com.fazecast.jSerialComm.SerialPortIOException
+            handlePortNotFound(portName, log, ex);
         }
         return serialPort;
     }

--- a/java/src/jmri/jmrix/acela/AcelaPortController.java
+++ b/java/src/jmri/jmrix/acela/AcelaPortController.java
@@ -1,8 +1,5 @@
 package jmri.jmrix.acela;
 
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
-
 /**
  * Abstract base for classes representing an Acela communications port
  *
@@ -18,14 +15,6 @@ public abstract class AcelaPortController extends jmri.jmrix.AbstractSerialPortC
     protected AcelaPortController(AcelaSystemConnectionMemo memo) {
         super(memo);
     }
-
-    // returns the InputStream from the port
-    @Override
-    public abstract DataInputStream getInputStream();
-
-    // returns the outputStream to the port
-    @Override
-    public abstract DataOutputStream getOutputStream();
 
     // check that this object is ready to operate
     @Override

--- a/java/src/jmri/jmrix/acela/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/acela/serialdriver/SerialDriverAdapter.java
@@ -31,10 +31,10 @@ public class SerialDriverAdapter extends AcelaPortController {
         // get and open the primary port
         currentSerialPort = activatePort(portName, log);
         if (currentSerialPort == null) {
-            log.error("failed to connect C/MRI to {}", portName);
+            log.error("failed to connect Acela to {}", portName);
             return Bundle.getMessage("SerialPortNotFound", portName);
         }
-        log.info("Connecting C/MRI to {} {}", portName, currentSerialPort);
+        log.info("Connecting Acela to {} {}", portName, currentSerialPort);
         
         // try to set it for communication via SerialDriver
         // find the baud rate value, configure comm options

--- a/java/src/jmri/jmrix/cmri/serial/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/cmri/serial/serialdriver/SerialDriverAdapter.java
@@ -10,7 +10,7 @@ import jmri.jmrix.cmri.serial.SerialTrafficController;
  * Provide access to C/MRI via a serial com port. Normally controlled by the
  * cmri.serial.serialdriver.SerialDriverFrame class.
  *
- * @author Bob Jacobsen Copyright (C) 2002
+ * @author Bob Jacobsen Copyright (C) 2002, 2023
  */
 public class SerialDriverAdapter extends SerialPortAdapter {
 

--- a/java/src/jmri/jmrix/direct/serial/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/direct/serial/SerialDriverAdapter.java
@@ -1,20 +1,7 @@
 package jmri.jmrix.direct.serial;
 
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.util.Enumeration;
-import java.util.Vector;
 import jmri.jmrix.direct.PortController;
 import jmri.jmrix.direct.TrafficController;
-
-import purejavacomm.CommPortIdentifier;
-import purejavacomm.NoSuchPortException;
-import purejavacomm.PortInUseException;
-import purejavacomm.SerialPort;
-import purejavacomm.UnsupportedCommOperationException;
 
 /**
  * Implements SerialPortAdapter for direct serial drive.
@@ -22,95 +9,35 @@ import purejavacomm.UnsupportedCommOperationException;
  * Normally controlled by the SerialDriverFrame class.
  * <p>
  * The current implementation only handles the 19,200 baud rate, and does not
- * use any other options at configuration time.
+ * use any other options at configuration time. A prior implementation
+ * tried 17240, then 16457, then finally 19200.
  *
- * @author Bob Jacobsen Copyright (C) 2001, 2002, 2004
+ * @author Bob Jacobsen Copyright (C) 2001, 2002, 2004, 2023
  */
 public class SerialDriverAdapter extends PortController {
 
-    Vector<String> portNameVector = null;
-    SerialPort activeSerialPort = null;
-
-    @Override
-    public Vector<String> getPortNames() {
-        // first, check that the comm package can be opened and ports seen
-        portNameVector = new Vector<>();
-        Enumeration<CommPortIdentifier> portIDs = CommPortIdentifier.getPortIdentifiers();
-        // find the names of suitable ports
-        while (portIDs.hasMoreElements()) {
-            CommPortIdentifier id = portIDs.nextElement();
-            // filter out line printers
-            if (id.getPortType() != CommPortIdentifier.PORT_PARALLEL) // accumulate the names in a vector
-            {
-                portNameVector.addElement(id.getName());
-            }
-        }
-        return portNameVector;
-    }
-
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(value="SR_NOT_CHECKED",
-    justification="this is for skip-chars while loop: no matter how many, we're skipping")
     @Override
     public String openPort(String portName, String appName) {
-        try {
-            // get and open the primary port
-            CommPortIdentifier portID = CommPortIdentifier.getPortIdentifier(portName);
-            try {
-                activeSerialPort = (SerialPort) portID.open(appName, 2000);  // name of program, msec to wait
-            } catch (PortInUseException p) {
-                return handlePortBusy(p, portName, log);
-            }
 
-            // try to set it for 17240, then 16457 baud, then 19200 if needed
-            try {
-                activeSerialPort.setSerialPortParams(17240, SerialPort.DATABITS_8, SerialPort.STOPBITS_1, SerialPort.PARITY_NONE);
-            } catch (UnsupportedCommOperationException e) {
-                // assume that's a baudrate problem, fall back.
-                log.warn("attempting to fall back to 16457 baud after 17240 failed");
-                try {
-                    activeSerialPort.setSerialPortParams(16457, SerialPort.DATABITS_8, SerialPort.STOPBITS_1, SerialPort.PARITY_NONE);
-                } catch (UnsupportedCommOperationException e2) {
-                    log.warn("trouble setting 16457 baud");
-                    activeSerialPort.setSerialPortParams(19200, SerialPort.DATABITS_8, SerialPort.STOPBITS_1, SerialPort.PARITY_NONE);
-                    jmri.util.swing.JmriJOptionPane.showMessageDialog(null,
-                            Bundle.getMessage("DirectBaudError", activeSerialPort.getBaudRate()),
-                            Bundle.getMessage("ErrorConnectionTitle"), jmri.util.swing.JmriJOptionPane.ERROR_MESSAGE);
-                }
-            }
-
-            // disable flow control; hardware lines used for signaling, XON/XOFF might appear in data
-            configureLeadsAndFlowControl(activeSerialPort, 0);
-
-            // activeSerialPort.enableReceiveTimeout(1000);
-            log.debug("Serial timeout was observed as: {} {}", activeSerialPort.getReceiveTimeout(),
-                    activeSerialPort.isReceiveTimeoutEnabled());
-
-            // get and save stream
-            serialInStream = activeSerialPort.getInputStream();
-            serialOutStream = activeSerialPort.getOutputStream();
-
-            // port is open, start work on the stream
-            // purge contents, if any
-            int count = serialInStream.available();
-            log.debug("input stream shows {} bytes available", count);
-            while (count > 0) {
-                serialInStream.skip(count);
-                count = serialInStream.available();
-            }
-
-            // report status?
-            if (log.isInfoEnabled()) {
-                log.info("{} port opened at {} baud, sees  DTR: {} RTS: {} DSR: {} CTS: {}  CD: {}", portName, activeSerialPort.getBaudRate(), activeSerialPort.isDTR(), activeSerialPort.isRTS(), activeSerialPort.isDSR(), activeSerialPort.isCTS(), activeSerialPort.isCD());
-            }
-
-        } catch (NoSuchPortException p) {
-            return handlePortNotFound(p, portName, log);
-        } catch (UnsupportedCommOperationException | IOException ex) {
-            log.error("Unexpected exception while opening port {}", portName, ex);
-            return "Unexpected error while opening port " + portName + ": " + ex;
+        // get and open the primary port
+        currentSerialPort = activatePort(portName, log);
+        if (currentSerialPort == null) {
+            log.error("failed to connect C/MRI to {}", portName);
+            return Bundle.getMessage("SerialPortNotFound", portName);
         }
+        log.info("Connecting Direct Serial to {} {}", portName, currentSerialPort);
+        
+        // try to set it for communication via SerialDriver
+        setBaudRate(currentSerialPort, 19200);
+        configureLeads(currentSerialPort, true, true);
+        setFlowControl(currentSerialPort, FlowControl.NONE);
 
-        return null; // normal termination
+        // report status
+        reportPortStatus(log, portName);
+
+        opened = true;
+
+        return null; // indicates OK return
     }
 
     /**
@@ -129,29 +56,6 @@ public class SerialDriverAdapter extends PortController {
     }
 
     // base class methods for the PortController interface
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public DataInputStream getInputStream() {
-        if (!opened) {
-            log.error("getInputStream called before load(), stream not available");
-            return null;
-        }
-        return new DataInputStream(serialInStream);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public DataOutputStream getOutputStream() {
-        if (!opened) {
-            log.error("getOutputStream called before load(), stream not available");
-        }
-        return new DataOutputStream(serialOutStream);
-    }
 
     /**
      * {@inheritDoc}
@@ -182,11 +86,6 @@ public class SerialDriverAdapter extends PortController {
     public int defaultBaudIndex() {
         return 0;
     }
-
-    // private control members
-    private boolean opened = false;
-    InputStream serialInStream = null;
-    OutputStream serialOutStream = null;
 
     private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(SerialDriverAdapter.class);
 

--- a/java/src/jmri/jmrix/direct/serial/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/direct/serial/SerialDriverAdapter.java
@@ -22,7 +22,7 @@ public class SerialDriverAdapter extends PortController {
         // get and open the primary port
         currentSerialPort = activatePort(portName, log);
         if (currentSerialPort == null) {
-            log.error("failed to connect C/MRI to {}", portName);
+            log.error("failed to connect Direct Serial to {}", portName);
             return Bundle.getMessage("SerialPortNotFound", portName);
         }
         log.info("Connecting Direct Serial to {} {}", portName, currentSerialPort);

--- a/java/src/jmri/jmrix/grapevine/SerialPortController.java
+++ b/java/src/jmri/jmrix/grapevine/SerialPortController.java
@@ -1,7 +1,5 @@
 package jmri.jmrix.grapevine;
 
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
 import jmri.SystemConnectionMemo;
 
 /**
@@ -16,18 +14,6 @@ public abstract class SerialPortController extends jmri.jmrix.AbstractSerialPort
     protected SerialPortController(SystemConnectionMemo connectionMemo) {
         super(connectionMemo);
     }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public abstract DataInputStream getInputStream();
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public abstract DataOutputStream getOutputStream();
 
     /**
      * {@inheritDoc}

--- a/java/src/jmri/jmrix/grapevine/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/grapevine/serialdriver/SerialDriverAdapter.java
@@ -31,7 +31,7 @@ public class SerialDriverAdapter extends SerialPortController {
         // get and open the primary port
         currentSerialPort = activatePort(portName, log);
         if (currentSerialPort == null) {
-            log.error("failed to connect C/MRI to {}", portName);
+            log.error("failed to connect Grapevine to {}", portName);
             return Bundle.getMessage("SerialPortNotFound", portName);
         }
         log.info("Connecting Grapevine to {} {}", portName, currentSerialPort);

--- a/java/src/jmri/jmrix/grapevine/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/grapevine/serialdriver/SerialDriverAdapter.java
@@ -1,30 +1,17 @@
 package jmri.jmrix.grapevine.serialdriver;
 
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
 import java.util.Arrays;
 import jmri.jmrix.grapevine.GrapevineSystemConnectionMemo;
 import jmri.jmrix.grapevine.SerialPortController;
 import jmri.jmrix.grapevine.SerialTrafficController;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import purejavacomm.CommPortIdentifier;
-import purejavacomm.NoSuchPortException;
-import purejavacomm.PortInUseException;
-import purejavacomm.SerialPort;
-import purejavacomm.UnsupportedCommOperationException;
 
 /**
  * Provide access to ProTrak Grapevine via a serial com port. Normally
  * controlled by the serialdriver.SerialDriverFrame class.
  *
- * @author Bob Jacobsen Copyright (C) 2006, 2007
+ * @author Bob Jacobsen Copyright (C) 2006, 2007, 2023
  */
 public class SerialDriverAdapter extends SerialPortController {
-
-    SerialPort activeSerialPort = null;
 
     /**
      * Create a new SerialDriverAdapter.
@@ -40,62 +27,28 @@ public class SerialDriverAdapter extends SerialPortController {
      */
     @Override
     public String openPort(String portName, String appName) {
-        try {
-            // get and open the primary port
-            CommPortIdentifier portID = CommPortIdentifier.getPortIdentifier(portName);
-            try {
-                activeSerialPort = (SerialPort) portID.open(appName, 2000); // name of program, msec to wait
-            } catch (PortInUseException p) {
-                return handlePortBusy(p, portName, log);
-            }
-            // try to set it for serial
-            try {
-                setSerialPort();
-            } catch (UnsupportedCommOperationException e) {
-                log.error("Cannot set serial parameters on port {}: {}", portName, e.getMessage());
-                return "Cannot set serial parameters on port " + portName + ": " + e.getMessage();
-            }
 
-            // set timeout; no framing in Grapevine
-            try {
-                activeSerialPort.enableReceiveTimeout(10);
-                log.debug("Serial timeout was observed as: {} {}",
-                        activeSerialPort.getReceiveTimeout(),
-                        activeSerialPort.isReceiveTimeoutEnabled());
-            } catch (Exception et) {
-                log.info("failed to set serial timeout", et);
-            }
-
-            // get and save stream
-            serialStream = activeSerialPort.getInputStream();
-
-            // purge contents, if any
-            purgeStream(serialStream);
-
-            // report status?
-            if (log.isInfoEnabled()) {
-                // report now
-                log.info("{} port opened at {} baud with DTR: {} RTS: {} DSR: {} CTS: {}  CD: {}", portName, activeSerialPort.getBaudRate(), activeSerialPort.isDTR(), activeSerialPort.isRTS(), activeSerialPort.isDSR(), activeSerialPort.isCTS(), activeSerialPort.isCD());
-            }
-            if (log.isDebugEnabled()) {
-                // report additional status
-                log.debug("port flow control shows {}", // NOI18N
-                        (activeSerialPort.getFlowControlMode() == SerialPort.FLOWCONTROL_RTSCTS_OUT ? "hardware flow control" : "no flow control")); // NOI18N
-
-                // log events
-                setPortEventLogging(activeSerialPort);
-            }
-
-            opened = true;
-
-        } catch (NoSuchPortException p) {
-            return handlePortNotFound(p, portName, log);
-        } catch (IOException ex) {
-            log.error("Unexpected exception while opening port {}: ", portName, ex);
-            return "Unexpected error while opening port " + portName + ": " + ex;
+        // get and open the primary port
+        currentSerialPort = activatePort(portName, log);
+        if (currentSerialPort == null) {
+            log.error("failed to connect C/MRI to {}", portName);
+            return Bundle.getMessage("SerialPortNotFound", portName);
         }
+        log.info("Connecting Grapevine to {} {}", portName, currentSerialPort);
+        
+        // try to set it for communication via SerialDriver
+        // find the baud rate value, configure comm options
+        int baud = currentBaudNumber(mBaudRate);
+        setBaudRate(currentSerialPort, baud);
+        configureLeads(currentSerialPort, true, true);
+        setFlowControl(currentSerialPort, FlowControl.NONE);
 
-        return null; // normal operation
+        // report status
+        reportPortStatus(log, portName);
+
+        opened = true;
+
+        return null; // indicates OK return
     }
 
     /**
@@ -129,51 +82,8 @@ public class SerialDriverAdapter extends SerialPortController {
      * {@inheritDoc}
      */
     @Override
-    public DataInputStream getInputStream() {
-        if (!opened) {
-            log.error("getInputStream called before load(), stream not available");
-            return null;
-        }
-        return new DataInputStream(serialStream);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public DataOutputStream getOutputStream() {
-        if (!opened) {
-            log.error("getOutputStream called before load(), stream not available");
-        }
-        try {
-            return new DataOutputStream(activeSerialPort.getOutputStream());
-        } catch (java.io.IOException e) {
-            log.error("getOutputStream exception: {}", e.getMessage());
-        }
-        return null;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
     public boolean status() {
         return opened;
-    }
-
-    /**
-     * Local method to do specific port configuration.
-     * @throws UnsupportedCommOperationException if the port can't implement the required options
-     */
-    protected void setSerialPort() throws UnsupportedCommOperationException {
-        // find the baud rate value, configure comm options
-        int baud = currentBaudNumber(mBaudRate);
-        activeSerialPort.setSerialPortParams(baud, SerialPort.DATABITS_8,
-                SerialPort.STOPBITS_2, SerialPort.PARITY_NONE);
-
-        // find and configure flow control
-        int flow = SerialPort.FLOWCONTROL_NONE; // default
-        configureLeadsAndFlowControl(activeSerialPort, flow);
     }
 
     /**
@@ -200,10 +110,6 @@ public class SerialDriverAdapter extends SerialPortController {
         return 0;
     }
 
-    // private control members
-    private boolean opened = false;
-    InputStream serialStream = null;
-
-    private final static Logger log = LoggerFactory.getLogger(SerialDriverAdapter.class);
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(SerialDriverAdapter.class);
 
 }

--- a/java/src/jmri/jmrix/maple/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/maple/serialdriver/SerialDriverAdapter.java
@@ -1,19 +1,8 @@
 package jmri.jmrix.maple.serialdriver;
 
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
 import java.util.Arrays;
 import jmri.jmrix.maple.MapleSystemConnectionMemo;
 import jmri.jmrix.maple.SerialPortController;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import purejavacomm.CommPortIdentifier;
-import purejavacomm.NoSuchPortException;
-import purejavacomm.PortInUseException;
-import purejavacomm.SerialPort;
-import purejavacomm.UnsupportedCommOperationException;
 
 /**
  * Provide access to Maple via a serial com port. Normally controlled by the
@@ -23,8 +12,6 @@ import purejavacomm.UnsupportedCommOperationException;
  */
 public class SerialDriverAdapter extends SerialPortController {
 
-    SerialPort activeSerialPort = null;
-
     public SerialDriverAdapter() {
         super(new MapleSystemConnectionMemo());
         this.manufacturerName = jmri.jmrix.maple.SerialConnectionTypeList.MAPLE;
@@ -32,72 +19,28 @@ public class SerialDriverAdapter extends SerialPortController {
 
     @Override
     public String openPort(String portName, String appName) {
-        try {
-            // get and open the primary port
-            CommPortIdentifier portID = CommPortIdentifier.getPortIdentifier(portName);
-            try {
-                activeSerialPort = (SerialPort) portID.open(appName, 2000); // name of program, msec to wait
-            } catch (PortInUseException p) {
-                return handlePortBusy(p, portName, log);
-            }
-            // try to set it for Maple serial
-            try {
-                setSerialPort();
-            } catch (UnsupportedCommOperationException e) {
-                log.error("Cannot set serial parameters on port {}: {}", portName, e.getMessage());
-                return "Cannot set serial parameters on port " + portName + ": " + e.getMessage();
-            }
 
-            // set framing (end) character
-            try {
-                activeSerialPort.enableReceiveFraming(0x03);
-                log.debug("Serial framing was observed as: {} {}",
-                        activeSerialPort.isReceiveFramingEnabled(),
-                        activeSerialPort.getReceiveFramingByte());
-            } catch (Exception ef) {
-                log.debug("failed to set serial framing: ", ef);
-            }
-
-            // set timeout; framing should work before this anyway
-            try {
-                activeSerialPort.enableReceiveTimeout(10);
-                log.debug("Serial timeout was observed as: {} {}",
-                        activeSerialPort.getReceiveTimeout(),
-                        activeSerialPort.isReceiveTimeoutEnabled());
-            } catch (Exception et) {
-                log.info("failed to set serial timeout: ", et);
-            }
-
-            // get and save stream
-            serialStream = activeSerialPort.getInputStream();
-
-            // purge contents, if any
-            purgeStream(serialStream);
-
-            // report status?
-            if (log.isInfoEnabled()) {
-                // report now
-                log.info("{} port opened at {} baud with DTR: {} RTS: {} DSR: {} CTS: {}  CD: {}", portName, activeSerialPort.getBaudRate(), activeSerialPort.isDTR(), activeSerialPort.isRTS(), activeSerialPort.isDSR(), activeSerialPort.isCTS(), activeSerialPort.isCD());
-            }
-            if (log.isDebugEnabled()) {
-                // report additional status
-                log.debug(" port flow control shows {}", // NOI18N
-                        (activeSerialPort.getFlowControlMode() == SerialPort.FLOWCONTROL_RTSCTS_OUT ? "hardware flow control" : "no flow control")); // NOI18N
-
-                // log events
-                setPortEventLogging(activeSerialPort);
-            }
-
-            opened = true;
-
-        } catch (NoSuchPortException p) {
-            return handlePortNotFound(p, portName, log);
-        } catch (IOException ex) {
-            log.error("Unexpected exception while opening port {}", portName, ex);
-            return "Unexpected error while opening port " + portName + ": " + ex;
+        // get and open the primary port
+        currentSerialPort = activatePort(portName, log, 2); // 2 stop bits
+        if (currentSerialPort == null) {
+            log.error("failed to connect C/MRI to {}", portName);
+            return Bundle.getMessage("SerialPortNotFound", portName);
         }
+        log.info("Connecting Maple to {} {}", portName, currentSerialPort);
+        
+        // try to set it for communication via SerialDriver
+        // find the baud rate value, configure comm options
+        int baud = currentBaudNumber(mBaudRate);
+        setBaudRate(currentSerialPort, baud);
+        configureLeads(currentSerialPort, true, true);
+        setFlowControl(currentSerialPort, FlowControl.NONE);
 
-        return null; // normal operation
+        // report status
+        reportPortStatus(log, portName);
+
+        opened = true;
+
+        return null; // indicates OK return
     }
 
     /**
@@ -124,51 +67,8 @@ public class SerialDriverAdapter extends SerialPortController {
      * {@inheritDoc}
      */
     @Override
-    public DataInputStream getInputStream() {
-        if (!opened) {
-            log.error("getInputStream called before load(), stream not available");
-            return null;
-        }
-        return new DataInputStream(serialStream);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public DataOutputStream getOutputStream() {
-        if (!opened) {
-            log.error("getOutputStream called before load(), stream not available");
-        }
-        try {
-            return new DataOutputStream(activeSerialPort.getOutputStream());
-        } catch (java.io.IOException e) {
-            log.error("getOutputStream exception: {}", e.getMessage());
-        }
-        return null;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
     public boolean status() {
         return opened;
-    }
-
-    /**
-     * Local method to do specific port configuration.
-     * @throws UnsupportedCommOperationException if the underlying port can't comply with request
-     */
-    protected void setSerialPort() throws UnsupportedCommOperationException {
-        // find the baud rate value, configure comm options
-        int baud = currentBaudNumber(mBaudRate);
-        activeSerialPort.setSerialPortParams(baud, SerialPort.DATABITS_8,
-                SerialPort.STOPBITS_2, SerialPort.PARITY_NONE);
-
-        // find and configure flow control
-        int flow = SerialPort.FLOWCONTROL_NONE; // default
-        configureLeadsAndFlowControl(activeSerialPort, flow);
     }
 
     /**
@@ -196,10 +96,6 @@ public class SerialDriverAdapter extends SerialPortController {
         return 1;
     }
 
-    // private control members
-    private boolean opened = false;
-    InputStream serialStream = null;
-
-    private final static Logger log = LoggerFactory.getLogger(SerialDriverAdapter.class);
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(SerialDriverAdapter.class);
 
 }

--- a/java/src/jmri/jmrix/maple/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/maple/serialdriver/SerialDriverAdapter.java
@@ -23,7 +23,7 @@ public class SerialDriverAdapter extends SerialPortController {
         // get and open the primary port
         currentSerialPort = activatePort(portName, log, 2); // 2 stop bits
         if (currentSerialPort == null) {
-            log.error("failed to connect C/MRI to {}", portName);
+            log.error("failed to connect Maple to {}", portName);
             return Bundle.getMessage("SerialPortNotFound", portName);
         }
         log.info("Connecting Maple to {} {}", portName, currentSerialPort);

--- a/java/src/jmri/jmrix/marklin/cdb/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/marklin/cdb/serialdriver/SerialDriverAdapter.java
@@ -27,7 +27,7 @@ public class SerialDriverAdapter extends CdBPortController {
         // get and open the primary port
         currentSerialPort = activatePort(portName, log);
         if (currentSerialPort == null) {
-            log.error("failed to connect C/MRI to {}", portName);
+            log.error("failed to connect Marklin CDB to {}", portName);
             return Bundle.getMessage("SerialPortNotFound", portName);
         }
         log.info("Connecting Marklin CDB to {} {}", portName, currentSerialPort);

--- a/java/src/jmri/jmrix/marklin/cdb/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/marklin/cdb/serialdriver/SerialDriverAdapter.java
@@ -1,20 +1,9 @@
 package jmri.jmrix.marklin.cdb.serialdriver;
 
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
 import java.util.Arrays;
 import jmri.jmrix.marklin.cdb.CdBPortController;
 import jmri.jmrix.marklin.cdb.CdBSystemConnectionMemo;
 import jmri.jmrix.marklin.MarklinTrafficController;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import purejavacomm.CommPortIdentifier;
-import purejavacomm.NoSuchPortException;
-import purejavacomm.PortInUseException;
-import purejavacomm.SerialPort;
-import purejavacomm.UnsupportedCommOperationException;
 
 /**
  * Implements SerialPortAdapter for the Marklin CDB system.
@@ -27,8 +16,6 @@ import purejavacomm.UnsupportedCommOperationException;
  */
 public class SerialDriverAdapter extends CdBPortController {
 
-    SerialPort activeSerialPort = null;
-
     public SerialDriverAdapter() {
         super(new CdBSystemConnectionMemo());
         setManufacturer(jmri.jmrix.marklin.cdb.CdBConnectionTypeList.CDB);
@@ -36,63 +23,26 @@ public class SerialDriverAdapter extends CdBPortController {
 
     @Override
     public String openPort(String portName, String appName) {
-        // open the port, check ability to set moderators
-        try {
-            // get and open the primary port
-            CommPortIdentifier portID = CommPortIdentifier.getPortIdentifier(portName);
-            try {
-                activeSerialPort = (SerialPort) portID.open(appName, 2000);  // name of program, msec to wait
-            } catch (PortInUseException p) {
-                return handlePortBusy(p, portName, log);
-            }
 
-            // try to set it for communication via SerialDriver
-            try {
-                // find the baud rate value, configure comm options
-                int baud = currentBaudNumber(mBaudRate);
-                activeSerialPort.setSerialPortParams(baud, SerialPort.DATABITS_8, SerialPort.STOPBITS_1, SerialPort.PARITY_NONE);
-            } catch (UnsupportedCommOperationException e) {
-                log.error("Cannot set serial parameters on port {}: {}", portName, e.getMessage());
-                return "Cannot set serial parameters on port " + portName + ": " + e.getMessage();
-            }
-
-            // Hardware flow control
-            // configureLeadsAndFlowControl(currentSerialPort, SerialPort.FLOWCONTROL_RTSCTS_IN | SerialPort.FLOWCONTROL_RTSCTS_OUT);
-
-            // Xon/Xoff flow control
-            configureLeadsAndFlowControl(activeSerialPort, 0);
-
-            // set timeout
-            try {
-                activeSerialPort.enableReceiveTimeout(50);  // Set to 50 was 10 mSec timeout before sending chars
-                log.debug("Serial timeout was observed as: {} {}", activeSerialPort.getReceiveTimeout(),
-                        activeSerialPort.isReceiveTimeoutEnabled());
-            } catch (Exception et) {
-                log.info("failed to set serial timeout: ", et);
-            }
-            // get and save stream
-            serialStream = activeSerialPort.getInputStream();
-
-            // purge contents, if any
-            purgeStream(serialStream);
-
-            if (log.isInfoEnabled()) {
-                log.info("{} port opened at {} baud, sees  DTR: {} RTS: {} DSR: {} CTS: {}  CD: {}", portName, activeSerialPort.getBaudRate(), activeSerialPort.isDTR(), activeSerialPort.isRTS(), activeSerialPort.isDSR(), activeSerialPort.isCTS(), activeSerialPort.isCD());
-            }
-
-            // report status
-            if (log.isInfoEnabled()) {
-                log.info("CC-Schnitte {} port opened at {} baud", portName,
-                        activeSerialPort.getBaudRate());
-            }
-            opened = true;
-
-        } catch (NoSuchPortException p) {
-            return handlePortNotFound(p, portName, log);
-        } catch (IOException ex) {
-            log.error("Unexpected exception while opening port {}", portName, ex);
-            return "Unexpected error while opening port " + portName + ": " + ex;
+        // get and open the primary port
+        currentSerialPort = activatePort(portName, log);
+        if (currentSerialPort == null) {
+            log.error("failed to connect C/MRI to {}", portName);
+            return Bundle.getMessage("SerialPortNotFound", portName);
         }
+        log.info("Connecting Marklin CDB to {} {}", portName, currentSerialPort);
+        
+        // try to set it for communication via SerialDriver
+        // find the baud rate value, configure comm options
+        int baud = currentBaudNumber(mBaudRate);
+        setBaudRate(currentSerialPort, baud);
+        configureLeads(currentSerialPort, true, true);
+        setFlowControl(currentSerialPort, FlowControl.NONE);
+
+        // report status
+        reportPortStatus(log, portName);
+
+        opened = true;
 
         return null; // indicates OK return
     }
@@ -113,27 +63,6 @@ public class SerialDriverAdapter extends CdBPortController {
     }
 
     // base class methods for the MarklinPortController interface
-    @Override
-    public DataInputStream getInputStream() {
-        if (!opened) {
-            log.error("getInputStream called before load(), stream not available");
-            return null;
-        }
-        return new DataInputStream(serialStream);
-    }
-
-    @Override
-    public DataOutputStream getOutputStream() {
-        if (!opened) {
-            log.error("getOutputStream called before load(), stream not available");
-        }
-        try {
-            return new DataOutputStream(activeSerialPort.getOutputStream());
-        } catch (java.io.IOException e) {
-            log.error("getOutputStream exception: ", e);
-        }
-        return null;
-    }
 
     @Override
     public boolean status() {
@@ -164,10 +93,6 @@ public class SerialDriverAdapter extends CdBPortController {
         return 0;
     }
 
-    // private control members
-    private boolean opened = false;
-    InputStream serialStream = null;
-
-    private final static Logger log = LoggerFactory.getLogger(SerialDriverAdapter.class);
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(SerialDriverAdapter.class);
 
 }

--- a/java/src/jmri/jmrix/oaktree/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/oaktree/serialdriver/SerialDriverAdapter.java
@@ -1,19 +1,8 @@
 package jmri.jmrix.oaktree.serialdriver;
 
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
 import java.util.Arrays;
 import jmri.jmrix.oaktree.OakTreeSystemConnectionMemo;
 import jmri.jmrix.oaktree.SerialPortController;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import purejavacomm.CommPortIdentifier;
-import purejavacomm.NoSuchPortException;
-import purejavacomm.PortInUseException;
-import purejavacomm.SerialPort;
-import purejavacomm.UnsupportedCommOperationException;
 
 /**
  * Provide access to Oak Tree via a serial com port. Normally controlled by the
@@ -23,8 +12,6 @@ import purejavacomm.UnsupportedCommOperationException;
  */
 public class SerialDriverAdapter extends SerialPortController {
 
-    SerialPort activeSerialPort = null;
-
     public SerialDriverAdapter() {
         super(new OakTreeSystemConnectionMemo());
         this.manufacturerName = jmri.jmrix.oaktree.SerialConnectionTypeList.OAK;
@@ -32,78 +19,28 @@ public class SerialDriverAdapter extends SerialPortController {
 
     @Override
     public String openPort(String portName, String appName) {
-        try {
-            // get and open the primary port
-            CommPortIdentifier portID = CommPortIdentifier.getPortIdentifier(portName);
-            try {
-                activeSerialPort = (SerialPort) portID.open(appName, 2000);  // name of program, msec to wait
-            } catch (PortInUseException p) {
-                return handlePortBusy(p, portName, log);
-            }
-            // try to set it for serial
-            try {
-                setSerialPort();
-            } catch (UnsupportedCommOperationException e) {
-                log.error("Cannot set serial parameters on port {}: {}", portName, e.getMessage());
-                return "Cannot set serial parameters on port " + portName + ": " + e.getMessage();
-            }
 
-            // set framing (end) character
-            try {
-                activeSerialPort.enableReceiveFraming(0x03);
-                log.debug("Serial framing was observed as: {} {}", activeSerialPort.isReceiveFramingEnabled(),
-                        activeSerialPort.getReceiveFramingByte());
-            } catch (Exception ef) {
-                log.debug("failed to set serial framing: ", ef);
-            }
-
-            // set timeout; framing should work before this anyway
-            try {
-                activeSerialPort.enableReceiveTimeout(10);
-                log.debug("Serial timeout was observed as: {} {}", activeSerialPort.getReceiveTimeout(),
-                        activeSerialPort.isReceiveTimeoutEnabled());
-            } catch (Exception et) {
-                log.info("failed to set serial timeout: ", et);
-            }
-
-            // get and save stream
-            serialStream = activeSerialPort.getInputStream();
-
-            // purge contents, if any
-            purgeStream(serialStream);
-
-            // report status?
-            if (log.isInfoEnabled()) {
-                // report now
-                log.info("{} port opened at {} baud with DTR:{} RTS:{} DSR:{} CTS:{} CD:{}",
-                        portName,
-                        activeSerialPort.getBaudRate(),
-                        activeSerialPort.isDTR(),
-                        activeSerialPort.isRTS(),
-                        activeSerialPort.isDSR(),
-                        activeSerialPort.isCTS(),
-                        activeSerialPort.isCD()
-                );
-            }
-            if (log.isDebugEnabled()) {
-                // report additional status
-                log.debug(" port flow control shows {}", // NOI18N
-                        (activeSerialPort.getFlowControlMode() == SerialPort.FLOWCONTROL_RTSCTS_OUT ? "hardware flow control" : "no flow control")); // NOI18N
-
-                // log events
-                setPortEventLogging(activeSerialPort);
-            }
-
-            opened = true;
-
-        } catch (NoSuchPortException p) {
-            return handlePortNotFound(p, portName, log);
-        } catch (IOException ex) {
-            log.error("Unexpected exception while opening port {}: ", portName, ex);
-            return "Unexpected error while opening port " + portName + ": " + ex;
+        // get and open the primary port
+        currentSerialPort = activatePort(portName, log);
+        if (currentSerialPort == null) {
+            log.error("failed to connect C/MRI to {}", portName);
+            return Bundle.getMessage("SerialPortNotFound", portName);
         }
+        log.info("Connecting Oak Tree to {} {}", portName, currentSerialPort);
+        
+        // try to set it for communication via SerialDriver
+        // find the baud rate value, configure comm options
+        int baud = currentBaudNumber(mBaudRate);
+        setBaudRate(currentSerialPort, baud);
+        configureLeads(currentSerialPort, true, true);
+        setFlowControl(currentSerialPort, FlowControl.NONE);
 
-        return null; // normal operation
+        // report status
+        reportPortStatus(log, portName);
+
+        opened = true;
+
+        return null; // indicates OK return
     }
 
     /**
@@ -131,45 +68,8 @@ public class SerialDriverAdapter extends SerialPortController {
     // base class methods for the SerialPortController interface
 
     @Override
-    public DataInputStream getInputStream() {
-        if (!opened) {
-            log.error("getInputStream called before load(), stream not available");
-            return null;
-        }
-        return new DataInputStream(serialStream);
-    }
-
-    @Override
-    public DataOutputStream getOutputStream() {
-        if (!opened) {
-            log.error("getOutputStream called before load(), stream not available");
-        }
-        try {
-            return new DataOutputStream(activeSerialPort.getOutputStream());
-        } catch (java.io.IOException e) {
-            log.error("getOutputStream exception: {}", e.getMessage());
-        }
-        return null;
-    }
-
-    @Override
     public boolean status() {
         return opened;
-    }
-
-    /**
-     * Local method to do specific port configuration.
-     * @throws UnsupportedCommOperationException if port can't comply with request
-     */
-    protected void setSerialPort() throws UnsupportedCommOperationException {
-        // find the baud rate value, configure comm options
-        int baud = currentBaudNumber(mBaudRate);
-        activeSerialPort.setSerialPortParams(baud, SerialPort.DATABITS_8,
-                SerialPort.STOPBITS_2, SerialPort.PARITY_NONE);
-
-        // find and configure flow control
-        int flow = SerialPort.FLOWCONTROL_NONE; // default
-        configureLeadsAndFlowControl(activeSerialPort, flow);
     }
 
     /**
@@ -196,10 +96,6 @@ public class SerialDriverAdapter extends SerialPortController {
         return 0;
     }
 
-    // private control members
-    private boolean opened = false;
-    InputStream serialStream = null;
-
-    private final static Logger log = LoggerFactory.getLogger(SerialDriverAdapter.class);
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(SerialDriverAdapter.class);
 
 }

--- a/java/src/jmri/jmrix/oaktree/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/oaktree/serialdriver/SerialDriverAdapter.java
@@ -23,7 +23,7 @@ public class SerialDriverAdapter extends SerialPortController {
         // get and open the primary port
         currentSerialPort = activatePort(portName, log);
         if (currentSerialPort == null) {
-            log.error("failed to connect C/MRI to {}", portName);
+            log.error("failed to connect Oak Tree to {}", portName);
             return Bundle.getMessage("SerialPortNotFound", portName);
         }
         log.info("Connecting Oak Tree to {} {}", portName, currentSerialPort);

--- a/java/src/jmri/jmrix/rps/serial/SerialAdapter.java
+++ b/java/src/jmri/jmrix/rps/serial/SerialAdapter.java
@@ -1,10 +1,7 @@
 package jmri.jmrix.rps.serial;
 
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
 import java.util.Arrays;
+import java.io.IOException;
 
 import jmri.InvokeOnGuiThread;
 import jmri.jmrix.rps.Distributor;
@@ -14,14 +11,6 @@ import jmri.jmrix.rps.RpsSystemConnectionMemo;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import purejavacomm.CommPortIdentifier;
-import purejavacomm.NoSuchPortException;
-import purejavacomm.PortInUseException;
-import purejavacomm.SerialPort;
-import purejavacomm.UnsupportedCommOperationException;
 
 /**
  * Implements SerialPortAdapter for the RPS system.
@@ -70,64 +59,39 @@ public class SerialAdapter extends jmri.jmrix.AbstractSerialPortController {
         this.getSystemConnectionMemo().configureManagers();
     }
 
-    transient SerialPort activeSerialPort = null;
-
     @Override
     public synchronized String openPort(String portName, String appName) {
-        // open the port, check ability to set moderators
-        try {
-            // get and open the primary port
-            CommPortIdentifier portID = CommPortIdentifier.getPortIdentifier(portName);
-            try {
-                activeSerialPort = (SerialPort) portID.open(appName, 2000);  // name of program, msec to wait
-            } catch (PortInUseException p) {
-                return handlePortBusy(p, portName, log);
-            }
 
-            // try to set it for communication via SerialDriver
-            try {
-                // find the baud rate value, configure comm options
-                int baud = currentBaudNumber(mBaudRate);
-                activeSerialPort.setSerialPortParams(baud, SerialPort.DATABITS_8, SerialPort.STOPBITS_1, SerialPort.PARITY_NONE);
-            } catch (UnsupportedCommOperationException e) {
-                log.error("Cannot set serial parameters on port {}: {}", portName, e.getMessage());
-                return "Cannot set serial parameters on port " + portName + ": " + e.getMessage();
-            }
-
-            // disable flow control; hardware lines used for signaling, XON/XOFF might appear in data
-            configureLeadsAndFlowControl(activeSerialPort, 0);
-
-            // set timeout
-            log.debug("Serial timeout was observed as: {} {}", activeSerialPort.getReceiveTimeout(),
-                    activeSerialPort.isReceiveTimeoutEnabled());
-
-            // get and save streams
-            serialStream = new DataInputStream(activeSerialPort.getInputStream());
-            ostream = activeSerialPort.getOutputStream();
-
-            // start getting the initial message
-            sendBytes(new byte[]{(byte) 'A', 13});
-
-            // purge contents, if any
-            purgeStream(serialStream);
-
-            // report status?
-            if (log.isInfoEnabled()) {
-                log.info("{} port opened at {} baud, sees  DTR: {} RTS: {} DSR: {} CTS: {}  CD: {}", portName, activeSerialPort.getBaudRate(), activeSerialPort.isDTR(), activeSerialPort.isRTS(), activeSerialPort.isDSR(), activeSerialPort.isCTS(), activeSerialPort.isCD());
-            }
-
-            opened = true;
-
-        } catch (NoSuchPortException p) {
-            return handlePortNotFound(p, portName, log);
-        } catch (IOException ex) {
-            log.error("Unexpected exception while opening port {}", portName, ex);
-            return "Unexpected error while opening port " + portName + ": " + ex;
+        // get and open the primary port
+        currentSerialPort = activatePort(portName, log);
+        if (currentSerialPort == null) {
+            log.error("failed to connect C/MRI to {}", portName);
+            return Bundle.getMessage("SerialPortNotFound", portName);
         }
+        log.info("Connecting RPS to {} {}", portName, currentSerialPort);
+        
+        // try to set it for communication via SerialDriver
+        // find the baud rate value, configure comm options
+        int baud = currentBaudNumber(mBaudRate);
+        setBaudRate(currentSerialPort, baud);
+        configureLeads(currentSerialPort, true, true);
+        setFlowControl(currentSerialPort, FlowControl.NONE);
+
+        // report status
+        reportPortStatus(log, portName);
+
+        opened = true;
+        
+        // capture streams
+        serialStream = getInputStream();
+        ostream = getOutputStream();
 
         return null; // indicates OK return
     }
 
+    java.io.DataInputStream serialStream;
+    java.io.OutputStream ostream;
+    
     /**
      * Send output bytes, e.g. characters controlling operation, with small
      * delays between the characters. This is used to reduce overrrun problems.
@@ -150,28 +114,6 @@ public class SerialAdapter extends jmri.jmrix.AbstractSerialPortController {
     }
 
     // base class methods for the PortController interface
-    @Override
-    public synchronized DataInputStream getInputStream() {
-        if (!opened) {
-            log.error("getInputStream called before load(), stream not available");
-            return null;
-        }
-        return new DataInputStream(serialStream);
-    }
-
-    @Override
-    public synchronized DataOutputStream getOutputStream() {
-        if (!opened) {
-            log.error("getOutputStream called before load(), stream not available");
-        }
-        try {
-            return new DataOutputStream(activeSerialPort.getOutputStream());
-        } catch (java.io.IOException e) {
-            log.error("getOutputStream exception: ", e);
-        }
-        return null;
-    }
-
     @Override
     public boolean status() {
         return opened;
@@ -217,9 +159,6 @@ public class SerialAdapter extends jmri.jmrix.AbstractSerialPortController {
     }
 
     // private control members
-    private boolean opened = false;
-    transient DataInputStream serialStream = null;
-    volatile OutputStream ostream = null;
     int[] offsetArray = null;
 
     // code for handling the input characters
@@ -450,6 +389,6 @@ public class SerialAdapter extends jmri.jmrix.AbstractSerialPortController {
         }
     }
 
-    private final static Logger log = LoggerFactory.getLogger(SerialAdapter.class);
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(SerialAdapter.class);
 
 }

--- a/java/src/jmri/jmrix/rps/serial/SerialAdapter.java
+++ b/java/src/jmri/jmrix/rps/serial/SerialAdapter.java
@@ -65,7 +65,7 @@ public class SerialAdapter extends jmri.jmrix.AbstractSerialPortController {
         // get and open the primary port
         currentSerialPort = activatePort(portName, log);
         if (currentSerialPort == null) {
-            log.error("failed to connect C/MRI to {}", portName);
+            log.error("failed to connect RPS to {}", portName);
             return Bundle.getMessage("SerialPortNotFound", portName);
         }
         log.info("Connecting RPS to {} {}", portName, currentSerialPort);

--- a/java/src/jmri/jmrix/secsi/SerialLightManager.java
+++ b/java/src/jmri/jmrix/secsi/SerialLightManager.java
@@ -40,7 +40,7 @@ public class SerialLightManager extends AbstractLightManager {
      *
      * @throws IllegalArgumentException if system name is not in a valid format 
      * or if the
-     * system name does not correspond to a configured C/MRI digital output bit
+     * system name does not correspond to a configured digital output bit
      */
     @Override
     @Nonnull

--- a/java/src/jmri/jmrix/secsi/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/secsi/serialdriver/SerialDriverAdapter.java
@@ -1,19 +1,8 @@
 package jmri.jmrix.secsi.serialdriver;
 
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
 import java.util.Arrays;
 import jmri.jmrix.secsi.SecsiSystemConnectionMemo;
 import jmri.jmrix.secsi.SerialPortController;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import purejavacomm.CommPortIdentifier;
-import purejavacomm.NoSuchPortException;
-import purejavacomm.PortInUseException;
-import purejavacomm.SerialPort;
-import purejavacomm.UnsupportedCommOperationException;
 
 /**
  * Provide access to SECSI via a serial com port. Normally controlled by the
@@ -23,8 +12,6 @@ import purejavacomm.UnsupportedCommOperationException;
  */
 public class SerialDriverAdapter extends SerialPortController {
 
-    SerialPort activeSerialPort = null;
-
     public SerialDriverAdapter() {
         super(new SecsiSystemConnectionMemo());
         this.manufacturerName = jmri.jmrix.secsi.SerialConnectionTypeList.TRACTRONICS;
@@ -32,78 +19,28 @@ public class SerialDriverAdapter extends SerialPortController {
 
     @Override
     public String openPort(String portName, String appName) {
-        try {
-            // get and open the primary port
-            CommPortIdentifier portID = CommPortIdentifier.getPortIdentifier(portName);
-            try {
-                activeSerialPort = (SerialPort) portID.open(appName, 2000);  // name of program, msec to wait
-            } catch (PortInUseException p) {
-                return handlePortBusy(p, portName, log);
-            }
-            // try to set it for serial
-            try {
-                setSerialPort();
-            } catch (UnsupportedCommOperationException e) {
-                log.error("Cannot set serial parameters on port {}: {}", portName, e.getMessage());
-                return "Cannot set serial parameters on port " + portName + ": " + e.getMessage();
-            }
 
-            // set framing (end) character
-            try {
-                activeSerialPort.enableReceiveFraming(0x03);
-                log.debug("Serial framing was observed as: {} {}", activeSerialPort.isReceiveFramingEnabled(),
-                        activeSerialPort.getReceiveFramingByte());
-            } catch (Exception ef) {
-                log.debug("failed to set serial framing", ef);
-            }
-
-            // set timeout; framing should work before this anyway
-            try {
-                activeSerialPort.enableReceiveTimeout(10);
-                log.debug("Serial timeout was observed as: {} {}", activeSerialPort.getReceiveTimeout(),
-                        activeSerialPort.isReceiveTimeoutEnabled());
-            } catch (Exception et) {
-                log.info("failed to set serial timeout: ", et);
-            }
-
-            // get and save stream
-            serialStream = activeSerialPort.getInputStream();
-
-            // purge contents, if any
-            purgeStream(serialStream);
-
-            // report status?
-            if (log.isInfoEnabled()) {
-                // report now
-                log.info("{} port opened at {} baud with DTR:{} RTS:{} DSR:{} CTS:{} CD:{}",
-                        portName,
-                        activeSerialPort.getBaudRate(),
-                        activeSerialPort.isDTR(),
-                        activeSerialPort.isRTS(),
-                        activeSerialPort.isDSR(),
-                        activeSerialPort.isCTS(),
-                        activeSerialPort.isCD()
-                );
-            }
-            if (log.isDebugEnabled()) {
-                // report additional status
-                log.debug(" port flow control shows {}", // NOI18N
-                        (activeSerialPort.getFlowControlMode() == SerialPort.FLOWCONTROL_RTSCTS_OUT ? "hardware flow control" : "no flow control")); // NOI18N
-
-                // log events
-                setPortEventLogging(activeSerialPort);
-            }
-
-            opened = true;
-
-        } catch (NoSuchPortException p) {
-            return handlePortNotFound(p, portName, log);
-        } catch (IOException ex) {
-            log.error("Unexpected exception while opening port {}", portName, ex);
-            return "Unexpected error while opening port " + portName + ": " + ex;
+        // get and open the primary port
+        currentSerialPort = activatePort(portName, log);
+        if (currentSerialPort == null) {
+            log.error("failed to connect C/MRI to {}", portName);
+            return Bundle.getMessage("SerialPortNotFound", portName);
         }
+        log.info("Connecting SECSI to {} {}", portName, currentSerialPort);
+        
+        // try to set it for communication via SerialDriver
+        // find the baud rate value, configure comm options
+        int baud = currentBaudNumber(mBaudRate);
+        setBaudRate(currentSerialPort, baud);
+        configureLeads(currentSerialPort, true, true);
+        setFlowControl(currentSerialPort, FlowControl.NONE);
 
-        return null; // normal operation
+        // report status
+        reportPortStatus(log, portName);
+
+        opened = true;
+
+        return null; // indicates OK return
     }
 
     /**
@@ -128,45 +65,8 @@ public class SerialDriverAdapter extends SerialPortController {
     // base class methods for the SerialPortController interface
 
     @Override
-    public DataInputStream getInputStream() {
-        if (!opened) {
-            log.error("getInputStream called before load(), stream not available");
-            return null;
-        }
-        return new DataInputStream(serialStream);
-    }
-
-    @Override
-    public DataOutputStream getOutputStream() {
-        if (!opened) {
-            log.error("getOutputStream called before load(), stream not available");
-        }
-        try {
-            return new DataOutputStream(activeSerialPort.getOutputStream());
-        } catch (java.io.IOException e) {
-            log.error("getOutputStream exception {}", e.getMessage());
-        }
-        return null;
-    }
-
-    @Override
     public boolean status() {
         return opened;
-    }
-
-    /**
-     * Local method to do specific port configuration.
-     * @throws UnsupportedCommOperationException from underlying operation
-     */
-    protected void setSerialPort() throws UnsupportedCommOperationException {
-        // find the baud rate value, configure comm options
-        int baud = currentBaudNumber(mBaudRate);
-        activeSerialPort.setSerialPortParams(baud, SerialPort.DATABITS_8,
-                SerialPort.STOPBITS_2, SerialPort.PARITY_NONE);
-
-        // find and configure flow control
-        int flow = SerialPort.FLOWCONTROL_NONE; // default
-        configureLeadsAndFlowControl(activeSerialPort, flow);
     }
 
     /**
@@ -211,10 +111,6 @@ public class SerialDriverAdapter extends SerialPortController {
         return "";
     }
 
-    // private control members
-    private boolean opened = false;
-    InputStream serialStream = null;
-
-    private final static Logger log = LoggerFactory.getLogger(SerialDriverAdapter.class);
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(SerialDriverAdapter.class);
 
 }

--- a/java/src/jmri/jmrix/secsi/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/secsi/serialdriver/SerialDriverAdapter.java
@@ -23,7 +23,7 @@ public class SerialDriverAdapter extends SerialPortController {
         // get and open the primary port
         currentSerialPort = activatePort(portName, log);
         if (currentSerialPort == null) {
-            log.error("failed to connect C/MRI to {}", portName);
+            log.error("failed to connect SECSI to {}", portName);
             return Bundle.getMessage("SerialPortNotFound", portName);
         }
         log.info("Connecting SECSI to {} {}", portName, currentSerialPort);

--- a/java/src/jmri/jmrix/tams/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/tams/serialdriver/SerialDriverAdapter.java
@@ -27,7 +27,7 @@ public class SerialDriverAdapter extends TamsPortController {
         // get and open the primary port
         currentSerialPort = activatePort(portName, log);
         if (currentSerialPort == null) {
-            log.error("failed to connect C/MRI to {}", portName);
+            log.error("failed to connect TAMS to {}", portName);
             return Bundle.getMessage("SerialPortNotFound", portName);
         }
         log.info("Connecting TAMS to {} {}", portName, currentSerialPort);

--- a/java/src/jmri/jmrix/tams/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/tams/serialdriver/SerialDriverAdapter.java
@@ -1,20 +1,9 @@
 package jmri.jmrix.tams.serialdriver;
 
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
 import java.util.Arrays;
 import jmri.jmrix.tams.TamsPortController;
 import jmri.jmrix.tams.TamsSystemConnectionMemo;
 import jmri.jmrix.tams.TamsTrafficController;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import purejavacomm.CommPortIdentifier;
-import purejavacomm.NoSuchPortException;
-import purejavacomm.PortInUseException;
-import purejavacomm.SerialPort;
-import purejavacomm.UnsupportedCommOperationException;
 
 /**
  * Implements SerialPortAdapter for the TAMS system.
@@ -27,8 +16,6 @@ import purejavacomm.UnsupportedCommOperationException;
  */
 public class SerialDriverAdapter extends TamsPortController {
 
-    SerialPort activeSerialPort = null;
-
     public SerialDriverAdapter() {
         super(new TamsSystemConnectionMemo());
         setManufacturer(jmri.jmrix.tams.TamsConnectionTypeList.TAMS);
@@ -36,63 +23,26 @@ public class SerialDriverAdapter extends TamsPortController {
 
     @Override
     public String openPort(String portName, String appName) {
-        // open the port, check ability to set moderators
-        try {
-            // get and open the primary port
-            CommPortIdentifier portID = CommPortIdentifier.getPortIdentifier(portName);
-            try {
-                activeSerialPort = (SerialPort) portID.open(appName, 2000);  // name of program, msec to wait
-            } catch (PortInUseException p) {
-                return handlePortBusy(p, portName, log);
-            }
 
-            // try to set it for communication via SerialDriver
-            try {
-                // find the baud rate value, configure comm options
-                int baud = currentBaudNumber(mBaudRate);
-                activeSerialPort.setSerialPortParams(baud, SerialPort.DATABITS_8, SerialPort.STOPBITS_1, SerialPort.PARITY_NONE);
-            } catch (UnsupportedCommOperationException e) {
-                log.error("Cannot set serial parameters on port {}: {}", portName, e.getMessage());
-                return "Cannot set serial parameters on port " + portName + ": " + e.getMessage();
-            }
-
-            // Hardware flow control
-            //configureLeadsAndFlowControl(currentSerialPort, SerialPort.FLOWCONTROL_RTSCTS_IN | SerialPort.FLOWCONTROL_RTSCTS_OUT);
-
-            // Xon/Xoff flow control
-            configureLeadsAndFlowControl(activeSerialPort, 0);
-
-            // set timeout
-            try {
-                activeSerialPort.enableReceiveTimeout(50);  // Set to 50 was 10 mSec timeout before sending chars
-                log.debug("Serial timeout was observed as: {} {}", activeSerialPort.getReceiveTimeout(),
-                        activeSerialPort.isReceiveTimeoutEnabled());
-            } catch (Exception et) {
-                log.info("failed to set serial timeout: ", et);
-            }
-            // get and save stream
-            serialStream = activeSerialPort.getInputStream();
-
-            // purge contents, if any
-            purgeStream(serialStream);
-
-            if (log.isInfoEnabled()) {
-                log.info("{} port opened at {} baud, sees  DTR: {} RTS: {} DSR: {} CTS: {}  CD: {}", portName, activeSerialPort.getBaudRate(), activeSerialPort.isDTR(), activeSerialPort.isRTS(), activeSerialPort.isDSR(), activeSerialPort.isCTS(), activeSerialPort.isCD());
-            }
-
-            // report status
-            if (log.isInfoEnabled()) {
-                log.info("TAMS {} port opened at {} baud", portName,
-                        activeSerialPort.getBaudRate());
-            }
-            opened = true;
-
-        } catch (NoSuchPortException p) {
-            return handlePortNotFound(p, portName, log);
-        } catch (IOException ex) {
-            log.error("Unexpected exception while opening port {}", portName, ex);
-            return "Unexpected error while opening port " + portName + ": " + ex;
+        // get and open the primary port
+        currentSerialPort = activatePort(portName, log);
+        if (currentSerialPort == null) {
+            log.error("failed to connect C/MRI to {}", portName);
+            return Bundle.getMessage("SerialPortNotFound", portName);
         }
+        log.info("Connecting TAMS to {} {}", portName, currentSerialPort);
+        
+        // try to set it for communication via SerialDriver
+        // find the baud rate value, configure comm options
+        int baud = currentBaudNumber(mBaudRate);
+        setBaudRate(currentSerialPort, baud);
+        configureLeads(currentSerialPort, true, true);
+        setFlowControl(currentSerialPort, FlowControl.NONE);
+
+        // report status
+        reportPortStatus(log, portName);
+
+        opened = true;
 
         return null; // indicates OK return
     }
@@ -113,27 +63,6 @@ public class SerialDriverAdapter extends TamsPortController {
     }
 
     // base class methods for the TamsPortController interface
-    @Override
-    public DataInputStream getInputStream() {
-        if (!opened) {
-            log.error("getInputStream called before load(), stream not available");
-            return null;
-        }
-        return new DataInputStream(serialStream);
-    }
-
-    @Override
-    public DataOutputStream getOutputStream() {
-        if (!opened) {
-            log.error("getOutputStream called before load(), stream not available");
-        }
-        try {
-            return new DataOutputStream(activeSerialPort.getOutputStream());
-        } catch (java.io.IOException e) {
-            log.error("getOutputStream exception: ", e);
-        }
-        return null;
-    }
 
     @Override
     public boolean status() {
@@ -166,10 +95,6 @@ public class SerialDriverAdapter extends TamsPortController {
         return 0;
     }
 
-    // private control members
-    private boolean opened = false;
-    InputStream serialStream = null;
-
-    private final static Logger log = LoggerFactory.getLogger(SerialDriverAdapter.class);
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(SerialDriverAdapter.class);
 
 }

--- a/java/src/jmri/jmrix/wangrow/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/wangrow/serialdriver/SerialDriverAdapter.java
@@ -32,7 +32,7 @@ public class SerialDriverAdapter extends NcePortController {
         // get and open the primary port
         currentSerialPort = activatePort(portName, log);
         if (currentSerialPort == null) {
-            log.error("failed to connect C/MRI to {}", portName);
+            log.error("failed to connect Wangrow to {}", portName);
             return Bundle.getMessage("SerialPortNotFound", portName);
         }
         log.info("Connecting Wangrow to {} {}", portName, currentSerialPort);

--- a/java/src/jmri/jmrix/wangrow/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/wangrow/serialdriver/SerialDriverAdapter.java
@@ -1,20 +1,8 @@
 package jmri.jmrix.wangrow.serialdriver;
 
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-
 import jmri.jmrix.nce.NcePortController;
 import jmri.jmrix.nce.NceSystemConnectionMemo;
 import jmri.jmrix.nce.NceTrafficController;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import purejavacomm.CommPortIdentifier;
-import purejavacomm.NoSuchPortException;
-import purejavacomm.PortInUseException;
-import purejavacomm.SerialPort;
-import purejavacomm.UnsupportedCommOperationException;
 
 /**
  * Implements SerialPortAdapter for the Wangrow system.
@@ -33,8 +21,6 @@ import purejavacomm.UnsupportedCommOperationException;
  */
 public class SerialDriverAdapter extends NcePortController {
 
-    SerialPort activeSerialPort = null;
-
     public SerialDriverAdapter() {
         super(new NceSystemConnectionMemo());
         setManufacturer(jmri.jmrix.wangrow.WangrowConnectionTypeList.WANGROW);
@@ -42,53 +28,26 @@ public class SerialDriverAdapter extends NcePortController {
 
     @Override
     public String openPort(String portName, String appName) {
-        // open the port, check ability to set moderators
-        try {
-            // get and open the primary port
-            CommPortIdentifier portID = CommPortIdentifier.getPortIdentifier(portName);
-            try {
-                activeSerialPort = (SerialPort) portID.open(appName, 2000);  // name of program, msec to wait
-            } catch (PortInUseException p) {
-                return handlePortBusy(p, portName, log);
-            }
 
-            // try to set it for communication via SerialDriver
-            try {
-                activeSerialPort.setSerialPortParams(9600, SerialPort.DATABITS_8, SerialPort.STOPBITS_1, SerialPort.PARITY_NONE);
-            } catch (UnsupportedCommOperationException e) {
-                log.error("Cannot set serial parameters on port {}: {}", portName, e.getMessage());
-                return "Cannot set serial parameters on port " + portName + ": " + e.getMessage();
-            }
-
-            // disable flow control; hardware lines used for signaling, XON/XOFF might appear in data
-            configureLeadsAndFlowControl(activeSerialPort, 0);
-            activeSerialPort.enableReceiveTimeout(50);  // 50 mSec timeout before sending chars
-
-            // set timeout
-            // activeSerialPort.enableReceiveTimeout(1000);
-            log.debug("Serial timeout was observed as: {} {}", activeSerialPort.getReceiveTimeout(), activeSerialPort.isReceiveTimeoutEnabled());
-
-            // get and save stream
-            serialStream = activeSerialPort.getInputStream();
-
-            // purge contents, if any
-            purgeStream(serialStream);
-
-            // report status
-            if (log.isInfoEnabled()) {
-                log.info("Wangrow {} port opened at {} baud", portName, activeSerialPort.getBaudRate());
-            }
-            opened = true;
-
-        } catch (NoSuchPortException p) {
-            return handlePortNotFound(p, portName, log);
-        } catch (UnsupportedCommOperationException | IOException ex) {
-            log.error("Unexpected exception while opening port {}", portName, ex);
-            return "Unexpected error while opening port " + portName + ": " + ex;
+        // get and open the primary port
+        currentSerialPort = activatePort(portName, log);
+        if (currentSerialPort == null) {
+            log.error("failed to connect C/MRI to {}", portName);
+            return Bundle.getMessage("SerialPortNotFound", portName);
         }
+        log.info("Connecting Wangrow to {} {}", portName, currentSerialPort);
+        
+        // try to set it for communication via SerialDriver, configure comm options
+        setBaudRate(currentSerialPort, 9600);
+        configureLeads(currentSerialPort, true, true);
+        setFlowControl(currentSerialPort, FlowControl.NONE);
+
+        // report status
+        reportPortStatus(log, portName);
+
+        opened = true;
 
         return null; // indicates OK return
-
     }
 
     /**
@@ -110,27 +69,6 @@ public class SerialDriverAdapter extends NcePortController {
     }
 
     // base class methods for the NcePortController interface
-    @Override
-    public DataInputStream getInputStream() {
-        if (!opened) {
-            log.error("getInputStream called before load(), stream not available");
-            return null;
-        }
-        return new DataInputStream(serialStream);
-    }
-
-    @Override
-    public DataOutputStream getOutputStream() {
-        if (!opened) {
-            log.error("getOutputStream called before load(), stream not available");
-        }
-        try {
-            return new DataOutputStream(activeSerialPort.getOutputStream());
-        } catch (java.io.IOException e) {
-            log.error("getOutputStream exception", e);
-        }
-        return null;
-    }
 
     @Override
     public boolean status() {
@@ -154,10 +92,6 @@ public class SerialDriverAdapter extends NcePortController {
         return new int[]{9600};
     }
 
-    // private control members
-    private boolean opened = false;
-    InputStream serialStream = null;
-
-    private final static Logger log = LoggerFactory.getLogger(SerialDriverAdapter.class);
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(SerialDriverAdapter.class);
 
 }

--- a/java/test/jmri/ArchitectureTest.java
+++ b/java/test/jmri/ArchitectureTest.java
@@ -323,10 +323,22 @@ public class ArchitectureTest {
      * Confine jSerialComm to jmri.jmrix packages.
      */
     @ArchTest
-    public static final ArchRule checkJSerialCommOutsideJmrix = noClasses()
-        .that().resideOutsideOfPackage("jmri.jmrix..").and()
-        .doNotHaveFullyQualifiedName("apps.util.issuereporter.SystemInfo").and()
-        .doNotHaveFullyQualifiedName("jmri.jmrit.mailreport.ReportContext")
+    public static final ArchRule checkJSerialCommAllowedUses = noClasses()
+        .that()
+        
+        .doNotHaveFullyQualifiedName("jmri.jmrix.AbstractSerialPortController").and()
+
+        // migrated atypical systems
+        .doNotHaveFullyQualifiedName("jmri.jmrix.can.adapters.gridconnect.GcSerialDriverAdapter").and()
+        .doNotHaveFullyQualifiedName("jmri.jmrix.dccpp.DCCppSerialPortController").and()
+        .doNotHaveFullyQualifiedName("jmri.jmrix.lenz.XNetSerialPortController").and()
+        .doNotHaveFullyQualifiedName("jmri.jmrix.loconet.locobuffer.LocoBufferAdapter").and()
+        .doNotHaveFullyQualifiedName("jmri.jmrix.powerline.SerialSystemConnectionMemo").and()
+        .doNotHaveFullyQualifiedName("jmri.jmrix.powerline.dmx512.SpecificTrafficController").and()
+        .doNotHaveFullyQualifiedName("jmri.jmrix.sprog.serialdriver.SerialDriverAdapter").and()
+        .doNotHaveFullyQualifiedName("jmri.jmrix.zimo.mx1.Mx1Adapter").and()
+        .doNotHaveFullyQualifiedName("jmri.jmrix.zimo.mxulf.SerialDriverAdapter")
+
         .should().accessClassesThat().resideInAPackage("com.fazecast.jSerialComm..");
 
     /**

--- a/java/test/jmri/ArchitectureTest.java
+++ b/java/test/jmri/ArchitectureTest.java
@@ -288,10 +288,35 @@ public class ArchitectureTest {
      * Confine purejavacomm to jmri.jmrix packages.
      */
     @ArchTest
-    public static final ArchRule checkPurejavacoomOutsideJmrix = noClasses()
-        .that().resideOutsideOfPackage("jmri.jmrix..").and()
+    public static final ArchRule checkPurejavacommUsage = noClasses()
+        .that()
+        //.resideOutsideOfPackage("jmri.jmrix..").and()
+        
         .doNotHaveFullyQualifiedName("apps.util.issuereporter.SystemInfo").and()
-        .doNotHaveFullyQualifiedName("jmri.jmrit.mailreport.ReportContext")
+        .doNotHaveFullyQualifiedName("jmri.jmrit.mailreport.ReportContext").and()
+
+        .doNotHaveFullyQualifiedName("jmri.jmrix.AbstractSerialConnectionConfig").and()
+        .doNotHaveFullyQualifiedName("jmri.jmrix.AbstractSerialPortController").and()
+        .doNotHaveFullyQualifiedName("jmri.jmrix.AbstractSerialPortController$1").and()
+
+        // non-typical systems that are not migrated
+        .doNotHaveFullyQualifiedName("jmri.jmrix.bachrus.SpeedoTrafficController").and()
+        .doNotHaveFullyQualifiedName("jmri.jmrix.bachrus.kpfserialdriver.SerialDriverAdapter").and()
+        .doNotHaveFullyQualifiedName("jmri.jmrix.bachrus.serialdriver.SerialDriverAdapter").and()
+        .doNotHaveFullyQualifiedName("jmri.jmrix.dcc4pc.Dcc4PcTrafficController").and()
+        .doNotHaveFullyQualifiedName("jmri.jmrix.dcc4pc.serialdriver.SerialDriverAdapter").and()
+        .doNotHaveFullyQualifiedName("jmri.jmrix.ieee802154.xbee.XBeeAdapter").and()
+        .doNotHaveFullyQualifiedName("jmri.jmrix.ieee802154.IEEE802154PortController").and()
+        .doNotHaveFullyQualifiedName("jmri.jmrix.ieee802154.serialdriver.SerialDriverAdapter").and()
+        .doNotHaveFullyQualifiedName("jmri.jmrix.ncemonitor.NcePacketMonitorPanel").and()
+        .doNotHaveFullyQualifiedName("jmri.jmrix.pricom.downloader.LoaderPane").and()
+        .doNotHaveFullyQualifiedName("jmri.jmrix.pricom.downloader.LoaderPane$LocalReader").and()
+        .doNotHaveFullyQualifiedName("jmri.jmrix.pricom.pockettester.DataSource").and()
+        .doNotHaveFullyQualifiedName("jmri.jmrix.qsi.serialdriver.SerialDriverAdapter").and()
+        .doNotHaveFullyQualifiedName("jmri.jmrix.serialsensor.SerialSensorAdapter").and()
+        .doNotHaveFullyQualifiedName("jmri.jmrix.serialsensor.SerialSensorAdapter$2").and()
+        .doNotHaveFullyQualifiedName("jmri.jmrix.xpa.serialdriver.SerialDriverAdapter")
+        
         .should().accessClassesThat().resideInAPackage("purejavacomm..");
 
     /**

--- a/java/test/jmri/ArchitectureTest.java
+++ b/java/test/jmri/ArchitectureTest.java
@@ -285,7 +285,8 @@ public class ArchitectureTest {
         .should().accessClassesThat().resideInAPackage("org.jdom2..");
 
     /**
-     * Confine purejavacomm to jmri.jmrix packages.
+     * Confine purejavacomm to existing uses. No additional ones permitted.
+     * Ideally these will all be migrated to jSerialComm eventually.
      */
     @ArchTest
     public static final ArchRule checkPurejavacommUsage = noClasses()
@@ -299,7 +300,7 @@ public class ArchitectureTest {
         .doNotHaveFullyQualifiedName("jmri.jmrix.AbstractSerialPortController").and()
         .doNotHaveFullyQualifiedName("jmri.jmrix.AbstractSerialPortController$1").and()
 
-        // non-typical systems that are not migrated
+        // non-typical systems that are not (yet) migrated
         .doNotHaveFullyQualifiedName("jmri.jmrix.bachrus.SpeedoTrafficController").and()
         .doNotHaveFullyQualifiedName("jmri.jmrix.bachrus.kpfserialdriver.SerialDriverAdapter").and()
         .doNotHaveFullyQualifiedName("jmri.jmrix.bachrus.serialdriver.SerialDriverAdapter").and()
@@ -320,7 +321,8 @@ public class ArchitectureTest {
         .should().accessClassesThat().resideInAPackage("purejavacomm..");
 
     /**
-     * Confine jSerialComm to jmri.jmrix packages.
+     * Confine jSerialComm to jmri.jmrix.AbstractSerialPortController with 
+     * limited exceptions
      */
     @ArchTest
     public static final ArchRule checkJSerialCommAllowedUses = noClasses()


### PR DESCRIPTION
Last in the current series of updating system connections to use the new jSerialComm library.  This updates Grapevine, Oak Tree, RPS, SECSI, TAMS and Wangrow.

Several systems have uncommon architectures (in the sense of not the shared common one).  These have not been migrated yet. They're being left with the old library until (a) somebody actually has a problem with them and (b) there's a place the changes can be tested. These are Bachrus, DCC4PC, IEEE802154, KPF, NCE Monitor, Pricom downloader and Pricom pocket tester, QSI, and Lenz XPA.

`jmri.ArchitectureTest` has been updated to enforce use of the new serial library and common architecture.