### PR TITLE
Improve LogixNG

### DIFF
--- a/help/en/html/tools/logixng/reference/chapter5.shtml
+++ b/help/en/html/tools/logixng/reference/chapter5.shtml
@@ -319,7 +319,7 @@
         <li><strong>Enable:</strong> Enable the selected LogixNG. The setting will be retained when
         a tables and panels store occurs.</li>
 
-        <li><strong>Disable:</strong> Disable the select LogixNG. The setting will be retained when a
+        <li><strong>Disable:</strong> Disable the selected LogixNG. The setting will be retained when a
         tables and panels store occurs.</li>
 
         <li><strong>Activate:</strong> Activate the selected LogixNG. The change only persists during

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -491,11 +491,21 @@ LogixNG: IQ:AUTO:0001
                     Log local variables
               </pre>
               </li>
+          <li>The LogixNG action <strong>For each</strong> now supports
+              Java arrays as well, for example the result of the expression
+              <strong>a_b.split("\_")</strong>.</li>
           <li>The LogixNG action <strong>Set reporter</strong> has been
               added.</li>
           <li>The actions <strong>Listen on Beans ...</strong> have been
               updated to fix a problem when several beans changes
               state at the same time.</li>
+          <li>Fixes a bug so that the methods <strong>toString()</strong>,
+              <strong>getKey()</strong> and <strong>getValue()</strong>
+              can be used for an item when using the action <strong>For each</strong>
+              on a Map.</li>
+          <li>Adds the LogixNG functions <strong>strlen()</strong> in module
+              <strong>String</strong> and <strong>length()</strong> in module
+              <strong>Common</strong>.</li>
           <li></li>
         </ul>
 

