### PR TITLE
LogixNG action "Table: For each" can now loop thru the headers

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -433,16 +433,16 @@
     <h3>LogixNG</h3>
         <a id="LogixNG" name="LogixNG"></a>
         <ul>
+          <li>The action <strong>Table: For each</strong> can now loop
+              thru the headers too. If indirect addressing is used for
+              the row or column name, use the empty string to get the
+              headers.</li>
           <li>The action <strong>Table</strong> is added. It  lets the
               user set the value of a cell in a LogixNG table.</li>
           <li>The action <strong>Request update of sensor</strong> is
               added. It requests that the state of a sensor is updated
               from the layout, if possible. Not all connections supports
               this, for example LocoNet.</li>
-          <li>The action <strong>Table: For each</strong> can now loop
-              thru the headers too. If indirect addressing is used for
-              the row or column name, use the empty string to get the
-              headers.</li>
         </ul>
 
     <h3>Meters and MeterFrames</h3>

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -439,6 +439,10 @@
               added. It requests that the state of a sensor is updated
               from the layout, if possible. Not all connections supports
               this, for example LocoNet.</li>
+          <li>The action <strong>Table: For each</strong> can now loop
+              thru the headers too. If indirect addressing is used for
+              the row or column name, use the empty string to get the
+              headers.</li>
         </ul>
 
     <h3>Meters and MeterFrames</h3>

--- a/java/src/jmri/jmrit/logixng/actions/ActionBundle.properties
+++ b/java/src/jmri/jmrit/logixng/actions/ActionBundle.properties
@@ -639,6 +639,7 @@ StringStringIO_StringIOInUseStringIOExpressionVeto = StringIO is in use by Strin
 
 TableForEach_Short          = Table: For each
 TableForEach_Long           = Table: For each {0} of {1} "{2}" in table "{3}" set variable "{4}" and execute action {5}
+TableForEach_Header         = -- Header --
 
 
 Timeout_Short               = Timeout

--- a/java/src/jmri/jmrit/logixng/actions/TableForEach.java
+++ b/java/src/jmri/jmrit/logixng/actions/TableForEach.java
@@ -109,10 +109,6 @@ public class TableForEach extends AbstractDigitalAction
             log.error("rowOrColumnName is null");
             return;
         }
