### PR TITLE
LogixNG Sensor Edge expression cannot use indirect addressing of the sensor

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -474,6 +474,17 @@
               <strong>Execute on change</strong> or
               <strong>Always execute</strong> as the default.
           </li>
+          <li>The expression <strong>Sensor Edge</strong> no longer
+              supports indirect addressing of the sensor. It has never
+              really worked since Sensor Edge needs to listen on the
+              sensor and it cannot listen on a sensor if indirect
+              addressing is used.<br>
+              If a panel is loaded and a Sensor Edge expression uses
+              indirect addressing, an error message is added to the
+              log:<br>
+              <strong>Error during loading Sensor Edge expression
+              IQDE:AUTO:0003 due to: Addressing must be Direct</strong>
+              there IQDE:AUTO:0003 is the system name of the expression.</li>
         </ul>
 
     <h3>Meters and MeterFrames</h3>

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -483,8 +483,8 @@
               indirect addressing, an error message is added to the
               log:<br>
               <strong>Error during loading Sensor Edge expression
-              IQDE:AUTO:0003 due to: Addressing must be Direct</strong>
-              there IQDE:AUTO:0003 is the system name of the expression.</li>
+              IQDE:AUTO:0003 due to: Addressing must be Direct</strong><br>
+              where IQDE:AUTO:0003 is the system name of the expression.</li>
         </ul>
 
     <h3>Meters and MeterFrames</h3>

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionSensorEdge.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionSensorEdge.java
@@ -34,6 +34,7 @@ public class ExpressionSensorEdge extends AbstractDigitalExpression
     public ExpressionSensorEdge(String sys, String user)
             throws BadUserNameException, BadSystemNameException {
         super(sys, user);
+        _selectNamedBean.setOnlyDirectAddressingAllowed();
     }
 
     @Override

--- a/java/src/jmri/jmrit/logixng/expressions/configurexml/ExpressionSensorEdgeXml.java
+++ b/java/src/jmri/jmrit/logixng/expressions/configurexml/ExpressionSensorEdgeXml.java
@@ -58,7 +58,12 @@ public class ExpressionSensorEdgeXml extends jmri.managers.configurexml.Abstract
         var selectNamedBeanXml = new LogixNG_SelectNamedBeanXml<Sensor>();
         var selectEnumFromStateXml = new LogixNG_SelectEnumXml<ExpressionSensorEdge.SensorState>();
         var selectEnumToStateXml = new LogixNG_SelectEnumXml<ExpressionSensorEdge.SensorState>();
-        selectNamedBeanXml.load(shared.getChild("namedBean"), h.getSelectNamedBean());
+
+        try {
+            selectNamedBeanXml.load(shared.getChild("namedBean"), h.getSelectNamedBean());
+        } catch (IllegalArgumentException e) {
+            log.error("Error during loading Sensor Edge expression {}", h.getDisplayName(), e);
+        }
 
         selectEnumFromStateXml.load(shared.getChild("fromState"), h.getSelectEnumFromState());
         selectEnumToStateXml.load(shared.getChild("toState"), h.getSelectEnumToState());
@@ -72,5 +77,5 @@ public class ExpressionSensorEdgeXml extends jmri.managers.configurexml.Abstract
         return true;
     }
 
-//    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ExpressionSensorEdgeXml.class);
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ExpressionSensorEdgeXml.class);
 }

--- a/java/src/jmri/jmrit/logixng/expressions/configurexml/ExpressionSensorEdgeXml.java
+++ b/java/src/jmri/jmrit/logixng/expressions/configurexml/ExpressionSensorEdgeXml.java
@@ -62,7 +62,7 @@ public class ExpressionSensorEdgeXml extends jmri.managers.configurexml.Abstract
         try {
             selectNamedBeanXml.load(shared.getChild("namedBean"), h.getSelectNamedBean());
         } catch (IllegalArgumentException e) {
-            log.error("Error during loading Sensor Edge expression {}", h.getDisplayName(), e);
+            log.error("Error during loading Sensor Edge expression {} due to: {}", h.getDisplayName(), e.getMessage());
         }
 
         selectEnumFromStateXml.load(shared.getChild("fromState"), h.getSelectEnumFromState());

