### PR TITLE
Multiple XML had references to "file:/" instead of "http://jmri.opg", this reverts those changes.

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -264,6 +264,11 @@
                 <li></li>
             </ul>
 
+        <h4>Leb</h4>
+            <ul>
+                <li>Fixed XML files when cross-referencing additional decoder details.</li>
+            </ul>
+
         <h4>MD Electronics</h4>
              <ul>
                 <li></li>
@@ -321,7 +326,7 @@
 
         <h4>SoundTraxx</h4>
             <ul>
-                <li></li>
+                <li>Fixed XML files when cross-referencing additional decoder details.</li>
             </ul>
 
         <h4>Tam Valley Depot</h4>

--- a/xml/decoders/Leb_ACC_4S.xml
+++ b/xml/decoders/Leb_ACC_4S.xml
@@ -24,7 +24,7 @@
     </family>
     <programming direct="no" paged="yes" register="no" ops="no"/>
     <variables>
- 	<xi:include href="file:/xml/decoders/leb/TableAllumage.xml"/>   
+ 	<xi:include href="http://jmri.org/xml/decoders/leb/TableAllumage.xml"/>   
      <variable CV="1" mask="XXVVVVVV" comment="Decoder address" item="Short Address" default="05">
         <splitVal highCV="9"/>
         <label>Decoder Address</label>
@@ -110,14 +110,14 @@
 
 
  	  	<variable CV="4" item="Indication a la mise sous tension" default="0" minOut="1">
-        <xi:include href="file:/xml/decoders/leb/enum-Signal_Indication.xml"/> 
+        <xi:include href="http://jmri.org/xml/decoders/leb/enum-Signal_Indication.xml"/> 
 	     <label>Indication a la mise sous tension</label>
 		<tooltip>Indication a la mise sous tension</tooltip>
 		</variable>
 
 
 	  	<variable CV="5" item="Allumage par no Cible" default="0" minOut="1">
-        <xi:include href="file:/xml/decoders/leb/enum-Signal_Cible.xml"/> 
+        <xi:include href="http://jmri.org/xml/decoders/leb/enum-Signal_Cible.xml"/> 
 	     <label>Allumage par no Cible</label>
 		<tooltip>Allumage par no Cible</tooltip>
 		</variable>
@@ -253,5 +253,5 @@
    
      <name>ACC_4S</name>
   </pane>
-  <xi:include href="file:/xml/decoders/leb/TableAllumagePane.xml"/>
+  <xi:include href="http://jmri.org/xml/decoders/leb/TableAllumagePane.xml"/>
  </decoder-config>

--- a/xml/decoders/Leb_DECSIGBF1_OP1.xml
+++ b/xml/decoders/Leb_DECSIGBF1_OP1.xml
@@ -21,7 +21,7 @@
 
 		<programming direct="no" paged="yes" register="no" ops="no"/>
 		<variables>
-		<xi:include href="file:/xml/decoders/leb/TableAllumageOptions.xml"/>	
+		<xi:include href="http://jmri.org/xml/decoders/leb/TableAllumageOptions.xml"/>	
 		
 			<variable CV="1" mask="XVVVVVVV" comment="Decoder A address " item="Short A Address " default="03" >
 <!--			<variable item="Low 7 bytes of Address CV1" CV="1" mask="XVVVVVVV" comment="Decoder address" default="01"> -->
@@ -175,7 +175,7 @@
 			</variable>
 			
 			<variable CV="12" item="CV 12/524 Indication a la mise sous tension" default="0" minOut="1">
-				<xi:include href="file:/xml/decoders/leb/enum-Signal_Indication.xml"/>
+				<xi:include href="http://jmri.org/xml/decoders/leb/enum-Signal_Indication.xml"/>
 				<label>      CV 12/524 Indication a la mise sous tension A</label>
 				<tooltip>Indication a la mise sous tension A</tooltip>
 			</variable>
@@ -197,7 +197,7 @@
 				<label>Table Allumage Personnalisee B</label>
 			</variable>
 			<variable CV="13" item="CV 13/525 Indication a la mise sous tension" default="0" minOut="1">
-				<xi:include href="file:/xml/decoders/leb/enum-Signal_Indication.xml"/>
+				<xi:include href="http://jmri.org/xml/decoders/leb/enum-Signal_Indication.xml"/>
 				<label>      CV 13/525 Indication a la mise sous tension B</label>
 				<tooltip>Indication a la mise sous tension B</tooltip>
 			</variable>
