### PR TITLE
LocoNet Message Interpret Javadoc encoding on windows-1252

### DIFF
--- a/java/src/jmri/jmrix/loconet/messageinterp/LocoNetMessageInterpret.java
+++ b/java/src/jmri/jmrix/loconet/messageinterp/LocoNetMessageInterpret.java
@@ -4173,7 +4173,7 @@ public class LocoNetMessageInterpret {
                             * the first data byte being the most significant bits of 
                             * the address. The Configuration variable being addressed 
                             * is the provided 10-bit address plus 1. For example, to 
-                            * address CV1 the 10 bit address is “00 00000000”.
+                            * address CV1 the 10 bit address is "00 00000000".
                             *
                             * The defined values for Instruction type (CC) are:
                             *       GG=00 Reserved for future use


### PR DESCRIPTION
`ant javadoc` currently failing on Win 11, fixed by using normal quotations.

```
javadoc:
  [javadoc] Generating Javadoc
  [javadoc] Javadoc execution
  [javadoc] C:\Users\Steve\Documents\GitHub\JMRI\java\src\jmri\jmrix\loconet\messageinterp\LocoNetMessageInterpret.java:4176: error: unmappable character (0x9D) for encoding windows-1252
  [javadoc]                             * address CV1 the 10 bit address is ÔÇ£00 00000000ÔÇ?.
  [javadoc]                                                                                 ^
  [javadoc] 1 error

BUILD FAILED
```