### PR TITLE
Routes can select feedback mode

### DIFF
--- a/help/en/html/tools/Routes.shtml
+++ b/help/en/html/tools/Routes.shtml
@@ -368,6 +368,15 @@
       of the 'veto' Sensors and the 'veto' Turnout, if there is one, must be in their non-veto
       state _and_ at least one of the triggering Sensors or a triggering Turnout must see the
       appropriate change for the Route to be set.</p>
+      
+      <p>You can also specify whether the Route should respond to changes in the Known state
+        (the default) or whether it should respond to changes in the Commanded state.
+        If you are not using
+        <a href="../doc/Technical/TurnoutFeedback.shtml">turnout feedback</a>
+        these are the same.  If you do have feedback enabled, the Commanded state is what 
+        JMRI has requested will be set on the turnout, and the Known state is what
+        is returned from the feedback. Usually the default is the right choice here.
+      
       <!--#include virtual="/help/en/parts/Footer.shtml" -->
     </div>
     <!-- closes #mainContent-->

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -489,7 +489,11 @@
     <h3>Routes</h3>
         <a id="Routes" name="Routes"></a>
        <ul>
-            <li></li>
+            <li>You can now specify where the control turnout should have its
+                known state (the default old behavior) or its commanded state
+                checked to see if the route should be set.  This can be useful
+                e.g. if you have feedback set on the turnout and want to react
+                quickly to a commanded change.</li>
        </ul>
 
     <h3>Scripting</h3>