@@ -219,7 +219,7 @@
 				<label>Table Allumage Personnalisee C</label>
 			</variable>
 			<variable CV="14" item="CV 14/526 Indication a la mise sous tension" default="0" minOut="1">
-				<xi:include href="file:/xml/decoders/leb/enum-Signal_Indication.xml"/>
+				<xi:include href="http://jmri.org/xml/decoders/leb/enum-Signal_Indication.xml"/>
 				<label>      CV 14/526 Indication a la mise sous tension C</label>
 				<tooltip>Indication a la mise sous tension C</tooltip>
 			</variable>
@@ -511,6 +511,6 @@
 		</column>
 		<name>DECSIG_B_O1_V1</name>
 	</pane>
-	<xi:include href="file:/xml/decoders/leb/TableAllumageOptionsPane.xml"/>
+	<xi:include href="http://jmri.org/xml/decoders/leb/TableAllumageOptionsPane.xml"/>
 
 </decoder-config>

--- a/xml/decoders/Leb_DECSIGBF1_V1.xml
+++ b/xml/decoders/Leb_DECSIGBF1_V1.xml
@@ -24,7 +24,7 @@
     </family>
     <programming direct="no" paged="yes" register="no" ops="no"/>
     <variables>
-<!-- 	<xi:include href="file:/xml/decoders/leb/TableAllumage.xml"/>  -->
+<!-- 	<xi:include href="http://jmri.org/xml/decoders/leb/TableAllumage.xml"/>  -->
      <variable CV="1" mask="XXVVVVVV" comment="Decoder address" item="Short Address" default="03">
         <splitVal highCV="9"/>
         <label>Decoder Address</label>
@@ -92,7 +92,7 @@
 
 
 <!--	  	<variable CV="4" item="Indication a la mise sous tension" default="0" minOut="1">-->
-<!--        <xi:include href="file:/xml/decoders/leb/enum-Signal_Indication.xml"/> -->
+<!--        <xi:include href="http://jmri.org/xml/decoders/leb/enum-Signal_Indication.xml"/> -->
 <!--	     <label>Indication a la mise sous tension</label>-->
 <!--		<tooltip>Indication a la mise sous tension</tooltip>-->
 <!--		</variable>-->
@@ -225,5 +225,5 @@
    
      <name>DECSIG_B_F1_V1</name>
   </pane>
-<!--  <xi:include href="file:/xml/decoders/leb/TableAllumagePane.xml"/>-->
+<!--  <xi:include href="http://jmri.org/xml/decoders/leb/TableAllumagePane.xml"/>-->
  </decoder-config>

--- a/xml/decoders/Leb_DECSIGBF1_V2.xml
+++ b/xml/decoders/Leb_DECSIGBF1_V2.xml
@@ -26,7 +26,7 @@
     </family>
     <programming direct="no" paged="yes" register="no" ops="no"/>
     <variables>
- 	<xi:include href="file:/xml/decoders/leb/TableAllumage.xml"/>   
+ 	<xi:include href="http://jmri.org/xml/decoders/leb/TableAllumage.xml"/>   
      <variable CV="1" mask="XXVVVVVV" comment="Decoder address" item="Short Address" default="03">
         <splitVal highCV="9"/>
         <label>Decoder Address</label>
@@ -94,7 +94,7 @@
 
 
  	  	<variable CV="4" item="Indication a la mise sous tension" default="0" minOut="1">
-        <xi:include href="file:/xml/decoders/leb/enum-Signal_Indication.xml"/> 
+        <xi:include href="http://jmri.org/xml/decoders/leb/enum-Signal_Indication.xml"/> 
 	     <label>Indication a la mise sous tension</label>
 		<tooltip>Indication a la mise sous tension</tooltip>
 		</variable>
@@ -224,5 +224,5 @@
    
      <name>DECSIG_B_F1_V2</name>
   </pane>
-  <xi:include href="file:/xml/decoders/leb/TableAllumagePane.xml"/>
+  <xi:include href="http://jmri.org/xml/decoders/leb/TableAllumagePane.xml"/>
  </decoder-config>

--- a/xml/decoders/Leb_DECSIGBF1_V3.xml
+++ b/xml/decoders/Leb_DECSIGBF1_V3.xml
@@ -20,7 +20,7 @@
 		</family>
 		<programming direct="no" paged="yes" register="no" ops="no"/>
 		<variables>
