### PR TITLE
Fix bug in the LogixNG ListenOnBeans... actions

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -461,6 +461,9 @@
               has been added.</li>
           <li>The LogixNG action <strong>Set reporter</strong> has been
               added.</li>
+          <li>The actions <strong>Listen on Beans ...</strong> have been
+              updated to fix a problem when several beans changes
+              state at the same time.</li>
           <li></li>
         </ul>
 

--- a/java/src/jmri/jmrit/logixng/actions/ActionListenOnBeansTable.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionListenOnBeansTable.java
@@ -10,6 +10,8 @@ import jmri.jmrit.logixng.*;
 import jmri.jmrit.logixng.util.LogixNG_SelectNamedBean;
 import jmri.jmrit.logixng.util.parser.ParserException;
 
+import net.jcip.annotations.GuardedBy;
+
 /**
  * This action listens on some beans and runs the ConditionalNG on property change.
  *
@@ -30,9 +32,9 @@ public class ActionListenOnBeansTable extends AbstractDigitalAction
     private String _localVariableNamedBean;
     private String _localVariableEvent;
     private String _localVariableNewValue;
-    private String _lastNamedBean;
-    private String _lastEvent;
-    private String _lastNewValue;
+
+    @GuardedBy("this")
+    private final Deque<PropertyChangeEvent> _eventQueue = new ArrayDeque<>();
 
     public ActionListenOnBeansTable(String sys, String user)
             throws BadUserNameException, BadSystemNameException {
@@ -198,20 +200,41 @@ public class ActionListenOnBeansTable extends AbstractDigitalAction
         // of the registered beans and execute the ConditionalNG when it
         // happens.
 
+        String namedBean;
+        String event;
+        String newValue;
+
+        boolean isQueueEmpty;
+
         synchronized(this) {
+            PropertyChangeEvent evt = _eventQueue.poll();
+            if (evt != null) {
+                namedBean = ((NamedBean)evt.getSource()).getDisplayName();
+                event = evt.getPropertyName();
+                newValue = evt.getNewValue() != null ? evt.getNewValue().toString() : null;
+            } else {
+                namedBean = null;
+                event = null;
+                newValue = null;
+            }
+
             SymbolTable symbolTable = getConditionalNG().getSymbolTable();
+
             if (_localVariableNamedBean != null) {
-                symbolTable.setValue(_localVariableNamedBean, _lastNamedBean);
+                symbolTable.setValue(_localVariableNamedBean, namedBean);
             }
             if (_localVariableEvent != null) {
-                symbolTable.setValue(_localVariableEvent, _lastEvent);
+                symbolTable.setValue(_localVariableEvent, event);
             }
             if (_localVariableNewValue != null) {
-                symbolTable.setValue(_localVariableNewValue, _lastNewValue);
+                symbolTable.setValue(_localVariableNewValue, newValue);
             }
-            _lastNamedBean = null;
-            _lastEvent = null;
-            _lastNewValue = null;
+
+            isQueueEmpty = _eventQueue.isEmpty();
+        }
+
+        if (!isQueueEmpty) {
+            getConditionalNG().execute();
         }
     }
 
@@ -341,13 +364,14 @@ public class ActionListenOnBeansTable extends AbstractDigitalAction
     /** {@inheritDoc} */
     @Override
     public void propertyChange(PropertyChangeEvent evt) {
-//        System.out.format("Table: Property: %s, Bean: %s, Listen: %b%n", evt.getPropertyName(), ((NamedBean)evt.getSource()).getDisplayName(), _listenOnAllProperties);
+        boolean isQueueEmpty;
         synchronized(this) {
-            _lastNamedBean = ((NamedBean)evt.getSource()).getDisplayName();
-            _lastEvent = evt.getPropertyName();
-            _lastNewValue = evt.getNewValue() != null ? evt.getNewValue().toString() : null;
+            isQueueEmpty = _eventQueue.isEmpty();
+            _eventQueue.add(evt);
         }
-        getConditionalNG().execute();
+        if (isQueueEmpty) {
+            getConditionalNG().execute();
+        }
     }
 
     /** {@inheritDoc} */

