### PR TITLE
UncaughtExceptionHandler - tweak Error handling

### DIFF
--- a/java/src/jmri/util/exceptionhandler/UncaughtExceptionHandler.java
+++ b/java/src/jmri/util/exceptionhandler/UncaughtExceptionHandler.java
@@ -33,7 +33,7 @@ public class UncaughtExceptionHandler implements Thread.UncaughtExceptionHandler
         if (e instanceof Error) {
             if (!GraphicsEnvironment.isHeadless()) {
                 jmri.util.swing.ExceptionDisplayFrame.displayExceptionDisplayFrame(null,
-                    new ErrorContext(new Exception(e)));
+                    new ErrorContext(e));
             }
             log.error("System Exiting");
             systemExit();


### PR DESCRIPTION
Do not create new Exception for java.lang.Error, pass Throwable to ErrorContext.

Some Errors struggle at line 36 of UncaughtExceptionHandler , eg.

https://jmri-developers.groups.io/g/jmri/message/9632