-			<xi:include href="file:/xml/decoders/leb/TableAllumage.xml"/>
+			<xi:include href="http://jmri.org/xml/decoders/leb/TableAllumage.xml"/>
 			<variable CV="1" mask="XXVVVVVV" comment="Decoder address" item="Short Address" default="03">
 				<splitVal highCV="9"/>
 				<label>Decoder Address</label>
@@ -83,12 +83,12 @@
 				<label>Table Allumage Personnalisee</label>
 			</variable>
 			<variable CV="4" item="Indication a la mise sous tension" default="0" minOut="1">
-				<xi:include href="file:/xml/decoders/leb/enum-Signal_Indication.xml"/>
+				<xi:include href="http://jmri.org/xml/decoders/leb/enum-Signal_Indication.xml"/>
 				<label>Indication a la mise sous tension</label>
 				<tooltip>Indication a la mise sous tension</tooltip>
 			</variable>
 			<variable CV="5" item="Allumage par no Cible" default="0" minOut="1">
-				<xi:include href="file:/xml/decoders/leb/enum-Signal_Cible.xml"/>
+				<xi:include href="http://jmri.org/xml/decoders/leb/enum-Signal_Cible.xml"/>
 				<label>Allumage par no Cible</label>
 				<tooltip>Allumage par no Cible</tooltip>
 			</variable>
@@ -206,5 +206,5 @@
 		</column>
 		<name>DECSIG_B_F1_V3</name>
 	</pane>
-	<xi:include href="file:/xml/decoders/leb/TableAllumagePane.xml"/>
+	<xi:include href="http://jmri.org/xml/decoders/leb/TableAllumagePane.xml"/>
 </decoder-config>

--- a/xml/decoders/Leb_DECSIGBF1_V4.xml
+++ b/xml/decoders/Leb_DECSIGBF1_V4.xml
@@ -20,7 +20,7 @@
 		</family>
 			<programming direct="no" paged="yes" register="no" ops="no"/>
 		<variables>
-			<xi:include href="file:/xml/decoders/leb/TableAllumage.xml"/>
+			<xi:include href="http://jmri.org/xml/decoders/leb/TableAllumage.xml"/>
 			
 			<variable CV="1" mask="XVVVVVVV" comment="Decoder address" item="Short Address" default="05">
 				<splitVal highCV="9"/>
@@ -89,41 +89,41 @@
 				<label>2ID separes</label>
 			</variable>
 			<variable CV="4" item="CV 4/516 Indication a la mise sous tension" default="0" minOut="1">
-				<xi:include href="file:/xml/decoders/leb/enum-Signal_Indication.xml"/>
+				<xi:include href="http://jmri.org/xml/decoders/leb/enum-Signal_Indication.xml"/>
 				<label>CV 4/516 Indication a la mise sous tension</label>
 				<tooltip>Indication a la mise sous tension</tooltip>
 			</variable>
 			<variable CV="5" item="CV 5/517 Allumage par no Cible" default="0" minOut="1">
-				<xi:include href="file:/xml/decoders/leb/enum-Signal_Cible.xml"/>
+				<xi:include href="http://jmri.org/xml/decoders/leb/enum-Signal_Cible.xml"/>
 				<label>CV 5/517 Allumage par no Cible</label>
 				<tooltip>Allumage par no Cible</tooltip>
 			</variable>
 			
 			
 			<variable CV="10" item="Mapping Redirection ID1" mask="VVVVXXXX" default="00">
-				<xi:include href="file:/xml/decoders/leb/enum-Signal_REMAP_ID1.xml"/> 
+				<xi:include href="http://jmri.org/xml/decoders/leb/enum-Signal_REMAP_ID1.xml"/> 
 				<label>Mapping Redirection ID1</label>
 				<tooltip>Mapping Redirection ID1</tooltip>
 			</variable>
 			<variable CV="10" item="Mapping Redirection ID2"  mask="XXXXVVVV" default="00">
-				<xi:include href="file:/xml/decoders/leb/enum-Signal_REMAP_ID2.xml"/> 
+				<xi:include href="http://jmri.org/xml/decoders/leb/enum-Signal_REMAP_ID2.xml"/> 
 				<label>Mapping Redirection ID2</label>
 				<tooltip>Mapping Redirection ID2</tooltip>
 			</variable>
 			<variable CV="11" item="Mapping Redirection ID3"  mask="VVVVXXXX" default="00">
