### PR TITLE
CBUS Node Delete Event - prevent NPE

### DIFF
--- a/java/src/jmri/jmrix/can/cbus/node/CbusBasicNode.java
+++ b/java/src/jmri/jmrix/can/cbus/node/CbusBasicNode.java
@@ -84,7 +84,7 @@ public class CbusBasicNode {
      * ALLNVUPDATE
      * SINGLEEVUPDATE ( newValue event row )
      * ALLEVUPDATE
-     * DELETEEVCOMPLETE ( newValue Error String else null )
+     * DELETEEVCOMPLETE ( newValue Error String else empty String )
      * ADDEVCOMPLETE ( newValue Error String else null )
      * ADDALLEVCOMPLETE ( Event Teach Loop Completed, newValue error count )
      * TEACHNVCOMPLETE ( newValue error count )

--- a/java/src/jmri/jmrix/can/cbus/node/CbusNodeEventManager.java
+++ b/java/src/jmri/jmrix/can/cbus/node/CbusNodeEventManager.java
@@ -233,12 +233,12 @@ public class CbusNodeEventManager {
      */
     public int getOutstandingEvVars(){
         int count = 0;
-        ArrayList<CbusNodeEvent> _evs = getEventArray();
-        if (  _evs == null ){
+        ArrayList<CbusNodeEvent> evs = getEventArray();
+        if (  evs == null ){
             return -1;
         }
-        for (int i = 0; i < _evs.size(); i++) {
-            count = count + _evs.get(i).getOutstandingVars();
+        for (int i = 0; i < evs.size(); i++) {
+            count += evs.get(i).getOutstandingVars();
         }
         return count;
     }
@@ -249,11 +249,11 @@ public class CbusNodeEventManager {
      * This sets the remaining ev vars to 0 so are not requested
      */
     protected void remainingEvVarsNotNeeded(){
-        ArrayList<CbusNodeEvent> _evs = getEventArray();
-        if (_evs!=null) {
-            for (int i = 0; i < _evs.size(); i++) {
-                if ( _evs.get(i).getNextOutstanding() > 0 ) {
-                    _evs.get(i).allOutstandingEvVarsNotNeeded();
+        ArrayList<CbusNodeEvent> evs = getEventArray();
+        if (evs!=null) {
+            for (int i = 0; i < evs.size(); i++) {
+                if ( evs.get(i).getNextOutstanding() > 0 ) {
+                    evs.get(i).allOutstandingEvVarsNotNeeded();
 
                     // cancel Timer
                     _node.getNodeTimerManager().clearNextEvVarTimeout();
@@ -455,10 +455,12 @@ public class CbusNodeEventManager {
             _node.send.nodeUnlearnEvent( nn, en );
             setEvIndexValid(false);
         }, 50 );
+        log.info("Deleted Event {} on Node {}",
+            new jmri.jmrix.can.cbus.CbusEvent(nn,en),_node.getNodeNumber());
         ThreadingUtil.runOnGUIDelayed( () -> {
             _node.send.nodeExitLearnEvMode( _node.getNodeNumber() );
             // notify ui
-            _node.notifyPropertyChangeListener("DELETEEVCOMPLETE", null, null);
+            _node.notifyPropertyChangeListener("DELETEEVCOMPLETE", null, "");
         }, 100 );
     }
 

--- a/java/test/jmri/jmrix/can/cbus/swing/nodeconfig/CbusNodeEditEventFrameTest.java
+++ b/java/test/jmri/jmrix/can/cbus/swing/nodeconfig/CbusNodeEditEventFrameTest.java
@@ -12,8 +12,7 @@ import jmri.util.JUnitUtil;
 import org.junit.Assert;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
-import org.netbeans.jemmy.operators.JButtonOperator;
-import org.netbeans.jemmy.operators.JFrameOperator;
+import org.netbeans.jemmy.operators.*;
 
 /**
  * Test simple functioning of CbusNodeEditEventFrame
@@ -49,6 +48,34 @@ public class CbusNodeEditEventFrameTest extends jmri.util.JmriJFrameTestBase {
         Assert.assertTrue(getDeleteButtonEnabled(jfo));
 
 
+        Thread t = new Thread(() -> {
+            // delete event? yes / no
+            JDialogOperator jdo = new JDialogOperator(Bundle.getMessage("DelEvPopTitle"));
+            JButtonOperator jbo = new JButtonOperator(jdo, Bundle.getMessage("ButtonYes"));
+            jbo.pushNoBlock();
+        });
+        t.setName("Confirm Delete Event Dialog Thread");
+        t.start();
+
+        new JButtonOperator(jfo,Bundle.getMessage("ButtonDelete")).doClick();
+
+        JUnitUtil.waitFor(()-> !t.isAlive(), "Confirm Delete Event Dialog finished");
+
+        JUnitUtil.waitFor(()-> !tcis.outbound.isEmpty(), "at least 1 frame sent");
+
+        Assertions.assertEquals("[5f8] 53 01 00", tcis.outbound.get(0).toString()
+            ,"Node Enter Learn Mode");
+
+        JUnitUtil.waitFor(()-> tcis.outbound.size() > 1, "2 frames sent");
+        Assertions.assertEquals("[5f8] 95 00 00 00 07", tcis.outbound.get(1).toString()
+            ,"Unlearn Event 7");
+
+        JUnitUtil.waitFor(()-> tcis.outbound.size() > 2, "3 frames sent");
+        Assertions.assertEquals("[5f8] 54 01 00", tcis.outbound.get(2).toString()
+            ,"Node Exit Learn Mode");
+
+        // window auto-closes as Event no longer exists
+        jfo.waitClosed();
     }
 
     private boolean getEditButtonEnabled( JFrameOperator jfo ){


### PR DESCRIPTION
Pass empty String if no error instead of null.
Minor rename internal vars.
Add logging statement on Event delete
Extends test to Delete Event, fails with current HOM.