### PR TITLE
Compacting choices for yes/no and no/yes.

### DIFF
--- a/xml/decoders/ANE_LC201.xml
+++ b/xml/decoders/ANE_LC201.xml
@@ -82,178 +82,103 @@
       <xi:include href="http://jmri.org/xml/decoders/nmra/cv29table1-28.xml"/>
       <!-- Define the fixed Function-Output mapping -->
       <variable item="FL(f) controls output 1" CV="33" mask="XXXXXXXV" minOut="1" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 1</label>
       </variable>
       <variable item="FL(r) controls output 1" CV="34" mask="XXXXXXXV" minOut="1" default="0">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 1</label>
       </variable>
       <variable item="FL(f) controls output 2" CV="33" mask="XXXXXXVX" minOut="1" default="0">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 2</label>
       </variable>
       <variable item="FL(r) controls output 2" CV="34" mask="XXXXXXVX" minOut="1" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 2</label>
       </variable>
       <variable item="FL(f) controls output 3" CV="33" mask="XXXXXVXX" minOut="1" default="0">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 3</label>
       </variable>
       <variable item="FL(r) controls output 3" CV="34" mask="XXXXXVXX" minOut="1" default="0">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 3</label>
       </variable>
       <variable item="FL(f) controls output 4" CV="33" mask="XXXXVXXX" minOut="1" default="0">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 4</label>
       </variable>
       <variable item="FL(r) controls output 4" CV="34" mask="XXXXVXXX" minOut="1" default="0">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 4</label>
       </variable>
       <variable item="FL(f) controls output 5" CV="33" mask="XXXVXXXX" minOut="1" default="0">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 5</label>
       </variable>
       <variable item="FL(r) controls output 5" CV="34" mask="XXXVXXXX" minOut="1" default="0">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 5</label>
       </variable>
       <variable item="F1 controls output 1" CV="35" mask="XXXXXXXV" minOut="1" default="0">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 1</label>
       </variable>
       <variable item="F1 controls output 2" CV="35" mask="XXXXXXVX" minOut="1" default="0">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 2</label>
       </variable>
       <variable item="F1 controls output 3" CV="35" mask="XXXXXVXX" minOut="1" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 3</label>
       </variable>
       <variable item="F1 controls output 4" CV="35" mask="XXXXVXXX" minOut="1" default="0">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 4</label>
       </variable>
       <variable item="F1 controls output 5" CV="35" mask="XXXVXXXX" minOut="1" default="0">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 5</label>
       </variable>
       <variable item="F2 controls output 1" CV="36" mask="XXXXXXXV" minOut="1" default="0">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 1</label>
       </variable>
       <variable item="F2 controls output 2" CV="36" mask="XXXXXXVX" minOut="1" default="0">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 2</label>
       </variable>
       <variable item="F2 controls output 3" CV="36" mask="XXXXXVXX" minOut="1" default="0">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 3</label>
       </variable>
       <variable item="F2 controls output 4" CV="36" mask="XXXXVXXX" minOut="1" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 4</label>
       </variable>
       <variable item="F2 controls output 5" CV="36" mask="XXXVXXXX" minOut="1" default="0">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 5</label>
       </variable>
       <variable item="F3 controls output 1" CV="37" mask="XXXXXXXV" minOut="1" default="0">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 1</label>
       </variable>
       <variable item="F3 controls output 2" CV="37" mask="XXXXXXVX" minOut="1" default="0">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 2</label>
       </variable>
       <variable item="F3 controls output 3" CV="37" mask="XXXXXVXX" minOut="1" default="0">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 3</label>
       </variable>
       <variable item="F3 controls output 4" CV="37" mask="XXXXVXXX" minOut="1" default="0">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 4</label>
       </variable>
       <variable item="F3 controls output 5" CV="37" mask="XXXVXXXX" minOut="1" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 5</label>
       </variable>
       <variable item="FOF is Light on" CV="49" mask="XXXXXXXV">

--- a/xml/decoders/CML_Systems_DAC10.xml
+++ b/xml/decoders/CML_Systems_DAC10.xml
@@ -2455,14 +2455,7 @@
         <label>Local route 1 sets turnout 2</label>
       </variable>
       <variable item="Turnout 3 included in local route 1" CV="48" mask="XXXXXVXX">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Turnout 3 included in local route 1</label>
       </variable>
       <variable item="Local route 1 sets turnout 3" CV="49" mask="XXXXXVXX">

--- a/xml/decoders/CT_Elektronik_DCX_old.xml
+++ b/xml/decoders/CT_Elektronik_DCX_old.xml
@@ -119,531 +119,195 @@
      <xi:include href="http://jmri.org/xml/decoders/nmra/cv29analog.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/nmra/cv29table3-28.xml"/>
       <variable item="FL(f) controls output 1" CV="33" default="1" mask="XXXXXXXV" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 1</label>
       </variable>
       <variable item="FL(f) controls output 2" CV="33" mask="XXXXXXVX" minOut="2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 2</label>
       </variable>
       <variable item="FL(f) controls output 3" CV="33" mask="XXXXXVXX" minOut="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 3</label>
       </variable>
       <variable item="FL(f) controls output 4" CV="33" mask="XXXXVXXX" minOut="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 4</label>
       </variable>
       <variable item="FL(f) controls output 5" CV="33" mask="XXXVXXXX" minOut="5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 5</label>
       </variable>
       <variable item="FL(f) controls output 6" CV="33" mask="XXVXXXXX" minOut="6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 6</label>
       </variable>
       <variable item="FL(f) controls output 7" CV="33" mask="XVXXXXXX" minOut="7">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 7</label>
       </variable>
       <variable item="FL(r) controls output 1" CV="34" mask="XXXXXXXV" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 1</label>
       </variable>
       <variable item="FL(r) controls output 2" CV="34" default="1" mask="XXXXXXVX" minOut="2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 2</label>
       </variable>
       <variable item="FL(r) controls output 3" CV="34" mask="XXXXXVXX" minOut="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 3</label>
       </variable>
       <variable item="FL(r) controls output 4" CV="34" mask="XXXXVXXX" minOut="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 4</label>
       </variable>
       <variable item="FL(r) controls output 5" CV="34" mask="XXXVXXXX" minOut="5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 5</label>
       </variable>
       <variable item="FL(r) controls output 6" CV="34" mask="XXVXXXXX" minOut="6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 6</label>
       </variable>
       <variable item="FL(r) controls output 7" CV="34" mask="XVXXXXXX" minOut="7">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 7</label>
       </variable>
       <variable item="F1 controls output 1" CV="35" mask="XXXXXXXV" minOut="1" minFn="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 1</label>
       </variable>
       <variable item="F1 controls output 2" CV="35" mask="XXXXXXVX" minOut="2" minFn="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 2</label>
       </variable>
       <variable item="F1 controls output 3" CV="35" default="1" mask="XXXXXVXX" minOut="3" minFn="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 3</label>
       </variable>
       <variable item="F1 controls output 4" CV="35" mask="XXXXVXXX" minOut="4" minFn="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 4</label>
       </variable>
       <variable item="F1 controls output 5" CV="35" mask="XXXVXXXX" minOut="5" minFn="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 5</label>
       </variable>
       <variable item="F1 controls output 6" CV="35" mask="XXVXXXXX" minOut="6" minFn="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 6</label>
       </variable>
       <variable item="F1 controls output 7" CV="35" mask="XVXXXXXX" minOut="7" minFn="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 7</label>
       </variable>
       <variable item="F2 controls output 1" CV="36" mask="XXXXXXXV" minOut="1" minFn="2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 1</label>
       </variable>
       <variable item="F2 controls output 2" CV="36" mask="XXXXXXVX" minOut="2" minFn="2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 2</label>
       </variable>
       <variable item="F2 controls output 3" CV="36" mask="XXXXXVXX" minOut="3" minFn="2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 3</label>
       </variable>
       <variable item="F2 controls output 4" CV="36" default="1" mask="XXXXVXXX" minOut="4" minFn="2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 4</label>
       </variable>
       <variable item="F2 controls output 5" CV="36" mask="XXXVXXXX" minOut="5" minFn="2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 5</label>
       </variable>
       <variable item="F2 controls output 6" CV="36" mask="XXVXXXXX" minOut="6" minFn="2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 6</label>
       </variable>
       <variable item="F2 controls output 7" CV="36" mask="XVXXXXXX" minOut="7" minFn="2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 7</label>
       </variable>
       <variable item="F3 controls output 3" CV="37" mask="XXXXXVXX" minOut="3" minFn="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 3</label>
       </variable>
       <variable item="F3 controls output 4" CV="37" mask="XXXXVXXX" minOut="4" minFn="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 4</label>
       </variable>
       <variable item="F3 controls output 5" CV="37" default="1" mask="XXXVXXXX" minOut="5" minFn="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 5</label>
       </variable>
       <variable item="F3 controls output 6" CV="37" mask="XXVXXXXX" minOut="6" minFn="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 6</label>
       </variable>
       <variable item="F3 controls output 7" CV="37" mask="XVXXXXXX" minOut="7" minFn="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 7</label>
       </variable>
       <variable item="F4 controls output 3" CV="38" mask="XXXXXXXV" minOut="3" minFn="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 3</label>
       </variable>
       <variable item="F4 controls output 4" CV="38" mask="XXXXXXVX" minOut="4" minFn="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 4</label>
       </variable>
       <variable item="F4 controls output 5" CV="38" mask="XXXXXVXX" minOut="5" minFn="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 5</label>
       </variable>
       <variable item="F4 controls output 6" CV="38" default="1" mask="XXXXVXXX" minOut="6" minFn="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 6</label>
       </variable>
       <variable item="F4 controls output 7" CV="38" mask="XXXVXXXX" minOut="7" minFn="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 7</label>
       </variable>
       <variable item="F5 controls output 3" CV="39" mask="XXXXXXXV" minOut="3" minFn="5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 3</label>
       </variable>
       <variable item="F5 controls output 4" CV="39" mask="XXXXXXVX" minOut="4" minFn="5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 4</label>
       </variable>
       <variable item="F5 controls output 5" CV="39" mask="XXXXXVXX" minOut="5" minFn="5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 5</label>
       </variable>
       <variable item="F5 controls output 6" CV="39" mask="XXXXVXXX" minOut="6" minFn="5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 6</label>
       </variable>
       <variable item="F5 controls output 7" CV="39" default="1" mask="XXXVXXXX" minOut="7" minFn="5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 7</label>
       </variable>
       <variable item="F6 controls output 3" CV="40" mask="XXXXXXXV" minOut="3" minFn="6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 3</label>
       </variable>
       <variable item="F6 controls output 4" CV="40" mask="XXXXXXVX" minOut="4" minFn="6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 4</label>
       </variable>
       <variable item="F6 controls output 5" CV="40" mask="XXXXXVXX" minOut="5" minFn="6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 5</label>
       </variable>
       <variable item="F6 controls output 6" CV="40" mask="XXXXVXXX" minOut="6" minFn="6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 6</label>
       </variable>
       <variable item="F6 controls output 7" CV="40" mask="XXXVXXXX" minOut="7" minFn="6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 7</label>
       </variable>
       <variable item="Signal Dependent Acceleration" CV="61" default="0" comment="Range 0-255">

--- a/xml/decoders/CT_Elektronik_Sound_GE_70.xml
+++ b/xml/decoders/CT_Elektronik_Sound_GE_70.xml
@@ -80,597 +80,219 @@
      <xi:include href="http://jmri.org/xml/decoders/nmra/cv29analog.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/nmra/cv29table3-28.xml"/>
       <variable item="F1 controls output 3" CV="35" mask="XXXXXXXV" minOut="3" minFn="1" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 3</label>
       </variable>
       <variable item="F1 controls output 4" CV="35" mask="XXXXXXVX" minOut="4" minFn="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 4</label>
       </variable>
       <variable item="F1 controls output 5" CV="35" mask="XXXXXVXX" minOut="5" minFn="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 5</label>
       </variable>
       <variable item="F1 controls output 6" CV="35" mask="XXXXVXXX" minOut="6" minFn="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 6</label>
       </variable>
       <variable item="F1 controls output 7" CV="35" mask="XXXVXXXX" minOut="7" minFn="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 7</label>
       </variable>
       <variable item="F1 controls output 8" CV="35" mask="XXVXXXXX" minOut="8" minFn="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 8</label>
       </variable>
       <variable item="F1 controls output 9" CV="35" mask="XVXXXXXX" minOut="9" minFn="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 9</label>
       </variable>
       <variable item="F1 controls output 10" CV="35" mask="VXXXXXXX" minOut="10" minFn="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 10</label>
       </variable>
       <variable item="F2 controls output 3" CV="36" mask="XXXXXXXV" minOut="3" minFn="2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 3</label>
       </variable>
       <variable item="F2 controls output 4" CV="36" mask="XXXXXXVX" minOut="4" minFn="2" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 4</label>
       </variable>
       <variable item="F2 controls output 5" CV="36" mask="XXXXXVXX" minOut="5" minFn="2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 5</label>
       </variable>
       <variable item="F2 controls output 6" CV="36" mask="XXXXVXXX" minOut="6" minFn="2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 6</label>
       </variable>
       <variable item="F2 controls output 7" CV="36" mask="XXXVXXXX" minOut="7" minFn="2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 7</label>
       </variable>
       <variable item="F2 controls output 8" CV="36" mask="XXVXXXXX" minOut="8" minFn="2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 8</label>
       </variable>
       <variable item="F2 controls output 9" CV="36" mask="XVXXXXXX" minOut="9" minFn="2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 9</label>
       </variable>
       <variable item="F2 controls output 10" CV="36" mask="VXXXXXXX" minOut="10" minFn="2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 10</label>
       </variable>
       <variable item="F3 controls output 3" CV="37" mask="XXXXXXXV" minOut="3" minFn="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 3</label>
       </variable>
       <variable item="F3 controls output 4" CV="37" mask="XXXXXXVX" minOut="4" minFn="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 4</label>
       </variable>
       <variable item="F3 controls output 5" CV="37" mask="XXXXXVXX" minOut="5" minFn="3" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 5</label>
       </variable>
       <variable item="F3 controls output 6" CV="37" mask="XXXXVXXX" minOut="6" minFn="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 6</label>
       </variable>
       <variable item="F3 controls output 7" CV="37" mask="XXXVXXXX" minOut="7" minFn="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 7</label>
       </variable>
       <variable item="F3 controls output 8" CV="37" mask="XXVXXXXX" minOut="8" minFn="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 8</label>
       </variable>
       <variable item="F3 controls output 9" CV="37" mask="XVXXXXXX" minOut="9" minFn="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 9</label>
       </variable>
       <variable item="F3 controls output 10" CV="37" mask="VXXXXXXX" minOut="10" minFn="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 10</label>
       </variable>
       <variable item="F4 controls output 3" CV="38" mask="XXXXXXXV" minOut="3" minFn="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 3</label>
       </variable>
       <variable item="F4 controls output 4" CV="38" mask="XXXXXXVX" minOut="4" minFn="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 4</label>
       </variable>
       <variable item="F4 controls output 5" CV="38" mask="XXXXXVXX" minOut="5" minFn="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 5</label>
       </variable>
       <variable item="F4 controls output 6" CV="38" mask="XXXXVXXX" minOut="6" minFn="4" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 6</label>
       </variable>
       <variable item="F4 controls output 7" CV="38" mask="XXXVXXXX" minOut="7" minFn="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 7</label>
       </variable>
       <variable item="F4 controls output 8" CV="38" mask="XXVXXXXX" minOut="8" minFn="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 8</label>
       </variable>
       <variable item="F4 controls output 9" CV="38" mask="XVXXXXXX" minOut="9" minFn="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 9</label>
       </variable>
       <variable item="F4 controls output 10" CV="38" mask="VXXXXXXX" minOut="10" minFn="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 10</label>
       </variable>
       <variable item="F5 controls output 3" CV="39" mask="XXXXXXXV" minOut="3" minFn="5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 3</label>
       </variable>
       <variable item="F5 controls output 4" CV="39" mask="XXXXXXVX" minOut="4" minFn="5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 4</label>
       </variable>
       <variable item="F5 controls output 5" CV="39" mask="XXXXXVXX" minOut="5" minFn="5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 5</label>
       </variable>
       <variable item="F5 controls output 6" CV="39" mask="XXXXVXXX" minOut="6" minFn="5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 6</label>
       </variable>
       <variable item="F5 controls output 7" CV="39" mask="XXXVXXXX" minOut="7" minFn="5" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 7</label>
       </variable>
       <variable item="F5 controls output 8" CV="39" mask="XXVXXXXX" minOut="8" minFn="5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 8</label>
       </variable>
       <variable item="F5 controls output 9" CV="39" mask="XVXXXXXX" minOut="9" minFn="5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 9</label>
       </variable>
       <variable item="F5 controls output 10" CV="39" mask="VXXXXXXX" minOut="10" minFn="5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 10</label>
       </variable>
       <variable item="F6 controls output 3" CV="40" mask="XXXXXXXV" minOut="3" minFn="6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 3</label>
       </variable>
       <variable item="F6 controls output 4" CV="40" mask="XXXXXXVX" minOut="4" minFn="6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 4</label>
       </variable>
       <variable item="F6 controls output 5" CV="40" mask="XXXXXVXX" minOut="5" minFn="6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 5</label>
       </variable>
       <variable item="F6 controls output 6" CV="40" mask="XXXXVXXX" minOut="6" minFn="6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 6</label>
       </variable>
       <variable item="F6 controls output 7" CV="40" mask="XXXVXXXX" minOut="7" minFn="6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 7</label>
       </variable>
       <variable item="F6 controls output 8" CV="40" mask="XXVXXXXX" minOut="8" minFn="6" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 8</label>
       </variable>
       <variable item="F6 controls output 9" CV="40" mask="XVXXXXXX" minOut="9" minFn="6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 9</label>
       </variable>
       <variable item="F6 controls output 10" CV="40" mask="VXXXXXXX" minOut="10" minFn="6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 10</label>
       </variable>
       <variable item="F7 controls output 8" CV="41" mask="XXVXXXXX" minOut="8" minFn="7">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output 8</label>
       </variable>
       <variable item="F7 controls output 9" CV="41" mask="XVXXXXXX" minOut="9" minFn="7" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output 9</label>
       </variable>
       <variable item="F7 controls output 10" CV="41" mask="VXXXXXXX" minOut="10" minFn="7">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output 10</label>
       </variable>
       <variable item="F8 controls output 8" CV="42" mask="XXVXXXXX" minOut="8" minFn="8">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output 8</label>
       </variable>
       <variable item="F8 controls output 9" CV="42" mask="XVXXXXXX" minOut="9" minFn="8">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output 9</label>
       </variable>
       <variable item="F8 controls output 10" CV="42" mask="VXXXXXXX" minOut="10" minFn="8" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output 10</label>
       </variable>
       <variable item="Decoder Properties/Synchropulses" CV="49" mask="XXXXXXXV" default="0" comment="Synchropulses">

--- a/xml/decoders/CT_Elektronik_Sound_SL_v100.xml
+++ b/xml/decoders/CT_Elektronik_Sound_SL_v100.xml
@@ -304,1235 +304,451 @@
       </variable>
       <!--	NMRA Function Mapping	-->
       <variable item="FL(f) controls output 1" CV="33" mask="XXXXXXXV" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 1</label>
       </variable>
       <variable item="FL(f) controls output 2" CV="33" mask="XXXXXXVX" minOut="2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 2</label>
       </variable>
       <variable item="FL(f) controls output 3" CV="33" mask="XXXXXVXX" minOut="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 3</label>
       </variable>
       <variable item="FL(f) controls output 4" CV="33" mask="XXXXVXXX" minOut="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 4</label>
       </variable>
       <variable item="FL(f) controls output 5" CV="33" mask="XXXVXXXX" minOut="5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 5</label>
       </variable>
       <variable item="FL(f) controls output 6" CV="33" mask="XXVXXXXX" minOut="6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 6</label>
       </variable>
       <variable item="FL(f) controls output 7" CV="33" mask="XVXXXXXX" minOut="7">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 7</label>
       </variable>
       <variable item="FL(f) controls output 8" CV="33" mask="VXXXXXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 8</label>
       </variable>
       <variable item="FL(r) controls output 1" CV="34" mask="XXXXXXXV" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 1</label>
       </variable>
       <variable item="FL(r) controls output 2" CV="34" mask="XXXXXXVX" minOut="2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 2</label>
       </variable>
       <variable item="FL(r) controls output 3" CV="34" mask="XXXXXVXX" minOut="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 3</label>
       </variable>
       <variable item="FL(r) controls output 4" CV="34" mask="XXXXVXXX" minOut="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 4</label>
       </variable>
       <variable item="FL(r) controls output 5" CV="34" mask="XXXVXXXX" minOut="5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 5</label>
       </variable>
       <variable item="FL(r) controls output 6" CV="34" mask="XXVXXXXX" minOut="6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 6</label>
       </variable>
       <variable item="FL(r) controls output 7" CV="34" mask="XVXXXXXX" minOut="7">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 7</label>
       </variable>
       <variable item="FL(r) controls output 8" CV="34" mask="VXXXXXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 8</label>
       </variable>
       <variable item="F1 controls output 1" CV="35" mask="XXXXXXXV" minOut="1" minFn="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 1</label>
       </variable>
       <variable item="F1 controls output 2" CV="35" mask="XXXXXXVX" minOut="2" minFn="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 2</label>
       </variable>
       <variable item="F1 controls output 3" CV="35" mask="XXXXXVXX" minOut="3" minFn="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 3</label>
       </variable>
       <variable item="F1 controls output 4" CV="35" mask="XXXXVXXX" minOut="4" minFn="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 4</label>
       </variable>
       <variable item="F1 controls output 5" CV="35" mask="XXXVXXXX" minOut="5" minFn="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 5</label>
       </variable>
       <variable item="F1 controls output 6" CV="35" mask="XXVXXXXX" minOut="6" minFn="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 6</label>
       </variable>
       <variable item="F1 controls output 7" CV="35" mask="XVXXXXXX" minOut="7" minFn="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 7</label>
       </variable>
       <variable item="F1 controls output 8" CV="35" mask="VXXXXXXX" minOut="8" minFn="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 8</label>
       </variable>
       <variable item="F2 controls output 1" CV="36" mask="XXXXXXXV" minOut="1" minFn="2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 1</label>
       </variable>
       <variable item="F2 controls output 2" CV="36" mask="XXXXXXVX" minOut="2" minFn="2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 2</label>
       </variable>
       <variable item="F2 controls output 3" CV="36" mask="XXXXXVXX" minOut="3" minFn="2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 3</label>
       </variable>
       <variable item="F2 controls output 4" CV="36" mask="XXXXVXXX" minOut="4" minFn="2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 4</label>
       </variable>
       <variable item="F2 controls output 5" CV="36" mask="XXXVXXXX" minOut="5" minFn="2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 5</label>
       </variable>
       <variable item="F2 controls output 6" CV="36" mask="XXVXXXXX" minOut="6" minFn="2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 6</label>
       </variable>
       <variable item="F2 controls output 7" CV="36" mask="XVXXXXXX" minOut="7" minFn="2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 7</label>
       </variable>
       <variable item="F2 controls output 8" CV="36" mask="VXXXXXXX" minOut="8" minFn="2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 8</label>
       </variable>
       <variable item="F3 controls output 1" CV="37" mask="XXXXXXXV" minOut="1" minFn="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 1</label>
       </variable>
       <variable item="F3 controls output 2" CV="37" mask="XXXXXXVX" minOut="2" minFn="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 2</label>
       </variable>
       <variable item="F3 controls output 3" CV="37" mask="XXXXXVXX" minOut="3" minFn="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 3</label>
       </variable>
       <variable item="F3 controls output 4" CV="37" mask="XXXXVXXX" minOut="4" minFn="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 4</label>
       </variable>
       <variable item="F3 controls output 5" CV="37" mask="XXXVXXXX" minOut="5" minFn="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 5</label>
       </variable>
       <variable item="F3 controls output 6" CV="37" mask="XXVXXXXX" minOut="6" minFn="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 6</label>
       </variable>
       <variable item="F3 controls output 7" CV="37" mask="XVXXXXXX" minOut="7" minFn="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 7</label>
       </variable>
       <variable item="F3 controls output 8" CV="37" mask="VXXXXXXX" minOut="8" minFn="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 8</label>
       </variable>
       <variable item="F4 controls output 4" CV="38" mask="XXXXXXXV" minOut="4" minFn="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 4</label>
       </variable>
       <variable item="F4 controls output 5" CV="38" mask="XXXXXXVX" minOut="5" minFn="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 5</label>
       </variable>
       <variable item="F4 controls output 6" CV="38" mask="XXXXXVXX" minOut="6" minFn="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 6</label>
       </variable>
       <variable item="F4 controls output 7" CV="38" mask="XXXXVXXX" minOut="7" minFn="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 7</label>
       </variable>
       <variable item="F4 controls output 8" CV="38" mask="XXXVXXXX" minOut="8" minFn="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 8</label>
       </variable>
       <variable item="F4 controls output Ra" CV="38" mask="XXVXXXXX" minFn="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output Ra</label>
       </variable>
       <variable item="F4 controls output Se" CV="38" mask="XVXXXXXX" minFn="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output Se</label>
       </variable>
       <variable item="F4 controls output Alt" CV="38" mask="VXXXXXXX" minFn="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output Alt</label>
       </variable>
       <variable item="F5 controls output 4" CV="39" mask="XXXXXXXV" minOut="4" minFn="5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 4</label>
       </variable>
       <variable item="F5 controls output 5" CV="39" mask="XXXXXXVX" minOut="5" minFn="5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 5</label>
       </variable>
       <variable item="F5 controls output 6" CV="39" mask="XXXXXVXX" minOut="6" minFn="5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 6</label>
       </variable>
       <variable item="F5 controls output 7" CV="39" mask="XXXXVXXX" minOut="7" minFn="5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 7</label>
       </variable>
       <variable item="F5 controls output 8" CV="39" mask="XXXVXXXX" minOut="8" minFn="5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 8</label>
       </variable>
       <variable item="F5 controls output Ra" CV="39" mask="XXVXXXXX" minFn="5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output Ra</label>
       </variable>
       <variable item="F5 controls output Se" CV="39" mask="XVXXXXXX" minFn="5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output Se</label>
       </variable>
       <variable item="F5 controls output Alt" CV="39" mask="VXXXXXXX" minFn="5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output Alt</label>
       </variable>
       <variable item="F6 controls output 4" CV="40" mask="XXXXXXXV" minOut="4" minFn="6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 4</label>
       </variable>
       <variable item="F6 controls output 5" CV="40" mask="XXXXXXVX" minOut="5" minFn="6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 5</label>
       </variable>
       <variable item="F6 controls output 6" CV="40" mask="XXXXXVXX" minOut="6" minFn="6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 6</label>
       </variable>
       <variable item="F6 controls output 7" CV="40" mask="XXXXVXXX" minOut="7" minFn="6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 7</label>
       </variable>
       <variable item="F6 controls output 8" CV="40" mask="XXXVXXXX" minOut="8" minFn="6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 8</label>
       </variable>
       <variable item="F6 controls output Ra" CV="40" mask="XXVXXXXX" minFn="6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output Ra</label>
       </variable>
       <variable item="F6 controls output Se" CV="40" mask="XVXXXXXX" minFn="6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output Se</label>
       </variable>
       <variable item="F6 controls output Alt" CV="40" mask="VXXXXXXX" minFn="6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output Alt</label>
       </variable>
       <variable item="F7 controls output 4" CV="41" mask="XXXXXXXV" minOut="4" minFn="7">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output 4</label>
       </variable>
       <variable item="F7 controls output 5" CV="41" mask="XXXXXXVX" minOut="5" minFn="7">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output 5</label>
       </variable>
       <variable item="F7 controls output 6" CV="41" mask="XXXXXVXX" minOut="6" minFn="7">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output 6</label>
       </variable>
       <variable item="F7 controls output 7" CV="41" mask="XXXXVXXX" minOut="7" minFn="7">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output 7</label>
       </variable>
       <variable item="F7 controls output 8" CV="41" mask="XXXVXXXX" minOut="8" minFn="7">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output 8</label>
       </variable>
       <variable item="F7 controls output Ra" CV="41" mask="XXVXXXXX" minFn="7">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output Ra</label>
       </variable>
       <variable item="F7 controls output Se" CV="41" mask="XVXXXXXX" minFn="7">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output Se</label>
       </variable>
       <variable item="F7 controls output Alt" CV="41" mask="VXXXXXXX" minFn="7">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output Alt</label>
       </variable>
       <variable item="F8 controls output 4" CV="42" mask="XXXXXXXV" minOut="4" minFn="8">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output 4</label>
       </variable>
       <variable item="F8 controls output 5" CV="42" mask="XXXXXXVX" minOut="5" minFn="8">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output 5</label>
       </variable>
       <variable item="F8 controls output 6" CV="42" mask="XXXXXVXX" minOut="6" minFn="8">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output 6</label>
       </variable>
       <variable item="F8 controls output 7" CV="42" mask="XXXXVXXX" minOut="7" minFn="8">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output 7</label>
       </variable>
       <variable item="F8 controls output 8" CV="42" mask="XXXVXXXX" minOut="8" minFn="8">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output 8</label>
       </variable>
       <variable item="F8 controls output Ra" CV="42" mask="XXVXXXXX" minFn="8">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output Ra</label>
       </variable>
       <variable item="F8 controls output Se" CV="42" mask="XVXXXXXX" minFn="8">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output Se</label>
       </variable>
       <variable item="F8 controls output Alt" CV="42" mask="VXXXXXXX" minFn="8">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output Alt</label>
       </variable>
       <variable item="F9 controls output 7" CV="43" mask="XXXXXXXV" minOut="7" minFn="9">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output 7</label>
       </variable>
       <variable item="F9 controls output 8" CV="43" mask="XXXXXXVX" minOut="8" minFn="9">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output 8</label>
       </variable>
       <variable item="F9 controls output Ra" CV="43" mask="XXXXXVXX" minFn="9">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output Ra</label>
       </variable>
       <variable item="F9 controls output Se" CV="43" mask="XXXXVXXX" minFn="9">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output Se</label>
       </variable>
       <variable item="F9 controls output Alt" CV="43" mask="XXXVXXXX" minFn="9">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output Alt</label>
       </variable>
       <variable item="F9 controls output G1" CV="43" mask="XXVXXXXX" minFn="9">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output G1</label>
       </variable>
       <variable item="F9 controls output G2" CV="43" mask="XVXXXXXX" minFn="9">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output G2</label>
       </variable>
       <variable item="F9 controls output G3" CV="43" mask="VXXXXXXX" minFn="9">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output G3</label>
       </variable>
       <variable item="F10 controls output 7" CV="44" mask="XXXXXXXV" minOut="7" minFn="10">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output 7</label>
       </variable>
       <variable item="F10 controls output 8" CV="44" mask="XXXXXXVX" minOut="8" minFn="10">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output 8</label>
       </variable>
       <variable item="F10 controls output Ra" CV="44" mask="XXXXXVXX" minFn="10">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output Ra</label>
       </variable>
       <variable item="F10 controls output Se" CV="44" mask="XXXXVXXX" minFn="10">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output Se</label>
       </variable>
       <variable item="F10 controls output Alt" CV="44" mask="XXXVXXXX" minFn="10">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output Alt</label>
       </variable>
       <variable item="F10 controls output G1" CV="44" mask="XXVXXXXX" minFn="10">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output G1</label>
       </variable>
       <variable item="F10 controls output G2" CV="44" mask="XVXXXXXX" minFn="10">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output G2</label>
       </variable>
       <variable item="F10 controls output G3" CV="44" mask="VXXXXXXX" minFn="10">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output G3</label>
       </variable>
       <variable item="F11 controls output 7" CV="45" mask="XXXXXXXV" minOut="7" minFn="11">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output 7</label>
       </variable>
       <variable item="F11 controls output 8" CV="45" mask="XXXXXXVX" minOut="8" minFn="11">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output 8</label>
       </variable>
       <variable item="F11 controls output Ra" CV="45" mask="XXXXXVXX" minFn="11">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output Ra</label>
       </variable>
       <variable item="F11 controls output Se" CV="45" mask="XXXXVXXX" minFn="11">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output Se</label>
       </variable>
       <variable item="F11 controls output Alt" CV="45" mask="XXXVXXXX" minFn="11">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output Alt</label>
       </variable>
       <variable item="F11 controls output G1" CV="45" mask="XXVXXXXX" minFn="11">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output G1</label>
       </variable>
       <variable item="F11 controls output G2" CV="45" mask="XVXXXXXX" minFn="11">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output G2</label>
       </variable>
       <variable item="F11 controls output G3" CV="45" mask="VXXXXXXX" minFn="11">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output G3</label>
       </variable>
       <variable item="F12 controls output 7" CV="46" mask="XXXXXXXV" minOut="7" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output 7</label>
       </variable>
       <variable item="F12 controls output 8" CV="46" mask="XXXXXXVX" minOut="8" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output 8</label>
       </variable>
       <variable item="F12 controls output Ra" CV="46" mask="XXXXXVXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output Ra</label>
       </variable>
       <variable item="F12 controls output Se" CV="46" mask="XXXXVXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output Se</label>
       </variable>
       <variable item="F12 controls output Alt" CV="46" mask="XXXVXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output Alt</label>
       </variable>
       <variable item="F12 controls output G1" CV="46" mask="XXVXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output G1</label>
       </variable>
       <variable item="F12 controls output G2" CV="46" mask="XVXXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output G2</label>
       </variable>
       <variable item="F12 controls output G3" CV="46" mask="VXXXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output G3</label>
       </variable>
       <!--  commented out options, instead drop downs below
@@ -3115,91 +2331,35 @@ CV116 = 128 knobs back quickly. Sound falls to idle knob position alters itself.
         <label>Sound Loop</label>
       </variable>
       <variable item="Loop Sound Slot 1" CV="145" mask="XXXXXXXV" default="0">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Loop Sound Slot 1</label>
       </variable>
       <variable item="Loop Sound Slot 2" CV="145" mask="XXXXXXVX" default="0">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Loop Sound Slot 2</label>
       </variable>
       <variable item="Loop Sound Slot 3" CV="145" mask="XXXXXVXX" default="0">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Loop Sound Slot 3</label>
       </variable>
       <variable item="Loop Sound Slot 4" CV="145" mask="XXXXVXXX" default="0">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Loop Sound Slot 4</label>
       </variable>
       <variable item="Loop Sound Slot 5" CV="145" mask="XXXVXXXX" default="0">
-        <enumVal>
-          <enumChoice choice="Off">
-            <choice>Off</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Loop Sound Slot 5</label>
       </variable>
       <variable item="Loop Sound Slot 6" CV="145" mask="XXVXXXXX" default="0">
-        <enumVal>
-          <enumChoice choice="Off">
-            <choice>Off</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Loop Sound Slot 6</label>
       </variable>
       <variable item="Loop Sound Slot 7" CV="145" mask="XVXXXXXX" default="0">
-        <enumVal>
-          <enumChoice choice="Off">
-            <choice>Off</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Loop Sound Slot 7</label>
       </variable>
       <variable item="Loop Sound Slot 8" CV="145" mask="VXXXXXXX" default="0" include="SL75,SL76,GE75,GE76,SL82">
-        <enumVal>
-          <enumChoice choice="Off">
-            <choice>Off</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Loop Sound Slot 8</label>
       </variable>
       <!--  
@@ -3613,1169 +2773,427 @@ Sept 2009 - believe this is obselete from V39 upwards, replaced by Function Mapp
       </variable>
       <!--  remainder of Tran Function Mapping -->
       <variable item="FL(f) controls output Ra" CV="163" mask="XXXXXXXV" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output Ra</label>
       </variable>
       <variable item="FL(f) controls output Se" CV="163" mask="XXXXXXVX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output Se</label>
       </variable>
       <variable item="FL(f) controls output Alt" CV="163" mask="XXXXXVXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output Alt</label>
       </variable>
       <variable item="FL(f) controls output G1" CV="163" mask="XXXXVXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output G1</label>
       </variable>
       <variable item="FL(f) controls output G2" CV="163" mask="XXXVXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output G2</label>
       </variable>
       <variable item="FL(f) controls output G3" CV="163" mask="XXVXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output G3</label>
       </variable>
       <variable item="FL(f) controls output G4" CV="163" mask="XVXXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output G4</label>
       </variable>
       <variable item="FL(f) controls output G5" CV="163" mask="VXXXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output G5</label>
       </variable>
       <variable item="FL(r) controls output Ra" CV="164" mask="XXXXXXXV" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output Ra</label>
       </variable>
       <variable item="FL(r) controls output Se" CV="164" mask="XXXXXXVX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output Se</label>
       </variable>
       <variable item="FL(r) controls output Alt" CV="164" mask="XXXXXVXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output Alt</label>
       </variable>
       <variable item="FL(r) controls output G1" CV="164" mask="XXXXVXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output G1</label>
       </variable>
       <variable item="FL(r) controls output G2" CV="164" mask="XXXVXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output G2</label>
       </variable>
       <variable item="FL(r) controls output G3" CV="164" mask="XXVXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output G3</label>
       </variable>
       <variable item="FL(r) controls output G4" CV="164" mask="XVXXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output G4</label>
       </variable>
       <variable item="FL(r) controls output G5" CV="164" mask="VXXXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output G5</label>
       </variable>
       <variable item="F1 controls output Ra" CV="165" mask="XXXXXXXV" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output Ra</label>
       </variable>
       <variable item="F1 controls output Se" CV="165" mask="XXXXXXVX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output Se</label>
       </variable>
       <variable item="F1 controls output Alt" CV="165" mask="XXXXXVXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output Alt</label>
       </variable>
       <variable item="F1 controls output G1" CV="165" mask="XXXXVXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output G1</label>
       </variable>
       <variable item="F1 controls output G2" CV="165" mask="XXXVXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output G2</label>
       </variable>
       <variable item="F1 controls output G3" CV="165" mask="XXVXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output G3</label>
       </variable>
       <variable item="F1 controls output G4" CV="165" mask="XVXXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output G4</label>
       </variable>
       <variable item="F1 controls output G5" CV="165" mask="VXXXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output G5</label>
       </variable>
       <variable item="F2 controls output Ra" CV="166" mask="XXXXXXXV" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output Ra</label>
       </variable>
       <variable item="F2 controls output Se" CV="166" mask="XXXXXXVX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output Se</label>
       </variable>
       <variable item="F2 controls output Alt" CV="166" mask="XXXXXVXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output Alt</label>
       </variable>
       <variable item="F2 controls output G1" CV="166" mask="XXXXVXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output G1</label>
       </variable>
       <variable item="F2 controls output G2" CV="166" mask="XXXVXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output G2</label>
       </variable>
       <variable item="F2 controls output G3" CV="166" mask="XXVXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output G3</label>
       </variable>
       <variable item="F2 controls output G4" CV="166" mask="XVXXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output G4</label>
       </variable>
       <variable item="F2 controls output G5" CV="166" mask="VXXXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output G5</label>
       </variable>
       <variable item="F3 controls output Ra" CV="167" mask="XXXXXXXV" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output Ra</label>
       </variable>
       <variable item="F3 controls output Se" CV="167" mask="XXXXXXVX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output Se</label>
       </variable>
       <variable item="F3 controls output Alt" CV="167" mask="XXXXXVXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output Alt</label>
       </variable>
       <variable item="F3 controls output G1" CV="167" mask="XXXXVXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output G1</label>
       </variable>
       <variable item="F3 controls output G2" CV="167" mask="XXXVXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output G2</label>
       </variable>
       <variable item="F3 controls output G3" CV="167" mask="XXVXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output G3</label>
       </variable>
       <variable item="F3 controls output G4" CV="167" mask="XVXXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output G4</label>
       </variable>
       <variable item="F3 controls output G5" CV="167" mask="VXXXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output G5</label>
       </variable>
       <variable item="F4 controls output G1" CV="168" mask="XXXXXXXV" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output G1</label>
       </variable>
       <variable item="F4 controls output G2" CV="168" mask="XXXXXXVX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output G2</label>
       </variable>
       <variable item="F4 controls output G3" CV="168" mask="XXXXXVXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output G3</label>
       </variable>
       <variable item="F4 controls output G4" CV="168" mask="XXXXVXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output G4</label>
       </variable>
       <variable item="F4 controls output G5" CV="168" mask="XXXVXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output G5</label>
       </variable>
       <variable item="F4 controls output G6" CV="168" mask="XXVXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output G6</label>
       </variable>
       <variable item="F4 controls output G7" CV="168" mask="XVXXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output G7</label>
       </variable>
       <variable item="F4 controls output G8" CV="168" mask="VXXXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output G8</label>
       </variable>
       <variable item="F5 controls output G1" CV="169" mask="XXXXXXXV" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output G1</label>
       </variable>
       <variable item="F5 controls output G2" CV="169" mask="XXXXXXVX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output G2</label>
       </variable>
       <variable item="F5 controls output G3" CV="169" mask="XXXXXVXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output G3</label>
       </variable>
       <variable item="F5 controls output G4" CV="169" mask="XXXXVXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output G4</label>
       </variable>
       <variable item="F5 controls output G5" CV="169" mask="XXXVXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output G5</label>
       </variable>
       <variable item="F5 controls output G6" CV="169" mask="XXVXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output G6</label>
       </variable>
       <variable item="F5 controls output G7" CV="169" mask="XVXXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output G7</label>
       </variable>
       <variable item="F5 controls output G8" CV="169" mask="VXXXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output G8</label>
       </variable>
       <variable item="F6 controls output G1" CV="170" mask="XXXXXXXV" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output G1</label>
       </variable>
       <variable item="F6 controls output G2" CV="170" mask="XXXXXXVX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output G2</label>
       </variable>
       <variable item="F6 controls output G3" CV="170" mask="XXXXXVXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output G3</label>
       </variable>
       <variable item="F6 controls output G4" CV="170" mask="XXXXVXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output G4</label>
       </variable>
       <variable item="F6 controls output G5" CV="170" mask="XXXVXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output G5</label>
       </variable>
       <variable item="F6 controls output G6" CV="170" mask="XXVXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output G6</label>
       </variable>
       <variable item="F6 controls output G7" CV="170" mask="XVXXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output G7</label>
       </variable>
       <variable item="F6 controls output G8" CV="170" mask="VXXXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output G8</label>
       </variable>
       <variable item="F7 controls output G1" CV="171" mask="XXXXXXXV" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output G1</label>
       </variable>
       <variable item="F7 controls output G2" CV="171" mask="XXXXXXVX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output G2</label>
       </variable>
       <variable item="F7 controls output G3" CV="171" mask="XXXXXVXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output G3</label>
       </variable>
       <variable item="F7 controls output G4" CV="171" mask="XXXXVXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output G4</label>
       </variable>
       <variable item="F7 controls output G5" CV="171" mask="XXXVXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output G5</label>
       </variable>
       <variable item="F7 controls output G6" CV="171" mask="XXVXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output G6</label>
       </variable>
       <variable item="F7 controls output G7" CV="171" mask="XVXXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output G7</label>
       </variable>
       <variable item="F7 controls output G8" CV="171" mask="VXXXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output G8</label>
       </variable>
       <variable item="F8 controls output G1" CV="172" mask="XXXXXXXV" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output G1</label>
       </variable>
       <variable item="F8 controls output G2" CV="172" mask="XXXXXXVX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output G2</label>
       </variable>
       <variable item="F8 controls output G3" CV="172" mask="XXXXXVXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output G3</label>
       </variable>
       <variable item="F8 controls output G4" CV="172" mask="XXXXVXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output G4</label>
       </variable>
       <variable item="F8 controls output G5" CV="172" mask="XXXVXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output G5</label>
       </variable>
       <variable item="F8 controls output G6" CV="172" mask="XXVXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output G6</label>
       </variable>
       <variable item="F8 controls output G7" CV="172" mask="XVXXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output G7</label>
       </variable>
       <variable item="F8 controls output G8" CV="172" mask="VXXXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output G8</label>
       </variable>
       <variable item="F9 controls output G4" CV="173" mask="XXXXXXXV" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output G4</label>
       </variable>
       <variable item="F9 controls output G5" CV="173" mask="XXXXXXVX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output G5</label>
       </variable>
       <variable item="F9 controls output G6" CV="173" mask="XXXXXVXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output G6</label>
       </variable>
       <variable item="F9 controls output G7" CV="173" mask="XXXXVXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output G7</label>
       </variable>
       <variable item="F9 controls output G8" CV="173" mask="XXXVXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output G8</label>
       </variable>
       <variable item="F9 controls output Z7" CV="173" mask="XXVXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output Z7</label>
       </variable>
       <variable item="F9 controls output Z8" CV="173" mask="XVXXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output Z8</label>
       </variable>
       <variable item="F9 controls output Z9" CV="173" mask="VXXXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output Z9</label>
       </variable>
       <variable item="F10 controls output G4" CV="174" mask="XXXXXXXV" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output G4</label>
       </variable>
       <variable item="F10 controls output G5" CV="174" mask="XXXXXXVX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output G5</label>
       </variable>
       <variable item="F10 controls output G6" CV="174" mask="XXXXXVXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output G6</label>
       </variable>
       <variable item="F10 controls output G7" CV="174" mask="XXXXVXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output G7</label>
       </variable>
       <variable item="F10 controls output G8" CV="174" mask="XXXVXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output G8</label>
       </variable>
       <variable item="F10 controls output Z7" CV="174" mask="XXVXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output Z7</label>
       </variable>
       <variable item="F10 controls output Z8" CV="174" mask="XVXXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output Z8</label>
       </variable>
       <variable item="F10 controls output Z9" CV="174" mask="VXXXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output Z9</label>
       </variable>
       <variable item="F11 controls output G4" CV="175" mask="XXXXXXXV" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output G4</label>
       </variable>
       <variable item="F11 controls output G5" CV="175" mask="XXXXXXVX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output G5</label>
       </variable>
       <variable item="F11 controls output G6" CV="175" mask="XXXXXVXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output G6</label>
       </variable>
       <variable item="F11 controls output G7" CV="175" mask="XXXXVXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output G7</label>
       </variable>
       <variable item="F11 controls output G8" CV="175" mask="XXXVXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output G8</label>
       </variable>
       <variable item="F12 controls output G4" CV="176" mask="XXXXXXXV" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output G4</label>
       </variable>
       <variable item="F12 controls output G5" CV="176" mask="XXXXXXVX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output G5</label>
       </variable>
       <variable item="F12 controls output G6" CV="176" mask="XXXXXVXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output G6</label>
       </variable>
       <variable item="F12 controls output G7" CV="176" mask="XXXXVXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output G7</label>
       </variable>
       <variable item="F12 controls output G8" CV="176" mask="XXXVXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output G8</label>
       </variable>
       <variable item="Acceleration Sound Trigger" CV="177" default="00" tooltip="rate of speed change to trigger accel noise slots 123-125">

--- a/xml/decoders/CT_Elektronik_Sound_SL_v40.xml
+++ b/xml/decoders/CT_Elektronik_Sound_SL_v40.xml
@@ -232,1235 +232,451 @@
       </variable>
       <!--	NMRA Function Mapping	-->
       <variable item="FL(f) controls output 1" CV="33" mask="XXXXXXXV" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 1</label>
       </variable>
       <variable item="FL(f) controls output 2" CV="33" mask="XXXXXXVX" minOut="2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 2</label>
       </variable>
       <variable item="FL(f) controls output 3" CV="33" mask="XXXXXVXX" minOut="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 3</label>
       </variable>
       <variable item="FL(f) controls output 4" CV="33" mask="XXXXVXXX" minOut="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 4</label>
       </variable>
       <variable item="FL(f) controls output 5" CV="33" mask="XXXVXXXX" minOut="5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 5</label>
       </variable>
       <variable item="FL(f) controls output 6" CV="33" mask="XXVXXXXX" minOut="6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 6</label>
       </variable>
       <variable item="FL(f) controls output 7" CV="33" mask="XVXXXXXX" minOut="7">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 7</label>
       </variable>
       <variable item="FL(f) controls output 8" CV="33" mask="VXXXXXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 8</label>
       </variable>
       <variable item="FL(r) controls output 1" CV="34" mask="XXXXXXXV" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 1</label>
       </variable>
       <variable item="FL(r) controls output 2" CV="34" mask="XXXXXXVX" minOut="2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 2</label>
       </variable>
       <variable item="FL(r) controls output 3" CV="34" mask="XXXXXVXX" minOut="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 3</label>
       </variable>
       <variable item="FL(r) controls output 4" CV="34" mask="XXXXVXXX" minOut="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 4</label>
       </variable>
       <variable item="FL(r) controls output 5" CV="34" mask="XXXVXXXX" minOut="5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 5</label>
       </variable>
       <variable item="FL(r) controls output 6" CV="34" mask="XXVXXXXX" minOut="6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 6</label>
       </variable>
       <variable item="FL(r) controls output 7" CV="34" mask="XVXXXXXX" minOut="7">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 7</label>
       </variable>
       <variable item="FL(r) controls output 8" CV="34" mask="VXXXXXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 8</label>
       </variable>
       <variable item="F1 controls output 1" CV="35" mask="XXXXXXXV" minOut="1" minFn="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 1</label>
       </variable>
       <variable item="F1 controls output 2" CV="35" mask="XXXXXXVX" minOut="2" minFn="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 2</label>
       </variable>
       <variable item="F1 controls output 3" CV="35" mask="XXXXXVXX" minOut="3" minFn="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 3</label>
       </variable>
       <variable item="F1 controls output 4" CV="35" mask="XXXXVXXX" minOut="4" minFn="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 4</label>
       </variable>
       <variable item="F1 controls output 5" CV="35" mask="XXXVXXXX" minOut="5" minFn="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 5</label>
       </variable>
       <variable item="F1 controls output 6" CV="35" mask="XXVXXXXX" minOut="6" minFn="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 6</label>
       </variable>
       <variable item="F1 controls output 7" CV="35" mask="XVXXXXXX" minOut="7" minFn="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 7</label>
       </variable>
       <variable item="F1 controls output 8" CV="35" mask="VXXXXXXX" minOut="8" minFn="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 8</label>
       </variable>
       <variable item="F2 controls output 1" CV="36" mask="XXXXXXXV" minOut="1" minFn="2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 1</label>
       </variable>
       <variable item="F2 controls output 2" CV="36" mask="XXXXXXVX" minOut="2" minFn="2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 2</label>
       </variable>
       <variable item="F2 controls output 3" CV="36" mask="XXXXXVXX" minOut="3" minFn="2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 3</label>
       </variable>
       <variable item="F2 controls output 4" CV="36" mask="XXXXVXXX" minOut="4" minFn="2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 4</label>
       </variable>
       <variable item="F2 controls output 5" CV="36" mask="XXXVXXXX" minOut="5" minFn="2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 5</label>
       </variable>
       <variable item="F2 controls output 6" CV="36" mask="XXVXXXXX" minOut="6" minFn="2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 6</label>
       </variable>
       <variable item="F2 controls output 7" CV="36" mask="XVXXXXXX" minOut="7" minFn="2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 7</label>
       </variable>
       <variable item="F2 controls output 8" CV="36" mask="VXXXXXXX" minOut="8" minFn="2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 8</label>
       </variable>
       <variable item="F3 controls output 1" CV="37" mask="XXXXXXXV" minOut="1" minFn="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 1</label>
       </variable>
       <variable item="F3 controls output 2" CV="37" mask="XXXXXXVX" minOut="2" minFn="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 2</label>
       </variable>
       <variable item="F3 controls output 3" CV="37" mask="XXXXXVXX" minOut="3" minFn="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 3</label>
       </variable>
       <variable item="F3 controls output 4" CV="37" mask="XXXXVXXX" minOut="4" minFn="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 4</label>
       </variable>
       <variable item="F3 controls output 5" CV="37" mask="XXXVXXXX" minOut="5" minFn="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 5</label>
       </variable>
       <variable item="F3 controls output 6" CV="37" mask="XXVXXXXX" minOut="6" minFn="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 6</label>
       </variable>
       <variable item="F3 controls output 7" CV="37" mask="XVXXXXXX" minOut="7" minFn="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 7</label>
       </variable>
       <variable item="F3 controls output 8" CV="37" mask="VXXXXXXX" minOut="8" minFn="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 8</label>
       </variable>
       <variable item="F4 controls output 4" CV="38" mask="XXXXXXXV" minOut="4" minFn="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 4</label>
       </variable>
       <variable item="F4 controls output 5" CV="38" mask="XXXXXXVX" minOut="5" minFn="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 5</label>
       </variable>
       <variable item="F4 controls output 6" CV="38" mask="XXXXXVXX" minOut="6" minFn="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 6</label>
       </variable>
       <variable item="F4 controls output 7" CV="38" mask="XXXXVXXX" minOut="7" minFn="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 7</label>
       </variable>
       <variable item="F4 controls output 8" CV="38" mask="XXXVXXXX" minOut="8" minFn="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 8</label>
       </variable>
       <variable item="F4 controls output Ra" CV="38" mask="XXVXXXXX" minFn="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output Ra</label>
       </variable>
       <variable item="F4 controls output Se" CV="38" mask="XVXXXXXX" minFn="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output Se</label>
       </variable>
       <variable item="F4 controls output Alt" CV="38" mask="VXXXXXXX" minFn="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output Alt</label>
       </variable>
       <variable item="F5 controls output 4" CV="39" mask="XXXXXXXV" minOut="4" minFn="5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 4</label>
       </variable>
       <variable item="F5 controls output 5" CV="39" mask="XXXXXXVX" minOut="5" minFn="5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 5</label>
       </variable>
       <variable item="F5 controls output 6" CV="39" mask="XXXXXVXX" minOut="6" minFn="5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 6</label>
       </variable>
       <variable item="F5 controls output 7" CV="39" mask="XXXXVXXX" minOut="7" minFn="5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 7</label>
       </variable>
       <variable item="F5 controls output 8" CV="39" mask="XXXVXXXX" minOut="8" minFn="5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 8</label>
       </variable>
       <variable item="F5 controls output Ra" CV="39" mask="XXVXXXXX" minFn="5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output Ra</label>
       </variable>
       <variable item="F5 controls output Se" CV="39" mask="XVXXXXXX" minFn="5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output Se</label>
       </variable>
       <variable item="F5 controls output Alt" CV="39" mask="VXXXXXXX" minFn="5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output Alt</label>
       </variable>
       <variable item="F6 controls output 4" CV="40" mask="XXXXXXXV" minOut="4" minFn="6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 4</label>
       </variable>
       <variable item="F6 controls output 5" CV="40" mask="XXXXXXVX" minOut="5" minFn="6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 5</label>
       </variable>
       <variable item="F6 controls output 6" CV="40" mask="XXXXXVXX" minOut="6" minFn="6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 6</label>
       </variable>
       <variable item="F6 controls output 7" CV="40" mask="XXXXVXXX" minOut="7" minFn="6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 7</label>
       </variable>
       <variable item="F6 controls output 8" CV="40" mask="XXXVXXXX" minOut="8" minFn="6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 8</label>
       </variable>
       <variable item="F6 controls output Ra" CV="40" mask="XXVXXXXX" minFn="6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output Ra</label>
       </variable>
       <variable item="F6 controls output Se" CV="40" mask="XVXXXXXX" minFn="6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output Se</label>
       </variable>
       <variable item="F6 controls output Alt" CV="40" mask="VXXXXXXX" minFn="6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output Alt</label>
       </variable>
       <variable item="F7 controls output 4" CV="41" mask="XXXXXXXV" minOut="4" minFn="7">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output 4</label>
       </variable>
       <variable item="F7 controls output 5" CV="41" mask="XXXXXXVX" minOut="5" minFn="7">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output 5</label>
       </variable>
       <variable item="F7 controls output 6" CV="41" mask="XXXXXVXX" minOut="6" minFn="7">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output 6</label>
       </variable>
       <variable item="F7 controls output 7" CV="41" mask="XXXXVXXX" minOut="7" minFn="7">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output 7</label>
       </variable>
       <variable item="F7 controls output 8" CV="41" mask="XXXVXXXX" minOut="8" minFn="7">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output 8</label>
       </variable>
       <variable item="F7 controls output Ra" CV="41" mask="XXVXXXXX" minFn="7">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output Ra</label>
       </variable>
       <variable item="F7 controls output Se" CV="41" mask="XVXXXXXX" minFn="7">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output Se</label>
       </variable>
       <variable item="F7 controls output Alt" CV="41" mask="VXXXXXXX" minFn="7">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output Alt</label>
       </variable>
       <variable item="F8 controls output 4" CV="42" mask="XXXXXXXV" minOut="4" minFn="8">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output 4</label>
       </variable>
       <variable item="F8 controls output 5" CV="42" mask="XXXXXXVX" minOut="5" minFn="8">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output 5</label>
       </variable>
       <variable item="F8 controls output 6" CV="42" mask="XXXXXVXX" minOut="6" minFn="8">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output 6</label>
       </variable>
       <variable item="F8 controls output 7" CV="42" mask="XXXXVXXX" minOut="7" minFn="8">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output 7</label>
       </variable>
       <variable item="F8 controls output 8" CV="42" mask="XXXVXXXX" minOut="8" minFn="8">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output 8</label>
       </variable>
       <variable item="F8 controls output Ra" CV="42" mask="XXVXXXXX" minFn="8">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output Ra</label>
       </variable>
       <variable item="F8 controls output Se" CV="42" mask="XVXXXXXX" minFn="8">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output Se</label>
       </variable>
       <variable item="F8 controls output Alt" CV="42" mask="VXXXXXXX" minFn="8">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output Alt</label>
       </variable>
       <variable item="F9 controls output 7" CV="43" mask="XXXXXXXV" minOut="7" minFn="9">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output 7</label>
       </variable>
       <variable item="F9 controls output 8" CV="43" mask="XXXXXXVX" minOut="8" minFn="9">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output 8</label>
       </variable>
       <variable item="F9 controls output Ra" CV="43" mask="XXXXXVXX" minFn="9">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output Ra</label>
       </variable>
       <variable item="F9 controls output Se" CV="43" mask="XXXXVXXX" minFn="9">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output Se</label>
       </variable>
       <variable item="F9 controls output Alt" CV="43" mask="XXXVXXXX" minFn="9">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output Alt</label>
       </variable>
       <variable item="F9 controls output G1" CV="43" mask="XXVXXXXX" minFn="9">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output G1</label>
       </variable>
       <variable item="F9 controls output G2" CV="43" mask="XVXXXXXX" minFn="9">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output G2</label>
       </variable>
       <variable item="F9 controls output G3" CV="43" mask="VXXXXXXX" minFn="9">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output G3</label>
       </variable>
       <variable item="F10 controls output 7" CV="44" mask="XXXXXXXV" minOut="7" minFn="10">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output 7</label>
       </variable>
       <variable item="F10 controls output 8" CV="44" mask="XXXXXXVX" minOut="8" minFn="10">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output 8</label>
       </variable>
       <variable item="F10 controls output Ra" CV="44" mask="XXXXXVXX" minFn="10">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output Ra</label>
       </variable>
       <variable item="F10 controls output Se" CV="44" mask="XXXXVXXX" minFn="10">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output Se</label>
       </variable>
       <variable item="F10 controls output Alt" CV="44" mask="XXXVXXXX" minFn="10">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output Alt</label>
       </variable>
       <variable item="F10 controls output G1" CV="44" mask="XXVXXXXX" minFn="10">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output G1</label>
       </variable>
       <variable item="F10 controls output G2" CV="44" mask="XVXXXXXX" minFn="10">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output G2</label>
       </variable>
       <variable item="F10 controls output G3" CV="44" mask="VXXXXXXX" minFn="10">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output G3</label>
       </variable>
       <variable item="F11 controls output 7" CV="45" mask="XXXXXXXV" minOut="7" minFn="11">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output 7</label>
       </variable>
       <variable item="F11 controls output 8" CV="45" mask="XXXXXXVX" minOut="8" minFn="11">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output 8</label>
       </variable>
       <variable item="F11 controls output Ra" CV="45" mask="XXXXXVXX" minFn="11">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output Ra</label>
       </variable>
       <variable item="F11 controls output Se" CV="45" mask="XXXXVXXX" minFn="11">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output Se</label>
       </variable>
       <variable item="F11 controls output Alt" CV="45" mask="XXXVXXXX" minFn="11">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output Alt</label>
       </variable>
       <variable item="F11 controls output G1" CV="45" mask="XXVXXXXX" minFn="11">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output G1</label>
       </variable>
       <variable item="F11 controls output G2" CV="45" mask="XVXXXXXX" minFn="11">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output G2</label>
       </variable>
       <variable item="F11 controls output G3" CV="45" mask="VXXXXXXX" minFn="11">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output G3</label>
       </variable>
       <variable item="F12 controls output 7" CV="46" mask="XXXXXXXV" minOut="7" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output 7</label>
       </variable>
       <variable item="F12 controls output 8" CV="46" mask="XXXXXXVX" minOut="8" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output 8</label>
       </variable>
       <variable item="F12 controls output Ra" CV="46" mask="XXXXXVXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output Ra</label>
       </variable>
       <variable item="F12 controls output Se" CV="46" mask="XXXXVXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output Se</label>
       </variable>
       <variable item="F12 controls output Alt" CV="46" mask="XXXVXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output Alt</label>
       </variable>
       <variable item="F12 controls output G1" CV="46" mask="XXVXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output G1</label>
       </variable>
       <variable item="F12 controls output G2" CV="46" mask="XVXXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output G2</label>
       </variable>
       <variable item="F12 controls output G3" CV="46" mask="VXXXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output G3</label>
       </variable>
       <!--  commented out options, instead drop downs below
@@ -3039,47 +2255,19 @@ CV116 = 128 knobs back quickly. Sound falls to idle knob position alters itself.
         <label>Sound Loop</label>
       </variable>
       <variable item="Loop Sound Slot 1" CV="145" mask="XXXXXXXV" default="0">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Loop Sound Slot 1</label>
       </variable>
       <variable item="Loop Sound Slot 2" CV="145" mask="XXXXXXVX" default="0">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Loop Sound Slot 2</label>
       </variable>
       <variable item="Loop Sound Slot 3" CV="145" mask="XXXXXVXX" default="0">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Loop Sound Slot 3</label>
       </variable>
       <variable item="Loop Sound Slot 4" CV="145" mask="XXXXVXXX" default="0">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Loop Sound Slot 4</label>
       </variable>
       <variable item="Loop Sound Slot 5" CV="145" mask="XXXVXXXX" default="0">
@@ -3453,1169 +2641,427 @@ Sept 2009 - believe this is obselete from V39 upwards, replaced by Function Mapp
       </variable>
       <!--  remainder of Tran Function Mapping -->
       <variable item="FL(f) controls output Ra" CV="163" mask="XXXXXXXV" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output Ra</label>
       </variable>
       <variable item="FL(f) controls output Se" CV="163" mask="XXXXXXVX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output Se</label>
       </variable>
       <variable item="FL(f) controls output Alt" CV="163" mask="XXXXXVXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output Alt</label>
       </variable>
       <variable item="FL(f) controls output G1" CV="163" mask="XXXXVXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output G1</label>
       </variable>
       <variable item="FL(f) controls output G2" CV="163" mask="XXXVXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output G2</label>
       </variable>
       <variable item="FL(f) controls output G3" CV="163" mask="XXVXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output G3</label>
       </variable>
       <variable item="FL(f) controls output G4" CV="163" mask="XVXXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output G4</label>
       </variable>
       <variable item="FL(f) controls output G5" CV="163" mask="VXXXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output G5</label>
       </variable>
       <variable item="FL(r) controls output Ra" CV="164" mask="XXXXXXXV" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output Ra</label>
       </variable>
       <variable item="FL(r) controls output Se" CV="164" mask="XXXXXXVX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output Se</label>
       </variable>
       <variable item="FL(r) controls output Alt" CV="164" mask="XXXXXVXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output Alt</label>
       </variable>
       <variable item="FL(r) controls output G1" CV="164" mask="XXXXVXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output G1</label>
       </variable>
       <variable item="FL(r) controls output G2" CV="164" mask="XXXVXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output G2</label>
       </variable>
       <variable item="FL(r) controls output G3" CV="164" mask="XXVXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output G3</label>
       </variable>
       <variable item="FL(r) controls output G4" CV="164" mask="XVXXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output G4</label>
       </variable>
       <variable item="FL(r) controls output G5" CV="164" mask="VXXXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output G5</label>
       </variable>
       <variable item="F1 controls output Ra" CV="165" mask="XXXXXXXV" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output Ra</label>
       </variable>
       <variable item="F1 controls output Se" CV="165" mask="XXXXXXVX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output Se</label>
       </variable>
       <variable item="F1 controls output Alt" CV="165" mask="XXXXXVXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output Alt</label>
       </variable>
       <variable item="F1 controls output G1" CV="165" mask="XXXXVXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output G1</label>
       </variable>
       <variable item="F1 controls output G2" CV="165" mask="XXXVXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output G2</label>
       </variable>
       <variable item="F1 controls output G3" CV="165" mask="XXVXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output G3</label>
       </variable>
       <variable item="F1 controls output G4" CV="165" mask="XVXXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output G4</label>
       </variable>
       <variable item="F1 controls output G5" CV="165" mask="VXXXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output G5</label>
       </variable>
       <variable item="F2 controls output Ra" CV="166" mask="XXXXXXXV" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output Ra</label>
       </variable>
       <variable item="F2 controls output Se" CV="166" mask="XXXXXXVX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output Se</label>
       </variable>
       <variable item="F2 controls output Alt" CV="166" mask="XXXXXVXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output Alt</label>
       </variable>
       <variable item="F2 controls output G1" CV="166" mask="XXXXVXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output G1</label>
       </variable>
       <variable item="F2 controls output G2" CV="166" mask="XXXVXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output G2</label>
       </variable>
       <variable item="F2 controls output G3" CV="166" mask="XXVXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output G3</label>
       </variable>
       <variable item="F2 controls output G4" CV="166" mask="XVXXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output G4</label>
       </variable>
       <variable item="F2 controls output G5" CV="166" mask="VXXXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output G5</label>
       </variable>
       <variable item="F3 controls output Ra" CV="167" mask="XXXXXXXV" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output Ra</label>
       </variable>
       <variable item="F3 controls output Se" CV="167" mask="XXXXXXVX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output Se</label>
       </variable>
       <variable item="F3 controls output Alt" CV="167" mask="XXXXXVXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output Alt</label>
       </variable>
       <variable item="F3 controls output G1" CV="167" mask="XXXXVXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output G1</label>
       </variable>
       <variable item="F3 controls output G2" CV="167" mask="XXXVXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output G2</label>
       </variable>
       <variable item="F3 controls output G3" CV="167" mask="XXVXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output G3</label>
       </variable>
       <variable item="F3 controls output G4" CV="167" mask="XVXXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output G4</label>
       </variable>
       <variable item="F3 controls output G5" CV="167" mask="VXXXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output G5</label>
       </variable>
       <variable item="F4 controls output G1" CV="168" mask="XXXXXXXV" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output G1</label>
       </variable>
       <variable item="F4 controls output G2" CV="168" mask="XXXXXXVX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output G2</label>
       </variable>
       <variable item="F4 controls output G3" CV="168" mask="XXXXXVXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output G3</label>
       </variable>
       <variable item="F4 controls output G4" CV="168" mask="XXXXVXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output G4</label>
       </variable>
       <variable item="F4 controls output G5" CV="168" mask="XXXVXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output G5</label>
       </variable>
       <variable item="F4 controls output G6" CV="168" mask="XXVXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output G6</label>
       </variable>
       <variable item="F4 controls output G7" CV="168" mask="XVXXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output G7</label>
       </variable>
       <variable item="F4 controls output G8" CV="168" mask="VXXXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output G8</label>
       </variable>
       <variable item="F5 controls output G1" CV="169" mask="XXXXXXXV" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output G1</label>
       </variable>
       <variable item="F5 controls output G2" CV="169" mask="XXXXXXVX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output G2</label>
       </variable>
       <variable item="F5 controls output G3" CV="169" mask="XXXXXVXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output G3</label>
       </variable>
       <variable item="F5 controls output G4" CV="169" mask="XXXXVXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output G4</label>
       </variable>
       <variable item="F5 controls output G5" CV="169" mask="XXXVXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output G5</label>
       </variable>
       <variable item="F5 controls output G6" CV="169" mask="XXVXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output G6</label>
       </variable>
       <variable item="F5 controls output G7" CV="169" mask="XVXXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output G7</label>
       </variable>
       <variable item="F5 controls output G8" CV="169" mask="VXXXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output G8</label>
       </variable>
       <variable item="F6 controls output G1" CV="170" mask="XXXXXXXV" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output G1</label>
       </variable>
       <variable item="F6 controls output G2" CV="170" mask="XXXXXXVX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output G2</label>
       </variable>
       <variable item="F6 controls output G3" CV="170" mask="XXXXXVXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output G3</label>
       </variable>
       <variable item="F6 controls output G4" CV="170" mask="XXXXVXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output G4</label>
       </variable>
       <variable item="F6 controls output G5" CV="170" mask="XXXVXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output G5</label>
       </variable>
       <variable item="F6 controls output G6" CV="170" mask="XXVXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output G6</label>
       </variable>
       <variable item="F6 controls output G7" CV="170" mask="XVXXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output G7</label>
       </variable>
       <variable item="F6 controls output G8" CV="170" mask="VXXXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output G8</label>
       </variable>
       <variable item="F7 controls output G1" CV="171" mask="XXXXXXXV" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output G1</label>
       </variable>
       <variable item="F7 controls output G2" CV="171" mask="XXXXXXVX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output G2</label>
       </variable>
       <variable item="F7 controls output G3" CV="171" mask="XXXXXVXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output G3</label>
       </variable>
       <variable item="F7 controls output G4" CV="171" mask="XXXXVXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output G4</label>
       </variable>
       <variable item="F7 controls output G5" CV="171" mask="XXXVXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output G5</label>
       </variable>
       <variable item="F7 controls output G6" CV="171" mask="XXVXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output G6</label>
       </variable>
       <variable item="F7 controls output G7" CV="171" mask="XVXXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output G7</label>
       </variable>
       <variable item="F7 controls output G8" CV="171" mask="VXXXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output G8</label>
       </variable>
       <variable item="F8 controls output G1" CV="172" mask="XXXXXXXV" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output G1</label>
       </variable>
       <variable item="F8 controls output G2" CV="172" mask="XXXXXXVX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output G2</label>
       </variable>
       <variable item="F8 controls output G3" CV="172" mask="XXXXXVXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output G3</label>
       </variable>
       <variable item="F8 controls output G4" CV="172" mask="XXXXVXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output G4</label>
       </variable>
       <variable item="F8 controls output G5" CV="172" mask="XXXVXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output G5</label>
       </variable>
       <variable item="F8 controls output G6" CV="172" mask="XXVXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output G6</label>
       </variable>
       <variable item="F8 controls output G7" CV="172" mask="XVXXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output G7</label>
       </variable>
       <variable item="F8 controls output G8" CV="172" mask="VXXXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output G8</label>
       </variable>
       <variable item="F9 controls output G4" CV="173" mask="XXXXXXXV" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output G4</label>
       </variable>
       <variable item="F9 controls output G5" CV="173" mask="XXXXXXVX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output G5</label>
       </variable>
       <variable item="F9 controls output G6" CV="173" mask="XXXXXVXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output G6</label>
       </variable>
       <variable item="F9 controls output G7" CV="173" mask="XXXXVXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output G7</label>
       </variable>
       <variable item="F9 controls output G8" CV="173" mask="XXXVXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output G8</label>
       </variable>
       <variable item="F9 controls output Z7" CV="173" mask="XXVXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output Z7</label>
       </variable>
       <variable item="F9 controls output Z8" CV="173" mask="XVXXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output Z8</label>
       </variable>
       <variable item="F9 controls output Z9" CV="173" mask="VXXXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output Z9</label>
       </variable>
       <variable item="F10 controls output G4" CV="174" mask="XXXXXXXV" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output G4</label>
       </variable>
       <variable item="F10 controls output G5" CV="174" mask="XXXXXXVX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output G5</label>
       </variable>
       <variable item="F10 controls output G6" CV="174" mask="XXXXXVXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output G6</label>
       </variable>
       <variable item="F10 controls output G7" CV="174" mask="XXXXVXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output G7</label>
       </variable>
       <variable item="F10 controls output G8" CV="174" mask="XXXVXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output G8</label>
       </variable>
       <variable item="F10 controls output Z7" CV="174" mask="XXVXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output Z7</label>
       </variable>
       <variable item="F10 controls output Z8" CV="174" mask="XVXXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output Z8</label>
       </variable>
       <variable item="F10 controls output Z9" CV="174" mask="VXXXXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output Z9</label>
       </variable>
       <variable item="F11 controls output G4" CV="175" mask="XXXXXXXV" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output G4</label>
       </variable>
       <variable item="F11 controls output G5" CV="175" mask="XXXXXXVX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output G5</label>
       </variable>
       <variable item="F11 controls output G6" CV="175" mask="XXXXXVXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output G6</label>
       </variable>
       <variable item="F11 controls output G7" CV="175" mask="XXXXVXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output G7</label>
       </variable>
       <variable item="F11 controls output G8" CV="175" mask="XXXVXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output G8</label>
       </variable>
       <variable item="F12 controls output G4" CV="176" mask="XXXXXXXV" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output G4</label>
       </variable>
       <variable item="F12 controls output G5" CV="176" mask="XXXXXXVX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output G5</label>
       </variable>
       <variable item="F12 controls output G6" CV="176" mask="XXXXXVXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output G6</label>
       </variable>
       <variable item="F12 controls output G7" CV="176" mask="XXXXVXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output G7</label>
       </variable>
       <variable item="F12 controls output G8" CV="176" mask="XXXVXXXX" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output G8</label>
       </variable>
       <variable item="Acceleration Sound Trigger" CV="177" default="00" tooltip="rate of speed change to trigger accel noise slots 123-125">

--- a/xml/decoders/DCC_Concepts_Loco.xml
+++ b/xml/decoders/DCC_Concepts_Loco.xml
@@ -601,179 +601,67 @@
         <label>Beacon Max Brightness</label>
       </variable>
       <variable item="FL(f) controls output Dim" CV="123" mask="XXXXXXXV" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output Dim</label>
       </variable>
       <variable item="FL(r) controls output Dim" CV="123" mask="XXXXXXVX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output Dim</label>
       </variable>
       <variable item="F1 controls output Dim" CV="123" mask="XXXXXVXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output Dim</label>
       </variable>
       <variable item="F2 controls output Dim" CV="123" mask="XXXXVXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output Dim</label>
       </variable>
       <variable item="F3 controls output Dim" CV="123" mask="XXXVXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output Dim</label>
       </variable>
       <variable item="F4 controls output Dim" CV="123" mask="XXVXXXXX" minOut="1" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output Dim</label>
       </variable>
       <variable item="F5 controls output Dim" CV="123" mask="XVXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output Dim</label>
       </variable>
       <variable item="F6 controls output Dim" CV="123" mask="VXXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output Dim</label>
       </variable>
       <variable item="FL(f) controls output Ditch" CV="124" mask="XXXXXXXV" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output Ditch</label>
       </variable>
       <variable item="FL(r) controls output Ditch" CV="124" mask="XXXXXXVX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output Ditch</label>
       </variable>
       <variable item="F1 controls output Ditch" CV="124" mask="XXXXXVXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output Ditch</label>
       </variable>
       <variable item="F2 controls output Ditch" CV="124" mask="XXXXVXXX" minOut="1" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output Ditch</label>
       </variable>
       <variable item="F3 controls output Ditch" CV="124" mask="XXXVXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output Ditch</label>
       </variable>
       <variable item="F4 controls output Ditch" CV="124" mask="XXVXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output Ditch</label>
       </variable>
       <variable item="F5 controls output Ditch" CV="124" mask="XVXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output Ditch</label>
       </variable>
       <variable item="F6 controls output Ditch" CV="124" mask="VXXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output Ditch</label>
       </variable>
       <variable item="Decel 2 Rate End Point" CV="125" default="0" tooltip="Sets the Decel 2 Rate End Point, range 0(default)-255" comment="Range 0-255">
@@ -821,91 +709,35 @@
         <label>Power to button controlled motor</label>
       </variable>
       <variable item="FL(f) controls output Motor" CV="134" mask="XXXXXXXV" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output Motor</label>
       </variable>
       <variable item="FL(r) controls output Motor" CV="134" mask="XXXXXXVX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output Motor</label>
       </variable>
       <variable item="F1 controls output Motor" CV="134" mask="XXXXXVXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output Motor</label>
       </variable>
       <variable item="F2 controls output Motor" CV="134" mask="XXXXVXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output Motor</label>
       </variable>
       <variable item="F3 controls output Motor" CV="134" mask="XXXVXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output Motor</label>
       </variable>
       <variable item="F4 controls output Motor" CV="134" mask="XXVXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output Motor</label>
       </variable>
       <variable item="F5 controls output Motor" CV="134" mask="XVXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output Motor</label>
       </variable>
       <variable item="F6 controls output Motor" CV="134" mask="VXXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output Motor</label>
       </variable>
       <variable CV="135" default="16" item="Function 4 effect generated" tooltip="Random Flicker for fireboxes">
@@ -913,91 +745,35 @@
         <label>Random Flicker Control</label>
       </variable>
       <variable item="F5 controls output BEMF" CV="136" mask="XXXXXXXV" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output BEMF</label>
       </variable>
       <variable item="F6 controls output BEMF" CV="136" mask="XXXXXXVX" minOut="1" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output BEMF</label>
       </variable>
       <variable item="F7 controls output BEMF" CV="136" mask="XXXXXVXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output BEMF</label>
       </variable>
       <variable item="F8 controls output BEMF" CV="136" mask="XXXXVXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output BEMF</label>
       </variable>
       <variable item="F9 controls output BEMF" CV="136" mask="XXXVXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output BEMF</label>
       </variable>
       <variable item="F10 controls output BEMF" CV="136" mask="XXVXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output BEMF</label>
       </variable>
       <variable item="F11 controls output BEMF" CV="136" mask="XVXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output BEMF</label>
       </variable>
       <variable item="F12 controls output BEMF" CV="136" mask="VXXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output BEMF</label>
       </variable>
     </variables>

--- a/xml/decoders/ESU_LokPilotDCC.xml
+++ b/xml/decoders/ESU_LokPilotDCC.xml
@@ -85,443 +85,163 @@
      <xi:include href="http://jmri.org/xml/decoders/nmra/cv29analog.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/nmra/cv29table3-28.xml"/>
       <variable item="FL(f) controls output 1" CV="33" mask="XXXXXXXV" minOut="1" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 1</label>
       </variable>
       <variable item="FL(f) controls output 2" CV="33" mask="XXXXXXVX" minOut="2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 2</label>
       </variable>
       <variable item="FL(f) controls output 3" CV="33" mask="XXXXXVXX" minOut="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 3</label>
       </variable>
       <variable item="FL(f) controls output 4" CV="33" mask="XXXXVXXX" minOut="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 4</label>
       </variable>
       <variable item="FL(f) controls output 5" CV="33" mask="XXXVXXXX" minOut="5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 5</label>
       </variable>
       <variable item="FL(f) controls output 6" CV="33" mask="XXVXXXXX" minOut="6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 6</label>
       </variable>
       <variable item="FL(r) controls output 1" CV="34" mask="XXXXXXXV" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 1</label>
       </variable>
       <variable item="FL(r) controls output 2" CV="34" mask="XXXXXXVX" minOut="2" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 2</label>
       </variable>
       <variable item="FL(r) controls output 3" CV="34" mask="XXXXXVXX" minOut="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 3</label>
       </variable>
       <variable item="FL(r) controls output 4" CV="34" mask="XXXXVXXX" minOut="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 4</label>
       </variable>
       <variable item="FL(r) controls output 5" CV="34" mask="XXXVXXXX" minOut="5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 5</label>
       </variable>
       <variable item="FL(r) controls output 6" CV="34" mask="XXVXXXXX" minOut="6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 6</label>
       </variable>
       <variable item="F1 controls output 1" CV="35" mask="XXXXXXXV" minOut="1" minFn="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 1</label>
       </variable>
       <variable item="F1 controls output 2" CV="35" mask="XXXXXXVX" minOut="2" minFn="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 2</label>
       </variable>
       <variable item="F1 controls output 3" CV="35" mask="XXXXXVXX" minOut="3" minFn="1" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 3</label>
       </variable>
       <variable item="F1 controls output 4" CV="35" mask="XXXXVXXX" minOut="4" minFn="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 4</label>
       </variable>
       <variable item="F1 controls output 5" CV="35" mask="XXXVXXXX" minOut="5" minFn="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 5</label>
       </variable>
       <variable item="F1 controls output 6" CV="35" mask="XXVXXXXX" minOut="6" minFn="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 6</label>
       </variable>
       <variable item="F2 controls output 1" CV="36" mask="XXXXXXXV" minOut="1" minFn="2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 1</label>
       </variable>
       <variable item="F2 controls output 2" CV="36" mask="XXXXXXVX" minOut="2" minFn="2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 2</label>
       </variable>
       <variable item="F2 controls output 3" CV="36" mask="XXXXXVXX" minOut="3" minFn="2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 3</label>
       </variable>
       <variable item="F2 controls output 4" CV="36" mask="XXXXVXXX" minOut="4" minFn="2" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 4</label>
       </variable>
       <variable item="F2 controls output 5" CV="36" mask="XXXVXXXX" minOut="5" minFn="2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 5</label>
       </variable>
       <variable item="F2 controls output 6" CV="36" mask="XXVXXXXX" minOut="6" minFn="2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 6</label>
       </variable>
       <variable item="F3 controls output 3" CV="37" mask="XXXXXXXV" minOut="3" minFn="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 3</label>
       </variable>
       <variable item="F3 controls output 4" CV="37" mask="XXXXXXVX" minOut="4" minFn="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 4</label>
       </variable>
       <variable item="F3 controls output 5" CV="37" mask="XXXXXVXX" minOut="5" minFn="3" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 5</label>
       </variable>
       <variable item="F3 controls output 6" CV="37" mask="XXXXVXXX" minOut="6" minFn="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 6</label>
       </variable>
       <variable item="F4 controls output 3" CV="38" mask="XXXXXXXV" minOut="3" minFn="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 3</label>
       </variable>
       <variable item="F4 controls output 4" CV="38" mask="XXXXXXVX" minOut="4" minFn="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 4</label>
       </variable>
       <variable item="F4 controls output 5" CV="38" mask="XXXXXVXX" minOut="5" minFn="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 5</label>
       </variable>
       <variable item="F4 controls output 6" CV="38" mask="XXXXVXXX" minOut="6" minFn="4" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 6</label>
       </variable>
       <variable item="F5 controls output 3" CV="39" mask="XXXXXXXV" minOut="3" minFn="5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 3</label>
       </variable>
       <variable item="F5 controls output 4" CV="39" mask="XXXXXXVX" minOut="4" minFn="5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 4</label>
       </variable>
       <variable item="F5 controls output 5" CV="39" mask="XXXXXVXX" minOut="5" minFn="5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 5</label>
       </variable>
       <variable item="F5 controls output 6" CV="39" mask="XXXXVXXX" minOut="6" minFn="5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 6</label>
       </variable>
       <variable item="F6 controls output 3" CV="40" mask="XXXXXXXV" minOut="3" minFn="6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 3</label>
       </variable>
       <variable item="F6 controls output 4" CV="40" mask="XXXXXXVX" minOut="4" minFn="6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 4</label>
       </variable>
       <variable item="F6 controls output 5" CV="40" mask="XXXXXVXX" minOut="5" minFn="6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 5</label>
       </variable>
       <variable item="F6 controls output 6" CV="40" mask="XXXXVXXX" minOut="6" minFn="6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 6</label>
       </variable>
       <variable item="EMF Static Config" CV="49" mask="XXXXXXXV" default="1">

--- a/xml/decoders/ESU_LokSound2_21.xml
+++ b/xml/decoders/ESU_LokSound2_21.xml
@@ -301,1323 +301,483 @@
      <xi:include href="http://jmri.org/xml/decoders/nmra/cv29analog.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/nmra/cv29table3-28.xml"/>
       <variable item="FL(f) controls output 1" CV="33" mask="XXXXXXXV" minOut="1" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 1</label>
       </variable>
       <variable item="FL(f) controls output 2" CV="33" mask="XXXXXXVX" minOut="2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 2</label>
       </variable>
       <variable item="FL(f) controls output 3" CV="33" mask="XXXXXVXX" minOut="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 3</label>
       </variable>
       <variable item="FL(f) controls output 4" CV="33" mask="XXXVXXXX" minOut="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 4</label>
       </variable>
       <variable item="FL(f) controls output 5" CV="33" mask="XXVXXXXX" minOut="5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 5</label>
       </variable>
       <variable item="FL(f) controls output 6" CV="33" mask="XVXXXXXX" minOut="6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 6</label>
       </variable>
       <variable item="FL(f) controls output 7" CV="33" mask="VXXXXXXX" minOut="7">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 7</label>
       </variable>
       <variable item="FL(r) controls output 1" CV="34" mask="XXXXXXXV" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 1</label>
       </variable>
       <variable item="FL(r) controls output 2" CV="34" mask="XXXXXXVX" minOut="2" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 2</label>
       </variable>
       <variable item="FL(r) controls output 3" CV="34" mask="XXXXXVXX" minOut="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 3</label>
       </variable>
       <variable item="FL(r) controls output 4" CV="34" mask="XXXVXXXX" minOut="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 4</label>
       </variable>
       <variable item="FL(r) controls output 5" CV="34" mask="XXVXXXXX" minOut="5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 5</label>
       </variable>
       <variable item="FL(r) controls output 6" CV="34" mask="XVXXXXXX" minOut="6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 6</label>
       </variable>
       <variable item="FL(r) controls output 7" CV="34" mask="VXXXXXXX" minOut="7">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 7</label>
       </variable>
       <variable item="F1 controls output 1" CV="35" mask="XXXXXXXV" minOut="1" minFn="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 1</label>
       </variable>
       <variable item="F1 controls output 2" CV="35" mask="XXXXXXVX" minOut="2" minFn="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 2</label>
       </variable>
       <variable item="F1 controls output 3" CV="35" mask="XXXXXVXX" minOut="3" minFn="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 3</label>
       </variable>
       <variable item="F1 controls output 4" CV="35" mask="XXXVXXXX" minOut="4" minFn="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 4</label>
       </variable>
       <variable item="F1 controls output 5" CV="35" mask="XXVXXXXX" minOut="5" minFn="1" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 5</label>
       </variable>
       <variable item="F1 controls output 6" CV="35" mask="XVXXXXXX" minOut="6" minFn="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 6</label>
       </variable>
       <variable item="F1 controls output 7" CV="35" mask="VXXXXXXX" minOut="7" minFn="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 7</label>
       </variable>
       <variable item="F2 controls output 1" CV="36" mask="XXXXXXXV" minOut="1" minFn="2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 1</label>
       </variable>
       <variable item="F2 controls output 2" CV="36" mask="XXXXXXVX" minOut="2" minFn="2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 2</label>
       </variable>
       <variable item="F2 controls output 3" CV="36" mask="XXXXXVXX" minOut="3" minFn="2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 3</label>
       </variable>
       <variable item="F2 controls output 4" CV="36" mask="XXXVXXXX" minOut="4" minFn="2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 4</label>
       </variable>
       <variable item="F2 controls output 5" CV="36" mask="XXVXXXXX" minOut="5" minFn="2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 5</label>
       </variable>
       <variable item="F2 controls output 6" CV="36" mask="XVXXXXXX" minOut="6" minFn="2" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 6</label>
       </variable>
       <variable item="F2 controls output 7" CV="36" mask="VXXXXXXX" minOut="7" minFn="2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 7</label>
       </variable>
       <variable item="F3 controls output 3" CV="37" mask="XXXXXXXV" minOut="3" minFn="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 3</label>
       </variable>
       <variable item="F3 controls output 4" CV="37" mask="XXXXXVXX" minOut="4" minFn="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 4</label>
       </variable>
       <variable item="F3 controls output 5" CV="37" mask="XXXXVXXX" minOut="5" minFn="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 5</label>
       </variable>
       <variable item="F3 controls output 6" CV="37" mask="XXXVXXXX" minOut="6" minFn="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 6</label>
       </variable>
       <variable item="F3 controls output 7" CV="37" mask="XXVXXXXX" minOut="7" minFn="3" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 7</label>
       </variable>
       <variable item="F3 controls output 8" CV="37" mask="XVXXXXXX" minOut="8" minFn="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 8</label>
       </variable>
       <variable item="F3 controls output 9" CV="37" mask="VXXXXXXX" minOut="9" minFn="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 9</label>
       </variable>
       <variable item="F4 controls output 3" CV="38" mask="XXXXXXXV" minOut="3" minFn="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 3</label>
       </variable>
       <variable item="F4 controls output 4" CV="38" mask="XXXXXVXX" minOut="4" minFn="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 4</label>
       </variable>
       <variable item="F4 controls output 5" CV="38" mask="XXXXVXXX" minOut="5" minFn="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 5</label>
       </variable>
       <variable item="F4 controls output 6" CV="38" mask="XXXVXXXX" minOut="6" minFn="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 6</label>
       </variable>
       <variable item="F4 controls output 7" CV="38" mask="XXVXXXXX" minOut="7" minFn="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 7</label>
       </variable>
       <variable item="F4 controls output 8" CV="38" mask="XVXXXXXX" minOut="8" minFn="4" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 8</label>
       </variable>
       <variable item="F4 controls output 9" CV="38" mask="VXXXXXXX" minOut="9" minFn="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 9</label>
       </variable>
       <variable item="F5 controls output 3" CV="39" mask="XXXXXXXV" minOut="3" minFn="5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 3</label>
       </variable>
       <variable item="F5 controls output 4" CV="39" mask="XXXXXVXX" minOut="4" minFn="5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 4</label>
       </variable>
       <variable item="F5 controls output 5" CV="39" mask="XXXXVXXX" minOut="5" minFn="5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 5</label>
       </variable>
       <variable item="F5 controls output 6" CV="39" mask="XXXVXXXX" minOut="6" minFn="5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 6</label>
       </variable>
       <variable item="F5 controls output 7" CV="39" mask="XXVXXXXX" minOut="7" minFn="5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 7</label>
       </variable>
       <variable item="F5 controls output 8" CV="39" mask="XVXXXXXX" minOut="8" minFn="5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 8</label>
       </variable>
       <variable item="F5 controls output 9" CV="39" mask="VXXXXXXX" minOut="9" minFn="5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 9</label>
       </variable>
       <variable item="F6 controls output 3" CV="40" mask="XXXXXXXV" minOut="3" minFn="6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 3</label>
       </variable>
       <variable item="F6 controls output 4" CV="40" mask="XXXXXVXX" minOut="4" minFn="6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 4</label>
       </variable>
       <variable item="F6 controls output 5" CV="40" mask="XXXXVXXX" minOut="5" minFn="6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 5</label>
       </variable>
       <variable item="F6 controls output 6" CV="40" mask="XXXVXXXX" minOut="6" minFn="6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 6</label>
       </variable>
       <variable item="F6 controls output 7" CV="40" mask="XXVXXXXX" minOut="7" minFn="6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 7</label>
       </variable>
       <variable item="F6 controls output 8" CV="40" mask="XVXXXXXX" minOut="8" minFn="6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 8</label>
       </variable>
       <variable item="F6 controls output 9" CV="40" mask="VXXXXXXX" minOut="9" minFn="6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 9</label>
       </variable>
       <variable item="F7 controls output 6" CV="41" mask="XXXXXXXV" minOut="6" minFn="7">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output 6</label>
       </variable>
       <variable item="F7 controls output 7" CV="41" mask="XXXXXXVX" minOut="7" minFn="7">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output 7</label>
       </variable>
       <variable item="F7 controls output 8" CV="41" mask="XXXXXVXX" minOut="8" minFn="7">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output 8</label>
       </variable>
       <variable item="F7 controls output 9" CV="41" mask="XXXXVXXX" minOut="9" minFn="7">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output 9</label>
       </variable>
       <variable item="F7 controls output 10" CV="41" mask="XXXVXXXX" minOut="10" minFn="7">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output 10</label>
       </variable>
       <variable item="F7 controls output 11" CV="41" mask="XXVXXXXX" minOut="11" minFn="7">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output 11</label>
       </variable>
       <variable item="F7 controls output 12" CV="41" mask="XVXXXXXX" minOut="12" minFn="7">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output 12</label>
       </variable>
       <variable item="F7 controls output 13" CV="41" mask="VXXXXXXX" minOut="13" minFn="7">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output 13</label>
       </variable>
       <variable item="F8 controls output 6" CV="42" mask="XXXXXXXV" minOut="6" minFn="8">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output 6</label>
       </variable>
       <variable item="F8 controls output 7" CV="42" mask="XXXXXXVX" minOut="7" minFn="8">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output 7</label>
       </variable>
       <variable item="F8 controls output 8" CV="42" mask="XXXXXVXX" minOut="8" minFn="8">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output 8</label>
       </variable>
       <variable item="F8 controls output 9" CV="42" mask="XXXXVXXX" minOut="9" minFn="8">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output 9</label>
       </variable>
       <variable item="F8 controls output 10" CV="42" mask="XXXVXXXX" minOut="10" minFn="8">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output 10</label>
       </variable>
       <variable item="F8 controls output 11" CV="42" mask="XXVXXXXX" minOut="11" minFn="8">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output 11</label>
       </variable>
       <variable item="F8 controls output 12" CV="42" mask="XVXXXXXX" minOut="12" minFn="8">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output 12</label>
       </variable>
       <variable item="F8 controls output 13" CV="42" mask="VXXXXXXX" minOut="13" minFn="8">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output 13</label>
       </variable>
       <variable item="F9 controls output 6" CV="43" mask="XXXXXXXV" minOut="6" minFn="9">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output 6</label>
       </variable>
       <variable item="F9 controls output 7" CV="43" mask="XXXXXXVX" minOut="7" minFn="9">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output 7</label>
       </variable>
       <variable item="F9 controls output 8" CV="43" mask="XXXXXVXX" minOut="8" minFn="9">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output 8</label>
       </variable>
       <variable item="F9 controls output 9" CV="43" mask="XXXXVXXX" minOut="9" minFn="9">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output 9</label>
       </variable>
       <variable item="F9 controls output 10" CV="43" mask="XXXVXXXX" minOut="10" minFn="9">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output 10</label>
       </variable>
       <variable item="F9 controls output 11" CV="43" mask="XXVXXXXX" minOut="11" minFn="9">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output 11</label>
       </variable>
       <variable item="F9 controls output 12" CV="43" mask="XVXXXXXX" minOut="12" minFn="9">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output 12</label>
       </variable>
       <variable item="F9 controls output 13" CV="43" mask="VXXXXXXX" minOut="13" minFn="9">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output 13</label>
       </variable>
       <variable item="F10 controls output 6" CV="44" mask="XXXXXXXV" minOut="6" minFn="10">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output 6</label>
       </variable>
       <variable item="F10 controls output 7" CV="44" mask="XXXXXXVX" minOut="7" minFn="10">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output 7</label>
       </variable>
       <variable item="F10 controls output 8" CV="44" mask="XXXXXVXX" minOut="8" minFn="10">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output 8</label>
       </variable>
       <variable item="F10 controls output 9" CV="44" mask="XXXXVXXX" minOut="9" minFn="10">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output 9</label>
       </variable>
       <variable item="F10 controls output 10" CV="44" mask="XXXVXXXX" minOut="10" minFn="10">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output 10</label>
       </variable>
       <variable item="F10 controls output 11" CV="44" mask="XXVXXXXX" minOut="11" minFn="10">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output 11</label>
       </variable>
       <variable item="F10 controls output 12" CV="44" mask="XVXXXXXX" minOut="12" minFn="10">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output 12</label>
       </variable>
       <variable item="F10 controls output 13" CV="44" mask="VXXXXXXX" minOut="13" minFn="10">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output 13</label>
       </variable>
       <variable item="F11 controls output 6" CV="45" mask="XXXXXXXV" minOut="6" minFn="11">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output 6</label>
       </variable>
       <variable item="F11 controls output 7" CV="45" mask="XXXXXXVX" minOut="7" minFn="11">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output 7</label>
       </variable>
       <variable item="F11 controls output 8" CV="45" mask="XXXXXVXX" minOut="8" minFn="11">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output 8</label>
       </variable>
       <variable item="F11 controls output 9" CV="45" mask="XXXXVXXX" minOut="9" minFn="11">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output 9</label>
       </variable>
       <variable item="F11 controls output 10" CV="45" mask="XXXVXXXX" minOut="10" minFn="11">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output 10</label>
       </variable>
       <variable item="F11 controls output 11" CV="45" mask="XXVXXXXX" minOut="11" minFn="11">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output 11</label>
       </variable>
       <variable item="F11 controls output 12" CV="45" mask="XVXXXXXX" minOut="12" minFn="11">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output 12</label>
       </variable>
       <variable item="F11 controls output 13" CV="45" mask="VXXXXXXX" minOut="13" minFn="11">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output 13</label>
       </variable>
       <variable item="F12 controls output 6" CV="46" mask="XXXXXXXV" minOut="6" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output 6</label>
       </variable>
       <variable item="F12 controls output 7" CV="46" mask="XXXXXXVX" minOut="7" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output 7</label>
       </variable>
       <variable item="F12 controls output 8" CV="46" mask="XXXXXVXX" minOut="8" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output 8</label>
       </variable>
       <variable item="F12 controls output 9" CV="46" mask="XXXXVXXX" minOut="9" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output 9</label>
       </variable>
       <variable item="F12 controls output 10" CV="46" mask="XXXVXXXX" minOut="10" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output 10</label>
       </variable>
       <variable item="F12 controls output 11" CV="46" mask="XXVXXXXX" minOut="11" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output 11</label>
       </variable>
       <variable item="F12 controls output 12" CV="46" mask="XVXXXXXX" minOut="12" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output 12</label>
       </variable>
       <variable item="F12 controls output 13" CV="46" mask="VXXXXXXX" minOut="13" minFn="12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output 13</label>
       </variable>
       <variable item="F9(r) controls output 6" CV="47" mask="XXXXXXXV" minOut="6" minFn="13">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9(r) controls output 6</label>
       </variable>
       <variable item="F9(r) controls output 7" CV="47" mask="XXXXXXVX" minOut="6" minFn="13">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9(r) controls output 7</label>
       </variable>
       <variable item="F9(r) controls output 8" CV="47" mask="XXXXXVXX" minOut="6" minFn="13">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9(r) controls output 8</label>
       </variable>
       <variable item="F9(r) controls output 9" CV="47" mask="XXXXVXXX" minOut="6" minFn="13">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9(r) controls output 9</label>
       </variable>
       <variable item="F9(r) controls output 10" CV="47" mask="XXXVXXXX" minOut="6" minFn="13">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9(r) controls output 10</label>
       </variable>
       <variable item="F9(r) controls output 11" CV="47" mask="XXVXXXXX" minOut="6" minFn="13">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9(r) controls output 11</label>
       </variable>
       <variable item="F9(r) controls output 12" CV="47" mask="XVXXXXXX" minOut="6" minFn="13">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9(r) controls output 12</label>
       </variable>
       <variable item="F9(r) controls output 13" CV="47" mask="VXXXXXXX" minOut="6" minFn="13">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9(r) controls output 13</label>
       </variable>
       <variable item="F10(r) controls output 6" CV="48" mask="XXXXXXXV" minOut="6" minFn="14">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10(r) controls output 6</label>
       </variable>
       <variable item="F10(r) controls output 7" CV="48" mask="XXXXXXVX" minOut="6" minFn="14">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10(r) controls output 7</label>
       </variable>
       <variable item="F10(r) controls output 8" CV="48" mask="XXXXXVXX" minOut="6" minFn="14">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10(r) controls output 8</label>
       </variable>
       <variable item="F10(r) controls output 9" CV="48" mask="XXXXVXXX" minOut="6" minFn="14">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10(r) controls output 9</label>
       </variable>
       <variable item="F10(r) controls output 10" CV="48" mask="XXXVXXXX" minOut="6" minFn="14">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10(r) controls output 10</label>
       </variable>
       <variable item="F10(r) controls output 11" CV="48" mask="XXVXXXXX" minOut="6" minFn="14">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10(r) controls output 11</label>
       </variable>
       <variable item="F10(r) controls output 12" CV="48" mask="XVXXXXXX" minOut="6" minFn="14">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10(r) controls output 12</label>
       </variable>
       <variable item="F10(r) controls output 13" CV="48" mask="VXXXXXXX" minOut="6" minFn="14">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10(r) controls output 13</label>
       </variable>
       <variable CV="49" mask="XXXXXXXV" default="1" item="EMF Static Config">

--- a/xml/decoders/Fleischmann_FMZ_DCC.xml
+++ b/xml/decoders/Fleischmann_FMZ_DCC.xml
@@ -82,36 +82,15 @@
       <!-- Function Mapping follows -->
       <!-- Decoder has virtually no function mapping capability ! -->
       <variable CV="39" mask="XVXXXXXX" default="1" item="Advanced Group 1 Option 4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 can disable accel/decel settings</label>
       </variable>
       <variable CV="40" mask="XVXXXXXX" default="1" item="Advanced Group 1 Option 5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 enables Shunt Speed</label>
       </variable>
       <variable CV="51" mask="XXXXXXXV" default="1" item="Advanced Group 2 Option 5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Motor Control</label>
       </variable>
       <variable CV="51" mask="XXXXXXVX" default="0" item="Advanced Group 2 Option 6">
@@ -148,14 +127,7 @@
         <label>Load Simulation under FMZ</label>
       </variable>
       <variable CV="51" mask="XXVXXXXX" default="1" item="Advanced Group 2 Option 4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Lamp indicates error state</label>
       </variable>
       <variable CV="52" mask="XXXXXVVV" item="Advanced Group 1 Option 7" default="7">

--- a/xml/decoders/Fleischmann_Twin_DCC.xml
+++ b/xml/decoders/Fleischmann_Twin_DCC.xml
@@ -90,179 +90,67 @@
       </variable>
       <!-- Function Mapping follows -->
       <variable item="FL(f) controls output 1" CV="33" mask="XXXXXXXV" minOut="1" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 1</label>
       </variable>
       <variable item="FL(f) controls output 2" CV="33" mask="XXXXXXVX" minOut="2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 2</label>
       </variable>
       <variable item="FL(r) controls output 1" CV="34" mask="XXXXXXXV" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 1</label>
       </variable>
       <variable item="FL(r) controls output 2" CV="34" mask="XXXXXXVX" minOut="2" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 2</label>
       </variable>
       <variable item="F1 controls output 1" CV="35" mask="XXXXXXXV" minOut="1" minFn="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 1</label>
       </variable>
       <variable item="F1 controls output 2" CV="35" mask="XXXXXXVX" minOut="2" minFn="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 2</label>
       </variable>
       <variable item="F1 controls output AC" CV="37" mask="XVXXXXXX" minOut="2" minFn="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output AC</label>
       </variable>
       <variable item="F2 controls output 1" CV="36" mask="XXXXXXXV" minOut="1" minFn="2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 1</label>
       </variable>
       <variable item="F2 controls output 2" CV="36" mask="XXXXXXVX" minOut="2" minFn="2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 2</label>
       </variable>
       <variable item="F2 controls output SH" CV="37" mask="VXXXXXXX" minOut="2" minFn="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output SH</label>
       </variable>
       <variable item="F3 controls output 1" CV="37" mask="XXXXXXXV" minOut="1" minFn="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 1</label>
       </variable>
       <variable item="F3 controls output 2" CV="37" mask="XXXXXXVX" minOut="2" minFn="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 2</label>
       </variable>
       <variable item="F4 controls output 4" CV="38" mask="XXXXXXXV" minOut="4" minFn="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 4</label>
       </variable>
       <variable item="F5 controls output 4" CV="39" mask="XXXXXXXV" minOut="2" minFn="5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 4</label>
       </variable>
       <variable item="F6 controls output 4" CV="40" mask="XXXXXXXV" minOut="2" minFn="6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 4</label>
       </variable>
       <variable CV="51" mask="XXXXXXXV" default="1" item="Advanced Group 2 Option 5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Motor Control</label>
       </variable>
       <variable CV="51" mask="XXXXXXVX" default="0" item="Advanced Group 2 Option 6">
@@ -277,14 +165,7 @@
         <label>Motor Cycles Summary</label>
       </variable>
       <variable CV="51" mask="XXVXXXXX" default="1" item="Advanced Group 2 Option 4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Lamp indicates error state</label>
       </variable>
       <variable CV="52" mask="XXXXXVVV" item="Advanced Group 1 Option 7" default="7">

--- a/xml/decoders/Gaugemaster.xml
+++ b/xml/decoders/Gaugemaster.xml
@@ -221,487 +221,179 @@
         <label>Addressing Mode</label>
       </variable>
       <variable item="FL(f) controls output 1" CV="33" mask="XXXXXXXV" minOut="1" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 1</label>
       </variable>
       <variable item="FL(r) controls output 1" CV="33" mask="XXXXXXVX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 1</label>
       </variable>
       <variable item="F1 controls output 1" CV="33" mask="XXXXXVXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 1</label>
       </variable>
       <variable item="F2 controls output 1" CV="33" mask="XXXXVXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 1</label>
       </variable>
       <variable item="F3 controls output 1" CV="33" mask="XXXVXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 1</label>
       </variable>
       <variable item="F4 controls output 1" CV="33" mask="XXVXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 1</label>
       </variable>
       <variable item="F5 controls output 1" CV="33" mask="XVXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 1</label>
       </variable>
       <variable item="F6 controls output 1" CV="33" mask="VXXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 1</label>
       </variable>
       <variable item="FL(f) controls output 2" CV="34" mask="XXXXXXXV" minOut="2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 2</label>
       </variable>
       <variable item="FL(r) controls output 2" CV="34" mask="XXXXXXVX" minOut="2" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 2</label>
       </variable>
       <variable item="F1 controls output 2" CV="34" mask="XXXXXVXX" minOut="2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 2</label>
       </variable>
       <variable item="F2 controls output 2" CV="34" mask="XXXXVXXX" minOut="2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 2</label>
       </variable>
       <variable item="F3 controls output 2" CV="34" mask="XXXVXXXX" minOut="2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 2</label>
       </variable>
       <variable item="F4 controls output 2" CV="34" mask="XXVXXXXX" minOut="2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 2</label>
       </variable>
       <variable item="F5 controls output 2" CV="34" mask="XVXXXXXX" minOut="2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 2</label>
       </variable>
       <variable item="F6 controls output 2" CV="34" mask="VXXXXXXX" minOut="2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 2</label>
       </variable>
       <variable item="FL(f) controls output 3" CV="35" mask="XXXXXXXV" minOut="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 3</label>
       </variable>
       <variable item="FL(r) controls output 3" CV="35" mask="XXXXXXVX" minOut="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 3</label>
       </variable>
       <variable item="F1 controls output 3" CV="35" mask="XXXXXVXX" minOut="3" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 3</label>
       </variable>
       <variable item="F2 controls output 3" CV="35" mask="XXXXVXXX" minOut="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 3</label>
       </variable>
       <variable item="F3 controls output 3" CV="35" mask="XXXVXXXX" minOut="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 3</label>
       </variable>
       <variable item="F4 controls output 3" CV="35" mask="XXVXXXXX" minOut="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 3</label>
       </variable>
       <variable item="F5 controls output 3" CV="35" mask="XVXXXXXX" minOut="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 3</label>
       </variable>
       <variable item="F6 controls output 3" CV="35" mask="VXXXXXXX" minOut="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 3</label>
       </variable>
       <variable item="FL(f) controls output 4" CV="36" mask="XXXXXXXV" minOut="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 4</label>
       </variable>
       <variable item="FL(r) controls output 4" CV="36" mask="XXXXXXVX" minOut="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 4</label>
       </variable>
       <variable item="F1 controls output 4" CV="36" mask="XXXXXVXX" minOut="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 4</label>
       </variable>
       <variable item="F2 controls output 4" CV="36" mask="XXXXVXXX" minOut="4" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 4</label>
       </variable>
       <variable item="F3 controls output 4" CV="36" mask="XXXVXXXX" minOut="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 4</label>
       </variable>
       <variable item="F4 controls output 4" CV="36" mask="XXVXXXXX" minOut="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 4</label>
       </variable>
       <variable item="F5 controls output 4" CV="36" mask="XVXXXXXX" minOut="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 4</label>
       </variable>
       <variable item="F6 controls output 4" CV="36" mask="VXXXXXXX" minOut="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 4</label>
       </variable>
       <variable item="F7 controls output 3" CV="37" mask="XXXXXVXX" minOut="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output 3</label>
       </variable>
       <variable item="F8 controls output 3" CV="37" mask="XXXXVXXX" minOut="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output 3</label>
       </variable>
       <variable item="F9 controls output 3" CV="37" mask="XXXVXXXX" minOut="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output 3</label>
       </variable>
       <variable item="F10 controls output 3" CV="37" mask="XXVXXXXX" minOut="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output 3</label>
       </variable>
       <variable item="F11 controls output 3" CV="37" mask="XVXXXXXX" minOut="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output 3</label>
       </variable>
       <variable item="F12 controls output 3" CV="37" mask="VXXXXXXX" minOut="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output 3</label>
       </variable>
       <variable item="F7 controls output 4" CV="38" mask="XXXXXVXX" minOut="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output 4</label>
       </variable>
       <variable item="F8 controls output 4" CV="38" mask="XXXXVXXX" minOut="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output 4</label>
       </variable>
       <variable item="F9 controls output 4" CV="38" mask="XXXVXXXX" minOut="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output 4</label>
       </variable>
       <variable item="F10 controls output 4" CV="38" mask="XXVXXXXX" minOut="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output 4</label>
       </variable>
       <variable item="F11 controls output 4" CV="38" mask="XVXXXXXX" minOut="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output 4</label>
       </variable>
       <variable item="F12 controls output 4" CV="38" mask="VXXXXXXX" minOut="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output 4</label>
       </variable>
       <variable CV="49" mask="XXXXVVVV" item="Output 1 effect generated">
@@ -1176,179 +868,67 @@
         <label>Beacon Max Brightness</label>
       </variable>
       <variable item="FL(f) controls output Dim" CV="123" mask="XXXXXXXV" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output Dim</label>
       </variable>
       <variable item="FL(r) controls output Dim" CV="123" mask="XXXXXXVX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output Dim</label>
       </variable>
       <variable item="F1 controls output Dim" CV="123" mask="XXXXXVXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output Dim</label>
       </variable>
       <variable item="F2 controls output Dim" CV="123" mask="XXXXVXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output Dim</label>
       </variable>
       <variable item="F3 controls output Dim" CV="123" mask="XXXVXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output Dim</label>
       </variable>
       <variable item="F4 controls output Dim" CV="123" mask="XXVXXXXX" minOut="1" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output Dim</label>
       </variable>
       <variable item="F5 controls output Dim" CV="123" mask="XVXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output Dim</label>
       </variable>
       <variable item="F6 controls output Dim" CV="123" mask="VXXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output Dim</label>
       </variable>
       <variable item="FL(f) controls output Ditch" CV="124" mask="XXXXXXXV" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output Ditch</label>
       </variable>
       <variable item="FL(r) controls output Ditch" CV="124" mask="XXXXXXVX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output Ditch</label>
       </variable>
       <variable item="F1 controls output Ditch" CV="124" mask="XXXXXVXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output Ditch</label>
       </variable>
       <variable item="F2 controls output Ditch" CV="124" mask="XXXXVXXX" minOut="1" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output Ditch</label>
       </variable>
       <variable item="F3 controls output Ditch" CV="124" mask="XXXVXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output Ditch</label>
       </variable>
       <variable item="F4 controls output Ditch" CV="124" mask="XXVXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output Ditch</label>
       </variable>
       <variable item="F5 controls output Ditch" CV="124" mask="XVXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output Ditch</label>
       </variable>
       <variable item="F6 controls output Ditch" CV="124" mask="VXXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output Ditch</label>
       </variable>
       <variable item="Decel 2 Rate End Point" CV="125" default="0" tooltip="Sets the Decel 2 Rate End Point, range 0(default)-255, CV125" comment="Range 0-255">
@@ -1396,91 +976,35 @@
         <label>Power to button controlled motor</label>
       </variable>
       <variable item="FL(f) controls output Motor" CV="134" mask="XXXXXXXV" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output Motor</label>
       </variable>
       <variable item="FL(r) controls output Motor" CV="134" mask="XXXXXXVX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output Motor</label>
       </variable>
       <variable item="F1 controls output Motor" CV="134" mask="XXXXXVXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output Motor</label>
       </variable>
       <variable item="F2 controls output Motor" CV="134" mask="XXXXVXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output Motor</label>
       </variable>
       <variable item="F3 controls output Motor" CV="134" mask="XXXVXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output Motor</label>
       </variable>
       <variable item="F4 controls output Motor" CV="134" mask="XXVXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output Motor</label>
       </variable>
       <variable item="F5 controls output Motor" CV="134" mask="XVXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output Motor</label>
       </variable>
       <variable item="F6 controls output Motor" CV="134" mask="VXXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output Motor</label>
       </variable>
       <variable CV="135" default="16" item="Function 4 effect generated" tooltip="Random Flicker for fireboxes">
@@ -1488,91 +1012,35 @@
         <label>Random Flicker Control</label>
       </variable>
       <variable item="F5 controls output BEMF" CV="136" mask="XXXXXXXV" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output BEMF</label>
       </variable>
       <variable item="F6 controls output BEMF" CV="136" mask="XXXXXXVX" minOut="1" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output BEMF</label>
       </variable>
       <variable item="F7 controls output BEMF" CV="136" mask="XXXXXVXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output BEMF</label>
       </variable>
       <variable item="F8 controls output BEMF" CV="136" mask="XXXXVXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output BEMF</label>
       </variable>
       <variable item="F9 controls output BEMF" CV="136" mask="XXXVXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output BEMF</label>
       </variable>
       <variable item="F10 controls output BEMF" CV="136" mask="XXVXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output BEMF</label>
       </variable>
       <variable item="F11 controls output BEMF" CV="136" mask="XVXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output BEMF</label>
       </variable>
       <variable item="F12 controls output BEMF" CV="136" mask="VXXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output BEMF</label>
       </variable>
     </variables>

--- a/xml/decoders/Harman_DIY_function_decoders.xml
+++ b/xml/decoders/Harman_DIY_function_decoders.xml
@@ -153,1795 +153,1027 @@
      <xi:include href="http://jmri.org/xml/decoders/nmra/cv29direction.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/nmra/cv29analog.xml"/>
       <variable item="FL(f) controls output 1" CV="33" mask="VXXXXXXX" minOut="1" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 1</label>
       </variable>
       <variable item="FL(f) controls output 2" CV="33" mask="XVXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 2</label>
       </variable>
       <variable item="FL(f) controls output 3" CV="33" mask="XXVXXXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 3</label>
       </variable>
       <variable item="FL(f) controls output 4" CV="33" mask="XXXVXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 4</label>
       </variable>
       <variable item="FL(f) controls output 5" CV="33" mask="XXXXVXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 5</label>
       </variable>
       <variable item="FL(f) controls output 6" CV="33" mask="XXXXXVXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 6</label>
       </variable>
       <variable item="FL(f) controls output 7" CV="33" mask="XXXXXXVX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 7</label>
       </variable>
       <variable item="FL(f) controls output 8" CV="33" mask="XXXXXXXV" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 8</label>
       </variable>
       <variable item="FL(r) controls output 1" CV="34" mask="VXXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 1</label>
       </variable>
       <variable item="FL(r) controls output 2" CV="34" mask="XVXXXXXX" minOut="1" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 2</label>
       </variable>
       <variable item="FL(r) controls output 3" CV="34" mask="XXVXXXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 3</label>
       </variable>
       <variable item="FL(r) controls output 4" CV="34" mask="XXXVXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 4</label>
       </variable>
       <variable item="FL(r) controls output 5" CV="34" mask="XXXXVXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 5</label>
       </variable>
       <variable item="FL(r) controls output 6" CV="34" mask="XXXXXVXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 6</label>
       </variable>
       <variable item="FL(r) controls output 7" CV="34" mask="XXXXXXVX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 7</label>
       </variable>
       <variable item="FL(r) controls output 8" CV="34" mask="XXXXXXXV" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 8</label>
       </variable>
       <variable item="F1 controls output 1" CV="35" mask="VXXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 1</label>
       </variable>
       <variable item="F1 controls output 2" CV="35" mask="XVXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 2</label>
       </variable>
       <variable item="F1 controls output 3" CV="35" mask="XXVXXXXX" minOut="8" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 3</label>
       </variable>
       <variable item="F1 controls output 4" CV="35" mask="XXXVXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 4</label>
       </variable>
       <variable item="F1 controls output 5" CV="35" mask="XXXXVXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 5</label>
       </variable>
       <variable item="F1 controls output 6" CV="35" mask="XXXXXVXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 6</label>
       </variable>
       <variable item="F1 controls output 7" CV="35" mask="XXXXXXVX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 7</label>
       </variable>
       <variable item="F1 controls output 8" CV="35" mask="XXXXXXXV" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 8</label>
       </variable>
       <variable item="F2 controls output 1" CV="36" mask="VXXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 1</label>
       </variable>
       <variable item="F2 controls output 2" CV="36" mask="XVXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 2</label>
       </variable>
       <variable item="F2 controls output 3" CV="36" mask="XXVXXXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 3</label>
       </variable>
       <variable item="F2 controls output 4" CV="36" mask="XXXVXXXX" minOut="1" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 4</label>
       </variable>
       <variable item="F2 controls output 5" CV="36" mask="XXXXVXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 5</label>
       </variable>
       <variable item="F2 controls output 6" CV="36" mask="XXXXXVXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 6</label>
       </variable>
       <variable item="F2 controls output 7" CV="36" mask="XXXXXXVX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 7</label>
       </variable>
       <variable item="F2 controls output 8" CV="36" mask="XXXXXXXV" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 8</label>
       </variable>
       <variable item="F3 controls output 1" CV="37" mask="VXXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 1</label>
       </variable>
       <variable item="F3 controls output 2" CV="37" mask="XVXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 2</label>
       </variable>
       <variable item="F3 controls output 3" CV="37" mask="XXVXXXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 3</label>
       </variable>
       <variable item="F3 controls output 4" CV="37" mask="XXXVXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 4</label>
       </variable>
       <variable item="F3 controls output 5" CV="37" mask="XXXXVXXX" minOut="8" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 5</label>
       </variable>
       <variable item="F3 controls output 6" CV="37" mask="XXXXXVXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 6</label>
       </variable>
       <variable item="F3 controls output 7" CV="37" mask="XXXXXXVX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 7</label>
       </variable>
       <variable item="F3 controls output 8" CV="37" mask="XXXXXXXV" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 8</label>
       </variable>
       <variable item="F4 controls output 1" CV="38" mask="VXXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 1</label>
       </variable>
       <variable item="F4 controls output 2" CV="38" mask="XVXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 2</label>
       </variable>
       <variable item="F4 controls output 3" CV="38" mask="XXVXXXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 3</label>
       </variable>
       <variable item="F4 controls output 4" CV="38" mask="XXXVXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 4</label>
       </variable>
       <variable item="F4 controls output 5" CV="38" mask="XXXXVXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 5</label>
       </variable>
       <variable item="F4 controls output 6" CV="38" mask="XXXXXVXX" minOut="8" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 6</label>
       </variable>
       <variable item="F4 controls output 7" CV="38" mask="XXXXXXVX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 7</label>
       </variable>
       <variable item="F4 controls output 8" CV="38" mask="XXXXXXXV" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 8</label>
       </variable>
       <variable item="F5 controls output 1" CV="39" mask="VXXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 1</label>
       </variable>
       <variable item="F5 controls output 2" CV="39" mask="XVXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 2</label>
       </variable>
       <variable item="F5 controls output 3" CV="39" mask="XXVXXXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 3</label>
       </variable>
       <variable item="F5 controls output 4" CV="39" mask="XXXVXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 4</label>
       </variable>
       <variable item="F5 controls output 5" CV="39" mask="XXXXVXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 5</label>
       </variable>
       <variable item="F5 controls output 6" CV="39" mask="XXXXXVXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 6</label>
       </variable>
       <variable item="F5 controls output 7" CV="39" mask="XXXXXXVX" minOut="8" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 7</label>
       </variable>
       <variable item="F5 controls output 8" CV="39" mask="XXXXXXXV" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 8</label>
       </variable>
       <variable item="F6 controls output 1" CV="40" mask="VXXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 1</label>
       </variable>
       <variable item="F6 controls output 2" CV="40" mask="XVXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 2</label>
       </variable>
       <variable item="F6 controls output 3" CV="40" mask="XXVXXXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 3</label>
       </variable>
       <variable item="F6 controls output 4" CV="40" mask="XXXVXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 4</label>
       </variable>
       <variable item="F6 controls output 5" CV="40" mask="XXXXVXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 5</label>
       </variable>
       <variable item="F6 controls output 6" CV="40" mask="XXXXXVXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 6</label>
       </variable>
       <variable item="F6 controls output 7" CV="40" mask="XXXXXXVX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 7</label>
       </variable>
       <variable item="F6 controls output 8" CV="40" mask="XXXXXXXV" minOut="8" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 8</label>
       </variable>
       <variable item="F7 controls output 1" CV="41" mask="VXXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output 1</label>
       </variable>
       <variable item="F7 controls output 2" CV="41" mask="XVXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output 2</label>
       </variable>
       <variable item="F7 controls output 3" CV="41" mask="XXVXXXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output 3</label>
       </variable>
       <variable item="F7 controls output 4" CV="41" mask="XXXVXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output 4</label>
       </variable>
       <variable item="F7 controls output 5" CV="41" mask="XXXXVXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output 5</label>
       </variable>
       <variable item="F7 controls output 6" CV="41" mask="XXXXXVXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output 6</label>
       </variable>
       <variable item="F7 controls output 7" CV="41" mask="XXXXXXVX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output 7</label>
       </variable>
       <variable item="F7 controls output 8" CV="41" mask="XXXXXXXV" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output 8</label>
       </variable>
       <variable item="F8 controls output 1" CV="42" mask="VXXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output 1</label>
       </variable>
       <variable item="F8 controls output 2" CV="42" mask="XVXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output 2</label>
       </variable>
       <variable item="F8 controls output 3" CV="42" mask="XXVXXXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output 3</label>
       </variable>
       <variable item="F8 controls output 4" CV="42" mask="XXXVXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output 4</label>
       </variable>
       <variable item="F8 controls output 5" CV="42" mask="XXXXVXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output 5</label>
       </variable>
       <variable item="F8 controls output 6" CV="42" mask="XXXXXVXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output 6</label>
       </variable>
       <variable item="F8 controls output 7" CV="42" mask="XXXXXXVX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output 7</label>
       </variable>
       <variable item="F8 controls output 8" CV="42" mask="XXXXXXXV" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output 8</label>
       </variable>
       <variable item="F9 controls output 1" CV="43" mask="VXXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output 1</label>
       </variable>
       <variable item="F9 controls output 2" CV="43" mask="XVXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output 2</label>
       </variable>
       <variable item="F9 controls output 3" CV="43" mask="XXVXXXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output 3</label>
       </variable>
       <variable item="F9 controls output 4" CV="43" mask="XXXVXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output 4</label>
       </variable>
       <variable item="F9 controls output 5" CV="43" mask="XXXXVXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output 5</label>
       </variable>
       <variable item="F9 controls output 6" CV="43" mask="XXXXXVXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output 6</label>
       </variable>
       <variable item="F9 controls output 7" CV="43" mask="XXXXXXVX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output 7</label>
       </variable>
       <variable item="F9 controls output 8" CV="43" mask="XXXXXXXV" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output 8</label>
       </variable>
       <variable item="F10 controls output 1" CV="44" mask="VXXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output 1</label>
       </variable>
       <variable item="F10 controls output 2" CV="44" mask="XVXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output 2</label>
       </variable>
       <variable item="F10 controls output 3" CV="44" mask="XXVXXXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output 3</label>
       </variable>
       <variable item="F10 controls output 4" CV="44" mask="XXXVXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output 4</label>
       </variable>
       <variable item="F10 controls output 5" CV="44" mask="XXXXVXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output 5</label>
       </variable>
       <variable item="F10 controls output 6" CV="44" mask="XXXXXVXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output 6</label>
       </variable>
       <variable item="F10 controls output 7" CV="44" mask="XXXXXXVX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output 7</label>
       </variable>
       <variable item="F10 controls output 8" CV="44" mask="XXXXXXXV" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output 8</label>
       </variable>
       <variable item="F11 controls output 1" CV="45" mask="VXXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output 1</label>
       </variable>
       <variable item="F11 controls output 2" CV="45" mask="XVXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output 2</label>
       </variable>
       <variable item="F11 controls output 3" CV="45" mask="XXVXXXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output 3</label>
       </variable>
       <variable item="F11 controls output 4" CV="45" mask="XXXVXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output 4</label>
       </variable>
       <variable item="F11 controls output 5" CV="45" mask="XXXXVXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output 5</label>
       </variable>
       <variable item="F11 controls output 6" CV="45" mask="XXXXXVXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output 6</label>
       </variable>
       <variable item="F11 controls output 7" CV="45" mask="XXXXXXVX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output 7</label>
       </variable>
       <variable item="F11 controls output 8" CV="45" mask="XXXXXXXV" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output 8</label>
       </variable>
       <variable item="F12 controls output 1" CV="46" mask="VXXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output 1</label>
       </variable>
       <variable item="F12 controls output 2" CV="46" mask="XVXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output 2</label>
       </variable>
       <variable item="F12 controls output 3" CV="46" mask="XXVXXXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output 3</label>
       </variable>
       <variable item="F12 controls output 4" CV="46" mask="XXXVXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output 4</label>
       </variable>
       <variable item="F12 controls output 5" CV="46" mask="XXXXVXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output 5</label>
       </variable>
       <variable item="F12 controls output 6" CV="46" mask="XXXXXVXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output 6</label>
       </variable>
       <variable item="F12 controls output 7" CV="46" mask="XXXXXXVX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output 7</label>
       </variable>
       <variable item="F12 controls output 8" CV="46" mask="XXXXXXXV" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output 8</label>
       </variable>
       <variable item="AltF13 controls output 1" CV="83" mask="VXXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF13 controls output 1</label>
       </variable>
       <variable item="AltF13 controls output 2" CV="83" mask="XVXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF13 controls output 2</label>
       </variable>
       <variable item="AltF13 controls output 3" CV="83" mask="XXVXXXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF13 controls output 3</label>
       </variable>
       <variable item="AltF13 controls output 4" CV="83" mask="XXXVXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF13 controls output 4</label>
       </variable>
       <variable item="AltF13 controls output 5" CV="83" mask="XXXXVXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF13 controls output 5</label>
       </variable>
       <variable item="AltF13 controls output 6" CV="83" mask="XXXXXVXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF13 controls output 6</label>
       </variable>
       <variable item="AltF13 controls output 7" CV="83" mask="XXXXXXVX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF13 controls output 7</label>
       </variable>
       <variable item="AltF13 controls output 8" CV="83" mask="XXXXXXXV" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF13 controls output 8</label>
       </variable>
       <variable item="AltF14 controls output 1" CV="84" mask="VXXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF14 controls output 1</label>
       </variable>
       <variable item="AltF14 controls output 2" CV="84" mask="XVXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF14 controls output 2</label>
       </variable>
       <variable item="AltF14 controls output 3" CV="84" mask="XXVXXXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF14 controls output 3</label>
       </variable>
       <variable item="AltF14 controls output 4" CV="84" mask="XXXVXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF14 controls output 4</label>
       </variable>
       <variable item="AltF14 controls output 5" CV="84" mask="XXXXVXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF14 controls output 5</label>
       </variable>
       <variable item="AltF14 controls output 6" CV="84" mask="XXXXXVXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF14 controls output 6</label>
       </variable>
       <variable item="AltF14 controls output 7" CV="84" mask="XXXXXXVX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF14 controls output 7</label>
       </variable>
       <variable item="AltF14 controls output 8" CV="84" mask="XXXXXXXV" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF14 controls output 8</label>
       </variable>
       <variable item="AltF15 controls output 1" CV="85" mask="VXXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF15 controls output 1</label>
       </variable>
       <variable item="AltF15 controls output 2" CV="85" mask="XVXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF15 controls output 2</label>
       </variable>
       <variable item="AltF15 controls output 3" CV="85" mask="XXVXXXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF15 controls output 3</label>
       </variable>
       <variable item="AltF15 controls output 4" CV="85" mask="XXXVXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF15 controls output 4</label>
       </variable>
       <variable item="AltF15 controls output 5" CV="85" mask="XXXXVXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF15 controls output 5</label>
       </variable>
       <variable item="AltF15 controls output 6" CV="85" mask="XXXXXVXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF15 controls output 6</label>
       </variable>
       <variable item="AltF15 controls output 7" CV="85" mask="XXXXXXVX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF15 controls output 7</label>
       </variable>
       <variable item="AltF15 controls output 8" CV="85" mask="XXXXXXXV" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF15 controls output 8</label>
       </variable>
       <variable item="AltF16 controls output 1" CV="86" mask="VXXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF16 controls output 1</label>
       </variable>
       <variable item="AltF16 controls output 2" CV="86" mask="XVXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF16 controls output 2</label>
       </variable>
       <variable item="AltF16 controls output 3" CV="86" mask="XXVXXXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF16 controls output 3</label>
       </variable>
       <variable item="AltF16 controls output 4" CV="86" mask="XXXVXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF16 controls output 4</label>
       </variable>
       <variable item="AltF16 controls output 5" CV="86" mask="XXXXVXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF16 controls output 5</label>
       </variable>
       <variable item="AltF16 controls output 6" CV="86" mask="XXXXXVXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF16 controls output 6</label>
       </variable>
       <variable item="AltF16 controls output 7" CV="86" mask="XXXXXXVX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF16 controls output 7</label>
       </variable>
       <variable item="AltF16 controls output 8" CV="86" mask="XXXXXXXV" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF16 controls output 8</label>
       </variable>
       <variable item="AltF17 controls output 1" CV="87" mask="VXXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF17 controls output 1</label>
       </variable>
       <variable item="AltF17 controls output 2" CV="87" mask="XVXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF17 controls output 2</label>
       </variable>
       <variable item="AltF17 controls output 3" CV="87" mask="XXVXXXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF17 controls output 3</label>
       </variable>
       <variable item="AltF17 controls output 4" CV="87" mask="XXXVXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF17 controls output 4</label>
       </variable>
       <variable item="AltF17 controls output 5" CV="87" mask="XXXXVXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF17 controls output 5</label>
       </variable>
       <variable item="AltF17 controls output 6" CV="87" mask="XXXXXVXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF17 controls output 6</label>
       </variable>
       <variable item="AltF17 controls output 7" CV="87" mask="XXXXXXVX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF17 controls output 7</label>
       </variable>
       <variable item="AltF17 controls output 8" CV="87" mask="XXXXXXXV" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF17 controls output 8</label>
       </variable>
       <variable item="AltF18 controls output 1" CV="88" mask="VXXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF18 controls output 1</label>
       </variable>
       <variable item="AltF18 controls output 2" CV="88" mask="XVXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF18 controls output 2</label>
       </variable>
       <variable item="AltF18 controls output 3" CV="88" mask="XXVXXXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF18 controls output 3</label>
       </variable>
       <variable item="AltF18 controls output 4" CV="88" mask="XXXVXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF18 controls output 4</label>
       </variable>
       <variable item="AltF18 controls output 5" CV="88" mask="XXXXVXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF18 controls output 5</label>
       </variable>
       <variable item="AltF18 controls output 6" CV="88" mask="XXXXXVXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF18 controls output 6</label>
       </variable>
       <variable item="AltF18 controls output 7" CV="88" mask="XXXXXXVX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF18 controls output 7</label>
       </variable>
       <variable item="AltF18 controls output 8" CV="88" mask="XXXXXXXV" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF18 controls output 8</label>
       </variable>
       <variable item="AltF19 controls output 1" CV="89" mask="VXXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF19 controls output 1</label>
       </variable>
       <variable item="AltF19 controls output 2" CV="89" mask="XVXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF19 controls output 2</label>
       </variable>
       <variable item="AltF19 controls output 3" CV="89" mask="XXVXXXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF19 controls output 3</label>
       </variable>
       <variable item="AltF19 controls output 4" CV="89" mask="XXXVXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF19 controls output 4</label>
       </variable>
       <variable item="AltF19 controls output 5" CV="89" mask="XXXXVXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF19 controls output 5</label>
       </variable>
       <variable item="AltF19 controls output 6" CV="89" mask="XXXXXVXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF19 controls output 6</label>
       </variable>
       <variable item="AltF19 controls output 7" CV="89" mask="XXXXXXVX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF19 controls output 7</label>
       </variable>
       <variable item="AltF19 controls output 8" CV="89" mask="XXXXXXXV" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF19 controls output 8</label>
       </variable>
       <variable item="AltF20 controls output 1" CV="90" mask="VXXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF20 controls output 1</label>
       </variable>
       <variable item="AltF20 controls output 2" CV="90" mask="XVXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF20 controls output 2</label>
       </variable>
       <variable item="AltF20 controls output 3" CV="90" mask="XXVXXXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF20 controls output 3</label>
       </variable>
       <variable item="AltF20 controls output 4" CV="90" mask="XXXVXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF20 controls output 4</label>
       </variable>
       <variable item="AltF20 controls output 5" CV="90" mask="XXXXVXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF20 controls output 5</label>
       </variable>
       <variable item="AltF20 controls output 6" CV="90" mask="XXXXXVXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF20 controls output 6</label>
       </variable>
       <variable item="AltF20 controls output 7" CV="90" mask="XXXXXXVX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF20 controls output 7</label>
       </variable>
       <variable item="AltF20 controls output 8" CV="90" mask="XXXXXXXV" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF20 controls output 8</label>
       </variable>
       <variable item="AltF21 controls output 1" CV="91" mask="VXXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF21 controls output 1</label>
       </variable>
       <variable item="AltF21 controls output 2" CV="91" mask="XVXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF21 controls output 2</label>
       </variable>
       <variable item="AltF21 controls output 3" CV="91" mask="XXVXXXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF21 controls output 3</label>
       </variable>
       <variable item="AltF21 controls output 4" CV="91" mask="XXXVXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF21 controls output 4</label>
       </variable>
       <variable item="AltF21 controls output 5" CV="91" mask="XXXXVXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF21 controls output 5</label>
       </variable>
       <variable item="AltF21 controls output 6" CV="91" mask="XXXXXVXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF21 controls output 6</label>
       </variable>
       <variable item="AltF21 controls output 7" CV="91" mask="XXXXXXVX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF21 controls output 7</label>
       </variable>
       <variable item="AltF21 controls output 8" CV="91" mask="XXXXXXXV" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF21 controls output 8</label>
       </variable>
       <variable item="AltF22 controls output 1" CV="92" mask="VXXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF22 controls output 1</label>
       </variable>
       <variable item="AltF22 controls output 2" CV="92" mask="XVXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF22 controls output 2</label>
       </variable>
       <variable item="AltF22 controls output 3" CV="92" mask="XXVXXXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF22 controls output 3</label>
       </variable>
       <variable item="AltF22 controls output 4" CV="92" mask="XXXVXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF22 controls output 4</label>
       </variable>
       <variable item="AltF22 controls output 5" CV="92" mask="XXXXVXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF22 controls output 5</label>
       </variable>
       <variable item="AltF22 controls output 6" CV="92" mask="XXXXXVXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF22 controls output 6</label>
       </variable>
       <variable item="AltF22 controls output 7" CV="92" mask="XXXXXXVX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF22 controls output 7</label>
       </variable>
       <variable item="AltF22 controls output 8" CV="92" mask="XXXXXXXV" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF22 controls output 8</label>
       </variable>
       <variable item="AltF23 controls output 1" CV="93" mask="VXXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF23 controls output 1</label>
       </variable>
       <variable item="AltF23 controls output 2" CV="93" mask="XVXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF23 controls output 2</label>
       </variable>
       <variable item="AltF23 controls output 3" CV="93" mask="XXVXXXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF23 controls output 3</label>
       </variable>
       <variable item="AltF23 controls output 4" CV="93" mask="XXXVXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF23 controls output 4</label>
       </variable>
       <variable item="AltF23 controls output 5" CV="93" mask="XXXXVXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF23 controls output 5</label>
       </variable>
       <variable item="AltF23 controls output 6" CV="93" mask="XXXXXVXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF23 controls output 6</label>
       </variable>
       <variable item="AltF23 controls output 7" CV="93" mask="XXXXXXVX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF23 controls output 7</label>
       </variable>
       <variable item="AltF23 controls output 8" CV="93" mask="XXXXXXXV" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF23 controls output 8</label>
       </variable>
       <variable item="AltF24 controls output 1" CV="94" mask="VXXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF24 controls output 1</label>
       </variable>
       <variable item="AltF24 controls output 2" CV="94" mask="XVXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF24 controls output 2</label>
       </variable>
       <variable item="AltF24 controls output 3" CV="94" mask="XXVXXXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF24 controls output 3</label>
       </variable>
       <variable item="AltF24 controls output 4" CV="94" mask="XXXVXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF24 controls output 4</label>
       </variable>
       <variable item="AltF24 controls output 5" CV="94" mask="XXXXVXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF24 controls output 5</label>
       </variable>
       <variable item="AltF24 controls output 6" CV="94" mask="XXXXXVXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF24 controls output 6</label>
       </variable>
       <variable item="AltF24 controls output 7" CV="94" mask="XXXXXXVX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF24 controls output 7</label>
       </variable>
       <variable item="AltF24 controls output 8" CV="94" mask="XXXXXXXV" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF24 controls output 8</label>
       </variable>
       <variable item="AltF25 controls output 1" CV="95" mask="VXXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF25 controls output 1</label>
       </variable>
       <variable item="AltF25 controls output 2" CV="95" mask="XVXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF25 controls output 2</label>
       </variable>
       <variable item="AltF25 controls output 3" CV="95" mask="XXVXXXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF25 controls output 3</label>
       </variable>
       <variable item="AltF25 controls output 4" CV="95" mask="XXXVXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF25 controls output 4</label>
       </variable>
       <variable item="AltF25 controls output 5" CV="95" mask="XXXXVXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF25 controls output 5</label>
       </variable>
       <variable item="AltF25 controls output 6" CV="95" mask="XXXXXVXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF25 controls output 6</label>
       </variable>
       <variable item="AltF25 controls output 7" CV="95" mask="XXXXXXVX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF25 controls output 7</label>
       </variable>
       <variable item="AltF25 controls output 8" CV="95" mask="XXXXXXXV" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF25 controls output 8</label>
       </variable>
       <variable item="AltF26 controls output 1" CV="96" mask="VXXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF26 controls output 1</label>
       </variable>
       <variable item="AltF26 controls output 2" CV="96" mask="XVXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF26 controls output 2</label>
       </variable>
       <variable item="AltF26 controls output 3" CV="96" mask="XXVXXXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF26 controls output 3</label>
       </variable>
       <variable item="AltF26 controls output 4" CV="96" mask="XXXVXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF26 controls output 4</label>
       </variable>
       <variable item="AltF26 controls output 5" CV="96" mask="XXXXVXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF26 controls output 5</label>
       </variable>
       <variable item="AltF26 controls output 6" CV="96" mask="XXXXXVXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF26 controls output 6</label>
       </variable>
       <variable item="AltF26 controls output 7" CV="96" mask="XXXXXXVX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF26 controls output 7</label>
       </variable>
       <variable item="AltF26 controls output 8" CV="96" mask="XXXXXXXV" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF26 controls output 8</label>
       </variable>
       <variable item="AltF27 controls output 1" CV="97" mask="VXXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF27 controls output 1</label>
       </variable>
       <variable item="AltF27 controls output 2" CV="97" mask="XVXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF27 controls output 2</label>
       </variable>
       <variable item="AltF27 controls output 3" CV="97" mask="XXVXXXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF27 controls output 3</label>
       </variable>
       <variable item="AltF27 controls output 4" CV="97" mask="XXXVXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF27 controls output 4</label>
       </variable>
       <variable item="AltF27 controls output 5" CV="97" mask="XXXXVXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF27 controls output 5</label>
       </variable>
       <variable item="AltF27 controls output 6" CV="97" mask="XXXXXVXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF27 controls output 6</label>
       </variable>
       <variable item="AltF27 controls output 7" CV="97" mask="XXXXXXVX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF27 controls output 7</label>
       </variable>
       <variable item="AltF27 controls output 8" CV="97" mask="XXXXXXXV" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF27 controls output 8</label>
       </variable>
       <variable item="AltF28 controls output 1" CV="98" mask="VXXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF28 controls output 1</label>
       </variable>
       <variable item="AltF28 controls output 2" CV="98" mask="XVXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF28 controls output 2</label>
       </variable>
       <variable item="AltF28 controls output 3" CV="98" mask="XXVXXXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF28 controls output 3</label>
       </variable>
       <variable item="AltF28 controls output 4" CV="98" mask="XXXVXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF28 controls output 4</label>
       </variable>
       <variable item="AltF28 controls output 5" CV="98" mask="XXXXVXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF28 controls output 5</label>
       </variable>
       <variable item="AltF28 controls output 6" CV="98" mask="XXXXXVXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF28 controls output 6</label>
       </variable>
       <variable item="AltF28 controls output 7" CV="98" mask="XXXXXXVX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF28 controls output 7</label>
       </variable>
       <variable item="AltF28 controls output 8" CV="98" mask="XXXXXXXV" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>AltF28 controls output 8</label>
       </variable>
       <variable item="invert output 1" CV="99" mask="VXXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>invert output 1</label>
       </variable>
       <variable item="invert output 2" CV="99" mask="XVXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>invert output 2</label>
       </variable>
       <variable item="invert output 3" CV="99" mask="XXVXXXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>invert output 3</label>
       </variable>
       <variable item="invert output 4" CV="99" mask="XXXVXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>invert output 4</label>
       </variable>
       <variable item="invert output 5" CV="99" mask="XXXXVXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>invert output 5</label>
       </variable>
       <variable item="invert output 6" CV="99" mask="XXXXXVXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>invert output 6</label>
       </variable>
       <variable item="invert output 7" CV="99" mask="XXXXXXVX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>invert output 7</label>
       </variable>
       <variable item="invert output 8" CV="99" mask="XXXXXXXV" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>invert output 8</label>
       </variable>
       <variable item="flicker output 1" CV="100" mask="VXXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>flicker output 1</label>
       </variable>
       <variable item="flicker output 2" CV="100" mask="XVXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>flicker output 2</label>
       </variable>
       <variable item="flicker output 3" CV="100" mask="XXVXXXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>flicker output 3</label>
       </variable>
       <variable item="flicker output 4" CV="100" mask="XXXVXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>flicker output 4</label>
       </variable>
       <variable item="flicker output 5" CV="100" mask="XXXXVXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>flicker output 5</label>
       </variable>
       <variable item="flicker output 6" CV="100" mask="XXXXXVXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>flicker output 6</label>
       </variable>
       <variable item="flicker output 7" CV="100" mask="XXXXXXVX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>flicker output 7</label>
       </variable>
       <variable item="flicker output 8" CV="100" mask="XXXXXXXV" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>flicker output 8</label>
       </variable>
       <variable CV="105" item="User Id #1">

--- a/xml/decoders/Harman_Sig_decoders.xml
+++ b/xml/decoders/Harman_Sig_decoders.xml
@@ -205,59 +205,35 @@
         <label>invert outputs</label>
       </variable>
       <variable item="Common anode output 1" CV="35" mask="VXXXXXXX" minOut="1" default="0">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>Common anode output 1</label>
       </variable>
       <variable item="Common anode output 2" CV="35" mask="XVXXXXXX" minOut="1" default="0">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>Common anode output 2</label>
       </variable>
       <variable item="Common anode output 3" CV="35" mask="XXVXXXXX" minOut="8" default="0">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>Common anode output 3</label>
       </variable>
       <variable item="Common anode output 4" CV="35" mask="XXXVXXXX" minOut="8" default="0">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>Common anode output 4</label>
       </variable>
       <variable item="Common anode output 5" CV="35" mask="XXXXVXXX" minOut="8" default="0">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>Common anode output 5</label>
       </variable>
       <variable item="Common anode output 6" CV="35" mask="XXXXXVXX" minOut="8" default="0">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>Common anode output 6</label>
       </variable>
       <variable item="Common anode output 7" CV="35" mask="XXXXXXVX" minOut="8" default="0">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>Common anode output 7</label>
       </variable>
       <variable item="Common anode output 8" CV="35" mask="XXXXXXXV" minOut="8" default="0">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>Common anode output 8</label>
       </variable>
       <variable item="default outputs" CV="37" default="0">
@@ -265,59 +241,35 @@
         <label>default outputs</label>
       </variable>
       <variable item="default output 1" CV="37" mask="VXXXXXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>default output 1</label>
       </variable>
       <variable item="default output 2" CV="37" mask="XVXXXXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>default output 2</label>
       </variable>
       <variable item="default output 3" CV="37" mask="XXVXXXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>default output 3</label>
       </variable>
       <variable item="default output 4" CV="37" mask="XXXVXXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>default output 4</label>
       </variable>
       <variable item="default output 5" CV="37" mask="XXXXVXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>default output 5</label>
       </variable>
       <variable item="default output 6" CV="37" mask="XXXXXVXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>default output 6</label>
       </variable>
       <variable item="default output 7" CV="37" mask="XXXXXXVX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>default output 7</label>
       </variable>
       <variable item="default output 8" CV="37" mask="XXXXXXXV" minOut="8">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>default output 8</label>
       </variable>
       <!-- use of item="Locomotive Direction" forces this onto the "basic" pane of the decoder -->
@@ -602,1795 +554,1027 @@
 	  -->
       <!--  Variables 192 to 223 for 32 custom aspects, V023 (productID=57379) and later -->
       <variable item="CustAspect0.A" CV="192" mask="VXXXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect0.A</label>
       </variable>
       <variable item="CustAspect0.B" CV="192" mask="XVXXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect0.B</label>
       </variable>
       <variable item="CustAspect0.C" CV="192" mask="XXVXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect0.C</label>
       </variable>
       <variable item="CustAspect0.D" CV="192" mask="XXXVXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect0.D</label>
       </variable>
       <variable item="CustAspect0.E" CV="192" mask="XXXXVXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect0.E</label>
       </variable>
       <variable item="CustAspect0.F" CV="192" mask="XXXXXVXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect0.F</label>
       </variable>
       <variable item="CustAspect0.G" CV="192" mask="XXXXXXVX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect0.G</label>
       </variable>
       <variable item="CustAspect0.H" CV="192" mask="XXXXXXXV" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect0.H</label>
       </variable>
       <variable item="CustAspect1.A" CV="193" mask="VXXXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect1.A</label>
       </variable>
       <variable item="CustAspect1.B" CV="193" mask="XVXXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect1.B</label>
       </variable>
       <variable item="CustAspect1.C" CV="193" mask="XXVXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect1.C</label>
       </variable>
       <variable item="CustAspect1.D" CV="193" mask="XXXVXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect1.D</label>
       </variable>
       <variable item="CustAspect1.E" CV="193" mask="XXXXVXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect1.E</label>
       </variable>
       <variable item="CustAspect1.F" CV="193" mask="XXXXXVXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect1.F</label>
       </variable>
       <variable item="CustAspect1.G" CV="193" mask="XXXXXXVX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect1.G</label>
       </variable>
       <variable item="CustAspect1.H" CV="193" mask="XXXXXXXV" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect1.H</label>
       </variable>
       <variable item="CustAspect2.A" CV="194" mask="VXXXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect2.A</label>
       </variable>
       <variable item="CustAspect2.B" CV="194" mask="XVXXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect2.B</label>
       </variable>
       <variable item="CustAspect2.C" CV="194" mask="XXVXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect2.C</label>
       </variable>
       <variable item="CustAspect2.D" CV="194" mask="XXXVXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect2.D</label>
       </variable>
       <variable item="CustAspect2.E" CV="194" mask="XXXXVXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect2.E</label>
       </variable>
       <variable item="CustAspect2.F" CV="194" mask="XXXXXVXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect2.F</label>
       </variable>
       <variable item="CustAspect2.G" CV="194" mask="XXXXXXVX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect2.G</label>
       </variable>
       <variable item="CustAspect2.H" CV="194" mask="XXXXXXXV" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect2.H</label>
       </variable>
       <variable item="CustAspect3.A" CV="195" mask="VXXXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect3.A</label>
       </variable>
       <variable item="CustAspect3.B" CV="195" mask="XVXXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect3.B</label>
       </variable>
       <variable item="CustAspect3.C" CV="195" mask="XXVXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect3.C</label>
       </variable>
       <variable item="CustAspect3.D" CV="195" mask="XXXVXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect3.D</label>
       </variable>
       <variable item="CustAspect3.E" CV="195" mask="XXXXVXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect3.E</label>
       </variable>
       <variable item="CustAspect3.F" CV="195" mask="XXXXXVXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect3.F</label>
       </variable>
       <variable item="CustAspect3.G" CV="195" mask="XXXXXXVX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect3.G</label>
       </variable>
       <variable item="CustAspect3.H" CV="195" mask="XXXXXXXV" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect3.H</label>
       </variable>
       <variable item="CustAspect4.A" CV="196" mask="VXXXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect4.A</label>
       </variable>
       <variable item="CustAspect4.B" CV="196" mask="XVXXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect4.B</label>
       </variable>
       <variable item="CustAspect4.C" CV="196" mask="XXVXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect4.C</label>
       </variable>
       <variable item="CustAspect4.D" CV="196" mask="XXXVXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect4.D</label>
       </variable>
       <variable item="CustAspect4.E" CV="196" mask="XXXXVXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect4.E</label>
       </variable>
       <variable item="CustAspect4.F" CV="196" mask="XXXXXVXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect4.F</label>
       </variable>
       <variable item="CustAspect4.G" CV="196" mask="XXXXXXVX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect4.G</label>
       </variable>
       <variable item="CustAspect4.H" CV="196" mask="XXXXXXXV" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect4.H</label>
       </variable>
       <variable item="CustAspect5.A" CV="197" mask="VXXXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect5.A</label>
       </variable>
       <variable item="CustAspect5.B" CV="197" mask="XVXXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect5.B</label>
       </variable>
       <variable item="CustAspect5.C" CV="197" mask="XXVXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect5.C</label>
       </variable>
       <variable item="CustAspect5.D" CV="197" mask="XXXVXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect5.D</label>
       </variable>
       <variable item="CustAspect5.E" CV="197" mask="XXXXVXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect5.E</label>
       </variable>
       <variable item="CustAspect5.F" CV="197" mask="XXXXXVXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect5.F</label>
       </variable>
       <variable item="CustAspect5.G" CV="197" mask="XXXXXXVX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect5.G</label>
       </variable>
       <variable item="CustAspect5.H" CV="197" mask="XXXXXXXV" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect5.H</label>
       </variable>
       <variable item="CustAspect6.A" CV="198" mask="VXXXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect6.A</label>
       </variable>
       <variable item="CustAspect6.B" CV="198" mask="XVXXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect6.B</label>
       </variable>
       <variable item="CustAspect6.C" CV="198" mask="XXVXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect6.C</label>
       </variable>
       <variable item="CustAspect6.D" CV="198" mask="XXXVXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect6.D</label>
       </variable>
       <variable item="CustAspect6.E" CV="198" mask="XXXXVXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect6.E</label>
       </variable>
       <variable item="CustAspect6.F" CV="198" mask="XXXXXVXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect6.F</label>
       </variable>
       <variable item="CustAspect6.G" CV="198" mask="XXXXXXVX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect6.G</label>
       </variable>
       <variable item="CustAspect6.H" CV="198" mask="XXXXXXXV" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect6.H</label>
       </variable>
       <variable item="CustAspect7.A" CV="199" mask="VXXXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect7.A</label>
       </variable>
       <variable item="CustAspect7.B" CV="199" mask="XVXXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect7.B</label>
       </variable>
       <variable item="CustAspect7.C" CV="199" mask="XXVXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect7.C</label>
       </variable>
       <variable item="CustAspect7.D" CV="199" mask="XXXVXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect7.D</label>
       </variable>
       <variable item="CustAspect7.E" CV="199" mask="XXXXVXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect7.E</label>
       </variable>
       <variable item="CustAspect7.F" CV="199" mask="XXXXXVXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect7.F</label>
       </variable>
       <variable item="CustAspect7.G" CV="199" mask="XXXXXXVX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect7.G</label>
       </variable>
       <variable item="CustAspect7.H" CV="199" mask="XXXXXXXV" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect7.H</label>
       </variable>
       <variable item="CustAspect8.A" CV="200" mask="VXXXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect8.A</label>
       </variable>
       <variable item="CustAspect8.B" CV="200" mask="XVXXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect8.B</label>
       </variable>
       <variable item="CustAspect8.C" CV="200" mask="XXVXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect8.C</label>
       </variable>
       <variable item="CustAspect8.D" CV="200" mask="XXXVXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect8.D</label>
       </variable>
       <variable item="CustAspect8.E" CV="200" mask="XXXXVXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect8.E</label>
       </variable>
       <variable item="CustAspect8.F" CV="200" mask="XXXXXVXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect8.F</label>
       </variable>
       <variable item="CustAspect8.G" CV="200" mask="XXXXXXVX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect8.G</label>
       </variable>
       <variable item="CustAspect8.H" CV="200" mask="XXXXXXXV" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect8.H</label>
       </variable>
       <variable item="CustAspect9.A" CV="201" mask="VXXXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect9.A</label>
       </variable>
       <variable item="CustAspect9.B" CV="201" mask="XVXXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect9.B</label>
       </variable>
       <variable item="CustAspect9.C" CV="201" mask="XXVXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect9.C</label>
       </variable>
       <variable item="CustAspect9.D" CV="201" mask="XXXVXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect9.D</label>
       </variable>
       <variable item="CustAspect9.E" CV="201" mask="XXXXVXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect9.E</label>
       </variable>
       <variable item="CustAspect9.F" CV="201" mask="XXXXXVXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect9.F</label>
       </variable>
       <variable item="CustAspect9.G" CV="201" mask="XXXXXXVX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect9.G</label>
       </variable>
       <variable item="CustAspect9.H" CV="201" mask="XXXXXXXV" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect9.H</label>
       </variable>
       <variable item="CustAspect10.A" CV="202" mask="VXXXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect10.A</label>
       </variable>
       <variable item="CustAspect10.B" CV="202" mask="XVXXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect10.B</label>
       </variable>
       <variable item="CustAspect10.C" CV="202" mask="XXVXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect10.C</label>
       </variable>
       <variable item="CustAspect10.D" CV="202" mask="XXXVXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect10.D</label>
       </variable>
       <variable item="CustAspect10.E" CV="202" mask="XXXXVXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect10.E</label>
       </variable>
       <variable item="CustAspect10.F" CV="202" mask="XXXXXVXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect10.F</label>
       </variable>
       <variable item="CustAspect10.G" CV="202" mask="XXXXXXVX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect10.G</label>
       </variable>
       <variable item="CustAspect10.H" CV="202" mask="XXXXXXXV" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect10.H</label>
       </variable>
       <variable item="CustAspect11.A" CV="203" mask="VXXXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect11.A</label>
       </variable>
       <variable item="CustAspect11.B" CV="203" mask="XVXXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect11.B</label>
       </variable>
       <variable item="CustAspect11.C" CV="203" mask="XXVXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect11.C</label>
       </variable>
       <variable item="CustAspect11.D" CV="203" mask="XXXVXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect11.D</label>
       </variable>
       <variable item="CustAspect11.E" CV="203" mask="XXXXVXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect11.E</label>
       </variable>
       <variable item="CustAspect11.F" CV="203" mask="XXXXXVXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect11.F</label>
       </variable>
       <variable item="CustAspect11.G" CV="203" mask="XXXXXXVX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect11.G</label>
       </variable>
       <variable item="CustAspect11.H" CV="203" mask="XXXXXXXV" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect11.H</label>
       </variable>
       <variable item="CustAspect12.A" CV="204" mask="VXXXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect12.A</label>
       </variable>
       <variable item="CustAspect12.B" CV="204" mask="XVXXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect12.B</label>
       </variable>
       <variable item="CustAspect12.C" CV="204" mask="XXVXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect12.C</label>
       </variable>
       <variable item="CustAspect12.D" CV="204" mask="XXXVXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect12.D</label>
       </variable>
       <variable item="CustAspect12.E" CV="204" mask="XXXXVXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect12.E</label>
       </variable>
       <variable item="CustAspect12.F" CV="204" mask="XXXXXVXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect12.F</label>
       </variable>
       <variable item="CustAspect12.G" CV="204" mask="XXXXXXVX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect12.G</label>
       </variable>
       <variable item="CustAspect12.H" CV="204" mask="XXXXXXXV" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect12.H</label>
       </variable>
       <variable item="CustAspect13.A" CV="205" mask="VXXXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect13.A</label>
       </variable>
       <variable item="CustAspect13.B" CV="205" mask="XVXXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect13.B</label>
       </variable>
       <variable item="CustAspect13.C" CV="205" mask="XXVXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect13.C</label>
       </variable>
       <variable item="CustAspect13.D" CV="205" mask="XXXVXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect13.D</label>
       </variable>
       <variable item="CustAspect13.E" CV="205" mask="XXXXVXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect13.E</label>
       </variable>
       <variable item="CustAspect13.F" CV="205" mask="XXXXXVXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect13.F</label>
       </variable>
       <variable item="CustAspect13.G" CV="205" mask="XXXXXXVX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect13.G</label>
       </variable>
       <variable item="CustAspect13.H" CV="205" mask="XXXXXXXV" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect13.H</label>
       </variable>
       <variable item="CustAspect14.A" CV="206" mask="VXXXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect14.A</label>
       </variable>
       <variable item="CustAspect14.B" CV="206" mask="XVXXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect14.B</label>
       </variable>
       <variable item="CustAspect14.C" CV="206" mask="XXVXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect14.C</label>
       </variable>
       <variable item="CustAspect14.D" CV="206" mask="XXXVXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect14.D</label>
       </variable>
       <variable item="CustAspect14.E" CV="206" mask="XXXXVXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect14.E</label>
       </variable>
       <variable item="CustAspect14.F" CV="206" mask="XXXXXVXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect14.F</label>
       </variable>
       <variable item="CustAspect14.G" CV="206" mask="XXXXXXVX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect14.G</label>
       </variable>
       <variable item="CustAspect14.H" CV="206" mask="XXXXXXXV" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect14.H</label>
       </variable>
       <variable item="CustAspect15.A" CV="207" mask="VXXXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect15.A</label>
       </variable>
       <variable item="CustAspect15.B" CV="207" mask="XVXXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect15.B</label>
       </variable>
       <variable item="CustAspect15.C" CV="207" mask="XXVXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect15.C</label>
       </variable>
       <variable item="CustAspect15.D" CV="207" mask="XXXVXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect15.D</label>
       </variable>
       <variable item="CustAspect15.E" CV="207" mask="XXXXVXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect15.E</label>
       </variable>
       <variable item="CustAspect15.F" CV="207" mask="XXXXXVXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect15.F</label>
       </variable>
       <variable item="CustAspect15.G" CV="207" mask="XXXXXXVX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect15.G</label>
       </variable>
       <variable item="CustAspect15.H" CV="207" mask="XXXXXXXV" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect15.H</label>
       </variable>
       <variable item="CustAspect16.A" CV="208" mask="VXXXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect16.A</label>
       </variable>
       <variable item="CustAspect16.B" CV="208" mask="XVXXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect16.B</label>
       </variable>
       <variable item="CustAspect16.C" CV="208" mask="XXVXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect16.C</label>
       </variable>
       <variable item="CustAspect16.D" CV="208" mask="XXXVXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect16.D</label>
       </variable>
       <variable item="CustAspect16.E" CV="208" mask="XXXXVXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect16.E</label>
       </variable>
       <variable item="CustAspect16.F" CV="208" mask="XXXXXVXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect16.F</label>
       </variable>
       <variable item="CustAspect16.G" CV="208" mask="XXXXXXVX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect16.G</label>
       </variable>
       <variable item="CustAspect16.H" CV="208" mask="XXXXXXXV" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect16.H</label>
       </variable>
       <variable item="CustAspect17.A" CV="209" mask="VXXXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect17.A</label>
       </variable>
       <variable item="CustAspect17.B" CV="209" mask="XVXXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect17.B</label>
       </variable>
       <variable item="CustAspect17.C" CV="209" mask="XXVXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect17.C</label>
       </variable>
       <variable item="CustAspect17.D" CV="209" mask="XXXVXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect17.D</label>
       </variable>
       <variable item="CustAspect17.E" CV="209" mask="XXXXVXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect17.E</label>
       </variable>
       <variable item="CustAspect17.F" CV="209" mask="XXXXXVXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect17.F</label>
       </variable>
       <variable item="CustAspect17.G" CV="209" mask="XXXXXXVX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect17.G</label>
       </variable>
       <variable item="CustAspect17.H" CV="209" mask="XXXXXXXV" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect17.H</label>
       </variable>
       <variable item="CustAspect18.A" CV="210" mask="VXXXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect18.A</label>
       </variable>
       <variable item="CustAspect18.B" CV="210" mask="XVXXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect18.B</label>
       </variable>
       <variable item="CustAspect18.C" CV="210" mask="XXVXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect18.C</label>
       </variable>
       <variable item="CustAspect18.D" CV="210" mask="XXXVXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect18.D</label>
       </variable>
       <variable item="CustAspect18.E" CV="210" mask="XXXXVXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect18.E</label>
       </variable>
       <variable item="CustAspect18.F" CV="210" mask="XXXXXVXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect18.F</label>
       </variable>
       <variable item="CustAspect18.G" CV="210" mask="XXXXXXVX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect18.G</label>
       </variable>
       <variable item="CustAspect18.H" CV="210" mask="XXXXXXXV" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect18.H</label>
       </variable>
       <variable item="CustAspect19.A" CV="211" mask="VXXXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect19.A</label>
       </variable>
       <variable item="CustAspect19.B" CV="211" mask="XVXXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect19.B</label>
       </variable>
       <variable item="CustAspect19.C" CV="211" mask="XXVXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect19.C</label>
       </variable>
       <variable item="CustAspect19.D" CV="211" mask="XXXVXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect19.D</label>
       </variable>
       <variable item="CustAspect19.E" CV="211" mask="XXXXVXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect19.E</label>
       </variable>
       <variable item="CustAspect19.F" CV="211" mask="XXXXXVXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect19.F</label>
       </variable>
       <variable item="CustAspect19.G" CV="211" mask="XXXXXXVX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect19.G</label>
       </variable>
       <variable item="CustAspect19.H" CV="211" mask="XXXXXXXV" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect19.H</label>
       </variable>
       <variable item="CustAspect20.A" CV="212" mask="VXXXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect20.A</label>
       </variable>
       <variable item="CustAspect20.B" CV="212" mask="XVXXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect20.B</label>
       </variable>
       <variable item="CustAspect20.C" CV="212" mask="XXVXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect20.C</label>
       </variable>
       <variable item="CustAspect20.D" CV="212" mask="XXXVXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect20.D</label>
       </variable>
       <variable item="CustAspect20.E" CV="212" mask="XXXXVXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect20.E</label>
       </variable>
       <variable item="CustAspect20.F" CV="212" mask="XXXXXVXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect20.F</label>
       </variable>
       <variable item="CustAspect20.G" CV="212" mask="XXXXXXVX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect20.G</label>
       </variable>
       <variable item="CustAspect20.H" CV="212" mask="XXXXXXXV" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect20.H</label>
       </variable>
       <variable item="CustAspect21.A" CV="213" mask="VXXXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect21.A</label>
       </variable>
       <variable item="CustAspect21.B" CV="213" mask="XVXXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect21.B</label>
       </variable>
       <variable item="CustAspect21.C" CV="213" mask="XXVXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect21.C</label>
       </variable>
       <variable item="CustAspect21.D" CV="213" mask="XXXVXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect21.D</label>
       </variable>
       <variable item="CustAspect21.E" CV="213" mask="XXXXVXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect21.E</label>
       </variable>
       <variable item="CustAspect21.F" CV="213" mask="XXXXXVXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect21.F</label>
       </variable>
       <variable item="CustAspect21.G" CV="213" mask="XXXXXXVX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect21.G</label>
       </variable>
       <variable item="CustAspect21.H" CV="213" mask="XXXXXXXV" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect21.H</label>
       </variable>
       <variable item="CustAspect22.A" CV="214" mask="VXXXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect22.A</label>
       </variable>
       <variable item="CustAspect22.B" CV="214" mask="XVXXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect22.B</label>
       </variable>
       <variable item="CustAspect22.C" CV="214" mask="XXVXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect22.C</label>
       </variable>
       <variable item="CustAspect22.D" CV="214" mask="XXXVXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect22.D</label>
       </variable>
       <variable item="CustAspect22.E" CV="214" mask="XXXXVXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect22.E</label>
       </variable>
       <variable item="CustAspect22.F" CV="214" mask="XXXXXVXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect22.F</label>
       </variable>
       <variable item="CustAspect22.G" CV="214" mask="XXXXXXVX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect22.G</label>
       </variable>
       <variable item="CustAspect22.H" CV="214" mask="XXXXXXXV" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect22.H</label>
       </variable>
       <variable item="CustAspect23.A" CV="215" mask="VXXXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect23.A</label>
       </variable>
       <variable item="CustAspect23.B" CV="215" mask="XVXXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect23.B</label>
       </variable>
       <variable item="CustAspect23.C" CV="215" mask="XXVXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect23.C</label>
       </variable>
       <variable item="CustAspect23.D" CV="215" mask="XXXVXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect23.D</label>
       </variable>
       <variable item="CustAspect23.E" CV="215" mask="XXXXVXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect23.E</label>
       </variable>
       <variable item="CustAspect23.F" CV="215" mask="XXXXXVXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect23.F</label>
       </variable>
       <variable item="CustAspect23.G" CV="215" mask="XXXXXXVX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect23.G</label>
       </variable>
       <variable item="CustAspect23.H" CV="215" mask="XXXXXXXV" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect23.H</label>
       </variable>
       <variable item="CustAspect24.A" CV="216" mask="VXXXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect24.A</label>
       </variable>
       <variable item="CustAspect24.B" CV="216" mask="XVXXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect24.B</label>
       </variable>
       <variable item="CustAspect24.C" CV="216" mask="XXVXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect24.C</label>
       </variable>
       <variable item="CustAspect24.D" CV="216" mask="XXXVXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect24.D</label>
       </variable>
       <variable item="CustAspect24.E" CV="216" mask="XXXXVXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect24.E</label>
       </variable>
       <variable item="CustAspect24.F" CV="216" mask="XXXXXVXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect24.F</label>
       </variable>
       <variable item="CustAspect24.G" CV="216" mask="XXXXXXVX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect24.G</label>
       </variable>
       <variable item="CustAspect24.H" CV="216" mask="XXXXXXXV" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect24.H</label>
       </variable>
       <variable item="CustAspect25.A" CV="217" mask="VXXXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect25.A</label>
       </variable>
       <variable item="CustAspect25.B" CV="217" mask="XVXXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect25.B</label>
       </variable>
       <variable item="CustAspect25.C" CV="217" mask="XXVXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect25.C</label>
       </variable>
       <variable item="CustAspect25.D" CV="217" mask="XXXVXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect25.D</label>
       </variable>
       <variable item="CustAspect25.E" CV="217" mask="XXXXVXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect25.E</label>
       </variable>
       <variable item="CustAspect25.F" CV="217" mask="XXXXXVXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect25.F</label>
       </variable>
       <variable item="CustAspect25.G" CV="217" mask="XXXXXXVX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect25.G</label>
       </variable>
       <variable item="CustAspect25.H" CV="217" mask="XXXXXXXV" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect25.H</label>
       </variable>
       <variable item="CustAspect26.A" CV="218" mask="VXXXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect26.A</label>
       </variable>
       <variable item="CustAspect26.B" CV="218" mask="XVXXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect26.B</label>
       </variable>
       <variable item="CustAspect26.C" CV="218" mask="XXVXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect26.C</label>
       </variable>
       <variable item="CustAspect26.D" CV="218" mask="XXXVXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect26.D</label>
       </variable>
       <variable item="CustAspect26.E" CV="218" mask="XXXXVXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect26.E</label>
       </variable>
       <variable item="CustAspect26.F" CV="218" mask="XXXXXVXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect26.F</label>
       </variable>
       <variable item="CustAspect26.G" CV="218" mask="XXXXXXVX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect26.G</label>
       </variable>
       <variable item="CustAspect26.H" CV="218" mask="XXXXXXXV" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect26.H</label>
       </variable>
       <variable item="CustAspect27.A" CV="219" mask="VXXXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect27.A</label>
       </variable>
       <variable item="CustAspect27.B" CV="219" mask="XVXXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect27.B</label>
       </variable>
       <variable item="CustAspect27.C" CV="219" mask="XXVXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect27.C</label>
       </variable>
       <variable item="CustAspect27.D" CV="219" mask="XXXVXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect27.D</label>
       </variable>
       <variable item="CustAspect27.E" CV="219" mask="XXXXVXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect27.E</label>
       </variable>
       <variable item="CustAspect27.F" CV="219" mask="XXXXXVXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect27.F</label>
       </variable>
       <variable item="CustAspect27.G" CV="219" mask="XXXXXXVX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect27.G</label>
       </variable>
       <variable item="CustAspect27.H" CV="219" mask="XXXXXXXV" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect27.H</label>
       </variable>
       <variable item="CustAspect28.A" CV="220" mask="VXXXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect28.A</label>
       </variable>
       <variable item="CustAspect28.B" CV="220" mask="XVXXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect28.B</label>
       </variable>
       <variable item="CustAspect28.C" CV="220" mask="XXVXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect28.C</label>
       </variable>
       <variable item="CustAspect28.D" CV="220" mask="XXXVXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect28.D</label>
       </variable>
       <variable item="CustAspect28.E" CV="220" mask="XXXXVXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect28.E</label>
       </variable>
       <variable item="CustAspect28.F" CV="220" mask="XXXXXVXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect28.F</label>
       </variable>
       <variable item="CustAspect28.G" CV="220" mask="XXXXXXVX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect28.G</label>
       </variable>
       <variable item="CustAspect28.H" CV="220" mask="XXXXXXXV" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect28.H</label>
       </variable>
       <variable item="CustAspect29.A" CV="221" mask="VXXXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect29.A</label>
       </variable>
       <variable item="CustAspect29.B" CV="221" mask="XVXXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect29.B</label>
       </variable>
       <variable item="CustAspect29.C" CV="221" mask="XXVXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect29.C</label>
       </variable>
       <variable item="CustAspect29.D" CV="221" mask="XXXVXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect29.D</label>
       </variable>
       <variable item="CustAspect29.E" CV="221" mask="XXXXVXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect29.E</label>
       </variable>
       <variable item="CustAspect29.F" CV="221" mask="XXXXXVXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect29.F</label>
       </variable>
       <variable item="CustAspect29.G" CV="221" mask="XXXXXXVX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect29.G</label>
       </variable>
       <variable item="CustAspect29.H" CV="221" mask="XXXXXXXV" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect29.H</label>
       </variable>
       <variable item="CustAspect30.A" CV="222" mask="VXXXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect30.A</label>
       </variable>
       <variable item="CustAspect30.B" CV="222" mask="XVXXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect30.B</label>
       </variable>
       <variable item="CustAspect30.C" CV="222" mask="XXVXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect30.C</label>
       </variable>
       <variable item="CustAspect30.D" CV="222" mask="XXXVXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect30.D</label>
       </variable>
       <variable item="CustAspect30.E" CV="222" mask="XXXXVXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect30.E</label>
       </variable>
       <variable item="CustAspect30.F" CV="222" mask="XXXXXVXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect30.F</label>
       </variable>
       <variable item="CustAspect30.G" CV="222" mask="XXXXXXVX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect30.G</label>
       </variable>
       <variable item="CustAspect30.H" CV="222" mask="XXXXXXXV" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect30.H</label>
       </variable>
       <variable item="CustAspect31.A" CV="223" mask="VXXXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect31.A</label>
       </variable>
       <variable item="CustAspect31.B" CV="223" mask="XVXXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect31.B</label>
       </variable>
       <variable item="CustAspect31.C" CV="223" mask="XXVXXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect31.C</label>
       </variable>
       <variable item="CustAspect31.D" CV="223" mask="XXXVXXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect31.D</label>
       </variable>
       <variable item="CustAspect31.E" CV="223" mask="XXXXVXXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect31.E</label>
       </variable>
       <variable item="CustAspect31.F" CV="223" mask="XXXXXVXX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect31.F</label>
       </variable>
       <variable item="CustAspect31.G" CV="223" mask="XXXXXXVX" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect31.G</label>
       </variable>
       <variable item="CustAspect31.H" CV="223" mask="XXXXXXXV" minOut="8" include="57379">
-        <enumVal>
-          <enumChoice choice="No" value="0"/>
-          <enumChoice choice="Yes" value="1"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes-0_1.xml"/>
         <label>CustAspect31.H</label>
       </variable>
     </variables>

--- a/xml/decoders/Hattons.xml
+++ b/xml/decoders/Hattons.xml
@@ -221,487 +221,179 @@
         <label>Addressing Mode</label>
       </variable>
       <variable item="FL(f) controls output 1" CV="33" mask="XXXXXXXV" minOut="1" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 1</label>
       </variable>
       <variable item="FL(r) controls output 1" CV="33" mask="XXXXXXVX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 1</label>
       </variable>
       <variable item="F1 controls output 1" CV="33" mask="XXXXXVXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 1</label>
       </variable>
       <variable item="F2 controls output 1" CV="33" mask="XXXXVXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 1</label>
       </variable>
       <variable item="F3 controls output 1" CV="33" mask="XXXVXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 1</label>
       </variable>
       <variable item="F4 controls output 1" CV="33" mask="XXVXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 1</label>
       </variable>
       <variable item="F5 controls output 1" CV="33" mask="XVXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 1</label>
       </variable>
       <variable item="F6 controls output 1" CV="33" mask="VXXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 1</label>
       </variable>
       <variable item="FL(f) controls output 2" CV="34" mask="XXXXXXXV" minOut="2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 2</label>
       </variable>
       <variable item="FL(r) controls output 2" CV="34" mask="XXXXXXVX" minOut="2" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 2</label>
       </variable>
       <variable item="F1 controls output 2" CV="34" mask="XXXXXVXX" minOut="2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 2</label>
       </variable>
       <variable item="F2 controls output 2" CV="34" mask="XXXXVXXX" minOut="2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 2</label>
       </variable>
       <variable item="F3 controls output 2" CV="34" mask="XXXVXXXX" minOut="2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 2</label>
       </variable>
       <variable item="F4 controls output 2" CV="34" mask="XXVXXXXX" minOut="2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 2</label>
       </variable>
       <variable item="F5 controls output 2" CV="34" mask="XVXXXXXX" minOut="2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 2</label>
       </variable>
       <variable item="F6 controls output 2" CV="34" mask="VXXXXXXX" minOut="2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 2</label>
       </variable>
       <variable item="FL(f) controls output 3" CV="35" mask="XXXXXXXV" minOut="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 3</label>
       </variable>
       <variable item="FL(r) controls output 3" CV="35" mask="XXXXXXVX" minOut="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 3</label>
       </variable>
       <variable item="F1 controls output 3" CV="35" mask="XXXXXVXX" minOut="3" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 3</label>
       </variable>
       <variable item="F2 controls output 3" CV="35" mask="XXXXVXXX" minOut="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 3</label>
       </variable>
       <variable item="F3 controls output 3" CV="35" mask="XXXVXXXX" minOut="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 3</label>
       </variable>
       <variable item="F4 controls output 3" CV="35" mask="XXVXXXXX" minOut="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 3</label>
       </variable>
       <variable item="F5 controls output 3" CV="35" mask="XVXXXXXX" minOut="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 3</label>
       </variable>
       <variable item="F6 controls output 3" CV="35" mask="VXXXXXXX" minOut="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 3</label>
       </variable>
       <variable item="FL(f) controls output 4" CV="36" mask="XXXXXXXV" minOut="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 4</label>
       </variable>
       <variable item="FL(r) controls output 4" CV="36" mask="XXXXXXVX" minOut="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 4</label>
       </variable>
       <variable item="F1 controls output 4" CV="36" mask="XXXXXVXX" minOut="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 4</label>
       </variable>
       <variable item="F2 controls output 4" CV="36" mask="XXXXVXXX" minOut="4" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 4</label>
       </variable>
       <variable item="F3 controls output 4" CV="36" mask="XXXVXXXX" minOut="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 4</label>
       </variable>
       <variable item="F4 controls output 4" CV="36" mask="XXVXXXXX" minOut="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 4</label>
       </variable>
       <variable item="F5 controls output 4" CV="36" mask="XVXXXXXX" minOut="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 4</label>
       </variable>
       <variable item="F6 controls output 4" CV="36" mask="VXXXXXXX" minOut="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 4</label>
       </variable>
       <variable item="F7 controls output 3" CV="37" mask="XXXXXVXX" minOut="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output 3</label>
       </variable>
       <variable item="F8 controls output 3" CV="37" mask="XXXXVXXX" minOut="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output 3</label>
       </variable>
       <variable item="F9 controls output 3" CV="37" mask="XXXVXXXX" minOut="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output 3</label>
       </variable>
       <variable item="F10 controls output 3" CV="37" mask="XXVXXXXX" minOut="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output 3</label>
       </variable>
       <variable item="F11 controls output 3" CV="37" mask="XVXXXXXX" minOut="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output 3</label>
       </variable>
       <variable item="F12 controls output 3" CV="37" mask="VXXXXXXX" minOut="3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output 3</label>
       </variable>
       <variable item="F7 controls output 4" CV="38" mask="XXXXXVXX" minOut="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output 4</label>
       </variable>
       <variable item="F8 controls output 4" CV="38" mask="XXXXVXXX" minOut="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output 4</label>
       </variable>
       <variable item="F9 controls output 4" CV="38" mask="XXXVXXXX" minOut="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output 4</label>
       </variable>
       <variable item="F10 controls output 4" CV="38" mask="XXVXXXXX" minOut="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output 4</label>
       </variable>
       <variable item="F11 controls output 4" CV="38" mask="XVXXXXXX" minOut="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output 4</label>
       </variable>
       <variable item="F12 controls output 4" CV="38" mask="VXXXXXXX" minOut="4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output 4</label>
       </variable>
       <variable CV="49" item="Output 1 effect generated" mask="XXXXVVVV">
@@ -1176,179 +868,67 @@
         <label>Beacon Max Brightness</label>
       </variable>
       <variable item="FL(f) controls output Dim" CV="123" mask="XXXXXXXV" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output Dim</label>
       </variable>
       <variable item="FL(r) controls output Dim" CV="123" mask="XXXXXXVX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output Dim</label>
       </variable>
       <variable item="F1 controls output Dim" CV="123" mask="XXXXXVXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output Dim</label>
       </variable>
       <variable item="F2 controls output Dim" CV="123" mask="XXXXVXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output Dim</label>
       </variable>
       <variable item="F3 controls output Dim" CV="123" mask="XXXVXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output Dim</label>
       </variable>
       <variable item="F4 controls output Dim" CV="123" mask="XXVXXXXX" minOut="1" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output Dim</label>
       </variable>
       <variable item="F5 controls output Dim" CV="123" mask="XVXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output Dim</label>
       </variable>
       <variable item="F6 controls output Dim" CV="123" mask="VXXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output Dim</label>
       </variable>
       <variable item="FL(f) controls output Ditch" CV="124" mask="XXXXXXXV" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output Ditch</label>
       </variable>
       <variable item="FL(r) controls output Ditch" CV="124" mask="XXXXXXVX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output Ditch</label>
       </variable>
       <variable item="F1 controls output Ditch" CV="124" mask="XXXXXVXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output Ditch</label>
       </variable>
       <variable item="F2 controls output Ditch" CV="124" mask="XXXXVXXX" minOut="1" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output Ditch</label>
       </variable>
       <variable item="F3 controls output Ditch" CV="124" mask="XXXVXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output Ditch</label>
       </variable>
       <variable item="F4 controls output Ditch" CV="124" mask="XXVXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output Ditch</label>
       </variable>
       <variable item="F5 controls output Ditch" CV="124" mask="XVXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output Ditch</label>
       </variable>
       <variable item="F6 controls output Ditch" CV="124" mask="VXXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output Ditch</label>
       </variable>
       <variable item="Decel 2 Rate End Point" CV="125" default="0" tooltip="Sets the Decel 2 Rate End Point, range 0(default)-255, CV125" comment="Range 0-255">
@@ -1396,91 +976,35 @@
         <label>Power to button controlled motor</label>
       </variable>
       <variable item="FL(f) controls output Motor" CV="134" mask="XXXXXXXV" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output Motor</label>
       </variable>
       <variable item="FL(r) controls output Motor" CV="134" mask="XXXXXXVX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output Motor</label>
       </variable>
       <variable item="F1 controls output Motor" CV="134" mask="XXXXXVXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output Motor</label>
       </variable>
       <variable item="F2 controls output Motor" CV="134" mask="XXXXVXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output Motor</label>
       </variable>
       <variable item="F3 controls output Motor" CV="134" mask="XXXVXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output Motor</label>
       </variable>
       <variable item="F4 controls output Motor" CV="134" mask="XXVXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output Motor</label>
       </variable>
       <variable item="F5 controls output Motor" CV="134" mask="XVXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output Motor</label>
       </variable>
       <variable item="F6 controls output Motor" CV="134" mask="VXXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output Motor</label>
       </variable>
       <variable CV="135" item="Function 4 effect generated" default="16" tooltip="Random Flicker for fireboxes">
@@ -1488,91 +1012,35 @@
         <label>Random Flicker Control</label>
       </variable>
       <variable item="F5 controls output BEMF" CV="136" mask="XXXXXXXV" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output BEMF</label>
       </variable>
       <variable item="F6 controls output BEMF" CV="136" mask="XXXXXXVX" minOut="1" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output BEMF</label>
       </variable>
       <variable item="F7 controls output BEMF" CV="136" mask="XXXXXVXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output BEMF</label>
       </variable>
       <variable item="F8 controls output BEMF" CV="136" mask="XXXXVXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output BEMF</label>
       </variable>
       <variable item="F9 controls output BEMF" CV="136" mask="XXXVXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output BEMF</label>
       </variable>
       <variable item="F10 controls output BEMF" CV="136" mask="XXVXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output BEMF</label>
       </variable>
       <variable item="F11 controls output BEMF" CV="136" mask="XVXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output BEMF</label>
       </variable>
       <variable item="F12 controls output BEMF" CV="136" mask="VXXXXXXX" minOut="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output BEMF</label>
       </variable>
     </variables>

--- a/xml/decoders/LDH_SyM-v60-port.xml
+++ b/xml/decoders/LDH_SyM-v60-port.xml
@@ -286,59 +286,83 @@
 
      <!-- *********  panel de mapeo ; estos labels no salen ; vienen de otro lado ***********-->
 
-			<variable label="FL(f) controls output 1" CV="33" default="1" mask="XXXXXXXV"> <enumVal>
-				<enumChoice choice="No"/> <enumChoice choice="Yes"/> </enumVal> </variable>
-			<variable label="FL(f) controls output 2" CV="33" mask="XXXXXXVX"> <enumVal>
-				<enumChoice choice="No"/> <enumChoice choice="Yes"/> </enumVal> </variable>
-			<variable label="FL(f) controls output 3" CV="33" mask="XXXXXVXX"> <enumVal>
-				<enumChoice choice="No"/> <enumChoice choice="Yes"/> </enumVal> </variable>
-			<variable label="FL(f) controls output 4" CV="33" mask="XXXXVXXX"> <enumVal>
-				<enumChoice choice="No"/> <enumChoice choice="Yes"/> </enumVal> </variable>
+			<variable label="FL(f) controls output 1" CV="33" default="1" mask="XXXXXXXV">
+				<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+			</variable>
+			<variable label="FL(f) controls output 2" CV="33" mask="XXXXXXVX">
+				<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+			</variable>
+			<variable label="FL(f) controls output 3" CV="33" mask="XXXXXVXX">
+				<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+			</variable>
+			<variable label="FL(f) controls output 4" CV="33" mask="XXXXVXXX">
+				<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+			</variable>
 
-			<variable label="FL(r) controls output 1" CV="34" mask="XXXXXXXV"> <enumVal>
-				<enumChoice choice="No"/> <enumChoice choice="Yes"/> </enumVal> </variable>
-			<variable label="FL(r) controls output 2" CV="34" default="1" mask="XXXXXXVX"> <enumVal>
-				<enumChoice choice="No"/> <enumChoice choice="Yes"/> </enumVal> </variable>
-			<variable label="FL(r) controls output 3" CV="34" mask="XXXXXVXX"> <enumVal>
-				<enumChoice choice="No"/> <enumChoice choice="Yes"/> </enumVal> </variable>
-			<variable label="FL(r) controls output 4" CV="34" mask="XXXXVXXX"> <enumVal>
-				<enumChoice choice="No"/> <enumChoice choice="Yes"/> </enumVal> </variable>
+			<variable label="FL(r) controls output 1" CV="34" mask="XXXXXXXV">
+				<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+			</variable>
+			<variable label="FL(r) controls output 2" CV="34" default="1" mask="XXXXXXVX">
+				<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+			</variable>
+			<variable label="FL(r) controls output 3" CV="34" mask="XXXXXVXX">
+				<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+			</variable>
+			<variable label="FL(r) controls output 4" CV="34" mask="XXXXVXXX">
+				<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+			</variable>
 
-			<variable label="F1 controls output 1" CV="35" mask="XXXXXXXV"> <enumVal>
-				<enumChoice choice="No"/> <enumChoice choice="Yes"/> </enumVal> </variable>
-			<variable label="F1 controls output 2" CV="35" mask="XXXXXXVX"> <enumVal>
-				<enumChoice choice="No"/> <enumChoice choice="Yes"/> </enumVal> </variable>
-			<variable label="F1 controls output 3" CV="35" default="0" mask="XXXXXVXX"> <enumVal>
-				<enumChoice choice="No"/> <enumChoice choice="Yes"/> </enumVal> </variable>
-			<variable label="F1 controls output 4" CV="39" mask="XXXXVXXX"> <enumVal>
-				<enumChoice choice="No"/> <enumChoice choice="Yes"/> </enumVal> </variable>
+			<variable label="F1 controls output 1" CV="35" mask="XXXXXXXV">
+				<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+			</variable>
+			<variable label="F1 controls output 2" CV="35" mask="XXXXXXVX">
+				<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+			</variable>
+			<variable label="F1 controls output 3" CV="35" default="0" mask="XXXXXVXX">
+				<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+			</variable>
+			<variable label="F1 controls output 4" CV="39" mask="XXXXVXXX">
+				<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+			</variable>
 
-			<variable label="F2 controls output 1" CV="36" mask="XXXXXXXV"> <enumVal>
-				<enumChoice choice="No"/> <enumChoice choice="Yes"/> </enumVal> </variable>
-			<variable label="F2 controls output 2" CV="36" mask="XXXXXXVX"> <enumVal>
-				<enumChoice choice="No"/> <enumChoice choice="Yes"/> </enumVal> </variable>
-			<variable label="F2 controls output 3" CV="36" mask="XXXXXVXX"> <enumVal>
-				<enumChoice choice="No"/> <enumChoice choice="Yes"/> </enumVal> </variable>
-			<variable label="F2 controls output 4" CV="36" default="0" mask="XXXXVXXX"> <enumVal>
-				<enumChoice choice="No"/> <enumChoice choice="Yes"/> </enumVal> </variable>
+			<variable label="F2 controls output 1" CV="36" mask="XXXXXXXV">
+				<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+			</variable>
+			<variable label="F2 controls output 2" CV="36" mask="XXXXXXVX">
+				<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+			</variable>
+			<variable label="F2 controls output 3" CV="36" mask="XXXXXVXX">
+				<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+			</variable>
+			<variable label="F2 controls output 4" CV="36" default="0" mask="XXXXVXXX">
+				<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+			</variable>
 
-			<variable label="F5 controls output 1" CV="39" mask="XXXXXXXV"> <enumVal>
-				<enumChoice choice="No"/> <enumChoice choice="Yes"/> </enumVal> </variable>
-			<variable label="F5 controls output 2" CV="39" mask="XXXXXXVX"> <enumVal>
-				<enumChoice choice="No"/> <enumChoice choice="Yes"/> </enumVal> </variable>
-			<variable label="F5 controls output 3" CV="39" default="1" mask="XXXXXVXX"> <enumVal>
-				<enumChoice choice="No"/> <enumChoice choice="Yes"/> </enumVal> </variable>
-			<variable label="F5 controls output 4" CV="39" mask="XXXXVXXX"> <enumVal>
-				<enumChoice choice="No"/> <enumChoice choice="Yes"/> </enumVal> </variable>
+			<variable label="F5 controls output 1" CV="39" mask="XXXXXXXV">
+				<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+			</variable>
+			<variable label="F5 controls output 2" CV="39" mask="XXXXXXVX">
+				<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+			</variable>
+			<variable label="F5 controls output 3" CV="39" default="1" mask="XXXXXVXX">
+				<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+			</variable>
+			<variable label="F5 controls output 4" CV="39" mask="XXXXVXXX">
+				<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+			</variable>
 
-			<variable label="F6 controls output 1" CV="40" mask="XXXXXXXV" minOut="1" minFn="2"> <enumVal>
-				<enumChoice choice="No"/> <enumChoice choice="Yes"/> </enumVal> </variable>
-			<variable label="F6 controls output 2" CV="40" mask="XXXXXXVX"> <enumVal>
-				<enumChoice choice="No"/> <enumChoice choice="Yes"/> </enumVal> </variable>
-			<variable label="F6 controls output 3" CV="40" mask="XXXXXVXX"> <enumVal>
-				<enumChoice choice="No"/> <enumChoice choice="Yes"/> </enumVal> </variable>
-			<variable label="F6 controls output 4" CV="40" default="1" mask="XXXXVXXX"> <enumVal>
-				<enumChoice choice="No"/> <enumChoice choice="Yes"/> </enumVal> </variable>
+			<variable label="F6 controls output 1" CV="40" mask="XXXXXXXV" minOut="1" minFn="2">
+				<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+			</variable>
+			<variable label="F6 controls output 2" CV="40" mask="XXXXXXVX">
+				<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+			</variable>
+			<variable label="F6 controls output 3" CV="40" mask="XXXXXVXX">
+				<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+			</variable>
+			<variable label="F6 controls output 4" CV="40" default="1" mask="XXXXVXXX">
+				<xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+			</variable>
 
  <!-- **************** fin panel de mapeo *****?**************  -->
 

--- a/xml/decoders/Massoth_PIKO.xml
+++ b/xml/decoders/Massoth_PIKO.xml
@@ -826,17 +826,11 @@
         <label>F3: Special Function Servo</label>
       </variable>
       <variable item="F3: Servo Inverse Operation" CV="121" mask="XXXXXVXX" default="0" tooltip="F3 servo has inverse operation">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3: Servo Inverse Operation</label>
       </variable>
       <variable item="F3: Servo Switched Off" CV="121" mask="XXXXVXXX" default="0" tooltip="F3 servo is switched off after a motion">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3: Servo Switched Off</label>
       </variable>
       <variable item="F3: Servo Lower End Position" CV="122" default="16" tooltip="Needs to be adjusted to servo">

--- a/xml/decoders/Mistral_XR.xml
+++ b/xml/decoders/Mistral_XR.xml
@@ -137,24 +137,15 @@
 
 <!--  Function Mapping definition for the 3 outputs available            -->
 	<variable item="F0(f) controls output 1" CV="33" mask="XXXXXXXV" minOut="1" default="1">
-		<enumVal> 
-			<enumChoice choice="No"/>
-			<enumChoice choice="Yes"/>
-		</enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
     <label>F0(f) controls output 1</label>
 	</variable>
 	<variable item="F0(f) controls output 2" CV="33" mask="XXXXXXVX" minOut="2">
-		<enumVal> 
-			<enumChoice choice="No"/>
-			<enumChoice choice="Yes"/>
-		</enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
     <label>F0(f) controls output 2</label>
 	</variable>
 	<variable item="F0(f) controls output 3" CV="33" mask="XXVXXXXX" minOut="3">
-		<enumVal> 
-			<enumChoice choice="No"/>
-			<enumChoice choice="Yes"/>
-		</enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
     <label>F0(f) controls output 3</label>
 	</variable>
 	<variable item="F0(r) controls output 1" CV="34" mask="XXXXXXXV" minOut="1">
@@ -165,94 +156,55 @@
     <label>F0(r) controls output 1</label>
 	</variable>
 	<variable item="F0(r) controls output 2" CV="34" 	mask="XXXXXXVX" minOut="2" default="1">
-		<enumVal> 
-			<enumChoice choice="No"/>
-			<enumChoice choice="Yes"/>
-		</enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
     <label>F0(r) controls output 2</label>
 	</variable>
 	<variable item="F0(r) controls output 3" CV="34" 	mask="XXVXXXXX" minOut="3">
-		<enumVal> 
-			<enumChoice choice="No"/>
-			<enumChoice choice="Yes"/>
-		</enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
     <label>F0(r) controls output 3</label>
 	</variable>
 	<variable item="F1 controls output 1" CV="35" mask="XXXXXXXV" minOut="1" minFn="1">
-		<enumVal> 
-			<enumChoice choice="No"/>
-			<enumChoice choice="Yes"/>
-		</enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
     <label>F1 controls output 1</label>
 	</variable>
 	<variable item="F1 controls output 2" CV="35" mask="XXXXXXVX" minOut="2" minFn="1">
-		<enumVal> 
-			<enumChoice choice="No"/>
-			<enumChoice choice="Yes"/>
-		</enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
     <label>F1 controls output 2</label>
 	</variable>
 	<variable item="F1 controls output 3" CV="35" mask="XXVXXXXX" minOut="3" minFn="1">
-		<enumVal> 
-			<enumChoice choice="No"/>
-			<enumChoice choice="Yes"/>
-		</enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
     <label>F1 controls output 3</label>
 	</variable>
 	<variable item="F2 controls output 1" CV="36" mask="XXXXXXXV" minOut="1" minFn="2">
-		<enumVal> 
-			<enumChoice choice="No"/>
-			<enumChoice choice="Yes"/>
-		</enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
     <label>F2 controls output 1</label>
 	</variable>
 	<variable item="F2 controls output 2" CV="36" mask="XXXXXXVX" minOut="2" minFn="2">
-		<enumVal> 
-			<enumChoice choice="No"/>
-			<enumChoice choice="Yes"/>
-		</enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
     <label>F2 controls output 2</label>
 	</variable>
 	<variable item="F2 controls output 3" CV="36" mask="XXVXXXXX" minOut="3" minFn="2">
-		<enumVal> 
-			<enumChoice choice="No"/>
-			<enumChoice choice="Yes"/>
-		</enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
     <label>F2 controls output 3</label>
 	</variable>
 	<variable item="F3 controls output 1" CV="37" mask="XXXXXXXV" minOut="1" minFn="3">
-		<enumVal> 
-			<enumChoice choice="No"/>
-			<enumChoice choice="Yes"/>
-		</enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
     <label>F3 controls output 1</label>
 	</variable>
 	<variable item="F3 controls output 2" CV="37" mask="XXXXXXVX" minOut="2" minFn="3">
-		<enumVal> 
-			<enumChoice choice="No"/>
-			<enumChoice choice="Yes"/>
-		</enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
     <label>F3 controls output 2</label>
 	</variable>
 	<variable item="F3 controls output 3" CV="37" mask="XXVXXXXX" minOut="3" minFn="3" default="1">
-		<enumVal> 
-			<enumChoice choice="No"/>
-			<enumChoice choice="Yes"/>
-		</enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
     <label>F3 controls output 3</label>
 	</variable>
 	<variable item="F4 controls output 1" CV="38" mask="XXXXXXXV" minOut="1" minFn="4" default="0">
-		<enumVal> 
-			<enumChoice choice="No"/>
-			<enumChoice choice="Yes"/>
-		</enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
     <label>F4 controls output 1</label>
 	</variable>
 	<variable item="F4 controls output 2" CV="38" mask="XXXXXXVX" minOut="2" minFn="4">
-		<enumVal> 
-			<enumChoice choice="No"/>
-			<enumChoice choice="Yes"/>
-		</enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
     <label>F4 controls output 2</label>
 	</variable>
 	<variable item="F4 controls output 3" CV="38" mask="XXVXXXXX" minOut="3" minFn="4">
@@ -263,87 +215,51 @@
     <label>F4 controls output 3</label>
 	</variable>
 	<variable item="F5 controls output 1" CV="39" mask="XXXXXXXV" minOut="1" minFn="5" default="0">
-		<enumVal> 
-			<enumChoice choice="No"/>
-			<enumChoice choice="Yes"/>
-		</enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
     <label>F5 controls output 1</label>
 	</variable>
 	<variable item="F5 controls output 2" CV="39" mask="XXXXXXVX" minOut="2" minFn="5">
-		<enumVal> 
-			<enumChoice choice="No"/>
-			<enumChoice choice="Yes"/>
-		</enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
     <label>F5 controls output 2</label>
 	</variable>
 	<variable item="F5 controls output 3" CV="39" mask="XXVXXXXX" minOut="3" minFn="5">
-		<enumVal> 
-			<enumChoice choice="No"/>
-			<enumChoice choice="Yes"/>
-		</enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
     <label>F5 controls output 3</label>
 	</variable>
 	<variable item="F6 controls output 1" CV="40" mask="XXXXXXXV" minOut="1" minFn="6" default="0">
-		<enumVal> 
-			<enumChoice choice="No"/>
-			<enumChoice choice="Yes"/>
-		</enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
     <label>F6 controls output 1</label>
 	</variable>
 	<variable item="F6 controls output 2" CV="40" mask="XXXXXXVX" minOut="2" minFn="6">
-		<enumVal> 
-			<enumChoice choice="No"/>
-			<enumChoice choice="Yes"/>
-		</enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
     <label>F6 controls output 2</label>
 	</variable>
 	<variable item="F6 controls output 3" CV="40" mask="XXVXXXXX" minOut="3" minFn="6">
-		<enumVal> 
-			<enumChoice choice="No"/>
-			<enumChoice choice="Yes"/>
-		</enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
     <label>F6 controls output 3</label>
 	</variable>
 	<variable item="F7 controls output 1" CV="41" mask="XXXXXXXV" minOut="1" minFn="7" default="0">
-		<enumVal> 
-			<enumChoice choice="No"/>
-			<enumChoice choice="Yes"/>
-		</enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
     <label>F7 controls output 1</label>
 	</variable>
 	<variable item="F7 controls output 2" CV="41" mask="XXXXXXVX" minOut="2" minFn="7">
-		<enumVal> 
-			<enumChoice choice="No"/>
-			<enumChoice choice="Yes"/>
-		</enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
     <label>F7 controls output 2</label>
 	</variable>
 	<variable item="F7 controls output 3" CV="41" mask="XXVXXXXX" minOut="3" minFn="7">
-		<enumVal> 
-			<enumChoice choice="No"/>
-			<enumChoice choice="Yes"/>
-		</enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
     <label>F7 controls output 3</label>
 	</variable>
 	<variable item="F8 controls output 1" CV="42" mask="XXXXXXXV" minOut="1" minFn="8" default="0">
-		<enumVal> 
-			<enumChoice choice="No"/>
-			<enumChoice choice="Yes"/>
-		</enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
     <label>F8 controls output 1</label>
 	</variable>
 	<variable item="F8 controls output 2" CV="42" mask="XXXXXXVX" minOut="2" minFn="8">
-		<enumVal> 
-			<enumChoice choice="No"/>
-			<enumChoice choice="Yes"/>
-		</enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
     <label>F8 controls output 2</label>
 	</variable>
 	<variable item="F8 controls output 3" CV="42" mask="XXVXXXXX" minOut="3" minFn="8">
-		<enumVal> 
-			<enumChoice choice="No"/>
-			<enumChoice choice="Yes"/>
-		</enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
     <label>F8 controls output 3</label>
 	</variable>
 </variables>

--- a/xml/decoders/QSI_Articulated_Steam.xml
+++ b/xml/decoders/QSI_Articulated_Steam.xml
@@ -771,14 +771,7 @@
         <decVal max="63"/>
       </variable>
       <variable label="Horn Triggered Doppler" CV="51.2" mask="XXXXXXXV" default="1" comment="QSI" item="CV51.2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
       </variable>
       <!-- Sound volumes -->
       <variable label="Whistle" CV="52.0" default="11" comment="QSI" item="CV52.0">

--- a/xml/decoders/QSI_Articulated_Steam_ver6.xml
+++ b/xml/decoders/QSI_Articulated_Steam_ver6.xml
@@ -763,14 +763,7 @@
         <decVal max="63"/>
       </variable>
       <variable label="Horn Triggered Doppler" CV="51.2" mask="XXXXXXXV" default="1" comment="QSI" item="CV51.2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
       </variable>
       <!-- Sound volumes -->
       <variable label="Whistle" CV="52.0" default="11" comment="QSI" item="CV52.0">

--- a/xml/decoders/QSI_Diesel.xml
+++ b/xml/decoders/QSI_Diesel.xml
@@ -701,14 +701,7 @@
         <decVal max="63"/>
       </variable>
       <variable label="Horn Triggered Doppler" CV="51.2" mask="XXXXXXXV" default="1" comment="QSI" item="CV51.2bit0">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
       </variable>
       <!-- Sound volumes -->
       <variable label="Horn" CV="52.0" default="11" comment="QSI" item="CV52.0">

--- a/xml/decoders/QSI_Diesel_Ver6.xml
+++ b/xml/decoders/QSI_Diesel_Ver6.xml
@@ -759,14 +759,7 @@
         <decVal max="63"/>
       </variable>
       <variable label="Horn Triggered Doppler" CV="51.2" mask="XXXXXXXV" default="1" comment="QSI" item="CV51.2bit0">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
       </variable>
       <!-- Sound volumes -->
       <variable label="Horn" CV="52.0" default="11" comment="QSI" item="CV52.0">

--- a/xml/decoders/QSI_Electric.xml
+++ b/xml/decoders/QSI_Electric.xml
@@ -695,14 +695,7 @@
         <decVal max="63"/>
       </variable>
       <variable label="Horn Triggered Doppler" CV="51.2" mask="XXXXXXXV" default="1" comment="QSI" item="CV51.2bit0">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
       </variable>
       <!-- Sound volumes -->
       <variable label="Horn" CV="52.0" default="11" comment="QSI" item="CV52.0">

--- a/xml/decoders/SoundTraxx_Lighting_Athearn_Genesis_Caboose.xml
+++ b/xml/decoders/SoundTraxx_Lighting_Athearn_Genesis_Caboose.xml
@@ -55,22 +55,19 @@
 
     <variables>
 
-      <variable CV="1" default="3"
-                item="Short Address"
+      <variable CV="1" default="3" item="Short Address"
                 tooltip="Sets the Primary (short, 2 digit) address">
         <shortAddressVal/>
         <label>Primary Address (1-127)</label>
       </variable>
 
-      <variable CV="3" default="0"
-                item="Accel"
+      <variable CV="3" default="0" item="Accel"
                 tooltip="Sets the acceleration rate (delay).  Higher number = slower rate">
         <decVal/>
         <label>Acceleration Rate (0-255)</label>
       </variable>
 
-      <variable CV="4" default="0"
-                item="Decel"
+      <variable CV="4" default="0" item="Decel"
                 tooltip="Sets the deceleration rate (delay).  Higher number = slower rate">
         <decVal/>
         <label>Braking Rate (0-255)</label>
@@ -89,8 +86,7 @@
         <label>Manufacturer ID</label>
       </variable>
 
-      <variable CV="12" mask="XXXXXXXV" default="1"
-                item="Analog Power Conversion"
+      <variable CV="12" mask="XXXXXXXV" default="1" item="Analog Power Conversion"
                 tooltip="&lt;html&gt;Defines the type of power source the decoder should&lt;br&gt;
                          switch to whenever a DCC signal is not present.&lt;br&gt;
                          (Tip: Alternate Power Source must be enabled)&lt;/html&gt;">
@@ -301,8 +297,7 @@
         <label>Analog Mode Function Status - F12</label>
       </variable>
 
-      <variable CV="15" mask="XXXXXVVV" default="0"
-                item="Advanced Group 1 Option 1"
+      <variable CV="15" mask="XXXXXVVV" default="0" item="Advanced Group 1 Option 1"
                 tooltip="&lt;html&gt;Enter the Lock ID Code to unlock access to the decoder CVs.&lt;br&gt;
                          (Tip: Establish the unlock code with CV Lock ID Code)&lt;/html&gt;">
         <decVal/>
@@ -316,8 +311,7 @@
         <label>CV Lock ID Code (0-7)</label>
       </variable>
 
-      <variable CV="17" default="3"
-                item="Long Address"
+      <variable CV="17" default="3" item="Long Address"
                 tooltip="Sets the Extended (long, 4 digit) address">
         <!-- defaults are: cv17=192, cv18=3 -->
         <longAddressVal/>
@@ -331,8 +325,7 @@
       <xi:include href="http://jmri.org/xml/decoders/nmra/consistAddrDirection.xml"/>
 
 
-      <variable CV="21" mask="XXXXXXXV" default="0" minFn="1"
-                item="Consist Address Active For F1">
+      <variable CV="21" mask="XXXXXXXV" default="0" minFn="1" item="Consist Address Active For F1">
         <enumVal>
           <enumChoice choice="Respond to locomotive address only">
             <choice>Respond to locomotive address only</choice>
@@ -344,8 +337,7 @@
         <label>Consist Address Activation for F1</label>
       </variable>
 
-      <variable CV="21" mask="XXXXXXVX" default="0" minFn="2"
-                item="Consist Address Active For F2">
+      <variable CV="21" mask="XXXXXXVX" default="0" minFn="2" item="Consist Address Active For F2">
         <enumVal>
           <enumChoice choice="Respond to locomotive address only">
             <choice>Respond to locomotive address only</choice>
@@ -357,8 +349,7 @@
         <label>Consist Address Activation for F2</label>
       </variable>
 
-      <variable CV="21" mask="XXXXXVXX" default="0" minFn="3"
-                item="Consist Address Active For F3">
+      <variable CV="21" mask="XXXXXVXX" default="0" minFn="3" item="Consist Address Active For F3">
         <enumVal>
           <enumChoice choice="Respond to locomotive address only">
             <choice>Respond to locomotive address only</choice>
@@ -370,8 +361,7 @@
         <label>Consist Address Activation for F3</label>
       </variable>
 
-      <variable CV="21" mask="XXXXVXXX" default="0" minFn="4"
-                item="Consist Address Active For F4">
+      <variable CV="21" mask="XXXXVXXX" default="0" minFn="4" item="Consist Address Active For F4">
         <enumVal>
           <enumChoice choice="Respond to locomotive address only">
             <choice>Respond to locomotive address only</choice>
@@ -383,8 +373,7 @@
         <label>Consist Address Activation for F4</label>
       </variable>
 
-      <variable CV="21" mask="XXXVXXXX" default="0" minFn="5"
-                item="Consist Address Active For F5">
+      <variable CV="21" mask="XXXVXXXX" default="0" minFn="5" item="Consist Address Active For F5">
         <enumVal>
           <enumChoice choice="Respond to locomotive address only">
             <choice>Respond to locomotive address only</choice>
@@ -396,8 +385,7 @@
         <label>Consist Address Activation for F5</label>
       </variable>
 
-      <variable CV="21" mask="XXVXXXXX" default="0" minFn="6"
-                item="Consist Address Active For F6">
+      <variable CV="21" mask="XXVXXXXX" default="0" minFn="6" item="Consist Address Active For F6">
         <enumVal>
           <enumChoice choice="Respond to locomotive address only">
             <choice>Respond to locomotive address only</choice>
@@ -409,8 +397,7 @@
         <label>Consist Address Activation for F6</label>
       </variable>
 
-      <variable CV="21" mask="XVXXXXXX" default="0" minFn="7"
-                item="Consist Address Active For F7">
+      <variable CV="21" mask="XVXXXXXX" default="0" minFn="7" item="Consist Address Active For F7">
         <enumVal>
           <enumChoice choice="Respond to locomotive address only">
             <choice>Respond to locomotive address only</choice>
@@ -422,8 +409,7 @@
         <label>Consist Address Activation for F7</label>
       </variable>
 
-      <variable CV="21" mask="VXXXXXXX" default="0" minFn="8"
-                item="Consist Address Active For F8">
+      <variable CV="21" mask="VXXXXXXX" default="0" minFn="8" item="Consist Address Active For F8">
         <enumVal>
           <enumChoice choice="Respond to locomotive address only">
             <choice>Respond to locomotive address only</choice>
@@ -435,8 +421,7 @@
         <label>Consist Address Activation for F8</label>
       </variable>
 
-      <variable CV="22" mask="XXXXXXXV" default="0"
-                item="Consist Address Active For FL in Forward">
+      <variable CV="22" mask="XXXXXXXV" default="0" item="Consist Address Active For FL in Forward">
         <enumVal>
           <enumChoice choice="Respond to locomotive address only">
             <choice>Respond to locomotive address only</choice>
@@ -448,8 +433,7 @@
         <label>Consist Address Activation for F0(f) in Forward</label>
       </variable>
 
-      <variable CV="22" mask="XXXXXXVX" default="0"
-                item="Consist Address Active For FL in Reverse">
+      <variable CV="22" mask="XXXXXXVX" default="0" item="Consist Address Active For FL in Reverse">
         <enumVal>
           <enumChoice choice="Respond to locomotive address only">
             <choice>Respond to locomotive address only</choice>
@@ -461,8 +445,7 @@
         <label>Consist Address Activation for F0(r) in Reverse</label>
       </variable>
 
-      <variable CV="22" mask="XXXXXVXX" default="0" minFn="9"
-                item="Consist Address Active For F9">
+      <variable CV="22" mask="XXXXXVXX" default="0" minFn="9" item="Consist Address Active For F9">
         <enumVal>
           <enumChoice choice="Respond to locomotive address only">
             <choice>Respond to locomotive address only</choice>
@@ -474,8 +457,7 @@
         <label>Consist Address Activation for F9</label>
       </variable>
 
-      <variable CV="22" mask="XXXXVXXX" default="0" minFn="10"
-                item="Consist Address Active For F10">
+      <variable CV="22" mask="XXXXVXXX" default="0" minFn="10" item="Consist Address Active For F10">
         <enumVal>
           <enumChoice choice="Respond to locomotive address only">
             <choice>Respond to locomotive address only</choice>
@@ -487,8 +469,7 @@
         <label>Consist Address Activation for F10</label>
       </variable>
 
-      <variable CV="22" mask="XXXVXXXX" default="0" minFn="11"
-                item="Consist Address Active For F11">
+      <variable CV="22" mask="XXXVXXXX" default="0" minFn="11" item="Consist Address Active For F11">
         <enumVal>
           <enumChoice choice="Respond to locomotive address only">
             <choice>Respond to locomotive address only</choice>
@@ -500,8 +481,7 @@
         <label>Consist Address Activation for F11</label>
       </variable>
 
-      <variable CV="22" mask="XXVXXXXX" default="0" minFn="12"
-                item="Consist Address Active For F12">
+      <variable CV="22" mask="XXVXXXXX" default="0" minFn="12" item="Consist Address Active For F12">
         <enumVal>
           <enumChoice choice="Respond to locomotive address only">
             <choice>Respond to locomotive address only</choice>
@@ -513,8 +493,7 @@
         <label>Consist Address Activation for F12</label>
       </variable>
 
-      <variable CV="23" mask="XVVVVVVV" default="0"
-                item="Consist Acceleration Adjustment"
+      <variable CV="23" mask="XVVVVVVV" default="0" item="Consist Acceleration Adjustment"
                 comment="Additional consist acceleration (combined with CV3)"
                 tooltip="When loco is in a consist, it's base acceleration rate is modified by this amount">
         <decVal max="127"/>
@@ -522,8 +501,7 @@
         <comment>Additional consist acceleration (combined with CV3)</comment>
       </variable>
 
-      <variable CV="23" mask="VXXXXXXX" default="0"
-                item="Consist Acceleration Adjustment Sign">
+      <variable CV="23" mask="VXXXXXXX" default="0" item="Consist Acceleration Adjustment Sign">
         <enumVal>
           <enumChoice choice="Add value to base acceleration rate (increases acceleration delay)">
             <choice>Add value to base acceleration rate (increases acceleration delay)</choice>
@@ -535,8 +513,7 @@
         <label>Consist Acceleration Sign</label>
       </variable>
 
-      <variable CV="24" mask="XVVVVVVV" default="0"
-                item="Consist Deceleration Adjustment"
+      <variable CV="24" mask="XVVVVVVV" default="0" item="Consist Deceleration Adjustment"
                 comment="Additional consist braking (combined with CV4)"
                 tooltip="When loco is in a consist, it's baseline braking rate is modified by this amount">
         <decVal max="127"/>
@@ -544,8 +521,7 @@
         <comment>Additional consist braking (combined with CV4)</comment>
       </variable>
 
-      <variable CV="24" mask="VXXXXXXX" default="0"
-                item="Consist Deceleration Adjustment Sign"
+      <variable CV="24" mask="VXXXXXXX" default="0" item="Consist Deceleration Adjustment Sign"
                 tooltip="Determines whether value is added to or subtracted from loco baseline braking rate">
         <enumVal>
           <enumChoice choice="Add value to baseline braking rate (increases braking delay)">
@@ -558,8 +534,7 @@
         <label>Consist Braking Sign</label>
       </variable>
 
-      <variable CV="29" mask="XXXXXXXV" default="0"
-                item="Locomotive Direction">
+      <variable CV="29" mask="XXXXXXXV" default="0" item="Locomotive Direction">
         <enumVal>
           <enumChoice choice="Forward">
             <choice>Forward</choice>
@@ -571,8 +546,7 @@
         <label>Locomotive's Normal Direction of Motion</label>
       </variable>
 
-      <variable CV="29" mask="XXXXXXVX" default="1"
-                item="Speed Step Mode">
+      <variable CV="29" mask="XXXXXXVX" default="1" item="Speed Step Mode">
         <enumVal>
           <enumChoice choice="14">
             <choice>14</choice>
@@ -584,8 +558,7 @@
         <label>Speed Steps</label>
       </variable>
 
-      <variable CV="29" mask="XXXXXVXX" default="1"
-                item="Analog (DC) Operation">
+      <variable CV="29" mask="XXXXXVXX" default="1" item="Analog (DC) Operation">
         <enumVal>
           <enumChoice choice="NMRA Digital Only">
             <choice>NMRA Digital Only</choice>
@@ -597,8 +570,7 @@
         <label>Alternate Power Source Enable</label>
       </variable>
 
-      <variable CV="29" mask="XXVXXXXX" default="0"
-                item="Address Format">
+      <variable CV="29" mask="XXVXXXXX" default="0" item="Address Format">
         <enumVal>
           <enumChoice choice="Use 2 digit address (primary address)">
             <choice>Use 2 digit address (primary address)</choice>
@@ -610,8 +582,7 @@
         <label>Extended Address Mode</label>
       </variable>
 
-      <variable CV="30" mask="XXXXXXXV" default="0"
-                item="Advanced Group 1 Option 3"
+      <variable CV="30" mask="XXXXXXXV" default="0" item="Advanced Group 1 Option 3"
                 tooltip="Enable locking of CVs when decoder is used in a multi-decoder installation">
         <enumVal>
           <enumChoice choice="Normal operation (no locking)">
@@ -624,8 +595,7 @@
         <label>CV Lock Enable</label>
       </variable>
 
-      <variable CV="30" mask="XXXXXXVX" default="0"
-                item="Advanced Group 1 Option 4"
+      <variable CV="30" mask="XXXXXXVX" default="0" item="Advanced Group 1 Option 4"
                 tooltip="Tip: To do a one-time decoder reset, use the menu [Reset] selection">
         <enumVal>
           <enumChoice choice="Normal operation">
@@ -638,8 +608,7 @@
         <label>CV Clear (CVCLR)</label>
       </variable>
 
-      <variable CV="30" mask="XXXXXVXX" default="0"
-                item="Advanced Group 1 Option 5"
+      <variable CV="30" mask="XXXXXVXX" default="0" item="Advanced Group 1 Option 5"
                 tooltip="Function Group 2 (F5-F8) assignments are swapped with Function Group 3 (F9-F12)">
         <enumVal>
           <enumChoice choice="Normal">
@@ -654,1459 +623,563 @@
 
 <!-- Function Mapping follows -->
 
-      <variable CV="33" mask="XXXXXXXV" default="1"
-                item="FL(f) controls output 1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="33" mask="XXXXXXXV" default="1" item="FL(f) controls output 1">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls FX0F</label>
       </variable>
 
-      <variable CV="33" mask="XXXXXXVX" default="0"
-                item="FL(f) controls output 2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="33" mask="XXXXXXVX" default="0" item="FL(f) controls output 2">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls FX0R</label>
       </variable>
 
-      <variable CV="33" mask="XXXXXVXX" default="0"
-                item="FL(f) controls output Grade Crossing Logic">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="33" mask="XXXXXVXX" default="0" item="FL(f) controls output Grade Crossing Logic">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls XingLogic</label>
       </variable>
 
-      <variable CV="33" mask="XXXXVXXX" default="0"
-                item="FL(f) controls output 4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="33" mask="XXXXVXXX" default="0" item="FL(f) controls output 4">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls Reserved_4</label>
       </variable>
 
-      <variable CV="33" mask="XXXVXXXX" default="0"
-                item="FL(f) controls output FX5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="33" mask="XXXVXXXX" default="0" item="FL(f) controls output FX5">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls FX5</label>
       </variable>
 
-      <variable CV="33" mask="XXVXXXXX" default="0"
-                item="FL(f) controls output FX6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="33" mask="XXVXXXXX" default="0" item="FL(f) controls output FX6">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls FX6</label>
       </variable>
 
-      <variable CV="33" mask="XVXXXXXX" default="0"
-                item="FL(f) controls output 7">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="33" mask="XVXXXXXX" default="0" item="FL(f) controls output 7">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls Reserved_7</label>
       </variable>
 
-      <variable CV="33" mask="VXXXXXXX" default="0"
-                item="FL(f) controls output 8">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="33" mask="VXXXXXXX" default="0" item="FL(f) controls output 8">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls Reserved_8</label>
       </variable>
 
-      <variable CV="34" mask="XXXXXXXV" default="0"
-                item="FL(r) controls output 1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="34" mask="XXXXXXXV" default="0" item="FL(r) controls output 1">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls FX0F</label>
       </variable>
 
-      <variable CV="34" mask="XXXXXXVX" default="1"
-                item="FL(r) controls output 2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="34" mask="XXXXXXVX" default="1" item="FL(r) controls output 2">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls FX0R</label>
       </variable>
 
-      <variable CV="34" mask="XXXXXVXX" default="0"
-                item="FL(r) controls output Grade Crossing Logic">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="34" mask="XXXXXVXX" default="0" item="FL(r) controls output Grade Crossing Logic">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls XingLogic</label>
       </variable>
 
-      <variable CV="34" mask="XXXXVXXX" default="0"
-                item="FL(r) controls output 4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="34" mask="XXXXVXXX" default="0" item="FL(r) controls output 4">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls Reserved_4</label>
       </variable>
 
-      <variable CV="34" mask="XXXVXXXX" default="0"
-                item="FL(r) controls output FX5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="34" mask="XXXVXXXX" default="0" item="FL(r) controls output FX5">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls FX5</label>
       </variable>
 
-      <variable CV="34" mask="XXVXXXXX" default="0"
-                item="FL(r) controls output FX6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="34" mask="XXVXXXXX" default="0" item="FL(r) controls output FX6">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls FX6</label>
       </variable>
 
-      <variable CV="34" mask="XVXXXXXX" default="0"
-                item="FL(r) controls output 7">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="34" mask="XVXXXXXX" default="0" item="FL(r) controls output 7">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls Reserved_7</label>
       </variable>
 
-      <variable CV="34" mask="VXXXXXXX" default="0"
-                item="FL(r) controls output 8">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="34" mask="VXXXXXXX" default="0" item="FL(r) controls output 8">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls Reserved_8</label>
       </variable>
 
-      <variable CV="35" mask="XXXXXXXV" default="0"
-                item="F1 controls output 1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="35" mask="XXXXXXXV" default="0" item="F1 controls output 1">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls FX0F</label>
       </variable>
 
-      <variable CV="35" mask="XXXXXXVX" default="0"
-                item="F1 controls output 2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="35" mask="XXXXXXVX" default="0" item="F1 controls output 2">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls FX0R</label>
       </variable>
 
-      <variable CV="35" mask="XXXXXVXX" default="0"
-                item="F1 controls output Grade Crossing Logic">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="35" mask="XXXXXVXX" default="0" item="F1 controls output Grade Crossing Logic">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls XingLogic</label>
       </variable>
 
-      <variable CV="35" mask="XXXXVXXX" default="0"
-                item="F1 controls output 4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="35" mask="XXXXVXXX" default="0" item="F1 controls output 4">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls Reserved_4</label>
       </variable>
 
-      <variable CV="35" mask="XXXVXXXX" default="0"
-                item="F1 controls output FX5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="35" mask="XXXVXXXX" default="0" item="F1 controls output FX5">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls FX5</label>
       </variable>
 
-      <variable CV="35" mask="XXVXXXXX" default="0"
-                item="F1 controls output FX6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="35" mask="XXVXXXXX" default="0" item="F1 controls output FX6">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls FX6</label>
       </variable>
 
-      <variable CV="35" mask="XVXXXXXX" default="0"
-                item="F1 controls output 7">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="35" mask="XVXXXXXX" default="0" item="F1 controls output 7">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls Reserved_7</label>
       </variable>
 
-      <variable CV="35" mask="VXXXXXXX" default="0"
-                item="F1 controls output 8">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="35" mask="VXXXXXXX" default="0" item="F1 controls output 8">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls Reserved_8</label>
       </variable>
 
-      <variable CV="36" mask="XXXXXXXV" default="0"
-                item="F2 controls output 1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="36" mask="XXXXXXXV" default="0" item="F2 controls output 1">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls FX0F</label>
       </variable>
 
-      <variable CV="36" mask="XXXXXXVX" default="0"
-                item="F2 controls output 2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="36" mask="XXXXXXVX" default="0" item="F2 controls output 2">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls FX0R</label>
       </variable>
 
-      <variable CV="36" mask="XXXXXVXX" default="0"
-                item="F2 controls output Grade Crossing Logic">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="36" mask="XXXXXVXX" default="0" item="F2 controls output Grade Crossing Logic">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls XingLogic</label>
       </variable>
 
-      <variable CV="36" mask="XXXXVXXX" default="0"
-                item="F2 controls output 4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="36" mask="XXXXVXXX" default="0" item="F2 controls output 4">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls Reserved_4</label>
       </variable>
 
-      <variable CV="36" mask="XXXVXXXX" default="0"
-                item="F2 controls output FX5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="36" mask="XXXVXXXX" default="0" item="F2 controls output FX5">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls FX5</label>
       </variable>
 
-      <variable CV="36" mask="XXVXXXXX" default="0"
-                item="F2 controls output FX6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="36" mask="XXVXXXXX" default="0" item="F2 controls output FX6">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls FX6</label>
       </variable>
 
-      <variable CV="36" mask="XVXXXXXX" default="0"
-                item="F2 controls output 7">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="36" mask="XVXXXXXX" default="0" item="F2 controls output 7">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls Reserved_7</label>
       </variable>
 
-      <variable CV="36" mask="VXXXXXXX" default="0"
-                item="F2 controls output 8">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="36" mask="VXXXXXXX" default="0" item="F2 controls output 8">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls Reserved_8</label>
       </variable>
 
-      <variable CV="37" mask="XXXXXXXV" default="0"
-                item="F3 controls output 4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="37" mask="XXXXXXXV" default="0" item="F3 controls output 4">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls Reserved_4</label>
       </variable>
 
-      <variable CV="37" mask="XXXXXXVX" default="0"
-                item="F3 controls output FX5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="37" mask="XXXXXXVX" default="0" item="F3 controls output FX5">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls FX5</label>
       </variable>
 
-      <variable CV="37" mask="XXXXXVXX" default="0"
-                item="F3 controls output FX6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="37" mask="XXXXXVXX" default="0" item="F3 controls output FX6">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls FX6</label>
       </variable>
 
-      <variable CV="37" mask="XXXXVXXX" default="0"
-                item="F3 controls output 7">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="37" mask="XXXXVXXX" default="0" item="F3 controls output 7">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls Reserved_7</label>
       </variable>
 
-      <variable CV="37" mask="XXXVXXXX" default="0"
-                item="F3 controls output 8">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="37" mask="XXXVXXXX" default="0" item="F3 controls output 8">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls Reserved_8</label>
       </variable>
 
-      <variable CV="37" mask="XXVXXXXX" default="0"
-                item="F3 controls output 9">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="37" mask="XXVXXXXX" default="0" item="F3 controls output 9">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls Reserved_8</label>
       </variable>
 
-      <variable CV="37" mask="XVXXXXXX" default="0"
-                item="F3 controls output 10">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="37" mask="XVXXXXXX" default="0" item="F3 controls output 10">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls Reserved_10</label>
       </variable>
 
-      <variable CV="37" mask="VXXXXXXX" default="0"
-                item="F3 controls output Dimming">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="37" mask="VXXXXXXX" default="0" item="F3 controls output Dimming">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls Dimming</label>
       </variable>
 
-      <variable CV="38" mask="XXXXXXXV" default="0"
-                item="F4 controls output 4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="38" mask="XXXXXXXV" default="0" item="F4 controls output 4">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls Reserved_4</label>
       </variable>
 
-      <variable CV="38" mask="XXXXXXVX" default="0"
-                item="F4 controls output FX5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="38" mask="XXXXXXVX" default="0" item="F4 controls output FX5">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls FX5</label>
       </variable>
 
-      <variable CV="38" mask="XXXXXVXX" default="0"
-                item="F4 controls output FX6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="38" mask="XXXXXVXX" default="0" item="F4 controls output FX6">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls FX6</label>
       </variable>
 
-      <variable CV="38" mask="XXXXVXXX" default="0"
-                item="F4 controls output 7">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="38" mask="XXXXVXXX" default="0" item="F4 controls output 7">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls Reserved_7</label>
       </variable>
 
-      <variable CV="38" mask="XXXVXXXX" default="0"
-                item="F4 controls output 8">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="38" mask="XXXVXXXX" default="0" item="F4 controls output 8">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls Reserved_8</label>
       </variable>
 
-      <variable CV="38" mask="XXVXXXXX" default="0"
-                item="F4 controls output 9">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="38" mask="XXVXXXXX" default="0" item="F4 controls output 9">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls Reserved_9</label>
       </variable>
 
-      <variable CV="38" mask="XVXXXXXX" default="0"
-                item="F4 controls output 10">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="38" mask="XVXXXXXX" default="0" item="F4 controls output 10">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls Reserved_10</label>
       </variable>
 
-      <variable CV="38" mask="VXXXXXXX" default="0"
-                item="F4 controls output Dimming">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="38" mask="VXXXXXXX" default="0" item="F4 controls output Dimming">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls Dimming</label>
       </variable>
 
-      <variable CV="39" mask="XXXXXXXV" default="0"
-                item="F5 controls output 4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="39" mask="XXXXXXXV" default="0" item="F5 controls output 4">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls Reserved_4</label>
       </variable>
 
-      <variable CV="39" mask="XXXXXXVX" default="1"
-                item="F5 controls output FX5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="39" mask="XXXXXXVX" default="1" item="F5 controls output FX5">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls FX5</label>
       </variable>
 
-      <variable CV="39" mask="XXXXXVXX" default="0"
-                item="F5 controls output FX6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="39" mask="XXXXXVXX" default="0" item="F5 controls output FX6">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls FX6</label>
       </variable>
 
-      <variable CV="39" mask="XXXXVXXX" default="0"
-                item="F5 controls output 7">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="39" mask="XXXXVXXX" default="0" item="F5 controls output 7">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls Reserved_7</label>
       </variable>
 
-      <variable CV="39" mask="XXXVXXXX" default="0"
-                item="F5 controls output 8">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="39" mask="XXXVXXXX" default="0" item="F5 controls output 8">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls Reserved_8</label>
       </variable>
 
-      <variable CV="39" mask="XXVXXXXX" default="0"
-                item="F5 controls output 9">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="39" mask="XXVXXXXX" default="0" item="F5 controls output 9">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls Reserved_9</label>
       </variable>
 
-      <variable CV="39" mask="XVXXXXXX" default="0"
-                item="F5 controls output 10">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="39" mask="XVXXXXXX" default="0" item="F5 controls output 10">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls Reserved_10</label>
       </variable>
 
-      <variable CV="39" mask="VXXXXXXX" default="0"
-                item="F5 controls output Dimming">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="39" mask="VXXXXXXX" default="0" item="F5 controls output Dimming">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls Dimming</label>
       </variable>
 
-      <variable CV="40" mask="XXXXXXXV" default="0"
-                item="F6 controls output 4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="40" mask="XXXXXXXV" default="0" item="F6 controls output 4">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls Reserved_4</label>
       </variable>
 
-      <variable CV="40" mask="XXXXXXVX" default="0"
-                item="F6 controls output FX5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="40" mask="XXXXXXVX" default="0" item="F6 controls output FX5">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls FX5</label>
       </variable>
 
-      <variable CV="40" mask="XXXXXVXX" default="1"
-                item="F6 controls output FX6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="40" mask="XXXXXVXX" default="1" item="F6 controls output FX6">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls FX6</label>
       </variable>
 
-      <variable CV="40" mask="XXXXVXXX" default="0"
-                item="F6 controls output 7">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="40" mask="XXXXVXXX" default="0" item="F6 controls output 7">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls Reserved_7</label>
       </variable>
 
-      <variable CV="40" mask="XXXVXXXX" default="0"
-                item="F6 controls output 8">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="40" mask="XXXVXXXX" default="0" item="F6 controls output 8">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls Reserved_8</label>
       </variable>
 
-      <variable CV="40" mask="XXVXXXXX" default="0"
-                item="F6 controls output 9">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="40" mask="XXVXXXXX" default="0" item="F6 controls output 9">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls Reserved_8</label>
       </variable>
 
-      <variable CV="40" mask="XVXXXXXX" default="0"
-                item="F6 controls output 10">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="40" mask="XVXXXXXX" default="0" item="F6 controls output 10">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls Reserved_10</label>
       </variable>
 
-      <variable CV="40" mask="VXXXXXXX" default="0"
-                item="F6 controls output Dimming">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="40" mask="VXXXXXXX" default="0" item="F6 controls output Dimming">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls Dimming</label>
       </variable>
 
-      <variable CV="41" mask="XXXXXXXV" default="0"
-                item="F7 controls output 7">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="41" mask="XXXXXXXV" default="0" item="F7 controls output 7">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls Reserved_7</label>
       </variable>
 
-      <variable CV="41" mask="XXXXXXVX" default="0"
-                item="F7 controls output 8">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="41" mask="XXXXXXVX" default="0" item="F7 controls output 8">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls Reserved_8</label>
       </variable>
 
-      <variable CV="41" mask="XXXXXVXX" default="0"
-                item="F7 controls output 9">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="41" mask="XXXXXVXX" default="0" item="F7 controls output 9">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls Reserved_8</label>
       </variable>
 
-      <variable CV="41" mask="XXXXVXXX" default="0"
-                item="F7 controls output 10">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="41" mask="XXXXVXXX" default="0" item="F7 controls output 10">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls Reserved_10</label>
       </variable>
 
-      <variable CV="41" mask="XXXVXXXX" default="1"
-                item="F7 controls output Dimming">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="41" mask="XXXVXXXX" default="1" item="F7 controls output Dimming">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls Dimming</label>
       </variable>
 
-      <variable CV="41" mask="XXVXXXXX" default="0"
-                item="F7 controls output 12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="41" mask="XXVXXXXX" default="0" item="F7 controls output 12">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls Reserved_12</label>
       </variable>
 
-      <variable CV="41" mask="XVXXXXXX" default="0"
-                item="F7 controls output 13">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="41" mask="XVXXXXXX" default="0" item="F7 controls output 13">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls Reserved_13</label>
       </variable>
 
-      <variable CV="41" mask="VXXXXXXX" default="0"
-                item="F7 controls output 14">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="41" mask="VXXXXXXX" default="0" item="F7 controls output 14">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls Reserved_14</label>
       </variable>
 
-      <variable CV="42" mask="XXXXXXXV" default="0"
-                item="F8 controls output 7">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="42" mask="XXXXXXXV" default="0" item="F8 controls output 7">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls Reserved_7</label>
       </variable>
 
-      <variable CV="42" mask="XXXXXXVX" default="0"
-                item="F8 controls output 8">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="42" mask="XXXXXXVX" default="0" item="F8 controls output 8">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls Reserved_8</label>
       </variable>
 
-      <variable CV="42" mask="XXXXXVXX" default="0"
-                item="F8 controls output 9">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="42" mask="XXXXXVXX" default="0" item="F8 controls output 9">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls Reserved_8</label>
       </variable>
 
-      <variable CV="42" mask="XXXXVXXX" default="0"
-                item="F8 controls output 10">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="42" mask="XXXXVXXX" default="0" item="F8 controls output 10">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls Reserved_10</label>
       </variable>
 
-      <variable CV="42" mask="XXXVXXXX" default="0"
-                item="F8 controls output Dimming">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="42" mask="XXXVXXXX" default="0" item="F8 controls output Dimming">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls Dimming</label>
       </variable>
 
-      <variable CV="42" mask="XXVXXXXX" default="0"
-                item="F8 controls output 12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="42" mask="XXVXXXXX" default="0" item="F8 controls output 12">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls Reserved_12</label>
       </variable>
 
-      <variable CV="42" mask="XVXXXXXX" default="0"
-                item="F8 controls output 13">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="42" mask="XVXXXXXX" default="0" item="F8 controls output 13">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls Reserved_13</label>
       </variable>
 
-      <variable CV="42" mask="VXXXXXXX" default="0"
-                item="F8 controls output 14">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="42" mask="VXXXXXXX" default="0" item="F8 controls output 14">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls Reserved_14</label>
       </variable>
 
-      <variable CV="43" mask="XXXXXXXV" default="0" minFn="9"
-                item="F9 controls output 7">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="43" mask="XXXXXXXV" default="0" minFn="9" item="F9 controls output 7">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls Reserved_7</label>
       </variable>
 
-      <variable CV="43" mask="XXXXXXVX" default="0" minFn="9"
-                item="F9 controls output 8">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="43" mask="XXXXXXVX" default="0" minFn="9" item="F9 controls output 8">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls Reserved_8</label>
       </variable>
 
-      <variable CV="43" mask="XXXXXVXX" default="0" minFn="9"
-                item="F9 controls output 9">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="43" mask="XXXXXVXX" default="0" minFn="9" item="F9 controls output 9">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls Reserved_8</label>
       </variable>
 
-      <variable CV="43" mask="XXXXVXXX" default="0" minFn="9"
-                item="F9 controls output 10">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="43" mask="XXXXVXXX" default="0" minFn="9" item="F9 controls output 10">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls Reserved_10</label>
       </variable>
 
-      <variable CV="43" mask="XXXVXXXX" default="0" minFn="9"
-                item="F9 controls output Dimming">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="43" mask="XXXVXXXX" default="0" minFn="9" item="F9 controls output Dimming">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls Dimming</label>
       </variable>
 
-      <variable CV="43" mask="XXVXXXXX" default="0" minFn="9"
-                item="F9 controls output 12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="43" mask="XXVXXXXX" default="0" minFn="9" item="F9 controls output 12">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls Reserved_12</label>
       </variable>
 
-      <variable CV="43" mask="XVXXXXXX" default="0" minFn="9"
-                item="F9 controls output 13">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="43" mask="XVXXXXXX" default="0" minFn="9" item="F9 controls output 13">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls Reserved_13</label>
       </variable>
 
-      <variable CV="43" mask="VXXXXXXX" default="0" minFn="9"
-                item="F9 controls output 14">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="43" mask="VXXXXXXX" default="0" minFn="9" item="F9 controls output 14">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls Reserved_14</label>
       </variable>
 
-      <variable CV="44" mask="XXXXXXXV" default="0" minFn="10"
-                item="F10 controls output 8">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="44" mask="XXXXXXXV" default="0" minFn="10" item="F10 controls output 8">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls Reserved_8</label>
       </variable>
 
-      <variable CV="44" mask="XXXXXXVX" default="0" minFn="10"
-                item="F10 controls output 9">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="44" mask="XXXXXXVX" default="0" minFn="10" item="F10 controls output 9">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls Reserved_8</label>
       </variable>
 
-      <variable CV="44" mask="XXXXXVXX" default="0" minFn="10"
-                item="F10 controls output 10">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="44" mask="XXXXXVXX" default="0" minFn="10" item="F10 controls output 10">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls Reserved_10</label>
       </variable>
 
-      <variable CV="44" mask="XXXXVXXX" default="0" minFn="10"
-                item="F10 controls output Dimming">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="44" mask="XXXXVXXX" default="0" minFn="10" item="F10 controls output Dimming">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls Dimming</label>
       </variable>
 
-      <variable CV="44" mask="XXXVXXXX" default="0" minFn="10"
-                item="F10 controls output 12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="44" mask="XXXVXXXX" default="0" minFn="10" item="F10 controls output 12">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls Reserved_12</label>
       </variable>
 
-      <variable CV="44" mask="XXVXXXXX" default="0" minFn="10"
-                item="F10 controls output 13">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="44" mask="XXVXXXXX" default="0" minFn="10" item="F10 controls output 13">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls Reserved_13</label>
       </variable>
 
-      <variable CV="44" mask="XVXXXXXX" default="0" minFn="10"
-                item="F10 controls output 14">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="44" mask="XVXXXXXX" default="0" minFn="10" item="F10 controls output 14">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls Reserved_14</label>
       </variable>
 
-      <variable CV="44" mask="VXXXXXXX" default="0" minFn="10"
-                item="F10 controls output 15">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="44" mask="VXXXXXXX" default="0" minFn="10" item="F10 controls output 15">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls Reserved_15</label>
       </variable>
 
-      <variable CV="45" mask="XXXXXXXV" default="0" minFn="11"
-                item="F11 controls output 8">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="45" mask="XXXXXXXV" default="0" minFn="11" item="F11 controls output 8">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls Reserved_8</label>
       </variable>
 
-      <variable CV="45" mask="XXXXXXVX" default="0" minFn="11"
-                item="F11 controls output 9">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="45" mask="XXXXXXVX" default="0" minFn="11" item="F11 controls output 9">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls Reserved_8</label>
       </variable>
 
-      <variable CV="45" mask="XXXXXVXX" default="0" minFn="11"
-                item="F11 controls output 10">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="45" mask="XXXXXVXX" default="0" minFn="11" item="F11 controls output 10">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls Reserved_10</label>
       </variable>
 
-      <variable CV="45" mask="XXXXVXXX" default="0" minFn="11"
-                item="F11 controls output Dimming">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="45" mask="XXXXVXXX" default="0" minFn="11" item="F11 controls output Dimming">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls Dimming</label>
       </variable>
 
-      <variable CV="45" mask="XXXVXXXX" default="0" minFn="11"
-                item="F11 controls output 12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="45" mask="XXXVXXXX" default="0" minFn="11" item="F11 controls output 12">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls Reserved_12</label>
       </variable>
 
-      <variable CV="45" mask="XXVXXXXX" default="0" minFn="11"
-                item="F11 controls output 13">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="45" mask="XXVXXXXX" default="0" minFn="11" item="F11 controls output 13">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls Reserved_13</label>
       </variable>
 
-      <variable CV="45" mask="XVXXXXXX" default="1" minFn="11"
-                item="F11 controls output 14">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="45" mask="XVXXXXXX" default="1" minFn="11" item="F11 controls output 14">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls Reserved_14</label>
       </variable>
 
-      <variable CV="45" mask="VXXXXXXX" default="0" minFn="11"
-                item="F11 controls output 15">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="45" mask="VXXXXXXX" default="0" minFn="11" item="F11 controls output 15">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls Reserved_15</label>
       </variable>
 
-      <variable CV="46" mask="XXXXXXXV" default="0" minFn="12"
-                item="F12 controls output 8">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="46" mask="XXXXXXXV" default="0" minFn="12" item="F12 controls output 8">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls Reserved_8</label>
       </variable>
 
-      <variable CV="46" mask="XXXXXXVX" default="0" minFn="12"
-                item="F12 controls output 9">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="46" mask="XXXXXXVX" default="0" minFn="12" item="F12 controls output 9">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls Reserved_8</label>
       </variable>
 
-      <variable CV="46" mask="XXXXXVXX" default="0" minFn="12"
-                item="F12 controls output 10">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="46" mask="XXXXXVXX" default="0" minFn="12" item="F12 controls output 10">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls Reserved_10</label>
       </variable>
 
-      <variable CV="46" mask="XXXXVXXX" default="0" minFn="12"
-                item="F12 controls output Dimming">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="46" mask="XXXXVXXX" default="0" minFn="12" item="F12 controls output Dimming">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls Dimming</label>
       </variable>
 
-      <variable CV="46" mask="XXXVXXXX" default="0" minFn="12"
-                item="F12 controls output 12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="46" mask="XXXVXXXX" default="0" minFn="12" item="F12 controls output 12">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls Reserved_12</label>
       </variable>
 
-      <variable CV="46" mask="XXVXXXXX" default="0" minFn="12"
-                item="F12 controls output 13">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="46" mask="XXVXXXXX" default="0" minFn="12" item="F12 controls output 13">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls Reserved_13</label>
       </variable>
 
-      <variable CV="46" mask="XVXXXXXX" default="0" minFn="12"
-                item="F12 controls output 14">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="46" mask="XVXXXXXX" default="0" minFn="12" item="F12 controls output 14">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls Reserved_14</label>
       </variable>
 
-      <variable CV="46" mask="VXXXXXXX" default="0" minFn="12"
-                item="F12 controls output 15">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+      <variable CV="46" mask="VXXXXXXX" default="0" minFn="12" item="F12 controls output 15">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls Reserved_15</label>
       </variable>
 
@@ -2790,8 +1863,7 @@
         <label>FX6B Light Type</label>
       </variable>
 
-      <variable CV="55" default="25"
-                item="Sound Setting 1"
+      <variable CV="55" default="25" item="Sound Setting 1"
                 tooltip="&lt;html&gt;The number entered will be the overall 
                          percentage of brightness. For example a value of 50 
                          would make the lights half as bright as the default, 
@@ -2804,8 +1876,7 @@
         <label>Marker Lamp Brightness</label>
       </variable>
 
-      <variable CV="56" default="75"
-                item="Sound Setting 2"
+      <variable CV="56" default="75" item="Sound Setting 2"
                 tooltip="&lt;html&gt;The number entered will be the overall 
                          percentage of brightness. For example a value of 50 
                          would make the lights half as bright as the default, 
@@ -2856,8 +1927,7 @@
 
 <!-- End Lighting Configuration -->
 
-      <variable CV="105"
-                item="User Id #1"
+      <variable CV="105" item="User Id #1"
                 tooltip="&lt;html&gt;Use to set a custom user ID or number.  Note: when&lt;br&gt;
                          the decoder is reset to default values, this CV is&lt;br&gt;
                          preset to the softwares minor revision code.&lt;/html&gt;">
@@ -2865,8 +1935,7 @@
         <label>User Identifier #1 (0-255)</label>
       </variable>
 
-      <variable CV="106"
-                item="User Id #2"
+      <variable CV="106" item="User Id #2"
                 tooltip="&lt;html&gt;Use to set a custom user ID or number.  Note: when&lt;br&gt;
                          the decoder is reset to default values, this CV is&lt;br&gt;
                          preset to the softwares default CV value configuration.&lt;/html&gt;">

--- a/xml/decoders/TAMS_FD-R_Basic.xml
+++ b/xml/decoders/TAMS_FD-R_Basic.xml
@@ -60,899 +60,451 @@
       <!-- Function tables for outputs 1-8  -->
       <!-- Code bits from http://jmri.org/xml/nmra/functionmap.xml , added full range off functions for Tams Decoders-->
       <variable item="FL(f) controls output 1" CV="33" mask="XXXXXXXV" minOut="1" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-		    </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 1</label>
       </variable>
       <variable item="FL(f) controls output 2" CV="33" mask="XXXXXXVX" minOut="2">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 2</label>
       </variable>
       <variable item="FL(f) controls output 3" CV="33" mask="XXXXXVXX" minOut="3">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 3</label>
       </variable>
       <variable item="FL(f) controls output 4" CV="33" mask="XXXXVXXX" minOut="4">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 4</label>
       </variable>
       <variable item="FL(f) controls output 5" CV="33" mask="XXXVXXXX" minOut="5">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 5</label>
       </variable>
       <variable item="FL(f) controls output 6" CV="33" mask="XXVXXXXX" minOut="6">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 6</label>
       </variable>
       <variable item="FL(f) controls output 7" CV="33" mask="XVXXXXXX" minOut="7">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 7</label>
       </variable>
       <variable item="FL(f) controls output 8" CV="33" mask="VXXXXXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 8</label>
       </variable>
       <variable item="FL(r) controls output 1" CV="34" mask="XXXXXXXV" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 1</label>
       </variable>
       <variable item="FL(r) controls output 2" CV="34" mask="XXXXXXVX" minOut="2" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 2</label>
       </variable>
       <variable item="FL(r) controls output 3" CV="34" mask="XXXXXVXX" minOut="3">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 3</label>
       </variable>
       <variable item="FL(r) controls output 4" CV="34" mask="XXXXVXXX" minOut="4">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 4</label>
       </variable>
       <variable item="FL(r) controls output 5" CV="34" mask="XXXVXXXX" minOut="5">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 5</label>
       </variable>
       <variable item="FL(r) controls output 6" CV="34" mask="XXVXXXXX" minOut="6">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 6</label>
       </variable>
       <variable item="FL(r) controls output 7" CV="34" mask="XVXXXXXX" minOut="7">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 7</label>
       </variable>
       <variable item="FL(r) controls output 8" CV="34" mask="VXXXXXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 8</label>
       </variable>
       <variable item="F1 controls output 1" CV="35" mask="XXXXXXXV" minOut="1" minFn="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 1</label>
       </variable>
       <variable item="F1 controls output 2" CV="35" mask="XXXXXXVX" minOut="2" minFn="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 2</label>
       </variable>
       <variable item="F1 controls output 3" CV="35" mask="XXXXXVXX" minOut="3" minFn="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 3</label>
       </variable>
       <variable item="F1 controls output 4" CV="35" mask="XXXXVXXX" minOut="4" minFn="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 4</label>
       </variable>
       <variable item="F1 controls output 5" CV="35" mask="XXXVXXXX" minOut="5" minFn="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 5</label>
       </variable>
       <variable item="F1 controls output 6" CV="35" mask="XXVXXXXX" minOut="6" minFn="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 6</label>
       </variable>
       <variable item="F1 controls output 7" CV="35" mask="XVXXXXXX" minOut="7" minFn="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 7</label>
       </variable>
       <variable item="F1 controls output 8" CV="35" mask="VXXXXXXX" minOut="8" minFn="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 8</label>
       </variable>
       <variable item="F2 controls output 1" CV="36" mask="XXXXXXXV" minOut="1" minFn="2">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 1</label>
       </variable>
       <variable item="F2 controls output 2" CV="36" mask="XXXXXXVX" minOut="2" minFn="2">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 2</label>
       </variable>
       <variable item="F2 controls output 3" CV="36" mask="XXXXXVXX" minOut="3" minFn="2">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 3</label>
       </variable>
       <variable item="F2 controls output 4" CV="36" mask="XXXXVXXX" minOut="4" minFn="2">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 4</label>
       </variable>
       <variable item="F2 controls output 5" CV="36" mask="XXXVXXXX" minOut="5" minFn="2">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 5</label>
       </variable>
       <variable item="F2 controls output 6" CV="36" mask="XXVXXXXX" minOut="6" minFn="2">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 6</label>
       </variable>
       <variable item="F2 controls output 7" CV="36" mask="XVXXXXXX" minOut="7" minFn="2">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 7</label>
       </variable>
       <variable item="F2 controls output 8" CV="36" mask="VXXXXXXX" minOut="8" minFn="2">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 8</label>
       </variable>
       <variable item="F3 controls output 1" CV="37" mask="XXXXXXXV" minOut="1" minFn="3">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 1</label>
       </variable>
       <variable item="F3 controls output 2" CV="37" mask="XXXXXXVX" minOut="2" minFn="3">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 2</label>
       </variable>
       <variable item="F3 controls output 3" CV="37" mask="XXXXXVXX" minOut="3" minFn="3">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 3</label>
       </variable>
       <variable item="F3 controls output 4" CV="37" mask="XXXXVXXX" minOut="4" minFn="3">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 4</label>
       </variable>
       <variable item="F3 controls output 5" CV="37" mask="XXXVXXXX" minOut="5" minFn="3">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 5</label>
       </variable>
       <variable item="F3 controls output 6" CV="37" mask="XXVXXXXX" minOut="6" minFn="3">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 6</label>
       </variable>
       <variable item="F3 controls output 7" CV="37" mask="XVXXXXXX" minOut="7" minFn="3">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 7</label>
       </variable>
       <variable item="F3 controls output 8" CV="37" mask="VXXXXXXX" minOut="8" minFn="3">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 8</label>
       </variable>
       <variable item="F4 controls output 1" CV="38" mask="XXXXXXXV" minOut="1" minFn="3">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 1</label>
       </variable>
       <variable item="F4 controls output 2" CV="38" mask="XXXXXXVX" minOut="2" minFn="4">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 2</label>
       </variable>
       <variable item="F4 controls output 3" CV="38" mask="XXXXXVXX" minOut="3" minFn="4">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 3</label>
       </variable>
       <variable item="F4 controls output 4" CV="38" mask="XXXXVXXX" minOut="4" minFn="4">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 4</label>
       </variable>
       <variable item="F4 controls output 5" CV="38" mask="XXXVXXXX" minOut="5" minFn="4">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 5</label>
       </variable>
       <variable item="F4 controls output 6" CV="38" mask="XXVXXXXX" minOut="6" minFn="4">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 6</label>
       </variable>
       <variable item="F4 controls output 7" CV="38" mask="XVXXXXXX" minOut="7" minFn="4">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 7</label>
       </variable>
       <variable item="F4 controls output 8" CV="38" mask="VXXXXXXX" minOut="8" minFn="4">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 8</label>
       </variable>
       <variable item="F5 controls output 1" CV="39" mask="XXXXXXXV" minOut="1" minFn="5">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 1</label>
       </variable>
       <variable item="F5 controls output 2" CV="39" mask="XXXXXXVX" minOut="2" minFn="5">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 2</label>
       </variable>
       <variable item="F5 controls output 3" CV="39" mask="XXXXXVXX" minOut="3" minFn="5">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 3</label>
       </variable>
       <variable item="F5 controls output 4" CV="39" mask="XXXXVXXX" minOut="4" minFn="5">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 4</label>
       </variable>
       <variable item="F5 controls output 5" CV="39" mask="XXXVXXXX" minOut="5" minFn="5">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 5</label>
       </variable>
       <variable item="F5 controls output 6" CV="39" mask="XXVXXXXX" minOut="6" minFn="5">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 6</label>
       </variable>
       <variable item="F5 controls output 7" CV="39" mask="XVXXXXXX" minOut="7" minFn="5">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 7</label>
       </variable>
       <variable item="F5 controls output 8" CV="39" mask="VXXXXXXX" minOut="8" minFn="5">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 8</label>
       </variable>
       <variable item="F6 controls output 1" CV="40" mask="XXXXXXXV" minOut="1" minFn="6">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 1</label>
       </variable>
       <variable item="F6 controls output 2" CV="40" mask="XXXXXXVX" minOut="2" minFn="6">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 2</label>
       </variable>
       <variable item="F6 controls output 3" CV="40" mask="XXXXXVXX" minOut="3" minFn="6">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 3</label>
       </variable>
       <variable item="F6 controls output 4" CV="40" mask="XXXXVXXX" minOut="4" minFn="6">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 4</label>
       </variable>
       <variable item="F6 controls output 5" CV="40" mask="XXXVXXXX" minOut="5" minFn="6">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 5</label>
       </variable>
       <variable item="F6 controls output 6" CV="40" mask="XXVXXXXX" minOut="6" minFn="6">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 6</label>
       </variable>
       <variable item="F6 controls output 7" CV="40" mask="XVXXXXXX" minOut="7" minFn="6">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 7</label>
       </variable>
       <variable item="F6 controls output 8" CV="40" mask="VXXXXXXX" minOut="8" minFn="6">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 8</label>
       </variable>
       <variable item="F7 controls output 1" CV="41" mask="XXXXXXXV" minOut="1" minFn="7">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output 1</label>
       </variable>
       <variable item="F7 controls output 2" CV="41" mask="XXXXXXVX" minOut="2" minFn="7">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output 2</label>
       </variable>
       <variable item="F7 controls output 3" CV="41" mask="XXXXXVXX" minOut="3" minFn="7">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output 3</label>
       </variable>
       <variable item="F7 controls output 4" CV="41" mask="XXXXVXXX" minOut="4" minFn="7">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output 4</label>
       </variable>
       <variable item="F7 controls output 5" CV="41" mask="XXXVXXXX" minOut="5" minFn="7">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output 5</label>
       </variable>
       <variable item="F7 controls output 6" CV="41" mask="XXVXXXXX" minOut="6" minFn="7">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output 6</label>
       </variable>
       <variable item="F7 controls output 7" CV="41" mask="XVXXXXXX" minOut="7" minFn="7">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output 7</label>
       </variable>
       <variable item="F7 controls output 8" CV="41" mask="VXXXXXXX" minOut="8" minFn="7">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output 8</label>
       </variable>
       <variable item="F8 controls output 1" CV="42" mask="XXXXXXXV" minOut="1" minFn="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output 1</label>
       </variable>
       <variable item="F8 controls output 2" CV="42" mask="XXXXXXVX" minOut="2" minFn="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output 2</label>
       </variable>
       <variable item="F8 controls output 3" CV="42" mask="XXXXXVXX" minOut="3" minFn="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output 3</label>
       </variable>
       <variable item="F8 controls output 4" CV="42" mask="XXXXVXXX" minOut="4" minFn="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output 4</label>
       </variable>
       <variable item="F8 controls output 5" CV="42" mask="XXXVXXXX" minOut="5" minFn="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output 5</label>
       </variable>
       <variable item="F8 controls output 6" CV="42" mask="XXVXXXXX" minOut="6" minFn="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output 6</label>
       </variable>
       <variable item="F8 controls output 7" CV="42" mask="XVXXXXXX" minOut="7" minFn="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output 7</label>
       </variable>
       <variable item="F8 controls output 8" CV="42" mask="VXXXXXXX" minOut="8" minFn="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output 8</label>
       </variable>
       <variable item="F9 controls output 1" CV="43" mask="XXXXXXXV" minOut="1" minFn="9">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output 1</label>
       </variable>
       <variable item="F9 controls output 2" CV="43" mask="XXXXXXVX" minOut="2" minFn="9">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output 2</label>
       </variable>
       <variable item="F9 controls output 3" CV="43" mask="XXXXXVXX" minOut="3" minFn="9">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output 3</label>
       </variable>
       <variable item="F9 controls output 4" CV="43" mask="XXXXVXXX" minOut="4" minFn="9">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output 4</label>
       </variable>
       <variable item="F9 controls output 5" CV="43" mask="XXXVXXXX" minOut="5" minFn="9">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output 5</label>
       </variable>
       <variable item="F9 controls output 6" CV="43" mask="XXVXXXXX" minOut="6" minFn="9">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output 6</label>
       </variable>
       <variable item="F9 controls output 7" CV="43" mask="XVXXXXXX" minOut="7" minFn="9">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output 7</label>
       </variable>
       <variable item="F9 controls output 8" CV="43" mask="VXXXXXXX" minOut="8" minFn="9">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output 8</label>
       </variable>
       <variable item="F10 controls output 1" CV="44" mask="XXXXXXXV" minOut="1" minFn="10">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output 1</label>
       </variable>
       <variable item="F10 controls output 2" CV="44" mask="XXXXXXVX" minOut="2" minFn="10">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output 2</label>
       </variable>
       <variable item="F10 controls output 3" CV="44" mask="XXXXXVXX" minOut="3" minFn="10">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output 3</label>
       </variable>
       <variable item="F10 controls output 4" CV="44" mask="XXXXVXXX" minOut="4" minFn="10">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output 4</label>
       </variable>
       <variable item="F10 controls output 5" CV="44" mask="XXXVXXXX" minOut="5" minFn="10">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output 5</label>
       </variable>
       <variable item="F10 controls output 6" CV="44" mask="XXVXXXXX" minOut="6" minFn="10">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output 6</label>
       </variable>
       <variable item="F10 controls output 7" CV="44" mask="XVXXXXXX" minOut="7" minFn="10">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output 7</label>
       </variable>
       <variable item="F10 controls output 8" CV="44" mask="VXXXXXXX" minOut="8" minFn="10">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output 8</label>
       </variable>
       <variable item="F11 controls output 1" CV="45" mask="XXXXXXXV" minOut="1" minFn="11">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output 1</label>
       </variable>
       <variable item="F11 controls output 2" CV="45" mask="XXXXXXVX" minOut="2" minFn="11">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output 2</label>
       </variable>
       <variable item="F11 controls output 3" CV="45" mask="XXXXXVXX" minOut="3" minFn="11">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output 3</label>
       </variable>
       <variable item="F11 controls output 4" CV="45" mask="XXXXVXXX" minOut="4" minFn="11">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output 4</label>
       </variable>
       <variable item="F11 controls output 5" CV="45" mask="XXXVXXXX" minOut="5" minFn="11">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output 5</label>
       </variable>
       <variable item="F11 controls output 6" CV="45" mask="XXVXXXXX" minOut="6" minFn="11">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output 6</label>
       </variable>
       <variable item="F11 controls output 7" CV="45" mask="XVXXXXXX" minOut="7" minFn="11">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output 7</label>
       </variable>
       <variable item="F11 controls output 8" CV="45" mask="VXXXXXXX" minOut="8" minFn="11">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output 8</label>
       </variable>
       <variable item="F12 controls output 1" CV="46" mask="XXXXXXXV" minOut="1" minFn="12">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output 1</label>
       </variable>
       <variable item="F12 controls output 2" CV="46" mask="XXXXXXVX" minOut="2" minFn="12">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output 2</label>
       </variable>
       <variable item="F12 controls output 3" CV="46" mask="XXXXXVXX" minOut="3" minFn="12">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output 3</label>
       </variable>
       <variable item="F12 controls output 4" CV="46" mask="XXXXVXXX" minOut="4" minFn="12">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output 4</label>
       </variable>
       <variable item="F12 controls output 5" CV="46" mask="XXXVXXXX" minOut="5" minFn="12">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output 5</label>
       </variable>
       <variable item="F12 controls output 6" CV="46" mask="XXVXXXXX" minOut="6" minFn="12">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output 6</label>
       </variable>
       <variable item="F12 controls output 7" CV="46" mask="XVXXXXXX" minOut="7" minFn="12">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output 7</label>
       </variable>
       <variable item="F12 controls output 8" CV="46" mask="VXXXXXXX" minOut="8" minFn="12">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output 8</label>
       </variable>
       <!-- Definitions for Direction dependant controls -->

--- a/xml/decoders/TAMS_FD-R_Basic2.xml
+++ b/xml/decoders/TAMS_FD-R_Basic2.xml
@@ -86,899 +86,451 @@
       <!-- Function tables for outputs 1-8  -->
       <!-- Code bits from http://jmri.org/xml/nmra/functionmap.xml , added full range off functions for Tams Decoders-->
       <variable item="FL(f) controls output 1" CV="33" mask="XXXXXXXV" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-		    </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 1</label>
       </variable>
       <variable item="FL(f) controls output 2" CV="33" mask="XXXXXXVX" minOut="2" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 2</label>
       </variable>
       <variable item="FL(f) controls output 3" CV="33" mask="XXXXXVXX" minOut="3">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 3</label>
       </variable>
       <variable item="FL(f) controls output 4" CV="33" mask="XXXXVXXX" minOut="4">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 4</label>
       </variable>
       <variable item="FL(f) controls output 5" CV="33" mask="XXXVXXXX" minOut="5">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 5</label>
       </variable>
       <variable item="FL(f) controls output 6" CV="33" mask="XXVXXXXX" minOut="6">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 6</label>
       </variable>
       <variable item="FL(f) controls output 7" CV="33" mask="XVXXXXXX" minOut="7">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 7</label>
       </variable>
       <variable item="FL(f) controls output 8" CV="33" mask="VXXXXXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 8</label>
       </variable>
       <variable item="FL(r) controls output 1" CV="34" mask="XXXXXXXV" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 1</label>
       </variable>
       <variable item="FL(r) controls output 2" CV="34" mask="XXXXXXVX" minOut="2">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 2</label>
       </variable>
       <variable item="FL(r) controls output 3" CV="34" mask="XXXXXVXX" minOut="3" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 3</label>
       </variable>
       <variable item="FL(r) controls output 4" CV="34" mask="XXXXVXXX" minOut="4">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 4</label>
       </variable>
       <variable item="FL(r) controls output 5" CV="34" mask="XXXVXXXX" minOut="5">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 5</label>
       </variable>
       <variable item="FL(r) controls output 6" CV="34" mask="XXVXXXXX" minOut="6">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 6</label>
       </variable>
       <variable item="FL(r) controls output 7" CV="34" mask="XVXXXXXX" minOut="7">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 7</label>
       </variable>
       <variable item="FL(r) controls output 8" CV="34" mask="VXXXXXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 8</label>
       </variable>
       <variable item="F1 controls output 1" CV="35" mask="XXXXXXXV" minOut="1" minFn="1" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 1</label>
       </variable>
       <variable item="F1 controls output 2" CV="35" mask="XXXXXXVX" minOut="2" minFn="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 2</label>
       </variable>
       <variable item="F1 controls output 3" CV="35" mask="XXXXXVXX" minOut="3" minFn="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 3</label>
       </variable>
       <variable item="F1 controls output 4" CV="35" mask="XXXXVXXX" minOut="4" minFn="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 4</label>
       </variable>
       <variable item="F1 controls output 5" CV="35" mask="XXXVXXXX" minOut="5" minFn="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 5</label>
       </variable>
       <variable item="F1 controls output 6" CV="35" mask="XXVXXXXX" minOut="6" minFn="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 6</label>
       </variable>
       <variable item="F1 controls output 7" CV="35" mask="XVXXXXXX" minOut="7" minFn="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 7</label>
       </variable>
       <variable item="F1 controls output 8" CV="35" mask="VXXXXXXX" minOut="8" minFn="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 8</label>
       </variable>
       <variable item="F2 controls output 1" CV="36" mask="XXXXXXXV" minOut="1" minFn="2">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 1</label>
       </variable>
       <variable item="F2 controls output 2" CV="36" mask="XXXXXXVX" minOut="2" minFn="2">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 2</label>
       </variable>
       <variable item="F2 controls output 3" CV="36" mask="XXXXXVXX" minOut="3" minFn="2">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 3</label>
       </variable>
       <variable item="F2 controls output 4" CV="36" mask="XXXXVXXX" minOut="4" minFn="2">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 4</label>
       </variable>
       <variable item="F2 controls output 5" CV="36" mask="XXXVXXXX" minOut="5" minFn="2">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 5</label>
       </variable>
       <variable item="F2 controls output 6" CV="36" mask="XXVXXXXX" minOut="6" minFn="2">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 6</label>
       </variable>
       <variable item="F2 controls output 7" CV="36" mask="XVXXXXXX" minOut="7" minFn="2">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 7</label>
       </variable>
       <variable item="F2 controls output 8" CV="36" mask="VXXXXXXX" minOut="8" minFn="2">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 8</label>
       </variable>
       <variable item="F3 controls output 1" CV="37" mask="XXXXXXXV" minOut="1" minFn="3">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 1</label>
       </variable>
       <variable item="F3 controls output 2" CV="37" mask="XXXXXXVX" minOut="2" minFn="3">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 2</label>
       </variable>
       <variable item="F3 controls output 3" CV="37" mask="XXXXXVXX" minOut="3" minFn="3">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 3</label>
       </variable>
       <variable item="F3 controls output 4" CV="37" mask="XXXXVXXX" minOut="4" minFn="3">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 4</label>
       </variable>
       <variable item="F3 controls output 5" CV="37" mask="XXXVXXXX" minOut="5" minFn="3">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 5</label>
       </variable>
       <variable item="F3 controls output 6" CV="37" mask="XXVXXXXX" minOut="6" minFn="3">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 6</label>
       </variable>
       <variable item="F3 controls output 7" CV="37" mask="XVXXXXXX" minOut="7" minFn="3">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 7</label>
       </variable>
       <variable item="F3 controls output 8" CV="37" mask="VXXXXXXX" minOut="8" minFn="3">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 8</label>
       </variable>
       <variable item="F4 controls output 1" CV="38" mask="XXXXXXXV" minOut="1" minFn="3">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 1</label>
       </variable>
       <variable item="F4 controls output 2" CV="38" mask="XXXXXXVX" minOut="2" minFn="4">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 2</label>
       </variable>
       <variable item="F4 controls output 3" CV="38" mask="XXXXXVXX" minOut="3" minFn="4">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 3</label>
       </variable>
       <variable item="F4 controls output 4" CV="38" mask="XXXXVXXX" minOut="4" minFn="4">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 4</label>
       </variable>
       <variable item="F4 controls output 5" CV="38" mask="XXXVXXXX" minOut="5" minFn="4">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 5</label>
       </variable>
       <variable item="F4 controls output 6" CV="38" mask="XXVXXXXX" minOut="6" minFn="4">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 6</label>
       </variable>
       <variable item="F4 controls output 7" CV="38" mask="XVXXXXXX" minOut="7" minFn="4">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 7</label>
       </variable>
       <variable item="F4 controls output 8" CV="38" mask="VXXXXXXX" minOut="8" minFn="4">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 8</label>
       </variable>
       <variable item="F5 controls output 1" CV="39" mask="XXXXXXXV" minOut="1" minFn="5">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 1</label>
       </variable>
       <variable item="F5 controls output 2" CV="39" mask="XXXXXXVX" minOut="2" minFn="5">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 2</label>
       </variable>
       <variable item="F5 controls output 3" CV="39" mask="XXXXXVXX" minOut="3" minFn="5">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 3</label>
       </variable>
       <variable item="F5 controls output 4" CV="39" mask="XXXXVXXX" minOut="4" minFn="5">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 4</label>
       </variable>
       <variable item="F5 controls output 5" CV="39" mask="XXXVXXXX" minOut="5" minFn="5">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 5</label>
       </variable>
       <variable item="F5 controls output 6" CV="39" mask="XXVXXXXX" minOut="6" minFn="5">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 6</label>
       </variable>
       <variable item="F5 controls output 7" CV="39" mask="XVXXXXXX" minOut="7" minFn="5">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 7</label>
       </variable>
       <variable item="F5 controls output 8" CV="39" mask="VXXXXXXX" minOut="8" minFn="5">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 8</label>
       </variable>
       <variable item="F6 controls output 1" CV="40" mask="XXXXXXXV" minOut="1" minFn="6">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 1</label>
       </variable>
       <variable item="F6 controls output 2" CV="40" mask="XXXXXXVX" minOut="2" minFn="6">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 2</label>
       </variable>
       <variable item="F6 controls output 3" CV="40" mask="XXXXXVXX" minOut="3" minFn="6">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 3</label>
       </variable>
       <variable item="F6 controls output 4" CV="40" mask="XXXXVXXX" minOut="4" minFn="6">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 4</label>
       </variable>
       <variable item="F6 controls output 5" CV="40" mask="XXXVXXXX" minOut="5" minFn="6">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 5</label>
       </variable>
       <variable item="F6 controls output 6" CV="40" mask="XXVXXXXX" minOut="6" minFn="6">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 6</label>
       </variable>
       <variable item="F6 controls output 7" CV="40" mask="XVXXXXXX" minOut="7" minFn="6">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 7</label>
       </variable>
       <variable item="F6 controls output 8" CV="40" mask="VXXXXXXX" minOut="8" minFn="6">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 8</label>
       </variable>
       <variable item="F7 controls output 1" CV="41" mask="XXXXXXXV" minOut="1" minFn="7">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output 1</label>
       </variable>
       <variable item="F7 controls output 2" CV="41" mask="XXXXXXVX" minOut="2" minFn="7">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output 2</label>
       </variable>
       <variable item="F7 controls output 3" CV="41" mask="XXXXXVXX" minOut="3" minFn="7">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output 3</label>
       </variable>
       <variable item="F7 controls output 4" CV="41" mask="XXXXVXXX" minOut="4" minFn="7">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output 4</label>
       </variable>
       <variable item="F7 controls output 5" CV="41" mask="XXXVXXXX" minOut="5" minFn="7">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output 5</label>
       </variable>
       <variable item="F7 controls output 6" CV="41" mask="XXVXXXXX" minOut="6" minFn="7">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output 6</label>
       </variable>
       <variable item="F7 controls output 7" CV="41" mask="XVXXXXXX" minOut="7" minFn="7">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output 7</label>
       </variable>
       <variable item="F7 controls output 8" CV="41" mask="VXXXXXXX" minOut="8" minFn="7">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output 8</label>
       </variable>
       <variable item="F8 controls output 1" CV="42" mask="XXXXXXXV" minOut="1" minFn="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output 1</label>
       </variable>
       <variable item="F8 controls output 2" CV="42" mask="XXXXXXVX" minOut="2" minFn="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output 2</label>
       </variable>
       <variable item="F8 controls output 3" CV="42" mask="XXXXXVXX" minOut="3" minFn="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output 3</label>
       </variable>
       <variable item="F8 controls output 4" CV="42" mask="XXXXVXXX" minOut="4" minFn="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output 4</label>
       </variable>
       <variable item="F8 controls output 5" CV="42" mask="XXXVXXXX" minOut="5" minFn="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output 5</label>
       </variable>
       <variable item="F8 controls output 6" CV="42" mask="XXVXXXXX" minOut="6" minFn="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output 6</label>
       </variable>
       <variable item="F8 controls output 7" CV="42" mask="XVXXXXXX" minOut="7" minFn="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output 7</label>
       </variable>
       <variable item="F8 controls output 8" CV="42" mask="VXXXXXXX" minOut="8" minFn="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output 8</label>
       </variable>
       <variable item="F9 controls output 1" CV="43" mask="XXXXXXXV" minOut="1" minFn="9">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output 1</label>
       </variable>
       <variable item="F9 controls output 2" CV="43" mask="XXXXXXVX" minOut="2" minFn="9">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output 2</label>
       </variable>
       <variable item="F9 controls output 3" CV="43" mask="XXXXXVXX" minOut="3" minFn="9">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output 3</label>
       </variable>
       <variable item="F9 controls output 4" CV="43" mask="XXXXVXXX" minOut="4" minFn="9">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output 4</label>
       </variable>
       <variable item="F9 controls output 5" CV="43" mask="XXXVXXXX" minOut="5" minFn="9">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output 5</label>
       </variable>
       <variable item="F9 controls output 6" CV="43" mask="XXVXXXXX" minOut="6" minFn="9">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output 6</label>
       </variable>
       <variable item="F9 controls output 7" CV="43" mask="XVXXXXXX" minOut="7" minFn="9">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output 7</label>
       </variable>
       <variable item="F9 controls output 8" CV="43" mask="VXXXXXXX" minOut="8" minFn="9">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output 8</label>
       </variable>
       <variable item="F10 controls output 1" CV="44" mask="XXXXXXXV" minOut="1" minFn="10">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output 1</label>
       </variable>
       <variable item="F10 controls output 2" CV="44" mask="XXXXXXVX" minOut="2" minFn="10">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output 2</label>
       </variable>
       <variable item="F10 controls output 3" CV="44" mask="XXXXXVXX" minOut="3" minFn="10">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output 3</label>
       </variable>
       <variable item="F10 controls output 4" CV="44" mask="XXXXVXXX" minOut="4" minFn="10">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output 4</label>
       </variable>
       <variable item="F10 controls output 5" CV="44" mask="XXXVXXXX" minOut="5" minFn="10">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output 5</label>
       </variable>
       <variable item="F10 controls output 6" CV="44" mask="XXVXXXXX" minOut="6" minFn="10">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output 6</label>
       </variable>
       <variable item="F10 controls output 7" CV="44" mask="XVXXXXXX" minOut="7" minFn="10">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output 7</label>
       </variable>
       <variable item="F10 controls output 8" CV="44" mask="VXXXXXXX" minOut="8" minFn="10">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output 8</label>
       </variable>
       <variable item="F11 controls output 1" CV="45" mask="XXXXXXXV" minOut="1" minFn="11">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output 1</label>
       </variable>
       <variable item="F11 controls output 2" CV="45" mask="XXXXXXVX" minOut="2" minFn="11">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output 2</label>
       </variable>
       <variable item="F11 controls output 3" CV="45" mask="XXXXXVXX" minOut="3" minFn="11">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output 3</label>
       </variable>
       <variable item="F11 controls output 4" CV="45" mask="XXXXVXXX" minOut="4" minFn="11">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output 4</label>
       </variable>
       <variable item="F11 controls output 5" CV="45" mask="XXXVXXXX" minOut="5" minFn="11">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output 5</label>
       </variable>
       <variable item="F11 controls output 6" CV="45" mask="XXVXXXXX" minOut="6" minFn="11">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output 6</label>
       </variable>
       <variable item="F11 controls output 7" CV="45" mask="XVXXXXXX" minOut="7" minFn="11">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output 7</label>
       </variable>
       <variable item="F11 controls output 8" CV="45" mask="VXXXXXXX" minOut="8" minFn="11">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output 8</label>
       </variable>
       <variable item="F12 controls output 1" CV="46" mask="XXXXXXXV" minOut="1" minFn="12">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output 1</label>
       </variable>
       <variable item="F12 controls output 2" CV="46" mask="XXXXXXVX" minOut="2" minFn="12">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output 2</label>
       </variable>
       <variable item="F12 controls output 3" CV="46" mask="XXXXXVXX" minOut="3" minFn="12">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output 3</label>
       </variable>
       <variable item="F12 controls output 4" CV="46" mask="XXXXVXXX" minOut="4" minFn="12">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output 4</label>
       </variable>
       <variable item="F12 controls output 5" CV="46" mask="XXXVXXXX" minOut="5" minFn="12">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output 5</label>
       </variable>
       <variable item="F12 controls output 6" CV="46" mask="XXVXXXXX" minOut="6" minFn="12">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output 6</label>
       </variable>
       <variable item="F12 controls output 7" CV="46" mask="XVXXXXXX" minOut="7" minFn="12">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output 7</label>
       </variable>
       <variable item="F12 controls output 8" CV="46" mask="VXXXXXXX" minOut="8" minFn="12">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output 8</label>
       </variable>
       <!-- Definitions for Direction dependant controls -->

--- a/xml/decoders/TAMS_FD-R_Extended.xml
+++ b/xml/decoders/TAMS_FD-R_Extended.xml
@@ -175,1925 +175,965 @@
       <!-- Function tables for outputs 1-8  -->
       <!-- Code bits from http://jmri.org/xml/nmra/functionmap.xml , added full range of functions for Tams Decoders-->
       <variable item="FL(f) controls output 1" CV="33" mask="XXXXXXXV" minOut="1" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-		    </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 1</label>
       </variable>
       <variable item="FL(f) controls output 2" CV="33" mask="XXXXXXVX" minOut="2">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 2</label>
       </variable>
       <variable item="FL(f) controls output 3" CV="33" mask="XXXXXVXX" minOut="3">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 3</label>
       </variable>
       <variable item="FL(f) controls output 4" CV="33" mask="XXXXVXXX" minOut="4">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 4</label>
       </variable>
       <variable item="FL(f) controls output 5" CV="33" mask="XXXVXXXX" minOut="5">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 5</label>
       </variable>
       <variable item="FL(f) controls output 6" CV="33" mask="XXVXXXXX" minOut="6">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 6</label>
       </variable>
       <variable item="FL(f) controls output 7" CV="33" mask="XVXXXXXX" minOut="7">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 7</label>
       </variable>
       <variable item="FL(f) controls output 8" CV="33" mask="VXXXXXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 8</label>
       </variable>
       <variable item="FL(r) controls output 1" CV="34" mask="XXXXXXXV" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 1</label>
       </variable>
       <variable item="FL(r) controls output 2" CV="34" mask="XXXXXXVX" minOut="2" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 2</label>
       </variable>
       <variable item="FL(r) controls output 3" CV="34" mask="XXXXXVXX" minOut="3">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 3</label>
       </variable>
       <variable item="FL(r) controls output 4" CV="34" mask="XXXXVXXX" minOut="4">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 4</label>
       </variable>
       <variable item="FL(r) controls output 5" CV="34" mask="XXXVXXXX" minOut="5">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 5</label>
       </variable>
       <variable item="FL(r) controls output 6" CV="34" mask="XXVXXXXX" minOut="6">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 6</label>
       </variable>
       <variable item="FL(r) controls output 7" CV="34" mask="XVXXXXXX" minOut="7">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 7</label>
       </variable>
       <variable item="FL(r) controls output 8" CV="34" mask="VXXXXXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 8</label>
       </variable>
       <variable item="F1 controls output 1" CV="35" mask="XXXXXXXV" minOut="1" minFn="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 1</label>
       </variable>
       <variable item="F1 controls output 2" CV="35" mask="XXXXXXVX" minOut="2" minFn="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 2</label>
       </variable>
       <variable item="F1 controls output 3" CV="35" mask="XXXXXVXX" minOut="3" minFn="1" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 3</label>
       </variable>
       <variable item="F1 controls output 4" CV="35" mask="XXXXVXXX" minOut="4" minFn="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 4</label>
       </variable>
       <variable item="F1 controls output 5" CV="35" mask="XXXVXXXX" minOut="5" minFn="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 5</label>
       </variable>
       <variable item="F1 controls output 6" CV="35" mask="XXVXXXXX" minOut="6" minFn="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 6</label>
       </variable>
       <variable item="F1 controls output 7" CV="35" mask="XVXXXXXX" minOut="7" minFn="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 7</label>
       </variable>
       <variable item="F1 controls output 8" CV="35" mask="VXXXXXXX" minOut="8" minFn="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 8</label>
       </variable>
       <variable item="F2 controls output 1" CV="36" mask="XXXXXXXV" minOut="1" minFn="2">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 1</label>
       </variable>
       <variable item="F2 controls output 2" CV="36" mask="XXXXXXVX" minOut="2" minFn="2">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 2</label>
       </variable>
       <variable item="F2 controls output 3" CV="36" mask="XXXXXVXX" minOut="3" minFn="2">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 3</label>
       </variable>
       <variable item="F2 controls output 4" CV="36" mask="XXXXVXXX" minOut="4" minFn="2" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 4</label>
       </variable>
       <variable item="F2 controls output 5" CV="36" mask="XXXVXXXX" minOut="5" minFn="2">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 5</label>
       </variable>
       <variable item="F2 controls output 6" CV="36" mask="XXVXXXXX" minOut="6" minFn="2">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 6</label>
       </variable>
       <variable item="F2 controls output 7" CV="36" mask="XVXXXXXX" minOut="7" minFn="2">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 7</label>
       </variable>
       <variable item="F2 controls output 8" CV="36" mask="VXXXXXXX" minOut="8" minFn="2">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 8</label>
       </variable>
       <variable item="F3 controls output 1" CV="37" mask="XXXXXXXV" minOut="1" minFn="3">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 1</label>
       </variable>
       <variable item="F3 controls output 2" CV="37" mask="XXXXXXVX" minOut="2" minFn="3">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 2</label>
       </variable>
       <variable item="F3 controls output 3" CV="37" mask="XXXXXVXX" minOut="3" minFn="3">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 3</label>
       </variable>
       <variable item="F3 controls output 4" CV="37" mask="XXXXVXXX" minOut="4" minFn="3">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 4</label>
       </variable>
       <variable item="F3 controls output 5" CV="37" mask="XXXVXXXX" minOut="5" minFn="3">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 5</label>
       </variable>
       <variable item="F3 controls output 6" CV="37" mask="XXVXXXXX" minOut="6" minFn="3">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 6</label>
       </variable>
       <variable item="F3 controls output 7" CV="37" mask="XVXXXXXX" minOut="7" minFn="3">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 7</label>
       </variable>
       <variable item="F3 controls output 8" CV="37" mask="VXXXXXXX" minOut="8" minFn="3">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 8</label>
       </variable>
       <variable item="F4 controls output 1" CV="38" mask="XXXXXXXV" minOut="1" minFn="3">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 1</label>
       </variable>
       <variable item="F4 controls output 2" CV="38" mask="XXXXXXVX" minOut="2" minFn="4">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 2</label>
       </variable>
       <variable item="F4 controls output 3" CV="38" mask="XXXXXVXX" minOut="3" minFn="4">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 3</label>
       </variable>
       <variable item="F4 controls output 4" CV="38" mask="XXXXVXXX" minOut="4" minFn="4">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 4</label>
       </variable>
       <variable item="F4 controls output 5" CV="38" mask="XXXVXXXX" minOut="5" minFn="4">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 5</label>
       </variable>
       <variable item="F4 controls output 6" CV="38" mask="XXVXXXXX" minOut="6" minFn="4">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 6</label>
       </variable>
       <variable item="F4 controls output 7" CV="38" mask="XVXXXXXX" minOut="7" minFn="4">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 7</label>
       </variable>
       <variable item="F4 controls output 8" CV="38" mask="VXXXXXXX" minOut="8" minFn="4">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 8</label>
       </variable>
       <variable item="F5 controls output 1" CV="39" mask="XXXXXXXV" minOut="1" minFn="5">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 1</label>
       </variable>
       <variable item="F5 controls output 2" CV="39" mask="XXXXXXVX" minOut="2" minFn="5">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 2</label>
       </variable>
       <variable item="F5 controls output 3" CV="39" mask="XXXXXVXX" minOut="3" minFn="5">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 3</label>
       </variable>
       <variable item="F5 controls output 4" CV="39" mask="XXXXVXXX" minOut="4" minFn="5">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 4</label>
       </variable>
       <variable item="F5 controls output 5" CV="39" mask="XXXVXXXX" minOut="5" minFn="5" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 5</label>
       </variable>
       <variable item="F5 controls output 6" CV="39" mask="XXVXXXXX" minOut="6" minFn="5">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 6</label>
       </variable>
       <variable item="F5 controls output 7" CV="39" mask="XVXXXXXX" minOut="7" minFn="5">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 7</label>
       </variable>
       <variable item="F5 controls output 8" CV="39" mask="VXXXXXXX" minOut="8" minFn="5">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 8</label>
       </variable>
       <variable item="F6 controls output 1" CV="40" mask="XXXXXXXV" minOut="1" minFn="6">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 1</label>
       </variable>
       <variable item="F6 controls output 2" CV="40" mask="XXXXXXVX" minOut="2" minFn="6">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 2</label>
       </variable>
       <variable item="F6 controls output 3" CV="40" mask="XXXXXVXX" minOut="3" minFn="6">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 3</label>
       </variable>
       <variable item="F6 controls output 4" CV="40" mask="XXXXVXXX" minOut="4" minFn="6">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 4</label>
       </variable>
       <variable item="F6 controls output 5" CV="40" mask="XXXVXXXX" minOut="5" minFn="6">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 5</label>
       </variable>
       <variable item="F6 controls output 6" CV="40" mask="XXVXXXXX" minOut="6" minFn="6" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 6</label>
       </variable>
       <variable item="F6 controls output 7" CV="40" mask="XVXXXXXX" minOut="7" minFn="6">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 7</label>
       </variable>
       <variable item="F6 controls output 8" CV="40" mask="VXXXXXXX" minOut="8" minFn="6">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 8</label>
       </variable>
       <variable item="F7 controls output 1" CV="41" mask="XXXXXXXV" minOut="1" minFn="7">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output 1</label>
       </variable>
       <variable item="F7 controls output 2" CV="41" mask="XXXXXXVX" minOut="2" minFn="7">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output 2</label>
       </variable>
       <variable item="F7 controls output 3" CV="41" mask="XXXXXVXX" minOut="3" minFn="7">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output 3</label>
       </variable>
       <variable item="F7 controls output 4" CV="41" mask="XXXXVXXX" minOut="4" minFn="7">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output 4</label>
       </variable>
       <variable item="F7 controls output 5" CV="41" mask="XXXVXXXX" minOut="5" minFn="7">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output 5</label>
       </variable>
       <variable item="F7 controls output 6" CV="41" mask="XXVXXXXX" minOut="6" minFn="7">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output 6</label>
       </variable>
       <variable item="F7 controls output 7" CV="41" mask="XVXXXXXX" minOut="7" minFn="7">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output 7</label>
       </variable>
       <variable item="F7 controls output 8" CV="41" mask="VXXXXXXX" minOut="8" minFn="7">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output 8</label>
       </variable>
       <variable item="F8 controls output 1" CV="42" mask="XXXXXXXV" minOut="1" minFn="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output 1</label>
       </variable>
       <variable item="F8 controls output 2" CV="42" mask="XXXXXXVX" minOut="2" minFn="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output 2</label>
       </variable>
       <variable item="F8 controls output 3" CV="42" mask="XXXXXVXX" minOut="3" minFn="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output 3</label>
       </variable>
       <variable item="F8 controls output 4" CV="42" mask="XXXXVXXX" minOut="4" minFn="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output 4</label>
       </variable>
       <variable item="F8 controls output 5" CV="42" mask="XXXVXXXX" minOut="5" minFn="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output 5</label>
       </variable>
       <variable item="F8 controls output 6" CV="42" mask="XXVXXXXX" minOut="6" minFn="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output 6</label>
       </variable>
       <variable item="F8 controls output 7" CV="42" mask="XVXXXXXX" minOut="7" minFn="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output 7</label>
       </variable>
       <variable item="F8 controls output 8" CV="42" mask="VXXXXXXX" minOut="8" minFn="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output 8</label>
       </variable>
       <variable item="F9 controls output 1" CV="43" mask="XXXXXXXV" minOut="1" minFn="9">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output 1</label>
       </variable>
       <variable item="F9 controls output 2" CV="43" mask="XXXXXXVX" minOut="2" minFn="9">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output 2</label>
       </variable>
       <variable item="F9 controls output 3" CV="43" mask="XXXXXVXX" minOut="3" minFn="9">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output 3</label>
       </variable>
       <variable item="F9 controls output 4" CV="43" mask="XXXXVXXX" minOut="4" minFn="9">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output 4</label>
       </variable>
       <variable item="F9 controls output 5" CV="43" mask="XXXVXXXX" minOut="5" minFn="9">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output 5</label>
       </variable>
       <variable item="F9 controls output 6" CV="43" mask="XXVXXXXX" minOut="6" minFn="9">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output 6</label>
       </variable>
       <variable item="F9 controls output 7" CV="43" mask="XVXXXXXX" minOut="7" minFn="9">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output 7</label>
       </variable>
       <variable item="F9 controls output 8" CV="43" mask="VXXXXXXX" minOut="8" minFn="9">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output 8</label>
       </variable>
       <variable item="F10 controls output 1" CV="44" mask="XXXXXXXV" minOut="1" minFn="10">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output 1</label>
       </variable>
       <variable item="F10 controls output 2" CV="44" mask="XXXXXXVX" minOut="2" minFn="10">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output 2</label>
       </variable>
       <variable item="F10 controls output 3" CV="44" mask="XXXXXVXX" minOut="3" minFn="10">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output 3</label>
       </variable>
       <variable item="F10 controls output 4" CV="44" mask="XXXXVXXX" minOut="4" minFn="10">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output 4</label>
       </variable>
       <variable item="F10 controls output 5" CV="44" mask="XXXVXXXX" minOut="5" minFn="10">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output 5</label>
       </variable>
       <variable item="F10 controls output 6" CV="44" mask="XXVXXXXX" minOut="6" minFn="10">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output 6</label>
       </variable>
       <variable item="F10 controls output 7" CV="44" mask="XVXXXXXX" minOut="7" minFn="10">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output 7</label>
       </variable>
       <variable item="F10 controls output 8" CV="44" mask="VXXXXXXX" minOut="8" minFn="10">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output 8</label>
       </variable>
       <variable item="F11 controls output 1" CV="45" mask="XXXXXXXV" minOut="1" minFn="11">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output 1</label>
       </variable>
       <variable item="F11 controls output 2" CV="45" mask="XXXXXXVX" minOut="2" minFn="11">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output 2</label>
       </variable>
       <variable item="F11 controls output 3" CV="45" mask="XXXXXVXX" minOut="3" minFn="11">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output 3</label>
       </variable>
       <variable item="F11 controls output 4" CV="45" mask="XXXXVXXX" minOut="4" minFn="11">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output 4</label>
       </variable>
       <variable item="F11 controls output 5" CV="45" mask="XXXVXXXX" minOut="5" minFn="11">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output 5</label>
       </variable>
       <variable item="F11 controls output 6" CV="45" mask="XXVXXXXX" minOut="6" minFn="11">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output 6</label>
       </variable>
       <variable item="F11 controls output 7" CV="45" mask="XVXXXXXX" minOut="7" minFn="11">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output 7</label>
       </variable>
       <variable item="F11 controls output 8" CV="45" mask="VXXXXXXX" minOut="8" minFn="11">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output 8</label>
       </variable>
       <variable item="F12 controls output 1" CV="46" mask="XXXXXXXV" minOut="1" minFn="12">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output 1</label>
       </variable>
       <variable item="F12 controls output 2" CV="46" mask="XXXXXXVX" minOut="2" minFn="12">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output 2</label>
       </variable>
       <variable item="F12 controls output 3" CV="46" mask="XXXXXVXX" minOut="3" minFn="12">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output 3</label>
       </variable>
       <variable item="F12 controls output 4" CV="46" mask="XXXXVXXX" minOut="4" minFn="12">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output 4</label>
       </variable>
       <variable item="F12 controls output 5" CV="46" mask="XXXVXXXX" minOut="5" minFn="12">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output 5</label>
       </variable>
       <variable item="F12 controls output 6" CV="46" mask="XXVXXXXX" minOut="6" minFn="12">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output 6</label>
       </variable>
       <variable item="F12 controls output 7" CV="46" mask="XVXXXXXX" minOut="7" minFn="12">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output 7</label>
       </variable>
       <variable item="F12 controls output 8" CV="46" mask="VXXXXXXX" minOut="8" minFn="12">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output 8</label>
       </variable>
       <!-- Function tables for F13 to F28 (max 8 outputs) -->
       <!-- Code bits from http://jmri.org/xml/nmra/functionmap.xml , added full range of functions for Tams Decoders-->
       <variable item="F13 controls output 1" CV="180" mask="XXXXXXXV" minOut="1" minFn="13">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-		    </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F13 controls output 1</label>
       </variable>
       <variable item="F13 controls output 2" CV="180" mask="XXXXXXVX" minOut="2" minFn="13">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F13 controls output 2</label>
       </variable>
       <variable item="F13 controls output 3" CV="180" mask="XXXXXVXX" minOut="3" minFn="13">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F13 controls output 3</label>
       </variable>
       <variable item="F13 controls output 4" CV="180" mask="XXXXVXXX" minOut="4" minFn="13">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F13 controls output 4</label>
       </variable>
       <variable item="F13 controls output 5" CV="180" mask="XXXVXXXX" minOut="5" minFn="13">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F13 controls output 5</label>
       </variable>
       <variable item="F13 controls output 6" CV="180" mask="XXVXXXXX" minOut="6" minFn="13">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F13 controls output 6</label>
       </variable>
       <variable item="F13 controls output 7" CV="180" mask="XVXXXXXX" minOut="7" minFn="13">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F13 controls output 7</label>
       </variable>
       <variable item="F13 controls output 8" CV="180" mask="VXXXXXXX" minOut="8" minFn="13">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F13 controls output 8</label>
       </variable>
       <variable item="F14 controls output 1" CV="181" mask="XXXXXXXV" minOut="1" minFn="14">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-		    </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F14 controls output 1</label>
       </variable>
       <variable item="F14 controls output 2" CV="181" mask="XXXXXXVX" minOut="2" minFn="14">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F14 controls output 2</label>
       </variable>
       <variable item="F14 controls output 3" CV="181" mask="XXXXXVXX" minOut="3" minFn="14">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F14 controls output 3</label>
       </variable>
       <variable item="F14 controls output 4" CV="181" mask="XXXXVXXX" minOut="4" minFn="14">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F14 controls output 4</label>
       </variable>
       <variable item="F14 controls output 5" CV="181" mask="XXXVXXXX" minOut="5" minFn="14">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F14 controls output 5</label>
       </variable>
       <variable item="F14 controls output 6" CV="181" mask="XXVXXXXX" minOut="6" minFn="14">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F14 controls output 6</label>
       </variable>
       <variable item="F14 controls output 7" CV="181" mask="XVXXXXXX" minOut="7" minFn="14">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F14 controls output 7</label>
       </variable>
       <variable item="F14 controls output 8" CV="181" mask="VXXXXXXX" minOut="8" minFn="14">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F14 controls output 8</label>
       </variable>
       <variable item="F15 controls output 1" CV="182" mask="XXXXXXXV" minOut="1" minFn="15">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-		    </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F15 controls output 1</label>
       </variable>
       <variable item="F15 controls output 2" CV="182" mask="XXXXXXVX" minOut="2" minFn="15">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F15 controls output 2</label>
       </variable>
       <variable item="F15 controls output 3" CV="182" mask="XXXXXVXX" minOut="3" minFn="15">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F15 controls output 3</label>
       </variable>
       <variable item="F15 controls output 4" CV="182" mask="XXXXVXXX" minOut="4" minFn="15">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F15 controls output 4</label>
       </variable>
       <variable item="F15 controls output 5" CV="182" mask="XXXVXXXX" minOut="5" minFn="15">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F15 controls output 5</label>
       </variable>
       <variable item="F15 controls output 6" CV="182" mask="XXVXXXXX" minOut="6" minFn="15">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F15 controls output 6</label>
       </variable>
       <variable item="F15 controls output 7" CV="182" mask="XVXXXXXX" minOut="7" minFn="15">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F15 controls output 7</label>
       </variable>
       <variable item="F15 controls output 8" CV="182" mask="VXXXXXXX" minOut="8" minFn="15">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F15 controls output 8</label>
       </variable>
       <variable item="F16 controls output 1" CV="183" mask="XXXXXXXV" minOut="1" minFn="16">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-		    </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F16 controls output 1</label>
       </variable>
       <variable item="F16 controls output 2" CV="183" mask="XXXXXXVX" minOut="2" minFn="16">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F16 controls output 2</label>
       </variable>
       <variable item="F16 controls output 3" CV="183" mask="XXXXXVXX" minOut="3" minFn="16">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F16 controls output 3</label>
       </variable>
       <variable item="F16 controls output 4" CV="183" mask="XXXXVXXX" minOut="4" minFn="16">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F16 controls output 4</label>
       </variable>
       <variable item="F16 controls output 5" CV="183" mask="XXXVXXXX" minOut="5" minFn="16">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F16 controls output 5</label>
       </variable>
       <variable item="F16 controls output 6" CV="183" mask="XXVXXXXX" minOut="6" minFn="16">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F16 controls output 6</label>
       </variable>
       <variable item="F16 controls output 7" CV="183" mask="XVXXXXXX" minOut="7" minFn="16">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F16 controls output 7</label>
       </variable>
       <variable item="F16 controls output 8" CV="183" mask="VXXXXXXX" minOut="8" minFn="16">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F16 controls output 8</label>
       </variable>
       <variable item="F17 controls output 1" CV="184" mask="XXXXXXXV" minOut="1" minFn="17">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-		    </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F17 controls output 1</label>
       </variable>
       <variable item="F17 controls output 2" CV="184" mask="XXXXXXVX" minOut="2" minFn="17">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F17 controls output 2</label>
       </variable>
       <variable item="F17 controls output 3" CV="184" mask="XXXXXVXX" minOut="3" minFn="17">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F17 controls output 3</label>
       </variable>
       <variable item="F17 controls output 4" CV="184" mask="XXXXVXXX" minOut="4" minFn="17">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F17 controls output 4</label>
       </variable>
       <variable item="F17 controls output 5" CV="184" mask="XXXVXXXX" minOut="5" minFn="17">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F17 controls output 5</label>
       </variable>
       <variable item="F17 controls output 6" CV="184" mask="XXVXXXXX" minOut="6" minFn="17">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F17 controls output 6</label>
       </variable>
       <variable item="F17 controls output 7" CV="184" mask="XVXXXXXX" minOut="7" minFn="17">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F17 controls output 7</label>
       </variable>
       <variable item="F17 controls output 8" CV="184" mask="VXXXXXXX" minOut="8" minFn="17">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F17 controls output 8</label>
       </variable>
       <variable item="F18 controls output 1" CV="185" mask="XXXXXXXV" minOut="1" minFn="18">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-		    </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F18 controls output 1</label>
       </variable>
       <variable item="F18 controls output 2" CV="185" mask="XXXXXXVX" minOut="2" minFn="18">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F18 controls output 2</label>
       </variable>
       <variable item="F18 controls output 3" CV="185" mask="XXXXXVXX" minOut="3" minFn="18">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F18 controls output 3</label>
       </variable>
       <variable item="F18 controls output 4" CV="185" mask="XXXXVXXX" minOut="4" minFn="18">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F18 controls output 4</label>
       </variable>
       <variable item="F18 controls output 5" CV="185" mask="XXXVXXXX" minOut="5" minFn="18">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F18 controls output 5</label>
       </variable>
       <variable item="F18 controls output 6" CV="185" mask="XXVXXXXX" minOut="6" minFn="18">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F18 controls output 6</label>
       </variable>
       <variable item="F18 controls output 7" CV="185" mask="XVXXXXXX" minOut="7" minFn="18">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F18 controls output 7</label>
       </variable>
       <variable item="F18 controls output 8" CV="185" mask="VXXXXXXX" minOut="8" minFn="18">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F18 controls output 8</label>
       </variable>
       <variable item="F19 controls output 1" CV="186" mask="XXXXXXXV" minOut="1" minFn="19">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-		    </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F19 controls output 1</label>
       </variable>
       <variable item="F19 controls output 2" CV="186" mask="XXXXXXVX" minOut="2" minFn="19">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F19 controls output 2</label>
       </variable>
       <variable item="F19 controls output 3" CV="186" mask="XXXXXVXX" minOut="3" minFn="19">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F19 controls output 3</label>
       </variable>
       <variable item="F19 controls output 4" CV="186" mask="XXXXVXXX" minOut="4" minFn="19">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F19 controls output 4</label>
       </variable>
       <variable item="F19 controls output 5" CV="186" mask="XXXVXXXX" minOut="5" minFn="19">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F19 controls output 5</label>
       </variable>
       <variable item="F19 controls output 6" CV="186" mask="XXVXXXXX" minOut="6" minFn="19">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F19 controls output 6</label>
       </variable>
       <variable item="F19 controls output 7" CV="186" mask="XVXXXXXX" minOut="7" minFn="19">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F19 controls output 7</label>
       </variable>
       <variable item="F19 controls output 8" CV="186" mask="VXXXXXXX" minOut="8" minFn="19">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F19 controls output 8</label>
       </variable>
       <variable item="F20 controls output 1" CV="187" mask="XXXXXXXV" minOut="1" minFn="20">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-		    </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F20 controls output 1</label>
       </variable>
       <variable item="F20 controls output 2" CV="187" mask="XXXXXXVX" minOut="2" minFn="20">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F20 controls output 2</label>
       </variable>
       <variable item="F20 controls output 3" CV="187" mask="XXXXXVXX" minOut="3" minFn="20">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F20 controls output 3</label>
       </variable>
       <variable item="F20 controls output 4" CV="187" mask="XXXXVXXX" minOut="4" minFn="20">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F20 controls output 4</label>
       </variable>
       <variable item="F20 controls output 5" CV="187" mask="XXXVXXXX" minOut="5" minFn="20">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F20 controls output 5</label>
       </variable>
       <variable item="F20 controls output 6" CV="187" mask="XXVXXXXX" minOut="6" minFn="20">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F20 controls output 6</label>
       </variable>
       <variable item="F20 controls output 7" CV="187" mask="XVXXXXXX" minOut="7" minFn="20">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F20 controls output 7</label>
       </variable>
       <variable item="F20 controls output 8" CV="187" mask="VXXXXXXX" minOut="8" minFn="20">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F20 controls output 8</label>
       </variable>
       <variable item="F21 controls output 1" CV="188" mask="XXXXXXXV" minOut="1" minFn="21">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-		    </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F21 controls output 1</label>
       </variable>
       <variable item="F21 controls output 2" CV="188" mask="XXXXXXVX" minOut="2" minFn="21">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F21 controls output 2</label>
       </variable>
       <variable item="F21 controls output 3" CV="188" mask="XXXXXVXX" minOut="3" minFn="21">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F21 controls output 3</label>
       </variable>
       <variable item="F21 controls output 4" CV="188" mask="XXXXVXXX" minOut="4" minFn="21">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F21 controls output 4</label>
       </variable>
       <variable item="F21 controls output 5" CV="188" mask="XXXVXXXX" minOut="5" minFn="21">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F21 controls output 5</label>
       </variable>
       <variable item="F21 controls output 6" CV="188" mask="XXVXXXXX" minOut="6" minFn="21">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F21 controls output 6</label>
       </variable>
       <variable item="F21 controls output 7" CV="188" mask="XVXXXXXX" minOut="7" minFn="21">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F21 controls output 7</label>
       </variable>
       <variable item="F21 controls output 8" CV="188" mask="VXXXXXXX" minOut="8" minFn="21">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F21 controls output 8</label>
       </variable>
       <variable item="F22 controls output 1" CV="189" mask="XXXXXXXV" minOut="1" minFn="22">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-		    </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F22 controls output 1</label>
       </variable>
       <variable item="F22 controls output 2" CV="189" mask="XXXXXXVX" minOut="2" minFn="22">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F22 controls output 2</label>
       </variable>
       <variable item="F22 controls output 3" CV="189" mask="XXXXXVXX" minOut="3" minFn="22">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F22 controls output 3</label>
       </variable>
       <variable item="F22 controls output 4" CV="189" mask="XXXXVXXX" minOut="4" minFn="22">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F22 controls output 4</label>
       </variable>
       <variable item="F22 controls output 5" CV="189" mask="XXXVXXXX" minOut="5" minFn="22">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F22 controls output 5</label>
       </variable>
       <variable item="F22 controls output 6" CV="189" mask="XXVXXXXX" minOut="6" minFn="22">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F22 controls output 6</label>
       </variable>
       <variable item="F22 controls output 7" CV="189" mask="XVXXXXXX" minOut="7" minFn="22">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F22 controls output 7</label>
       </variable>
       <variable item="F22 controls output 8" CV="189" mask="VXXXXXXX" minOut="8" minFn="22">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F22 controls output 8</label>
       </variable>
       <variable item="F23 controls output 1" CV="190" mask="XXXXXXXV" minOut="1" minFn="23">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-		    </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F23 controls output 1</label>
       </variable>
       <variable item="F23 controls output 2" CV="190" mask="XXXXXXVX" minOut="2" minFn="23">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F23 controls output 2</label>
       </variable>
       <variable item="F23 controls output 3" CV="190" mask="XXXXXVXX" minOut="3" minFn="23">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F23 controls output 3</label>
       </variable>
       <variable item="F23 controls output 4" CV="190" mask="XXXXVXXX" minOut="4" minFn="23">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F23 controls output 4</label>
       </variable>
       <variable item="F23 controls output 5" CV="190" mask="XXXVXXXX" minOut="5" minFn="23">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F23 controls output 5</label>
       </variable>
       <variable item="F23 controls output 6" CV="190" mask="XXVXXXXX" minOut="6" minFn="23">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F23 controls output 6</label>
       </variable>
       <variable item="F23 controls output 7" CV="190" mask="XVXXXXXX" minOut="7" minFn="23">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F23 controls output 7</label>
       </variable>
       <variable item="F23 controls output 8" CV="190" mask="VXXXXXXX" minOut="8" minFn="23">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F23 controls output 8</label>
       </variable>
       <variable item="F24 controls output 1" CV="191" mask="XXXXXXXV" minOut="1" minFn="24">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-		    </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F24 controls output 1</label>
       </variable>
       <variable item="F24 controls output 2" CV="191" mask="XXXXXXVX" minOut="2" minFn="24">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F24 controls output 2</label>
       </variable>
       <variable item="F24 controls output 3" CV="191" mask="XXXXXVXX" minOut="3" minFn="24">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F24 controls output 3</label>
       </variable>
       <variable item="F24 controls output 4" CV="191" mask="XXXXVXXX" minOut="4" minFn="24">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F24 controls output 4</label>
       </variable>
       <variable item="F24 controls output 5" CV="191" mask="XXXVXXXX" minOut="5" minFn="24">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F24 controls output 5</label>
       </variable>
       <variable item="F24 controls output 6" CV="191" mask="XXVXXXXX" minOut="6" minFn="24">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F24 controls output 6</label>
       </variable>
       <variable item="F24 controls output 7" CV="191" mask="XVXXXXXX" minOut="7" minFn="24">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F24 controls output 7</label>
       </variable>
       <variable item="F24 controls output 8" CV="191" mask="VXXXXXXX" minOut="8" minFn="24">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F24 controls output 8</label>
       </variable>
       <variable item="F25 controls output 1" CV="192" mask="XXXXXXXV" minOut="1" minFn="25">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-		    </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F25 controls output 1</label>
       </variable>
       <variable item="F25 controls output 2" CV="192" mask="XXXXXXVX" minOut="2" minFn="25">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F25 controls output 2</label>
       </variable>
       <variable item="F25 controls output 3" CV="192" mask="XXXXXVXX" minOut="3" minFn="25">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F25 controls output 3</label>
       </variable>
       <variable item="F25 controls output 4" CV="192" mask="XXXXVXXX" minOut="4" minFn="25">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F25 controls output 4</label>
       </variable>
       <variable item="F25 controls output 5" CV="192" mask="XXXVXXXX" minOut="5" minFn="25">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F25 controls output 5</label>
       </variable>
       <variable item="F25 controls output 6" CV="192" mask="XXVXXXXX" minOut="6" minFn="25">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F25 controls output 6</label>
       </variable>
       <variable item="F25 controls output 7" CV="192" mask="XVXXXXXX" minOut="7" minFn="25">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F25 controls output 7</label>
       </variable>
       <variable item="F25 controls output 8" CV="192" mask="VXXXXXXX" minOut="8" minFn="25">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F25 controls output 8</label>
       </variable>
       <variable item="F26 controls output 1" CV="193" mask="XXXXXXXV" minOut="1" minFn="26">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-		    </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F26 controls output 1</label>
       </variable>
       <variable item="F26 controls output 2" CV="193" mask="XXXXXXVX" minOut="2" minFn="26">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F26 controls output 2</label>
       </variable>
       <variable item="F26 controls output 3" CV="193" mask="XXXXXVXX" minOut="3" minFn="26">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F26 controls output 3</label>
       </variable>
       <variable item="F26 controls output 4" CV="193" mask="XXXXVXXX" minOut="4" minFn="26">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F26 controls output 4</label>
       </variable>
       <variable item="F26 controls output 5" CV="193" mask="XXXVXXXX" minOut="5" minFn="26">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F26 controls output 5</label>
       </variable>
       <variable item="F26 controls output 6" CV="193" mask="XXVXXXXX" minOut="6" minFn="26">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F26 controls output 6</label>
       </variable>
       <variable item="F26 controls output 7" CV="193" mask="XVXXXXXX" minOut="7" minFn="26">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F26 controls output 7</label>
       </variable>
       <variable item="F26 controls output 8" CV="193" mask="VXXXXXXX" minOut="8" minFn="26">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F26 controls output 8</label>
       </variable>
       <variable item="F27 controls output 1" CV="194" mask="XXXXXXXV" minOut="1" minFn="27">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-		    </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F27 controls output 1</label>
       </variable>
       <variable item="F27 controls output 2" CV="194" mask="XXXXXXVX" minOut="2" minFn="27">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F27 controls output 2</label>
       </variable>
       <variable item="F27 controls output 3" CV="194" mask="XXXXXVXX" minOut="3" minFn="27">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F27 controls output 3</label>
       </variable>
       <variable item="F27 controls output 4" CV="194" mask="XXXXVXXX" minOut="4" minFn="27">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F27 controls output 4</label>
       </variable>
       <variable item="F27 controls output 5" CV="194" mask="XXXVXXXX" minOut="5" minFn="27">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F27 controls output 5</label>
       </variable>
       <variable item="F27 controls output 6" CV="194" mask="XXVXXXXX" minOut="6" minFn="27">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F27 controls output 6</label>
       </variable>
       <variable item="F27 controls output 7" CV="194" mask="XVXXXXXX" minOut="7" minFn="27">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F27 controls output 7</label>
       </variable>
       <variable item="F27 controls output 8" CV="194" mask="VXXXXXXX" minOut="8" minFn="27">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F27 controls output 8</label>
       </variable>
       <variable item="F28 controls output 1" CV="195" mask="XXXXXXXV" minOut="1" minFn="28">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-		    </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F28 controls output 1</label>
       </variable>
       <variable item="F28 controls output 2" CV="195" mask="XXXXXXVX" minOut="2" minFn="28">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F28 controls output 2</label>
       </variable>
       <variable item="F28 controls output 3" CV="195" mask="XXXXXVXX" minOut="3" minFn="28">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F28 controls output 3</label>
       </variable>
       <variable item="F28 controls output 4" CV="195" mask="XXXXVXXX" minOut="4" minFn="28">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F28 controls output 4</label>
       </variable>
       <variable item="F28 controls output 5" CV="195" mask="XXXVXXXX" minOut="5" minFn="28">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F28 controls output 5</label>
       </variable>
       <variable item="F28 controls output 6" CV="195" mask="XXVXXXXX" minOut="6" minFn="28">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F28 controls output 6</label>
       </variable>
       <variable item="F28 controls output 7" CV="195" mask="XVXXXXXX" minOut="7" minFn="28">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F28 controls output 7</label>
       </variable>
       <variable item="F28 controls output 8" CV="195" mask="VXXXXXXX" minOut="8" minFn="28">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F28 controls output 8</label>
       </variable>
       <!-- Definitions for Direction dependant controls -->

--- a/xml/decoders/TAMS_WIB-30.xml
+++ b/xml/decoders/TAMS_WIB-30.xml
@@ -832,899 +832,451 @@
       <!-- Function tables for outputs 1-8 (integrated LEDs)    -->
       <!-- Code bits from http://jmri.org/xml/nmra/functionmap.xml , added full range off functions for Tams Decoders-->
       <variable item="FL(f) controls output 1" CV="33" mask="XXXXXXXV" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-		    </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 1</label>
       </variable>
       <variable item="FL(f) controls output 2" CV="33" mask="XXXXXXVX" minOut="2">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 2</label>
       </variable>
       <variable item="FL(f) controls output 3" CV="33" mask="XXXXXVXX" minOut="3">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 3</label>
       </variable>
       <variable item="FL(f) controls output 4" CV="33" mask="XXXXVXXX" minOut="4">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 4</label>
       </variable>
       <variable item="FL(f) controls output 5" CV="33" mask="XXXVXXXX" minOut="5">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 5</label>
       </variable>
       <variable item="FL(f) controls output 6" CV="33" mask="XXVXXXXX" minOut="6">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 6</label>
       </variable>
       <variable item="FL(f) controls output 7" CV="33" mask="XVXXXXXX" minOut="7">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 7</label>
       </variable>
       <variable item="FL(f) controls output 8" CV="33" mask="VXXXXXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(f) controls output 8</label>
       </variable>
       <variable item="FL(r) controls output 1" CV="34" mask="XXXXXXXV" minOut="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 1</label>
       </variable>
       <variable item="FL(r) controls output 2" CV="34" mask="XXXXXXVX" minOut="2">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 2</label>
       </variable>
       <variable item="FL(r) controls output 3" CV="34" mask="XXXXXVXX" minOut="3">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 3</label>
       </variable>
       <variable item="FL(r) controls output 4" CV="34" mask="XXXXVXXX" minOut="4">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 4</label>
       </variable>
       <variable item="FL(r) controls output 5" CV="34" mask="XXXVXXXX" minOut="5">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 5</label>
       </variable>
       <variable item="FL(r) controls output 6" CV="34" mask="XXVXXXXX" minOut="6">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 6</label>
       </variable>
       <variable item="FL(r) controls output 7" CV="34" mask="XVXXXXXX" minOut="7">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 7</label>
       </variable>
       <variable item="FL(r) controls output 8" CV="34" mask="VXXXXXXX" minOut="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>FL(r) controls output 8</label>
       </variable>
       <variable item="F1 controls output 1" CV="35" mask="XXXXXXXV" minOut="1" minFn="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 1</label>
       </variable>
       <variable item="F1 controls output 2" CV="35" mask="XXXXXXVX" minOut="2" minFn="1" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 2</label>
       </variable>
       <variable item="F1 controls output 3" CV="35" mask="XXXXXVXX" minOut="3" minFn="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 3</label>
       </variable>
       <variable item="F1 controls output 4" CV="35" mask="XXXXVXXX" minOut="4" minFn="1" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 4</label>
       </variable>
       <variable item="F1 controls output 5" CV="35" mask="XXXVXXXX" minOut="5" minFn="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 5</label>
       </variable>
       <variable item="F1 controls output 6" CV="35" mask="XXVXXXXX" minOut="6" minFn="1" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 6</label>
       </variable>
       <variable item="F1 controls output 7" CV="35" mask="XVXXXXXX" minOut="7" minFn="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 7</label>
       </variable>
       <variable item="F1 controls output 8" CV="35" mask="VXXXXXXX" minOut="8" minFn="1" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 controls output 8</label>
       </variable>
       <variable item="F2 controls output 1" CV="36" mask="XXXXXXXV" minOut="1" minFn="2" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 1</label>
       </variable>
       <variable item="F2 controls output 2" CV="36" mask="XXXXXXVX" minOut="2" minFn="2">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 2</label>
       </variable>
       <variable item="F2 controls output 3" CV="36" mask="XXXXXVXX" minOut="3" minFn="2" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 3</label>
       </variable>
       <variable item="F2 controls output 4" CV="36" mask="XXXXVXXX" minOut="4" minFn="2">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 4</label>
       </variable>
       <variable item="F2 controls output 5" CV="36" mask="XXXVXXXX" minOut="5" minFn="2" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 5</label>
       </variable>
       <variable item="F2 controls output 6" CV="36" mask="XXVXXXXX" minOut="6" minFn="2">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 6</label>
       </variable>
       <variable item="F2 controls output 7" CV="36" mask="XVXXXXXX" minOut="7" minFn="2" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 7</label>
       </variable>
       <variable item="F2 controls output 8" CV="36" mask="VXXXXXXX" minOut="8" minFn="2">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F2 controls output 8</label>
       </variable>
       <variable item="F3 controls output 1" CV="37" mask="XXXXXXXV" minOut="1" minFn="3">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 1</label>
       </variable>
       <variable item="F3 controls output 2" CV="37" mask="XXXXXXVX" minOut="2" minFn="3">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 2</label>
       </variable>
       <variable item="F3 controls output 3" CV="37" mask="XXXXXVXX" minOut="3" minFn="3">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 3</label>
       </variable>
       <variable item="F3 controls output 4" CV="37" mask="XXXXVXXX" minOut="4" minFn="3">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 4</label>
       </variable>
       <variable item="F3 controls output 5" CV="37" mask="XXXVXXXX" minOut="5" minFn="3">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 5</label>
       </variable>
       <variable item="F3 controls output 6" CV="37" mask="XXVXXXXX" minOut="6" minFn="3">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 6</label>
       </variable>
       <variable item="F3 controls output 7" CV="37" mask="XVXXXXXX" minOut="7" minFn="3">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 7</label>
       </variable>
       <variable item="F3 controls output 8" CV="37" mask="VXXXXXXX" minOut="8" minFn="3">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 8</label>
       </variable>
       <variable item="F4 controls output 1" CV="38" mask="XXXXXXXV" minOut="1" minFn="3">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 1</label>
       </variable>
       <variable item="F4 controls output 2" CV="38" mask="XXXXXXVX" minOut="2" minFn="4">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 2</label>
       </variable>
       <variable item="F4 controls output 3" CV="38" mask="XXXXXVXX" minOut="3" minFn="4">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 3</label>
       </variable>
       <variable item="F4 controls output 4" CV="38" mask="XXXXVXXX" minOut="4" minFn="4">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 4</label>
       </variable>
       <variable item="F4 controls output 5" CV="38" mask="XXXVXXXX" minOut="5" minFn="4">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 5</label>
       </variable>
       <variable item="F4 controls output 6" CV="38" mask="XXVXXXXX" minOut="6" minFn="4">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 6</label>
       </variable>
       <variable item="F4 controls output 7" CV="38" mask="XVXXXXXX" minOut="7" minFn="4">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 7</label>
       </variable>
       <variable item="F4 controls output 8" CV="38" mask="VXXXXXXX" minOut="8" minFn="4">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F4 controls output 8</label>
       </variable>
       <variable item="F5 controls output 1" CV="39" mask="XXXXXXXV" minOut="1" minFn="5">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 1</label>
       </variable>
       <variable item="F5 controls output 2" CV="39" mask="XXXXXXVX" minOut="2" minFn="5">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 2</label>
       </variable>
       <variable item="F5 controls output 3" CV="39" mask="XXXXXVXX" minOut="3" minFn="5">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 3</label>
       </variable>
       <variable item="F5 controls output 4" CV="39" mask="XXXXVXXX" minOut="4" minFn="5">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 4</label>
       </variable>
       <variable item="F5 controls output 5" CV="39" mask="XXXVXXXX" minOut="5" minFn="5">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 5</label>
       </variable>
       <variable item="F5 controls output 6" CV="39" mask="XXVXXXXX" minOut="6" minFn="5">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 6</label>
       </variable>
       <variable item="F5 controls output 7" CV="39" mask="XVXXXXXX" minOut="7" minFn="5">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 7</label>
       </variable>
       <variable item="F5 controls output 8" CV="39" mask="VXXXXXXX" minOut="8" minFn="5">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F5 controls output 8</label>
       </variable>
       <variable item="F6 controls output 1" CV="40" mask="XXXXXXXV" minOut="1" minFn="6">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 1</label>
       </variable>
       <variable item="F6 controls output 2" CV="40" mask="XXXXXXVX" minOut="2" minFn="6">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 2</label>
       </variable>
       <variable item="F6 controls output 3" CV="40" mask="XXXXXVXX" minOut="3" minFn="6">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 3</label>
       </variable>
       <variable item="F6 controls output 4" CV="40" mask="XXXXVXXX" minOut="4" minFn="6">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 4</label>
       </variable>
       <variable item="F6 controls output 5" CV="40" mask="XXXVXXXX" minOut="5" minFn="6">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 5</label>
       </variable>
       <variable item="F6 controls output 6" CV="40" mask="XXVXXXXX" minOut="6" minFn="6">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 6</label>
       </variable>
       <variable item="F6 controls output 7" CV="40" mask="XVXXXXXX" minOut="7" minFn="6">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 7</label>
       </variable>
       <variable item="F6 controls output 8" CV="40" mask="VXXXXXXX" minOut="8" minFn="6">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F6 controls output 8</label>
       </variable>
       <variable item="F7 controls output 1" CV="41" mask="XXXXXXXV" minOut="1" minFn="7">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output 1</label>
       </variable>
       <variable item="F7 controls output 2" CV="41" mask="XXXXXXVX" minOut="2" minFn="7">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output 2</label>
       </variable>
       <variable item="F7 controls output 3" CV="41" mask="XXXXXVXX" minOut="3" minFn="7">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output 3</label>
       </variable>
       <variable item="F7 controls output 4" CV="41" mask="XXXXVXXX" minOut="4" minFn="7">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output 4</label>
       </variable>
       <variable item="F7 controls output 5" CV="41" mask="XXXVXXXX" minOut="5" minFn="7">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output 5</label>
       </variable>
       <variable item="F7 controls output 6" CV="41" mask="XXVXXXXX" minOut="6" minFn="7">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output 6</label>
       </variable>
       <variable item="F7 controls output 7" CV="41" mask="XVXXXXXX" minOut="7" minFn="7">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output 7</label>
       </variable>
       <variable item="F7 controls output 8" CV="41" mask="VXXXXXXX" minOut="8" minFn="7">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F7 controls output 8</label>
       </variable>
       <variable item="F8 controls output 1" CV="42" mask="XXXXXXXV" minOut="1" minFn="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output 1</label>
       </variable>
       <variable item="F8 controls output 2" CV="42" mask="XXXXXXVX" minOut="2" minFn="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output 2</label>
       </variable>
       <variable item="F8 controls output 3" CV="42" mask="XXXXXVXX" minOut="3" minFn="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output 3</label>
       </variable>
       <variable item="F8 controls output 4" CV="42" mask="XXXXVXXX" minOut="4" minFn="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output 4</label>
       </variable>
       <variable item="F8 controls output 5" CV="42" mask="XXXVXXXX" minOut="5" minFn="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output 5</label>
       </variable>
       <variable item="F8 controls output 6" CV="42" mask="XXVXXXXX" minOut="6" minFn="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output 6</label>
       </variable>
       <variable item="F8 controls output 7" CV="42" mask="XVXXXXXX" minOut="7" minFn="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output 7</label>
       </variable>
       <variable item="F8 controls output 8" CV="42" mask="VXXXXXXX" minOut="8" minFn="8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F8 controls output 8</label>
       </variable>
       <variable item="F9 controls output 1" CV="43" mask="XXXXXXXV" minOut="1" minFn="9">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output 1</label>
       </variable>
       <variable item="F9 controls output 2" CV="43" mask="XXXXXXVX" minOut="2" minFn="9">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output 2</label>
       </variable>
       <variable item="F9 controls output 3" CV="43" mask="XXXXXVXX" minOut="3" minFn="9">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output 3</label>
       </variable>
       <variable item="F9 controls output 4" CV="43" mask="XXXXVXXX" minOut="4" minFn="9">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output 4</label>
       </variable>
       <variable item="F9 controls output 5" CV="43" mask="XXXVXXXX" minOut="5" minFn="9">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output 5</label>
       </variable>
       <variable item="F9 controls output 6" CV="43" mask="XXVXXXXX" minOut="6" minFn="9">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output 6</label>
       </variable>
       <variable item="F9 controls output 7" CV="43" mask="XVXXXXXX" minOut="7" minFn="9">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output 7</label>
       </variable>
       <variable item="F9 controls output 8" CV="43" mask="VXXXXXXX" minOut="8" minFn="9">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F9 controls output 8</label>
       </variable>
       <variable item="F10 controls output 1" CV="44" mask="XXXXXXXV" minOut="1" minFn="10">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output 1</label>
       </variable>
       <variable item="F10 controls output 2" CV="44" mask="XXXXXXVX" minOut="2" minFn="10">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output 2</label>
       </variable>
       <variable item="F10 controls output 3" CV="44" mask="XXXXXVXX" minOut="3" minFn="10">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output 3</label>
       </variable>
       <variable item="F10 controls output 4" CV="44" mask="XXXXVXXX" minOut="4" minFn="10">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output 4</label>
       </variable>
       <variable item="F10 controls output 5" CV="44" mask="XXXVXXXX" minOut="5" minFn="10">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output 5</label>
       </variable>
       <variable item="F10 controls output 6" CV="44" mask="XXVXXXXX" minOut="6" minFn="10">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output 6</label>
       </variable>
       <variable item="F10 controls output 7" CV="44" mask="XVXXXXXX" minOut="7" minFn="10">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output 7</label>
       </variable>
       <variable item="F10 controls output 8" CV="44" mask="VXXXXXXX" minOut="8" minFn="10">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F10 controls output 8</label>
       </variable>
       <variable item="F11 controls output 1" CV="45" mask="XXXXXXXV" minOut="1" minFn="11">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output 1</label>
       </variable>
       <variable item="F11 controls output 2" CV="45" mask="XXXXXXVX" minOut="2" minFn="11">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output 2</label>
       </variable>
       <variable item="F11 controls output 3" CV="45" mask="XXXXXVXX" minOut="3" minFn="11">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output 3</label>
       </variable>
       <variable item="F11 controls output 4" CV="45" mask="XXXXVXXX" minOut="4" minFn="11">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output 4</label>
       </variable>
       <variable item="F11 controls output 5" CV="45" mask="XXXVXXXX" minOut="5" minFn="11">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output 5</label>
       </variable>
       <variable item="F11 controls output 6" CV="45" mask="XXVXXXXX" minOut="6" minFn="11">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output 6</label>
       </variable>
       <variable item="F11 controls output 7" CV="45" mask="XVXXXXXX" minOut="7" minFn="11">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output 7</label>
       </variable>
       <variable item="F11 controls output 8" CV="45" mask="VXXXXXXX" minOut="8" minFn="11">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F11 controls output 8</label>
       </variable>
       <variable item="F12 controls output 1" CV="46" mask="XXXXXXXV" minOut="1" minFn="12">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output 1</label>
       </variable>
       <variable item="F12 controls output 2" CV="46" mask="XXXXXXVX" minOut="2" minFn="12">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output 2</label>
       </variable>
       <variable item="F12 controls output 3" CV="46" mask="XXXXXVXX" minOut="3" minFn="12">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output 3</label>
       </variable>
       <variable item="F12 controls output 4" CV="46" mask="XXXXVXXX" minOut="4" minFn="12">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output 4</label>
       </variable>
       <variable item="F12 controls output 5" CV="46" mask="XXXVXXXX" minOut="5" minFn="12">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output 5</label>
       </variable>
       <variable item="F12 controls output 6" CV="46" mask="XXVXXXXX" minOut="6" minFn="12">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output 6</label>
       </variable>
       <variable item="F12 controls output 7" CV="46" mask="XVXXXXXX" minOut="7" minFn="12">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output 7</label>
       </variable>
       <variable item="F12 controls output 8" CV="46" mask="VXXXXXXX" minOut="8" minFn="12">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes">
-			  </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F12 controls output 8</label>
       </variable>
     </variables>

--- a/xml/decoders/TD_BlocD8.xml
+++ b/xml/decoders/TD_BlocD8.xml
@@ -54,24 +54,15 @@
         <label xml:lang="de">Hersteller ID: </label>
       </variable>
       <variable CV="9" mask="XXXXXXXV" item="Op1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Ops Mode</label>
       </variable>
       <variable item="Power On Send Input State" CV="10" mask="XXXXXXXV" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Power On Send Input State</label>
       </variable>
       <variable item="Interrogate input" CV="10" mask="XXXXXVXX">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Interrogate input</label>
       </variable>
       <variable item="Route send delay" CV="11" mask="XVVVVVVV">
@@ -84,17 +75,11 @@
         <label>Primary Address 1</label>
       </variable>
       <variable CV="17" mask="VXXXXXXX" default="1" item="Inv P1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="17" mask="XVXXXXXX" item="Tog P1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable item="Primary Type 1" CV="17" mask="XXVVXXXX" default="2">
@@ -119,10 +104,7 @@
         <label>Secondary Address 1</label>
       </variable>
       <variable CV="20" mask="VXXXXXXX" item="Inv S1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable item="Secondary Type 1" CV="20" mask="XXVVXXXX">
@@ -147,17 +129,11 @@
         <label>Primary Address 2</label>
       </variable>
       <variable CV="22" mask="VXXXXXXX" default="1" item="Inv P2">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="22" mask="XVXXXXXX" item="Tog P2">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable item="Primary Type 2" CV="22" mask="XXVVXXXX" default="2">
@@ -182,10 +158,7 @@
         <label>Secondary Address 2</label>
       </variable>
       <variable CV="25" mask="VXXXXXXX" item="Inv S2">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable item="Secondary Type 2" CV="25" mask="XXVVXXXX">
@@ -210,17 +183,11 @@
         <label>Primary Address 3</label>
       </variable>
       <variable CV="27" mask="VXXXXXXX" default="1" item="Inv P3">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="27" mask="XVXXXXXX" item="Tog P3">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable item="Primary Type 3" CV="27" mask="XXVVXXXX" default="2">

--- a/xml/decoders/TD_CSC.xml
+++ b/xml/decoders/TD_CSC.xml
@@ -913,10 +913,7 @@
         <label>Condition A Address</label>
       </variable>
       <variable CV="66" mask="XXXXVXXX" item="DCC Message 2A">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="66" mask="XXVVXXXX" item="Message 2A">
@@ -952,10 +949,7 @@
         <label>Condition B Address</label>
       </variable>
       <variable CV="68" mask="XXXXVXXX" item="DCC Message 2B">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="68" mask="XXVVXXXX" item="Message 2B">
@@ -998,10 +992,7 @@
         <label>Condition C Address</label>
       </variable>
       <variable CV="70" mask="XXXXVXXX" item="DCC Message 2C">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="70" mask="XXVVXXXX" item="Message 2C">
@@ -1111,10 +1102,7 @@
         <label>Condition B Address</label>
       </variable>
       <variable CV="75" mask="XXXXVXXX" item="DCC Message 3B">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="75" mask="XXVVXXXX" item="Message 3B">
@@ -1200,10 +1188,7 @@
         <label>Invert State</label>
       </variable>
       <variable CV="78" mask="XXXXXVXX" item="Recip3">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="78" mask="XXXVVXXX" item="Eff3">
@@ -1262,10 +1247,7 @@
         <label>Condition B Address</label>
       </variable>
       <variable CV="82" mask="XXXXVXXX" item="DCC Message 4B">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="82" mask="XXVVXXXX" item="Message 4B">
@@ -1304,10 +1286,7 @@
         <label>Condition C Address</label>
       </variable>
       <variable CV="84" mask="XXXXVXXX" item="DCC Message 4C">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="84" mask="XXVVXXXX" item="Message 4C">
@@ -1413,10 +1392,7 @@
         <label>Condition B Address</label>
       </variable>
       <variable CV="89" mask="XXXXVXXX" item="DCC Message 5B">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="89" mask="XXVVXXXX" item="Message 5B">
@@ -2866,10 +2842,7 @@
         <label>Condition B Address</label>
       </variable>
       <variable CV="159" mask="XXXXVXXX" item="DCC Message 15B">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="159" mask="XXVVXXXX" item="Message 15B">
@@ -2908,10 +2881,7 @@
         <label>Condition C Address</label>
       </variable>
       <variable CV="161" mask="XXXXVXXX" item="DCC Message 15C">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="161" mask="XXVVXXXX" item="Message 15C">
@@ -6280,10 +6250,7 @@
         <label>Condition B Address</label>
       </variable>
       <variable CV="368" mask="XXXXVXXX" item="DCC Message 43B">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="368" mask="XXVVXXXX" item="Message 43B">
@@ -6322,10 +6289,7 @@
         <label>Condition C Address</label>
       </variable>
       <variable CV="370" mask="XXXXVXXX" item="DCC Message 43C">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="370" mask="XXVVXXXX" item="Message 43C">
@@ -6365,10 +6329,7 @@
         <label>Condition A Address</label>
       </variable>
       <variable CV="372" mask="XXXXVXXX" item="DCC Message 44A">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="372" mask="XXVVXXXX" item="Message 44A">
@@ -6400,10 +6361,7 @@
         <label>Condition B Address</label>
       </variable>
       <variable CV="374" mask="XXXXVXXX" item="DCC Message 44B">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="374" mask="XXVVXXXX" item="Message 44B">
@@ -6442,10 +6400,7 @@
         <label>Condition C Address</label>
       </variable>
       <variable CV="376" mask="XXXXVXXX" item="DCC Message 44C">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="376" mask="XXVVXXXX" item="Message 44C">
@@ -6485,10 +6440,7 @@
         <label>Condition A Address</label>
       </variable>
       <variable CV="378" mask="XXXXVXXX" item="DCC Message 45A">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="378" mask="XXVVXXXX" item="Message 45A">
@@ -6520,10 +6472,7 @@
         <label>Condition B Address</label>
       </variable>
       <variable CV="380" mask="XXXXVXXX" item="DCC Message 45B">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="380" mask="XXVVXXXX" item="Message 45B">
@@ -6562,10 +6511,7 @@
         <label>Condition C Address</label>
       </variable>
       <variable CV="382" mask="XXXXVXXX" item="DCC Message 45C">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="382" mask="XXVVXXXX" item="Message 45C">
@@ -6605,10 +6551,7 @@
         <label>Condition A Address</label>
       </variable>
       <variable CV="384" mask="XXXXVXXX" item="DCC Message 46A">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="384" mask="XXVVXXXX" item="Message 46A">
@@ -6640,10 +6583,7 @@
         <label>Condition B Address</label>
       </variable>
       <variable CV="386" mask="XXXXVXXX" item="DCC Message 46B">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="386" mask="XXVVXXXX" item="Message 46B">
@@ -6682,10 +6622,7 @@
         <label>Condition C Address</label>
       </variable>
       <variable CV="388" mask="XXXXVXXX" item="DCC Message 46C">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="388" mask="XXVVXXXX" item="Message 46C">
@@ -6725,10 +6662,7 @@
         <label>Condition A Address</label>
       </variable>
       <variable CV="390" mask="XXXXVXXX" item="DCC Message 47A">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="390" mask="XXVVXXXX" item="Message 47A">
@@ -6760,10 +6694,7 @@
         <label>Condition B Address</label>
       </variable>
       <variable CV="392" mask="XXXXVXXX" item="DCC Message 47B">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="392" mask="XXVVXXXX" item="Message 47B">
@@ -6802,10 +6733,7 @@
         <label>Condition C Address</label>
       </variable>
       <variable CV="394" mask="XXXXVXXX" item="DCC Message 47C">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="394" mask="XXVVXXXX" item="Message 47C">
@@ -6845,10 +6773,7 @@
         <label>Condition A Address</label>
       </variable>
       <variable CV="396" mask="XXXXVXXX" item="DCC Message 48A">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="396" mask="XXVVXXXX" item="Message 48A">
@@ -6880,10 +6805,7 @@
         <label>Condition B Address</label>
       </variable>
       <variable CV="398" mask="XXXXVXXX" item="DCC Message 48B">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="398" mask="XXVVXXXX" item="Message 48B">
@@ -6922,10 +6844,7 @@
         <label>Condition C Address</label>
       </variable>
       <variable CV="400" mask="XXXXVXXX" item="DCC Message 48C">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="400" mask="XXVVXXXX" item="Message 48C">
@@ -6965,10 +6884,7 @@
         <label>Condition A Address</label>
       </variable>
       <variable CV="402" mask="XXXXVXXX" item="DCC Message 49A">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="402" mask="XXVVXXXX" item="Message 49A">
@@ -7000,10 +6916,7 @@
         <label>Condition B Address</label>
       </variable>
       <variable CV="404" mask="XXXXVXXX" item="DCC Message 49B">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="404" mask="XXVVXXXX" item="Message 49B">
@@ -7042,10 +6955,7 @@
         <label>Condition C Address</label>
       </variable>
       <variable CV="406" mask="XXXXVXXX" item="DCC Message 49C">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="406" mask="XXVVXXXX" item="Message 49C">
@@ -7085,10 +6995,7 @@
         <label>Condition A Address</label>
       </variable>
       <variable CV="408" mask="XXXXVXXX" item="DCC Message 50A">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="408" mask="XXVVXXXX" item="Message 50A">
@@ -7120,10 +7027,7 @@
         <label>Condition B Address</label>
       </variable>
       <variable CV="410" mask="XXXXVXXX" item="DCC Message 50B">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="410" mask="XXVVXXXX" item="Message 50B">
@@ -7162,10 +7066,7 @@
         <label>Condition C Address</label>
       </variable>
       <variable CV="412" mask="XXXXVXXX" item="DCC Message 50C">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="412" mask="XXVVXXXX" item="Message 50C">
@@ -7205,10 +7106,7 @@
         <label>Condition A Address</label>
       </variable>
       <variable CV="414" mask="XXXXVXXX" item="DCC Message 51A">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="414" mask="XXVVXXXX" item="Message 51A">
@@ -7240,10 +7138,7 @@
         <label>Condition B Address</label>
       </variable>
       <variable CV="416" mask="XXXXVXXX" item="DCC Message 51B">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="416" mask="XXVVXXXX" item="Message 51B">
@@ -7282,10 +7177,7 @@
         <label>Condition C Address</label>
       </variable>
       <variable CV="418" mask="XXXXVXXX" item="DCC Message 51C">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="418" mask="XXVVXXXX" item="Message 51C">
@@ -7325,10 +7217,7 @@
         <label>Condition A Address</label>
       </variable>
       <variable CV="420" mask="XXXXVXXX" item="DCC Message 52A">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="420" mask="XXVVXXXX" item="Message 52A">
@@ -7360,10 +7249,7 @@
         <label>Condition B Address</label>
       </variable>
       <variable CV="422" mask="XXXXVXXX" item="DCC Message 52B">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="422" mask="XXVVXXXX" item="Message 52B">
@@ -7402,10 +7288,7 @@
         <label>Condition C Address</label>
       </variable>
       <variable CV="424" mask="XXXXVXXX" item="DCC Message 52C">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="424" mask="XXVVXXXX" item="Message 52C">
@@ -7445,10 +7328,7 @@
         <label>Condition A Address</label>
       </variable>
       <variable CV="426" mask="XXXXVXXX" item="DCC Message 53A">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="426" mask="XXVVXXXX" item="Message 53A">
@@ -7480,10 +7360,7 @@
         <label>Condition B Address</label>
       </variable>
       <variable CV="428" mask="XXXXVXXX" item="DCC Message 53B">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="428" mask="XXVVXXXX" item="Message 53B">
@@ -7522,10 +7399,7 @@
         <label>Condition C Address</label>
       </variable>
       <variable CV="430" mask="XXXXVXXX" item="DCC Message 53C">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="430" mask="XXVVXXXX" item="Message 53C">
@@ -7565,10 +7439,7 @@
         <label>Condition A Address</label>
       </variable>
       <variable CV="432" mask="XXXXVXXX" item="DCC Message 54A">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="432" mask="XXVVXXXX" item="Message 54A">
@@ -7600,10 +7471,7 @@
         <label>Condition B Address</label>
       </variable>
       <variable CV="434" mask="XXXXVXXX" item="DCC Message 54B">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="434" mask="XXVVXXXX" item="Message 54B">
@@ -7642,10 +7510,7 @@
         <label>Condition C Address</label>
       </variable>
       <variable CV="436" mask="XXXXVXXX" item="DCC Message 54C">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="436" mask="XXVVXXXX" item="Message 54C">
@@ -7685,10 +7550,7 @@
         <label>Condition A Address</label>
       </variable>
       <variable CV="438" mask="XXXXVXXX" item="DCC Message 55A">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="438" mask="XXVVXXXX" item="Message 55A">
@@ -7720,10 +7582,7 @@
         <label>Condition B Address</label>
       </variable>
       <variable CV="440" mask="XXXXVXXX" item="DCC Message 55B">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="440" mask="XXVVXXXX" item="Message 55B">
@@ -7762,10 +7621,7 @@
         <label>Condition C Address</label>
       </variable>
       <variable CV="442" mask="XXXXVXXX" item="DCC Message 55C">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="442" mask="XXVVXXXX" item="Message 55C">
@@ -7805,10 +7661,7 @@
         <label>Condition A Address</label>
       </variable>
       <variable CV="444" mask="XXXXVXXX" item="DCC Message 56A">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="444" mask="XXVVXXXX" item="Message 56A">
@@ -7840,10 +7693,7 @@
         <label>Condition B Address</label>
       </variable>
       <variable CV="446" mask="XXXXVXXX" item="DCC Message 56B">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="446" mask="XXVVXXXX" item="Message 56B">
@@ -7882,10 +7732,7 @@
         <label>Condition C Address</label>
       </variable>
       <variable CV="448" mask="XXXXVXXX" item="DCC Message 56C">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="448" mask="XXVVXXXX" item="Message 56C">
@@ -7925,10 +7772,7 @@
         <label>Condition A Address</label>
       </variable>
       <variable CV="450" mask="XXXXVXXX" item="DCC Message 57A">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="450" mask="XXVVXXXX" item="Message 57A">
@@ -7960,10 +7804,7 @@
         <label>Condition B Address</label>
       </variable>
       <variable CV="452" mask="XXXXVXXX" item="DCC Message 57B">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="452" mask="XXVVXXXX" item="Message 57B">
@@ -8002,10 +7843,7 @@
         <label>Condition C Address</label>
       </variable>
       <variable CV="454" mask="XXXXVXXX" item="DCC Message 57C">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="454" mask="XXVVXXXX" item="Message 57C">
@@ -8045,10 +7883,7 @@
         <label>Condition A Address</label>
       </variable>
       <variable CV="456" mask="XXXXVXXX" item="DCC Message 58A">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="456" mask="XXVVXXXX" item="Message 58A">
@@ -8080,10 +7915,7 @@
         <label>Condition B Address</label>
       </variable>
       <variable CV="458" mask="XXXXVXXX" item="DCC Message 58B">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="458" mask="XXVVXXXX" item="Message 58B">
@@ -8122,10 +7954,7 @@
         <label>Condition C Address</label>
       </variable>
       <variable CV="460" mask="XXXXVXXX" item="DCC Message 58C">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="460" mask="XXVVXXXX" item="Message 58C">
@@ -8165,10 +7994,7 @@
         <label>Condition A Address</label>
       </variable>
       <variable CV="462" mask="XXXXVXXX" item="DCC Message 59A">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="462" mask="XXVVXXXX" item="Message 59A">
@@ -8200,10 +8026,7 @@
         <label>Condition B Address</label>
       </variable>
       <variable CV="464" mask="XXXXVXXX" item="DCC Message 59B">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="464" mask="XXVVXXXX" item="Message 59B">
@@ -8242,10 +8065,7 @@
         <label>Condition C Address</label>
       </variable>
       <variable CV="466" mask="XXXXVXXX" item="DCC Message 59C">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="466" mask="XXVVXXXX" item="Message 59C">
@@ -8285,10 +8105,7 @@
         <label>Condition A Address</label>
       </variable>
       <variable CV="468" mask="XXXXVXXX" item="DCC Message 60A">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="468" mask="XXVVXXXX" item="Message 60A">
@@ -8320,10 +8137,7 @@
         <label>Condition B Address</label>
       </variable>
       <variable CV="470" mask="XXXXVXXX" item="DCC Message 60B">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="470" mask="XXVVXXXX" item="Message 60B">
@@ -8362,10 +8176,7 @@
         <label>Condition C Address</label>
       </variable>
       <variable CV="472" mask="XXXXVXXX" item="DCC Message 60C">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="472" mask="XXVVXXXX" item="Message 60C">
@@ -8405,10 +8216,7 @@
         <label>Condition A Address</label>
       </variable>
       <variable CV="474" mask="XXXXVXXX" item="DCC Message 61A">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="474" mask="XXVVXXXX" item="Message 61A">
@@ -8440,10 +8248,7 @@
         <label>Condition B Address</label>
       </variable>
       <variable CV="476" mask="XXXXVXXX" item="DCC Message 61B">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="476" mask="XXVVXXXX" item="Message 61B">
@@ -8482,10 +8287,7 @@
         <label>Condition C Address</label>
       </variable>
       <variable CV="478" mask="XXXXVXXX" item="DCC Message 61C">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="478" mask="XXVVXXXX" item="Message 61C">
@@ -8525,10 +8327,7 @@
         <label>Condition A Address</label>
       </variable>
       <variable CV="480" mask="XXXXVXXX" item="DCC Message 62A">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="480" mask="XXVVXXXX" item="Message 62A">
@@ -8560,10 +8359,7 @@
         <label>Condition B Address</label>
       </variable>
       <variable CV="482" mask="XXXXVXXX" item="DCC Message 62B">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="482" mask="XXVVXXXX" item="Message 62B">
@@ -8602,10 +8398,7 @@
         <label>Condition C Address</label>
       </variable>
       <variable CV="484" mask="XXXXVXXX" item="DCC Message 62C">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="484" mask="XXVVXXXX" item="Message 62C">
@@ -8645,10 +8438,7 @@
         <label>Condition A Address</label>
       </variable>
       <variable CV="486" mask="XXXXVXXX" item="DCC Message 63A">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="486" mask="XXVVXXXX" item="Message 63A">
@@ -8680,10 +8470,7 @@
         <label>Condition B Address</label>
       </variable>
       <variable CV="488" mask="XXXXVXXX" item="DCC Message 63B">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="488" mask="XXVVXXXX" item="Message 63B">
@@ -8722,10 +8509,7 @@
         <label>Condition C Address</label>
       </variable>
       <variable CV="490" mask="XXXXVXXX" item="DCC Message 63C">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="490" mask="XXVVXXXX" item="Message 63C">
@@ -8765,10 +8549,7 @@
         <label>Condition A Address</label>
       </variable>
       <variable CV="492" mask="XXXXVXXX" item="DCC Message 64A">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="492" mask="XXVVXXXX" item="Message 64A">
@@ -8800,10 +8581,7 @@
         <label>Condition B Address</label>
       </variable>
       <variable CV="494" mask="XXXXVXXX" item="DCC Message 64B">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="494" mask="XXVVXXXX" item="Message 64B">
@@ -8842,10 +8620,7 @@
         <label>Condition C Address</label>
       </variable>
       <variable CV="496" mask="XXXXVXXX" item="DCC Message 64C">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="496" mask="XXVVXXXX" item="Message 64C">
@@ -8885,10 +8660,7 @@
         <label>Condition A Address</label>
       </variable>
       <variable CV="498" mask="XXXXVXXX" item="DCC Message 65A">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="498" mask="XXVVXXXX" item="Message 65A">
@@ -8920,10 +8692,7 @@
         <label>Condition B Address</label>
       </variable>
       <variable CV="500" mask="XXXXVXXX" item="DCC Message 65B">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="500" mask="XXVVXXXX" item="Message 65B">
@@ -8962,10 +8731,7 @@
         <label>Condition C Address</label>
       </variable>
       <variable CV="502" mask="XXXXVXXX" item="DCC Message 65C">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="502" mask="XXVVXXXX" item="Message 65C">
@@ -9005,10 +8771,7 @@
         <label>Condition A Address</label>
       </variable>
       <variable CV="504" mask="XXXXVXXX" item="DCC Message 66A">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="504" mask="XXVVXXXX" item="Message 66A">
@@ -9040,10 +8803,7 @@
         <label>Condition B Address</label>
       </variable>
       <variable CV="506" mask="XXXXVXXX" item="DCC Message 66B">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="506" mask="XXVVXXXX" item="Message 66B">
@@ -9082,10 +8842,7 @@
         <label>Condition C Address</label>
       </variable>
       <variable CV="508" mask="XXXXVXXX" item="DCC Message 66C">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="508" mask="XXVVXXXX" item="Message 66C">
@@ -9125,10 +8882,7 @@
         <label>Address</label>
       </variable>
       <variable CV="514" mask="XXXXVXXX" item="DCC Message 1D" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="514" mask="XXVVXXXX" item="Message 1D">
@@ -9160,10 +8914,7 @@
         <label>Address</label>
       </variable>
       <variable CV="516" mask="XXXXVXXX" item="DCC Message 2D" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="516" mask="XXVVXXXX" item="Message 2D">
@@ -9195,10 +8946,7 @@
         <label>Address</label>
       </variable>
       <variable CV="518" mask="XXXXVXXX" item="DCC Message 3D" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="518" mask="XXVVXXXX" item="Message 3D">
@@ -9230,10 +8978,7 @@
         <label>Address</label>
       </variable>
       <variable CV="520" mask="XXXXVXXX" item="DCC Message 4D" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="520" mask="XXVVXXXX" item="Message 4D">
@@ -9265,10 +9010,7 @@
         <label>Address</label>
       </variable>
       <variable CV="522" mask="XXXXVXXX" item="DCC Message 5D" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="522" mask="XXVVXXXX" item="Message 5D">
@@ -9300,10 +9042,7 @@
         <label>Address</label>
       </variable>
       <variable CV="524" mask="XXXXVXXX" item="DCC Message 6D" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="524" mask="XXVVXXXX" item="Message 6D">
@@ -9335,10 +9074,7 @@
         <label>Address</label>
       </variable>
       <variable CV="526" mask="XXXXVXXX" item="DCC Message 7D" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="526" mask="XXVVXXXX" item="Message 7D">
@@ -9370,10 +9106,7 @@
         <label>Address</label>
       </variable>
       <variable CV="528" mask="XXXXVXXX" item="DCC Message 8D" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="528" mask="XXVVXXXX" item="Message 8D">
@@ -9405,10 +9138,7 @@
         <label>Address</label>
       </variable>
       <variable CV="530" mask="XXXXVXXX" item="DCC Message 9D" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="530" mask="XXVVXXXX" item="Message 9D">
@@ -9440,10 +9170,7 @@
         <label>Address</label>
       </variable>
       <variable CV="532" mask="XXXXVXXX" item="DCC Message 10D" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="532" mask="XXVVXXXX" item="Message 10D">
@@ -9475,10 +9202,7 @@
         <label>Address</label>
       </variable>
       <variable CV="534" mask="XXXXVXXX" item="DCC Message 11D" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="534" mask="XXVVXXXX" item="Message 11D">
@@ -9510,10 +9234,7 @@
         <label>Address</label>
       </variable>
       <variable CV="536" mask="XXXXVXXX" item="DCC Message 12D" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="536" mask="XXVVXXXX" item="Message 12D">
@@ -9545,10 +9266,7 @@
         <label>Address</label>
       </variable>
       <variable CV="538" mask="XXXXVXXX" item="DCC Message 13D" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="538" mask="XXVVXXXX" item="Message 13D">
@@ -9580,10 +9298,7 @@
         <label>Address</label>
       </variable>
       <variable CV="540" mask="XXXXVXXX" item="DCC Message 14D" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="540" mask="XXVVXXXX" item="Message 14D">
@@ -9615,10 +9330,7 @@
         <label>Address</label>
       </variable>
       <variable CV="542" mask="XXXXVXXX" item="DCC Message 15D" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="542" mask="XXVVXXXX" item="Message 15D">
@@ -9650,10 +9362,7 @@
         <label>Address</label>
       </variable>
       <variable CV="544" mask="XXXXVXXX" item="DCC Message 16D" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="544" mask="XXVVXXXX" item="Message 16D">
@@ -9685,10 +9394,7 @@
         <label>Address</label>
       </variable>
       <variable CV="546" mask="XXXXVXXX" item="DCC Message 17D" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="546" mask="XXVVXXXX" item="Message 17D">
@@ -9720,10 +9426,7 @@
         <label>Address</label>
       </variable>
       <variable CV="548" mask="XXXXVXXX" item="DCC Message 18D" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="548" mask="XXVVXXXX" item="Message 18D">
@@ -9755,10 +9458,7 @@
         <label>Address</label>
       </variable>
       <variable CV="550" mask="XXXXVXXX" item="DCC Message 19D" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="550" mask="XXVVXXXX" item="Message 19D">
@@ -9790,10 +9490,7 @@
         <label>Address</label>
       </variable>
       <variable CV="552" mask="XXXXVXXX" item="DCC Message 20D" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="552" mask="XXVVXXXX" item="Message 20D">
@@ -9825,10 +9522,7 @@
         <label>Address</label>
       </variable>
       <variable CV="554" mask="XXXXVXXX" item="DCC Message 21D" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="554" mask="XXVVXXXX" item="Message 21D">
@@ -9860,10 +9554,7 @@
         <label>Address</label>
       </variable>
       <variable CV="556" mask="XXXXVXXX" item="DCC Message 22D" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="556" mask="XXVVXXXX" item="Message 22D">
@@ -9895,10 +9586,7 @@
         <label>Address</label>
       </variable>
       <variable CV="558" mask="XXXXVXXX" item="DCC Message 23D" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="558" mask="XXVVXXXX" item="Message 23D">
@@ -9930,10 +9618,7 @@
         <label>Address</label>
       </variable>
       <variable CV="560" mask="XXXXVXXX" item="DCC Message 24D" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="560" mask="XXVVXXXX" item="Message 24D">
@@ -9965,10 +9650,7 @@
         <label>Address</label>
       </variable>
       <variable CV="562" mask="XXXXVXXX" item="DCC Message 25D" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="562" mask="XXVVXXXX" item="Message 25D">
@@ -10000,10 +9682,7 @@
         <label>Address</label>
       </variable>
       <variable CV="564" mask="XXXXVXXX" item="DCC Message 26D" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="564" mask="XXVVXXXX" item="Message 26D">
@@ -10035,10 +9714,7 @@
         <label>Address</label>
       </variable>
       <variable CV="566" mask="XXXXVXXX" item="DCC Message 27D" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="566" mask="XXVVXXXX" item="Message 27D">
@@ -10070,10 +9746,7 @@
         <label>Address</label>
       </variable>
       <variable CV="568" mask="XXXXVXXX" item="DCC Message 28D" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="568" mask="XXVVXXXX" item="Message 28D">
@@ -10105,10 +9778,7 @@
         <label>Address</label>
       </variable>
       <variable CV="570" mask="XXXXVXXX" item="DCC Message 29D" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="570" mask="XXVVXXXX" item="Message 29D">
@@ -10140,10 +9810,7 @@
         <label>Address</label>
       </variable>
       <variable CV="572" mask="XXXXVXXX" item="DCC Message 30D" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="572" mask="XXVVXXXX" item="Message 30D">
@@ -10175,10 +9842,7 @@
         <label>Address</label>
       </variable>
       <variable CV="574" mask="XXXXVXXX" item="DCC Message 31D" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="574" mask="XXVVXXXX" item="Message 31D">
@@ -10210,10 +9874,7 @@
         <label>Address</label>
       </variable>
       <variable CV="576" mask="XXXXVXXX" item="DCC Message 32D" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="576" mask="XXVVXXXX" item="Message 32D">
@@ -10245,10 +9906,7 @@
         <label>Address</label>
       </variable>
       <variable CV="578" mask="XXXXVXXX" item="DCC Message 33D" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="578" mask="XXVVXXXX" item="Message 33D">
@@ -10280,10 +9938,7 @@
         <label>Address</label>
       </variable>
       <variable CV="580" mask="XXXXVXXX" item="DCC Message 34D" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="580" mask="XXVVXXXX" item="Message 34D">
@@ -10315,10 +9970,7 @@
         <label>Address</label>
       </variable>
       <variable CV="582" mask="XXXXVXXX" item="DCC Message 35D" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="582" mask="XXVVXXXX" item="Message 35D">
@@ -10350,10 +10002,7 @@
         <label>Address</label>
       </variable>
       <variable CV="584" mask="XXXXVXXX" item="DCC Message 36D" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="584" mask="XXVVXXXX" item="Message 36D">
@@ -10385,10 +10034,7 @@
         <label>Address</label>
       </variable>
       <variable CV="586" mask="XXXXVXXX" item="DCC Message 37D" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="586" mask="XXVVXXXX" item="Message 37D">
@@ -10420,10 +10066,7 @@
         <label>Address</label>
       </variable>
       <variable CV="588" mask="XXXXVXXX" item="DCC Message 38D" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="588" mask="XXVVXXXX" item="Message 38D">
@@ -10455,10 +10098,7 @@
         <label>Address</label>
       </variable>
       <variable CV="590" mask="XXXXVXXX" item="DCC Message 39D" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="590" mask="XXVVXXXX" item="Message 39D">
@@ -10490,10 +10130,7 @@
         <label>Address</label>
       </variable>
       <variable CV="592" mask="XXXXVXXX" item="DCC Message 40D" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="592" mask="XXVVXXXX" item="Message 40D">
@@ -10525,10 +10162,7 @@
         <label>Address</label>
       </variable>
       <variable CV="594" mask="XXXXVXXX" item="DCC Message 41D" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="594" mask="XXVVXXXX" item="Message 41D">
@@ -10560,10 +10194,7 @@
         <label>Address</label>
       </variable>
       <variable CV="596" mask="XXXXVXXX" item="DCC Message 42D" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="596" mask="XXVVXXXX" item="Message 42D">
@@ -10595,10 +10226,7 @@
         <label>Address</label>
       </variable>
       <variable CV="598" mask="XXXXVXXX" item="DCC Message 43D" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="598" mask="XXVVXXXX" item="Message 43D">
@@ -10630,10 +10258,7 @@
         <label>Address</label>
       </variable>
       <variable CV="600" mask="XXXXVXXX" item="DCC Message 44D" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="600" mask="XXVVXXXX" item="Message 44D">
@@ -10665,10 +10290,7 @@
         <label>Address</label>
       </variable>
       <variable CV="602" mask="XXXXVXXX" item="DCC Message 45D" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="602" mask="XXVVXXXX" item="Message 45D">
@@ -10700,10 +10322,7 @@
         <label>Address</label>
       </variable>
       <variable CV="604" mask="XXXXVXXX" item="DCC Message 46D" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="604" mask="XXVVXXXX" item="Message 46D">
@@ -10735,10 +10354,7 @@
         <label>Address</label>
       </variable>
       <variable CV="606" mask="XXXXVXXX" item="DCC Message 47D" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="606" mask="XXVVXXXX" item="Message 47D">
@@ -10770,10 +10386,7 @@
         <label>Address</label>
       </variable>
       <variable CV="608" mask="XXXXVXXX" item="DCC Message 48D" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="608" mask="XXVVXXXX" item="Message 48D">
@@ -10805,10 +10418,7 @@
         <label>Address</label>
       </variable>
       <variable CV="610" mask="XXXXVXXX" item="DCC Message 49D" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="610" mask="XXVVXXXX" item="Message 49D">
@@ -10840,10 +10450,7 @@
         <label>Address</label>
       </variable>
       <variable CV="612" mask="XXXXVXXX" item="DCC Message 50D" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="612" mask="XXVVXXXX" item="Message 50D">
@@ -10875,10 +10482,7 @@
         <label>Address</label>
       </variable>
       <variable CV="614" mask="XXXXVXXX" item="DCC Message 51D" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="614" mask="XXVVXXXX" item="Message 51D">
@@ -10910,10 +10514,7 @@
         <label>Address</label>
       </variable>
       <variable CV="616" mask="XXXXVXXX" item="DCC Message 52D" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="616" mask="XXVVXXXX" item="Message 52D">
@@ -10945,10 +10546,7 @@
         <label>Address</label>
       </variable>
       <variable CV="618" mask="XXXXVXXX" item="DCC Message 53D" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="618" mask="XXVVXXXX" item="Message 53D">
@@ -10980,10 +10578,7 @@
         <label>Address</label>
       </variable>
       <variable CV="620" mask="XXXXVXXX" item="DCC Message 54D" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="620" mask="XXVVXXXX" item="Message 54D">
@@ -11015,10 +10610,7 @@
         <label>Address</label>
       </variable>
       <variable CV="622" mask="XXXXVXXX" item="DCC Message 55D" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="622" mask="XXVVXXXX" item="Message 55D">
@@ -11050,10 +10642,7 @@
         <label>Address</label>
       </variable>
       <variable CV="624" mask="XXXXVXXX" item="DCC Message 56D" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="624" mask="XXVVXXXX" item="Message 56D">
@@ -11085,10 +10674,7 @@
         <label>Address</label>
       </variable>
       <variable CV="626" mask="XXXXVXXX" item="DCC Message 57D" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="626" mask="XXVVXXXX" item="Message 57D">
@@ -11120,10 +10706,7 @@
         <label>Address</label>
       </variable>
       <variable CV="628" mask="XXXXVXXX" item="DCC Message 58D" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="628" mask="XXVVXXXX" item="Message 58D">
@@ -11155,10 +10738,7 @@
         <label>Address</label>
       </variable>
       <variable CV="630" mask="XXXXVXXX" item="DCC Message 59D" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="630" mask="XXVVXXXX" item="Message 59D">
@@ -11190,10 +10770,7 @@
         <label>Address</label>
       </variable>
       <variable CV="632" mask="XXXXVXXX" item="DCC Message 60D" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="632" mask="XXVVXXXX" item="Message 60D">
@@ -11225,10 +10802,7 @@
         <label>Address</label>
       </variable>
       <variable CV="634" mask="XXXXVXXX" item="DCC Message 61D" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="634" mask="XXVVXXXX" item="Message 61D">
@@ -11260,10 +10834,7 @@
         <label>Address</label>
       </variable>
       <variable CV="636" mask="XXXXVXXX" item="DCC Message 62D" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="636" mask="XXVVXXXX" item="Message 62D">
@@ -11295,10 +10866,7 @@
         <label>Address</label>
       </variable>
       <variable CV="638" mask="XXXXVXXX" item="DCC Message 63D" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="638" mask="XXVVXXXX" item="Message 63D">
@@ -11330,10 +10898,7 @@
         <label>Address</label>
       </variable>
       <variable CV="640" mask="XXXXVXXX" item="DCC Message 64D" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="640" mask="XXVVXXXX" item="Message 64D">
@@ -11365,10 +10930,7 @@
         <label>Address</label>
       </variable>
       <variable CV="642" mask="XXXXVXXX" item="DCC Message 65D" default="1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC Signal</label>
       </variable>
       <variable CV="642" mask="XXVVXXXX" item="Message 65D">

--- a/xml/decoders/TD_SC8.xml
+++ b/xml/decoders/TD_SC8.xml
@@ -133,47 +133,19 @@
       </variable>
       <!-- Status Report variable definition. only send output states are used -->
       <variable item="Power On Send Input State" CV="28" mask="XXXXXXXV">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Power On Send Input State</label>
       </variable>
       <variable item="Power On Send Output State" CV="28" mask="XXXXXXVX">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Power On Send Output State</label>
       </variable>
       <variable item="Interrogate input" CV="28" mask="XXXXXVXX">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Interrogate input</label>
       </variable>
       <variable item="Interrogate output" CV="28" mask="XXXXVXXX">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Interrogate output</label>
       </variable>
       <!-- Decoder Configuration variable definition -->
@@ -189,58 +161,23 @@
         <label>Mode</label>
       </variable>
       <variable item="Fix Power On State" CV="29" mask="XXXXXXVX" default="0">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Select Power On Option</label>
       </variable>
       <variable CV="29" mask="XXXXXVXX" item="Op2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Option 2</label>
       </variable>
       <variable item="DCC gateway" CV="29" mask="XXXXVXXX">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC gateway</label>
       </variable>
       <variable item="Bus interface" CV="29" mask="XXXVXXXX">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Bus interface</label>
       </variable>
       <variable item="DCC control" CV="29" mask="XXVXXXXX">
-        <enumVal>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-YesNo.xml"/>
         <label>DCC control</label>
       </variable>
       <variable CV="31" mask="XVVVVVVV" item="Short Address" default="1" tooltip="Range 1-99">
@@ -366,25 +303,11 @@
         <label>Address</label>
       </variable>
       <variable CV="36" mask="VXXXXXXX" item="PInv P1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="36" mask="XVXXXXXX" item="PTog P1" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="36" mask="XXVVXXXX" item="PTy1">
@@ -427,25 +350,11 @@
         <label>Address</label>
       </variable>
       <variable CV="39" mask="VXXXXXXX" item="PInv P2" default="0">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="39" mask="XVXXXXXX" item="PTog P2" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="39" mask="XXVVXXXX" item="PTy2">
@@ -488,25 +397,11 @@
         <label>Address</label>
       </variable>
       <variable CV="42" mask="VXXXXXXX" item="PInv P3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="42" mask="XVXXXXXX" item="PTog P3" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="42" mask="XXVVXXXX" item="PTy3">
@@ -549,25 +444,11 @@
         <label>Address</label>
       </variable>
       <variable CV="45" mask="VXXXXXXX" item="PInv P4" default="0">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="45" mask="XVXXXXXX" item="PTog P4" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="45" mask="XXVVXXXX" item="PTy4">
@@ -610,25 +491,11 @@
         <label>Address</label>
       </variable>
       <variable CV="48" mask="VXXXXXXX" item="PInv P5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="48" mask="XVXXXXXX" item="PTog P5" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="48" mask="XXVVXXXX" item="PTy5">
@@ -671,25 +538,11 @@
         <label>Address</label>
       </variable>
       <variable CV="51" mask="VXXXXXXX" item="PInv P6" default="0">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="51" mask="XVXXXXXX" item="PTog P6" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="51" mask="XXVVXXXX" item="PTy6">
@@ -732,25 +585,11 @@
         <label>Address</label>
       </variable>
       <variable CV="54" mask="VXXXXXXX" item="PInv P7">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="54" mask="XVXXXXXX" item="PTog P7" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="54" mask="XXVVXXXX" item="PTy7">
@@ -793,25 +632,11 @@
         <label>Address</label>
       </variable>
       <variable CV="57" mask="VXXXXXXX" item="PInv P8" default="0">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="57" mask="XVXXXXXX" item="PTog P8" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="57" mask="XXVVXXXX" item="PTy8">
@@ -926,121 +751,51 @@
       </variable>
       <!-- Begin servo behavior variable definition -->
       <variable item="Beh1" CV="81" mask="XXXXXXVX" default="0">
-        <enumVal>
-          <enumChoice choice="no">
-          </enumChoice>
-          <enumChoice choice="yes">
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Servo 1 Behavior - Speed to Position</label>
       </variable>
       <variable item="Rev1" CV="81" mask="VXXXXXXX" default="0">
-        <enumVal>
-          <enumChoice choice="no">
-          </enumChoice>
-          <enumChoice choice="yes">
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reverse</label>
       </variable>
       <variable item="Beh2" CV="82" mask="XXXXXXVX" default="0">
-        <enumVal>
-          <enumChoice choice="no">
-          </enumChoice>
-          <enumChoice choice="yes">
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Servo 2 Behavior - Speed to Position</label>
       </variable>
       <variable item="Rev2" CV="82" mask="VXXXXXXX" default="0">
-        <enumVal>
-          <enumChoice choice="no">
-          </enumChoice>
-          <enumChoice choice="yes">
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reverse</label>
       </variable>
       <variable item="Beh3" CV="83" mask="XXXXXXVX" default="0">
-        <enumVal>
-          <enumChoice choice="no">
-          </enumChoice>
-          <enumChoice choice="yes">
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Servo 3 Behavior - Speed to Position</label>
       </variable>
       <variable item="Rev3" CV="83" mask="VXXXXXXX" default="0">
-        <enumVal>
-          <enumChoice choice="no">
-          </enumChoice>
-          <enumChoice choice="yes">
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reverse</label>
       </variable>
       <variable item="Beh4" CV="84" mask="XXXXXXVX" default="0">
-        <enumVal>
-          <enumChoice choice="no">
-          </enumChoice>
-          <enumChoice choice="yes">
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Servo 4 Behavior - Speed to Position</label>
       </variable>
       <variable item="Rev4" CV="84" mask="VXXXXXXX" default="0">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reverse</label>
       </variable>
       <variable item="Rev5" CV="85" mask="VXXXXXXX" default="0">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reverse</label>
       </variable>
       <variable item="Rev6" CV="86" mask="VXXXXXXX" default="0">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reverse</label>
       </variable>
       <variable item="Rev7" CV="87" mask="VXXXXXXX" default="0">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reverse</label>
       </variable>
       <variable item="Rev8" CV="88" mask="VXXXXXXX" default="0">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reverse</label>
       </variable>
       <variable item="Servo 5 Move Range" CV="91" mask="XVVVVVVV" default="35">

--- a/xml/decoders/TD_SC82.xml
+++ b/xml/decoders/TD_SC82.xml
@@ -92,124 +92,47 @@
         <label>Select Power On Option</label>
       </variable>
       <variable CV="9" mask="XXXXXVXX" item="Op1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Ops Mode</label>
       </variable>
       <variable item="DCC gateway" CV="9" mask="XXXXVXXX">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC gateway</label>
       </variable>
       <variable item="Bus interface" CV="9" mask="XXXVXXXX">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Bus interface</label>
       </variable>
       <variable item="DCC control" CV="9" mask="XXVXXXXX">
-        <enumVal>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-YesNo.xml"/>
         <label>DCC control</label>
       </variable>
       <variable item="Disable Power Save" CV="9" mask="XVXXXXXX">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Disable Power Save</label>
       </variable>
       <variable item="Common Cathode" CV="9" mask="VXXXXXXX">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Common Cathode</label>
       </variable>
       <variable item="Power On Send Input State" CV="10" mask="XXXXXXXV">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Power On Send Input State</label>
       </variable>
       <variable item="Power On Send Output State" CV="10" mask="XXXXXXVX">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Power On Send Output State</label>
       </variable>
       <variable item="Interrogate input" CV="10" mask="XXXXXVXX">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Interrogate input</label>
       </variable>
       <variable item="Interrogate output" CV="10" mask="XXXXVXXX">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Interrogate output</label>
       </variable>
       <variable item="One LED output" CV="10" mask="XXXVXXXX">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>One LED output</label>
       </variable>
       
@@ -344,25 +267,11 @@
         <label>Address</label>
       </variable>
       <variable CV="17" mask="VXXXXXXX" item="PInv P1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="17" mask="XVXXXXXX" item="PTog P1" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="17" mask="XXVVXXXX" item="PTy1">
@@ -405,25 +314,11 @@
         <label>Address</label>
       </variable>
       <variable CV="20" mask="VXXXXXXX" item="PInv P2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="20" mask="XVXXXXXX" item="PTog P2" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="20" mask="XXVVXXXX" item="PTy2">
@@ -466,25 +361,11 @@
         <label>Address</label>
       </variable>
       <variable CV="23" mask="VXXXXXXX" item="PInv P3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="23" mask="XVXXXXXX" item="PTog P3" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="23" mask="XXVVXXXX" item="PTy3">
@@ -527,25 +408,11 @@
         <label>Address</label>
       </variable>
       <variable CV="26" mask="VXXXXXXX" item="PInv P4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="26" mask="XVXXXXXX" item="PTog P4" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="26" mask="XXVVXXXX" item="PTy4">
@@ -588,25 +455,11 @@
         <label>Address</label>
       </variable>
       <variable CV="29" mask="VXXXXXXX" item="PInv P5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="29" mask="XVXXXXXX" item="PTog P5" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="29" mask="XXVVXXXX" item="PTy5">
@@ -649,25 +502,11 @@
         <label>Address</label>
       </variable>
       <variable CV="32" mask="VXXXXXXX" item="PInv P6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="32" mask="XVXXXXXX" item="PTog P6" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="32" mask="XXVVXXXX" item="PTy6">
@@ -710,25 +549,11 @@
         <label>Address</label>
       </variable>
       <variable CV="35" mask="VXXXXXXX" item="PInv P7">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="35" mask="XVXXXXXX" item="PTog P7" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="35" mask="XXVVXXXX" item="PTy7">
@@ -771,25 +596,11 @@
         <label>Address</label>
       </variable>
       <variable CV="38" mask="VXXXXXXX" item="PInv P8">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="38" mask="XVXXXXXX" item="PTog P8" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="38" mask="XXVVXXXX" item="PTy8">
@@ -995,157 +806,67 @@
 
       <!-- Begin servo behavior variable definition -->
       <variable item="Beh1" CV="104" mask="XXXVXXXX" default="0">
-        <enumVal>
-          <enumChoice choice="no">
-          </enumChoice>
-          <enumChoice choice="yes">
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Servo 1 Position Indication</label>
       </variable>
       <variable item="Rev1" CV="104" mask="VXXXXXXX" default="0">
-        <enumVal>
-          <enumChoice choice="no">
-          </enumChoice>
-          <enumChoice choice="yes">
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reverse</label>
       </variable>
       <variable item="Beh2" CV="105" mask="XXXVXXXX" default="0">
-        <enumVal>
-          <enumChoice choice="no">
-          </enumChoice>
-          <enumChoice choice="yes">
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Servo 2 Position Indication</label>
       </variable>
       <variable item="Rev2" CV="105" mask="VXXXXXXX" default="0">
-        <enumVal>
-          <enumChoice choice="no">
-          </enumChoice>
-          <enumChoice choice="yes">
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reverse</label>
       </variable>
       <variable item="Beh3" CV="106" mask="XXXVXXXX" default="0">
-        <enumVal>
-          <enumChoice choice="no">
-          </enumChoice>
-          <enumChoice choice="yes">
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Servo 3 Position Indication</label>
       </variable>
       <variable item="Rev3" CV="106" mask="VXXXXXXX" default="0">
-        <enumVal>
-          <enumChoice choice="no">
-          </enumChoice>
-          <enumChoice choice="yes">
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reverse</label>
       </variable>
       <variable item="Beh4" CV="107" mask="XXXVXXXX" default="0">
-        <enumVal>
-          <enumChoice choice="no">
-          </enumChoice>
-          <enumChoice choice="yes">
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Servo 4 Position Indication</label>
       </variable>
       <variable item="Rev4" CV="107" mask="VXXXXXXX" default="0">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reverse</label>
       </variable>
       <variable item="Beh5" CV="108" mask="XXXVXXXX" default="0">
-        <enumVal>
-          <enumChoice choice="no">
-          </enumChoice>
-          <enumChoice choice="yes">
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Servo 5 Position Indication</label>
       </variable>
       <variable item="Rev5" CV="108" mask="VXXXXXXX" default="0">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reverse</label>
       </variable>
       <variable item="Beh6" CV="109" mask="XXXVXXXX" default="0">
-        <enumVal>
-          <enumChoice choice="no">
-          </enumChoice>
-          <enumChoice choice="yes">
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Servo 6 Position Indication</label>
       </variable>
       <variable item="Rev6" CV="109" mask="VXXXXXXX" default="0">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reverse</label>
       </variable>
       <variable item="Beh7" CV="110" mask="XXXVXXXX" default="0">
-        <enumVal>
-          <enumChoice choice="no">
-          </enumChoice>
-          <enumChoice choice="yes">
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Servo 7 Position Indication</label>
       </variable>
       <variable item="Rev7" CV="110" mask="VXXXXXXX" default="0">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reverse</label>
       </variable>
       <variable item="Beh8" CV="111" mask="XXXVXXXX" default="0">
-        <enumVal>
-          <enumChoice choice="no">
-          </enumChoice>
-          <enumChoice choice="yes">
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Servo 8 Position Indication</label>
       </variable>
       <variable item="Rev8" CV="111" mask="VXXXXXXX" default="0">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reverse</label>
       </variable>
       

--- a/xml/decoders/TD_SHD2.xml
+++ b/xml/decoders/TD_SHD2.xml
@@ -105,47 +105,19 @@
         <label>Lunar 2</label>
       </variable>
       <variable CV="29" mask="XXXXXXXV" item="Opt1" default="0">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Option 1</label>
       </variable>
       <variable CV="29" mask="XXXXXXVX" item="Opt2" default="0">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Option 2</label>
       </variable>
       <variable CV="29" mask="XXXXXVXX" item="Opt3" default="0">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Option 3</label>
       </variable>
       <variable CV="29" mask="XXXXVXXX" item="Opt4" default="0">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Option 4</label>
       </variable>      
     </variables>

--- a/xml/decoders/TD_SIC24.xml
+++ b/xml/decoders/TD_SIC24.xml
@@ -39,58 +39,23 @@
         <label>through</label>
       </variable>
       <variable CV="2" mask="XXXXXXXV" item="Op1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Option 1</label>
       </variable>
       <variable CV="2" mask="XXXXXXVX" item="Op2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Option 2</label>
       </variable>
       <variable CV="2" mask="XXXXXVXX" item="Op3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Option 3</label>
       </variable>
       <variable CV="2" mask="XXXXVXXX" item="Op4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Option 4</label>
       </variable>
       <variable CV="2" mask="XXXVXXXX" item="Op5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Option 5</label>
       </variable>
       <variable item="CV2" CV="2" mask="VVVVVVVV">
@@ -122,25 +87,11 @@
         <label>Primary Address 1</label>
       </variable>
       <variable CV="11" mask="XVXXXXXX" item="Tog P1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="11" mask="VXXXXXXX" item="Inv P1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable item="Primary Type 1" CV="11" mask="XXVVXXXX">
@@ -182,14 +133,7 @@
         <label>Secondary Address 1</label>
       </variable>
       <variable CV="14" mask="VXXXXXXX" item="Inv S1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable item="Secondary Type 1" CV="14" mask="XXVVXXXX">
@@ -231,25 +175,11 @@
         <label>Primary Address 2</label>
       </variable>
       <variable CV="16" mask="XVXXXXXX" item="Tog P2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="16" mask="VXXXXXXX" item="Inv P2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable item="Primary Type 2" CV="16" mask="XXVVXXXX">
@@ -291,14 +221,7 @@
         <label>Secondary Address 2</label>
       </variable>
       <variable CV="19" mask="VXXXXXXX" item="Inv S2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable item="Secondary Type 2" CV="19" mask="XXVVXXXX">
@@ -340,25 +263,11 @@
         <label>Primary Address 3</label>
       </variable>
       <variable CV="21" mask="XVXXXXXX" item="Tog P3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="21" mask="VXXXXXXX" item="Inv P3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable item="Primary Type 3" CV="21" mask="XXVVXXXX">
@@ -400,14 +309,7 @@
         <label>Secondary Address 3</label>
       </variable>
       <variable CV="24" mask="VXXXXXXX" item="Inv S3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable item="Secondary Type 3" CV="24" mask="XXVVXXXX">
@@ -449,25 +351,11 @@
         <label>Primary Address 4</label>
       </variable>
       <variable CV="26" mask="XVXXXXXX" item="Tog P4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="26" mask="VXXXXXXX" item="Inv P4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable item="Primary Type 4" CV="26" mask="XXVVXXXX">
@@ -509,14 +397,7 @@
         <label>Secondary Address 4</label>
       </variable>
       <variable CV="29" mask="VXXXXXXX" item="Inv S4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable item="Secondary Type 4" CV="29" mask="XXVVXXXX">
@@ -558,25 +439,11 @@
         <label>Primary Address 5</label>
       </variable>
       <variable CV="31" mask="XVXXXXXX" item="Tog P5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="31" mask="VXXXXXXX" item="Inv P5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable item="Primary Type 5" CV="31" mask="XXVVXXXX">
@@ -618,14 +485,7 @@
         <label>Secondary Address 5</label>
       </variable>
       <variable CV="34" mask="VXXXXXXX" item="Inv S5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable item="Secondary Type 5" CV="34" mask="XXVVXXXX">
@@ -667,25 +527,11 @@
         <label>Primary Address 6</label>
       </variable>
       <variable CV="36" mask="XVXXXXXX" item="Tog P6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="36" mask="VXXXXXXX" item="Inv P6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable item="Primary Type 6" CV="36" mask="XXVVXXXX">
@@ -727,14 +573,7 @@
         <label>Secondary Address 6</label>
       </variable>
       <variable CV="39" mask="VXXXXXXX" item="Inv S6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable item="Secondary Type 6" CV="39" mask="XXVVXXXX">
@@ -776,25 +615,11 @@
         <label>Primary Address 7</label>
       </variable>
       <variable CV="41" mask="XVXXXXXX" item="Tog P7">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="41" mask="VXXXXXXX" item="Inv P7">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable item="Primary Type 7" CV="41" mask="XXVVXXXX">
@@ -836,14 +661,7 @@
         <label>Secondary Address 7</label>
       </variable>
       <variable CV="44" mask="VXXXXXXX" item="Inv S7">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable item="Secondary Type 7" CV="44" mask="XXVVXXXX">
@@ -885,25 +703,11 @@
         <label>Primary Address 8</label>
       </variable>
       <variable CV="46" mask="XVXXXXXX" item="Tog P8">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="46" mask="VXXXXXXX" item="Inv P8">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable item="Primary Type 8" CV="46" mask="XXVVXXXX">
@@ -945,14 +749,7 @@
         <label>Secondary Address 8</label>
       </variable>
       <variable CV="49" mask="VXXXXXXX" item="Inv S8">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable item="Secondary Type 8" CV="49" mask="XXVVXXXX">
@@ -1113,25 +910,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="56" mask="VXXXXXXX" item="Inv o1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="56" mask="XXXXXVXX" item="Recip1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="56" mask="XXXVVXXX" item="Eff1">
@@ -1292,25 +1075,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="63" mask="VXXXXXXX" item="Inv o2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="63" mask="XXXXXVXX" item="Recip2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="63" mask="XXXVVXXX" item="Eff2">
@@ -1471,25 +1240,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="70" mask="VXXXXXXX" item="Inv o3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="70" mask="XXXXXVXX" item="Recip3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="70" mask="XXXVVXXX" item="Eff3">
@@ -1650,25 +1405,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="77" mask="VXXXXXXX" item="Inv o4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="77" mask="XXXXXVXX" item="Recip4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="77" mask="XXXVVXXX" item="Eff4">
@@ -1829,25 +1570,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="84" mask="VXXXXXXX" item="Inv o5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="84" mask="XXXXXVXX" item="Recip5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="84" mask="XXXVVXXX" item="Eff5">
@@ -2008,25 +1735,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="91" mask="VXXXXXXX" item="Inv o6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="91" mask="XXXXXVXX" item="Recip6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="91" mask="XXXVVXXX" item="Eff6">
@@ -2187,25 +1900,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="98" mask="VXXXXXXX" item="Inv o7">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="98" mask="XXXXXVXX" item="Recip7">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="98" mask="XXXVVXXX" item="Eff7">
@@ -2366,25 +2065,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="105" mask="VXXXXXXX" item="Inv o8">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="105" mask="XXXXXVXX" item="Recip8">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="105" mask="XXXVVXXX" item="Eff8">
@@ -2545,25 +2230,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="112" mask="VXXXXXXX" item="Inv o9">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="112" mask="XXXXXVXX" item="Recip9">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="112" mask="XXXVVXXX" item="Eff9">
@@ -2724,25 +2395,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="119" mask="VXXXXXXX" item="Inv o10">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="119" mask="XXXXXVXX" item="Recip10">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="119" mask="XXXVVXXX" item="Eff10">
@@ -2903,25 +2560,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="126" mask="VXXXXXXX" item="Inv o11">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="126" mask="XXXXXVXX" item="Recip11">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="126" mask="XXXVVXXX" item="Eff11">
@@ -3082,25 +2725,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="133" mask="VXXXXXXX" item="Inv o12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="133" mask="XXXXXVXX" item="Recip12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="133" mask="XXXVVXXX" item="Eff12">
@@ -3261,25 +2890,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="140" mask="VXXXXXXX" item="Inv o13">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="140" mask="XXXXXVXX" item="Recip13">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="140" mask="XXXVVXXX" item="Eff13">
@@ -3440,25 +3055,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="147" mask="VXXXXXXX" item="Inv o14">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="147" mask="XXXXXVXX" item="Recip14">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="147" mask="XXXVVXXX" item="Eff14">
@@ -3619,25 +3220,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="154" mask="VXXXXXXX" item="Inv o15">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="154" mask="XXXXXVXX" item="Recip15">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="154" mask="XXXVVXXX" item="Eff15">
@@ -3798,25 +3385,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="161" mask="VXXXXXXX" item="Inv o16">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="161" mask="XXXXXVXX" item="Recip16">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="161" mask="XXXVVXXX" item="Eff16">
@@ -3977,25 +3550,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="168" mask="VXXXXXXX" item="Inv o17">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="168" mask="XXXXXVXX" item="Recip17">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="168" mask="XXXVVXXX" item="Eff17">
@@ -4156,25 +3715,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="175" mask="VXXXXXXX" item="Inv o18">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="175" mask="XXXXXVXX" item="Recip18">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="175" mask="XXXVVXXX" item="Eff18">
@@ -4335,25 +3880,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="182" mask="VXXXXXXX" item="Inv o19">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="182" mask="XXXXXVXX" item="Recip19">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="182" mask="XXXVVXXX" item="Eff19">
@@ -4514,25 +4045,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="189" mask="VXXXXXXX" item="Inv o20">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="189" mask="XXXXXVXX" item="Recip20">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="189" mask="XXXVVXXX" item="Eff20">
@@ -4693,25 +4210,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="196" mask="VXXXXXXX" item="Inv o21">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="196" mask="XXXXXVXX" item="Recip21">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="196" mask="XXXVVXXX" item="Eff21">
@@ -4872,25 +4375,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="203" mask="VXXXXXXX" item="Inv o22">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="203" mask="XXXXXVXX" item="Recip22">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="203" mask="XXXVVXXX" item="Eff22">
@@ -5051,25 +4540,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="210" mask="VXXXXXXX" item="Inv o23">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="210" mask="XXXXXVXX" item="Recip23">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="210" mask="XXXVVXXX" item="Eff23">
@@ -5230,25 +4705,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="217" mask="VXXXXXXX" item="Inv o24">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="217" mask="XXXXXVXX" item="Recip24">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="217" mask="XXXVVXXX" item="Eff24">

--- a/xml/decoders/TD_SIC24AD.xml
+++ b/xml/decoders/TD_SIC24AD.xml
@@ -153,10 +153,7 @@
         <label>Manufacturer ID</label>
       </variable>
       <variable item="Ops Mode" CV="9" mask="XXXXXXXV">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Ops Mode</label>
       </variable>
       <variable item="Logic Cell Msg" CV="9" mask="XXXXXXVX">
@@ -167,38 +164,23 @@
         <label>Logic Cell Msg</label>
       </variable>
       <variable item="DCC gateway" CV="9" mask="XXXXXVXX">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC gateway</label>
       </variable>
       <variable item="Sw Throw Msg" CV="9" mask="XXXXVXXX">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Sw Throw Msg</label>
       </variable>
       <variable item="Sw Close Msg" CV="9" mask="XXXVXXXX">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Sw Close Msg</label>
       </variable>
       <variable item="Interrogate input" CV="9" mask="XVXXXXXX">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Interrogate input</label>
       </variable>
       <variable item="Common Cathode LEDs" CV="9" mask="VXXXXXXX">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Common Cathode LEDs</label>
       </variable>
       <variable item="Primary Address 1" CV="10" mask="VVVVVVVV">
@@ -206,17 +188,11 @@
         <label>Primary Address 1</label>
       </variable>
       <variable CV="11" mask="VXXXXXXX" item="Inv P1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="11" mask="XVXXXXXX" item="Tog P1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable item="Primary Type 1" CV="11" mask="XXVVXXXX">
@@ -241,10 +217,7 @@
         <label>Secondary Address 1</label>
       </variable>
       <variable CV="14" mask="VXXXXXXX" item="Inv S1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable item="Secondary Type 1" CV="14" mask="XXVVXXXX">
@@ -269,17 +242,11 @@
         <label>Primary Address 2</label>
       </variable>
       <variable CV="16" mask="VXXXXXXX" item="Inv P2">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="16" mask="XVXXXXXX" item="Tog P2">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable item="Primary Type 2" CV="16" mask="XXVVXXXX">
@@ -304,10 +271,7 @@
         <label>Secondary Address 2</label>
       </variable>
       <variable CV="19" mask="VXXXXXXX" item="Inv S2">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable item="Secondary Type 2" CV="19" mask="XXVVXXXX">
@@ -332,17 +296,11 @@
         <label>Primary Address 3</label>
       </variable>
       <variable CV="21" mask="VXXXXXXX" item="Inv P3">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="21" mask="XVXXXXXX" item="Tog P3">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable item="Primary Type 3" CV="21" mask="XXVVXXXX">
@@ -367,10 +325,7 @@
         <label>Secondary Address 3</label>
       </variable>
       <variable CV="24" mask="VXXXXXXX" item="Inv S3">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable item="Secondary Type 3" CV="24" mask="XXVVXXXX">
@@ -396,17 +351,11 @@
         <label>Primary Address 4</label>
       </variable>
       <variable CV="26" mask="VXXXXXXX" item="Inv P4">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="26" mask="XVXXXXXX" item="Tog P4">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable item="Primary Type 4" CV="26" mask="XXVVXXXX">
@@ -431,10 +380,7 @@
         <label>Secondary Address 4</label>
       </variable>
       <variable CV="29" mask="VXXXXXXX" item="Inv S4">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable item="Secondary Type 4" CV="29" mask="XXVVXXXX">
@@ -459,17 +405,11 @@
         <label>Primary Address 5</label>
       </variable>
       <variable CV="31" mask="VXXXXXXX" item="Inv P5">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="31" mask="XVXXXXXX" item="Tog P5">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable item="Primary Type 5" CV="31" mask="XXVVXXXX">
@@ -494,10 +434,7 @@
         <label>Secondary Address 5</label>
       </variable>
       <variable CV="34" mask="VXXXXXXX" item="Inv S5">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable item="Secondary Type 5" CV="34" mask="XXVVXXXX">
@@ -522,17 +459,11 @@
         <label>Primary Address 6</label>
       </variable>
       <variable CV="36" mask="VXXXXXXX" item="Inv P6">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="36" mask="XVXXXXXX" item="Tog P6">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable item="Primary Type 6" CV="36" mask="XXVVXXXX">
@@ -557,10 +488,7 @@
         <label>Secondary Address 6</label>
       </variable>
       <variable CV="39" mask="VXXXXXXX" item="Inv S6">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable item="Secondary Type 6" CV="39" mask="XXVVXXXX">
@@ -585,17 +513,11 @@
         <label>Primary Address 7</label>
       </variable>
       <variable CV="41" mask="VXXXXXXX" item="Inv P7">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="41" mask="XVXXXXXX" item="Tog P7">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable item="Primary Type 7" CV="41" mask="XXVVXXXX">
@@ -620,10 +542,7 @@
         <label>Secondary Address 7</label>
       </variable>
       <variable CV="44" mask="VXXXXXXX" item="Inv S7">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable item="Secondary Type 7" CV="44" mask="XXVVXXXX">
@@ -648,17 +567,11 @@
         <label>Primary Address 8</label>
       </variable>
       <variable CV="46" mask="VXXXXXXX" item="Inv P8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="46" mask="XVXXXXXX" item="Tog P8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable item="Primary Type 8" CV="46" mask="XXVVXXXX">
@@ -683,10 +596,7 @@
         <label>Secondary Address 8</label>
       </variable>
       <variable CV="49" mask="VXXXXXXX" item="Inv S8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable item="Secondary Type 8" CV="49" mask="XXVVXXXX">
@@ -786,17 +696,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="56" mask="VXXXXXXX" item="Inv o1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="56" mask="XXXXXVXX" item="Recip1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="56" mask="XXXVVXXX" item="Eff1">
@@ -897,17 +801,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="63" mask="VXXXXXXX" item="Inv o2">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="63" mask="XXXXXVXX" item="Recip2">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="63" mask="XXXVVXXX" item="Eff2">
@@ -1008,17 +906,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="70" mask="VXXXXXXX" item="Inv o3">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="70" mask="XXXXXVXX" item="Recip3">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="70" mask="XXXVVXXX" item="Eff3">
@@ -1119,17 +1011,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="77" mask="VXXXXXXX" item="Inv o4">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="77" mask="XXXXXVXX" item="Recip4">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="77" mask="XXXVVXXX" item="Eff4">
@@ -1230,17 +1116,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="84" mask="VXXXXXXX" item="Inv o5">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="84" mask="XXXXXVXX" item="Recip5">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="84" mask="XXXVVXXX" item="Eff5">
@@ -1341,17 +1221,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="91" mask="VXXXXXXX" item="Inv o6">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="91" mask="XXXXXVXX" item="Recip6">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="91" mask="XXXVVXXX" item="Eff6">
@@ -1452,17 +1326,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="98" mask="VXXXXXXX" item="Inv o7">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="98" mask="XXXXXVXX" item="Recip7">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="98" mask="XXXVVXXX" item="Eff7">
@@ -1563,17 +1431,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="105" mask="VXXXXXXX" item="Inv o8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="105" mask="XXXXXVXX" item="Recip8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="105" mask="XXXVVXXX" item="Eff8">
@@ -1674,17 +1536,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="112" mask="VXXXXXXX" item="Inv o9">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="112" mask="XXXXXVXX" item="Recip9">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="112" mask="XXXVVXXX" item="Eff9">
@@ -1785,17 +1641,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="119" mask="VXXXXXXX" item="Inv o10">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="119" mask="XXXXXVXX" item="Recip10">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="119" mask="XXXVVXXX" item="Eff10">
@@ -1896,17 +1746,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="126" mask="VXXXXXXX" item="Inv o11">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="126" mask="XXXXXVXX" item="Recip11">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="126" mask="XXXVVXXX" item="Eff11">
@@ -2007,17 +1851,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="133" mask="VXXXXXXX" item="Inv o12">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="133" mask="XXXXXVXX" item="Recip12">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="133" mask="XXXVVXXX" item="Eff12">
@@ -2118,17 +1956,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="140" mask="VXXXXXXX" item="Inv o13">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="140" mask="XXXXXVXX" item="Recip13">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="140" mask="XXXVVXXX" item="Eff13">
@@ -2229,17 +2061,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="147" mask="VXXXXXXX" item="Inv o14">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="147" mask="XXXXXVXX" item="Recip14">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="147" mask="XXXVVXXX" item="Eff14">
@@ -2340,17 +2166,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="154" mask="VXXXXXXX" item="Inv o15">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="154" mask="XXXXXVXX" item="Recip15">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="154" mask="XXXVVXXX" item="Eff15">
@@ -2451,17 +2271,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="161" mask="VXXXXXXX" item="Inv o16">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="161" mask="XXXXXVXX" item="Recip16">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="161" mask="XXXVVXXX" item="Eff16">
@@ -2562,17 +2376,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="168" mask="VXXXXXXX" item="Inv o17">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="168" mask="XXXXXVXX" item="Recip17">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="168" mask="XXXVVXXX" item="Eff17">
@@ -2673,17 +2481,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="175" mask="VXXXXXXX" item="Inv o18">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="175" mask="XXXXXVXX" item="Recip18">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="175" mask="XXXVVXXX" item="Eff18">
@@ -2784,17 +2586,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="182" mask="VXXXXXXX" item="Inv o19">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="182" mask="XXXXXVXX" item="Recip19">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="182" mask="XXXVVXXX" item="Eff19">
@@ -2895,17 +2691,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="189" mask="VXXXXXXX" item="Inv o20">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="189" mask="XXXXXVXX" item="Recip20">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="189" mask="XXXVVXXX" item="Eff20">
@@ -3006,17 +2796,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="196" mask="VXXXXXXX" item="Inv o21">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="196" mask="XXXXXVXX" item="Recip21">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="196" mask="XXXVVXXX" item="Eff21">
@@ -3117,17 +2901,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="203" mask="VXXXXXXX" item="Inv o22">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="203" mask="XXXXXVXX" item="Recip22">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="203" mask="XXXVVXXX" item="Eff22">
@@ -3228,17 +3006,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="210" mask="VXXXXXXX" item="Inv o23">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="210" mask="XXXXXVXX" item="Recip23">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="210" mask="XXXVVXXX" item="Eff23">
@@ -3339,17 +3111,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="217" mask="VXXXXXXX" item="Inv o24">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="217" mask="XXXXXVXX" item="Recip24">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="217" mask="XXXVVXXX" item="Eff24">

--- a/xml/decoders/TD_SIC24e.xml
+++ b/xml/decoders/TD_SIC24e.xml
@@ -147,10 +147,7 @@
         <label>Manufacturer ID</label>
       </variable>
       <variable item="Ops Mode" CV="9" mask="XXXXXXXV">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Ops Mode</label>
       </variable>
       <variable item="Logic Cell Msg" CV="9" mask="XXXXXXVX">
@@ -161,38 +158,23 @@
         <label>Logic Cell Msg</label>
       </variable>
       <variable item="DCC gateway" CV="9" mask="XXXXXVXX">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC gateway</label>
       </variable>
       <variable item="Sw Throw Msg" CV="9" mask="XXXXVXXX">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Sw Throw Msg</label>
       </variable>
       <variable item="Sw Close Msg" CV="9" mask="XXXVXXXX">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Sw Close Msg</label>
       </variable>
       <variable item="Interrogate input" CV="9" mask="XVXXXXXX">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Interrogate input</label>
       </variable>
       <variable item="Common Cathode LEDs" CV="9" mask="VXXXXXXX">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Common Cathode LEDs</label>
       </variable>
       <variable item="Primary Address 1" CV="10" mask="VVVVVVVV">
@@ -200,17 +182,11 @@
         <label>Primary Address 1</label>
       </variable>
       <variable CV="11" mask="VXXXXXXX" item="Inv P1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="11" mask="XVXXXXXX" item="Tog P1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable item="Primary Type 1" CV="11" mask="XXVVXXXX">
@@ -235,10 +211,7 @@
         <label>Secondary Address 1</label>
       </variable>
       <variable CV="14" mask="VXXXXXXX" item="Inv S1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable item="Secondary Type 1" CV="14" mask="XXVVXXXX">
@@ -263,17 +236,11 @@
         <label>Primary Address 2</label>
       </variable>
       <variable CV="16" mask="VXXXXXXX" item="Inv P2">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="16" mask="XVXXXXXX" item="Tog P2">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable item="Primary Type 2" CV="16" mask="XXVVXXXX">
@@ -298,10 +265,7 @@
         <label>Secondary Address 2</label>
       </variable>
       <variable CV="19" mask="VXXXXXXX" item="Inv S2">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable item="Secondary Type 2" CV="19" mask="XXVVXXXX">
@@ -326,17 +290,11 @@
         <label>Primary Address 3</label>
       </variable>
       <variable CV="21" mask="VXXXXXXX" item="Inv P3">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="21" mask="XVXXXXXX" item="Tog P3">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable item="Primary Type 3" CV="21" mask="XXVVXXXX">
@@ -361,10 +319,7 @@
         <label>Secondary Address 3</label>
       </variable>
       <variable CV="24" mask="VXXXXXXX" item="Inv S3">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable item="Secondary Type 3" CV="24" mask="XXVVXXXX">
@@ -390,17 +345,11 @@
         <label>Primary Address 4</label>
       </variable>
       <variable CV="26" mask="VXXXXXXX" item="Inv P4">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="26" mask="XVXXXXXX" item="Tog P4">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable item="Primary Type 4" CV="26" mask="XXVVXXXX">
@@ -425,10 +374,7 @@
         <label>Secondary Address 4</label>
       </variable>
       <variable CV="29" mask="VXXXXXXX" item="Inv S4">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable item="Secondary Type 4" CV="29" mask="XXVVXXXX">
@@ -453,17 +399,11 @@
         <label>Primary Address 5</label>
       </variable>
       <variable CV="31" mask="VXXXXXXX" item="Inv P5">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="31" mask="XVXXXXXX" item="Tog P5">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable item="Primary Type 5" CV="31" mask="XXVVXXXX">
@@ -488,10 +428,7 @@
         <label>Secondary Address 5</label>
       </variable>
       <variable CV="34" mask="VXXXXXXX" item="Inv S5">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable item="Secondary Type 5" CV="34" mask="XXVVXXXX">
@@ -516,17 +453,11 @@
         <label>Primary Address 6</label>
       </variable>
       <variable CV="36" mask="VXXXXXXX" item="Inv P6">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="36" mask="XVXXXXXX" item="Tog P6">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable item="Primary Type 6" CV="36" mask="XXVVXXXX">
@@ -551,10 +482,7 @@
         <label>Secondary Address 6</label>
       </variable>
       <variable CV="39" mask="VXXXXXXX" item="Inv S6">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable item="Secondary Type 6" CV="39" mask="XXVVXXXX">
@@ -579,17 +507,11 @@
         <label>Primary Address 7</label>
       </variable>
       <variable CV="41" mask="VXXXXXXX" item="Inv P7">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="41" mask="XVXXXXXX" item="Tog P7">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable item="Primary Type 7" CV="41" mask="XXVVXXXX">
@@ -614,10 +536,7 @@
         <label>Secondary Address 7</label>
       </variable>
       <variable CV="44" mask="VXXXXXXX" item="Inv S7">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable item="Secondary Type 7" CV="44" mask="XXVVXXXX">
@@ -642,17 +561,11 @@
         <label>Primary Address 8</label>
       </variable>
       <variable CV="46" mask="VXXXXXXX" item="Inv P8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="46" mask="XVXXXXXX" item="Tog P8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable item="Primary Type 8" CV="46" mask="XXVVXXXX">
@@ -677,10 +590,7 @@
         <label>Secondary Address 8</label>
       </variable>
       <variable CV="49" mask="VXXXXXXX" item="Inv S8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable item="Secondary Type 8" CV="49" mask="XXVVXXXX">
@@ -780,17 +690,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="56" mask="VXXXXXXX" item="Inv o1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="56" mask="XXXXXVXX" item="Recip1">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="56" mask="XXXVVXXX" item="Eff1">
@@ -891,17 +795,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="63" mask="VXXXXXXX" item="Inv o2">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="63" mask="XXXXXVXX" item="Recip2">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="63" mask="XXXVVXXX" item="Eff2">
@@ -1002,17 +900,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="70" mask="VXXXXXXX" item="Inv o3">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="70" mask="XXXXXVXX" item="Recip3">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="70" mask="XXXVVXXX" item="Eff3">
@@ -1113,17 +1005,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="77" mask="VXXXXXXX" item="Inv o4">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="77" mask="XXXXXVXX" item="Recip4">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="77" mask="XXXVVXXX" item="Eff4">
@@ -1224,17 +1110,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="84" mask="VXXXXXXX" item="Inv o5">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="84" mask="XXXXXVXX" item="Recip5">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="84" mask="XXXVVXXX" item="Eff5">
@@ -1335,17 +1215,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="91" mask="VXXXXXXX" item="Inv o6">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="91" mask="XXXXXVXX" item="Recip6">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="91" mask="XXXVVXXX" item="Eff6">
@@ -1446,17 +1320,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="98" mask="VXXXXXXX" item="Inv o7">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="98" mask="XXXXXVXX" item="Recip7">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="98" mask="XXXVVXXX" item="Eff7">
@@ -1557,17 +1425,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="105" mask="VXXXXXXX" item="Inv o8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="105" mask="XXXXXVXX" item="Recip8">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="105" mask="XXXVVXXX" item="Eff8">
@@ -1668,17 +1530,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="112" mask="VXXXXXXX" item="Inv o9">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="112" mask="XXXXXVXX" item="Recip9">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="112" mask="XXXVVXXX" item="Eff9">
@@ -1779,17 +1635,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="119" mask="VXXXXXXX" item="Inv o10">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="119" mask="XXXXXVXX" item="Recip10">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="119" mask="XXXVVXXX" item="Eff10">
@@ -1890,17 +1740,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="126" mask="VXXXXXXX" item="Inv o11">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="126" mask="XXXXXVXX" item="Recip11">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="126" mask="XXXVVXXX" item="Eff11">
@@ -2001,17 +1845,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="133" mask="VXXXXXXX" item="Inv o12">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="133" mask="XXXXXVXX" item="Recip12">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="133" mask="XXXVVXXX" item="Eff12">
@@ -2112,17 +1950,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="140" mask="VXXXXXXX" item="Inv o13">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="140" mask="XXXXXVXX" item="Recip13">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="140" mask="XXXVVXXX" item="Eff13">
@@ -2223,17 +2055,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="147" mask="VXXXXXXX" item="Inv o14">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="147" mask="XXXXXVXX" item="Recip14">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="147" mask="XXXVVXXX" item="Eff14">
@@ -2334,17 +2160,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="154" mask="VXXXXXXX" item="Inv o15">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="154" mask="XXXXXVXX" item="Recip15">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="154" mask="XXXVVXXX" item="Eff15">
@@ -2445,17 +2265,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="161" mask="VXXXXXXX" item="Inv o16">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="161" mask="XXXXXVXX" item="Recip16">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="161" mask="XXXVVXXX" item="Eff16">
@@ -2556,17 +2370,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="168" mask="VXXXXXXX" item="Inv o17">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="168" mask="XXXXXVXX" item="Recip17">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="168" mask="XXXVVXXX" item="Eff17">
@@ -2667,17 +2475,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="175" mask="VXXXXXXX" item="Inv o18">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="175" mask="XXXXXVXX" item="Recip18">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="175" mask="XXXVVXXX" item="Eff18">
@@ -2778,17 +2580,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="182" mask="VXXXXXXX" item="Inv o19">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="182" mask="XXXXXVXX" item="Recip19">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="182" mask="XXXVVXXX" item="Eff19">
@@ -2889,17 +2685,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="189" mask="VXXXXXXX" item="Inv o20">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="189" mask="XXXXXVXX" item="Recip20">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="189" mask="XXXVVXXX" item="Eff20">
@@ -3000,17 +2790,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="196" mask="VXXXXXXX" item="Inv o21">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="196" mask="XXXXXVXX" item="Recip21">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="196" mask="XXXVVXXX" item="Eff21">
@@ -3111,17 +2895,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="203" mask="VXXXXXXX" item="Inv o22">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="203" mask="XXXXXVXX" item="Recip22">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="203" mask="XXXVVXXX" item="Eff22">
@@ -3222,17 +3000,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="210" mask="VXXXXXXX" item="Inv o23">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="210" mask="XXXXXVXX" item="Recip23">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="210" mask="XXXVVXXX" item="Eff23">
@@ -3333,17 +3105,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="217" mask="VXXXXXXX" item="Inv o24">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="217" mask="XXXXXVXX" item="Recip24">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="217" mask="XXXVVXXX" item="Eff24">

--- a/xml/decoders/TD_SMC4.xml
+++ b/xml/decoders/TD_SMC4.xml
@@ -146,36 +146,15 @@
         <label>Mode</label>
       </variable>
       <variable item="Option 1" CV="29" mask="XXXXVXXX">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Option 1</label>
       </variable>
       <variable item="Option 2" CV="29" mask="XXXVXXXX">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Option 2</label>
       </variable>
       <variable item="Option 3" CV="29" mask="XXVXXXXX">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Option 3</label>
       </variable>
       <variable CV="31" mask="XVVVVVVV" item="Short Address" default="1" tooltip="Range 1-99">
@@ -635,14 +614,7 @@
         <label>Servo 1 Behavior</label>
       </variable>
       <variable item="Rev1" CV="71" mask="VXXXXXXX" default="0">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reverse</label>
       </variable>
       <variable item="Servo 2 Behavior" CV="72" mask="XXXXVVVV" default="0">
@@ -666,14 +638,7 @@
         <label>Servo 2 Behavior</label>
       </variable>
       <variable item="Rev2" CV="72" mask="VXXXXXXX" default="0">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reverse</label>
       </variable>
       <variable item="Servo 3 Behavior" CV="73" mask="XXXXVVVV" default="0">
@@ -697,14 +662,7 @@
         <label>Servo 3 Behavior</label>
       </variable>
       <variable item="Rev3" CV="73" mask="VXXXXXXX" default="0">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reverse</label>
       </variable>
       <variable item="Servo 4 Behavior" CV="74" mask="XXXXVVVV" default="0">
@@ -728,14 +686,7 @@
         <label>Servo 4 Behavior</label>
       </variable>
       <variable item="Rev4" CV="74" mask="VXXXXXXX" default="0">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reverse</label>
       </variable>
       <variable item="Output 5" CV="75" mask="XXXXXXVV" default="00">
@@ -753,36 +704,15 @@
         <label>Output 5</label>
       </variable>
       <variable item="Output 6" CV="75" mask="XXXXXVXX">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Output 6</label>
       </variable>
       <variable item="Output 7" CV="75" mask="XXXXVXXX">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Output 7</label>
       </variable>
       <variable item="Output 8" CV="75" mask="XXXVXXXX">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Output 8</label>
       </variable>
       <!-- Begin route variable definition -->
@@ -795,91 +725,35 @@
         <label>Route Group 9-16 Address</label>
       </variable>
       <variable item="R1 Out1" CV="81" mask="XXXXXXXV" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R1 Out2" CV="81" mask="XXXXXXVX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R1 Out3" CV="81" mask="XXXXXVXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R1 Out4" CV="81" mask="XXXXVXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R1 Out5" CV="81" mask="XXXVXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R1 Out6" CV="81" mask="XXVXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R1 Out7" CV="81" mask="XVXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R1 Out8" CV="81" mask="VXXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R1 S1" CV="82" mask="XXXXXXXV" default="0">
@@ -971,91 +845,35 @@
         <label/>
       </variable>
       <variable item="R2 Out1" CV="83" mask="XXXXXXXV" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R2 Out2" CV="83" mask="XXXXXXVX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R2 Out3" CV="83" mask="XXXXXVXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R2 Out4" CV="83" mask="XXXXVXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R2 Out5" CV="83" mask="XXXVXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R2 Out6" CV="83" mask="XXVXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R2 Out7" CV="83" mask="XVXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R2 Out8" CV="83" mask="VXXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R2 S1" CV="84" mask="XXXXXXXV" default="0">
@@ -1147,91 +965,35 @@
         <label/>
       </variable>
       <variable item="R3 Out1" CV="85" mask="XXXXXXXV" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R3 Out2" CV="85" mask="XXXXXXVX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R3 Out3" CV="85" mask="XXXXXVXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R3 Out4" CV="85" mask="XXXXVXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R3 Out5" CV="85" mask="XXXVXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R3 Out6" CV="85" mask="XXVXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R3 Out7" CV="85" mask="XVXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R3 Out8" CV="85" mask="VXXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R3 S1" CV="86" mask="XXXXXXXV" default="0">
@@ -1323,91 +1085,35 @@
         <label/>
       </variable>
       <variable item="R4 Out1" CV="87" mask="XXXXXXXV" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R4 Out2" CV="87" mask="XXXXXXVX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R4 Out3" CV="87" mask="XXXXXVXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R4 Out4" CV="87" mask="XXXXVXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R4 Out5" CV="87" mask="XXXVXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R4 Out6" CV="87" mask="XXVXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R4 Out7" CV="87" mask="XVXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R4 Out8" CV="87" mask="VXXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R4 S1" CV="88" mask="XXXXXXXV" default="0">
@@ -1499,91 +1205,35 @@
         <label/>
       </variable>
       <variable item="R5 Out1" CV="89" mask="XXXXXXXV" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R5 Out2" CV="89" mask="XXXXXXVX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R5 Out3" CV="89" mask="XXXXXVXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R5 Out4" CV="89" mask="XXXXVXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R5 Out5" CV="89" mask="XXXVXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R5 Out6" CV="89" mask="XXVXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R5 Out7" CV="89" mask="XVXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R5 Out8" CV="89" mask="VXXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R5 S1" CV="90" mask="XXXXXXXV" default="0">
@@ -1675,91 +1325,35 @@
         <label/>
       </variable>
       <variable item="R6 Out1" CV="91" mask="XXXXXXXV" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R6 Out2" CV="91" mask="XXXXXXVX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R6 Out3" CV="91" mask="XXXXXVXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R6 Out4" CV="91" mask="XXXXVXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R6 Out5" CV="91" mask="XXXVXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R6 Out6" CV="91" mask="XXVXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R6 Out7" CV="91" mask="XVXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R6 Out8" CV="91" mask="VXXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R6 S1" CV="92" mask="XXXXXXXV" default="0">
@@ -1851,91 +1445,35 @@
         <label/>
       </variable>
       <variable item="R7 Out1" CV="93" mask="XXXXXXXV" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R7 Out2" CV="93" mask="XXXXXXVX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R7 Out3" CV="93" mask="XXXXXVXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R7 Out4" CV="93" mask="XXXXVXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R7 Out5" CV="93" mask="XXXVXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R7 Out6" CV="93" mask="XXVXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R7 Out7" CV="93" mask="XVXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R7 Out8" CV="93" mask="VXXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R7 S1" CV="94" mask="XXXXXXXV" default="0">
@@ -2027,91 +1565,35 @@
         <label/>
       </variable>
       <variable item="R8 Out1" CV="95" mask="XXXXXXXV" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R8 Out2" CV="95" mask="XXXXXXVX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R8 Out3" CV="95" mask="XXXXXVXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R8 Out4" CV="95" mask="XXXXVXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R8 Out5" CV="95" mask="XXXVXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R8 Out6" CV="95" mask="XXVXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R8 Out7" CV="95" mask="XVXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R8 Out8" CV="95" mask="VXXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R8 S1" CV="96" mask="XXXXXXXV" default="0">
@@ -2203,91 +1685,35 @@
         <label/>
       </variable>
       <variable item="R9 Out1" CV="97" mask="XXXXXXXV" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R9 Out2" CV="97" mask="XXXXXXVX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R9 Out3" CV="97" mask="XXXXXVXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R9 Out4" CV="97" mask="XXXXVXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R9 Out5" CV="97" mask="XXXVXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R9 Out6" CV="97" mask="XXVXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R9 Out7" CV="97" mask="XVXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R9 Out8" CV="97" mask="VXXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R9 S1" CV="98" mask="XXXXXXXV" default="0">
@@ -2379,91 +1805,35 @@
         <label/>
       </variable>
       <variable item="R10 Out1" CV="99" mask="XXXXXXXV" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R10 Out2" CV="99" mask="XXXXXXVX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R10 Out3" CV="99" mask="XXXXXVXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R10 Out4" CV="99" mask="XXXXVXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R10 Out5" CV="99" mask="XXXVXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R10 Out6" CV="99" mask="XXVXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R10 Out7" CV="99" mask="XVXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R10 Out8" CV="99" mask="VXXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R10 S1" CV="100" mask="XXXXXXXV" default="0">
@@ -2555,91 +1925,35 @@
         <label/>
       </variable>
       <variable item="R11 Out1" CV="101" mask="XXXXXXXV" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R11 Out2" CV="101" mask="XXXXXXVX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R11 Out3" CV="101" mask="XXXXXVXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R11 Out4" CV="101" mask="XXXXVXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R11 Out5" CV="101" mask="XXXVXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R11 Out6" CV="101" mask="XXVXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R11 Out7" CV="101" mask="XVXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R11 Out8" CV="101" mask="VXXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R11 S1" CV="102" mask="XXXXXXXV" default="0">
@@ -2731,91 +2045,35 @@
         <label/>
       </variable>
       <variable item="R12 Out1" CV="103" mask="XXXXXXXV" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R12 Out2" CV="103" mask="XXXXXXVX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R12 Out3" CV="103" mask="XXXXXVXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R12 Out4" CV="103" mask="XXXXVXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R12 Out5" CV="103" mask="XXXVXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R12 Out6" CV="103" mask="XXVXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R12 Out7" CV="103" mask="XVXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R12 Out8" CV="103" mask="VXXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R12 S1" CV="104" mask="XXXXXXXV" default="0">
@@ -2907,91 +2165,35 @@
         <label/>
       </variable>
       <variable item="R13 Out1" CV="105" mask="XXXXXXXV" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R13 Out2" CV="105" mask="XXXXXXVX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R13 Out3" CV="105" mask="XXXXXVXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R13 Out4" CV="105" mask="XXXXVXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R13 Out5" CV="105" mask="XXXVXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R13 Out6" CV="105" mask="XXVXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R13 Out7" CV="105" mask="XVXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R13 Out8" CV="105" mask="VXXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R13 S1" CV="106" mask="XXXXXXXV" default="0">
@@ -3083,91 +2285,35 @@
         <label/>
       </variable>
       <variable item="R14 Out1" CV="107" mask="XXXXXXXV" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R14 Out2" CV="107" mask="XXXXXXVX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R14 Out3" CV="107" mask="XXXXXVXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R14 Out4" CV="107" mask="XXXXVXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R14 Out5" CV="107" mask="XXXVXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R14 Out6" CV="107" mask="XXVXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R14 Out7" CV="107" mask="XVXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R14 Out8" CV="107" mask="VXXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R14 S1" CV="108" mask="XXXXXXXV" default="0">
@@ -3259,91 +2405,35 @@
         <label/>
       </variable>
       <variable item="R15 Out1" CV="109" mask="XXXXXXXV" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R15 Out2" CV="109" mask="XXXXXXVX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R15 Out3" CV="109" mask="XXXXXVXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R15 Out4" CV="109" mask="XXXXVXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R15 Out5" CV="109" mask="XXXVXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R15 Out6" CV="109" mask="XXVXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R15 Out7" CV="109" mask="XVXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R15 Out8" CV="109" mask="VXXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R15 S1" CV="110" mask="XXXXXXXV" default="0">
@@ -3435,91 +2525,35 @@
         <label/>
       </variable>
       <variable item="R16 Out1" CV="111" mask="XXXXXXXV" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R16 Out2" CV="111" mask="XXXXXXVX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R16 Out3" CV="111" mask="XXXXXVXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R16 Out4" CV="111" mask="XXXXVXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R16 Out5" CV="111" mask="XXXVXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R16 Out6" CV="111" mask="XXVXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R16 Out7" CV="111" mask="XVXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R16 Out8" CV="111" mask="VXXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R16 S1" CV="112" mask="XXXXXXXV" default="0">

--- a/xml/decoders/TD_SMD8.xml
+++ b/xml/decoders/TD_SMD8.xml
@@ -192,135 +192,51 @@
         <label>Output 8 Type</label>
       </variable>
       <variable item="Input 1 Toggle" CV="14" mask="XXXXXXXV" default="0" tooltip="Check to enable toggle function">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Input 1 Toggle</label>
       </variable>
       <variable item="Input 2 Toggle" CV="14" mask="XXXXXXVX" default="0" tooltip="Check to enable toggle function">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Input 2 Toggle</label>
       </variable>
       <variable item="Input 3 Toggle" CV="14" mask="XXXXXVXX" default="0" tooltip="Check to enable toggle function">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Input 3 Toggle</label>
       </variable>
       <variable item="Input 4 Toggle" CV="14" mask="XXXXVXXX" default="0" tooltip="Check to enable toggle function">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Input 4 Toggle</label>
       </variable>
       <variable item="LR1 Out1" CV="15" mask="XXXXXXXV" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="LR1 Out2" CV="15" mask="XXXXXXVX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="LR1 Out3" CV="15" mask="XXXXXVXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="LR1 Out4" CV="15" mask="XXXXVXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="LR1 Out5" CV="15" mask="XXXVXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="LR1 Out6" CV="15" mask="XXVXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="LR1 Out7" CV="15" mask="XVXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="LR1 Out8" CV="15" mask="VXXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="LR1 S1" CV="16" mask="XXXXXXXV" default="0">
@@ -412,91 +328,35 @@
         <label/>
       </variable>
       <variable item="LR2 Out1" CV="17" mask="XXXXXXXV" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="LR2 Out2" CV="17" mask="XXXXXXVX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="LR2 Out3" CV="17" mask="XXXXXVXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="LR2 Out4" CV="17" mask="XXXXVXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="LR2 Out5" CV="17" mask="XXXVXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="LR2 Out6" CV="17" mask="XXVXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="LR2 Out7" CV="17" mask="XVXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="LR2 Out8" CV="17" mask="VXXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="LR2 S1" CV="18" mask="XXXXXXXV" default="0">
@@ -588,91 +448,35 @@
         <label/>
       </variable>
       <variable item="LR3 Out1" CV="19" mask="XXXXXXXV" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="LR3 Out2" CV="19" mask="XXXXXXVX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="LR3 Out3" CV="19" mask="XXXXXVXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="LR3 Out4" CV="19" mask="XXXXVXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="LR3 Out5" CV="19" mask="XXXVXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="LR3 Out6" CV="19" mask="XXVXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="LR3 Out7" CV="19" mask="XVXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="LR3 Out8" CV="19" mask="VXXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="LR3 S1" CV="20" mask="XXXXXXXV" default="0">
@@ -764,91 +568,35 @@
         <label/>
       </variable>
       <variable item="LR4 Out1" CV="21" mask="XXXXXXXV" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="LR4 Out2" CV="21" mask="XXXXXXVX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="LR4 Out3" CV="21" mask="XXXXXVXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="LR4 Out4" CV="21" mask="XXXXVXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="LR4 Out5" CV="21" mask="XXXVXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="LR4 Out6" CV="21" mask="XXVXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="LR4 Out7" CV="21" mask="XVXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="LR4 Out8" CV="21" mask="VXXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="LR4 S1" CV="22" mask="XXXXXXXV" default="0">
@@ -978,91 +726,35 @@
         <label>Select Power On Option</label>
       </variable>
       <variable item="R1 Out1" CV="30" mask="XXXXXXXV" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R1 Out2" CV="30" mask="XXXXXXVX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R1 Out3" CV="30" mask="XXXXXVXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R1 Out4" CV="30" mask="XXXXVXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R1 Out5" CV="30" mask="XXXVXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R1 Out6" CV="30" mask="XXVXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R1 Out7" CV="30" mask="XVXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R1 Out8" CV="30" mask="VXXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R1 S1" CV="31" mask="XXXXXXXV" default="0">
@@ -1154,91 +846,35 @@
         <label/>
       </variable>
       <variable item="R2 Out1" CV="32" mask="XXXXXXXV" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R2 Out2" CV="32" mask="XXXXXXVX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R2 Out3" CV="32" mask="XXXXXVXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R2 Out4" CV="32" mask="XXXXVXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R2 Out5" CV="32" mask="XXXVXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R2 Out6" CV="32" mask="XXVXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R2 Out7" CV="32" mask="XVXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R2 Out8" CV="32" mask="VXXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R2 S1" CV="33" mask="XXXXXXXV" default="0">
@@ -1330,91 +966,35 @@
         <label/>
       </variable>
       <variable item="R3 Out1" CV="34" mask="XXXXXXXV" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R3 Out2" CV="34" mask="XXXXXXVX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R3 Out3" CV="34" mask="XXXXXVXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R3 Out4" CV="34" mask="XXXXVXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R3 Out5" CV="34" mask="XXXVXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R3 Out6" CV="34" mask="XXVXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R3 Out7" CV="34" mask="XVXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R3 Out8" CV="34" mask="VXXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R3 S1" CV="35" mask="XXXXXXXV" default="0">
@@ -1506,91 +1086,35 @@
         <label/>
       </variable>
       <variable item="R4 Out1" CV="36" mask="XXXXXXXV" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R4 Out2" CV="36" mask="XXXXXXVX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R4 Out3" CV="36" mask="XXXXXVXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R4 Out4" CV="36" mask="XXXXVXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R4 Out5" CV="36" mask="XXXVXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R4 Out6" CV="36" mask="XXVXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R4 Out7" CV="36" mask="XVXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R4 Out8" CV="36" mask="VXXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R4 S1" CV="37" mask="XXXXXXXV" default="0">
@@ -1682,91 +1206,35 @@
         <label/>
       </variable>
       <variable item="R5 Out1" CV="38" mask="XXXXXXXV" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R5 Out2" CV="38" mask="XXXXXXVX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R5 Out3" CV="38" mask="XXXXXVXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R5 Out4" CV="38" mask="XXXXVXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R5 Out5" CV="38" mask="XXXVXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R5 Out6" CV="38" mask="XXVXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R5 Out7" CV="38" mask="XVXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R5 Out8" CV="38" mask="VXXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R5 S1" CV="39" mask="XXXXXXXV" default="0">
@@ -1858,91 +1326,35 @@
         <label/>
       </variable>
       <variable item="R6 Out1" CV="40" mask="XXXXXXXV" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R6 Out2" CV="40" mask="XXXXXXVX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R6 Out3" CV="40" mask="XXXXXVXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R6 Out4" CV="40" mask="XXXXVXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R6 Out5" CV="40" mask="XXXVXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R6 Out6" CV="40" mask="XXVXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R6 Out7" CV="40" mask="XVXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R6 Out8" CV="40" mask="VXXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R6 S1" CV="41" mask="XXXXXXXV" default="0">
@@ -2034,91 +1446,35 @@
         <label/>
       </variable>
       <variable item="R7 Out1" CV="42" mask="XXXXXXXV" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R7 Out2" CV="42" mask="XXXXXXVX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R7 Out3" CV="42" mask="XXXXXVXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R7 Out4" CV="42" mask="XXXXVXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R7 Out5" CV="42" mask="XXXVXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R7 Out6" CV="42" mask="XXVXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R7 Out7" CV="42" mask="XVXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R7 Out8" CV="42" mask="VXXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R7 S1" CV="43" mask="XXXXXXXV" default="0">
@@ -2210,91 +1566,35 @@
         <label/>
       </variable>
       <variable item="R8 Out1" CV="44" mask="XXXXXXXV" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R8 Out2" CV="44" mask="XXXXXXVX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R8 Out3" CV="44" mask="XXXXXVXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R8 Out4" CV="44" mask="XXXXVXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R8 Out5" CV="44" mask="XXXVXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R8 Out6" CV="44" mask="XXVXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R8 Out7" CV="44" mask="XVXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R8 Out8" CV="44" mask="VXXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R8 S1" CV="45" mask="XXXXXXXV" default="0">
@@ -2386,91 +1686,35 @@
         <label/>
       </variable>
       <variable item="R9 Out1" CV="46" mask="XXXXXXXV" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R9 Out2" CV="46" mask="XXXXXXVX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R9 Out3" CV="46" mask="XXXXXVXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R9 Out4" CV="46" mask="XXXXVXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R9 Out5" CV="46" mask="XXXVXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R9 Out6" CV="46" mask="XXVXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R9 Out7" CV="46" mask="XVXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R9 Out8" CV="46" mask="VXXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R9 S1" CV="47" mask="XXXXXXXV" default="0">
@@ -2562,91 +1806,35 @@
         <label/>
       </variable>
       <variable item="R10 Out1" CV="48" mask="XXXXXXXV" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R10 Out2" CV="48" mask="XXXXXXVX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R10 Out3" CV="48" mask="XXXXXVXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R10 Out4" CV="48" mask="XXXXVXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R10 Out5" CV="48" mask="XXXVXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R10 Out6" CV="48" mask="XXVXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R10 Out7" CV="48" mask="XVXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R10 Out8" CV="48" mask="VXXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R10 S1" CV="49" mask="XXXXXXXV" default="0">
@@ -2738,91 +1926,35 @@
         <label/>
       </variable>
       <variable item="R11 Out1" CV="50" mask="XXXXXXXV" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R11 Out2" CV="50" mask="XXXXXXVX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R11 Out3" CV="50" mask="XXXXXVXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R11 Out4" CV="50" mask="XXXXVXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R11 Out5" CV="50" mask="XXXVXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R11 Out6" CV="50" mask="XXVXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R11 Out7" CV="50" mask="XVXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R11 Out8" CV="50" mask="VXXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R11 S1" CV="51" mask="XXXXXXXV" default="0">
@@ -2914,91 +2046,35 @@
         <label/>
       </variable>
       <variable item="R12 Out1" CV="52" mask="XXXXXXXV" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R12 Out2" CV="52" mask="XXXXXXVX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R12 Out3" CV="52" mask="XXXXXVXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R12 Out4" CV="52" mask="XXXXVXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R12 Out5" CV="52" mask="XXXVXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R12 Out6" CV="52" mask="XXVXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R12 Out7" CV="52" mask="XVXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R12 Out8" CV="52" mask="VXXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R12 S1" CV="53" mask="XXXXXXXV" default="0">
@@ -3090,91 +2166,35 @@
         <label/>
       </variable>
       <variable item="R13 Out1" CV="54" mask="XXXXXXXV" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R13 Out2" CV="54" mask="XXXXXXVX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R13 Out3" CV="54" mask="XXXXXVXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R13 Out4" CV="54" mask="XXXXVXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R13 Out5" CV="54" mask="XXXVXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R13 Out6" CV="54" mask="XXVXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R13 Out7" CV="54" mask="XVXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R13 Out8" CV="54" mask="VXXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R13 S1" CV="55" mask="XXXXXXXV" default="0">
@@ -3266,91 +2286,35 @@
         <label/>
       </variable>
       <variable item="R14 Out1" CV="56" mask="XXXXXXXV" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R14 Out2" CV="56" mask="XXXXXXVX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R14 Out3" CV="56" mask="XXXXXVXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R14 Out4" CV="56" mask="XXXXVXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R14 Out5" CV="56" mask="XXXVXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R14 Out6" CV="56" mask="XXVXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R14 Out7" CV="56" mask="XVXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R14 Out8" CV="56" mask="VXXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R14 S1" CV="57" mask="XXXXXXXV" default="0">
@@ -3442,91 +2406,35 @@
         <label/>
       </variable>
       <variable item="R15 Out1" CV="58" mask="XXXXXXXV" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R15 Out2" CV="58" mask="XXXXXXVX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R15 Out3" CV="58" mask="XXXXXVXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R15 Out4" CV="58" mask="XXXXVXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R15 Out5" CV="58" mask="XXXVXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R15 Out6" CV="58" mask="XXVXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R15 Out7" CV="58" mask="XVXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R15 Out8" CV="58" mask="VXXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R15 S1" CV="59" mask="XXXXXXXV" default="0">
@@ -3618,91 +2526,35 @@
         <label/>
       </variable>
       <variable item="R16 Out1" CV="60" mask="XXXXXXXV" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R16 Out2" CV="60" mask="XXXXXXVX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R16 Out3" CV="60" mask="XXXXXVXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R16 Out4" CV="60" mask="XXXXVXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R16 Out5" CV="60" mask="XXXVXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R16 Out6" CV="60" mask="XXVXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R16 Out7" CV="60" mask="XVXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R16 Out8" CV="60" mask="VXXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R16 S1" CV="61" mask="XXXXXXXV" default="0">

--- a/xml/decoders/TD_SMD82.xml
+++ b/xml/decoders/TD_SMD82.xml
@@ -222,14 +222,7 @@
         <label>Select Power On Option</label>
       </variable>
       <variable CV="29" mask="XXXXXVXX" item="Op1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Option 3</label>
       </variable>
       <variable CV="31" mask="XVVVVVVV" item="Short Address" tooltip="Range 1-99">
@@ -981,14 +974,7 @@
         <label>Route Number</label>
       </variable>
       <variable item="Cond1" CV="67" mask="VXXXXXXX" default="0">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Conditional Route</label>
       </variable>
       <variable item="Transition A1" CV="68" mask="XXXXXXVV" default="2">
@@ -1031,14 +1017,7 @@
         <label>Route Number</label>
       </variable>
       <variable item="Cond2" CV="69" mask="VXXXXXXX" default="0">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Conditional Route</label>
       </variable>
       <variable item="Transition A2" CV="70" mask="XXXXXXVV" default="2">
@@ -1081,14 +1060,7 @@
         <label>Route Number</label>
       </variable>
       <variable item="Cond3" CV="71" mask="VXXXXXXX" default="0">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Conditional Route</label>
       </variable>
       <variable item="Transition A3" CV="72" mask="XXXXXXVV" default="2">
@@ -1131,14 +1103,7 @@
         <label>Route Number</label>
       </variable>
       <variable item="Cond4" CV="73" mask="VXXXXXXX" default="0">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Conditional Route</label>
       </variable>
       <variable item="Transition A4" CV="74" mask="XXXXXXVV" default="2">
@@ -1181,14 +1146,7 @@
         <label>Route Number</label>
       </variable>
       <variable item="Cond5" CV="75" mask="VXXXXXXX" default="0">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Conditional Route</label>
       </variable>
       <variable item="Transition A5" CV="76" mask="XXXXXXVV" default="2">
@@ -1236,91 +1194,35 @@
         <label>Route Group 9-16 Address</label>
       </variable>
       <variable item="R1 Out1" CV="81" mask="XXXXXXXV" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R1 Out2" CV="81" mask="XXXXXXVX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R1 Out3" CV="81" mask="XXXXXVXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R1 Out4" CV="81" mask="XXXXVXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R1 Out5" CV="81" mask="XXXVXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R1 Out6" CV="81" mask="XXVXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R1 Out7" CV="81" mask="XVXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R1 Out8" CV="81" mask="VXXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R1 S1" CV="82" mask="XXXXXXXV" default="0">
@@ -1412,91 +1314,35 @@
         <label/>
       </variable>
       <variable item="R2 Out1" CV="83" mask="XXXXXXXV" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R2 Out2" CV="83" mask="XXXXXXVX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R2 Out3" CV="83" mask="XXXXXVXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R2 Out4" CV="83" mask="XXXXVXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R2 Out5" CV="83" mask="XXXVXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R2 Out6" CV="83" mask="XXVXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R2 Out7" CV="83" mask="XVXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R2 Out8" CV="83" mask="VXXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R2 S1" CV="84" mask="XXXXXXXV" default="0">
@@ -1588,91 +1434,35 @@
         <label/>
       </variable>
       <variable item="R3 Out1" CV="85" mask="XXXXXXXV" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R3 Out2" CV="85" mask="XXXXXXVX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R3 Out3" CV="85" mask="XXXXXVXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R3 Out4" CV="85" mask="XXXXVXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R3 Out5" CV="85" mask="XXXVXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R3 Out6" CV="85" mask="XXVXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R3 Out7" CV="85" mask="XVXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R3 Out8" CV="85" mask="VXXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R3 S1" CV="86" mask="XXXXXXXV" default="0">
@@ -1764,91 +1554,35 @@
         <label/>
       </variable>
       <variable item="R4 Out1" CV="87" mask="XXXXXXXV" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R4 Out2" CV="87" mask="XXXXXXVX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R4 Out3" CV="87" mask="XXXXXVXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R4 Out4" CV="87" mask="XXXXVXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R4 Out5" CV="87" mask="XXXVXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R4 Out6" CV="87" mask="XXVXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R4 Out7" CV="87" mask="XVXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R4 Out8" CV="87" mask="VXXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R4 S1" CV="88" mask="XXXXXXXV" default="0">
@@ -1940,91 +1674,35 @@
         <label/>
       </variable>
       <variable item="R5 Out1" CV="89" mask="XXXXXXXV" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R5 Out2" CV="89" mask="XXXXXXVX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R5 Out3" CV="89" mask="XXXXXVXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R5 Out4" CV="89" mask="XXXXVXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R5 Out5" CV="89" mask="XXXVXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R5 Out6" CV="89" mask="XXVXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R5 Out7" CV="89" mask="XVXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R5 Out8" CV="89" mask="VXXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R5 S1" CV="90" mask="XXXXXXXV" default="0">
@@ -2116,91 +1794,35 @@
         <label/>
       </variable>
       <variable item="R6 Out1" CV="91" mask="XXXXXXXV" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R6 Out2" CV="91" mask="XXXXXXVX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R6 Out3" CV="91" mask="XXXXXVXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R6 Out4" CV="91" mask="XXXXVXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R6 Out5" CV="91" mask="XXXVXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R6 Out6" CV="91" mask="XXVXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R6 Out7" CV="91" mask="XVXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R6 Out8" CV="91" mask="VXXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R6 S1" CV="92" mask="XXXXXXXV" default="0">
@@ -2292,91 +1914,35 @@
         <label/>
       </variable>
       <variable item="R7 Out1" CV="93" mask="XXXXXXXV" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R7 Out2" CV="93" mask="XXXXXXVX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R7 Out3" CV="93" mask="XXXXXVXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R7 Out4" CV="93" mask="XXXXVXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R7 Out5" CV="93" mask="XXXVXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R7 Out6" CV="93" mask="XXVXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R7 Out7" CV="93" mask="XVXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R7 Out8" CV="93" mask="VXXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R7 S1" CV="94" mask="XXXXXXXV" default="0">
@@ -2468,91 +2034,35 @@
         <label/>
       </variable>
       <variable item="R8 Out1" CV="95" mask="XXXXXXXV" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R8 Out2" CV="95" mask="XXXXXXVX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R8 Out3" CV="95" mask="XXXXXVXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R8 Out4" CV="95" mask="XXXXVXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R8 Out5" CV="95" mask="XXXVXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R8 Out6" CV="95" mask="XXVXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R8 Out7" CV="95" mask="XVXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R8 Out8" CV="95" mask="VXXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R8 S1" CV="96" mask="XXXXXXXV" default="0">
@@ -2644,91 +2154,35 @@
         <label/>
       </variable>
       <variable item="R9 Out1" CV="97" mask="XXXXXXXV" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R9 Out2" CV="97" mask="XXXXXXVX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R9 Out3" CV="97" mask="XXXXXVXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R9 Out4" CV="97" mask="XXXXVXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R9 Out5" CV="97" mask="XXXVXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R9 Out6" CV="97" mask="XXVXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R9 Out7" CV="97" mask="XVXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R9 Out8" CV="97" mask="VXXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R9 S1" CV="98" mask="XXXXXXXV" default="0">
@@ -2820,91 +2274,35 @@
         <label/>
       </variable>
       <variable item="R10 Out1" CV="99" mask="XXXXXXXV" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R10 Out2" CV="99" mask="XXXXXXVX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R10 Out3" CV="99" mask="XXXXXVXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R10 Out4" CV="99" mask="XXXXVXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R10 Out5" CV="99" mask="XXXVXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R10 Out6" CV="99" mask="XXVXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R10 Out7" CV="99" mask="XVXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R10 Out8" CV="99" mask="VXXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R10 S1" CV="100" mask="XXXXXXXV" default="0">
@@ -2996,91 +2394,35 @@
         <label/>
       </variable>
       <variable item="R11 Out1" CV="101" mask="XXXXXXXV" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R11 Out2" CV="101" mask="XXXXXXVX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R11 Out3" CV="101" mask="XXXXXVXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R11 Out4" CV="101" mask="XXXXVXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R11 Out5" CV="101" mask="XXXVXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R11 Out6" CV="101" mask="XXVXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R11 Out7" CV="101" mask="XVXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R11 Out8" CV="101" mask="VXXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R11 S1" CV="102" mask="XXXXXXXV" default="0">
@@ -3172,91 +2514,35 @@
         <label/>
       </variable>
       <variable item="R12 Out1" CV="103" mask="XXXXXXXV" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R12 Out2" CV="103" mask="XXXXXXVX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R12 Out3" CV="103" mask="XXXXXVXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R12 Out4" CV="103" mask="XXXXVXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R12 Out5" CV="103" mask="XXXVXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R12 Out6" CV="103" mask="XXVXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R12 Out7" CV="103" mask="XVXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R12 Out8" CV="103" mask="VXXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R12 S1" CV="104" mask="XXXXXXXV" default="0">
@@ -3348,91 +2634,35 @@
         <label/>
       </variable>
       <variable item="R13 Out1" CV="105" mask="XXXXXXXV" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R13 Out2" CV="105" mask="XXXXXXVX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R13 Out3" CV="105" mask="XXXXXVXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R13 Out4" CV="105" mask="XXXXVXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R13 Out5" CV="105" mask="XXXVXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R13 Out6" CV="105" mask="XXVXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R13 Out7" CV="105" mask="XVXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R13 Out8" CV="105" mask="VXXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R13 S1" CV="106" mask="XXXXXXXV" default="0">
@@ -3524,91 +2754,35 @@
         <label/>
       </variable>
       <variable item="R14 Out1" CV="107" mask="XXXXXXXV" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R14 Out2" CV="107" mask="XXXXXXVX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R14 Out3" CV="107" mask="XXXXXVXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R14 Out4" CV="107" mask="XXXXVXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R14 Out5" CV="107" mask="XXXVXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R14 Out6" CV="107" mask="XXVXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R14 Out7" CV="107" mask="XVXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R14 Out8" CV="107" mask="VXXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R14 S1" CV="108" mask="XXXXXXXV" default="0">
@@ -3700,91 +2874,35 @@
         <label/>
       </variable>
       <variable item="R15 Out1" CV="109" mask="XXXXXXXV" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R15 Out2" CV="109" mask="XXXXXXVX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R15 Out3" CV="109" mask="XXXXXVXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R15 Out4" CV="109" mask="XXXXVXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R15 Out5" CV="109" mask="XXXVXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R15 Out6" CV="109" mask="XXVXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R15 Out7" CV="109" mask="XVXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R15 Out8" CV="109" mask="VXXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R15 S1" CV="110" mask="XXXXXXXV" default="0">
@@ -3876,91 +2994,35 @@
         <label/>
       </variable>
       <variable item="R16 Out1" CV="111" mask="XXXXXXXV" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R16 Out2" CV="111" mask="XXXXXXVX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R16 Out3" CV="111" mask="XXXXXVXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R16 Out4" CV="111" mask="XXXXVXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R16 Out5" CV="111" mask="XXXVXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R16 Out6" CV="111" mask="XXVXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R16 Out7" CV="111" mask="XVXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R16 Out8" CV="111" mask="VXXXXXXX" default="0" tooltip="Check to add output to this route">
-        <enumVal>
-          <enumChoice choice="no">
-            <choice>no</choice>
-          </enumChoice>
-          <enumChoice choice="yes">
-            <choice>yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label/>
       </variable>
       <variable item="R16 S1" CV="112" mask="XXXXXXXV" default="0">

--- a/xml/decoders/TD_SMD84.xml
+++ b/xml/decoders/TD_SMD84.xml
@@ -210,47 +210,19 @@
       </variable>
       <!-- Status Report variable definition -->
       <variable item="Power On Send Input State" CV="28" mask="XXXXXXXV">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Power On Send Input State</label>
       </variable>
       <variable item="Power On Send Output State" CV="28" mask="XXXXXXVX">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Power On Send Output State</label>
       </variable>
       <variable item="Interrogate input" CV="28" mask="XXXXXVXX">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Interrogate input</label>
       </variable>
       <variable item="Interrogate output" CV="28" mask="XXXXVXXX">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Interrogate output</label>
       </variable>
       <!-- Decoder Configuration variable definition -->
@@ -269,47 +241,19 @@
         <label>Select Power On Option</label>
       </variable>
       <variable CV="29" mask="XXXXXVXX" item="Op3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Option 3</label>
       </variable>
       <variable item="DCC gateway" CV="29" mask="XXXXVXXX">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC gateway</label>
       </variable>
       <variable item="Bus interface" CV="29" mask="XXXVXXXX">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Bus interface</label>
       </variable>
       <variable item="DCC control" CV="29" mask="XXVXXXXX">
-        <enumVal>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-YesNo.xml"/>
         <label>DCC control</label>
       </variable>
       <variable CV="31" mask="XVVVVVVV" item="Short Address" tooltip="Range 1-99" default="1">
@@ -435,25 +379,11 @@
         <label>Address</label>
       </variable>
       <variable CV="36" mask="VXXXXXXX" item="PInv P1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="36" mask="XVXXXXXX" item="PTog P1" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="36" mask="XXVVXXXX" item="PTy1">
@@ -496,25 +426,11 @@
         <label>Address</label>
       </variable>
       <variable CV="39" mask="VXXXXXXX" item="PInv P2" default="0">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="39" mask="XVXXXXXX" item="PTog P2" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="39" mask="XXVVXXXX" item="PTy2">
@@ -557,25 +473,11 @@
         <label>Address</label>
       </variable>
       <variable CV="42" mask="VXXXXXXX" item="PInv P3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="42" mask="XVXXXXXX" item="PTog P3" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="42" mask="XXVVXXXX" item="PTy3">
@@ -618,25 +520,11 @@
         <label>Address</label>
       </variable>
       <variable CV="45" mask="VXXXXXXX" item="PInv P4" default="0">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="45" mask="XVXXXXXX" item="PTog P4" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="45" mask="XXVVXXXX" item="PTy4">
@@ -679,25 +567,11 @@
         <label>Address</label>
       </variable>
       <variable CV="48" mask="VXXXXXXX" item="PInv P5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="48" mask="XVXXXXXX" item="PTog P5" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="48" mask="XXVVXXXX" item="PTy5">
@@ -740,25 +614,11 @@
         <label>Address</label>
       </variable>
       <variable CV="51" mask="VXXXXXXX" item="PInv P6" default="0">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="51" mask="XVXXXXXX" item="PTog P6" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="51" mask="XXVVXXXX" item="PTy6">
@@ -801,25 +661,11 @@
         <label>Address</label>
       </variable>
       <variable CV="54" mask="VXXXXXXX" item="PInv P7">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="54" mask="XVXXXXXX" item="PTog P7" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="54" mask="XXVVXXXX" item="PTy7">
@@ -862,25 +708,11 @@
         <label>Address</label>
       </variable>
       <variable CV="57" mask="VXXXXXXX" item="PInv P8" default="0">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="57" mask="XVXXXXXX" item="PTog P8" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="57" mask="XXVVXXXX" item="PTy8">
@@ -924,25 +756,11 @@
         <label>Address</label>
       </variable>
       <variable CV="60" mask="VXXXXXXX" item="SInv S1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="60" mask="XVXXXXXX" item="STog S1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="60" mask="XXVVXXXX" item="STy1">
@@ -985,25 +803,11 @@
         <label>Address</label>
       </variable>
       <variable CV="63" mask="VXXXXXXX" item="SInv S2" default="0">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="63" mask="XVXXXXXX" item="STog S2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="63" mask="XXVVXXXX" item="STy2">
@@ -1046,25 +850,11 @@
         <label>Address</label>
       </variable>
       <variable CV="66" mask="VXXXXXXX" item="SInv S3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="66" mask="XVXXXXXX" item="STog S3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="66" mask="XXVVXXXX" item="STy3">
@@ -1107,25 +897,11 @@
         <label>Address</label>
       </variable>
       <variable CV="69" mask="VXXXXXXX" item="SInv S4" default="0">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="69" mask="XVXXXXXX" item="STog S4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="69" mask="XXVVXXXX" item="STy4">
@@ -1168,25 +944,11 @@
         <label>Address</label>
       </variable>
       <variable CV="72" mask="VXXXXXXX" item="SInv S5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="72" mask="XVXXXXXX" item="STog S5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="72" mask="XXVVXXXX" item="STy5">
@@ -1229,25 +991,11 @@
         <label>Address</label>
       </variable>
       <variable CV="75" mask="VXXXXXXX" item="SInv S6" default="0">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="75" mask="XVXXXXXX" item="STog S6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="75" mask="XXVVXXXX" item="STy6">
@@ -1290,25 +1038,11 @@
         <label>Address</label>
       </variable>
       <variable CV="78" mask="VXXXXXXX" item="SInv S7">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="78" mask="XVXXXXXX" item="STog S7">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="78" mask="XXVVXXXX" item="STy7">
@@ -1351,25 +1085,11 @@
         <label>Address</label>
       </variable>
       <variable CV="81" mask="VXXXXXXX" item="SInv S8" default="0">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="81" mask="XVXXXXXX" item="STog S8">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="81" mask="XXVVXXXX" item="STy8">
@@ -1413,25 +1133,11 @@
         <label>Address</label>
       </variable>
       <variable CV="84" mask="VXXXXXXX" item="AInv A1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="84" mask="XVXXXXXX" item="ATog A1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="84" mask="XXVVXXXX" item="ATy1">
@@ -1474,25 +1180,11 @@
         <label>Address</label>
       </variable>
       <variable CV="87" mask="VXXXXXXX" item="AInv A2" default="0">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="87" mask="XVXXXXXX" item="ATog A2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="87" mask="XXVVXXXX" item="ATy2">
@@ -1535,25 +1227,11 @@
         <label>Address</label>
       </variable>
       <variable CV="90" mask="VXXXXXXX" item="AInv A3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="90" mask="XVXXXXXX" item="ATog A3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="90" mask="XXVVXXXX" item="ATy3">
@@ -1596,25 +1274,11 @@
         <label>Address</label>
       </variable>
       <variable CV="93" mask="VXXXXXXX" item="SInv A4" default="0">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="93" mask="XVXXXXXX" item="ATog A4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="93" mask="XXVVXXXX" item="ATy4">
@@ -1657,25 +1321,11 @@
         <label>Address</label>
       </variable>
       <variable CV="96" mask="VXXXXXXX" item="AInv A5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="96" mask="XVXXXXXX" item="ATog A5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="96" mask="XXVVXXXX" item="ATy5">

--- a/xml/decoders/TD_SRC16.xml
+++ b/xml/decoders/TD_SRC16.xml
@@ -72,124 +72,47 @@
         <label>Select Power On Option</label>
       </variable>
       <variable CV="9" mask="XXXXXVXX" item="Op1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Ops Mode</label>
       </variable>
       <variable item="DCC gateway" CV="9" mask="XXXXVXXX">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC gateway</label>
       </variable>
       <variable item="Bus interface" CV="9" mask="XXXVXXXX">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Bus interface</label>
       </variable>
       <variable item="DCC control" CV="9" mask="XXVXXXXX">
-        <enumVal>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-YesNo.xml"/>
         <label>DCC control</label>
       </variable>
       <variable item="Output Lockout" CV="9" mask="XVXXXXXX">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Output Lockout</label>
       </variable>
       <variable item="Common Cathode" CV="9" mask="VXXXXXXX">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Common Cathode</label>
       </variable>
       <variable item="Power On Send Input State" CV="10" mask="XXXXXXXV">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Power On Send Input State</label>
       </variable>
       <variable item="Power On Send Output State" CV="10" mask="XXXXXXVX">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Power On Send Output State</label>
       </variable>
       <variable item="Interrogate input" CV="10" mask="XXXXXVXX">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Interrogate input</label>
       </variable>
       <variable item="Interrogate output" CV="10" mask="XXXXVXXX">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Interrogate output</label>
       </variable>
       <variable item="Power On Send 16" CV="10" mask="XXXVXXXX">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Power On Send 16</label>
       </variable>
       <variable item="Route send delay" CV="11" mask="XVVVVVVV">
@@ -497,25 +420,11 @@
         <label>Address</label>
       </variable>
       <variable CV="17" mask="VXXXXXXX" item="PInv P1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="17" mask="XVXXXXXX" item="PTog P1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="17" mask="XXVVXXXX" item="PTy1">
@@ -558,25 +467,11 @@
         <label>Address</label>
       </variable>
       <variable CV="20" mask="VXXXXXXX" item="PInv P2" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="20" mask="XVXXXXXX" item="PTog P2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="20" mask="XXVVXXXX" item="PTy2">
@@ -619,25 +514,11 @@
         <label>Address</label>
       </variable>
       <variable CV="23" mask="VXXXXXXX" item="PInv P3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="23" mask="XVXXXXXX" item="PTog P3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="23" mask="XXVVXXXX" item="PTy3">
@@ -680,25 +561,11 @@
         <label>Address</label>
       </variable>
       <variable CV="26" mask="VXXXXXXX" item="PInv P4" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="26" mask="XVXXXXXX" item="PTog P4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="26" mask="XXVVXXXX" item="PTy4">
@@ -741,25 +608,11 @@
         <label>Address</label>
       </variable>
       <variable CV="29" mask="VXXXXXXX" item="PInv P5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="29" mask="XVXXXXXX" item="PTog P5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="29" mask="XXVVXXXX" item="PTy5">
@@ -802,25 +655,11 @@
         <label>Address</label>
       </variable>
       <variable CV="32" mask="VXXXXXXX" item="PInv P6" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="32" mask="XVXXXXXX" item="PTog P6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="32" mask="XXVVXXXX" item="PTy6">
@@ -863,25 +702,11 @@
         <label>Address</label>
       </variable>
       <variable CV="35" mask="VXXXXXXX" item="PInv P7">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="35" mask="XVXXXXXX" item="PTog P7">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="35" mask="XXVVXXXX" item="PTy7">
@@ -924,25 +749,11 @@
         <label>Address</label>
       </variable>
       <variable CV="38" mask="VXXXXXXX" item="PInv P8" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="38" mask="XVXXXXXX" item="PTog P8">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="38" mask="XXVVXXXX" item="PTy8">
@@ -986,25 +797,11 @@
         <label>Address</label>
       </variable>
       <variable CV="41" mask="VXXXXXXX" item="SInv P1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="41" mask="XVXXXXXX" item="STog P1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="41" mask="XXVVXXXX" item="STy1">
@@ -1047,25 +844,11 @@
         <label>Address</label>
       </variable>
       <variable CV="44" mask="VXXXXXXX" item="SInv P2" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="44" mask="XVXXXXXX" item="STog P2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="44" mask="XXVVXXXX" item="STy2">
@@ -1108,25 +891,11 @@
         <label>Address</label>
       </variable>
       <variable CV="47" mask="VXXXXXXX" item="SInv P3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="47" mask="XVXXXXXX" item="STog P3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="47" mask="XXVVXXXX" item="STy3">
@@ -1169,25 +938,11 @@
         <label>Address</label>
       </variable>
       <variable CV="50" mask="VXXXXXXX" item="SInv P4" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="50" mask="XVXXXXXX" item="STog P4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="50" mask="XXVVXXXX" item="STy4">
@@ -1230,25 +985,11 @@
         <label>Address</label>
       </variable>
       <variable CV="53" mask="VXXXXXXX" item="SInv P5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="53" mask="XVXXXXXX" item="STog P5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="53" mask="XXVVXXXX" item="STy5">
@@ -1291,25 +1032,11 @@
         <label>Address</label>
       </variable>
       <variable CV="56" mask="VXXXXXXX" item="SInv P6" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="56" mask="XVXXXXXX" item="STog P6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="56" mask="XXVVXXXX" item="STy6">
@@ -1352,25 +1079,11 @@
         <label>Address</label>
       </variable>
       <variable CV="59" mask="VXXXXXXX" item="SInv P7">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="59" mask="XVXXXXXX" item="STog P7">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="59" mask="XXVVXXXX" item="STy7">
@@ -1413,25 +1126,11 @@
         <label>Address</label>
       </variable>
       <variable CV="62" mask="VXXXXXXX" item="SInv P8" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="62" mask="XVXXXXXX" item="STog P8">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="62" mask="XXVVXXXX" item="STy8">
@@ -1514,25 +1213,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="66" mask="VXXXXXXX" item="Inv o1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="66" mask="XXXXXVXX" item="Recip1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="66" mask="XXXVVXXX" item="Eff1">
@@ -1610,25 +1295,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="69" mask="VXXXXXXX" item="Inv o2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="69" mask="XXXXXVXX" item="Recip2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="69" mask="XXXVVXXX" item="Eff2">
@@ -1706,25 +1377,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="72" mask="VXXXXXXX" item="Inv o3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="72" mask="XXXXXVXX" item="Recip3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="72" mask="XXXVVXXX" item="Eff3">
@@ -1802,25 +1459,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="75" mask="VXXXXXXX" item="Inv o4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="75" mask="XXXXXVXX" item="Recip4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="75" mask="XXXVVXXX" item="Eff4">
@@ -1898,25 +1541,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="78" mask="VXXXXXXX" item="Inv o5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="78" mask="XXXXXVXX" item="Recip5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="78" mask="XXXVVXXX" item="Eff5">
@@ -1994,25 +1623,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="81" mask="VXXXXXXX" item="Inv o6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="81" mask="XXXXXVXX" item="Recip6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="81" mask="XXXVVXXX" item="Eff6">
@@ -2090,25 +1705,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="84" mask="VXXXXXXX" item="Inv o7">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="84" mask="XXXXXVXX" item="Recip7">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="84" mask="XXXVVXXX" item="Eff7">
@@ -2186,25 +1787,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="87" mask="VXXXXXXX" item="Inv o8">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="87" mask="XXXXXVXX" item="Recip8">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="87" mask="XXXVVXXX" item="Eff8">
@@ -2282,25 +1869,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="90" mask="VXXXXXXX" item="Inv o9">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="90" mask="XXXXXVXX" item="Recip9">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="90" mask="XXXVVXXX" item="Eff9">
@@ -2378,25 +1951,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="93" mask="VXXXXXXX" item="Inv o10">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="93" mask="XXXXXVXX" item="Recip10">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="93" mask="XXXVVXXX" item="Eff10">
@@ -2474,25 +2033,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="96" mask="VXXXXXXX" item="Inv o11">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="96" mask="XXXXXVXX" item="Recip11">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="96" mask="XXXVVXXX" item="Eff11">
@@ -2570,25 +2115,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="99" mask="VXXXXXXX" item="Inv o12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="99" mask="XXXXXVXX" item="Recip12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="99" mask="XXXVVXXX" item="Eff12">
@@ -2666,25 +2197,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="102" mask="VXXXXXXX" item="Inv o13">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="102" mask="XXXXXVXX" item="Recip13">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="102" mask="XXXVVXXX" item="Eff13">
@@ -2762,25 +2279,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="105" mask="VXXXXXXX" item="Inv o14">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="105" mask="XXXXXVXX" item="Recip14">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="105" mask="XXXVVXXX" item="Eff14">
@@ -2858,25 +2361,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="108" mask="VXXXXXXX" item="Inv o15">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="108" mask="XXXXXVXX" item="Recip15">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="108" mask="XXXVVXXX" item="Eff15">
@@ -2954,25 +2443,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="111" mask="VXXXXXXX" item="Inv o16">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="111" mask="XXXXXVXX" item="Recip16">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="111" mask="XXXVVXXX" item="Eff16">

--- a/xml/decoders/TD_SRC162.xml
+++ b/xml/decoders/TD_SRC162.xml
@@ -64,124 +64,47 @@
         <label>Select Power On Option</label>
       </variable>
       <variable CV="9" mask="XXXXXVXX" item="Op1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Ops Mode</label>
       </variable>
       <variable item="DCC gateway" CV="9" mask="XXXXVXXX">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>DCC gateway</label>
       </variable>
       <variable item="Bus interface" CV="9" mask="XXXVXXXX">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Bus interface</label>
       </variable>
       <variable item="DCC control" CV="9" mask="XXVXXXXX">
-        <enumVal>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-YesNo.xml"/>
         <label>DCC control</label>
       </variable>
       <variable item="Output Lockout" CV="9" mask="XVXXXXXX">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Output Lockout</label>
       </variable>
       <variable item="Common Cathode" CV="9" mask="VXXXXXXX">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Common Cathode</label>
       </variable>
       <variable item="Power On Send Input State" CV="10" mask="XXXXXXXV">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Power On Send Input State</label>
       </variable>
       <variable item="Power On Send Output State" CV="10" mask="XXXXXXVX">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Power On Send Output State</label>
       </variable>
       <variable item="Interrogate input" CV="10" mask="XXXXXVXX">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Interrogate input</label>
       </variable>
       <variable item="Interrogate output" CV="10" mask="XXXXVXXX">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Interrogate output</label>
       </variable>
       <variable item="Power On Send 16" CV="10" mask="XXXVXXXX">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Power On Send 16</label>
       </variable>
       <variable item="Route send delay" CV="11" mask="XVVVVVVV">
@@ -489,25 +412,11 @@
         <label>Address</label>
       </variable>
       <variable CV="17" mask="VXXXXXXX" item="PInv P1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="17" mask="XVXXXXXX" item="PTog P1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="17" mask="XXVVXXXX" item="PTy1">
@@ -550,25 +459,11 @@
         <label>Address</label>
       </variable>
       <variable CV="20" mask="VXXXXXXX" item="PInv P2" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="20" mask="XVXXXXXX" item="PTog P2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="20" mask="XXVVXXXX" item="PTy2">
@@ -611,25 +506,11 @@
         <label>Address</label>
       </variable>
       <variable CV="23" mask="VXXXXXXX" item="PInv P3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="23" mask="XVXXXXXX" item="PTog P3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="23" mask="XXVVXXXX" item="PTy3">
@@ -672,25 +553,11 @@
         <label>Address</label>
       </variable>
       <variable CV="26" mask="VXXXXXXX" item="PInv P4" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="26" mask="XVXXXXXX" item="PTog P4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="26" mask="XXVVXXXX" item="PTy4">
@@ -733,25 +600,11 @@
         <label>Address</label>
       </variable>
       <variable CV="29" mask="VXXXXXXX" item="PInv P5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="29" mask="XVXXXXXX" item="PTog P5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="29" mask="XXVVXXXX" item="PTy5">
@@ -794,25 +647,11 @@
         <label>Address</label>
       </variable>
       <variable CV="32" mask="VXXXXXXX" item="PInv P6" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="32" mask="XVXXXXXX" item="PTog P6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="32" mask="XXVVXXXX" item="PTy6">
@@ -855,25 +694,11 @@
         <label>Address</label>
       </variable>
       <variable CV="35" mask="VXXXXXXX" item="PInv P7">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="35" mask="XVXXXXXX" item="PTog P7">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="35" mask="XXVVXXXX" item="PTy7">
@@ -916,25 +741,11 @@
         <label>Address</label>
       </variable>
       <variable CV="38" mask="VXXXXXXX" item="PInv P8" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="38" mask="XVXXXXXX" item="PTog P8">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="38" mask="XXVVXXXX" item="PTy8">
@@ -978,25 +789,11 @@
         <label>Address</label>
       </variable>
       <variable CV="41" mask="VXXXXXXX" item="SInv P1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="41" mask="XVXXXXXX" item="STog P1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="41" mask="XXVVXXXX" item="STy1">
@@ -1039,25 +836,11 @@
         <label>Address</label>
       </variable>
       <variable CV="44" mask="VXXXXXXX" item="SInv P2" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="44" mask="XVXXXXXX" item="STog P2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="44" mask="XXVVXXXX" item="STy2">
@@ -1100,25 +883,11 @@
         <label>Address</label>
       </variable>
       <variable CV="47" mask="VXXXXXXX" item="SInv P3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="47" mask="XVXXXXXX" item="STog P3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="47" mask="XXVVXXXX" item="STy3">
@@ -1161,25 +930,11 @@
         <label>Address</label>
       </variable>
       <variable CV="50" mask="VXXXXXXX" item="SInv P4" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="50" mask="XVXXXXXX" item="STog P4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="50" mask="XXVVXXXX" item="STy4">
@@ -1222,25 +977,11 @@
         <label>Address</label>
       </variable>
       <variable CV="53" mask="VXXXXXXX" item="SInv P5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="53" mask="XVXXXXXX" item="STog P5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="53" mask="XXVVXXXX" item="STy5">
@@ -1283,25 +1024,11 @@
         <label>Address</label>
       </variable>
       <variable CV="56" mask="VXXXXXXX" item="SInv P6" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="56" mask="XVXXXXXX" item="STog P6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="56" mask="XXVVXXXX" item="STy6">
@@ -1344,25 +1071,11 @@
         <label>Address</label>
       </variable>
       <variable CV="59" mask="VXXXXXXX" item="SInv P7">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="59" mask="XVXXXXXX" item="STog P7">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="59" mask="XXVVXXXX" item="STy7">
@@ -1405,25 +1118,11 @@
         <label>Address</label>
       </variable>
       <variable CV="62" mask="VXXXXXXX" item="SInv P8" default="1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert</label>
       </variable>
       <variable CV="62" mask="XVXXXXXX" item="STog P8">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Toggle</label>
       </variable>
       <variable CV="62" mask="XXVVXXXX" item="STy8">
@@ -1506,25 +1205,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="66" mask="VXXXXXXX" item="Inv o1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="66" mask="XXXXXVXX" item="Recip1">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="66" mask="XXXVVXXX" item="Eff1">
@@ -1602,25 +1287,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="69" mask="VXXXXXXX" item="Inv o2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="69" mask="XXXXXVXX" item="Recip2">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="69" mask="XXXVVXXX" item="Eff2">
@@ -1698,25 +1369,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="72" mask="VXXXXXXX" item="Inv o3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="72" mask="XXXXXVXX" item="Recip3">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="72" mask="XXXVVXXX" item="Eff3">
@@ -1794,25 +1451,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="75" mask="VXXXXXXX" item="Inv o4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="75" mask="XXXXXVXX" item="Recip4">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="75" mask="XXXVVXXX" item="Eff4">
@@ -1890,25 +1533,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="78" mask="VXXXXXXX" item="Inv o5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="78" mask="XXXXXVXX" item="Recip5">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="78" mask="XXXVVXXX" item="Eff5">
@@ -1986,25 +1615,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="81" mask="VXXXXXXX" item="Inv o6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="81" mask="XXXXXVXX" item="Recip6">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="81" mask="XXXVVXXX" item="Eff6">
@@ -2082,25 +1697,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="84" mask="VXXXXXXX" item="Inv o7">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="84" mask="XXXXXVXX" item="Recip7">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="84" mask="XXXVVXXX" item="Eff7">
@@ -2178,25 +1779,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="87" mask="VXXXXXXX" item="Inv o8">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="87" mask="XXXXXVXX" item="Recip8">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="87" mask="XXXVVXXX" item="Eff8">
@@ -2274,25 +1861,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="90" mask="VXXXXXXX" item="Inv o9">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="90" mask="XXXXXVXX" item="Recip9">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="90" mask="XXXVVXXX" item="Eff9">
@@ -2370,25 +1943,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="93" mask="VXXXXXXX" item="Inv o10">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="93" mask="XXXXXVXX" item="Recip10">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="93" mask="XXXVVXXX" item="Eff10">
@@ -2466,25 +2025,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="96" mask="VXXXXXXX" item="Inv o11">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="96" mask="XXXXXVXX" item="Recip11">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="96" mask="XXXVVXXX" item="Eff11">
@@ -2562,25 +2107,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="99" mask="VXXXXXXX" item="Inv o12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="99" mask="XXXXXVXX" item="Recip12">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="99" mask="XXXVVXXX" item="Eff12">
@@ -2658,25 +2189,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="102" mask="VXXXXXXX" item="Inv o13">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="102" mask="XXXXXVXX" item="Recip13">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="102" mask="XXXVVXXX" item="Eff13">
@@ -2754,25 +2271,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="105" mask="VXXXXXXX" item="Inv o14">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="105" mask="XXXXXVXX" item="Recip14">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="105" mask="XXXVVXXX" item="Eff14">
@@ -2850,25 +2353,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="108" mask="VXXXXXXX" item="Inv o15">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="108" mask="XXXXXVXX" item="Recip15">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="108" mask="XXXVVXXX" item="Eff15">
@@ -2946,25 +2435,11 @@
         <label>Bi-Color</label>
       </variable>
       <variable CV="111" mask="VXXXXXXX" item="Inv o16">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Invert State</label>
       </variable>
       <variable CV="111" mask="XXXXXVXX" item="Recip16">
-        <enumVal>
-          <enumChoice choice="No">
-            <choice>No</choice>
-          </enumChoice>
-          <enumChoice choice="Yes">
-            <choice>Yes</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reciprocal</label>
       </variable>
       <variable CV="111" mask="XXXVVXXX" item="Eff16">

--- a/xml/decoders/TD_Servette.xml
+++ b/xml/decoders/TD_Servette.xml
@@ -109,24 +109,15 @@
         <label>Mode</label>
       </variable>
       <variable item="Option 1" CV="29" mask="XXXXVXXX">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Option 1</label>
       </variable>
       <variable item="Option 2" CV="29" mask="XXXVXXXX">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Option 2</label>
       </variable>
       <variable item="Option 3" CV="29" mask="XXVXXXXX">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Option 3</label>
       </variable>
       <variable CV="31" mask="XVVVVVVV" item="Short Address" default="1" tooltip="Range 1-99">
@@ -206,10 +197,7 @@
         <label>Servo Behavior</label>
       </variable>
       <variable item="Rev1" CV="71" mask="VXXXXXXX" default="0">
-        <enumVal>
-          <enumChoice choice="no"/>
-          <enumChoice choice="yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Reverse</label>
       </variable>
       <variable item="Relay" CV="75" mask="XXXXXXVV" default="00">

--- a/xml/decoders/Uhlenbrock_77500.xml
+++ b/xml/decoders/Uhlenbrock_77500.xml
@@ -763,59 +763,35 @@
         <label>Assignment of function key to switch output 8</label>
       </variable>
       <variable item="Special function 1 dimmed" CV="112" mask="XXXXXXXV" default="0">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Special function 1 dimmed</label>
       </variable>
       <variable item="Special function 2 dimmed" CV="112" mask="XXXXXXVX" default="0">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Special function 2 dimmed</label>
       </variable>
       <variable item="Special function 3 dimmed" CV="112" mask="XXXXXVXX" default="0">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Special function 3 dimmed</label>
       </variable>
       <variable item="Special function 4 dimmed" CV="112" mask="XXXXVXXX" default="0">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Special function 4 dimmed</label>
       </variable>
       <variable item="Special function 5 dimmed" CV="112" mask="XXXVXXXX" default="0">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Special function 5 dimmed</label>
       </variable>
       <variable item="Special function 6 dimmed" CV="112" mask="XXVXXXXX" default="0">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Special function 6 dimmed</label>
       </variable>
       <variable item="Special function 7 dimmed" CV="112" mask="XVXXXXXX" default="0">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Special function 7 dimmed</label>
       </variable>
       <variable item="Special function 8 dimmed" CV="112" mask="VXXXXXXX" default="0">
-        <enumVal>
-          <enumChoice choice="No"/>
-          <enumChoice choice="Yes"/>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Special function 8 dimmed</label>
       </variable>
       <variable item="Dimming value" CV="113" default="32" tooltip="(0=off, 63=100%">


### PR DESCRIPTION
While working on importing the XML files into DCCWiki, I noticed a ton of duplicate yes/no and no/yes. I've moved them over to using the common versions so that translations will display.

Please check my work. I've not worked on your XML files to this extent. Did i place the import correctly and use the correct syntax?