--- a/java/src/jmri/jmrit/logixng/util/LogixNG_Thread.java
+++ b/java/src/jmri/jmrit/logixng/util/LogixNG_Thread.java
@@ -290,6 +290,10 @@ public class LogixNG_Thread {
         }
     }
 
+    public boolean isQueueEmpty() {
+        return _eventQueue.isEmpty();
+    }
+
     /**
      * Check if on the LogixNG-operation thread.
      *

--- a/java/test/jmri/jmrit/logixng/actions/ActionListenOnBeansTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ActionListenOnBeansTest.java
@@ -2,9 +2,13 @@ package jmri.jmrit.logixng.actions;
 
 import java.util.ArrayList;
 
+import javax.swing.JTextArea;
+
 import jmri.*;
 import jmri.jmrit.logixng.*;
 import jmri.jmrit.logixng.implementation.DefaultConditionalNGScaffold;
+import jmri.jmrit.logixng.util.parser.ParserException;
+import jmri.script.swing.ScriptOutput;
 import jmri.util.JUnitUtil;
 
 import org.junit.After;
@@ -19,9 +23,12 @@ import org.junit.Test;
  */
 public class ActionListenOnBeansTest extends AbstractDigitalActionTestBase {
 
+    private Sensor s1, s2, s3, sensorWait, s99;
     private LogixNG logixNG;
     private ConditionalNG conditionalNG;
+    private WaitForScaffold actionWaitFor;
     private ActionListenOnBeans actionListenOnBeans;
+
 
     @Override
     public ConditionalNG getConditionalNG() {
@@ -49,7 +56,21 @@ public class ActionListenOnBeansTest extends AbstractDigitalActionTestBase {
                 "LogixNG: A logixNG%n" +
                 "   ConditionalNG: A conditionalNG%n" +
                 "      ! A%n" +
-                "         Listen on beans ::: Use default%n");
+                "         Many ::: Use default%n" +
+                "            ::: Local variable \"bean\", init to None \"null\"%n" +
+                "            ::: Local variable \"event\", init to None \"null\"%n" +
+                "            ::: Local variable \"value\", init to None \"null\"%n" +
+                "            ! A1%n" +
+                "               Wait for ::: Use default%n" +
+                "            ! A2%n" +
+                "               Listen on beans ::: Use default%n" +
+                "            ! A3%n" +
+                "               Log data: Comma separated list ::: Use default%n" +
+                "            ! A4%n" +
+                "               Set sensor IS99 to state Active ::: Use default%n" +
+                "            ! A5%n" +
+                "               Socket not connected%n"
+        );
     }
 
     @Override
@@ -100,9 +121,85 @@ public class ActionListenOnBeansTest extends AbstractDigitalActionTestBase {
         Assert.assertEquals("strings are equal", "Listen on beans", a2.getLongDescription());
     }
 