--- a/java/src/jmri/jmrit/logixng/expressions/swing/ExpressionSensorEdgeSwing.java
+++ b/java/src/jmri/jmrit/logixng/expressions/swing/ExpressionSensorEdgeSwing.java
@@ -38,6 +38,11 @@ public class ExpressionSensorEdgeSwing extends AbstractDigitalExpressionSwing {
     protected void createPanel(@CheckForNull Base object, @Nonnull JPanel buttonPanel) {
         ExpressionSensorEdge expression = (ExpressionSensorEdge)object;
 
+        if (expression == null) {
+            // Create a temporary expression since only direct addressing is allowed
+            expression = new ExpressionSensorEdge("IQDE1", null);
+        }
+
         panel = new JPanel();
         panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
 
@@ -54,16 +59,10 @@ public class ExpressionSensorEdgeSwing extends AbstractDigitalExpressionSwing {
         JPanel _tabbedPaneEnumFromState;
         JPanel _tabbedPaneEnumToState;
 
-        if (expression != null) {
-            _tabbedPaneNamedBean = _selectNamedBeanSwing.createPanel(expression.getSelectNamedBean());
-            _tabbedPaneEnumFromState = _selectEnumFromStateSwing.createPanel(expression.getSelectEnumFromState(), SensorState.values());
-            _tabbedPaneEnumToState = _selectEnumToStateSwing.createPanel(expression.getSelectEnumToState(), SensorState.values());
-            _onlyTrueOnceCheckBox.setSelected(expression.getOnlyTrueOnce());
-        } else {
-            _tabbedPaneNamedBean = _selectNamedBeanSwing.createPanel(null);
-            _tabbedPaneEnumFromState = _selectEnumFromStateSwing.createPanel(null, SensorState.values());
-            _tabbedPaneEnumToState = _selectEnumToStateSwing.createPanel(null, SensorState.values());
-        }
+        _tabbedPaneNamedBean = _selectNamedBeanSwing.createPanel(expression.getSelectNamedBean());
+        _tabbedPaneEnumFromState = _selectEnumFromStateSwing.createPanel(expression.getSelectEnumFromState(), SensorState.values());
+        _tabbedPaneEnumToState = _selectEnumToStateSwing.createPanel(expression.getSelectEnumToState(), SensorState.values());
+        _onlyTrueOnceCheckBox.setSelected(expression.getOnlyTrueOnce());
 
 
         JComponent[] components = new JComponent[]{

--- a/java/src/jmri/jmrit/logixng/util/LogixNG_SelectNamedBean.java
+++ b/java/src/jmri/jmrit/logixng/util/LogixNG_SelectNamedBean.java
@@ -65,6 +65,10 @@ public class LogixNG_SelectNamedBean<E extends NamedBean> implements VetoableCha
         _onlyDirectAddressingAllowed = true;
     }
 
+    public boolean getOnlyDirectAddressingAllowed() {
+        return _onlyDirectAddressingAllowed;
+    }
+
     public void copy(LogixNG_SelectNamedBean<E> copy) throws ParserException {
         copy.setAddressing(_addressing);
         if (_handle != null) copy.setNamedBean(_handle);

--- a/java/src/jmri/jmrit/logixng/util/swing/LogixNG_SelectNamedBeanSwing.java
+++ b/java/src/jmri/jmrit/logixng/util/swing/LogixNG_SelectNamedBeanSwing.java
@@ -27,6 +27,8 @@ public class LogixNG_SelectNamedBeanSwing<E extends NamedBean> {
     private final JDialog _dialog;
     private final LogixNG_SelectTableSwing _selectTableSwing;
 
+    private boolean onlyDirectAddressing = false;
+
     private JTabbedPane _tabbedPane;
     private BeanSelectPanel<E> _namedBeanPanel;
     private JPanel _panelDirect;
@@ -59,6 +61,9 @@ public class LogixNG_SelectNamedBeanSwing<E extends NamedBean> {
     public JPanel createPanel(
             @CheckForNull LogixNG_SelectNamedBean<E> selectNamedBean,
             @CheckForNull Predicate<E> filter) {
+
+        onlyDirectAddressing = selectNamedBean != null
+                && selectNamedBean.getOnlyDirectAddressingAllowed();
 
         JPanel panel = new JPanel();
 
@@ -124,7 +129,11 @@ public class LogixNG_SelectNamedBeanSwing<E extends NamedBean> {
             _formulaTextField.setText(selectNamedBean.getFormula());
         }
 
-        panel.add(_tabbedPane);
+        if (!onlyDirectAddressing) {
+            panel.add(_tabbedPane);
+        } else {
+            panel.add(_panelDirect);
+        }
         return panel;
     }
 
@@ -155,7 +164,7 @@ public class LogixNG_SelectNamedBeanSwing<E extends NamedBean> {
 
     public void updateObject(@Nonnull LogixNG_SelectNamedBean<E> selectNamedBean) {
 
-        if (_tabbedPane.getSelectedComponent() == _panelDirect) {
+        if (onlyDirectAddressing || _tabbedPane.getSelectedComponent() == _panelDirect) {
             E namedBean = _namedBeanPanel.getNamedBean();
             if (namedBean != null) {
                 NamedBeanHandle<E> handle
@@ -210,6 +219,10 @@ public class LogixNG_SelectNamedBeanSwing<E extends NamedBean> {
     }
 
     public NamedBeanAddressing getAddressing() {
+        if (onlyDirectAddressing) {
+            return NamedBeanAddressing.Direct;
+        }
+
         if (_tabbedPane.getSelectedComponent() == _panelDirect) {
             return NamedBeanAddressing.Direct;
         } else if (_tabbedPane.getSelectedComponent() == _panelReference) {

--- a/java/test/jmri/jmrit/logixng/CreateLogixNGTreeScaffold.java
+++ b/java/test/jmri/jmrit/logixng/CreateLogixNGTreeScaffold.java
@@ -4442,10 +4442,6 @@ public class CreateLogixNGTreeScaffold {
         expressionSensorEdge = new ExpressionSensorEdge(digitalExpressionManager.getAutoSystemName(), null);
         expressionSensorEdge.setComment("A comment");
         expressionSensorEdge.getSelectNamedBean().setNamedBean(sensor1);
-        expressionSensorEdge.getSelectNamedBean().setAddressing(NamedBeanAddressing.LocalVariable);
-        expressionSensorEdge.getSelectNamedBean().setFormula("\"IT\"+index");
-        expressionSensorEdge.getSelectNamedBean().setLocalVariable("index");
-        expressionSensorEdge.getSelectNamedBean().setReference("{IM1}");
         expressionSensorEdge.getSelectEnumFromState().setEnum(ExpressionSensorEdge.SensorState.Inactive);
         expressionSensorEdge.getSelectEnumFromState().setAddressing(NamedBeanAddressing.Formula);
         expressionSensorEdge.getSelectEnumFromState().setFormula("\"IT\"+index2");
@@ -4462,10 +4458,6 @@ public class CreateLogixNGTreeScaffold {
         expressionSensorEdge = new ExpressionSensorEdge(digitalExpressionManager.getAutoSystemName(), null);
         expressionSensorEdge.setComment("A comment");
         expressionSensorEdge.getSelectNamedBean().setNamedBean(sensor1);
-        expressionSensorEdge.getSelectNamedBean().setAddressing(NamedBeanAddressing.Formula);
-        expressionSensorEdge.getSelectNamedBean().setFormula("\"IT\"+index");
-        expressionSensorEdge.getSelectNamedBean().setLocalVariable("index");
-        expressionSensorEdge.getSelectNamedBean().setReference("{IM1}");
         expressionSensorEdge.getSelectEnumFromState().setEnum(ExpressionSensorEdge.SensorState.Inactive);
         expressionSensorEdge.getSelectEnumFromState().setAddressing(NamedBeanAddressing.Reference);
         expressionSensorEdge.getSelectEnumFromState().setFormula("\"IT\"+index2");
@@ -4478,10 +4470,6 @@ public class CreateLogixNGTreeScaffold {
         expressionSensorEdge = new ExpressionSensorEdge(digitalExpressionManager.getAutoSystemName(), null);
         expressionSensorEdge.setComment("A comment");
         expressionSensorEdge.getSelectNamedBean().setNamedBean(sensor1);
-        expressionSensorEdge.getSelectNamedBean().setAddressing(NamedBeanAddressing.Reference);
-        expressionSensorEdge.getSelectNamedBean().setFormula("\"IT\"+index");
-        expressionSensorEdge.getSelectNamedBean().setLocalVariable("index");
-        expressionSensorEdge.getSelectNamedBean().setReference("{IM1}");
         expressionSensorEdge.getSelectEnumFromState().setEnum(ExpressionSensorEdge.SensorState.Inactive);
         expressionSensorEdge.getSelectEnumFromState().setAddressing(NamedBeanAddressing.Direct);
         expressionSensorEdge.getSelectEnumFromState().setFormula("\"IT\"+index2");

--- a/java/test/jmri/jmrit/logixng/configurexml/load/LogixNG.5.5.5.xml
+++ b/java/test/jmri/jmrit/logixng/configurexml/load/LogixNG.5.5.5.xml
@@ -10280,7 +10280,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <systemName>IQDE:AUTO:0106</systemName>
       <comment>A comment</comment>
       <namedBean>
-        <addressing>LocalVariable</addressing>
+        <addressing>Direct</addressing>
         <name>IS1</name>
         <reference>{IM1}</reference>
         <listenToMemory>no</listenToMemory>
@@ -10380,7 +10380,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <systemName>IQDE:AUTO:0107</systemName>
       <comment>A comment</comment>
       <namedBean>
-        <addressing>Formula</addressing>
+        <addressing>Direct</addressing>
         <name>IS1</name>
         <reference>{IM1}</reference>
         <listenToMemory>no</listenToMemory>
@@ -10477,7 +10477,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <systemName>IQDE:AUTO:0108</systemName>
       <comment>A comment</comment>
       <namedBean>
-        <addressing>Reference</addressing>
+        <addressing>Direct</addressing>
         <name>IS1</name>
         <reference>{IM1}</reference>
         <listenToMemory>no</listenToMemory>

--- a/java/test/jmri/jmrit/logixng/configurexml/load/LogixNG.xml
+++ b/java/test/jmri/jmrit/logixng/configurexml/load/LogixNG.xml
@@ -85,7 +85,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
     <memory>
       <systemName>IM3</systemName>
     </memory>
-    <memory value="1:56 PM">
+    <memory value="10:09 PM">
       <systemName>IMCURRENTTIME</systemName>
     </memory>
     <memory value="1.0">
@@ -176,7 +176,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <userName>First conditional</userName>
     </conditional>
   </conditionals>
-  <timebase class="jmri.jmrit.simpleclock.configurexml.SimpleTimebaseXml" time="Wed Jan 17 13:56:42 CET 2024" rate="1.0" startrate="1.0" run="yes" master="yes" sync="no" correct="no" display="no" startstopped="no" startrunning="yes" startsettime="no" startclockoption="0" showbutton="no" startsetrate="yes" />
+  <timebase class="jmri.jmrit.simpleclock.configurexml.SimpleTimebaseXml" time="Mon Jan 22 22:09:16 CET 2024" rate="1.0" startrate="1.0" run="yes" master="yes" sync="no" correct="no" display="no" startstopped="no" startrunning="yes" startsettime="no" startclockoption="0" showbutton="no" startsetrate="yes" />
   <LogixNGs class="jmri.jmrit.logixng.implementation.configurexml.DefaultLogixNGManagerXml">
     <Thread>
       <id>0</id>
@@ -10512,12 +10512,9 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <systemName>IQDE:AUTO:0107</systemName>
       <comment>A comment</comment>
       <namedBean>
-        <addressing>LocalVariable</addressing>
+        <addressing>Direct</addressing>
         <name>IS1</name>
-        <reference>{IM1}</reference>
         <listenToMemory>no</listenToMemory>
-        <localVariable>index</localVariable>
-        <formula>"IT"+index</formula>
       </namedBean>
       <fromState>
         <addressing>Formula</addressing>
@@ -10612,12 +10609,9 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <systemName>IQDE:AUTO:0108</systemName>
       <comment>A comment</comment>
       <namedBean>
-        <addressing>Formula</addressing>
+        <addressing>Direct</addressing>
         <name>IS1</name>
-        <reference>{IM1}</reference>
         <listenToMemory>no</listenToMemory>
-        <localVariable>index</localVariable>
-        <formula>"IT"+index</formula>
       </namedBean>
       <fromState>
         <addressing>Reference</addressing>
@@ -10709,12 +10703,9 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <systemName>IQDE:AUTO:0109</systemName>
       <comment>A comment</comment>
       <namedBean>
-        <addressing>Reference</addressing>
+        <addressing>Direct</addressing>
         <name>IS1</name>
-        <reference>{IM1}</reference>
         <listenToMemory>no</listenToMemory>
-        <localVariable>index</localVariable>
-        <formula>"IT"+index</formula>
       </namedBean>
       <fromState>
         <addressing>Direct</addressing>
@@ -49574,9 +49565,9 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
   <filehistory>
     <operation>
       <type>Store</type>
-      <date>Wed Jan 17 13:56:46 CET 2024</date>
+      <date>Mon Jan 22 22:09:22 CET 2024</date>
       <filename>/home/daniel/Dokument/GitHub/JMRI/temp/temp/LogixNG_temp.xml</filename>
     </operation>
   </filehistory>
-  <!--Written by JMRI version 5.7.3plus+daniel+2024-01-17T12:56:37Z+RUNKNOWN on Wed Jan 17 13:56:46 CET 2024-->
+  <!--Written by JMRI version 5.7.3plus+daniel+2024-01-22T21:09:10Z+RUNKNOWN on Mon Jan 22 22:09:22 CET 2024-->
 </layout-config>

--- a/java/test/jmri/jmrit/logixng/configurexml/loadref/LogixNG.5.5.5.xml
+++ b/java/test/jmri/jmrit/logixng/configurexml/loadref/LogixNG.5.5.5.xml
@@ -10280,7 +10280,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <systemName>IQDE:AUTO:0106</systemName>
       <comment>A comment</comment>
       <namedBean>
-        <addressing>LocalVariable</addressing>
+        <addressing>Direct</addressing>
         <name>IS1</name>
         <reference>{IM1}</reference>
         <listenToMemory>no</listenToMemory>
@@ -10380,7 +10380,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <systemName>IQDE:AUTO:0107</systemName>
       <comment>A comment</comment>
       <namedBean>
-        <addressing>Formula</addressing>
+        <addressing>Direct</addressing>
         <name>IS1</name>
         <reference>{IM1}</reference>
         <listenToMemory>no</listenToMemory>
@@ -10477,7 +10477,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <systemName>IQDE:AUTO:0108</systemName>
       <comment>A comment</comment>
       <namedBean>
-        <addressing>Reference</addressing>
+        <addressing>Direct</addressing>
         <name>IS1</name>
         <reference>{IM1}</reference>
         <listenToMemory>no</listenToMemory>


### PR DESCRIPTION
This PR disables indirect addressing of the sensor used by the LogixNG expression `Sensor Edge`.