-				<xi:include href="file:/xml/decoders/leb/enum-Signal_REMAP_ID3.xml"/> 
+				<xi:include href="http://jmri.org/xml/decoders/leb/enum-Signal_REMAP_ID3.xml"/> 
 				<label>Mapping Redirection ID3</label>
 				<tooltip>Mapping Redirection ID3</tooltip>
 			</variable>
 			<variable CV="11" item="Mapping Redirection OPTION"  mask="XXXXVVVV" default="00">
-				<xi:include href="file:/xml/decoders/leb/enum-Signal_REMAP_OPTION.xml"/> 
+				<xi:include href="http://jmri.org/xml/decoders/leb/enum-Signal_REMAP_OPTION.xml"/> 
 				<label>Mapping Redirection OPTION</label>
 				<tooltip>Mapping Redirection OPTION</tooltip>
 			</variable>
 
 
 			<variable CV="12" item="CV 12/524 Choix Mode de Commande" default="0" minOut="1">
-				<xi:include href="file:/xml/decoders/leb/enum-Commande_BinLin.xml"/> 
+				<xi:include href="http://jmri.org/xml/decoders/leb/enum-Commande_BinLin.xml"/> 
 				<label>CV 12/524 Choix Mode de Commande</label>
 				<tooltip>Mode de Commande</tooltip>
 			</variable>
@@ -278,5 +278,5 @@
 		</column>
 		<name>DECSIG_B_F1_V4</name>
 	</pane>
-	<xi:include href="file:/xml/decoders/leb/TableAllumagePane.xml"/>
+	<xi:include href="http://jmri.org/xml/decoders/leb/TableAllumagePane.xml"/>
 </decoder-config>

--- a/xml/decoders/SoundTraxx_Blu_Diesel.xml
+++ b/xml/decoders/SoundTraxx_Blu_Diesel.xml
@@ -167,7 +167,7 @@
         </programming>
         <!-- Configuration Variable (CV) information follows -->
         <variables>
-            <xi:include href="/xml/decoders/soundtraxx/SoundTraxx_Blu_Tsu2_Diesel_cv.xml"/>
+            <xi:include href="http://jmri.org/xml/decoders/soundtraxx/SoundTraxx_Blu_Tsu2_Diesel_cv.xml"/>
         </variables>
         <resets>
             <factReset label="Reset all CVs to factory defaults" CV="8" default="8"/>

--- a/xml/decoders/leb/TableAllumage.xml
+++ b/xml/decoders/leb/TableAllumage.xml
@@ -48,97 +48,97 @@
   
 	<variable CV="13" item="Switching Mode Affichage no 0" default="0" minOut="1">
 <!--		<xi:include href="http://jmri.org/xml/decoders/qdecoder/enum-SwitchingModesPlus.xml"/>  --> 
-	    <xi:include href="file:/xml/decoders/leb/enum-Signal_Indication.xml"/> 
+	    <xi:include href="http://jmri.org/xml/decoders/leb/enum-Signal_Indication.xml"/> 
 		<label>CV 13/525 Affichage no   0</label>
 		<tooltip>Affichage no  0</tooltip>
 	</variable>
 	<variable CV="14" item="Switching Mode Affichage no 1" default="4" minOut="1">
 <!--		<xi:include href="http://jmri.org/xml/decoders/qdecoder/enum-SwitchingModesPlus.xml"/>  --> 
-	    <xi:include href="file:/xml/decoders/leb/enum-Signal_Indication.xml"/> 
+	    <xi:include href="http://jmri.org/xml/decoders/leb/enum-Signal_Indication.xml"/> 
 		<label>CV 14/526 Affichage no   1</label>
 		<tooltip>Affichage no  1</tooltip>
 	</variable>
 	<variable CV="15" item="Switching Mode Affichage no 2" default="8" minOut="1">
 <!--		<xi:include href="http://jmri.org/xml/decoders/qdecoder/enum-SwitchingModesPlus.xml"/>  --> 
-	    <xi:include href="file:/xml/decoders/leb/enum-Signal_Indication.xml"/> 
+	    <xi:include href="http://jmri.org/xml/decoders/leb/enum-Signal_Indication.xml"/> 
 		<label>CV 15/527 Affichage no   2</label>
 		<tooltip>Affichage no  2</tooltip>
 	</variable>
 	<variable CV="16" item="Switching Mode Affichage no 3" default="13" minOut="1">
 <!--		<xi:include href="http://jmri.org/xml/decoders/qdecoder/enum-SwitchingModesPlus.xml"/>  --> 