+    private JTextArea getOutputArea() {
+        return ScriptOutput.getDefault().getOutputArea();
+    }
+
+    @Test
+    public void testExecute() throws JmriException {
+
+        var oldReleaseCondition = actionWaitFor.getReleaseCondition();
+
+        actionWaitFor.setReleaseCondition(() -> { return sensorWait.getState() == Sensor.ACTIVE; });
+        sensorWait.setState(Sensor.ACTIVE);
+//        sensorWait.setState(Sensor.INACTIVE);
+
+        conditionalNG.setRunDelayed(true);
+
+        // Test listen on sensor s1
+        Assert.assertTrue(conditionalNG.getCurrentThread().isQueueEmpty());
+        getOutputArea().setText("");
+        s99.setState(Sensor.INACTIVE);
+        s1.setState(Sensor.INACTIVE);
+        Assert.assertTrue(JUnitUtil.waitFor(() -> {return s99.getState() == Sensor.ACTIVE;}));
+        Assert.assertTrue(conditionalNG.getCurrentThread().isQueueEmpty());
+        Assert.assertEquals("IS1, KnownState, 4", getOutputArea().getText().trim());
+        getOutputArea().setText("");
+        s99.setState(Sensor.INACTIVE);
+        Assert.assertEquals("", getOutputArea().getText());
+        s1.setState(Sensor.ACTIVE);
+        Assert.assertEquals("", getOutputArea().getText());
+        Assert.assertTrue(JUnitUtil.waitFor(() -> {return s99.getState() == Sensor.ACTIVE;}));
+        Assert.assertTrue(conditionalNG.getCurrentThread().isQueueEmpty());
+        Assert.assertEquals("IS1, KnownState, 2", getOutputArea().getText().trim());
+
+        // Test listen on sensor s1
+        Assert.assertTrue(conditionalNG.getCurrentThread().isQueueEmpty());
+        getOutputArea().setText("");
+        s99.setState(Sensor.INACTIVE);
+        s1.setState(Sensor.INACTIVE);
+        Assert.assertTrue(JUnitUtil.waitFor(() -> {return s99.getState() == Sensor.ACTIVE;}));
+        Assert.assertTrue(conditionalNG.getCurrentThread().isQueueEmpty());
+        Assert.assertEquals("IS1, KnownState, 4", getOutputArea().getText().trim());
+        getOutputArea().setText("");
+        s99.setState(Sensor.INACTIVE);
+        Assert.assertEquals("", getOutputArea().getText());
+        s1.setState(Sensor.ACTIVE);
+        Assert.assertEquals("", getOutputArea().getText());
+        Assert.assertTrue(JUnitUtil.waitFor(() -> {return s99.getState() == Sensor.ACTIVE;}));
+        Assert.assertTrue(conditionalNG.getCurrentThread().isQueueEmpty());
+        Assert.assertEquals("IS1, KnownState, 2", getOutputArea().getText().trim());
+
+        // Test listen on sensor s1, s2 and s3, when s1 and s2 goes active
+        // while the conditionalNG is running.
+        Assert.assertTrue(conditionalNG.getCurrentThread().isQueueEmpty());
+        getOutputArea().setText("");
+        sensorWait.setState(Sensor.INACTIVE);
+        s99.setState(Sensor.INACTIVE);
+        s1.setState(Sensor.INACTIVE);
+        s2.setState(Sensor.INACTIVE);
+        s3.setState(Sensor.INACTIVE);
+        sensorWait.setState(Sensor.ACTIVE);
+        Assert.assertTrue(JUnitUtil.waitFor(() -> {return s99.getState() == Sensor.ACTIVE;}));
+        Assert.assertTrue(conditionalNG.getCurrentThread().isQueueEmpty());
+        Assert.assertTrue(JUnitUtil.waitFor(() -> {return String.format("IS1, KnownState, 4%nIS2, KnownState, 4%nIS3, KnownState, 4%n").equals(getOutputArea().getText());}));
+        Assert.assertEquals(String.format("IS1, KnownState, 4%nIS2, KnownState, 4%nIS3, KnownState, 4%n"), getOutputArea().getText());
+        getOutputArea().setText("");
+        s99.setState(Sensor.INACTIVE);
+        Assert.assertEquals("", getOutputArea().getText());
+        s1.setState(Sensor.ACTIVE);
+        Assert.assertEquals("", getOutputArea().getText());
+        Assert.assertTrue(JUnitUtil.waitFor(() -> {return s99.getState() == Sensor.ACTIVE;}));
+        Assert.assertTrue(conditionalNG.getCurrentThread().isQueueEmpty());
+        Assert.assertEquals("IS1, KnownState, 2", getOutputArea().getText().trim());
+
+        actionWaitFor.setReleaseCondition(oldReleaseCondition);
+    }
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ActionListenOnBeans.class);
+
     // The minimal setup for log4J
     @Before
