### PR TITLE
Config and Temp not shown same as rest

### DIFF
--- a/java/src/jmri/jmrit/Bundle.properties
+++ b/java/src/jmri/jmrit/Bundle.properties
@@ -230,8 +230,8 @@ ButtonSettingsLoc   = Settings Location
 ButtonScriptsLoc    = Scripts Location
 ButtonProgramLoc    = Program Location
 ButtonLogFilesLoc   = Log Files Location
-CurrentConfig       = Current Config file:
-TempFilesLoc        = Temp Files Location:
+CurrentConfig       = Current Config file
+TempFilesLoc        = Temp Files Location
 
 # Xml file validation action title
 XmlFileValidateAction = Validate XML File...

--- a/java/src/jmri/jmrit/Bundle_ca.properties
+++ b/java/src/jmri/jmrit/Bundle_ca.properties
@@ -218,8 +218,8 @@ ButtonSettingsLoc   = Localitzaci\u00f3 de Configuraci\u00f3
 ButtonScriptsLoc    = Localitzaci\u00f3 d'Scripts
 ButtonProgramLoc    = Localitzaci\u00f3 de Programaci\u00f3
 ButtonLogFilesLoc   = Localitzaci\u00f3 d'Arxius de Log
-CurrentConfig       = Arxiu de Configuraci\u00f3 Actual:
-TempFilesLoc        = Localitzaci\u00f3 d'Arxius Temporals:
+CurrentConfig       = Arxiu de Configuraci\u00f3 Actual
+TempFilesLoc        = Localitzaci\u00f3 d'Arxius Temporals
 
 #Xml file validation action title
 XmlFileValidateAction = Valida un fitxer XML...

--- a/java/src/jmri/jmrit/Bundle_cs.properties
+++ b/java/src/jmri/jmrit/Bundle_cs.properties
@@ -229,8 +229,8 @@ ButtonSettingsLoc   = Nastaven\u00ed um\u00edst\u011bn\u00ed
 ButtonScriptsLoc    = Um\u00edst\u011bn\u00ed skript\u016f
 ButtonProgramLoc    = Um\u00edst\u011bn\u00ed programu
 ButtonLogFilesLoc   = Um\u00edst\u011bn\u00ed soubor\u016f Protokolu
-CurrentConfig       = Sou\u010dasn\u00fd konfigura\u010dn\u00ed soubor:
-TempFilesLoc        = Um\u00edst\u011bn\u00ed do\u010dasn\u00fdch soubor\u016f:
+CurrentConfig       = Sou\u010dasn\u00fd konfigura\u010dn\u00ed soubor
+TempFilesLoc        = Um\u00edst\u011bn\u00ed do\u010dasn\u00fdch soubor\u016f
 
 # Xml file validation action title
 XmlFileValidateAction   = Validovat soubor XML...

--- a/java/src/jmri/jmrit/Bundle_da.properties
+++ b/java/src/jmri/jmrit/Bundle_da.properties
@@ -216,8 +216,8 @@ ButtonSettingsLoc   = Indstillinger Placering
 ButtonScriptsLoc    = Scripts Placering
 ButtonProgramLoc    = Program Placering
 ButtonLogFilesLoc   = Log Filer Placering
-CurrentConfig       = Current Config file:
-TempFilesLoc        = Temp Filer Placering:
+CurrentConfig       = Current Config file
+TempFilesLoc        = Temp Filer Placering
 
 #Xml file validation action title
 XmlFileValidateAction=Valider XML Fil...

--- a/java/src/jmri/jmrit/Bundle_de.properties
+++ b/java/src/jmri/jmrit/Bundle_de.properties
@@ -211,8 +211,8 @@ ButtonSettingsLoc   = Einstellungenverzeichnis
 ButtonScriptsLoc    = Ablaufdateiverzeichnis
 ButtonProgramLoc    = Programmverzeichnis
 ButtonLogFilesLoc   = Logbuchdateiverzeichnis
-CurrentConfig       = Aktuelle Configurationsdatei:
-TempFilesLoc        = Ablageort Tempor\u00e4re Dateien:
+CurrentConfig       = Aktuelle Configurationsdatei
+TempFilesLoc        = Ablageort Tempor\u00e4re Dateien
 
 # AmpMeter items
 TrackCurrentMeterTitle = Anlagestromanzeige

--- a/java/src/jmri/jmrit/Bundle_es.properties
+++ b/java/src/jmri/jmrit/Bundle_es.properties
@@ -224,8 +224,8 @@ ButtonSettingsLoc   = Settings Location
 ButtonScriptsLoc    = Scripts Location
 ButtonProgramLoc    = Program Location
 ButtonLogFilesLoc   = Log Files Location