-        if (rowOrColumnName.isEmpty()) {
-            log.error("rowOrColumnName is empty string");
-            return;
-        }
         if (_variableName == null) {
             log.error("variableName is null");
             return;
@@ -125,7 +121,10 @@ public class TableForEach extends AbstractDigitalAction
         SymbolTable symbolTable = getConditionalNG().getSymbolTable();
 
         if (_tableRowOrColumn == TableRowOrColumn.Row) {
-            int row = table.getRowNumber(rowOrColumnName);
+            int row = 0;    // Empty row name is header row
+            if (!rowOrColumnName.isEmpty()) {
+                row = table.getRowNumber(rowOrColumnName);
+            }
             for (int column=1; column <= table.numColumns(); column++) {
                 // If the header is null or empty, treat the row as a comment
                 Object header = table.getCell(0, column);
@@ -141,7 +140,10 @@ public class TableForEach extends AbstractDigitalAction
                 }
             }
         } else {
-            int column = table.getColumnNumber(rowOrColumnName);
+            int column = 0;    // Empty column name is header column
+            if (!rowOrColumnName.isEmpty()) {
+                column = table.getColumnNumber(rowOrColumnName);
+            }
             for (int row=1; row <= table.numRows(); row++) {
                 // If the header is null or empty, treat the row as a comment
                 Object header = table.getCell(row, 0);
@@ -305,7 +307,9 @@ public class TableForEach extends AbstractDigitalAction
 
         switch (_rowOrColumnAddressing) {
             case Direct:
-                rowOrColumnName = Bundle.getMessage(locale, "AddressByDirect", _rowOrColumnName);
+                String name = _rowOrColumnName;
+                if (name.isEmpty()) name = Bundle.getMessage("TableForEach_Header");
+                rowOrColumnName = Bundle.getMessage(locale, "AddressByDirect", name);
                 break;
 
             case Reference:

--- a/java/src/jmri/jmrit/logixng/actions/swing/DigitalActionSwingBundle.properties
+++ b/java/src/jmri/jmrit/logixng/actions/swing/DigitalActionSwingBundle.properties
@@ -204,6 +204,7 @@ TableForEachSwing_RowOrColumn       = Row or column
 TableForEachSwing_RowName           = Row
 TableForEachSwing_ColumnName        = Column
 TableForEachSwing_LocalVariable     = Local variable
+TableForEachSwing_Info  = For indirect addressing of row or column name, use empty string for "-- Header --".
 
 Timeout_Components                  = Timeout delay {0} with unit {1}
 

--- a/java/src/jmri/jmrit/logixng/actions/swing/LogLocalVariablesSwing.java
+++ b/java/src/jmri/jmrit/logixng/actions/swing/LogLocalVariablesSwing.java
@@ -54,6 +54,7 @@ public class LogLocalVariablesSwing extends AbstractDigitalActionSwing {
     @Override
     public MaleSocket createNewObject(@Nonnull String systemName, @CheckForNull String userName) {
         LogLocalVariables action = new LogLocalVariables(systemName, userName);
+        updateObject(action);
         return InstanceManager.getDefault(DigitalActionManager.class).registerAction(action);
     }
 

--- a/java/src/jmri/jmrit/logixng/actions/swing/TableForEachSwing.java
+++ b/java/src/jmri/jmrit/logixng/actions/swing/TableForEachSwing.java
@@ -143,6 +143,10 @@ public class TableForEachSwing extends AbstractDigitalActionSwing {
         localVariablePanel.add(_localVariable);
         panel.add(localVariablePanel);
 
+        JPanel infoPanel = new JPanel();
+        infoPanel.add(new JLabel(Bundle.getMessage("TableForEachSwing_Info")));
+        panel.add(infoPanel);
+
         if (action != null) {
             _tableRowOrColumnComboBox.setSelectedItem(action.getRowOrColumn());
 
@@ -168,6 +172,8 @@ public class TableForEachSwing extends AbstractDigitalActionSwing {
             _rowOrColumnNameComboBox.removeAllItems();
             NamedTable table = _selectNamedBeanSwing.getBean();
             if (table != null) {
+                _rowOrColumnNameComboBox.addItem(Bundle.getMessage("TableForEach_Header"));
+
                 if (_tableRowOrColumnComboBox.getItemAt(_tableRowOrColumnComboBox.getSelectedIndex()) == TableRowOrColumn.Column) {
                     for (int column=0; column <= table.numColumns(); column++) {
                         // If the header is null or empty, treat the row as a comment
@@ -185,7 +191,11 @@ public class TableForEachSwing extends AbstractDigitalActionSwing {
                         }
                     }
                 }
-                _rowOrColumnNameComboBox.setSelectedItem(rowOrColumnName);
+                if (rowOrColumnName.isEmpty()) {    // Header row or column
+                    _rowOrColumnNameComboBox.setSelectedIndex(0);
+                } else {
+                    _rowOrColumnNameComboBox.setSelectedItem(rowOrColumnName);
+                }
             }
         }
     }
@@ -242,10 +252,10 @@ public class TableForEachSwing extends AbstractDigitalActionSwing {
             if (_tabbedRowOrColumnPane.getSelectedComponent() == _panelRowOrColumnName) {
                 action.setRowOrColumnAddressing(NamedBeanAddressing.Direct);
                 if (_selectNamedBeanSwing.getAddressing() == NamedBeanAddressing.Direct) {
-                    if (_rowOrColumnNameComboBox.getSelectedIndex() != -1) {
+                    if (_rowOrColumnNameComboBox.getSelectedIndex() > 0) {
                         action.setRowOrColumnName(_rowOrColumnNameComboBox.getItemAt(_rowOrColumnNameComboBox.getSelectedIndex()));
                     } else {
-                        action.setRowOrColumnName("");
+                        action.setRowOrColumnName("");  // Header row or column
                     }
                 } else {
                     action.setRowOrColumnName(_rowOrColumnNameTextField.getText());

--- a/java/test/jmri/jmrit/logixng/actions/ForTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ForTest.java
@@ -224,7 +224,7 @@ public class ForTest extends AbstractDigitalActionTestBase {
         TableForEach a1 = new TableForEach("IQDA321", null);
         Assert.assertEquals("strings are equal", "Table: For each", a1.getShortDescription());
         TableForEach a2 = new TableForEach("IQDA321", null);
-        Assert.assertEquals("strings are equal", "Table: For each column of row \"\" in table \"''\" set variable \"\" and execute action A1", a2.getLongDescription());
+        Assert.assertEquals("strings are equal", "Table: For each column of row \"-- Header --\" in table \"''\" set variable \"\" and execute action A1", a2.getLongDescription());
     }
 
     @Test

--- a/java/test/jmri/jmrit/logixng/actions/TableForEachTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/TableForEachTest.java
@@ -53,7 +53,7 @@ public class TableForEachTest extends AbstractDigitalActionTestBase {
     @Override
     public String getExpectedPrintedTree() {
         return String.format(
-                "Table: For each column of row \"\" in table \"''\" set variable \"\" and execute action A1 ::: Use default%n" +
+                "Table: For each column of row \"-- Header --\" in table \"''\" set variable \"\" and execute action A1 ::: Use default%n" +
                 "   ! A1%n" +
                 "      MyAction ::: Use default%n");
     }
@@ -64,7 +64,7 @@ public class TableForEachTest extends AbstractDigitalActionTestBase {
                 "LogixNG: A new logix for test%n" +
                 "   ConditionalNG: A conditionalNG%n" +
                 "      ! A%n" +
-                "         Table: For each column of row \"\" in table \"''\" set variable \"\" and execute action A1 ::: Use default%n" +
+                "         Table: For each column of row \"-- Header --\" in table \"''\" set variable \"\" and execute action A1 ::: Use default%n" +
                 "            ! A1%n" +
                 "               MyAction ::: Use default%n");
     }
@@ -213,7 +213,7 @@ public class TableForEachTest extends AbstractDigitalActionTestBase {
         TableForEach a1 = new TableForEach("IQDA321", null);
         Assert.assertEquals("strings are equal", "Table: For each", a1.getShortDescription());
         TableForEach a2 = new TableForEach("IQDA321", null);
-        Assert.assertEquals("strings are equal", "Table: For each column of row \"\" in table \"''\" set variable \"\" and execute action A1", a2.getLongDescription());
+        Assert.assertEquals("strings are equal", "Table: For each column of row \"-- Header --\" in table \"''\" set variable \"\" and execute action A1", a2.getLongDescription());
     }
 
     @Test


### PR DESCRIPTION
The LogixNG action `Table: For each` can now loop thru the headers. It lets the user to access several columns or rows for each loop using the action `Local variable`.

Fixes a bug in the LogixNG action  `Log local variables`. When the action was created, the settings wasn't saved. So the user had to edit the action again to set the settings.