-	    <xi:include href="file:/xml/decoders/leb/enum-Signal_Indication.xml"/> 
+	    <xi:include href="http://jmri.org/xml/decoders/leb/enum-Signal_Indication.xml"/> 
 		<label>CV 16/528 Affichage no   3</label>
 		<tooltip>Affichage no 3</tooltip>
 	</variable>
 	<variable CV="17" item="Switching Mode Affichage no 4" default="0" minOut="1">
 <!--		<xi:include href="http://jmri.org/xml/decoders/qdecoder/enum-SwitchingModesPlus.xml"/>  --> 
-	    <xi:include href="file:/xml/decoders/leb/enum-Signal_Indication.xml"/> 
+	    <xi:include href="http://jmri.org/xml/decoders/leb/enum-Signal_Indication.xml"/> 
 		<label>CV 17/529 Affichage no   4</label>
 		<tooltip>Affichage no 4</tooltip>
 	</variable>
 	<variable CV="18" item="Switching Mode Affichage no 5" default="4" minOut="1">
 <!--		<xi:include href="http://jmri.org/xml/decoders/qdecoder/enum-SwitchingModesPlus.xml"/>  --> 
-	    <xi:include href="file:/xml/decoders/leb/enum-Signal_Indication.xml"/> 
+	    <xi:include href="http://jmri.org/xml/decoders/leb/enum-Signal_Indication.xml"/> 
 		<label>CV 18/530 Affichage no   5</label>
 		<tooltip>Affichage no 5</tooltip>
 	</variable>
 	<variable CV="19" item="Switching Mode Affichage no 6" default="3" minOut="1">
 <!--		<xi:include href="http://jmri.org/xml/decoders/qdecoder/enum-SwitchingModesPlus.xml"/>  --> 
-	    <xi:include href="file:/xml/decoders/leb/enum-Signal_Indication.xml"/> 
+	    <xi:include href="http://jmri.org/xml/decoders/leb/enum-Signal_Indication.xml"/> 
 		<label>CV 19/531 Affichage no   6</label>
 		<tooltip>Affichage no 6</tooltip>
 	</variable>
 	<variable CV="20" item="Switching Mode Affichage no 7" default="2" minOut="1">
 <!--		<xi:include href="http://jmri.org/xml/decoders/qdecoder/enum-SwitchingModesPlus.xml"/>  --> 
-	    <xi:include href="file:/xml/decoders/leb/enum-Signal_Indication.xml"/> 
+	    <xi:include href="http://jmri.org/xml/decoders/leb/enum-Signal_Indication.xml"/> 
 		<label>CV 20/532 Affichage no   7</label>
 		<tooltip>Affichage no 7</tooltip>
 	</variable>
 	<variable CV="21" item="Switching Mode Affichage no 8" default="0" minOut="1">
 <!--		<xi:include href="http://jmri.org/xml/decoders/qdecoder/enum-SwitchingModesPlus.xml"/>  --> 
-	    <xi:include href="file:/xml/decoders/leb/enum-Signal_Indication.xml"/> 
+	    <xi:include href="http://jmri.org/xml/decoders/leb/enum-Signal_Indication.xml"/> 
 		<label>CV 21/533 Affichage no   8</label>
 		<tooltip>Affichage no 8</tooltip>
 	</variable>
 	<variable CV="22" item="Switching Mode Affichage no 9" default="4" minOut="1">
 <!--		<xi:include href="http://jmri.org/xml/decoders/qdecoder/enum-SwitchingModesPlus.xml"/>  --> 
-	    <xi:include href="file:/xml/decoders/leb/enum-Signal_Indication.xml"/> 
+	    <xi:include href="http://jmri.org/xml/decoders/leb/enum-Signal_Indication.xml"/> 
 		<label>CV 22/534 Affichage no   9</label>
 		<tooltip>Affichage no 9</tooltip>
 	</variable>
 	<variable CV="23" item="Switching Mode Affichage no 10" default="6" minOut="1">
 <!--		<xi:include href="http://jmri.org/xml/decoders/qdecoder/enum-SwitchingModesPlus.xml"/>  --> 
-	    <xi:include href="file:/xml/decoders/leb/enum-Signal_Indication.xml"/> 
+	    <xi:include href="http://jmri.org/xml/decoders/leb/enum-Signal_Indication.xml"/> 
 		<label>CV 23/535 Affichage no  10</label>
 		<tooltip>Affichage no 10</tooltip>
 	</variable>
 	<variable CV="24" item="Switching Mode Affichage no 11" default="14" minOut="1">
 <!--		<xi:include href="http://jmri.org/xml/decoders/qdecoder/enum-SwitchingModesPlus.xml"/>  --> 
