### PR TITLE
Fix two bugs in LogixNG functions. Improve testing of LogixNG functions.

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -506,6 +506,11 @@ LogixNG: IQ:AUTO:0001
           <li>Adds the LogixNG functions <strong>strlen()</strong> in module
               <strong>String</strong> and <strong>length()</strong> in module
               <strong>Common</strong>.</li>
+          <li>Bug fix: The LogixNG function <strong>boolJython()</strong>
+              now return false if the value is an empty array. It returns
+              true if the value is a non empty array.</li>
+          <li>Bug fix: The LogixNG function <strong>evaluateMemory()</strong>
+              didn't behaved as documented. It's now fixed.</li>
           <li></li>
         </ul>
 

--- a/java/src/jmri/jmrit/logixng/util/parser/functions/AbstractFunction.java
+++ b/java/src/jmri/jmrit/logixng/util/parser/functions/AbstractFunction.java
@@ -1,0 +1,41 @@
+package jmri.jmrit.logixng.util.parser.functions;
+
+import jmri.jmrit.logixng.util.parser.*;
+
+/**
+ * Abstract class to help writing LogixNG functions easier.
+ *
+ * @author Daniel Bergqvist 2024
+ */
+public abstract class AbstractFunction implements Function {
+
+    private final FunctionFactory _functionFactory;
+    private final String _name;
+    private final String _description;
+
+    public AbstractFunction(FunctionFactory functionFactory, String name, String description) {
+        _functionFactory = functionFactory;
+        _name = name;
+        _description = description;
+    }
+
+    @Override
+    public String getModule() {
+        return _functionFactory.getModule();
+    }
+
+    @Override
+    public String getConstantDescriptions() {
+        return _functionFactory.getConstantDescription();
+    }
+
+    @Override
+    public String getName() {
+        return _name;
+    }
+
+    @Override
+    public String getDescription() {
+        return _description;
+    }
+}