--- a/java/src/jmri/Route.java
+++ b/java/src/jmri/Route.java
@@ -326,6 +326,21 @@ public interface Route extends NamedBean {
      */
     int getControlTurnoutState();
 
+
+    /**
+     * Set the feedback to use when checking the control turnout state
+     *
+     * @param turnoutFeedbackIsCommanded true if commanded state is to be checked; default is false
+     */
+    void setControlTurnoutFeedback(boolean turnoutFeedbackIsCommanded);
+
+    /**
+     * Get the feedback to use when checking the control turnout state
+     *
+     * @return true if commanded state is to be checked; false is known state
+     */
+    boolean getControlTurnoutFeedback();
+
     /**
      * Set the lock control Turnout for this Route.
      *

--- a/java/src/jmri/implementation/DefaultRoute.java
+++ b/java/src/jmri/implementation/DefaultRoute.java
@@ -64,6 +64,7 @@ public class DefaultRoute extends AbstractNamedBean implements Route, java.beans
     protected NamedBeanHandle<Turnout> mControlNamedTurnout = null;
     protected int mControlTurnoutState = jmri.Turnout.THROWN;
     protected int mDelay = 0;
+    protected boolean mTurnoutFeedbackIsCommanded = false;
 
     protected String mLockControlTurnout = "";
     protected NamedBeanHandle<Turnout> mLockControlNamedTurnout = null;
@@ -735,6 +736,18 @@ public class DefaultRoute extends AbstractNamedBean implements Route, java.beans
 
     /** {@inheritDoc} */
     @Override
+    public void setControlTurnoutFeedback(boolean turnoutFeedbackIsCommanded) {
+        mTurnoutFeedbackIsCommanded  = turnoutFeedbackIsCommanded;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean getControlTurnoutFeedback() {
+        return mTurnoutFeedbackIsCommanded;
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public void setLockControlTurnoutState(int turnoutState) {
         if ((turnoutState == Route.ONTHROWN)
                 || (turnoutState == Route.ONCLOSED)
@@ -954,7 +967,11 @@ public class DefaultRoute extends AbstractNamedBean implements Route, java.beans
         Turnout ctl = getCtlTurnout();
         if (ctl != null) {
             mTurnoutListener = (java.beans.PropertyChangeEvent e) -> {
-                if (e.getPropertyName().equals("KnownState")) {
+                String name = "KnownState";
+                if (this.getControlTurnoutFeedback()) {
+                    name = "CommandedState";
+                }
+                if (e.getPropertyName().equals(name)) {
                     int now = ((Integer) e.getNewValue());
                     int then = ((Integer) e.getOldValue());
                     checkTurnout(now, then, (Turnout) e.getSource());

--- a/java/src/jmri/jmrit/beantable/BeanTableBundle.properties
+++ b/java/src/jmri/jmrit/beantable/BeanTableBundle.properties
@@ -518,6 +518,10 @@ SetBeanState                         = Set {0} {1}
 ColumnLabelSetState                  = Set State
 ButtonCancelEdit                     = Cancel {0}
 ButtonKeep                           = Keep
+TurnoutFeedbackKnown                 = Known
+TurnoutFeedbackCommanded             = Commanded
+Is                                   = Is
+TooltipTurnoutFeedback               = Select which kind of turnout state will be monitored
 
 # Oblock table (tabbed)
 TitleOBlocksTabbedFrame              = Occupancy Block Tables

--- a/java/src/jmri/jmrit/beantable/routetable/AbstractRouteAddEditFrame.java
+++ b/java/src/jmri/jmrit/beantable/routetable/AbstractRouteAddEditFrame.java
@@ -74,6 +74,9 @@ public abstract class AbstractRouteAddEditFrame extends JmriJFrame {
             "Veto " + Bundle.getMessage("WhenCondition") + " " + Bundle.getMessage("TurnoutStateClosed"),
             "Veto " + Bundle.getMessage("WhenCondition") + " " + Bundle.getMessage("TurnoutStateThrown")
     };
+    private static String[] turnoutFeedbackModes = new String[]{Bundle.getMessage("TurnoutFeedbackKnown"), 
+                                                                Bundle.getMessage("TurnoutFeedbackCommanded")};
+    
     private static String[] lockTurnoutInputModes = new String[]{
             Bundle.getMessage("OnCondition") + " " + Bundle.getMessage("TurnoutStateClosed"),
             Bundle.getMessage("OnCondition") + " " + Bundle.getMessage("TurnoutStateThrown"),
@@ -89,6 +92,7 @@ public abstract class AbstractRouteAddEditFrame extends JmriJFrame {
     final JComboBox<String> sensor3mode = new JComboBox<>(sensorInputModes);
     final JSpinner timeDelay = new JSpinner();
     final JComboBox<String> cTurnoutStateBox = new JComboBox<>(turnoutInputModes);
+    final JComboBox<String> cTurnoutFeedbackBox = new JComboBox<>(turnoutFeedbackModes);
     final JComboBox<String> cLockTurnoutStateBox = new JComboBox<>(lockTurnoutInputModes);
     final JLabel nameLabel = new JLabel(Bundle.getMessage("LabelSystemName"));
     final JLabel userLabel = new JLabel(Bundle.getMessage("LabelUserName"));
@@ -385,6 +389,9 @@ public abstract class AbstractRouteAddEditFrame extends JmriJFrame {
         p34.add(new JLabel("   " + Bundle.getMessage("MakeLabel", Bundle.getMessage("LabelCondition"))));
         cTurnoutStateBox.setToolTipText(Bundle.getMessage("TooltipTurnoutCondition"));
         p34.add(cTurnoutStateBox);
+        p34.add(new JLabel(Bundle.getMessage("Is")));
+        cTurnoutFeedbackBox.setToolTipText(Bundle.getMessage("TooltipTurnoutFeedback"));
+        p34.add(cTurnoutFeedbackBox);
         p3.add(p34);
         // add additional route-specific delay
         JPanel p36 = new JPanel();
@@ -680,6 +687,8 @@ public abstract class AbstractRouteAddEditFrame extends JmriJFrame {
             g.setControlTurnout(cTurnout.getSelectedItemDisplayName());
             // set up Control Turnout state
             g.setControlTurnoutState(turnoutModeFromBox(cTurnoutStateBox));
+            g.setControlTurnoutFeedback(cTurnoutFeedbackBox.getSelectedIndex() == 1);
+            
         } else {
             // No Control Turnout was entered
             g.setControlTurnout("");
@@ -836,6 +845,12 @@ public abstract class AbstractRouteAddEditFrame extends JmriJFrame {
         cTurnout.setSelectedItem(route.getCtlTurnout());
 
         setTurnoutModeBox(route.getControlTurnoutState(), cTurnoutStateBox);
+        
+        if (route.getControlTurnoutFeedback()) {
+            cTurnoutFeedbackBox.setSelectedIndex(1); // Known
+        } else {
+            cTurnoutFeedbackBox.setSelectedIndex(0);  // Commanded
+        }
 
         // set up Lock Control Turnout if there is one
         cLockTurnout.setSelectedItem(route.getLockCtlTurnout());

--- a/java/src/jmri/managers/configurexml/DefaultRouteManagerXml.java
+++ b/java/src/jmri/managers/configurexml/DefaultRouteManagerXml.java
@@ -80,6 +80,10 @@ public class DefaultRouteManagerXml extends jmri.managers.configurexml.AbstractN
                     } else {
                         elem.setAttribute("controlTurnoutState", "CLOSED");
                     }
+                    
+                    if (r.getControlTurnoutFeedback()) {
+                        elem.setAttribute("controlTurnoutFeedback", "true");
+                    } // don't write if not set, accept default
                 }
                 if (cLockTurnout != null && !cLockTurnout.equals("")) {
                     elem.setAttribute("controlLockTurnout", cLockTurnout);
@@ -260,6 +264,7 @@ public class DefaultRouteManagerXml extends jmri.managers.configurexml.AbstractN
             String userName = getUserName(el);
             String cTurnout = null;
             String cTurnoutState = null;
+            boolean cTurnoutFeedback = false;
             String addedDelayTxt = null;
             String routeLockedTxt = null;
             String cLockTurnout = null;
@@ -271,6 +276,9 @@ public class DefaultRouteManagerXml extends jmri.managers.configurexml.AbstractN
             }
             if (el.getAttribute("controlTurnoutState") != null) {
                 cTurnoutState = el.getAttribute("controlTurnoutState").getValue();
+            }
+            if (el.getAttribute("controlTurnoutFeedback") != null) {
+                cTurnoutFeedback = el.getAttribute("controlTurnoutFeedback").getValue().equals("true");
             }
             if (el.getAttribute("controlLockTurnout") != null) {
                 cLockTurnout = el.getAttribute("controlLockTurnout").getValue();
@@ -324,6 +332,7 @@ public class DefaultRouteManagerXml extends jmri.managers.configurexml.AbstractN
                 } else {
                     log.error("cTurnoutState was null!");
                 }
+                r.setControlTurnoutFeedback(cTurnoutFeedback);
             }
             // set added delay
             r.setRouteCommandDelay(addedDelay);

--- a/xml/schema/types/routes-2-9-6.xsd
+++ b/xml/schema/types/routes-2-9-6.xsd
@@ -96,6 +96,7 @@
             </xs:sequence>
             <xs:attribute name="controlTurnout" type="xs:string" />
             <xs:attribute name="controlTurnoutState" type="xs:string" /> <!-- CLOSED/THROWN/? -->
+            <xs:attribute name="controlTurnoutFeedback" type="xs:string" /> <!-- true/false -->
             <xs:attribute name="controlLockTurnout" type="xs:string" />
             <xs:attribute name="controlLockTurnoutState" type="xs:string" /> <!-- CLOSED/THROWN/? -->
             <xs:attribute name="routeLocked" type="xs:string" /> <!-- Locked -->

--- a/xml/schema/types/routes.xsd
+++ b/xml/schema/types/routes.xsd
@@ -95,6 +95,7 @@
             <xs:attribute name="userName" type="userNameType" />
             <xs:attribute name="controlTurnout" type="xs:string" />
             <xs:attribute name="controlTurnoutState" type="xs:string" /> <!-- CLOSED/THROWN/? -->
+            <xs:attribute name="controlTurnoutFeedback" type="xs:string" /> <!-- true/false -->
             <xs:attribute name="controlLockTurnout" type="xs:string" />
             <xs:attribute name="controlLockTurnoutState" type="xs:string" /> <!-- CLOSED/THROWN/? -->
             <xs:attribute name="addedDelay" type="xs:int" />


### PR DESCRIPTION
Previously (and still the default), a route would react to changed in the Known state of its control turnout.  This allows the user to select responding to the Commanded state instead.   

This was added in response to a user request to be able to react to a Commanded change before the feedback had time to respond.

No changes to the behavior of existing routes.