-	    <xi:include href="file:/xml/decoders/leb/enum-Signal_Indication.xml"/> 
+	    <xi:include href="http://jmri.org/xml/decoders/leb/enum-Signal_Indication.xml"/> 
 		<label>CV 24/536 Affichage no  11</label>
 		<tooltip>Affichage no 11</tooltip>
 	</variable>
 	<variable CV="25" item="Switching Mode Affichage no 12" default="9" minOut="1">
 <!--		<xi:include href="http://jmri.org/xml/decoders/qdecoder/enum-SwitchingModesPlus.xml"/>  --> 
-	    <xi:include href="file:/xml/decoders/leb/enum-Signal_Indication.xml"/> 
+	    <xi:include href="http://jmri.org/xml/decoders/leb/enum-Signal_Indication.xml"/> 
 		<label>CV 25/537 Affichage no  12</label>
 		<tooltip>Affichage no 12</tooltip>
 	</variable>
 	<variable CV="26" item="Switching Mode Affichage no 13" default="8" minOut="1">
 <!--		<xi:include href="http://jmri.org/xml/decoders/qdecoder/enum-SwitchingModesPlus.xml"/>  --> 
-	    <xi:include href="file:/xml/decoders/leb/enum-Signal_Indication.xml"/> 
+	    <xi:include href="http://jmri.org/xml/decoders/leb/enum-Signal_Indication.xml"/> 
 		<label>CV 26/538 Affichage no  13</label>
 		<tooltip>Affichage no 13</tooltip>
 	</variable>
 	<variable CV="27" item="Switching Mode Affichage no 14" default="13" minOut="1">
 <!--		<xi:include href="http://jmri.org/xml/decoders/qdecoder/enum-SwitchingModesPlus.xml"/>  --> 
-	    <xi:include href="file:/xml/decoders/leb/enum-Signal_Indication.xml"/> 
+	    <xi:include href="http://jmri.org/xml/decoders/leb/enum-Signal_Indication.xml"/> 
 		<label>CV 27/539 Affichage no  14</label>
 		<tooltip>Affichage no 14</tooltip>
 	</variable>
 	<variable CV="28" item="Switching Mode Affichage no 15" default="12" minOut="1">
 <!--		<xi:include href="http://jmri.org/xml/decoders/qdecoder/enum-SwitchingModesPlus.xml"/>  --> 
-	    <xi:include href="file:/xml/decoders/leb/enum-Signal_Indication.xml"/> 
+	    <xi:include href="http://jmri.org/xml/decoders/leb/enum-Signal_Indication.xml"/> 
 		<label>CV 28/540 Affichage no  15</label>
 		<tooltip>Affichage no 15</tooltip>
 	</variable>

--- a/xml/decoders/leb/TableAllumageOptions.xml
+++ b/xml/decoders/leb/TableAllumageOptions.xml
@@ -48,58 +48,58 @@
   </revhistory>
   
 	<variable CV="15" item="Switching Mode Affichage no 0" default="0" minOut="1">
-	    <xi:include href="file:/xml/decoders/leb/enum-Signal_Options.xml"/> 
+	    <xi:include href="http://jmri.org/xml/decoders/leb/enum-Signal_Options.xml"/> 
 		<label>CV 15/527 Choix Allumage Led no  1</label>
 		<tooltip>Led  1</tooltip>
 	</variable>
 	<variable CV="16" item="Switching Mode Affichage no 1" default="4" minOut="1">
-	    <xi:include href="file:/xml/decoders/leb/enum-Signal_Options.xml"/> 
+	    <xi:include href="http://jmri.org/xml/decoders/leb/enum-Signal_Options.xml"/> 
 		<label>CV 16/528 Choix Allumage Led no  2</label>
 		<tooltip>Led  2</tooltip>
 	</variable>
 	<variable CV="17" item="Switching Mode Affichage no 2" default="8" minOut="1">
-	    <xi:include href="file:/xml/decoders/leb/enum-Signal_Options.xml"/> 
+	    <xi:include href="http://jmri.org/xml/decoders/leb/enum-Signal_Options.xml"/> 
 		<label>CV 17/529 Choix Allumage Led no  3</label>
 		<tooltip>Led  3</tooltip>
 	</variable>
 	<variable CV="18" item="Switching Mode Affichage no 3" default="12" minOut="1">