--- a/java/src/jmri/jmrit/logixng/util/parser/functions/NamedBeanFunctions.java
+++ b/java/src/jmri/jmrit/logixng/util/parser/functions/NamedBeanFunctions.java
@@ -149,9 +149,8 @@ public class NamedBeanFunctions implements FunctionFactory {
      * Reads the value of a memory if the memory exists and then evaluates that
      * value.
      * If the value is a reference, it evaluates that reference. Else it
-     * evaluates the value as a formula.
-     * Return null if the memory does not exists or if the parameter cannot
-     * be evaluated to a String.
+     * evaluates the value.
+     * Return null if the memory does not exists.
      */
     public static class EvaluateMemoryFunction implements Function {
 
@@ -192,12 +191,7 @@ public class NamedBeanFunctions implements FunctionFactory {
                 return ReferenceUtil.getReference(symbolTable, (String)value);
             }
 
-            s = TypeConversionUtil.convertToString(value, false);
-
-            Map<String, Variable> variables = new HashMap<>();
-            RecursiveDescentParser parser = new RecursiveDescentParser(variables);
-            ExpressionNode expressionNode = parser.parseExpression(s);
-            return expressionNode.calculate(symbolTable);
+            return value;
         }
 
         @Override

--- a/java/src/jmri/util/TypeConversionUtil.java
+++ b/java/src/jmri/util/TypeConversionUtil.java
@@ -211,6 +211,11 @@ public final class TypeConversionUtil {
             return !collection.isEmpty();
         }
 
+        if (value.getClass().isArray()) {
+            var array = ((Object[])value);
+            return array.length > 0;
+        }
+
         // JSON text node
         if (value instanceof com.fasterxml.jackson.databind.node.TextNode) {
             value = ((com.fasterxml.jackson.databind.node.TextNode)value).asText();

--- a/java/test/jmri/jmrit/logixng/util/parser/functions/ClockFunctionsTest.java
+++ b/java/test/jmri/jmrit/logixng/util/parser/functions/ClockFunctionsTest.java
@@ -2,14 +2,12 @@ package jmri.jmrit.logixng.util.parser.functions;
 
 import java.time.Instant;
 import java.util.*;
+
 import jmri.InstanceManager;
 import jmri.jmrit.logixng.SymbolTable;
 import jmri.jmrit.logixng.implementation.DefaultConditionalNG;
 import jmri.jmrit.logixng.implementation.DefaultSymbolTable;
-import jmri.jmrit.logixng.util.parser.ExpressionNode;
-import jmri.jmrit.logixng.util.parser.ExpressionNodeString;
-import jmri.jmrit.logixng.util.parser.Token;
-import jmri.jmrit.logixng.util.parser.TokenType;
+import jmri.jmrit.logixng.util.parser.*;
 import jmri.util.JUnitUtil;
 
 import org.junit.After;
@@ -45,7 +43,7 @@ public class ClockFunctionsTest {
     @Test
     @SuppressWarnings("deprecation")        // Date.getMinutes, Date.getHours
     public void testSystemClockFunction() throws Exception {
-        ClockFunctions.SystemClockFunction systemClockFunction = new ClockFunctions.SystemClockFunction();
+        Function systemClockFunction = InstanceManager.getDefault(FunctionManager.class).get("systemClock");
         Assert.assertEquals("strings matches", "systemClock", systemClockFunction.getName());
 
         SymbolTable symbolTable = new DefaultSymbolTable(new DefaultConditionalNG("IQC1", null));
@@ -64,7 +62,7 @@ public class ClockFunctionsTest {
     @Test
     @SuppressWarnings("deprecation")        // Date.getMinutes, Date.getHours
     public void testFastClockFunction() throws Exception {
-        ClockFunctions.FastClockFunction fastClockFunction = new ClockFunctions.FastClockFunction();
+        Function fastClockFunction = InstanceManager.getDefault(FunctionManager.class).get("fastClock");
         Assert.assertEquals("strings matches", "fastClock", fastClockFunction.getName());
 
         SymbolTable symbolTable = new DefaultSymbolTable(new DefaultConditionalNG("IQC1", null));
@@ -78,6 +76,44 @@ public class ClockFunctionsTest {
         Assert.assertEquals(11, (int)fastClockFunction.calculate(symbolTable, getParameterList(expr_str_HOUR)));
         Assert.assertEquals(5, (int)fastClockFunction.calculate(symbolTable, getParameterList(expr_str_MIN)));
         Assert.assertEquals(minSinceMidnight, (int)fastClockFunction.calculate(symbolTable, getParameterList(expr_str_MIN_OF_DAY)));
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")        // Date.getMinutes, Date.getHours
+    public void testFastClockRateFunction() throws Exception {
+        Function fastClockRateFunction = InstanceManager.getDefault(FunctionManager.class).get("fastClockRate");
+        Assert.assertEquals("strings matches", "fastClockRate", fastClockRateFunction.getName());
+
+        SymbolTable symbolTable = new DefaultSymbolTable(new DefaultConditionalNG("IQC1", null));
+
+        jmri.Timebase fastClock = InstanceManager.getDefault(jmri.Timebase.class);
+        fastClock.setRate(1.0);
+        Assert.assertEquals(1.0, (double)fastClockRateFunction.calculate(symbolTable, getParameterList()), 0.000001);
+        fastClock.setRate(2.0);
+        Assert.assertEquals(2.0, (double)fastClockRateFunction.calculate(symbolTable, getParameterList()), 0.000001);
+        fastClock.setRate(60.0);
+        Assert.assertEquals(60.0, (double)fastClockRateFunction.calculate(symbolTable, getParameterList()), 0.000001);
+        fastClock.setRate(1.0);
+        Assert.assertEquals(1.0, (double)fastClockRateFunction.calculate(symbolTable, getParameterList()), 0.000001);
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")        // Date.getMinutes, Date.getHours
+    public void testIsFastClockRunningFunction() throws Exception {
+        Function isFastClockFunction = InstanceManager.getDefault(FunctionManager.class).get("isFastClockRunning");
+        Assert.assertEquals("strings matches", "isFastClockRunning", isFastClockFunction.getName());
+
+        SymbolTable symbolTable = new DefaultSymbolTable(new DefaultConditionalNG("IQC1", null));
+
+        jmri.Timebase fastClock = InstanceManager.getDefault(jmri.Timebase.class);
+        fastClock.setRun(false);
+        Assert.assertFalse((boolean)isFastClockFunction.calculate(symbolTable, getParameterList()));
+        fastClock.setRun(true);
+        Assert.assertTrue((boolean)isFastClockFunction.calculate(symbolTable, getParameterList()));
+        fastClock.setRun(false);
+        Assert.assertFalse((boolean)isFastClockFunction.calculate(symbolTable, getParameterList()));
+        fastClock.setRun(true);
+        Assert.assertTrue((boolean)isFastClockFunction.calculate(symbolTable, getParameterList()));
     }
 
     // The minimal setup for log4J

--- a/java/test/jmri/jmrit/logixng/util/parser/functions/CommonFunctionsTest.java
+++ b/java/test/jmri/jmrit/logixng/util/parser/functions/CommonFunctionsTest.java
@@ -3,15 +3,12 @@ package jmri.jmrit.logixng.util.parser.functions;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import jmri.InstanceManager;
 import jmri.jmrit.logixng.SymbolTable;
 import jmri.jmrit.logixng.implementation.DefaultConditionalNG;
 import jmri.jmrit.logixng.implementation.DefaultSymbolTable;
 import jmri.jmrit.logixng.util.LogixNG_Thread;
-import jmri.jmrit.logixng.util.parser.ExpressionNode;
-import jmri.jmrit.logixng.util.parser.ExpressionNodeString;
-import jmri.jmrit.logixng.util.parser.Token;
-import jmri.jmrit.logixng.util.parser.TokenType;
-import jmri.jmrit.logixng.util.parser.WrongNumberOfParametersException;
+import jmri.jmrit.logixng.util.parser.*;
 import jmri.util.JUnitUtil;
 
 import org.junit.After;
@@ -35,7 +32,7 @@ public class CommonFunctionsTest {
 
     @Test
     public void testLengthFunction() throws Exception {
-        CommonFunctions.LengthFunction lengthFunction = new CommonFunctions.LengthFunction();
+        Function lengthFunction = InstanceManager.getDefault(FunctionManager.class).get("length");
         Assert.assertEquals("strings matches", "length", lengthFunction.getName());
 
         AtomicBoolean hasThrown = new AtomicBoolean(false);
@@ -56,8 +53,7 @@ public class CommonFunctionsTest {
                         new ExpressionNodeString(new Token(TokenType.NONE, "A string", 0)))));
 
         Assert.assertEquals("Strings are equal", 4,
-                (int)lengthFunction.calculate(symbolTable, getParameterList(
-                        new ExpressionNodeConstant(
+                (int)lengthFunction.calculate(symbolTable, getParameterList(new ExpressionNodeConstantScaffold(
                                 new String[]{"Red", "Green", "Blue", "Yellow"}))));
 
         List<String> list = new ArrayList<>();
@@ -69,8 +65,7 @@ public class CommonFunctionsTest {
         list.add("H");
         list.add("III");
         Assert.assertEquals("Strings are equal", 7,
-                (int)lengthFunction.calculate(symbolTable, getParameterList(
-                        new ExpressionNodeConstant(list))));
+                (int)lengthFunction.calculate(symbolTable, getParameterList(new ExpressionNodeConstantScaffold(list))));
 
         Set<String> set = new HashSet<>();
         set.add("A");
@@ -84,15 +79,13 @@ public class CommonFunctionsTest {
         set.add("H");
         set.add("III");
         Assert.assertEquals("Strings are equal", 10,
-                (int)lengthFunction.calculate(symbolTable, getParameterList(
-                        new ExpressionNodeConstant(set))));
+                (int)lengthFunction.calculate(symbolTable, getParameterList(new ExpressionNodeConstantScaffold(set))));
 
         Map<String, Integer> map = new HashMap<>();
         map.put("Hello",72);
         map.put("Something", 33);
         Assert.assertEquals("Strings are equal", 2,
-                (int)lengthFunction.calculate(symbolTable, getParameterList(
-                        new ExpressionNodeConstant(map))));
+                (int)lengthFunction.calculate(symbolTable, getParameterList(new ExpressionNodeConstantScaffold(map))));
     }
 
     // The minimal setup for log4J
@@ -104,29 +97,8 @@ public class CommonFunctionsTest {
     @After
     public void tearDown() {
         LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
-    }
-
-
-    public static class ExpressionNodeConstant implements ExpressionNode {
-
-        private final Object _value;
-
-        public ExpressionNodeConstant(Object value) {
-            _value = value;
-        }
-
-        @Override
-        public Object calculate(SymbolTable symbolTable) {
-            return _value;
-        }
-
-        /** {@inheritDoc} */
-        @Override
-        public String getDefinitionString() {
-            return null;    // This value is never used
-        }
-
     }
 
 }

--- a/java/test/jmri/jmrit/logixng/util/parser/functions/ConvertFunctionsTest.java
+++ b/java/test/jmri/jmrit/logixng/util/parser/functions/ConvertFunctionsTest.java
@@ -1,24 +1,14 @@
 package jmri.jmrit.logixng.util.parser.functions;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Locale;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import jmri.InstanceManager;
 import jmri.jmrit.logixng.SymbolTable;
 import jmri.jmrit.logixng.implementation.DefaultConditionalNG;
 import jmri.jmrit.logixng.implementation.DefaultSymbolTable;
 import jmri.jmrit.logixng.util.LogixNG_Thread;
-import jmri.jmrit.logixng.util.parser.ExpressionNode;
-import jmri.jmrit.logixng.util.parser.ExpressionNodeIntegerNumber;
-import jmri.jmrit.logixng.util.parser.ExpressionNodeFalse;
-import jmri.jmrit.logixng.util.parser.ExpressionNodeFloatingNumber;
-import jmri.jmrit.logixng.util.parser.ExpressionNodeString;
-import jmri.jmrit.logixng.util.parser.ExpressionNodeTrue;
-import jmri.jmrit.logixng.util.parser.Token;
-import jmri.jmrit.logixng.util.parser.TokenType;
-import jmri.jmrit.logixng.util.parser.WrongNumberOfParametersException;
+import jmri.jmrit.logixng.util.parser.*;
 import jmri.util.JUnitAppender;
 import jmri.util.JUnitUtil;
 
@@ -78,9 +68,8 @@ public class ConvertFunctionsTest {
 
     @Test
     public void testIsIntFunction() throws Exception {
-        ConvertFunctions.IsIntFunction isIntFunction = new ConvertFunctions.IsIntFunction();
+        Function isIntFunction = InstanceManager.getDefault(FunctionManager.class).get("isInt");
         Assert.assertEquals("strings matches", "isInt", isIntFunction.getName());
-        Assert.assertEquals("strings matches", "isInt", new ConvertFunctions.IsIntFunction().getName());
 
         AtomicBoolean hasThrown = new AtomicBoolean(false);
 
@@ -131,9 +120,8 @@ public class ConvertFunctionsTest {
 
     @Test
     public void testIsFloatFunction() throws Exception {
-        ConvertFunctions.IsFloatFunction isFloatFunction = new ConvertFunctions.IsFloatFunction();
+        Function isFloatFunction = InstanceManager.getDefault(FunctionManager.class).get("isFloat");
         Assert.assertEquals("strings matches", "isFloat", isFloatFunction.getName());
-        Assert.assertEquals("strings matches", "isFloat", new ConvertFunctions.IsFloatFunction().getName());
 
         AtomicBoolean hasThrown = new AtomicBoolean(false);
 
@@ -182,9 +170,8 @@ public class ConvertFunctionsTest {
 
     @Test
     public void testBoolFunction() throws Exception {
-        ConvertFunctions.BoolFunction boolFunction = new ConvertFunctions.BoolFunction();
+        Function boolFunction = InstanceManager.getDefault(FunctionManager.class).get("bool");
         Assert.assertEquals("strings matches", "bool", boolFunction.getName());
-        Assert.assertEquals("strings matches", "bool", new ConvertFunctions.BoolFunction().getName());
 
         AtomicBoolean hasThrown = new AtomicBoolean(false);
 
@@ -213,13 +200,82 @@ public class ConvertFunctionsTest {
         } catch (WrongNumberOfParametersException e) {
             hasThrown.set(true);
         }
+
+        // Test array
+        hasThrown.set(false);
+        try {
+            boolFunction.calculate(symbolTable, getParameterList(
+                    new ExpressionNodeConstantScaffold(new String[]{"Red", "Green"})));
+        } catch (IllegalArgumentException e) {
+            hasThrown.set(true);
+        }
+        Assert.assertTrue("exception is thrown", hasThrown.get());
+    }
+
+    @Test
+    public void testBoolJythonFunction() throws Exception {
+        Function boolJythonFunction = InstanceManager.getDefault(FunctionManager.class).get("boolJython");
+        Assert.assertEquals("strings matches", "boolJython", boolJythonFunction.getName());
+
+        AtomicBoolean hasThrown = new AtomicBoolean(false);
+
+        SymbolTable symbolTable = new DefaultSymbolTable(new DefaultConditionalNG("IQC1", null));
+
+        // Test unsupported token type
+        hasThrown.set(false);
+        try {
+            boolJythonFunction.calculate(symbolTable, getParameterList());
+        } catch (WrongNumberOfParametersException e) {
+            hasThrown.set(true);
+        }
+        Assert.assertTrue("exception is thrown", hasThrown.get());
+
+        Assert.assertTrue("result is true", (boolean)boolJythonFunction.calculate(symbolTable, getParameterList(expr12)));
+        Assert.assertTrue("result is true", (boolean)boolJythonFunction.calculate(symbolTable, getParameterList(expr12_34)));
+        Assert.assertFalse("result is false", (boolean)boolJythonFunction.calculate(symbolTable, getParameterList(expr0)));
+        Assert.assertFalse("result is false", (boolean)boolJythonFunction.calculate(symbolTable, getParameterList(expr0_34)));
+        Assert.assertTrue("result is true", (boolean)boolJythonFunction.calculate(symbolTable, getParameterList(exprTrue)));
+        Assert.assertFalse("result is false", (boolean)boolJythonFunction.calculate(symbolTable, getParameterList(exprFalse)));
+
+        Assert.assertFalse("result is false", (boolean)boolJythonFunction.calculate(symbolTable, getParameterList(
+                new ExpressionNodeConstantScaffold(new String[]{}))));
+        Assert.assertTrue("result is true", (boolean)boolJythonFunction.calculate(symbolTable, getParameterList(
+                new ExpressionNodeConstantScaffold(new String[]{"Red", "Green"}))));
+
+        List<String> list = new ArrayList<>();
+        Assert.assertFalse("result is false", (boolean)boolJythonFunction.calculate(symbolTable, getParameterList(
+                new ExpressionNodeConstantScaffold(list))));
+        list.add("Blue");
+        Assert.assertTrue("result is true", (boolean)boolJythonFunction.calculate(symbolTable, getParameterList(
+                new ExpressionNodeConstantScaffold(list))));
+
+        Set<String> set = new HashSet<>();
+        Assert.assertFalse("result is false", (boolean)boolJythonFunction.calculate(symbolTable, getParameterList(
+                new ExpressionNodeConstantScaffold(set))));
+        set.add("Green");
+        Assert.assertTrue("result is true", (boolean)boolJythonFunction.calculate(symbolTable, getParameterList(
+                new ExpressionNodeConstantScaffold(set))));
+
+        Map<String, Integer> map = new HashMap<>();
+        Assert.assertFalse("result is false", (boolean)boolJythonFunction.calculate(symbolTable, getParameterList(
+                new ExpressionNodeConstantScaffold(map))));
+        map.put("Red", 2);
+        Assert.assertTrue("result is true", (boolean)boolJythonFunction.calculate(symbolTable, getParameterList(
+                new ExpressionNodeConstantScaffold(map))));
+
+        // Test unsupported token type
+        hasThrown.set(false);
+        try {
+            boolJythonFunction.calculate(symbolTable, getParameterList(expr12_34, expr25_46));
+        } catch (WrongNumberOfParametersException e) {
+            hasThrown.set(true);
+        }
     }
 
     @Test
     public void testIntFunction() throws Exception {
-        ConvertFunctions.IntFunction intFunction = new ConvertFunctions.IntFunction();
+        Function intFunction = InstanceManager.getDefault(FunctionManager.class).get("int");
         Assert.assertEquals("strings matches", "int", intFunction.getName());
-        Assert.assertEquals("strings matches", "int", new ConvertFunctions.IntFunction().getName());
 
         AtomicBoolean hasThrown = new AtomicBoolean(false);
 
@@ -246,8 +302,98 @@ public class ConvertFunctionsTest {
     }
 
     @Test
+    public void testFloatFunction() throws Exception {
+        Function floatFunction = InstanceManager.getDefault(FunctionManager.class).get("float");
+        Assert.assertEquals("strings matches", "float", floatFunction.getName());
+
+        AtomicBoolean hasThrown = new AtomicBoolean(false);
+
+        SymbolTable symbolTable = new DefaultSymbolTable(new DefaultConditionalNG("IQC1", null));
+
+        // Test unsupported token type
+        hasThrown.set(false);
+        try {
+            floatFunction.calculate(symbolTable, getParameterList());
+        } catch (WrongNumberOfParametersException e) {
+            hasThrown.set(true);
+        }
+        Assert.assertTrue("exception is thrown", hasThrown.get());
+
+        Assert.assertEquals("numbers are equal", 12.34, floatFunction.calculate(symbolTable, getParameterList(expr12_34)));
+
+        // Test unsupported token type
+        hasThrown.set(false);
+        try {
+            floatFunction.calculate(symbolTable, getParameterList(expr12_34, expr25_46));
+        } catch (WrongNumberOfParametersException e) {
+            hasThrown.set(true);
+        }
+    }
+
+    @Test
+    public void testStrFunction() throws Exception {
+        Function strFunction = InstanceManager.getDefault(FunctionManager.class).get("str");
+        Assert.assertEquals("strings matches", "str", strFunction.getName());
+
+        AtomicBoolean hasThrown = new AtomicBoolean(false);
+
+        SymbolTable symbolTable = new DefaultSymbolTable(new DefaultConditionalNG("IQC1", null));
+
+        // Test unsupported token type
+        hasThrown.set(false);
+        try {
+            strFunction.calculate(symbolTable, getParameterList());
+        } catch (WrongNumberOfParametersException e) {
+            hasThrown.set(true);
+        }
+        Assert.assertTrue("exception is thrown", hasThrown.get());
+
+        Assert.assertEquals("strings are equal", "12", strFunction.calculate(symbolTable, getParameterList(expr12)));
+        Assert.assertEquals("strings are equal", "12.34", strFunction.calculate(symbolTable, getParameterList(expr12_34)));
+
+        Assert.assertEquals("Strings are equal", "Blue",
+                strFunction.calculate(symbolTable, getParameterList(new ExpressionNodeConstantScaffold("Blue"))));
+        Assert.assertTrue(((String)strFunction.calculate(symbolTable, getParameterList(
+                new ExpressionNodeConstantScaffold(new String[0])))).startsWith("[Ljava.lang.String;@"));
+        Assert.assertTrue(((String)strFunction.calculate(symbolTable, getParameterList(
+                new ExpressionNodeConstantScaffold(new String[]{"Blue", "Red"})))).startsWith("[Ljava.lang.String;@"));
+
+        List<String> list = new ArrayList<>();
+        Assert.assertEquals("Strings are equal", "[]", strFunction.calculate(symbolTable, getParameterList(
+                new ExpressionNodeConstantScaffold(list))));
+        list.add("Blue");
+        list.add("Green");
+        Assert.assertEquals("Strings are equal", "[Blue, Green]", strFunction.calculate(symbolTable, getParameterList(
+                new ExpressionNodeConstantScaffold(list))));
+
+        Set<String> set = new HashSet<>();
+        Assert.assertEquals("Strings are equal", "[]", strFunction.calculate(symbolTable, getParameterList(
+                new ExpressionNodeConstantScaffold(set))));
+        set.add("Green");
+        set.add("Yellow");
+        Assert.assertEquals("Strings are equal", "[Yellow, Green]", strFunction.calculate(symbolTable, getParameterList(
+                new ExpressionNodeConstantScaffold(set))));
+
+        Map<String, Integer> map = new HashMap<>();
+        Assert.assertEquals("Strings are equal", "{}", strFunction.calculate(symbolTable, getParameterList(
+                new ExpressionNodeConstantScaffold(map))));
+        map.put("Red", 2);
+        map.put("Green", 4);
+        Assert.assertEquals("Strings are equal", "{Red=2, Green=4}", strFunction.calculate(symbolTable, getParameterList(
+                new ExpressionNodeConstantScaffold(map))));
+
+        // Test unsupported token type
+        hasThrown.set(false);
+        try {
+            strFunction.calculate(symbolTable, getParameterList(expr12_34, expr25_46));
+        } catch (WrongNumberOfParametersException e) {
+            hasThrown.set(true);
+        }
+    }
+
+    @Test
     public void testHex2DecFunction() throws Exception {
-        ConvertFunctions.Hex2DecFunction hex2DecFunction = new ConvertFunctions.Hex2DecFunction();
+        Function hex2DecFunction = InstanceManager.getDefault(FunctionManager.class).get("hex2dec");
         Assert.assertEquals("strings matches", "hex2dec", hex2DecFunction.getName());
         Assert.assertEquals("strings matches", "hex2dec", new ConvertFunctions.Hex2DecFunction().getName());
 
@@ -287,6 +433,7 @@ public class ConvertFunctionsTest {
     @AfterEach
     public void tearDown() {
         LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/util/parser/functions/ExpressionNodeConstantScaffold.java
+++ b/java/test/jmri/jmrit/logixng/util/parser/functions/ExpressionNodeConstantScaffold.java
@@ -1,0 +1,30 @@
+package jmri.jmrit.logixng.util.parser.functions;
+
+import jmri.jmrit.logixng.SymbolTable;
+import jmri.jmrit.logixng.util.parser.ExpressionNode;
+
+/**
+ * ExpressionNodeConstant Scaffold
+ *
+ * @author Daniel Bergqvist 2024
+ */
+public class ExpressionNodeConstantScaffold implements ExpressionNode {
+
+    private final Object _value;
+
+    public ExpressionNodeConstantScaffold(Object value) {
+        _value = value;
+    }
+
+    @Override
+    public Object calculate(SymbolTable symbolTable) {
+        return _value;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getDefinitionString() {
+        return null; // This value is never used
+    }
+
+}

--- a/java/test/jmri/jmrit/logixng/util/parser/functions/JavaFunctionsTest.java
+++ b/java/test/jmri/jmrit/logixng/util/parser/functions/JavaFunctionsTest.java
@@ -1,0 +1,77 @@
+package jmri.jmrit.logixng.util.parser.functions;
+
+import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import jmri.InstanceManager;
+import jmri.jmrit.logixng.SymbolTable;
+import jmri.jmrit.logixng.implementation.DefaultConditionalNG;
+import jmri.jmrit.logixng.implementation.DefaultSymbolTable;
+import jmri.jmrit.logixng.util.LogixNG_Thread;
+import jmri.jmrit.logixng.util.parser.*;
+import jmri.util.JUnitUtil;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Test ParsedExpression
+ *
+ * @author Daniel Bergqvist 2024
+ */
+public class JavaFunctionsTest {
+
+
+    private List<ExpressionNode> getParameterList(ExpressionNode... exprNodes) {
+        List<ExpressionNode> list = new ArrayList<>();
+        Collections.addAll(list, exprNodes);
+        return list;
+    }
+
+    @Test
+    public void testNewFunction() throws Exception {
+        Function newFunction = InstanceManager.getDefault(FunctionManager.class).get("new");
+        Assert.assertEquals("strings matches", "new", newFunction.getName());
+
+        AtomicBoolean hasThrown = new AtomicBoolean(false);
+
+        SymbolTable symbolTable = new DefaultSymbolTable(new DefaultConditionalNG("IQC1", null));
+
+        // Test unsupported token type
+        hasThrown.set(false);
+        try {
+            newFunction.calculate(symbolTable, getParameterList());
+        } catch (WrongNumberOfParametersException e) {
+            hasThrown.set(true);
+        }
+        Assert.assertTrue("exception is thrown", hasThrown.get());
+
+        Object obj = newFunction.calculate(symbolTable, getParameterList(
+                new ExpressionNodeString(new Token(TokenType.NONE, "jmri.jmrit.logixng.util.parser.functions.ExpressionNodeConstantScaffold", 0)),
+                new ExpressionNodeString(new Token(TokenType.NONE, "Parameter", 0))
+                ));
+        Assert.assertNotNull(obj);
+        Assert.assertEquals("jmri.jmrit.logixng.util.parser.functions.ExpressionNodeConstantScaffold", obj.getClass().getName());
+
+        obj = newFunction.calculate(symbolTable, getParameterList(
+                new ExpressionNodeString(new Token(TokenType.NONE, "java.lang.StringBuilder", 0))));
+        Assert.assertNotNull(obj);
+        Assert.assertEquals("java.lang.StringBuilder", obj.getClass().getName());
+    }
+
+    // The minimal setup for log4J
+    @Before
+    public void setUp() {
+        JUnitUtil.setUp();
+    }
+
+    @After
+    public void tearDown() {
+        LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
+        JUnitUtil.tearDown();
+    }
+
+}

--- a/java/test/jmri/jmrit/logixng/util/parser/functions/LayoutFunctionsTest.java
+++ b/java/test/jmri/jmrit/logixng/util/parser/functions/LayoutFunctionsTest.java
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test LayoutFunctions
- * 
+ *
  * @author Daniel Bergqvist 2021
  */
 public class LayoutFunctionsTest {
@@ -30,47 +30,47 @@ public class LayoutFunctionsTest {
     private final ExpressionNode exprTurnoutMyTurnout = new ExpressionNodeString(new Token(TokenType.NONE, "My turnout", 0));
     private final ExpressionNode exprTurnoutClosed = new ExpressionNodeString(new Token(TokenType.NONE, Integer.toString(Turnout.CLOSED), 0));
     private final ExpressionNode exprTurnoutThrown = new ExpressionNodeString(new Token(TokenType.NONE, Integer.toString(Turnout.THROWN), 0));
-    
+
     private final ExpressionNode exprSensorIS1 = new ExpressionNodeString(new Token(TokenType.NONE, "IS1", 0));
     private final ExpressionNode exprSensorMySensor = new ExpressionNodeString(new Token(TokenType.NONE, "My sensor", 0));
     private final ExpressionNode exprSensorInactive = new ExpressionNodeString(new Token(TokenType.NONE, Integer.toString(Sensor.INACTIVE), 0));
     private final ExpressionNode exprSensorActive = new ExpressionNodeString(new Token(TokenType.NONE, Integer.toString(Sensor.ACTIVE), 0));
-    
+
     private final ExpressionNode exprLightIL1 = new ExpressionNodeString(new Token(TokenType.NONE, "IL1", 0));
     private final ExpressionNode exprLightMyLight = new ExpressionNodeString(new Token(TokenType.NONE, "My light", 0));
     private final ExpressionNode exprLightOff = new ExpressionNodeString(new Token(TokenType.NONE, Integer.toString(Sensor.INACTIVE), 0));
     private final ExpressionNode exprLightOn = new ExpressionNodeString(new Token(TokenType.NONE, Integer.toString(Sensor.ACTIVE), 0));
-    
+
     private final static int SIGNAL_HEAD_RED = 1;
     private final static int SIGNAL_HEAD_GREEN = 2;
-    
+
     private final ExpressionNode exprSignalHeadIH1 = new ExpressionNodeString(new Token(TokenType.NONE, "IH1", 0));
     private final ExpressionNode exprSignalHeadMySignalHead = new ExpressionNodeString(new Token(TokenType.NONE, "My signal head", 0));
     private final ExpressionNode exprSignalHeadRed = new ExpressionNodeString(new Token(TokenType.NONE, Integer.toString(SIGNAL_HEAD_RED), 0));
     private final ExpressionNode exprSignalHeadGreen = new ExpressionNodeString(new Token(TokenType.NONE, Integer.toString(SIGNAL_HEAD_GREEN), 0));
-    
+
     private final ExpressionNode exprSignalMastIF1 = new ExpressionNodeString(new Token(TokenType.NONE, "IF1", 0));
     private final ExpressionNode exprSignalMastMySignalMast = new ExpressionNodeString(new Token(TokenType.NONE, "My signal mast", 0));
     private final ExpressionNode exprSignalMastRed = new ExpressionNodeString(new Token(TokenType.NONE, "Red", 0));
     private final ExpressionNode exprSignalMastGreen = new ExpressionNodeString(new Token(TokenType.NONE, "Green", 0));
-    
-    
+
+
     private List<ExpressionNode> getParameterList(ExpressionNode... exprNodes) {
         List<ExpressionNode> list = new ArrayList<>();
         Collections.addAll(list, exprNodes);
         return list;
     }
-    
+
     @Test
     public void testTurnoutExistsFunction() throws Exception {
-        LayoutFunctions.TurnoutExistsFunction turnoutExistsFunction = new LayoutFunctions.TurnoutExistsFunction();
+        Function turnoutExistsFunction = InstanceManager.getDefault(FunctionManager.class).get("turnoutExists");
         Assert.assertEquals("strings matches", "turnoutExists", turnoutExistsFunction.getName());
         Assert.assertNotNull("Function has description", turnoutExistsFunction.getDescription());
-        
+
         AtomicBoolean hasThrown = new AtomicBoolean(false);
-        
+
         SymbolTable symbolTable = new DefaultSymbolTable(new DefaultConditionalNG("IQC1", null));
-        
+
         hasThrown.set(false);
         try {
             turnoutExistsFunction.calculate(symbolTable, getParameterList());
@@ -78,13 +78,13 @@ public class LayoutFunctionsTest {
             hasThrown.set(true);
         }
         Assert.assertTrue("exception is thrown", hasThrown.get());
-        
+
         Assert.assertFalse("Turnout doesn't exists",
                 (boolean)turnoutExistsFunction.calculate(symbolTable, getParameterList(exprTurnoutIT1)));
-        
+
         Assert.assertFalse("Turnout doesn't exists",
                 (boolean)turnoutExistsFunction.calculate(symbolTable, getParameterList(exprTurnoutMyTurnout)));
-        
+
         MyTurnout t = new MyTurnout();
         InstanceManager.getDefault(TurnoutManager.class).register(t);
         Assert.assertTrue("Turnout exists",
@@ -92,21 +92,21 @@ public class LayoutFunctionsTest {
         Assert.assertTrue("Turnout exists",
                 (boolean)turnoutExistsFunction.calculate(symbolTable, getParameterList(exprTurnoutMyTurnout)));
     }
-    
+
     @Test
     public void testGetSetTurnoutStateFunction() throws Exception {
-        LayoutFunctions.GetTurnoutStateFunction getTurnoutStateFunction = new LayoutFunctions.GetTurnoutStateFunction();
+        Function getTurnoutStateFunction = InstanceManager.getDefault(FunctionManager.class).get("getTurnoutState");
         Assert.assertEquals("strings matches", "getTurnoutState", getTurnoutStateFunction.getName());
         Assert.assertNotNull("Function has description", getTurnoutStateFunction.getDescription());
-        
-        LayoutFunctions.SetTurnoutStateFunction setTurnoutStateFunction = new LayoutFunctions.SetTurnoutStateFunction();
+
+        Function setTurnoutStateFunction = InstanceManager.getDefault(FunctionManager.class).get("setTurnoutState");
         Assert.assertEquals("strings matches", "setTurnoutState", setTurnoutStateFunction.getName());
         Assert.assertNotNull("Function has description", setTurnoutStateFunction.getDescription());
-        
+
         AtomicBoolean hasThrown = new AtomicBoolean(false);
-        
+
         SymbolTable symbolTable = new DefaultSymbolTable(new DefaultConditionalNG("IQC1", null));
-        
+
         hasThrown.set(false);
         try {
             getTurnoutStateFunction.calculate(symbolTable, getParameterList());
@@ -114,63 +114,63 @@ public class LayoutFunctionsTest {
             hasThrown.set(true);
         }
         Assert.assertTrue("exception is thrown", hasThrown.get());
-        
+
         Assertions.assertThrows(CalculateException.class, () -> {
             Assert.assertEquals("Turnout has correct state", Turnout.THROWN,
                     (int)getTurnoutStateFunction.calculate(symbolTable, getParameterList(exprTurnoutIT1)));
         });
-        
+
         Assertions.assertThrows(CalculateException.class, () -> {
             Assert.assertEquals("Turnout has correct state", Turnout.THROWN,
                     (int)getTurnoutStateFunction.calculate(symbolTable, getParameterList(exprTurnoutMyTurnout)));
         });
-        
+
         MyTurnout t = new MyTurnout();
         InstanceManager.getDefault(TurnoutManager.class).register(t);
         t.setState(Turnout.UNKNOWN);
-        
+
         t._lastSetState = -1;
         t._knownState = Turnout.THROWN;
         Assert.assertEquals("Turnout has correct state", Turnout.THROWN,
                 (int)getTurnoutStateFunction.calculate(symbolTable, getParameterList(exprTurnoutIT1)));
         Assert.assertEquals("Turnout is not set", -1, t._lastSetState);
-        
+
         t._knownState = Turnout.THROWN;
         Assert.assertEquals("Turnout has correct state", Turnout.THROWN,
                 (int)getTurnoutStateFunction.calculate(symbolTable, getParameterList(exprTurnoutMyTurnout)));
         Assert.assertEquals("Turnout is not set", -1, t._lastSetState);
-        
+
         t._knownState = Turnout.CLOSED;
         Assert.assertEquals("Turnout has correct state", Turnout.CLOSED,
                 (int)getTurnoutStateFunction.calculate(symbolTable, getParameterList(exprTurnoutIT1)));
         Assert.assertEquals("Turnout is not set", -1, t._lastSetState);
-        
+
         t._knownState = Turnout.CLOSED;
         Assert.assertEquals("Turnout has correct state", Turnout.CLOSED,
                 (int)getTurnoutStateFunction.calculate(symbolTable, getParameterList(exprTurnoutMyTurnout)));
         Assert.assertEquals("Turnout is not set", -1, t._lastSetState);
-        
+
         t._lastSetState = -1;
         t._knownState = Turnout.THROWN;
         Assert.assertEquals("Turnout has correct state", Turnout.UNKNOWN,
                 (int)setTurnoutStateFunction.calculate(symbolTable,
                         getParameterList(exprTurnoutIT1, exprTurnoutThrown)));
         Assert.assertEquals("Turnout is set", Turnout.THROWN, t._lastSetState);
-        
+
         t._lastSetState = -1;
         t._knownState = Turnout.THROWN;
         Assert.assertEquals("Turnout has correct state", Turnout.UNKNOWN,
                 (int)setTurnoutStateFunction.calculate(symbolTable,
                         getParameterList(exprTurnoutMyTurnout, exprTurnoutThrown)));
         Assert.assertEquals("Turnout is set", Turnout.THROWN, t._lastSetState);
-        
+
         t._lastSetState = -1;
         t._knownState = Turnout.CLOSED;
         Assert.assertEquals("Turnout has correct state", Turnout.UNKNOWN,
                 (int)setTurnoutStateFunction.calculate(symbolTable,
                         getParameterList(exprTurnoutIT1, exprTurnoutClosed)));
         Assert.assertEquals("Turnout is set", Turnout.CLOSED, t._lastSetState);
-        
+
         t._lastSetState = -1;
         t._knownState = Turnout.CLOSED;
         Assert.assertEquals("Turnout has correct state", Turnout.UNKNOWN,
@@ -178,17 +178,17 @@ public class LayoutFunctionsTest {
                         getParameterList(exprTurnoutMyTurnout, exprTurnoutClosed)));
         Assert.assertEquals("Turnout is set", Turnout.CLOSED, t._lastSetState);
     }
-    
+
     @Test
     public void testSensorExistsFunction() throws Exception {
-        LayoutFunctions.SensorExistsFunction sensorExistsFunction = new LayoutFunctions.SensorExistsFunction();
+        Function sensorExistsFunction = InstanceManager.getDefault(FunctionManager.class).get("sensorExists");
         Assert.assertEquals("strings matches", "sensorExists", sensorExistsFunction.getName());
         Assert.assertNotNull("Function has description", sensorExistsFunction.getDescription());
-        
+
         AtomicBoolean hasThrown = new AtomicBoolean(false);
-        
+
         SymbolTable symbolTable = new DefaultSymbolTable(new DefaultConditionalNG("IQC1", null));
-        
+
         hasThrown.set(false);
         try {
             sensorExistsFunction.calculate(symbolTable, getParameterList());
@@ -196,13 +196,13 @@ public class LayoutFunctionsTest {
             hasThrown.set(true);
         }
         Assert.assertTrue("exception is thrown", hasThrown.get());
-        
+
         Assert.assertFalse("Sensor doesn't exists",
                 (boolean)sensorExistsFunction.calculate(symbolTable, getParameterList(exprSensorIS1)));
-        
+
         Assert.assertFalse("Sensor doesn't exists",
                 (boolean)sensorExistsFunction.calculate(symbolTable, getParameterList(exprSensorMySensor)));
-        
+
         MySensor t = new MySensor();
         InstanceManager.getDefault(SensorManager.class).register(t);
         Assert.assertTrue("Sensor exists",
@@ -210,21 +210,21 @@ public class LayoutFunctionsTest {
         Assert.assertTrue("Sensor exists",
                 (boolean)sensorExistsFunction.calculate(symbolTable, getParameterList(exprSensorMySensor)));
     }
-    
+
     @Test
     public void testGetSetSensorStateFunction() throws Exception {
-        LayoutFunctions.GetSensorStateFunction getSensorStateFunction = new LayoutFunctions.GetSensorStateFunction();
+        Function getSensorStateFunction = InstanceManager.getDefault(FunctionManager.class).get("getSensorState");
         Assert.assertEquals("strings matches", "getSensorState", getSensorStateFunction.getName());
         Assert.assertNotNull("Function has description", getSensorStateFunction.getDescription());
-        
-        LayoutFunctions.SetSensorStateFunction setSensorStateFunction = new LayoutFunctions.SetSensorStateFunction();
+
+        Function setSensorStateFunction = InstanceManager.getDefault(FunctionManager.class).get("setSensorState");
         Assert.assertEquals("strings matches", "setSensorState", setSensorStateFunction.getName());
         Assert.assertNotNull("Function has description", setSensorStateFunction.getDescription());
-        
+
         AtomicBoolean hasThrown = new AtomicBoolean(false);
-        
+
         SymbolTable symbolTable = new DefaultSymbolTable(new DefaultConditionalNG("IQC1", null));
-        
+
         hasThrown.set(false);
         try {
             getSensorStateFunction.calculate(symbolTable, getParameterList());
@@ -232,63 +232,63 @@ public class LayoutFunctionsTest {
             hasThrown.set(true);
         }
         Assert.assertTrue("exception is thrown", hasThrown.get());
-        
+
         Assertions.assertThrows(CalculateException.class, () -> {
             Assert.assertEquals("Sensor has correct state", Sensor.ACTIVE,
                     (int)getSensorStateFunction.calculate(symbolTable, getParameterList(exprSensorIS1)));
         });
-        
+
         Assertions.assertThrows(CalculateException.class, () -> {
             Assert.assertEquals("Sensor has correct state", Sensor.ACTIVE,
                     (int)getSensorStateFunction.calculate(symbolTable, getParameterList(exprSensorMySensor)));
         });
-        
+
         MySensor s = new MySensor();
         InstanceManager.getDefault(SensorManager.class).register(s);
         s.setState(Sensor.UNKNOWN);
-        
+
         s._lastSetState = -1;
         s.setTestKnownState(Sensor.ACTIVE);
         Assert.assertEquals("Sensor has correct state", Sensor.ACTIVE,
                 (int)getSensorStateFunction.calculate(symbolTable, getParameterList(exprSensorIS1)));
         Assert.assertEquals("Sensor is not set", -1, s._lastSetState);
-        
+
         s.setTestKnownState(Sensor.ACTIVE);
         Assert.assertEquals("Sensor has correct state", Sensor.ACTIVE,
                 (int)getSensorStateFunction.calculate(symbolTable, getParameterList(exprSensorMySensor)));
         Assert.assertEquals("Sensor is not set", -1, s._lastSetState);
-        
+
         s.setTestKnownState(Sensor.INACTIVE);
         Assert.assertEquals("Sensor has correct state", Sensor.INACTIVE,
                 (int)getSensorStateFunction.calculate(symbolTable, getParameterList(exprSensorIS1)));
         Assert.assertEquals("Sensor is not set", -1, s._lastSetState);
-        
+
         s.setTestKnownState(Sensor.INACTIVE);
         Assert.assertEquals("Sensor has correct state", Sensor.INACTIVE,
                 (int)getSensorStateFunction.calculate(symbolTable, getParameterList(exprSensorMySensor)));
         Assert.assertEquals("Sensor is not set", -1, s._lastSetState);
-        
+
         s._lastSetState = -1;
         s.setTestKnownState(Sensor.ACTIVE);
         Assert.assertEquals("Sensor has correct state", Sensor.UNKNOWN,
                 (int)setSensorStateFunction.calculate(symbolTable,
                         getParameterList(exprSensorIS1, exprSensorActive)));
         Assert.assertEquals("Sensor is set", Sensor.ACTIVE, s._lastSetState);
-        
+
         s._lastSetState = -1;
         s.setTestKnownState(Sensor.ACTIVE);
         Assert.assertEquals("Sensor has correct state", Sensor.UNKNOWN,
                 (int)setSensorStateFunction.calculate(symbolTable,
                         getParameterList(exprSensorMySensor, exprSensorActive)));
         Assert.assertEquals("Sensor is set", Sensor.ACTIVE, s._lastSetState);
-        
+
         s._lastSetState = -1;
         s.setTestKnownState(Sensor.INACTIVE);
         Assert.assertEquals("Sensor has correct state", Sensor.UNKNOWN,
                 (int)setSensorStateFunction.calculate(symbolTable,
                         getParameterList(exprSensorIS1, exprSensorInactive)));
         Assert.assertEquals("Sensor is set", Sensor.INACTIVE, s._lastSetState);
-        
+
         s._lastSetState = -1;
         s.setTestKnownState(Sensor.INACTIVE);
         Assert.assertEquals("Sensor has correct state", Sensor.UNKNOWN,
@@ -296,17 +296,17 @@ public class LayoutFunctionsTest {
                         getParameterList(exprSensorMySensor, exprSensorInactive)));
         Assert.assertEquals("Sensor is set", Sensor.INACTIVE, s._lastSetState);
     }
-    
+
     @Test
     public void testLightExistsFunction() throws Exception {
-        LayoutFunctions.LightExistsFunction lightExistsFunction = new LayoutFunctions.LightExistsFunction();
+        Function lightExistsFunction = InstanceManager.getDefault(FunctionManager.class).get("lightExists");
         Assert.assertEquals("strings matches", "lightExists", lightExistsFunction.getName());
         Assert.assertNotNull("Function has description", lightExistsFunction.getDescription());
-        
+
         AtomicBoolean hasThrown = new AtomicBoolean(false);
-        
+
         SymbolTable symbolTable = new DefaultSymbolTable(new DefaultConditionalNG("IQC1", null));
-        
+
         hasThrown.set(false);
         try {
             lightExistsFunction.calculate(symbolTable, getParameterList());
@@ -314,13 +314,13 @@ public class LayoutFunctionsTest {
             hasThrown.set(true);
         }
         Assert.assertTrue("exception is thrown", hasThrown.get());
-        
+
         Assert.assertFalse("Light doesn't exists",
                 (boolean)lightExistsFunction.calculate(symbolTable, getParameterList(exprLightIL1)));
-        
+
         Assert.assertFalse("Light doesn't exists",
                 (boolean)lightExistsFunction.calculate(symbolTable, getParameterList(exprLightMyLight)));
-        
+
         MyLight t = new MyLight();
         InstanceManager.getDefault(LightManager.class).register(t);
         Assert.assertTrue("Light exists",
@@ -328,21 +328,21 @@ public class LayoutFunctionsTest {
         Assert.assertTrue("Light exists",
                 (boolean)lightExistsFunction.calculate(symbolTable, getParameterList(exprLightMyLight)));
     }
-    
+
     @Test
     public void testGetSetLightStateFunction() throws Exception {
-        LayoutFunctions.GetLightStateFunction getLightStateFunction = new LayoutFunctions.GetLightStateFunction();
+        Function getLightStateFunction = InstanceManager.getDefault(FunctionManager.class).get("getLightState");
         Assert.assertEquals("strings matches", "getLightState", getLightStateFunction.getName());
         Assert.assertNotNull("Function has description", getLightStateFunction.getDescription());
-        
-        LayoutFunctions.SetLightStateFunction setLightStateFunction = new LayoutFunctions.SetLightStateFunction();
+
+        Function setLightStateFunction = InstanceManager.getDefault(FunctionManager.class).get("setLightState");
         Assert.assertEquals("strings matches", "setLightState", setLightStateFunction.getName());
         Assert.assertNotNull("Function has description", setLightStateFunction.getDescription());
-        
+
         AtomicBoolean hasThrown = new AtomicBoolean(false);
-        
+
         SymbolTable symbolTable = new DefaultSymbolTable(new DefaultConditionalNG("IQC1", null));
-        
+
         hasThrown.set(false);
         try {
             getLightStateFunction.calculate(symbolTable, getParameterList());
@@ -350,63 +350,63 @@ public class LayoutFunctionsTest {
             hasThrown.set(true);
         }
         Assert.assertTrue("exception is thrown", hasThrown.get());
-        
+
         Assertions.assertThrows(CalculateException.class, () -> {
             Assert.assertEquals("Light has correct state", Light.ON,
                     (int)getLightStateFunction.calculate(symbolTable, getParameterList(exprLightIL1)));
         });
-        
+
         Assertions.assertThrows(CalculateException.class, () -> {
             Assert.assertEquals("Light has correct state", Light.ON,
                     (int)getLightStateFunction.calculate(symbolTable, getParameterList(exprLightMyLight)));
         });
-        
+
         MyLight s = new MyLight();
         InstanceManager.getDefault(LightManager.class).register(s);
         s.setState(Light.UNKNOWN);
-        
+
         s._lastSetState = -1;
         s.setTestKnownState(Light.ON);
         Assert.assertEquals("Light has correct state", Light.ON,
                 (int)getLightStateFunction.calculate(symbolTable, getParameterList(exprLightIL1)));
         Assert.assertEquals("Light is not set", -1, s._lastSetState);
-        
+
         s.setTestKnownState(Light.ON);
         Assert.assertEquals("Light has correct state", Light.ON,
                 (int)getLightStateFunction.calculate(symbolTable, getParameterList(exprLightMyLight)));
         Assert.assertEquals("Light is not set", -1, s._lastSetState);
-        
+
         s.setTestKnownState(Light.OFF);
         Assert.assertEquals("Light has correct state", Light.OFF,
                 (int)getLightStateFunction.calculate(symbolTable, getParameterList(exprLightIL1)));
         Assert.assertEquals("Light is not set", -1, s._lastSetState);
-        
+
         s.setTestKnownState(Light.OFF);
         Assert.assertEquals("Light has correct state", Light.OFF,
                 (int)getLightStateFunction.calculate(symbolTable, getParameterList(exprLightMyLight)));
         Assert.assertEquals("Light is not set", -1, s._lastSetState);
-        
+
         s._lastSetState = -1;
         s.setTestKnownState(Light.ON);
         Assert.assertEquals("Light has correct state", Light.UNKNOWN,
                 (int)setLightStateFunction.calculate(symbolTable,
                         getParameterList(exprLightIL1, exprLightOn)));
         Assert.assertEquals("Light is set", Light.ON, s._lastSetState);
-        
+
         s._lastSetState = -1;
         s.setTestKnownState(Light.ON);
         Assert.assertEquals("Light has correct state", Light.UNKNOWN,
                 (int)setLightStateFunction.calculate(symbolTable,
                         getParameterList(exprLightMyLight, exprLightOn)));
         Assert.assertEquals("Light is set", Light.ON, s._lastSetState);
-        
+
         s._lastSetState = -1;
         s.setTestKnownState(Light.OFF);
         Assert.assertEquals("Light has correct state", Light.UNKNOWN,
                 (int)setLightStateFunction.calculate(symbolTable,
                         getParameterList(exprLightIL1, exprLightOff)));
         Assert.assertEquals("Light is set", Light.OFF, s._lastSetState);
-        
+
         s._lastSetState = -1;
         s.setTestKnownState(Light.OFF);
         Assert.assertEquals("Light has correct state", Light.UNKNOWN,
@@ -414,17 +414,17 @@ public class LayoutFunctionsTest {
                         getParameterList(exprLightMyLight, exprLightOff)));
         Assert.assertEquals("Light is set", Light.OFF, s._lastSetState);
     }
-    
+
     @Test
     public void testSignalHeadExistsFunction() throws Exception {
-        LayoutFunctions.SignalHeadExistsFunction signalHeadExistsFunction = new LayoutFunctions.SignalHeadExistsFunction();
+        Function signalHeadExistsFunction = InstanceManager.getDefault(FunctionManager.class).get("signalHeadExists");
         Assert.assertEquals("strings matches", "signalHeadExists", signalHeadExistsFunction.getName());
         Assert.assertNotNull("Function has description", signalHeadExistsFunction.getDescription());
-        
+
         AtomicBoolean hasThrown = new AtomicBoolean(false);
-        
+
         SymbolTable symbolTable = new DefaultSymbolTable(new DefaultConditionalNG("IQC1", null));
-        
+
         hasThrown.set(false);
         try {
             signalHeadExistsFunction.calculate(symbolTable, getParameterList());
@@ -432,13 +432,13 @@ public class LayoutFunctionsTest {
             hasThrown.set(true);
         }
         Assert.assertTrue("exception is thrown", hasThrown.get());
-        
+
         Assert.assertFalse("SignalHead doesn't exists",
                 (boolean)signalHeadExistsFunction.calculate(symbolTable, getParameterList(exprSignalHeadIH1)));
-        
+
         Assert.assertFalse("SignalHead doesn't exists",
                 (boolean)signalHeadExistsFunction.calculate(symbolTable, getParameterList(exprSignalHeadMySignalHead)));
-        
+
         MySignalHead t = new MySignalHead();
         InstanceManager.getDefault(SignalHeadManager.class).register(t);
         Assert.assertTrue("SignalHead exists",
@@ -446,21 +446,21 @@ public class LayoutFunctionsTest {
         Assert.assertTrue("SignalHead exists",
                 (boolean)signalHeadExistsFunction.calculate(symbolTable, getParameterList(exprSignalHeadMySignalHead)));
     }
-    
+
     @Test
     public void testGetSetSignalHeadAppearanceFunction() throws Exception {
-        LayoutFunctions.GetSignalHeadAppearanceFunction getSignalHeadStateFunction = new LayoutFunctions.GetSignalHeadAppearanceFunction();
+        Function getSignalHeadStateFunction = InstanceManager.getDefault(FunctionManager.class).get("getSignalHeadAppearance");
         Assert.assertEquals("strings matches", "getSignalHeadAppearance", getSignalHeadStateFunction.getName());
         Assert.assertNotNull("Function has description", getSignalHeadStateFunction.getDescription());
-        
-        LayoutFunctions.SetSignalHeadAppearanceFunction setSignalHeadStateFunction = new LayoutFunctions.SetSignalHeadAppearanceFunction();
+
+        Function setSignalHeadStateFunction = InstanceManager.getDefault(FunctionManager.class).get("setSignalHeadAppearance");
         Assert.assertEquals("strings matches", "setSignalHeadAppearance", setSignalHeadStateFunction.getName());
         Assert.assertNotNull("Function has description", setSignalHeadStateFunction.getDescription());
-        
+
         AtomicBoolean hasThrown = new AtomicBoolean(false);
-        
+
         SymbolTable symbolTable = new DefaultSymbolTable(new DefaultConditionalNG("IQC1", null));
-        
+
         hasThrown.set(false);
         try {
             getSignalHeadStateFunction.calculate(symbolTable, getParameterList());
@@ -468,64 +468,64 @@ public class LayoutFunctionsTest {
             hasThrown.set(true);
         }
         Assert.assertTrue("exception is thrown", hasThrown.get());
-        
+
         Assertions.assertThrows(CalculateException.class, () -> {
             Assert.assertEquals("SignalHead has correct appearance", SIGNAL_HEAD_GREEN,
                     (int)getSignalHeadStateFunction.calculate(symbolTable, getParameterList(exprSignalHeadIH1)));
         });
-        
+
         Assertions.assertThrows(CalculateException.class, () -> {
             Assert.assertEquals("SignalHead has correct appearance", SIGNAL_HEAD_GREEN,
                     (int)getSignalHeadStateFunction.calculate(symbolTable, getParameterList(exprSignalHeadMySignalHead)));
         });
-        
+
         MySignalHead sh = new MySignalHead();
         InstanceManager.getDefault(SignalHeadManager.class).register(sh);
         sh.setState(SignalHead.UNKNOWN);
         sh.setState(SIGNAL_HEAD_RED);
-        
+
         sh._lastAppearance = -1;
         sh._appearance = SIGNAL_HEAD_GREEN;
         Assert.assertEquals("SignalHead has correct appearance", SIGNAL_HEAD_GREEN,
                 (int)getSignalHeadStateFunction.calculate(symbolTable, getParameterList(exprSignalHeadIH1)));
         Assert.assertEquals("SignalHead is not set", -1, sh._lastAppearance);
-        
+
         sh._appearance = SIGNAL_HEAD_GREEN;
         Assert.assertEquals("SignalHead has correct appearance", SIGNAL_HEAD_GREEN,
                 (int)getSignalHeadStateFunction.calculate(symbolTable, getParameterList(exprSignalHeadMySignalHead)));
         Assert.assertEquals("SignalHead is not set", -1, sh._lastAppearance);
-        
+
         sh._appearance = SIGNAL_HEAD_RED;
         Assert.assertEquals("SignalHead has correct appearance", SIGNAL_HEAD_RED,
                 (int)getSignalHeadStateFunction.calculate(symbolTable, getParameterList(exprSignalHeadIH1)));
         Assert.assertEquals("SignalHead is not set", -1, sh._lastAppearance);
-        
+
         sh._appearance = SIGNAL_HEAD_RED;
         Assert.assertEquals("SignalHead has correct appearance", SIGNAL_HEAD_RED,
                 (int)getSignalHeadStateFunction.calculate(symbolTable, getParameterList(exprSignalHeadMySignalHead)));
         Assert.assertEquals("SignalHead is not set", -1, sh._lastAppearance);
-        
+
         sh._lastAppearance = -1;
         sh._appearance = SIGNAL_HEAD_GREEN;
         Assert.assertEquals("SignalHead has correct appearance", -1,
                 (int)setSignalHeadStateFunction.calculate(symbolTable,
                         getParameterList(exprSignalHeadIH1, exprSignalHeadGreen)));
         Assert.assertEquals("SignalHead is set", SIGNAL_HEAD_GREEN, sh._lastAppearance);
-        
+
         sh._lastAppearance = -1;
         sh._appearance = SIGNAL_HEAD_GREEN;
         Assert.assertEquals("SignalHead has correct appearance", -1,
                 (int)setSignalHeadStateFunction.calculate(symbolTable,
                         getParameterList(exprSignalHeadMySignalHead, exprSignalHeadGreen)));
         Assert.assertEquals("SignalHead is set", SIGNAL_HEAD_GREEN, sh._lastAppearance);
-        
+
         sh._lastAppearance = -1;
         sh._appearance = SIGNAL_HEAD_RED;
         Assert.assertEquals("SignalHead has correct appearance", -1,
                 (int)setSignalHeadStateFunction.calculate(symbolTable,
                         getParameterList(exprSignalHeadIH1, exprSignalHeadRed)));
         Assert.assertEquals("SignalHead is set", SIGNAL_HEAD_RED, sh._lastAppearance);
-        
+
         sh._lastAppearance = -1;
         sh._appearance = SIGNAL_HEAD_RED;
         Assert.assertEquals("SignalHead has correct appearance", -1,
@@ -533,17 +533,17 @@ public class LayoutFunctionsTest {
                         getParameterList(exprSignalHeadMySignalHead, exprSignalHeadRed)));
         Assert.assertEquals("SignalHead is set", SIGNAL_HEAD_RED, sh._lastAppearance);
     }
-    
+
     @Test
     public void testSignalMastExistsFunction() throws Exception {
-        LayoutFunctions.SignalMastExistsFunction signalMastExistsFunction = new LayoutFunctions.SignalMastExistsFunction();
+        Function signalMastExistsFunction = InstanceManager.getDefault(FunctionManager.class).get("signalMastExists");
         Assert.assertEquals("strings matches", "signalMastExists", signalMastExistsFunction.getName());
         Assert.assertNotNull("Function has description", signalMastExistsFunction.getDescription());
-        
+
         AtomicBoolean hasThrown = new AtomicBoolean(false);
-        
+
         SymbolTable symbolTable = new DefaultSymbolTable(new DefaultConditionalNG("IQC1", null));
-        
+
         hasThrown.set(false);
         try {
             signalMastExistsFunction.calculate(symbolTable, getParameterList());
@@ -551,13 +551,13 @@ public class LayoutFunctionsTest {
             hasThrown.set(true);
         }
         Assert.assertTrue("exception is thrown", hasThrown.get());
-        
+
         Assert.assertFalse("SignalMast doesn't exists",
                 (boolean)signalMastExistsFunction.calculate(symbolTable, getParameterList(exprSignalMastIF1)));
-        
+
         Assert.assertFalse("SignalMast doesn't exists",
                 (boolean)signalMastExistsFunction.calculate(symbolTable, getParameterList(exprSignalMastMySignalMast)));
-        
+
         MySignalMast t = new MySignalMast();
         InstanceManager.getDefault(SignalMastManager.class).register(t);
         Assert.assertTrue("SignalMast exists",
@@ -565,21 +565,21 @@ public class LayoutFunctionsTest {
         Assert.assertTrue("SignalMast exists",
                 (boolean)signalMastExistsFunction.calculate(symbolTable, getParameterList(exprSignalMastMySignalMast)));
     }
-    
+
     @Test
     public void testGetSetSignalMastAspectFunction() throws Exception {
-        LayoutFunctions.GetSignalMastAspectFunction getSignalMastAspectFunction = new LayoutFunctions.GetSignalMastAspectFunction();
+        Function getSignalMastAspectFunction = InstanceManager.getDefault(FunctionManager.class).get("getSignalMastAspect");
         Assert.assertEquals("strings matches", "getSignalMastAspect", getSignalMastAspectFunction.getName());
         Assert.assertNotNull("Function has description", getSignalMastAspectFunction.getDescription());
-        
-        LayoutFunctions.SetSignalMastAspectFunction setSignalMastAspectFunction = new LayoutFunctions.SetSignalMastAspectFunction();
+
+        Function setSignalMastAspectFunction = InstanceManager.getDefault(FunctionManager.class).get("setSignalMastAspect");
         Assert.assertEquals("strings matches", "setSignalMastAspect", setSignalMastAspectFunction.getName());
         Assert.assertNotNull("Function has description", setSignalMastAspectFunction.getDescription());
-        
+
         AtomicBoolean hasThrown = new AtomicBoolean(false);
-        
+
         SymbolTable symbolTable = new DefaultSymbolTable(new DefaultConditionalNG("IQC1", null));
-        
+
         hasThrown.set(false);
         try {
             getSignalMastAspectFunction.calculate(symbolTable, getParameterList());
@@ -587,63 +587,63 @@ public class LayoutFunctionsTest {
             hasThrown.set(true);
         }
         Assert.assertTrue("exception is thrown", hasThrown.get());
-        
+
         Assertions.assertThrows(CalculateException.class, () -> {
             Assert.assertEquals("SignalMast has correct aspect", "Green",
                     getSignalMastAspectFunction.calculate(symbolTable, getParameterList(exprSignalMastIF1)));
         });
-        
+
         Assertions.assertThrows(CalculateException.class, () -> {
             Assert.assertEquals("SignalMast has correct aspect", "Green",
                     getSignalMastAspectFunction.calculate(symbolTable, getParameterList(exprSignalMastMySignalMast)));
         });
-        
+
         MySignalMast sm = new MySignalMast();
         InstanceManager.getDefault(SignalMastManager.class).register(sm);
         sm.setState(SignalMast.UNKNOWN);
-        
+
         sm._lastAspect = null;
         sm._aspect = "Green";
         Assert.assertEquals("SignalMast has correct aspect", "Green",
                 getSignalMastAspectFunction.calculate(symbolTable, getParameterList(exprSignalMastIF1)));
         Assert.assertNull("SignalMast is not set", sm._lastAspect);
-        
+
         sm._aspect = "Green";
         Assert.assertEquals("SignalMast has correct aspect", "Green",
                 getSignalMastAspectFunction.calculate(symbolTable, getParameterList(exprSignalMastMySignalMast)));
         Assert.assertNull("SignalMast is not set", sm._lastAspect);
-        
+
         sm._aspect = "Red";
         Assert.assertEquals("SignalMast has correct aspect", "Red",
                 getSignalMastAspectFunction.calculate(symbolTable, getParameterList(exprSignalMastIF1)));
         Assert.assertNull("SignalMast is not set", sm._lastAspect);
-        
+
         sm._aspect = "Red";
         Assert.assertEquals("SignalMast has correct aspect", "Red",
                 getSignalMastAspectFunction.calculate(symbolTable, getParameterList(exprSignalMastMySignalMast)));
         Assert.assertNull("SignalMast is not set", sm._lastAspect);
-        
+
         sm._lastAspect = null;
         sm._aspect = "Green";
         Assert.assertNull("SignalMast has correct aspect",
                 setSignalMastAspectFunction.calculate(symbolTable,
                         getParameterList(exprSignalMastIF1, exprSignalMastGreen)));
         Assert.assertEquals("SignalMast is set", "Green", sm._lastAspect);
-        
+
         sm._lastAspect = null;
         sm._aspect = "Green";
         Assert.assertNull("SignalMast has correct aspect",
                 setSignalMastAspectFunction.calculate(symbolTable,
                         getParameterList(exprSignalMastMySignalMast, exprSignalMastGreen)));
         Assert.assertEquals("SignalMast is set", "Green", sm._lastAspect);
-        
+
         sm._lastAspect = null;
         sm._aspect = "Red";
         Assert.assertNull("SignalMast has correct aspect",
                 setSignalMastAspectFunction.calculate(symbolTable,
                         getParameterList(exprSignalMastIF1, exprSignalMastRed)));
         Assert.assertEquals("SignalMast is set", "Red", sm._lastAspect);
-        
+
         sm._lastAspect = null;
         sm._aspect = "Red";
         Assert.assertNull("SignalMast has correct aspect",
@@ -651,7 +651,7 @@ public class LayoutFunctionsTest {
                         getParameterList(exprSignalMastMySignalMast, exprSignalMastRed)));
         Assert.assertEquals("SignalMast is set", "Red", sm._lastAspect);
     }
-    
+
     // The minimal setup for log4J
     @BeforeEach
     public void setUp() {
@@ -661,10 +661,11 @@ public class LayoutFunctionsTest {
     @AfterEach
     public void tearDown() {
         LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
-    
-    
+
+
     private static class MyTurnout extends jmri.implementation.AbstractTurnout {
 
         int _knownState = Turnout.UNKNOWN;
@@ -693,8 +694,8 @@ public class LayoutFunctionsTest {
         }
 
     }
-    
-    
+
+
     private static class MySensor extends jmri.implementation.AbstractSensor {
 
         int _lastSetState = Sensor.UNKNOWN;
@@ -725,8 +726,8 @@ public class LayoutFunctionsTest {
         }
 
     }
-    
-    
+
+
     private static class MyLight extends jmri.implementation.AbstractLight {
 
         int _knownState = Turnout.UNKNOWN;
@@ -758,8 +759,8 @@ public class LayoutFunctionsTest {
         }
 
     }
-    
-    
+
+
     private static class MySignalHead extends jmri.implementation.VirtualSignalHead {
 
         int _lastAppearance = -1;
@@ -792,8 +793,8 @@ public class LayoutFunctionsTest {
         }
 
     }
-    
-    
+
+
     private static class MySignalMast extends jmri.implementation.AbstractSignalMast {
 
         String _lastAspect = null;
@@ -816,5 +817,5 @@ public class LayoutFunctionsTest {
         }
 
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/util/parser/functions/MathFunctionsTest.java
+++ b/java/test/jmri/jmrit/logixng/util/parser/functions/MathFunctionsTest.java
@@ -6,18 +6,12 @@ import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import jmri.InstanceManager;
 import jmri.jmrit.logixng.SymbolTable;
 import jmri.jmrit.logixng.implementation.DefaultConditionalNG;
 import jmri.jmrit.logixng.implementation.DefaultSymbolTable;
 import jmri.jmrit.logixng.util.LogixNG_Thread;
-import jmri.jmrit.logixng.util.parser.CalculateException;
-import jmri.jmrit.logixng.util.parser.ExpressionNode;
-import jmri.jmrit.logixng.util.parser.ExpressionNodeFloatingNumber;
-import jmri.jmrit.logixng.util.parser.ExpressionNodeString;
-import jmri.jmrit.logixng.util.parser.ExpressionNodeTrue;
-import jmri.jmrit.logixng.util.parser.Token;
-import jmri.jmrit.logixng.util.parser.TokenType;
-import jmri.jmrit.logixng.util.parser.WrongNumberOfParametersException;
+import jmri.jmrit.logixng.util.parser.*;
 import jmri.util.JUnitUtil;
 
 import org.junit.After;
@@ -27,7 +21,7 @@ import org.junit.Test;
 
 /**
  * Test ParsedExpression
- * 
+ *
  * @author Daniel Bergqvist 2019
  */
 public class MathFunctionsTest {
@@ -36,21 +30,22 @@ public class MathFunctionsTest {
     ExpressionNode expr_str_HELLO = new ExpressionNodeString(new Token(TokenType.NONE, "hello", 0));
     ExpressionNode expr_str_RAD = new ExpressionNodeString(new Token(TokenType.NONE, "rad", 0));
     ExpressionNode expr_str_DEG = new ExpressionNodeString(new Token(TokenType.NONE, "deg", 0));
-    ExpressionNode expr_str_0_34 = new ExpressionNodeString(new Token(TokenType.NONE, "0.34", 0));
     ExpressionNode expr0_34 = new ExpressionNodeFloatingNumber(new Token(TokenType.NONE, "0.34", 0));
     ExpressionNode expr0_95 = new ExpressionNodeFloatingNumber(new Token(TokenType.NONE, "0.95", 0));
     ExpressionNode expr12_34 = new ExpressionNodeFloatingNumber(new Token(TokenType.NONE, "12.34", 0));
-    ExpressionNode expr25_46 = new ExpressionNodeFloatingNumber(new Token(TokenType.NONE, "25.46", 0));
     ExpressionNode expr12 = new ExpressionNodeFloatingNumber(new Token(TokenType.NONE, "12", 0));
     ExpressionNode expr23 = new ExpressionNodeFloatingNumber(new Token(TokenType.NONE, "23", 0));
-    
-    
+    ExpressionNode exprNeg0_34 = new ExpressionNodeFloatingNumber(new Token(TokenType.NONE, "-0.34", 0));
+    ExpressionNode exprNeg0_95 = new ExpressionNodeFloatingNumber(new Token(TokenType.NONE, "-0.95", 0));
+    ExpressionNode exprNeg12_34 = new ExpressionNodeFloatingNumber(new Token(TokenType.NONE, "-12.34", 0));
+
+
     private List<ExpressionNode> getParameterList(ExpressionNode... exprNodes) {
         List<ExpressionNode> list = new ArrayList<>();
         Collections.addAll(list, exprNodes);
         return list;
     }
-    
+
     @Test
     public void testBundle() {
         Assert.assertEquals("strings are equal",
@@ -60,26 +55,25 @@ public class MathFunctionsTest {
                 "Function \"sin\" has wrong number of parameters",
                 Bundle.getMessage(Locale.CANADA, "WrongNumberOfParameters1", "sin"));
         // Test Bundle.retry(Locale, String)
-        Assert.assertEquals("strings matches","Item",Bundle.getMessage("CategoryItem"));
-    }
-    
+        Assert.assertEquals("strings matches","Item",Bundle.getMessage("CategoryItem"));    }
+
     @Test
     public void testSinFunction() throws Exception {
-        MathFunctions.SinFunction sinFunction = new MathFunctions.SinFunction();
+        Function sinFunction = InstanceManager.getDefault(FunctionManager.class).get("sin");
         Assert.assertEquals("strings matches", "sin", sinFunction.getName());
-        
+
         SymbolTable symbolTable = new DefaultSymbolTable(new DefaultConditionalNG("IQC1", null));
-        
+
         // Test sin(x)
         Assert.assertEquals("numbers are equal", (Double)0.3334870921408144, (Double)sinFunction.calculate(symbolTable, getParameterList(expr0_34)), 0.0000001d);
         Assert.assertEquals("numbers are equal", (Double)0.8134155047893737, (Double)sinFunction.calculate(symbolTable, getParameterList(expr0_95)), 0.0000001d);
         Assert.assertEquals("numbers are equal", (Double)(-0.22444221895185537), (Double)sinFunction.calculate(symbolTable, getParameterList(expr12_34)), 0.0000001d);
-        
+
         // Test sin(x) with a string as parameter
         Assert.assertEquals("numbers are equal", (Double)0.3334870921408144, (Double)sinFunction.calculate(symbolTable, getParameterList(expr0_34)), 0.0000001d);
-        
+
         AtomicBoolean hasThrown = new AtomicBoolean(false);
-        
+
         // Test sin(x,"rad"), sin(x,"deg"), sin(x,"hello"), sin(x, true)
         Assert.assertEquals("numbers are equal", (Double)0.3334870921408144, (Double)sinFunction.calculate(symbolTable, getParameterList(expr0_34, expr_str_RAD)), 0.0000001d);
         Assert.assertEquals("numbers are equal", (Double)0.21371244079399437, (Double)sinFunction.calculate(symbolTable, getParameterList(expr12_34, expr_str_DEG)), 0.0000001d);
@@ -97,10 +91,10 @@ public class MathFunctionsTest {
             hasThrown.set(true);
         }
         Assert.assertTrue("exception is thrown", hasThrown.get());
-        
+
         // Test sin(x,"deg", 12, 23)
         Assert.assertEquals("numbers are equal", (Double)18.675418424366967, (Double)sinFunction.calculate(symbolTable, getParameterList(expr12_34, expr_str_DEG, expr12, expr23)), 0.0000001d);
-        
+
         // Test sin()
         hasThrown.set(false);
         try {
@@ -110,7 +104,61 @@ public class MathFunctionsTest {
         }
         Assert.assertTrue("exception is thrown", hasThrown.get());
     }
-    
+
+    @Test
+    public void testAbsFunction() throws Exception {
+        Function absFunction = InstanceManager.getDefault(FunctionManager.class).get("abs");
+        Assert.assertEquals("strings matches", "abs", absFunction.getName());
+
+        SymbolTable symbolTable = new DefaultSymbolTable(new DefaultConditionalNG("IQC1", null));
+
+        Assert.assertEquals("numbers are equal", (Double)0.34, (Double)absFunction.calculate(symbolTable, getParameterList(expr0_34)), 0.0000001d);
+        Assert.assertEquals("numbers are equal", (Double)0.95, (Double)absFunction.calculate(symbolTable, getParameterList(expr0_95)), 0.0000001d);
+        Assert.assertEquals("numbers are equal", (Double)(12.34), (Double)absFunction.calculate(symbolTable, getParameterList(expr12_34)), 0.0000001d);
+
+        Assert.assertEquals("numbers are equal", (Double)0.34, (Double)absFunction.calculate(symbolTable, getParameterList(exprNeg0_34)), 0.0000001d);
+        Assert.assertEquals("numbers are equal", (Double)0.95, (Double)absFunction.calculate(symbolTable, getParameterList(exprNeg0_95)), 0.0000001d);
+        Assert.assertEquals("numbers are equal", (Double)(12.34), (Double)absFunction.calculate(symbolTable, getParameterList(exprNeg12_34)), 0.0000001d);
+    }
+
+    @Test
+    public void testRandomFunction() throws Exception {
+        Function randomFunction = InstanceManager.getDefault(FunctionManager.class).get("random");
+        Assert.assertEquals("strings matches", "random", randomFunction.getName());
+
+        SymbolTable symbolTable = new DefaultSymbolTable(new DefaultConditionalNG("IQC1", null));
+
+        // Test random()
+        for (int i=0; i < 100; i++) {
+            double value = (double) randomFunction.calculate(symbolTable, getParameterList());
+            Assert.assertTrue(value >= 0.0);
+            Assert.assertTrue(value < 1.0);
+        }
+
+        // Test random(max)
+        for (int max=1; max < 1000; max += 100) {
+            for (int i=0; i < 100; i++) {
+                double value = (double) randomFunction.calculate(symbolTable, getParameterList(
+                        new ExpressionNodeFloatingNumber(new Token(TokenType.NONE, Integer.toString(max), 0))));
+                Assert.assertTrue(value >= 0.0);
+                Assert.assertTrue(value < max);
+            }
+        }
+
+        // Test random(min, max)
+        for (int min=1; min < 1000; min += 100) {
+            for (int size=1; size < 1000; size += 100) {
+                for (int i=0; i < 100; i++) {
+                    double value = (double) randomFunction.calculate(symbolTable, getParameterList(
+                            new ExpressionNodeFloatingNumber(new Token(TokenType.NONE, Integer.toString(min), 0)),
+                            new ExpressionNodeFloatingNumber(new Token(TokenType.NONE, Integer.toString(min+size), 0))));
+                    Assert.assertTrue(value >= min);
+                    Assert.assertTrue(value < min+size);
+                }
+            }
+        }
+    }
+
     // The minimal setup for log4J
     @Before
     public void setUp() {
@@ -120,7 +168,8 @@ public class MathFunctionsTest {
     @After
     public void tearDown() {
         LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/util/parser/functions/NamedBeanFunctionsTest.java
+++ b/java/test/jmri/jmrit/logixng/util/parser/functions/NamedBeanFunctionsTest.java
@@ -1,0 +1,263 @@
+package jmri.jmrit.logixng.util.parser.functions;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import jmri.*;
+import jmri.jmrit.logixng.*;
+import jmri.jmrit.logixng.implementation.*;
+import jmri.jmrit.logixng.util.LogixNG_Thread;
+import jmri.jmrit.logixng.util.parser.*;
+import jmri.util.JUnitUtil;
+
+import org.junit.Assert;
+import org.junit.jupiter.api.*;
+
+/**
+ * Test LayoutFunctions
+ *
+ * @author Daniel Bergqvist 2021
+ */
+public class NamedBeanFunctionsTest {
+
+    private final ExpressionNode exprLogixNGTableIQT1 = new ExpressionNodeString(new Token(TokenType.NONE, "IQT1", 0));
+    private final ExpressionNode exprLogixNGTableMyTable = new ExpressionNodeString(new Token(TokenType.NONE, "My table", 0));
+
+    private final ExpressionNode exprMemoryIM1 = new ExpressionNodeString(new Token(TokenType.NONE, "IM1", 0));
+    private final ExpressionNode exprMyMemory1 = new ExpressionNodeString(new Token(TokenType.NONE, "My memory 1", 0));
+    private final ExpressionNode exprRed = new ExpressionNodeString(new Token(TokenType.NONE, "Red", 0));
+    private final ExpressionNode exprGreen = new ExpressionNodeString(new Token(TokenType.NONE, "Green", 0));
+
+
+    private List<ExpressionNode> getParameterList(ExpressionNode... exprNodes) {
+        List<ExpressionNode> list = new ArrayList<>();
+        Collections.addAll(list, exprNodes);
+        return list;
+    }
+
+    @Test
+    public void testGetLogixNGTableFunction() throws Exception {
+        Function getLogixNGTableFunction = InstanceManager.getDefault(FunctionManager.class).get("getLogixNGTable");
+        Assert.assertEquals("strings matches", "getLogixNGTable", getLogixNGTableFunction.getName());
+        Assert.assertNotNull("Function has description", getLogixNGTableFunction.getDescription());
+
+        SymbolTable symbolTable = new DefaultSymbolTable(new DefaultConditionalNG("IQC1", null));
+
+        NamedTable table = new DefaultInternalNamedTable("IQT1", "My table", 2, 3);
+        InstanceManager.getDefault(NamedTableManager.class).register(table);
+
+        Object myTable = getLogixNGTableFunction.calculate(symbolTable, getParameterList(exprLogixNGTableIQT1));
+        Assert.assertNotNull(myTable);
+        Assert.assertEquals("jmri.jmrit.logixng.implementation.DefaultInternalNamedTable", myTable.getClass().getName());
+        Assert.assertEquals("IQT1", ((NamedBean)myTable).getSystemName());
+        Assert.assertEquals("My table", ((NamedBean)myTable).getUserName());
+
+        myTable = getLogixNGTableFunction.calculate(symbolTable, getParameterList(exprLogixNGTableMyTable));
+        Assert.assertNotNull(myTable);
+        Assert.assertEquals("jmri.jmrit.logixng.implementation.DefaultInternalNamedTable", myTable.getClass().getName());
+        Assert.assertEquals("IQT1", ((NamedBean)myTable).getSystemName());
+        Assert.assertEquals("My table", ((NamedBean)myTable).getUserName());
+    }
+
+    @Test
+    public void testGetSetMemoryFunction() throws Exception {
+        Function readMemoryFunction = InstanceManager.getDefault(FunctionManager.class).get("readMemory");
+        Assert.assertEquals("strings matches", "readMemory", readMemoryFunction.getName());
+        Assert.assertNotNull("Function has description", readMemoryFunction.getDescription());
+
+        Function writeMemoryFunction = InstanceManager.getDefault(FunctionManager.class).get("writeMemory");
+        Assert.assertEquals("strings matches", "writeMemory", writeMemoryFunction.getName());
+        Assert.assertNotNull("Function has description", writeMemoryFunction.getDescription());
+
+        AtomicBoolean hasThrown = new AtomicBoolean(false);
+
+        SymbolTable symbolTable = new DefaultSymbolTable(new DefaultConditionalNG("IQC1", null));
+
+        hasThrown.set(false);
+        try {
+            readMemoryFunction.calculate(symbolTable, getParameterList());
+        } catch (WrongNumberOfParametersException e) {
+            hasThrown.set(true);
+        }
+        Assert.assertTrue("exception is thrown", hasThrown.get());
+
+        Assert.assertEquals("Memory has correct value", null,
+                readMemoryFunction.calculate(symbolTable, getParameterList(exprMemoryIM1)));
+
+        Assert.assertEquals("Memory has correct value", null,
+                readMemoryFunction.calculate(symbolTable, getParameterList(exprMyMemory1)));
+
+        MyMemory memory = new MyMemory();
+        InstanceManager.getDefault(MemoryManager.class).register(memory);
+
+        memory._lastValue = null;
+        memory._value = "Green";
+        Assert.assertEquals("Memory has correct value", "Green",
+                readMemoryFunction.calculate(symbolTable, getParameterList(exprMemoryIM1)));
+        Assert.assertNull("Memory is not set", memory._lastValue);
+
+        memory._value = "Green";
+        Assert.assertEquals("Memory has correct value", "Green",
+                readMemoryFunction.calculate(symbolTable, getParameterList(exprMyMemory1)));
+        Assert.assertNull("Memory is not set", memory._lastValue);
+
+        memory._value = "Red";
+        Assert.assertEquals("Memory has correct value", "Red",
+                readMemoryFunction.calculate(symbolTable, getParameterList(exprMemoryIM1)));
+        Assert.assertNull("Memory is not set", memory._lastValue);
+
+        memory._value = "Red";
+        Assert.assertEquals("Memory has correct value", "Red",
+                readMemoryFunction.calculate(symbolTable, getParameterList(exprMyMemory1)));
+        Assert.assertNull("Memory is not set", memory._lastValue);
+
+        memory._lastValue = null;
+        memory._value = null;
+        Assert.assertEquals("Memory has correct value",
+                "Green",
+                writeMemoryFunction.calculate(symbolTable,
+                        getParameterList(exprMemoryIM1, exprGreen)));
+        Assert.assertEquals("Memory is set", "Green", memory._lastValue);
+
+        memory._lastValue = null;
+        memory._value = null;
+        Assert.assertEquals("Memory has correct value",
+                "Green",
+                writeMemoryFunction.calculate(symbolTable,
+                        getParameterList(exprMyMemory1, exprGreen)));
+        Assert.assertEquals("Memory is set", "Green", memory._lastValue);
+
+        memory._lastValue = null;
+        memory._value = null;
+        Assert.assertEquals("Memory has correct value",
+                "Red",
+                writeMemoryFunction.calculate(symbolTable,
+                        getParameterList(exprMemoryIM1, exprRed)));
+        Assert.assertEquals("Memory is set", "Red", memory._lastValue);
+
+        memory._lastValue = null;
+        memory._value = null;
+        Assert.assertEquals("Memory has correct value",
+                "Red",
+                writeMemoryFunction.calculate(symbolTable,
+                        getParameterList(exprMyMemory1, exprRed)));
+        Assert.assertEquals("Memory is set", "Red", memory._lastValue);
+    }
+
+    @Test
+    public void testEvaluateMemoryFunction() throws Exception {
+        Function evaluateMemoryFunction = InstanceManager.getDefault(FunctionManager.class).get("evaluateMemory");
+        Assert.assertEquals("strings matches", "evaluateMemory", evaluateMemoryFunction.getName());
+        Assert.assertNotNull("Function has description", evaluateMemoryFunction.getDescription());
+
+        AtomicBoolean hasThrown = new AtomicBoolean(false);
+
+        SymbolTable symbolTable = new DefaultSymbolTable(new DefaultConditionalNG("IQC1", null));
+
+        hasThrown.set(false);
+        try {
+            evaluateMemoryFunction.calculate(symbolTable, getParameterList());
+        } catch (WrongNumberOfParametersException e) {
+            hasThrown.set(true);
+        }
+        Assert.assertTrue("exception is thrown", hasThrown.get());
+
+        Assert.assertEquals("Memory has correct value", null,
+                evaluateMemoryFunction.calculate(symbolTable, getParameterList(exprMemoryIM1)));
+
+        Assert.assertEquals("Memory has correct value", null,
+                evaluateMemoryFunction.calculate(symbolTable, getParameterList(exprMyMemory1)));
+
+        MyMemory memory = new MyMemory();
+        InstanceManager.getDefault(MemoryManager.class).register(memory);
+
+        MyMemory otherMemory = new MyMemory("IM2", "My other memory");
+        otherMemory._value = "Other memory value";
+        InstanceManager.getDefault(MemoryManager.class).register(otherMemory);
+
+        memory._lastValue = null;
+        memory._value = "Green";
+        Assert.assertEquals("Memory has correct value", "Green",
+                evaluateMemoryFunction.calculate(symbolTable, getParameterList(exprMemoryIM1)));
+        Assert.assertNull("Memory is not set", memory._lastValue);
+
+        memory._value = "Green";
+        Assert.assertEquals("Memory has correct value", "Green",
+                evaluateMemoryFunction.calculate(symbolTable, getParameterList(exprMyMemory1)));
+        Assert.assertNull("Memory is not set", memory._lastValue);
+
+        memory._value = "Red";
+        Assert.assertEquals("Memory has correct value", "Red",
+                evaluateMemoryFunction.calculate(symbolTable, getParameterList(exprMemoryIM1)));
+        Assert.assertNull("Memory is not set", memory._lastValue);
+
+        memory._value = "Red";
+        Assert.assertEquals("Memory has correct value", "Red",
+                evaluateMemoryFunction.calculate(symbolTable, getParameterList(exprMyMemory1)));
+        Assert.assertNull("Memory is not set", memory._lastValue);
+
+        memory._value = "{IM2}";
+        Assert.assertEquals("Memory has correct value", "Other memory value",
+                evaluateMemoryFunction.calculate(symbolTable, getParameterList(exprMyMemory1)));
+        Assert.assertNull("Memory is not set", memory._lastValue);
+
+        memory._value = "{My other memory}";
+        Assert.assertEquals("Memory has correct value", "Other memory value",
+                evaluateMemoryFunction.calculate(symbolTable, getParameterList(exprMyMemory1)));
+        Assert.assertNull("Memory is not set", memory._lastValue);
+    }
+
+    // The minimal setup for log4J
+    @BeforeEach
+    public void setUp() {
+        JUnitUtil.setUp();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
+        JUnitUtil.tearDown();
+    }
+
+
+    private static class MyMemory extends jmri.implementation.AbstractMemory {
+
+        Object _lastValue = null;
+        Object _value = null;
+
+        MyMemory() {
+            super("IM1", "My memory 1");
+        }
+
+        MyMemory(String sys, String user) {
+            super(sys, user);
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        public Object getValue() {
+            return _value;
+        }
+
+        @Override
+        public void setValue(Object value) {
+            _lastValue = value;
+            _value = null;
+        }
+
+        @Override
+        public int getState() {
+            return 0;
+        }
+
+        @Override
+        public void setState(int s) throws JmriException {
+            // Do nothing
+        }
+
+    }
+
+}

--- a/java/test/jmri/jmrit/logixng/util/parser/functions/StringFunctionsTest.java
+++ b/java/test/jmri/jmrit/logixng/util/parser/functions/StringFunctionsTest.java
@@ -3,17 +3,12 @@ package jmri.jmrit.logixng.util.parser.functions;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import jmri.InstanceManager;
 import jmri.jmrit.logixng.SymbolTable;
 import jmri.jmrit.logixng.implementation.DefaultConditionalNG;
 import jmri.jmrit.logixng.implementation.DefaultSymbolTable;
 import jmri.jmrit.logixng.util.LogixNG_Thread;
-import jmri.jmrit.logixng.util.parser.ExpressionNode;
-import jmri.jmrit.logixng.util.parser.ExpressionNodeFloatingNumber;
-import jmri.jmrit.logixng.util.parser.ExpressionNodeIntegerNumber;
-import jmri.jmrit.logixng.util.parser.ExpressionNodeString;
-import jmri.jmrit.logixng.util.parser.Token;
-import jmri.jmrit.logixng.util.parser.TokenType;
-import jmri.jmrit.logixng.util.parser.WrongNumberOfParametersException;
+import jmri.jmrit.logixng.util.parser.*;
 import jmri.util.JUnitUtil;
 
 import org.junit.After;
@@ -41,7 +36,7 @@ public class StringFunctionsTest {
 
     @Test
     public void testFormatFunction() throws Exception {
-        StringFunctions.FormatFunction formatFunction = new StringFunctions.FormatFunction();
+        Function formatFunction = InstanceManager.getDefault(FunctionManager.class).get("format");
         Assert.assertEquals("strings matches", "format", formatFunction.getName());
 
         AtomicBoolean hasThrown = new AtomicBoolean(false);
@@ -74,7 +69,7 @@ public class StringFunctionsTest {
 
     @Test
     public void testStrLenFunction() throws Exception {
-        StringFunctions.StrLenFunction strlenFunction = new StringFunctions.StrLenFunction();
+        Function strlenFunction = InstanceManager.getDefault(FunctionManager.class).get("strlen");
         Assert.assertEquals("strings matches", "strlen", strlenFunction.getName());
 
         AtomicBoolean hasThrown = new AtomicBoolean(false);
@@ -104,6 +99,7 @@ public class StringFunctionsTest {
     @After
     public void tearDown() {
         LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 


### PR DESCRIPTION
@bobjacobsen @dsand47 

This PR fixes two bugs in LogixNG functions:

- The LogixNG function `boolJython()` now return false if the value is an empty array. It returns true if the value is a non empty array.
  The function `boolJython()` was added in #12897 for JMRI 5.7.5 and I don't think anyone has been affected with this bug yet.

- The LogixNG function `evaluateMemory()` didn't behaved as documented. It's now fixed.
  This method didn't behaved as expected as all. I don't think anyone is using this function since it's behavior was strange. Now this method works as expected.

Besides that, this PR also adds the class `AbstractFunction` which will aid refactor the LogixNG functions. But it's not used yet.

The rest of the PR is improved and added tests. I have now ensured that all the existing LogixNG functions have some tests, which is how I discovered the two bugs above.

If possible, I would appreciate if this PR and #12945 could be merged early without the 24 hour delay. It will help me refactor the LogixNG functions which in turn will help adding more LogixNG functions.