-    public void setUp() throws SocketAlreadyConnectedException {
+    public void setUp() throws SocketAlreadyConnectedException, ParserException {
         JUnitUtil.setUp();
         JUnitUtil.resetInstanceManager();
         JUnitUtil.resetProfileManager();
@@ -114,18 +211,60 @@ public class ActionListenOnBeansTest extends AbstractDigitalActionTestBase {
         _category = Category.ITEM;
         _isExternal = true;
 
+        s1 = InstanceManager.getDefault(SensorManager.class).provideSensor("IS1");
+        s2 = InstanceManager.getDefault(SensorManager.class).provideSensor("IS2");
+        s3 = InstanceManager.getDefault(SensorManager.class).provideSensor("IS3");
+        sensorWait = InstanceManager.getDefault(SensorManager.class).provideSensor("ISWait");
+        s99 = InstanceManager.getDefault(SensorManager.class).provideSensor("IS99");
+
         logixNG = InstanceManager.getDefault(LogixNG_Manager.class).createLogixNG("A logixNG");
         conditionalNG = new DefaultConditionalNGScaffold("IQC1", "A conditionalNG");  // NOI18N;
         InstanceManager.getDefault(ConditionalNG_Manager.class).register(conditionalNG);
         logixNG.addConditionalNG(conditionalNG);
         conditionalNG.setRunDelayed(false);
         conditionalNG.setEnabled(true);
-        actionListenOnBeans = new ActionListenOnBeans(InstanceManager.getDefault(DigitalActionManager.class).getAutoSystemName(), null);
-        MaleSocket socket = InstanceManager.getDefault(DigitalActionManager.class).registerAction(actionListenOnBeans);
+
+        DigitalActionManager digitalActionManager = InstanceManager.getDefault(DigitalActionManager.class);
+
+        DigitalMany many = new DigitalMany(digitalActionManager.getAutoSystemName(), null);
+        MaleSocket socket = digitalActionManager.registerAction(many);
+        socket.addLocalVariable("bean", SymbolTable.InitialValueType.None, null);
+        socket.addLocalVariable("event", SymbolTable.InitialValueType.None, null);
+        socket.addLocalVariable("value", SymbolTable.InitialValueType.None, null);
         conditionalNG.getChild(0).connect(socket);
+
+        actionWaitFor = new WaitForScaffold(digitalActionManager.getAutoSystemName(), null, ()->{return true;});
+        socket = digitalActionManager.registerAction(actionWaitFor);
+        many.getChild(0).connect(socket);
+
+        actionListenOnBeans = new ActionListenOnBeans(digitalActionManager.getAutoSystemName(), null);
+        actionListenOnBeans.addReference("Sensor:IS1");
+        actionListenOnBeans.addReference("Sensor:IS2");
+        actionListenOnBeans.addReference("Sensor:IS3");
+        actionListenOnBeans.setLocalVariableNamedBean("bean");
+        actionListenOnBeans.setLocalVariableEvent("event");
+        actionListenOnBeans.setLocalVariableNewValue("value");
+        socket = digitalActionManager.registerAction(actionListenOnBeans);
+        many.getChild(1).connect(socket);
 
         _base = actionListenOnBeans;
         _baseMaleSocket = socket;
+
+        LogData logData = new LogData(digitalActionManager.getAutoSystemName(), null);
+        logData.setFormatType(LogData.FormatType.CommaSeparatedList);
+        logData.getDataList().add(new LogData.Data(LogData.DataType.LocalVariable, "bean"));
+        logData.getDataList().add(new LogData.Data(LogData.DataType.LocalVariable, "event"));
+        logData.getDataList().add(new LogData.Data(LogData.DataType.LocalVariable, "value"));
+        logData.setLogToLog(false);
+        logData.setLogToScriptOutput(true);
+        socket = digitalActionManager.registerAction(logData);
+        many.getChild(2).connect(socket);
+
+        ActionSensor actionSensor = new ActionSensor(digitalActionManager.getAutoSystemName(), null);
+        actionSensor.getSelectNamedBean().setNamedBean("IS99");
+        actionSensor.getSelectEnum().setEnum(ActionSensor.SensorState.Active);
+        socket = digitalActionManager.registerAction(actionSensor);
+        many.getChild(3).connect(socket);
 
         if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
         logixNG.activate();
@@ -137,6 +276,11 @@ public class ActionListenOnBeansTest extends AbstractDigitalActionTestBase {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
+        s1 = s2 = s3 = s99 = null;
+        logixNG = null;
+        conditionalNG = null;
+        actionWaitFor = null;
+        actionListenOnBeans = null;
     }
 
 }

--- a/java/test/jmri/jmrit/logixng/actions/ActionListenOnBeansTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ActionListenOnBeansTest.java
@@ -195,7 +195,6 @@ public class ActionListenOnBeansTest extends AbstractDigitalActionTestBase {
 
         actionWaitFor.setReleaseCondition(oldReleaseCondition);
     }
-    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ActionListenOnBeans.class);
 
     // The minimal setup for log4J
     @Before

--- a/java/test/jmri/jmrit/logixng/actions/WaitForScaffold.java
+++ b/java/test/jmri/jmrit/logixng/actions/WaitForScaffold.java
@@ -1,0 +1,106 @@
+package jmri.jmrit.logixng.actions;
+
+import java.util.Locale;
+import java.util.Map;
+
+import jmri.InstanceManager;
+import jmri.JmriException;
+import jmri.jmrit.logixng.*;
+import jmri.util.JUnitUtil;
+import jmri.util.JUnitUtil.ReleaseUntil;
+
+/**
+ * This action waits for a condition to be true. It is used for tests.
+ *
+ * @author Daniel Bergqvist Copyright 2024
+ */
+public class WaitForScaffold extends AbstractDigitalAction {
+
+    private ReleaseUntil _condition;
+
+    public WaitForScaffold(ReleaseUntil condition)
+            throws BadUserNameException {
+        super(InstanceManager.getDefault(DigitalActionManager.class).getAutoSystemName(), null);
+        _condition = condition;
+    }
+
+    public WaitForScaffold(String sys, String user, ReleaseUntil condition)
+            throws BadUserNameException, BadSystemNameException {
+        super(sys, user);
+        _condition = condition;
+    }
+
+    @Override
+    public Base getDeepCopy(Map<String, String> systemNames, Map<String, String> userNames) {
+        DigitalActionManager manager = InstanceManager.getDefault(DigitalActionManager.class);
+        String sysName = systemNames.get(getSystemName());
+        String userName = userNames.get(getSystemName());
+        if (sysName == null) sysName = manager.getAutoSystemName();
+        WaitForScaffold copy = new WaitForScaffold(sysName, userName, _condition);
+        copy.setComment(getComment());
+        return manager.registerAction(copy);
+    }
+
+    public void setReleaseCondition(ReleaseUntil condition) {
+        _condition = condition;
+    }
+
+    public ReleaseUntil getReleaseCondition() {
+        return _condition;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Category getCategory() {
+        return Category.OTHER;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void execute() throws JmriException {
+        if (!JUnitUtil.waitFor(_condition)) {
+            throw new JmriException("WaitFor condition didn't returned true in time");
+        }
+    }
+
+    @Override
+    public FemaleSocket getChild(int index) throws IllegalArgumentException, UnsupportedOperationException {
+        throw new UnsupportedOperationException("Not supported.");
+    }
+
+    @Override
+    public int getChildCount() {
+        return 0;
+    }
+
+    @Override
+    public String getShortDescription(Locale locale) {
+        return "Wait for";
+    }
+
+    @Override
+    public String getLongDescription(Locale locale) {
+        return "Wait for";
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void setup() {
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void registerListenersForThisClass() {
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void unregisterListenersForThisClass() {
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void disposeMe() {
+    }
+
+}


### PR DESCRIPTION
The `ListenOnBeans...` had a bug that caused these actions to miss a PropertyChange event if there was two or more events coming at the same time.

More info in Issue #12906.