-	    <xi:include href="file:/xml/decoders/leb/enum-Signal_Options.xml"/> 
+	    <xi:include href="http://jmri.org/xml/decoders/leb/enum-Signal_Options.xml"/> 
 		<label>CV 18/530 Choix Allumage Led no  4</label>
 		<tooltip>Led 4</tooltip>
 	</variable>
 	<variable CV="19" item="Switching Mode Affichage no 4" default="0" minOut="1">
-	    <xi:include href="file:/xml/decoders/leb/enum-Signal_Options.xml"/> 
+	    <xi:include href="http://jmri.org/xml/decoders/leb/enum-Signal_Options.xml"/> 
 		<label>CV 19/531 Choix Allumage Led no  5</label>
 		<tooltip>Led 5</tooltip>
 	</variable>
 	<variable CV="20" item="Switching Mode Affichage no 5" default="4" minOut="1">
-	    <xi:include href="file:/xml/decoders/leb/enum-Signal_Options.xml"/> 
+	    <xi:include href="http://jmri.org/xml/decoders/leb/enum-Signal_Options.xml"/> 
 		<label>CV 20/532 Choix Allumage Led no  6</label>
 		<tooltip>Led 6</tooltip>
 	</variable>
 	<variable CV="21" item="Switching Mode Affichage no 6" default="3" minOut="1">
-	    <xi:include href="file:/xml/decoders/leb/enum-Signal_Options.xml"/> 
+	    <xi:include href="http://jmri.org/xml/decoders/leb/enum-Signal_Options.xml"/> 
 		<label>CV 21/533 Choix Allumage Led no  7</label>
 		<tooltip>Led 7</tooltip>
 	</variable>
 	<!--
 	<variable CV="534" item="Switching Mode Affichage no 7" default="2" minOut="1">
-	    <xi:include href="file:/xml/decoders/leb/enum-Signal_Options.xml"/> 
+	    <xi:include href="http://jmri.org/xml/decoders/leb/enum-Signal_Options.xml"/> 
 		<label>CV 22/534 Choix Allumage Led no  8</label>
 		<tooltip>Led 8</tooltip>
 	</variable>
 	<variable CV="535" item="Switching Mode Affichage no 8" default="0" minOut="1">
-	    <xi:include href="file:/xml/decoders/leb/enum-Signal_Options.xml"/> 
+	    <xi:include href="http://jmri.org/xml/decoders/leb/enum-Signal_Options.xml"/> 
 		<label>CV 23/535 Choix Allumage Led no  9</label>
 		<tooltip>Led 9</tooltip>
 	</variable>
 		<variable CV="536" item="Switching Mode Affichage no 9" default="4" minOut="1">
-	    <xi:include href="file:/xml/decoders/leb/enum-Signal_Options.xml"/> 
+	    <xi:include href="http://jmri.org/xml/decoders/leb/enum-Signal_Options.xml"/> 
 		<label>CV 24/536 Choix Allumage Led no 10</label>
 		<tooltip>Led 10</tooltip>
 	</variable>
 	<variable CV="537" item="Switching Mode Affichage no 10" default="4" minOut="1">
-	    <xi:include href="file:/xml/decoders/leb/enum-Signal_Options.xml"/> 
+	    <xi:include href="http://jmri.org/xml/decoders/leb/enum-Signal_Options.xml"/> 
 		<label>CV 25/537 Choix Allumage Led no 11</label>
 		<tooltip>Led 11</tooltip>
 	</variable>

--- a/xml/decoders/leb/enum-Commande_BinLin.xml
+++ b/xml/decoders/leb/enum-Commande_BinLin.xml
@@ -35,5 +35,5 @@
   </revhistory>
   <!-- Specific for Qdecoder accessory decoder -->
 	<!-- Switching modes for + (plus) decoders   -->
-	<xi:include href="file:/xml/decoders/leb/choix-BinLin.xml"/>  
+	<xi:include href="http://jmri.org/xml/decoders/leb/choix-BinLin.xml"/>  
 </enumVal>

--- a/xml/decoders/leb/enum-Signal_Cible.xml
+++ b/xml/decoders/leb/enum-Signal_Cible.xml
@@ -35,5 +35,5 @@
   </revhistory>
   <!-- Specific for Qdecoder accessory decoder -->
 	<!-- Switching modes for + (plus) decoders   -->