--- a/java/src/jmri/jmrit/logixng/actions/ForEach.java
+++ b/java/src/jmri/jmrit/logixng/actions/ForEach.java
@@ -184,6 +184,10 @@ public class ForEach extends AbstractDigitalAction
 
                 if (value instanceof Manager) {
                     collectionRef.set(((Manager<? extends NamedBean>) value).getNamedBeanSet());
+                } else if (value != null && value.getClass().isArray()) {
+                    // Note: (Object[]) is needed to tell that the parameter is an array and not a vararg argument
+                    // See: https://stackoverflow.com/questions/2607289/converting-array-to-list-in-java/2607327#2607327
+                    collectionRef.set(Arrays.asList((Object[])value));
                 } else if (value instanceof Collection) {
                     collectionRef.set((Collection<? extends Object>) value);
                 } else if (value instanceof Map) {

--- a/java/src/jmri/jmrit/logixng/util/parser/ExpressionNodeMethod.java
+++ b/java/src/jmri/jmrit/logixng/util/parser/ExpressionNodeMethod.java
@@ -123,6 +123,8 @@ public class ExpressionNodeMethod implements ExpressionNodeWithParameter {
         try {
             return method.invoke(obj, newParams);
         } catch (IllegalAccessException ex) {
+            // https://stackoverflow.com/questions/50306093/java-9-calling-map-entrygetvalue-via-reflection#comment87628501_50306192
+            // https://stackoverflow.com/a/12038265
             if (obj instanceof Map.Entry && newParams.length == 0) {
                 switch (method.getName()) {
                     case "toString": return obj.toString();

--- a/java/src/jmri/jmrit/logixng/util/parser/ExpressionNodeMethod.java
+++ b/java/src/jmri/jmrit/logixng/util/parser/ExpressionNodeMethod.java
@@ -70,6 +70,7 @@ public class ExpressionNodeMethod implements ExpressionNodeWithParameter {
         return true;
     }
 
+    @SuppressWarnings("rawtypes")   // We don't know the generic types of Map.Entry in this method
     private Object callMethod(Method method, Object obj, Object[] params)
             throws IllegalAccessException, IllegalArgumentException, InvocationTargetException {
 

--- a/java/src/jmri/jmrit/logixng/util/parser/ExpressionNodeMethod.java
+++ b/java/src/jmri/jmrit/logixng/util/parser/ExpressionNodeMethod.java
@@ -119,7 +119,19 @@ public class ExpressionNodeMethod implements ExpressionNodeWithParameter {
 
             newParams[i] = newParam;
         }
-        return method.invoke(obj, newParams);
+        try {
+            return method.invoke(obj, newParams);
+        } catch (IllegalAccessException ex) {
+            if (obj instanceof Map.Entry && newParams.length == 0) {
+                switch (method.getName()) {
+                    case "toString": return obj.toString();
+                    case "getKey": return ((Map.Entry)obj).getKey();
+                    case "getValue": return ((Map.Entry)obj).getValue();
+                    default: throw ex;
+                }
+            }
+            throw ex;
+        }
     }
 
     @Override

--- a/java/src/jmri/jmrit/logixng/util/parser/FunctionManager.java
+++ b/java/src/jmri/jmrit/logixng/util/parser/FunctionManager.java
@@ -4,18 +4,22 @@ import java.util.*;
 
 /**
  * Manager for LogixNG formula functions.
- * 
+ *
  * @author Daniel Bergqvist   Copyright (C) 2020
  */
 public class FunctionManager implements jmri.InstanceManagerAutoDefault {
-    
+
     private final Map<String, Constant> _constants = new HashMap<>();
     private final Map<String, Function> _functions = new HashMap<>();
-    
-    
+
+
     public FunctionManager() {
         for (FunctionFactory actionFactory : ServiceLoader.load(FunctionFactory.class)) {
             actionFactory.getConstants().forEach((constant) -> {
+                if (!constant.getModule().equals(actionFactory.getModule())) {
+                    log.error("Constant \"{}\" doesn't belong to the module \"{}\" of its declaring class {}",
+                            constant.getName(), actionFactory.getModule(), actionFactory.getClass().getName());
+                }
                 if (_constants.containsKey(constant.getName())) {
                     throw new RuntimeException("Constant " + constant.getName() + " is already registered. Class: " + constant.getClass().getName());
                 }
@@ -23,6 +27,10 @@ public class FunctionManager implements jmri.InstanceManagerAutoDefault {
                 _constants.put(constant.getName(), constant);
             });
             actionFactory.getFunctions().forEach((function) -> {
+                if (!function.getModule().equals(actionFactory.getModule())) {
+                    log.error("Function \"{}\" doesn't belong to the module \"{}\" of its declaring class {}",
+                            function.getName(), actionFactory.getModule(), actionFactory.getClass().getName());
+                }
                 if (_functions.containsKey(function.getName())) {
                     throw new RuntimeException("Function " + function.getName() + " is already registered. Class: " + function.getClass().getName());
                 }
@@ -31,25 +39,26 @@ public class FunctionManager implements jmri.InstanceManagerAutoDefault {
             });
         }
     }
-    
+
     public Map<String, Function> getFunctions() {
         return Collections.unmodifiableMap(_functions);
     }
-    
+
     public Function get(String name) {
         return _functions.get(name);
     }
-    
+
     public Function put(String name, Function function) {
         return _functions.put(name, function);
     }
-    
+
     public Constant getConstant(String name) {
         return _constants.get(name);
     }
-    
+
     public void put(String name, Constant constant) {
         _constants.put(name, constant);
     }
-    
+
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(FunctionManager.class);
 }

--- a/java/src/jmri/jmrit/logixng/util/parser/functions/CommonFunctions.java
+++ b/java/src/jmri/jmrit/logixng/util/parser/functions/CommonFunctions.java
@@ -1,0 +1,92 @@
+package jmri.jmrit.logixng.util.parser.functions;
+
+import java.util.*;
+
+import jmri.JmriException;
+import jmri.jmrit.logixng.SymbolTable;
+import jmri.jmrit.logixng.util.parser.*;
+
+import org.openide.util.lookup.ServiceProvider;
+
+/**
+ * Implementation of common functions.
+ *
+ * @author Daniel Bergqvist 2024
+ */
+@ServiceProvider(service = FunctionFactory.class)
+public class CommonFunctions implements FunctionFactory {
+
+    @Override
+    public String getModule() {
+        return "Common";
+    }
+
+    @Override
+    public Set<Function> getFunctions() {
+        Set<Function> functionClasses = new HashSet<>();
+        functionClasses.add(new LengthFunction());
+        return functionClasses;
+    }
+
+    @Override
+    public Set<Constant> getConstants() {
+        return new HashSet<>();
+    }
+
+    @Override
+    public String getConstantDescription() {
+        // This module doesn't define any constants
+        return null;
+    }
+
+
+
+    public static class LengthFunction implements Function {
+
+        @Override
+        public String getModule() {
+            return new CommonFunctions().getModule();
+        }
+
+        @Override
+        public String getConstantDescriptions() {
+            return new CommonFunctions().getConstantDescription();
+        }
+
+        @Override
+        public String getName() {
+            return "length";
+        }
+
+        @Override
+        public Object calculate(SymbolTable symbolTable, List<ExpressionNode> parameterList)
+                throws CalculateException, JmriException {
+            if (parameterList.size() != 1) {
+                throw new WrongNumberOfParametersException(Bundle.getMessage("WrongNumberOfParameters1", getName(), 1));
+            }
+
+            Object parameter = parameterList.get(0).calculate(symbolTable);
+
+            if (parameter == null) {
+                throw new NullPointerException("Parameter is null");
+            } else if (parameter instanceof String) {
+                return ((String)parameter).length();
+            } else if (parameter.getClass().isArray()) {
+                return ((Object[])parameter).length;
+            } else if (parameter instanceof Collection) {
+                return ((Collection)parameter).size();
+            } else if (parameter instanceof Map) {
+                return ((Map)parameter).size();
+            }
+
+            throw new IllegalArgumentException("Parameter is not a String, Array or a List, Set or Map: "+parameter.getClass().getName());
+        }
+
+        @Override
+        public String getDescription() {
+            return Bundle.getMessage("Common.length_Descr");
+        }
+
+    }
+
+}

--- a/java/src/jmri/jmrit/logixng/util/parser/functions/CommonFunctions.java
+++ b/java/src/jmri/jmrit/logixng/util/parser/functions/CommonFunctions.java
@@ -58,6 +58,7 @@ public class CommonFunctions implements FunctionFactory {
             return "length";
         }
 
+        @SuppressWarnings("rawtypes")   // We don't know the generic types of Collection and Map in this method
         @Override
         public Object calculate(SymbolTable symbolTable, List<ExpressionNode> parameterList)
                 throws CalculateException, JmriException {

--- a/java/src/jmri/jmrit/logixng/util/parser/functions/CommonFunctions.java
+++ b/java/src/jmri/jmrit/logixng/util/parser/functions/CommonFunctions.java
@@ -80,7 +80,7 @@ public class CommonFunctions implements FunctionFactory {
                 return ((Map)parameter).size();
             }
 
-            throw new IllegalArgumentException("Parameter is not a String, Array or a List, Set or Map: "+parameter.getClass().getName());
+            throw new IllegalArgumentException("Parameter is not a String, Array, List, Set or Map: "+parameter.getClass().getName());
         }
 
         @Override

--- a/java/src/jmri/jmrit/logixng/util/parser/functions/FunctionsBundle.properties
+++ b/java/src/jmri/jmrit/logixng/util/parser/functions/FunctionsBundle.properties
@@ -51,6 +51,15 @@ Returns the number of seconds since midnight                                    
 </html>
 
 
+Common.length_Descr                 = <html>                                                \
+<h1>length()</h1>                                                                           \
+<h2>length(parameter)</h2>                                                                  \
+Returns the length of <i>parameter</i> if it's a String.<br>                                \
+Returns the number of items in <i>parameter</i> if it's an array, list or set.<br>          \
+Returns the number of keys in <i>parameter</i> if it's a map.                               \
+</html>
+
+
 Convert.isInt                   = <html>                                                    \
 <h1>isInt()</h1>                                                                            \
 <h2>isInt(value)</h2>                                                                       \
@@ -323,6 +332,16 @@ specifier in the <i>formatString</i> must match its corresponding parameter.    
 <p>                                                                                         \
 For the syntax of the <i>formatString</i>, see the Java documentation:<br>                  \
 https://docs.oracle.com/javase/8/docs/api/java/util/Formatter.html#syntax                   \
+</html>
+
+
+String.strlen_Descr                 = <html>                                                \
+<h1>strlen()</h1>                                                                           \
+<h2>strlen(parameter)</h2>                                                                  \
+Returns the length of <i>parameter</i> if it's a String.                                    \
+<p>                                                                                         \
+Note the function <i>length()</i> in the <i>Common</i> module.<br>                          \
+It supports strings, arrays, lists, sets and maps.                                          \
 </html>
 
 

--- a/java/src/jmri/jmrit/logixng/util/parser/functions/StringFunctions.java
+++ b/java/src/jmri/jmrit/logixng/util/parser/functions/StringFunctions.java
@@ -14,7 +14,7 @@ import org.openide.util.lookup.ServiceProvider;
 
 /**
  * Implementation of string functions.
- * 
+ *
  * @author Daniel Bergqvist 2020
  */
 @ServiceProvider(service = FunctionFactory.class)
@@ -24,11 +24,12 @@ public class StringFunctions implements FunctionFactory {
     public String getModule() {
         return "String";
     }
-    
+
     @Override
     public Set<Function> getFunctions() {
         Set<Function> functionClasses = new HashSet<>();
         functionClasses.add(new FormatFunction());
+        functionClasses.add(new StrLenFunction());
         return functionClasses;
     }
 
@@ -42,49 +43,93 @@ public class StringFunctions implements FunctionFactory {
         // This module doesn't define any constants
         return null;
     }
-    
-    
-    
+
+
+
     public static class FormatFunction implements Function {
-        
+
         @Override
         public String getModule() {
             return new StringFunctions().getModule();
         }
-        
+
         @Override
         public String getConstantDescriptions() {
             return new StringFunctions().getConstantDescription();
         }
-        
+
         @Override
         public String getName() {
             return "format";
         }
-        
+
         @Override
         public Object calculate(SymbolTable symbolTable, List<ExpressionNode> parameterList)
                 throws CalculateException, JmriException {
             if (parameterList.isEmpty()) {
                 throw new WrongNumberOfParametersException(Bundle.getMessage("WrongNumberOfParameters1", getName(), 1));
             }
-            
+
             String formatStr = TypeConversionUtil.convertToString(
                     parameterList.get(0).calculate(symbolTable), false);
-            
+
             List<Object> list = new ArrayList<>();
             for (int i=1; i < parameterList.size(); i++) {
                 list.add(parameterList.get(i).calculate(symbolTable));
             }
-            
+
             return String.format(formatStr, list.toArray());
         }
-        
+
         @Override
         public String getDescription() {
             return Bundle.getMessage("String.format_Descr");
         }
-        
+
     }
-    
+
+
+
+    public static class StrLenFunction implements Function {
+
+        @Override
+        public String getModule() {
+            return new StringFunctions().getModule();
+        }
+
+        @Override
+        public String getConstantDescriptions() {
+            return new CommonFunctions().getConstantDescription();
+        }
+
+        @Override
+        public String getName() {
+            return "strlen";
+        }
+
+        @Override
+        public Object calculate(SymbolTable symbolTable, List<ExpressionNode> parameterList)
+                throws CalculateException, JmriException {
+            if (parameterList.size() != 1) {
+                throw new WrongNumberOfParametersException(Bundle.getMessage("WrongNumberOfParameters1", getName(), 1));
+            }
+
+            Object parameter = parameterList.get(0).calculate(symbolTable);
+
+            if (parameter == null) {
+                throw new NullPointerException("Parameter is null");
+            } else if (parameter instanceof String) {
+                return ((String)parameter).length();
+            }
+
+            throw new IllegalArgumentException("Parameter is not a String: "+parameter.getClass().getName());
+        }
+
+        @Override
+        public String getDescription() {
+            return Bundle.getMessage("String.strlen_Descr");
+        }
+
+    }
+
 }

--- a/java/test/jmri/jmrit/logixng/actions/ForEachTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ForEachTest.java
@@ -1,0 +1,306 @@
+package jmri.jmrit.logixng.actions;
+
+import java.io.IOException;
+import java.util.*;
+
+import jmri.*;
+import jmri.jmrit.logixng.*;
+import jmri.jmrit.logixng.implementation.DefaultConditionalNGScaffold;
+import jmri.jmrit.logixng.util.parser.ParserException;
+import jmri.util.JUnitUtil;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Test ForEach
+ *
+ * @author Daniel Bergqvist 2024
+ */
+public class ForEachTest extends AbstractDigitalActionTestBase {
+
+    Memory _memory;
+    Memory _memoryResult;
+    LogixNG _logixNG;
+    ConditionalNG _conditionalNG;
+    ForEach _forEach;
+    MaleSocket _maleSocket;
+    DigitalFormula _formula;
+
+    @Override
+    public ConditionalNG getConditionalNG() {
+        return _conditionalNG;
+    }
+
+    @Override
+    public LogixNG getLogixNG() {
+        return _logixNG;
+    }
+
+    @Override
+    public MaleSocket getConnectableChild() {
+        DigitalMany action = new DigitalMany("IQDA999", null);
+        MaleSocket maleSocket =
+                InstanceManager.getDefault(DigitalActionManager.class).registerAction(action);
+        return maleSocket;
+    }
+
+    @Override
+    public String getExpectedPrintedTree() {
+        return String.format(
+                "For each value, set variable \"item\" and execute action A. Values from memory IM1 ::: Use default%n" +
+                "   ::: Local variable \"item\", init to None \"null\"%n" +
+                "   ! A%n" +
+                "      Digital Formula: writeMemory(\"IMResult\", readMemory(\"IMResult\") + item + \", \") ::: Use default%n" +
+                "         ?* E1%n" +
+                "            Socket not connected%n");
+    }
+
+    @Override
+    public String getExpectedPrintedTreeFromRoot() {
+        return String.format(
+                "LogixNG: A new logix for test%n" +
+                "   ConditionalNG: A conditionalNG%n" +
+                "      ! A%n" +
+                "         For each value, set variable \"item\" and execute action A. Values from memory IM1 ::: Use default%n" +
+                "            ::: Local variable \"item\", init to None \"null\"%n" +
+                "            ! A%n" +
+                "               Digital Formula: writeMemory(\"IMResult\", readMemory(\"IMResult\") + item + \", \") ::: Use default%n" +
+                "                  ?* E1%n" +
+                "                     Socket not connected%n");
+    }
+
+    @Override
+    public NamedBean createNewBean(String systemName) {
+        return new TableForEach(systemName, null);
+    }
+
+    @Override
+    public boolean addNewSocket() {
+        return false;
+    }
+
+    @Test
+    public void testCtor() {
+        TableForEach t = new TableForEach("IQDA321", null);
+        Assert.assertNotNull("exists",t);
+        t = new TableForEach("IQDA321", null);
+        Assert.assertNotNull("exists",t);
+    }
+
+    @Test
+    public void testGetChild() {
+        Assert.assertTrue("getChildCount() returns 1", 1 == _forEach.getChildCount());
+
+        Assert.assertNotNull("getChild(0) returns a non null value",
+                _forEach.getChild(0));
+
+        boolean hasThrown = false;
+        try {
+            _forEach.getChild(1);
+        } catch (IllegalArgumentException ex) {
+            hasThrown = true;
+            Assert.assertEquals("Error message is correct", "index has invalid value: 1", ex.getMessage());
+        }
+        Assert.assertTrue("Exception is thrown", hasThrown);
+    }
+
+    @Test
+    public void testCategory() {
+        Assert.assertTrue("Category matches", Category.FLOW_CONTROL == _base.getCategory());
+    }
+
+    @Test
+    public void testDescription() {
+        ForEach a1 = new ForEach("IQDA321", null);
+        Assert.assertEquals("strings are equal", "For each", a1.getShortDescription());
+        ForEach a2 = new ForEach("IQDA321", null);
+        Assert.assertEquals("strings are equal", "For each value, set variable \"\" and execute action A. Values from Sensors", a2.getLongDescription());
+    }
+
+    @Test
+    public void testExecute()
+            throws IOException, SocketAlreadyConnectedException, ParserException {
+
+        _memory.setValue(new ArrayList<String>());
+        _memoryResult.setValue("");
+        _formula.setFormula("writeMemory(\"IMResult\", readMemory(\"IMResult\") + item + \", \")");
+        _logixNG.execute();
+        Assert.assertEquals("", _memoryResult.getValue());
+        Assert.assertEquals("For each value, set variable \"item\" and execute action A. Values from memory IM1", _forEach.getLongDescription());
+
+        List<String> list = new ArrayList<>();
+        list.add("A");
+        list.add("B");
+        list.add("C");
+        _memory.setValue(list);
+        _memoryResult.setValue("");
+        _formula.setFormula("writeMemory(\"IMResult\", readMemory(\"IMResult\") + item + \", \")");
+        _logixNG.execute();
+        Assert.assertEquals("A, B, C, ", _memoryResult.getValue());
+        Assert.assertEquals("For each value, set variable \"item\" and execute action A. Values from memory IM1", _forEach.getLongDescription());
+
+        Map<String, Integer> map = new HashMap<>();
+        map.put("A", 10);
+        map.put("B", 20);
+        map.put("C", -3);
+        _memory.setValue(map);
+        _memoryResult.setValue("");
+        _formula.setFormula("writeMemory(\"IMResult\", readMemory(\"IMResult\") + item.getKey() + \":\" + str(item.getValue()) + \", \")");
+        _logixNG.execute();
+        Assert.assertEquals("A:10, B:20, C:-3, ", _memoryResult.getValue());
+        Assert.assertEquals("For each value, set variable \"item\" and execute action A. Values from memory IM1", _forEach.getLongDescription());
+
+        map = new HashMap<>();
+        map.put("A", 8);
+        map.put("B", -55);
+        map.put("C", 32);
+        _memory.setValue(map);
+        _memoryResult.setValue("");
+        _formula.setFormula("writeMemory(\"IMResult\", readMemory(\"IMResult\") + \"toString:>\" + item.toString() + \"<\" + \", \")");
+        _logixNG.execute();
+        Assert.assertEquals("toString:>A=8<, toString:>B=-55<, toString:>C=32<, ", _memoryResult.getValue());
+        Assert.assertEquals("For each value, set variable \"item\" and execute action A. Values from memory IM1", _forEach.getLongDescription());
+
+        map = new HashMap<>();
+        map.put("A", 8);
+        map.put("B", -55);
+        map.put("C", 32);
+        _memory.setValue(map);
+        _memoryResult.setValue("");
+        _formula.setFormula("writeMemory(\"IMResult\", readMemory(\"IMResult\") + \"getClass().getName():>\" + item.getClass().getName() + \"<\" + \", \")");
+        _logixNG.execute();
+        Assert.assertEquals("getClass().getName():>java.util.HashMap$Node<, getClass().getName():>java.util.HashMap$Node<, getClass().getName():>java.util.HashMap$Node<, ", _memoryResult.getValue());
+        Assert.assertEquals("For each value, set variable \"item\" and execute action A. Values from memory IM1", _forEach.getLongDescription());
+
+        _memory.setValue(new String[]{"A", "B", "C"});
+        _memoryResult.setValue("");
+        _formula.setFormula("writeMemory(\"IMResult\", readMemory(\"IMResult\") + item + \", \")");
+        _logixNG.execute();
+        Assert.assertEquals("A, B, C, ", _memoryResult.getValue());
+        Assert.assertEquals("For each value, set variable \"item\" and execute action A. Values from memory IM1", _forEach.getLongDescription());
+
+        _memoryResult.setValue("");
+        _forEach.setUseCommonSource(true);
+        _forEach.setCommonManager(CommonManager.Sensors);
+        InstanceManager.getDefault(SensorManager.class).provideSensor("ISSomething");
+        InstanceManager.getDefault(SensorManager.class).provideSensor("ISSomethingElse");
+        _formula.setFormula("writeMemory(\"IMResult\", readMemory(\"IMResult\") + item.getSystemName() + \", \")");
+        _logixNG.execute();
+        Assert.assertEquals("ISCLOCKRUNNING, ISSomething, ISSomethingElse, ", _memoryResult.getValue());
+        Assert.assertEquals("For each value, set variable \"item\" and execute action A. Values from Sensors", _forEach.getLongDescription());
+
+        _memoryResult.setValue("");
+        _forEach.setUseCommonSource(true);
+        _forEach.setCommonManager(CommonManager.Turnouts);
+        InstanceManager.getDefault(TurnoutManager.class).provideTurnout("ITSomething");
+        InstanceManager.getDefault(TurnoutManager.class).provideTurnout("ITSomethingElse");
+        _formula.setFormula("writeMemory(\"IMResult\", readMemory(\"IMResult\") + item.getSystemName() + \", \")");
+        _logixNG.execute();
+        Assert.assertEquals("ITSomething, ITSomethingElse, ", _memoryResult.getValue());
+        Assert.assertEquals("For each value, set variable \"item\" and execute action A. Values from Turnouts", _forEach.getLongDescription());
+
+        _memoryResult.setValue("");
+        _forEach.setUseCommonSource(true);
+        _forEach.setCommonManager(CommonManager.Lights);
+        InstanceManager.getDefault(LightManager.class).provideLight("ILSomething");
+        InstanceManager.getDefault(LightManager.class).provideLight("ILSomethingElse");
+        _formula.setFormula("writeMemory(\"IMResult\", readMemory(\"IMResult\") + item.getSystemName() + \", \")");
+        _logixNG.execute();
+        Assert.assertEquals("ILSomething, ILSomethingElse, ", _memoryResult.getValue());
+        Assert.assertEquals("For each value, set variable \"item\" and execute action A. Values from Lights", _forEach.getLongDescription());
+
+        _memoryResult.setValue("");
+        _forEach.setUseCommonSource(true);
+        _forEach.setCommonManager(CommonManager.Memories);
+        InstanceManager.getDefault(MemoryManager.class).provideMemory("IMSomething");
+        InstanceManager.getDefault(MemoryManager.class).provideMemory("IMSomethingElse");
+        _formula.setFormula("writeMemory(\"IMResult\", readMemory(\"IMResult\") + item.getSystemName() + \", \")");
+        _logixNG.execute();
+        Assert.assertEquals("IM1, IMCURRENTTIME, IMRATEFACTOR, IMResult, IMSomething, IMSomethingElse, ", _memoryResult.getValue());
+        Assert.assertEquals("For each value, set variable \"item\" and execute action A. Values from Memories", _forEach.getLongDescription());
+    }
+
+    @Test
+    @Override
+    public void testIsActive() {
+        _logixNG.setEnabled(true);
+        super.testIsActive();
+    }
+
+    @Test
+    @Override
+    public void testMaleSocketIsActive() {
+        _logixNG.setEnabled(true);
+        super.testMaleSocketIsActive();
+    }
+
+    // The minimal setup for log4J
+    @Before
+    public void setUp() throws SocketAlreadyConnectedException, ParserException {
+        JUnitUtil.setUp();
+        JUnitUtil.resetInstanceManager();
+        JUnitUtil.resetProfileManager();
+        JUnitUtil.initConfigureManager();
+        JUnitUtil.initInternalSensorManager();
+        JUnitUtil.initInternalTurnoutManager();
+        JUnitUtil.initLogixNGManager();
+
+        _category = Category.OTHER;
+        _isExternal = false;
+
+        _memory = InstanceManager.getDefault(MemoryManager.class).provideMemory("IM1");  // NOI18N
+        _memory.setValue(new ArrayList<String>());
+
+        _memoryResult = InstanceManager.getDefault(MemoryManager.class).provideMemory("IMResult");  // NOI18N
+        _memoryResult.setValue("");
+
+        _logixNG = InstanceManager.getDefault(LogixNG_Manager.class).createLogixNG("A new logix for test");  // NOI18N
+        _conditionalNG = new DefaultConditionalNGScaffold("IQC1", "A conditionalNG");  // NOI18N;
+        InstanceManager.getDefault(ConditionalNG_Manager.class).register(_conditionalNG);
+        _conditionalNG.setEnabled(true);
+        _conditionalNG.setRunDelayed(false);
+        _logixNG.addConditionalNG(_conditionalNG);
+        _forEach = new ForEach("IQDA321", null);
+        _forEach.setUserSpecifiedSource(ForEach.UserSpecifiedSource.Memory);
+        _forEach.setUseCommonSource(false);
+        _forEach.getSelectMemoryNamedBean().setNamedBean(_memory);
+        _forEach.setLocalVariableName("item");
+        _maleSocket =
+                InstanceManager.getDefault(DigitalActionManager.class).registerAction(_forEach);
+        _maleSocket.addLocalVariable("item", SymbolTable.InitialValueType.None, null);
+        _conditionalNG.getChild(0).connect(_maleSocket);
+        _base = _forEach;
+        _baseMaleSocket = _maleSocket;
+
+        _formula = new DigitalFormula(
+                InstanceManager.getDefault(DigitalActionManager.class).getAutoSystemName(), null);
+        _formula.setFormula("writeMemory(\"IMResult\", readMemory(\"IMResult\") + item + \", \")");
+        _forEach.getChild(0).connect(InstanceManager.getDefault(DigitalActionManager.class)
+                .registerAction(_formula));
+
+        if (! _logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
+        _logixNG.activate();
+        _logixNG.setEnabled(false);
+    }
+
+    @After
+    public void tearDown() {
+        _logixNG.setEnabled(false);
+        jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
+        JUnitUtil.tearDown();
+        _category = null;
+        _memory = null;
+        _memoryResult = null;
+        _logixNG = null;
+        _conditionalNG = null;
+        _forEach = null;
+        _base = null;
+        _baseMaleSocket = null;
+        _maleSocket = null;
+    }
+
+}

--- a/java/test/jmri/jmrit/logixng/util/parser/functions/CommonFunctionsTest.java
+++ b/java/test/jmri/jmrit/logixng/util/parser/functions/CommonFunctionsTest.java
@@ -1,0 +1,132 @@
+package jmri.jmrit.logixng.util.parser.functions;
+
+import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import jmri.jmrit.logixng.SymbolTable;
+import jmri.jmrit.logixng.implementation.DefaultConditionalNG;
+import jmri.jmrit.logixng.implementation.DefaultSymbolTable;
+import jmri.jmrit.logixng.util.LogixNG_Thread;
+import jmri.jmrit.logixng.util.parser.ExpressionNode;
+import jmri.jmrit.logixng.util.parser.ExpressionNodeString;
+import jmri.jmrit.logixng.util.parser.Token;
+import jmri.jmrit.logixng.util.parser.TokenType;
+import jmri.jmrit.logixng.util.parser.WrongNumberOfParametersException;
+import jmri.util.JUnitUtil;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Test ParsedExpression
+ *
+ * @author Daniel Bergqvist 2024
+ */
+public class CommonFunctionsTest {
+
+
+    private List<ExpressionNode> getParameterList(ExpressionNode... exprNodes) {
+        List<ExpressionNode> list = new ArrayList<>();
+        Collections.addAll(list, exprNodes);
+        return list;
+    }
+
+    @Test
+    public void testLengthFunction() throws Exception {
+        CommonFunctions.LengthFunction lengthFunction = new CommonFunctions.LengthFunction();
+        Assert.assertEquals("strings matches", "length", lengthFunction.getName());
+
+        AtomicBoolean hasThrown = new AtomicBoolean(false);
+
+        SymbolTable symbolTable = new DefaultSymbolTable(new DefaultConditionalNG("IQC1", null));
+
+        // Test unsupported token type
+        hasThrown.set(false);
+        try {
+            lengthFunction.calculate(symbolTable, getParameterList());
+        } catch (WrongNumberOfParametersException e) {
+            hasThrown.set(true);
+        }
+        Assert.assertTrue("exception is thrown", hasThrown.get());
+
+        Assert.assertEquals("Values are equal", 8,
+                (int)lengthFunction.calculate(symbolTable, getParameterList(
+                        new ExpressionNodeString(new Token(TokenType.NONE, "A string", 0)))));
+
+        Assert.assertEquals("Strings are equal", 4,
+                (int)lengthFunction.calculate(symbolTable, getParameterList(
+                        new ExpressionNodeConstant(
+                                new String[]{"Red", "Green", "Blue", "Yellow"}))));
+
+        List<String> list = new ArrayList<>();
+        list.add("A");
+        list.add("x");
+        list.add("Hello");
+        list.add("Something");
+        list.add("EE");
+        list.add("H");
+        list.add("III");
+        Assert.assertEquals("Strings are equal", 7,
+                (int)lengthFunction.calculate(symbolTable, getParameterList(
+                        new ExpressionNodeConstant(list))));
+
+        Set<String> set = new HashSet<>();
+        set.add("A");
+        set.add("x");
+        set.add("Hello");
+        set.add("Something");
+        set.add("EE");
+        set.add("12");
+        set.add("32");
+        set.add("Jjjj");
+        set.add("H");
+        set.add("III");
+        Assert.assertEquals("Strings are equal", 10,
+                (int)lengthFunction.calculate(symbolTable, getParameterList(
+                        new ExpressionNodeConstant(set))));
+
+        Map<String, Integer> map = new HashMap<>();
+        map.put("Hello",72);
+        map.put("Something", 33);
+        Assert.assertEquals("Strings are equal", 2,
+                (int)lengthFunction.calculate(symbolTable, getParameterList(
+                        new ExpressionNodeConstant(map))));
+    }
+
+    // The minimal setup for log4J
+    @Before
+    public void setUp() {
+        JUnitUtil.setUp();
+    }
+
+    @After
+    public void tearDown() {
+        LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.tearDown();
+    }
+
+
+    public static class ExpressionNodeConstant implements ExpressionNode {
+
+        private final Object _value;
+
+        public ExpressionNodeConstant(Object value) {
+            _value = value;
+        }
+
+        @Override
+        public Object calculate(SymbolTable symbolTable) {
+            return _value;
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        public String getDefinitionString() {
+            return null;    // This value is never used
+        }
+
+    }
+
+}

--- a/java/test/jmri/jmrit/logixng/util/parser/functions/StringFunctionsTest.java
+++ b/java/test/jmri/jmrit/logixng/util/parser/functions/StringFunctionsTest.java
@@ -1,8 +1,6 @@
 package jmri.jmrit.logixng.util.parser.functions;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import jmri.jmrit.logixng.SymbolTable;
@@ -13,7 +11,6 @@ import jmri.jmrit.logixng.util.parser.ExpressionNode;
 import jmri.jmrit.logixng.util.parser.ExpressionNodeFloatingNumber;
 import jmri.jmrit.logixng.util.parser.ExpressionNodeIntegerNumber;
 import jmri.jmrit.logixng.util.parser.ExpressionNodeString;
-import jmri.jmrit.logixng.util.parser.ExpressionNodeTrue;
 import jmri.jmrit.logixng.util.parser.Token;
 import jmri.jmrit.logixng.util.parser.TokenType;
 import jmri.jmrit.logixng.util.parser.WrongNumberOfParametersException;
@@ -26,39 +23,31 @@ import org.junit.Test;
 
 /**
  * Test ParsedExpression
- * 
+ *
  * @author Daniel Bergqvist 2020
  */
 public class StringFunctionsTest {
 
-    ExpressionNode expr_boolean_true = new ExpressionNodeTrue();
     ExpressionNode expr_str_HELLO = new ExpressionNodeString(new Token(TokenType.NONE, "hello", 0));
-    ExpressionNode expr_str_RAD = new ExpressionNodeString(new Token(TokenType.NONE, "rad", 0));
-    ExpressionNode expr_str_DEG = new ExpressionNodeString(new Token(TokenType.NONE, "deg", 0));
-    ExpressionNode expr_str_0_34 = new ExpressionNodeString(new Token(TokenType.NONE, "0.34", 0));
-    ExpressionNode expr0_34 = new ExpressionNodeFloatingNumber(new Token(TokenType.NONE, "0.34", 0));
     ExpressionNode expr0_95 = new ExpressionNodeFloatingNumber(new Token(TokenType.NONE, "0.95", 0));
-    ExpressionNode expr12_34 = new ExpressionNodeFloatingNumber(new Token(TokenType.NONE, "12.34", 0));
-    ExpressionNode expr25_46 = new ExpressionNodeFloatingNumber(new Token(TokenType.NONE, "25.46", 0));
     ExpressionNode expr12 = new ExpressionNodeIntegerNumber(new Token(TokenType.NONE, "12", 0));
-    ExpressionNode expr23 = new ExpressionNodeIntegerNumber(new Token(TokenType.NONE, "23", 0));
-    
-    
+
+
     private List<ExpressionNode> getParameterList(ExpressionNode... exprNodes) {
         List<ExpressionNode> list = new ArrayList<>();
         Collections.addAll(list, exprNodes);
         return list;
     }
-    
+
     @Test
     public void testFormatFunction() throws Exception {
         StringFunctions.FormatFunction formatFunction = new StringFunctions.FormatFunction();
         Assert.assertEquals("strings matches", "format", formatFunction.getName());
-        
+
         AtomicBoolean hasThrown = new AtomicBoolean(false);
-        
+
         SymbolTable symbolTable = new DefaultSymbolTable(new DefaultConditionalNG("IQC1", null));
-        
+
         // Test unsupported token type
         hasThrown.set(false);
         try {
@@ -67,22 +56,45 @@ public class StringFunctionsTest {
             hasThrown.set(true);
         }
         Assert.assertTrue("exception is thrown", hasThrown.get());
-        
+
         Assert.assertEquals("Strings are equal", "A format string",
                 formatFunction.calculate(symbolTable, getParameterList(new ExpressionNodeString(
                         new Token(TokenType.NONE, "A format string", 0)))));
-        
+
         Assert.assertEquals("Strings are equal", "Number: 12, String: hello",
                 formatFunction.calculate(symbolTable, getParameterList(new ExpressionNodeString(
                         new Token(TokenType.NONE, "Number: %d, String: %s", 0)),
                         expr12, expr_str_HELLO)));
-        
+
         Assert.assertEquals("Strings are equal", "Number: 012, String:   hello, Float:  0.9500",
                 formatFunction.calculate(symbolTable, getParameterList(new ExpressionNodeString(
                         new Token(TokenType.NONE, "Number: %03d, String: %7s, Float: %7.4f", 0)),
                         expr12, expr_str_HELLO, expr0_95)));
     }
-    
+
+    @Test
+    public void testStrLenFunction() throws Exception {
+        StringFunctions.StrLenFunction strlenFunction = new StringFunctions.StrLenFunction();
+        Assert.assertEquals("strings matches", "strlen", strlenFunction.getName());
+
+        AtomicBoolean hasThrown = new AtomicBoolean(false);
+
+        SymbolTable symbolTable = new DefaultSymbolTable(new DefaultConditionalNG("IQC1", null));
+
+        // Test unsupported token type
+        hasThrown.set(false);
+        try {
+            strlenFunction.calculate(symbolTable, getParameterList());
+        } catch (WrongNumberOfParametersException e) {
+            hasThrown.set(true);
+        }
+        Assert.assertTrue("exception is thrown", hasThrown.get());
+
+        Assert.assertEquals("Values are equal", 8,
+                (int)strlenFunction.calculate(symbolTable, getParameterList(
+                        new ExpressionNodeString(new Token(TokenType.NONE, "A string", 0)))));
+    }
+
     // The minimal setup for log4J
     @Before
     public void setUp() {
@@ -94,5 +106,5 @@ public class StringFunctionsTest {
         LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.tearDown();
     }
-    
+
 }


### PR DESCRIPTION
- Add support for arrays to LogixNG action `For each`.

- Handle a bug in Java so that the methods `toString()`, `getKey()` and `getValue()` can be used for an item when using `For each` on a Map.

- Adds the LogixNG functions `strlen()` in module `String` and `length()` in module `Common`.
  The main reason for adding the function `strlen()` is that it might be difficult to find the function `length()` since its in the module Common. I didn't want to put the length() function in the String module since it supports collections as well.