### PR TITLE
Three sample scripts

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -554,7 +554,18 @@ LogixNG: IQ:AUTO:0001
     <h3>Scripting</h3>
         <a id="Scripting" name="Scripting"></a>
         <ul>
-            <li></li>
+            <li>Added three sample scripts
+                <ul>
+                    <li>AddPowerButton.py - shows how to add a button to the main
+                            PanelPro window. In this case, the button turns power on and off.
+                    <li>MainWindowToBack.py - moves the main PanelPro window to the back.
+                            Useful when you want PanelPro to start up with a panel
+                            at the front of the screen.
+                    <li>MenuItemDisable.py - shows how to disable menu items so they
+                            can't be used.  Sample disables LocoNet ability to reset slots,
+                            and ability to start the WiThrottle server.  Meant for e.g.
+                            club use.
+            </li>
         </ul>
 
     <h3>Signals</h3>

--- a/jython/AddPowerButton.py
+++ b/jython/AddPowerButton.py
@@ -1,0 +1,52 @@
+# Sample script to add a button to the main
+# JMRI application window that controls layout power
+#
+# Author: Bob Jacobsen, copyright 2007, 2024
+# Part of the JMRI distribution
+
+#
+# NOTE: This script does not support DecoderPro. Use the recommended
+# method if you need to add a script to a button in DecoderPro.
+#
+
+import jmri
+import java
+import javax.swing.JButton
+import apps
+
+# create the button, and add an action routine to it
+powerButton = javax.swing.JButton("Starting...")
+def whenMyButtonClicked(event) :
+    # alternate the power state
+    power = jmri.InstanceManager.getDefault(jmri.PowerManager).getPower()
+    if (power == jmri.PowerManager.ON) :
+       powermanager.setPower(jmri.PowerManager.OFF) 
+    else :
+       powermanager.setPower(jmri.PowerManager.ON)
+    return
+powerButton.actionPerformed = whenMyButtonClicked
+
+# add the button to the main screen
+apps.Apps.buttonSpace().add(powerButton)
+
+# force redisplay
+apps.Apps.buttonSpace().revalidate()
+
+# create a listener to the powerManager to update the button
+class PowerListener(java.beans.PropertyChangeListener):
+  def propertyChange(self, event):
+    # here, power has changed. Find new state
+    power = jmri.InstanceManager.getDefault(jmri.PowerManager).getPower()
+    if (power == jmri.PowerManager.ON) :
+       powerButton.setText("Turn Off")
+    else :
+       powerButton.setText("Turn On")
+    return 
+    
+# attach that to the power manager
+powerListener = PowerListener()
+p = jmri.InstanceManager.getDefault(jmri.PowerManager)
+p.addPropertyChangeListener(powerListener)
+
+# and run it once to set the initial state
+powerListener.propertyChange(None)

--- a/jython/MainWindowToBack.py
+++ b/jython/MainWindowToBack.py
@@ -1,0 +1,29 @@
+# 
+# Find the Main PanelPro window and send to back.
+# This puts it behind any panels you might want to display (completely) at startup
+
+import jmri
+import java
+import javax
+
+class MainPanelToBack(jmri.jmrit.automat.AbstractAutomaton) :
+
+    # handle() is called repeatedly until it returns false.
+    def handle(self):
+        self.waitMsec(8000)  # has to wait for main window to exist
+        for frame in jmri.util.JmriJFrame.getFrameList() :
+            if frame.getTitle() == "PanelPro" :
+                frame.toBack()
+                return
+        print ("Did not find main window, probably need a longer delay")
+
+# create one of these
+a = MainPanelToBack()
+
+# set the name, as a example of configuring it
+a.setName("Move main PanelPro window to back")
+
+# and start it running - this will only take a short time
+a.start()
+
+    

--- a/jython/MenuItemDisable.py
+++ b/jython/MenuItemDisable.py
@@ -1,0 +1,76 @@
+# Disable some specific menus at startup time.
+#
+# This might be useful if e.g. you're letting general users access the menus
+#
+# There are reports of it not working on Windows. These are
+# not understood - it seems that some windows on Windows don't have 
+# an accessible menu bar
+
+import jmri
+
+def findMenu(frame, menuName) :
+    bar = frame.getMenuBar()
+    if bar is None:
+        print "No menu bar on frame"
+        return None
+    for i in range(0,bar.getMenuCount()-1) :
+        menu = bar.getMenu(i)
+        if menuName == menu.getLabel() : return menu
+    print "Did not find menu", menuName
+    return None # error
+
+def findItem(menu, itemName) :
+    for i in range(0, menu.getItemCount()) :
+        item = menu.getItem(i)
+        if itemName == item.getLabel() : return item
+    print "Did not find item", itemName
+    return None # error
+
+# this includes a delay to make sure the window is created if run during startup
+class MenuItemDisable(jmri.jmrit.automat.AbstractAutomaton) :
+    # handle() is called repeatedly until it returns false.
+    def handle(self):
+        self.waitMsec(8000)
+
+        # find the frame containing the menus to disable
+        frame = jmri.util.JmriJFrame.getFrame("PanelPro")
+        
+        # find the menu in the menu bar
+        loconetMenu = findMenu(frame, "LocoNet")
+        
+        if loconetMenu is not None: # skip if run on some other connection
+           
+            # Find an item within that menu and disable it
+            monitorSlots = findItem(loconetMenu, "Monitor Slots")
+            monitorSlots.disable()
+            
+            configureCS = findItem(loconetMenu, "Configure Command Station")
+            configureCS.disable()
+        else :
+            print "Did not find LocoNet menu"
+            
+        toolsMenu = findMenu(frame, "Tools")
+
+        if toolsMenu is not None:
+        
+            # need to go down one extra level for these next
+            servers = findItem(toolsMenu, "Servers")
+            startWiThrottle = findItem(servers, "Start WiThrottle Server")
+            startWiThrottle.disable()
+        
+            throttles = findItem(toolsMenu, "Throttles")
+            startWiThrottle = findItem(throttles, "Start WiThrottle Server")
+            startWiThrottle.disable()
+        else :
+            print "Did not find Tools menu"
+        
+
+# create one of these
+a = MenuItemDisable()
+
+# set the name, as a example of configuring it
+a.setName("Some editing of the menus")
+
+# and start it running - this will only take a short time
+a.start()
+


### PR DESCRIPTION
Adds three sample scripts:

 - AddPowerButton.py - shows how to add a button to the main PanelPro window. In this case, the button turns power on and off.

 - MainWindowToBack.py - moves the main PanelPro window to the back. Useful when you want PanelPro to start up with a panel at the front of the screen.

 - MenuItemDisable.py - shows how to disable menu items so they can't be used.  Sample disables LocoNet ability to reset slots, and ability to start the WiThrottle server.  Meant for e.g. club use.
