### PR TITLE
Fixes for MQTT Unsubscribe Issue #12811 

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -106,6 +106,9 @@
 
         <h4>MQTT</h4>
             <ul>
+                <li>Fixed missing topic unsubscribes when deleting turnouts, sensors, etc</li>
+                <li>Fixed missing topic unsubscribe on throttle release for cab functions</li>
+                <li>Added code to properly dispose of MQTT components</li>
                 <li></li>
             </ul>
 

--- a/java/src/jmri/jmrix/mqtt/MqttAdapter.java
+++ b/java/src/jmri/jmrix/mqtt/MqttAdapter.java
@@ -110,6 +110,7 @@ public class MqttAdapter extends jmri.jmrix.AbstractNetworkPortController implem
         options.put("LastWillMessage", new Option(Bundle.getMessage("NameMessageLastWill"),
                     new String[]{Bundle.getMessage("MessageLastWill")}, Option.Type.TEXT));
         allowConnectionRecovery = true;
+
     }
 
     public MqttConnectOptions getMqttConnectionOptions() {
@@ -245,6 +246,7 @@ public class MqttAdapter extends jmri.jmrix.AbstractNetworkPortController implem
             mqttEventListeners.get(fullTopic).remove(mel);
         } catch (NullPointerException e) {
             // Not subscribed
+            log.debug("Unsubscribe but not subscribed: \"{}\"", fullTopic);
             return;
         }
         if (mqttEventListeners.get(fullTopic).isEmpty()) {
@@ -377,6 +379,26 @@ public class MqttAdapter extends jmri.jmrix.AbstractNetworkPortController implem
     @API(status=API.Status.INTERNAL)
     public void deliveryComplete(IMqttDeliveryToken imdt) {
         log.debug("Message delivered");
+    }
+
+
+    @Override
+    protected void closeConnection(){
+       log.debug("Closing MqttAdapter");
+        try {
+            mqttClient.disconnect();
+        }
+        catch (Exception exception) {
+            log.error("MqttEventListener exception: ", exception);
+        }
+
+    }
+
+    @Override
+    public void dispose() {
+        log.debug("Disposing MqttAdapter");
+        closeConnection();
+        super.dispose();
     }
 
     private final static Logger log = LoggerFactory.getLogger(MqttAdapter.class);

--- a/java/src/jmri/jmrix/mqtt/MqttLight.java
+++ b/java/src/jmri/jmrix/mqtt/MqttLight.java
@@ -13,7 +13,7 @@ import javax.annotation.Nonnull;
  * @author Fredrik Elestedt  Copyright (C) 2020
  */
 public class MqttLight extends AbstractVariableLight implements MqttEventListener {
-    private final MqttAdapter mqttAdapter;
+    private MqttAdapter mqttAdapter;
     private final String sendTopic;
     private final String rcvTopic;
 
@@ -190,6 +190,13 @@ public class MqttLight extends AbstractVariableLight implements MqttEventListene
 
         // handle on/off
         parser.beanFromPayload(this, message, receivedTopic);
+    }
+
+    @Override
+    public void dispose() {
+        mqttAdapter.unsubscribe(rcvTopic,this);
+        mqttAdapter = null;
+        super.dispose();
     }
 
     private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(MqttLight.class);

--- a/java/src/jmri/jmrix/mqtt/MqttLight.java
+++ b/java/src/jmri/jmrix/mqtt/MqttLight.java
@@ -13,7 +13,7 @@ import javax.annotation.Nonnull;
  * @author Fredrik Elestedt  Copyright (C) 2020
  */
 public class MqttLight extends AbstractVariableLight implements MqttEventListener {
-    private MqttAdapter mqttAdapter;
+    private final MqttAdapter mqttAdapter;
     private final String sendTopic;
     private final String rcvTopic;
 
@@ -195,7 +195,6 @@ public class MqttLight extends AbstractVariableLight implements MqttEventListene
     @Override
     public void dispose() {
         mqttAdapter.unsubscribe(rcvTopic,this);
-        mqttAdapter = null;
         super.dispose();
     }
 

--- a/java/src/jmri/jmrix/mqtt/MqttPowerManager.java
+++ b/java/src/jmri/jmrix/mqtt/MqttPowerManager.java
@@ -17,7 +17,7 @@ public class MqttPowerManager extends AbstractPowerManager<MqttSystemConnectionM
 
     private static final String onText = "ON";
     private static final String offText = "OFF";
-    private MqttAdapter mqttAdapter;
+    private final MqttAdapter mqttAdapter;
 
     public MqttPowerManager(MqttSystemConnectionMemo memo) {
         super(memo);
@@ -66,7 +66,6 @@ public class MqttPowerManager extends AbstractPowerManager<MqttSystemConnectionM
     @Override
     public void dispose() throws JmriException {
             this.mqttAdapter.unsubscribe(rcvTopic, this);
-            mqttAdapter = null;
     }
 
 

--- a/java/src/jmri/jmrix/mqtt/MqttPowerManager.java
+++ b/java/src/jmri/jmrix/mqtt/MqttPowerManager.java
@@ -17,7 +17,7 @@ public class MqttPowerManager extends AbstractPowerManager<MqttSystemConnectionM
 
     private static final String onText = "ON";
     private static final String offText = "OFF";
-    private final MqttAdapter mqttAdapter;
+    private MqttAdapter mqttAdapter;
 
     public MqttPowerManager(MqttSystemConnectionMemo memo) {
         super(memo);
@@ -65,6 +65,8 @@ public class MqttPowerManager extends AbstractPowerManager<MqttSystemConnectionM
     // to free resources when no longer used
     @Override
     public void dispose() throws JmriException {
+            this.mqttAdapter.unsubscribe(rcvTopic, this);
+            mqttAdapter = null;
     }
 
 

--- a/java/src/jmri/jmrix/mqtt/MqttReporter.java
+++ b/java/src/jmri/jmrix/mqtt/MqttReporter.java
@@ -29,7 +29,7 @@ class MqttReporter extends AbstractIdTagReporter implements MqttEventListener {
         mqttAdapter.subscribe(rcvTopic, MqttReporter.this);
     }
 
-    private final MqttAdapter mqttAdapter;
+    private MqttAdapter mqttAdapter;
     private final String rcvTopic;
 
     @Override
@@ -74,6 +74,13 @@ class MqttReporter extends AbstractIdTagReporter implements MqttEventListener {
         } catch (IllegalArgumentException e) {
             log.error("Reporter {} cannot make a tag from input ({})", getSystemName(), message);
         }
+    }
+
+    @Override
+    public void dispose() {
+        mqttAdapter.unsubscribe(rcvTopic, this);
+        mqttAdapter = null;
+        super.dispose();
     }
 
     private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(MqttReporter.class);

--- a/java/src/jmri/jmrix/mqtt/MqttReporter.java
+++ b/java/src/jmri/jmrix/mqtt/MqttReporter.java
@@ -29,7 +29,7 @@ class MqttReporter extends AbstractIdTagReporter implements MqttEventListener {
         mqttAdapter.subscribe(rcvTopic, MqttReporter.this);
     }
 
-    private MqttAdapter mqttAdapter;
+    private final MqttAdapter mqttAdapter;
     private final String rcvTopic;
 
     @Override
@@ -79,7 +79,6 @@ class MqttReporter extends AbstractIdTagReporter implements MqttEventListener {
     @Override
     public void dispose() {
         mqttAdapter.unsubscribe(rcvTopic, this);
-        mqttAdapter = null;
         super.dispose();
     }
 

--- a/java/src/jmri/jmrix/mqtt/MqttSensor.java
+++ b/java/src/jmri/jmrix/mqtt/MqttSensor.java
@@ -12,7 +12,7 @@ import jmri.implementation.AbstractSensor;
  */
 public class MqttSensor extends AbstractSensor implements MqttEventListener {
 
-    private MqttAdapter mqttAdapter;
+    private final MqttAdapter mqttAdapter;
     private final String sendTopic;
     private final String rcvTopic;
 
@@ -117,7 +117,6 @@ public class MqttSensor extends AbstractSensor implements MqttEventListener {
     @Override
     public void dispose() {
         mqttAdapter.unsubscribe(rcvTopic, this);
-        mqttAdapter = null;
         super.dispose();
     }
 

--- a/java/src/jmri/jmrix/mqtt/MqttSensor.java
+++ b/java/src/jmri/jmrix/mqtt/MqttSensor.java
@@ -12,7 +12,7 @@ import jmri.implementation.AbstractSensor;
  */
 public class MqttSensor extends AbstractSensor implements MqttEventListener {
 
-    private final MqttAdapter mqttAdapter;
+    private MqttAdapter mqttAdapter;
     private final String sendTopic;
     private final String rcvTopic;
 
@@ -111,6 +111,14 @@ public class MqttSensor extends AbstractSensor implements MqttEventListener {
         }
         
         parser.beanFromPayload(this, message, receivedTopic);
+    }
+
+
+    @Override
+    public void dispose() {
+        mqttAdapter.unsubscribe(rcvTopic, this);
+        mqttAdapter = null;
+        super.dispose();
     }
 
     private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(MqttSensor.class);

--- a/java/src/jmri/jmrix/mqtt/MqttSystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/mqtt/MqttSystemConnectionMemo.java
@@ -41,6 +41,12 @@ public class MqttSystemConnectionMemo extends DefaultSystemConnectionMemo implem
     }
 
     @Override
+    public void dispose() {
+        InstanceManager.deregister(this, MqttSystemConnectionMemo.class);
+        super.dispose();
+    }
+
+    @Override
     protected ResourceBundle getActionModelResourceBundle() {
         return null;
     }

--- a/java/src/jmri/jmrix/mqtt/MqttThrottle.java
+++ b/java/src/jmri/jmrix/mqtt/MqttThrottle.java
@@ -198,7 +198,8 @@ import java.util.regex.*;
 
         mqttAdapter.unsubscribe(this.rcvThrottleTopic.replaceFirst("\\{0\\}", String.valueOf(address)), this);
         mqttAdapter.unsubscribe(this.rcvDirectionTopic.replaceFirst("\\{0\\}", String.valueOf(address)), this);
-        mqttAdapter.unsubscribe(this.rcvFunctionTopic.replaceFirst("\\{0\\}", String.valueOf(address)).replaceFirst("\\{0\\}", "#"),  this);
+        mqttAdapter.unsubscribe(this.rcvFunctionTopic.replaceFirst("\\{0\\}", String.valueOf(address)).replaceFirst("\\{1\\}", "+"), this);
+
 
     }
 
@@ -234,13 +235,13 @@ import java.util.regex.*;
 
             mqttAdapter.unsubscribe(this.rcvThrottleTopic.replaceFirst("\\{0\\}", String.valueOf(address)), this);
             mqttAdapter.unsubscribe(this.rcvDirectionTopic.replaceFirst("\\{0\\}", String.valueOf(address)), this);
-            mqttAdapter.unsubscribe(this.rcvFunctionTopic.replaceFirst("\\{0\\}", String.valueOf(address)).replaceFirst("\\{1\\}", "#"), this);
+            mqttAdapter.unsubscribe(this.rcvFunctionTopic.replaceFirst("\\{0\\}", String.valueOf(address)).replaceFirst("\\{1\\}", "+"), this);
         }
         address = newaddress;
 
         mqttAdapter.subscribe(this.rcvThrottleTopic.replaceFirst("\\{0\\}", String.valueOf(address)), this);
         mqttAdapter.subscribe(this.rcvDirectionTopic.replaceFirst("\\{0\\}", String.valueOf(address)), this);
-        mqttAdapter.subscribe(this.rcvFunctionTopic.replaceFirst("\\{0\\}", String.valueOf(address)).replaceFirst("\\{1\\}", "#"), this);
+        mqttAdapter.subscribe(this.rcvFunctionTopic.replaceFirst("\\{0\\}", String.valueOf(address)).replaceFirst("\\{1\\}", "+"), this);
 
         consistManager.activateConsist(getLocoAddress());
         setSpeedSetting(0);

--- a/java/src/jmri/jmrix/mqtt/MqttTurnout.java
+++ b/java/src/jmri/jmrix/mqtt/MqttTurnout.java
@@ -12,7 +12,7 @@ import jmri.implementation.AbstractTurnout;
  */
 public class MqttTurnout extends AbstractTurnout implements MqttEventListener {
 
-    private MqttAdapter mqttAdapter;
+    private final MqttAdapter mqttAdapter;
     private final String sendTopic;
     private final String rcvTopic;
 
@@ -145,7 +145,6 @@ public class MqttTurnout extends AbstractTurnout implements MqttEventListener {
     @Override
     public void dispose() {
         mqttAdapter.unsubscribe(rcvTopic, this);
-        mqttAdapter = null;
         super.dispose();
     }
 

--- a/java/src/jmri/jmrix/mqtt/MqttTurnout.java
+++ b/java/src/jmri/jmrix/mqtt/MqttTurnout.java
@@ -12,7 +12,7 @@ import jmri.implementation.AbstractTurnout;
  */
 public class MqttTurnout extends AbstractTurnout implements MqttEventListener {
 
-    private final MqttAdapter mqttAdapter;
+    private MqttAdapter mqttAdapter;
     private final String sendTopic;
     private final String rcvTopic;
 
@@ -141,6 +141,14 @@ public class MqttTurnout extends AbstractTurnout implements MqttEventListener {
     protected void turnoutPushbuttonLockout(boolean _pushButtonLockout) {
         log.warn("Send command to {} Pushbutton in {} not yet coded", (_pushButtonLockout ? "Lock" : "Unlock"), getSystemName());
     }
+
+    @Override
+    public void dispose() {
+        mqttAdapter.unsubscribe(rcvTopic, this);
+        mqttAdapter = null;
+        super.dispose();
+    }
+
 
     private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(MqttTurnout.class);
 


### PR DESCRIPTION
Fixes for issue #12811 

- Fixed bug preventing unsubscribe for Function topics on Throttle close
- Fixed missing topic unsubscribes when deleting turnouts, sensors, etc
- Improved object disposal cleanup