-	<xi:include href="file:/xml/decoders/leb/choix-Signal_Cible.xml"/>  
+	<xi:include href="http://jmri.org/xml/decoders/leb/choix-Signal_Cible.xml"/>  
 </enumVal>

--- a/xml/decoders/leb/enum-Signal_Indication.xml
+++ b/xml/decoders/leb/enum-Signal_Indication.xml
@@ -35,5 +35,5 @@
   </revhistory>
   <!-- Specific for Qdecoder accessory decoder -->
 	<!-- Switching modes for + (plus) decoders   -->
-	<xi:include href="file:/xml/decoders/leb/choix-Signal_Indication.xml"/>  
+	<xi:include href="http://jmri.org/xml/decoders/leb/choix-Signal_Indication.xml"/>  
 </enumVal>

--- a/xml/decoders/leb/enum-Signal_Options.xml
+++ b/xml/decoders/leb/enum-Signal_Options.xml
@@ -35,5 +35,5 @@
   </revhistory>
   <!-- Specific for Qdecoder accessory decoder -->
 	<!-- Switching modes for + (plus) decoders   -->
-	<xi:include href="file:/xml/decoders/leb/choix-Signal_Options.xml"/>  
+	<xi:include href="http://jmri.org/xml/decoders/leb/choix-BinLin.xml"/>  
 </enumVal>

--- a/xml/decoders/leb/enum-Signal_Options.xml
+++ b/xml/decoders/leb/enum-Signal_Options.xml
@@ -35,5 +35,5 @@
   </revhistory>
   <!-- Specific for Qdecoder accessory decoder -->
 	<!-- Switching modes for + (plus) decoders   -->
-	<xi:include href="http://jmri.org/xml/decoders/leb/choix-BinLin.xml"/>  
+	<xi:include href="http://jmri.org/xml/decoders/leb/choix-Signal_Options.xml"/>  
 </enumVal>

--- a/xml/decoders/leb/enum-Signal_REMAP_ID1.xml
+++ b/xml/decoders/leb/enum-Signal_REMAP_ID1.xml
@@ -35,5 +35,5 @@
   </revhistory>
   <!-- Specific for Qdecoder accessory decoder -->
 	<!-- Switching modes for + (plus) decoders   -->
-	<xi:include href="file:/xml/decoders/leb/choix-Remap_led.xml"/>  
+	<xi:include href="http://jmri.org/xml/decoders/leb/choix-Remap_led.xml"/>  
 </enumVal>

--- a/xml/decoders/leb/enum-Signal_REMAP_ID2.xml
+++ b/xml/decoders/leb/enum-Signal_REMAP_ID2.xml
@@ -35,5 +35,5 @@
   </revhistory>
   <!-- Specific for Qdecoder accessory decoder -->
 	<!-- Switching modes for + (plus) decoders   -->
-	<xi:include href="file:/xml/decoders/leb/choix-Remap_led.xml"/>  
+	<xi:include href="http://jmri.org/xml/decoders/leb/choix-Remap_led.xml"/>  
 </enumVal>

--- a/xml/decoders/leb/enum-Signal_REMAP_ID3.xml
+++ b/xml/decoders/leb/enum-Signal_REMAP_ID3.xml
@@ -35,5 +35,5 @@
   </revhistory>
   <!-- Specific for Qdecoder accessory decoder -->
 	<!-- Switching modes for + (plus) decoders   -->
-	<xi:include href="file:/xml/decoders/leb/choix-Remap_led.xml"/>  
+	<xi:include href="http://jmri.org/xml/decoders/leb/choix-Remap_led.xml"/>  
 </enumVal>

--- a/xml/decoders/leb/enum-Signal_REMAP_OPTION.xml
+++ b/xml/decoders/leb/enum-Signal_REMAP_OPTION.xml
@@ -35,5 +35,5 @@
   </revhistory>
   <!-- Specific for Qdecoder accessory decoder -->
 	<!-- Switching modes for + (plus) decoders   -->
-	<xi:include href="file:/xml/decoders/leb/choix-Remap_led.xml"/>  
+	<xi:include href="http://jmri.org/xml/decoders/leb/choix-Remap_led.xml"/>  
 </enumVal>


### PR DESCRIPTION
Looks like commit #110615748341c619a0c796eb4ab9d49e4cc863f3 that added some files. Those original files had file:/ instead of http://jmri.org/

Don't worry. I'm not scrapping jmri.org website for these files, i'm using a local version.