-CurrentConfig       = Current Config file:
-TempFilesLoc        = Temp Files Location:
+CurrentConfig       = Current Config file
+TempFilesLoc        = Temp Files Location
 
 # Xml file validation action title
 XmlFileValidateAction = Validar fichero XML...

--- a/java/src/jmri/jmrit/Bundle_fr.properties
+++ b/java/src/jmri/jmrit/Bundle_fr.properties
@@ -218,8 +218,8 @@ ButtonSettingsLoc   = Emplacement Param\u00e8tres
 ButtonScriptsLoc    = Emplacement Scripts
 ButtonProgramLoc    = Emplacement Programme
 ButtonLogFilesLoc   = Emplacement Fichiers Log
-CurrentConfig       = Fichier Configuration courant:
-TempFilesLoc        = Emplacement Fichiers Temporaires:
+CurrentConfig       = Fichier Configuration courant
+TempFilesLoc        = Emplacement Fichiers Temporaires
 
 # Xml file validation action title
 XmlFileValidateAction = Valider Fichier XML...

--- a/java/src/jmri/jmrit/Bundle_nl.properties
+++ b/java/src/jmri/jmrit/Bundle_nl.properties
@@ -222,8 +222,8 @@ ButtonSettingsLoc   = Instellingen-locatie
 ButtonScriptsLoc    = Scripts-locatie
 ButtonProgramLoc    = Programma-locatie
 ButtonLogFilesLoc   = Locatie Log-bestanden
-CurrentConfig       = Huidig Configuratiebestand:
-TempFilesLoc        = Locatie Tijdelijke bestanden:
+CurrentConfig       = Huidig Configuratiebestand
+TempFilesLoc        = Locatie Tijdelijke bestanden
 
 # AmpMeter items
 TrackCurrentMeterTitle  = Baanstroommeter

--- a/java/src/jmri/jmrit/XmlFileLocationAction.java
+++ b/java/src/jmri/jmrit/XmlFileLocationAction.java
@@ -152,10 +152,10 @@ public class XmlFileLocationAction extends AbstractAction {
         s.append(Bundle.getMessage("ButtonRosterLoc") + ": ").append(Roster.getDefault().getRosterLocation()).append("\n");
         s.append(Bundle.getMessage("ButtonProfileLoc") + ": ").append(FileUtil.getProfilePath()).append("\n");
         s.append(Bundle.getMessage("ButtonSettingsLoc") + ": ").append(FileUtil.getPreferencesPath()).append("\n");
-        s.append(Bundle.getMessage("CurrentConfig")).append(configName).append("\n");
+        s.append(Bundle.getMessage("CurrentConfig") + ": ").append(configName).append("\n");
         s.append(Bundle.getMessage("ButtonScriptsLoc") + ": ").append(FileUtil.getScriptsPath()).append("\n");
         s.append(Bundle.getMessage("ButtonProgramLoc") + ": ").append(System.getProperty("user.dir")).append("\n");
-        s.append(Bundle.getMessage("TempFilesLoc")).append(System.getProperty("java.io.tmpdir")).append("\n");
+        s.append(Bundle.getMessage("TempFilesLoc") + ": ").append(System.getProperty("java.io.tmpdir")).append("\n");
         s.append(Bundle.getMessage("ButtonLogFilesLoc") + ": ").append(logDir).append("\n");
 
         //include names of any *.log files in log folder

--- a/java/src/jmri/jmrix/ncemonitor/NcePacketMonitorPanel.java
+++ b/java/src/jmri/jmrix/ncemonitor/NcePacketMonitorPanel.java
@@ -60,7 +60,7 @@ public class NcePacketMonitorPanel extends jmri.jmrix.AbstractMonPane implements
     protected JRadioButton locoOffButton = new JRadioButton(Bundle.getMessage("LocoOffLabel"));
     protected JRadioButton locoOnButton = new JRadioButton(Bundle.getMessage("LocoOnLabel"));
     protected JRadioButton resetOffButton = new JRadioButton(Bundle.getMessage("ResetOffLabel"));
-    protected JRadioButton resetOnButton = new JRadioButton(Bundle.getMessage("ResetOffLabel"));
+    protected JRadioButton resetOnButton = new JRadioButton(Bundle.getMessage("ResetOnLabel"));
     protected JRadioButton signalOffButton = new JRadioButton(Bundle.getMessage("SignalOffLabel"));
     protected JRadioButton signalOnButton = new JRadioButton(Bundle.getMessage("SignalOnLabel"));
     protected JRadioButton accSingleButton = new JRadioButton(Bundle.getMessage("AccSingleLabel"));


### PR DESCRIPTION
I noticed there was no space on the line for the Temp file or Config file locations between the colon and the path. Saw only those had the colon in the property but the rest did not. Changed the code and the properties to remove the colon from the properties and make all the code parts the same.