### PR TITLE
Fix German language tag syntax for Firbox / Feuerbüchse

### DIFF
--- a/xml/decoders/ANE_Model_LocoCruiser_V201.xml
+++ b/xml/decoders/ANE_Model_LocoCruiser_V201.xml
@@ -669,7 +669,7 @@
           </enumChoice>
           <enumChoice choice="Firebox" value="36">
             <choice>Firebox</choice>
-            <choice xml:lang="Feuerbüchse"></choice>
+            <choice xml:lang="de">Feuerbüchse</choice>
             <choice xml:lang="nl">Vuurkist</choice>
           </enumChoice>
           <enumChoice choice="Warning light" value="69">
@@ -740,7 +740,7 @@
           </enumChoice>
           <enumChoice choice="Firebox" value="36">
             <choice>Firebox</choice>
-            <choice xml:lang="Feuerbüchse"></choice>
+            <choice xml:lang="de">Feuerbüchse</choice>
             <choice xml:lang="nl">Vuurkist</choice>
           </enumChoice>
           <enumChoice choice="Warning light" value="69">
@@ -811,7 +811,7 @@
           </enumChoice>
           <enumChoice choice="Firebox" value="36">
             <choice>Firebox</choice>
-            <choice xml:lang="Feuerbüchse"></choice>
+            <choice xml:lang="de">Feuerbüchse</choice>
             <choice xml:lang="nl">Vuurkist</choice>
           </enumChoice>
           <enumChoice choice="Warning light" value="69">
@@ -882,7 +882,7 @@
           </enumChoice>
           <enumChoice choice="Firebox" value="36">
             <choice>Firebox</choice>
-            <choice xml:lang="Feuerbüchse"></choice>
+            <choice xml:lang="de">Feuerbüchse</choice>
             <choice xml:lang="nl">Vuurkist</choice>
           </enumChoice>
           <enumChoice choice="Warning light" value="69">
@@ -953,7 +953,7 @@
           </enumChoice>
           <enumChoice choice="Firebox" value="36">
             <choice>Firebox</choice>
-            <choice xml:lang="Feuerbüchse"></choice>
+            <choice xml:lang="de">Feuerbüchse</choice>
             <choice xml:lang="nl">Vuurkist</choice>
           </enumChoice>
           <enumChoice choice="Warning light" value="69">
@@ -1024,7 +1024,7 @@
           </enumChoice>
           <enumChoice choice="Firebox" value="36">
             <choice>Firebox</choice>
-            <choice xml:lang="Feuerbüchse"></choice>
+            <choice xml:lang="de">Feuerbüchse</choice>
             <choice xml:lang="nl">Vuurkist</choice>
           </enumChoice>
           <enumChoice choice="Warning light" value="69">


### PR DESCRIPTION
This file wasn't passing some of my checks, turns out that this file hasn't had a proper German language tag for 2 years.