### PR TITLE
Add new LogixNG functions

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -511,6 +511,10 @@ LogixNG: IQ:AUTO:0001
               true if the value is a non empty array.</li>
           <li>Bug fix: The LogixNG function <strong>evaluateMemory()</strong>
               didn't behaved as documented. It's now fixed.</li>
+          <li>The LogixNG functions <strong>cos()</strong>, <strong>tan()</strong>,
+              <strong>atan()</strong>, <strong>sqr()</strong> and
+              <strong>sqrt()</strong> has been added to the <strong>Math</strong>
+              module.</li>
           <li></li>
         </ul>
 

--- a/java/src/jmri/jmrit/logixng/util/parser/functions/FunctionsBundle.properties
+++ b/java/src/jmri/jmrit/logixng/util/parser/functions/FunctionsBundle.properties
@@ -239,6 +239,70 @@ the brightness be between 20 and 100. You can then use the following formula:   
 </html>
 
 
+Math.cos_Descr                  = <html>                                                    \
+<h1>cos()</h1>                                                                              \
+<h2>cos(angle)</h2>                                                                         \
+Returns the cosine value of <i>angle</i>, where <i>angle</i> is measured in radians.        \
+<hr>                                                                                        \
+<h2>cos(angle, unit)</h2>                                                                   \
+Returns the cosine value of <i>angle</i>, there <i>angle</i> is measured in <i>unit</i>.    \
+<p>                                                                                         \
+The <i>unit</i> may be given by a string or by the number of units per full                 \
+rotation of the circle. The supported strings are "rad" for radians and "deg"               \
+for degrees.                                                                                \
+<hr>                                                                                        \
+<h2>cos(angle, unit, min, max)</h2>                                                         \
+Returns the cosine value of <i>angle</i>, there <i>angle</i> is measured in <i>unit</i>     \
+between <i>min</i> and <i>max</i>.                                                          \
+</html>
+
+
+Math.tan_Descr                  = <html>                                                    \
+<h1>tan()</h1>                                                                              \
+<h2>tan(angle)</h2>                                                                         \
+Returns the tangens value of <i>angle</i>, where <i>angle</i> is measured in radians.       \
+<hr>                                                                                        \
+<h2>tan(angle, unit)</h2>                                                                   \
+Returns the tangens value of <i>angle</i>, there <i>angle</i> is measured in <i>unit</i>.   \
+<p>                                                                                         \
+The <i>unit</i> may be given by a string or by the number of units per full                 \
+rotation of the circle. The supported strings are "rad" for radians and "deg"               \
+for degrees.                                                                                \
+</html>
+
+
+Math.atan_Descr                  = <html>                                                   \
+<h1>atan()</h1>                                                                             \
+<h2>atan(value)</h2>                                                                        \
+Returns the arcus tangens <i>value</i>, there the resulting angle is measured in radians.   \
+<hr>                                                                                        \
+<h2>atan(value, unit)</h2>                                                                  \
+Returns the arcus tangens of <i>value</i>, there the resulting angle is measured in         \
+<i>unit</i>.                                                                                \
+<p>                                                                                         \
+The <i>unit</i> may be given by a string or by the number of units per full                 \
+rotation of the circle. The supported strings are "rad" for radians and "deg"               \
+for degrees.                                                                                \
+</html>
+
+
+Math.sqr_Descr                  = <html>                                                    \
+<h1>sqr()</h1>                                                                              \
+<h2>sqr(value)</h2>                                                                         \
+Returns the square of <i>value</i>, or <i>value</i> * <i>value</i>.<br>                     \
+If the parameter is an integer, it returns an integer.                                      \
+Otherwise it returns a double.                                                              \
+</html>
+
+
+Math.sqrt_Descr                  = <html>                                                   \
+<h1>sqrt()</h1>                                                                             \
+<h2>sqrt(value)</h2>                                                                        \
+Returns the square root of <i>value</i>.<br>                                                \
+<i>value</i> = sqrt(<i>value</i>) * sqrt(<i>value</i>)                                      \
+</html>
+
+
 NamedBean.getLogixNGTable_Descr     = <html>                                                \
 <h1>getLogixNGTable()</h1>                                                                  \
 <h2>getLogixNGTable(name)</h2>                                                              \

--- a/java/src/jmri/jmrit/logixng/util/parser/functions/MathFunctions.java
+++ b/java/src/jmri/jmrit/logixng/util/parser/functions/MathFunctions.java
@@ -31,6 +31,11 @@ public class MathFunctions implements FunctionFactory {
         addRandomFunction(functionClasses);
         addAbsFunction(functionClasses);
         addSinFunction(functionClasses);
+        addCosFunction(functionClasses);
+        addTanFunction(functionClasses);
+        addArctanFunction(functionClasses);
+        addSqrFunction(functionClasses);
+        addSqrtFunction(functionClasses);
 
         return functionClasses;
     }
@@ -159,6 +164,188 @@ public class MathFunctions implements FunctionFactory {
                     }
                 }
                 throw new WrongNumberOfParametersException(Bundle.getMessage("WrongNumberOfParameters1", getName()));
+            }
+        });
+    }
+
+    private void addCosFunction(Set<Function> functionClasses) {
+        functionClasses.add(new AbstractFunction(this, "cos", Bundle.getMessage("Math.cos_Descr")) {
+            @Override
+            public Object calculate(SymbolTable symbolTable, List<ExpressionNode> parameterList)
+                    throws JmriException {
+
+                if (parameterList.size() == 1) {
+                    double param = TypeConversionUtil.convertToDouble(
+                            parameterList.get(0).calculate(symbolTable), false);
+                    return Math.cos(param);
+                } else if (parameterList.size() >= 2) {
+                    double param0 = TypeConversionUtil.convertToDouble(
+                            parameterList.get(0).calculate(symbolTable), false);
+                    Object param1 = parameterList.get(1).calculate(symbolTable);
+                    double result;
+                    if (param1 instanceof String) {
+                        switch ((String)param1) {
+                            case "rad":
+                                result = Math.cos(param0);
+                                break;
+                            case "deg":
+                                result = Math.cos(Math.toRadians(param0));
+                                break;
+                            default:
+                                throw new CalculateException(Bundle.getMessage("IllegalParameter", 2, param1, getName()));
+                        }
+                    } else if (param1 instanceof Number) {
+                        double p1 = TypeConversionUtil.convertToDouble(param1, false);
+                        double angle = param0 / p1 * 2.0 * Math.PI;
+                        result = Math.cos(angle);
+                    } else {
+                        throw new CalculateException(Bundle.getMessage("IllegalParameter", 2, param1, getName()));
+                    }
+
+                    switch (parameterList.size()) {
+                        case 2:
+                            return result;
+                        case 4:
+                            double min = TypeConversionUtil.convertToDouble(
+                                    parameterList.get(2).calculate(symbolTable), false);
+                            double max = TypeConversionUtil.convertToDouble(
+                                    parameterList.get(3).calculate(symbolTable), false);
+                            return (result+1.0)/2.0 * (max-min) + min;
+                        default:
+                            throw new WrongNumberOfParametersException(Bundle.getMessage("WrongNumberOfParameters1", getName()));
+                    }
+                }
+                throw new WrongNumberOfParametersException(Bundle.getMessage("WrongNumberOfParameters1", getName()));
+            }
+        });
+    }
+
+    private void addTanFunction(Set<Function> functionClasses) {
+        functionClasses.add(new AbstractFunction(this, "tan", Bundle.getMessage("Math.tan_Descr")) {
+            @Override
+            public Object calculate(SymbolTable symbolTable, List<ExpressionNode> parameterList)
+                    throws JmriException {
+
+                if (parameterList.size() == 1) {
+                    double param = TypeConversionUtil.convertToDouble(
+                            parameterList.get(0).calculate(symbolTable), false);
+                    return Math.tan(param);
+                } else if (parameterList.size() == 2) {
+                    double param0 = TypeConversionUtil.convertToDouble(
+                            parameterList.get(0).calculate(symbolTable), false);
+                    Object param1 = parameterList.get(1).calculate(symbolTable);
+                    double result;
+                    if (param1 instanceof String) {
+                        switch ((String)param1) {
+                            case "rad":
+                                return Math.tan(param0);
+                            case "deg":
+                                return Math.tan(Math.toRadians(param0));
+                            default:
+                                throw new CalculateException(Bundle.getMessage("IllegalParameter", 2, param1, getName()));
+                        }
+                    } else if (param1 instanceof Number) {
+                        double p1 = TypeConversionUtil.convertToDouble(param1, false);
+                        double angle = param0 / p1 * 2.0 * Math.PI;
+                        return Math.tan(angle);
+                    } else {
+                        throw new CalculateException(Bundle.getMessage("IllegalParameter", 2, param1, getName()));
+                    }
+                }
+                throw new WrongNumberOfParametersException(Bundle.getMessage("WrongNumberOfParameters1", getName()));
+            }
+        });
+    }
+
+    private void addArctanFunction(Set<Function> functionClasses) {
+        functionClasses.add(new AbstractFunction(this, "atan", Bundle.getMessage("Math.atan_Descr")) {
+            @Override
+            public Object calculate(SymbolTable symbolTable, List<ExpressionNode> parameterList)
+                    throws JmriException {
+
+                if (parameterList.size() == 1) {
+                    double param = TypeConversionUtil.convertToDouble(
+                            parameterList.get(0).calculate(symbolTable), false);
+                    return Math.atan(param);
+                } else if (parameterList.size() == 2) {
+                    double param0 = TypeConversionUtil.convertToDouble(
+                            parameterList.get(0).calculate(symbolTable), false);
+                    Object param1 = parameterList.get(1).calculate(symbolTable);
+                    if (param1 instanceof String) {
+                        switch ((String)param1) {
+                            case "rad":
+                                return Math.atan(param0);
+                            case "deg":
+                                return Math.toDegrees(Math.atan(param0));
+                            default:
+                                throw new CalculateException(Bundle.getMessage("IllegalParameter", 2, param1, getName()));
+                        }
+                    } else if (param1 instanceof Number) {
+                        double p1 = TypeConversionUtil.convertToDouble(param1, false);
+                        double angle = Math.atan(param0);
+                        return angle * p1 / 2.0 / Math.PI;
+                    } else {
+                        throw new CalculateException(Bundle.getMessage("IllegalParameter", 2, param1, getName()));
+                    }
+                }
+                throw new WrongNumberOfParametersException(Bundle.getMessage("WrongNumberOfParameters1", getName()));
+            }
+        });
+    }
+
+    private void addSqrFunction(Set<Function> functionClasses) {
+        functionClasses.add(new AbstractFunction(this, "sqr", Bundle.getMessage("Math.sqr_Descr")) {
+            @Override
+            public Object calculate(SymbolTable symbolTable, List<ExpressionNode> parameterList)
+                    throws CalculateException, JmriException {
+
+                switch (parameterList.size()) {
+                    case 1:
+                        Object value = parameterList.get(0).calculate(symbolTable);
+                        if ((value instanceof java.util.concurrent.atomic.AtomicInteger)
+                                || (value instanceof java.util.concurrent.atomic.AtomicLong)
+                                || (value instanceof java.math.BigInteger)
+                                || (value instanceof Byte)
+                                || (value instanceof Short)
+                                || (value instanceof Integer)
+                                || (value instanceof Long)
+                                || (value instanceof java.util.concurrent.atomic.LongAccumulator)
+                                || (value instanceof java.util.concurrent.atomic.LongAdder)) {
+
+                            long val = ((Number)value).longValue();
+                            return val * val;
+                        }
+                        if ((value instanceof java.math.BigDecimal)
+                                || (value instanceof Float)
+                                || (value instanceof Double)
+                                || (value instanceof java.util.concurrent.atomic.DoubleAccumulator)
+                                || (value instanceof java.util.concurrent.atomic.DoubleAdder)) {
+
+                            double val = ((Number)value).doubleValue();
+                            return val * val;
+                        }
+                        double val = TypeConversionUtil.convertToDouble(value, false);
+                        return val * val;
+                    default:
+                        throw new WrongNumberOfParametersException(Bundle.getMessage("WrongNumberOfParameters1", getName()));
+                }
+            }
+        });
+    }
+
+    private void addSqrtFunction(Set<Function> functionClasses) {
+        functionClasses.add(new AbstractFunction(this, "sqrt", Bundle.getMessage("Math.sqrt_Descr")) {
+            @Override
+            public Object calculate(SymbolTable symbolTable, List<ExpressionNode> parameterList)
+                    throws JmriException {
+
+                if (parameterList.size() == 1) {
+                    double param = TypeConversionUtil.convertToDouble(
+                            parameterList.get(0).calculate(symbolTable), false);
+                    return Math.sqrt(param);
+                } else {
+                    throw new WrongNumberOfParametersException(Bundle.getMessage("WrongNumberOfParameters1", getName()));
+                }
             }
         });
     }

--- a/java/src/jmri/jmrit/logixng/util/parser/functions/MathFunctions.java
+++ b/java/src/jmri/jmrit/logixng/util/parser/functions/MathFunctions.java
@@ -234,7 +234,6 @@ public class MathFunctions implements FunctionFactory {
                     double param0 = TypeConversionUtil.convertToDouble(
                             parameterList.get(0).calculate(symbolTable), false);
                     Object param1 = parameterList.get(1).calculate(symbolTable);
-                    double result;
                     if (param1 instanceof String) {
                         switch ((String)param1) {
                             case "rad":

--- a/java/test/jmri/jmrit/logixng/util/parser/functions/MathFunctionsTest.java
+++ b/java/test/jmri/jmrit/logixng/util/parser/functions/MathFunctionsTest.java
@@ -33,12 +33,22 @@ public class MathFunctionsTest {
     ExpressionNode expr0_34 = new ExpressionNodeFloatingNumber(new Token(TokenType.NONE, "0.34", 0));
     ExpressionNode expr0_95 = new ExpressionNodeFloatingNumber(new Token(TokenType.NONE, "0.95", 0));
     ExpressionNode expr12_34 = new ExpressionNodeFloatingNumber(new Token(TokenType.NONE, "12.34", 0));
-    ExpressionNode expr12 = new ExpressionNodeFloatingNumber(new Token(TokenType.NONE, "12", 0));
-    ExpressionNode expr23 = new ExpressionNodeFloatingNumber(new Token(TokenType.NONE, "23", 0));
+    ExpressionNode expr12 = new ExpressionNodeIntegerNumber(new Token(TokenType.NONE, "12", 0));
+    ExpressionNode expr23 = new ExpressionNodeIntegerNumber(new Token(TokenType.NONE, "23", 0));
     ExpressionNode exprNeg0_34 = new ExpressionNodeFloatingNumber(new Token(TokenType.NONE, "-0.34", 0));
     ExpressionNode exprNeg0_95 = new ExpressionNodeFloatingNumber(new Token(TokenType.NONE, "-0.95", 0));
     ExpressionNode exprNeg12_34 = new ExpressionNodeFloatingNumber(new Token(TokenType.NONE, "-12.34", 0));
 
+    ExpressionNode exprPi2 = new ExpressionNodeFloatingNumber(new Token(TokenType.NONE, Double.toString(1.0/2*Math.PI), 0));
+    ExpressionNode exprPi = new ExpressionNodeFloatingNumber(new Token(TokenType.NONE, Double.toString(Math.PI), 0));
+    ExpressionNode expr3Pi2 = new ExpressionNodeFloatingNumber(new Token(TokenType.NONE, Double.toString(3.0/2*Math.PI), 0));
+    ExpressionNode expr2Pi = new ExpressionNodeFloatingNumber(new Token(TokenType.NONE, Double.toString(2*Math.PI), 0));
+
+    ExpressionNode expr0 = new ExpressionNodeFloatingNumber(new Token(TokenType.NONE, "0", 0));
+    ExpressionNode expr90 = new ExpressionNodeFloatingNumber(new Token(TokenType.NONE, "90", 0));
+    ExpressionNode expr180 = new ExpressionNodeFloatingNumber(new Token(TokenType.NONE, "180", 0));
+    ExpressionNode expr270 = new ExpressionNodeFloatingNumber(new Token(TokenType.NONE, "270", 0));
+    ExpressionNode expr360 = new ExpressionNodeFloatingNumber(new Token(TokenType.NONE, "360", 0));
 
     private List<ExpressionNode> getParameterList(ExpressionNode... exprNodes) {
         List<ExpressionNode> list = new ArrayList<>();
@@ -95,10 +105,172 @@ public class MathFunctionsTest {
         // Test sin(x,"deg", 12, 23)
         Assert.assertEquals("numbers are equal", (Double)18.675418424366967, (Double)sinFunction.calculate(symbolTable, getParameterList(expr12_34, expr_str_DEG, expr12, expr23)), 0.0000001d);
 
+        Assert.assertEquals("numbers are equal", (Double)17.5, (Double)sinFunction.calculate(symbolTable, getParameterList(expr0, expr_str_RAD, expr12, expr23)), 0.0000001d);
+        Assert.assertEquals("numbers are equal", (Double)23.0, (Double)sinFunction.calculate(symbolTable, getParameterList(exprPi2, expr_str_RAD, expr12, expr23)), 0.0000001d);
+        Assert.assertEquals("numbers are equal", (Double)17.5, (Double)sinFunction.calculate(symbolTable, getParameterList(exprPi, expr_str_RAD, expr12, expr23)), 0.0000001d);
+        Assert.assertEquals("numbers are equal", (Double)12.0, (Double)sinFunction.calculate(symbolTable, getParameterList(expr3Pi2, expr_str_RAD, expr12, expr23)), 0.0000001d);
+        Assert.assertEquals("numbers are equal", (Double)17.5, (Double)sinFunction.calculate(symbolTable, getParameterList(expr2Pi, expr_str_RAD, expr12, expr23)), 0.0000001d);
+
+        Assert.assertEquals("numbers are equal", (Double)17.5, (Double)sinFunction.calculate(symbolTable, getParameterList(expr0, expr_str_DEG, expr12, expr23)), 0.0000001d);
+        Assert.assertEquals("numbers are equal", (Double)23.0, (Double)sinFunction.calculate(symbolTable, getParameterList(expr90, expr_str_DEG, expr12, expr23)), 0.0000001d);
+        Assert.assertEquals("numbers are equal", (Double)17.5, (Double)sinFunction.calculate(symbolTable, getParameterList(expr180, expr_str_DEG, expr12, expr23)), 0.0000001d);
+        Assert.assertEquals("numbers are equal", (Double)12.0, (Double)sinFunction.calculate(symbolTable, getParameterList(expr270, expr_str_DEG, expr12, expr23)), 0.0000001d);
+        Assert.assertEquals("numbers are equal", (Double)17.5, (Double)sinFunction.calculate(symbolTable, getParameterList(expr360, expr_str_DEG, expr12, expr23)), 0.0000001d);
+
         // Test sin()
         hasThrown.set(false);
         try {
             sinFunction.calculate(symbolTable, getParameterList());
+        } catch (WrongNumberOfParametersException e) {
+            hasThrown.set(true);
+        }
+        Assert.assertTrue("exception is thrown", hasThrown.get());
+    }
+
+    @Test
+    public void testCosFunction() throws Exception {
+        Function cosFunction = InstanceManager.getDefault(FunctionManager.class).get("cos");
+        Assert.assertEquals("strings matches", "cos", cosFunction.getName());
+
+        SymbolTable symbolTable = new DefaultSymbolTable(new DefaultConditionalNG("IQC1", null));
+
+        // Test cos(x)
+        Assert.assertEquals("numbers are equal", (Double)0.9427546655283462, (Double)cosFunction.calculate(symbolTable, getParameterList(expr0_34)), 0.0000001d);
+        Assert.assertEquals("numbers are equal", (Double)0.5816830894638836, (Double)cosFunction.calculate(symbolTable, getParameterList(expr0_95)), 0.0000001d);
+        Assert.assertEquals("numbers are equal", (Double)(0.9744873987650982), (Double)cosFunction.calculate(symbolTable, getParameterList(expr12_34)), 0.0000001d);
+
+        // Test cos(x) with a string as parameter
+        Assert.assertEquals("numbers are equal", (Double)0.9427546655283462, (Double)cosFunction.calculate(symbolTable, getParameterList(expr0_34)), 0.0000001d);
+
+        AtomicBoolean hasThrown = new AtomicBoolean(false);
+
+        // Test cos(x,"rad"), cos(x,"deg"), cos(x,"hello"), cos(x, true)
+        Assert.assertEquals("numbers are equal", (Double)0.9427546655283462, (Double)cosFunction.calculate(symbolTable, getParameterList(expr0_34, expr_str_RAD)), 0.0000001d);
+        Assert.assertEquals("numbers are equal", (Double)0.976896613081381, (Double)cosFunction.calculate(symbolTable, getParameterList(expr12_34, expr_str_DEG)), 0.0000001d);
+        hasThrown.set(false);
+        try {
+            cosFunction.calculate(symbolTable, getParameterList(expr12_34, expr_str_HELLO));
+        } catch (CalculateException e) {
+            hasThrown.set(true);
+        }
+        Assert.assertTrue("exception is thrown", hasThrown.get());
+        hasThrown.set(false);
+        try {
+            cosFunction.calculate(symbolTable, getParameterList(expr12_34, expr_boolean_true));
+        } catch (CalculateException e) {
+            hasThrown.set(true);
+        }
+        Assert.assertTrue("exception is thrown", hasThrown.get());
+
+        // Test cos(x,"deg", 12, 23)
+        Assert.assertEquals("numbers are equal", (Double)22.872931371947594, (Double)cosFunction.calculate(symbolTable, getParameterList(expr12_34, expr_str_DEG, expr12, expr23)), 0.0000001d);
+
+        Assert.assertEquals("numbers are equal", (Double)23.0, (Double)cosFunction.calculate(symbolTable, getParameterList(expr0, expr_str_RAD, expr12, expr23)), 0.0000001d);
+        Assert.assertEquals("numbers are equal", (Double)17.5, (Double)cosFunction.calculate(symbolTable, getParameterList(exprPi2, expr_str_RAD, expr12, expr23)), 0.0000001d);
+        Assert.assertEquals("numbers are equal", (Double)12.0, (Double)cosFunction.calculate(symbolTable, getParameterList(exprPi, expr_str_RAD, expr12, expr23)), 0.0000001d);
+        Assert.assertEquals("numbers are equal", (Double)17.5, (Double)cosFunction.calculate(symbolTable, getParameterList(expr3Pi2, expr_str_RAD, expr12, expr23)), 0.0000001d);
+        Assert.assertEquals("numbers are equal", (Double)23.0, (Double)cosFunction.calculate(symbolTable, getParameterList(expr2Pi, expr_str_RAD, expr12, expr23)), 0.0000001d);
+
+        Assert.assertEquals("numbers are equal", (Double)23.0, (Double)cosFunction.calculate(symbolTable, getParameterList(expr0, expr_str_DEG, expr12, expr23)), 0.0000001d);
+        Assert.assertEquals("numbers are equal", (Double)17.5, (Double)cosFunction.calculate(symbolTable, getParameterList(expr90, expr_str_DEG, expr12, expr23)), 0.0000001d);
+        Assert.assertEquals("numbers are equal", (Double)12.0, (Double)cosFunction.calculate(symbolTable, getParameterList(expr180, expr_str_DEG, expr12, expr23)), 0.0000001d);
+        Assert.assertEquals("numbers are equal", (Double)17.5, (Double)cosFunction.calculate(symbolTable, getParameterList(expr270, expr_str_DEG, expr12, expr23)), 0.0000001d);
+        Assert.assertEquals("numbers are equal", (Double)23.0, (Double)cosFunction.calculate(symbolTable, getParameterList(expr360, expr_str_DEG, expr12, expr23)), 0.0000001d);
+
+        // Test cos()
+        hasThrown.set(false);
+        try {
+            cosFunction.calculate(symbolTable, getParameterList());
+        } catch (WrongNumberOfParametersException e) {
+            hasThrown.set(true);
+        }
+        Assert.assertTrue("exception is thrown", hasThrown.get());
+    }
+
+    @Test
+    public void testTanFunction() throws Exception {
+        Function tanFunction = InstanceManager.getDefault(FunctionManager.class).get("tan");
+        Assert.assertEquals("strings matches", "tan", tanFunction.getName());
+
+        SymbolTable symbolTable = new DefaultSymbolTable(new DefaultConditionalNG("IQC1", null));
+
+        // Test tan(x)
+        Assert.assertEquals("numbers are equal", (Double)0.35373687803912257, (Double)tanFunction.calculate(symbolTable, getParameterList(expr0_34)), 0.0000001d);
+        Assert.assertEquals("numbers are equal", (Double)1.398382589287699, (Double)tanFunction.calculate(symbolTable, getParameterList(expr0_95)), 0.0000001d);
+        Assert.assertEquals("numbers are equal", (Double)(-0.23031823627096235), (Double)tanFunction.calculate(symbolTable, getParameterList(expr12_34)), 0.0000001d);
+
+        // Test tan(x) with a string as parameter
+        Assert.assertEquals("numbers are equal", (Double)0.35373687803912257, (Double)tanFunction.calculate(symbolTable, getParameterList(expr0_34)), 0.0000001d);
+
+        AtomicBoolean hasThrown = new AtomicBoolean(false);
+
+        // Test tan(x,"rad"), tan(x,"deg"), tan(x,"hello"), tan(x, true)
+        Assert.assertEquals("numbers are equal", (Double)0.35373687803912257, (Double)tanFunction.calculate(symbolTable, getParameterList(expr0_34, expr_str_RAD)), 0.0000001d);
+        Assert.assertEquals("numbers are equal", (Double)0.21876669233184345, (Double)tanFunction.calculate(symbolTable, getParameterList(expr12_34, expr_str_DEG)), 0.0000001d);
+        hasThrown.set(false);
+        try {
+            tanFunction.calculate(symbolTable, getParameterList(expr12_34, expr_str_HELLO));
+        } catch (CalculateException e) {
+            hasThrown.set(true);
+        }
+        Assert.assertTrue("exception is thrown", hasThrown.get());
+        hasThrown.set(false);
+        try {
+            tanFunction.calculate(symbolTable, getParameterList(expr12_34, expr_boolean_true));
+        } catch (CalculateException e) {
+            hasThrown.set(true);
+        }
+        Assert.assertTrue("exception is thrown", hasThrown.get());
+
+        // Test tan()
+        hasThrown.set(false);
+        try {
+            tanFunction.calculate(symbolTable, getParameterList());
+        } catch (WrongNumberOfParametersException e) {
+            hasThrown.set(true);
+        }
+        Assert.assertTrue("exception is thrown", hasThrown.get());
+    }
+
+    @Test
+    public void testArctanFunction() throws Exception {
+        Function atanFunction = InstanceManager.getDefault(FunctionManager.class).get("atan");
+        Assert.assertEquals("strings matches", "atan", atanFunction.getName());
+
+        SymbolTable symbolTable = new DefaultSymbolTable(new DefaultConditionalNG("IQC1", null));
+
+        // Test atan(x)
+        Assert.assertEquals("numbers are equal", (Double)0.3277385067805555, (Double)atanFunction.calculate(symbolTable, getParameterList(expr0_34)), 0.0000001d);
+        Assert.assertEquals("numbers are equal", (Double)0.7597627548757708, (Double)atanFunction.calculate(symbolTable, getParameterList(expr0_95)), 0.0000001d);
+        Assert.assertEquals("numbers are equal", (Double)1.4899357456343294, (Double)atanFunction.calculate(symbolTable, getParameterList(expr12_34)), 0.0000001d);
+
+        // Test atan(x) with a string as parameter
+        Assert.assertEquals("numbers are equal", (Double)0.3277385067805555, (Double)atanFunction.calculate(symbolTable, getParameterList(expr0_34)), 0.0000001d);
+
+        AtomicBoolean hasThrown = new AtomicBoolean(false);
+
+        // Test atan(x,"rad"), atan(x,"deg"), atan(x,"hello"), atan(x, true)
+        Assert.assertEquals("numbers are equal", (Double)0.3277385067805555, (Double)atanFunction.calculate(symbolTable, getParameterList(expr0_34, expr_str_RAD)), 0.0000001d);
+        Assert.assertEquals("numbers are equal", (Double)85.36702997052444, (Double)atanFunction.calculate(symbolTable, getParameterList(expr12_34, expr_str_DEG)), 0.0000001d);
+        hasThrown.set(false);
+        try {
+            atanFunction.calculate(symbolTable, getParameterList(expr12_34, expr_str_HELLO));
+        } catch (CalculateException e) {
+            hasThrown.set(true);
+        }
+        Assert.assertTrue("exception is thrown", hasThrown.get());
+        hasThrown.set(false);
+        try {
+            atanFunction.calculate(symbolTable, getParameterList(expr12_34, expr_boolean_true));
+        } catch (CalculateException e) {
+            hasThrown.set(true);
+        }
+        Assert.assertTrue("exception is thrown", hasThrown.get());
+
+        // Test atan()
+        hasThrown.set(false);
+        try {
+            atanFunction.calculate(symbolTable, getParameterList());
         } catch (WrongNumberOfParametersException e) {
             hasThrown.set(true);
         }
@@ -157,6 +329,44 @@ public class MathFunctionsTest {
                 }
             }
         }
+    }
+
+    @Test
+    public void testSqrFunction() throws Exception {
+        Function sqrFunction = InstanceManager.getDefault(FunctionManager.class).get("sqr");
+        Assert.assertEquals("strings matches", "sqr", sqrFunction.getName());
+
+        SymbolTable symbolTable = new DefaultSymbolTable(new DefaultConditionalNG("IQC1", null));
+
+        Assert.assertEquals("numbers are equal", 144L, (long)(Long)sqrFunction.calculate(symbolTable, getParameterList(expr12)));
+        Assert.assertEquals("numbers are equal", 529, (long)(Long)sqrFunction.calculate(symbolTable, getParameterList(expr23)));
+
+        Assert.assertEquals("numbers are equal", (Double)0.1156, (Double)sqrFunction.calculate(symbolTable, getParameterList(expr0_34)), 0.0000001d);
+        Assert.assertEquals("numbers are equal", (Double)0.9025, (Double)sqrFunction.calculate(symbolTable, getParameterList(expr0_95)), 0.0000001d);
+        Assert.assertEquals("numbers are equal", (Double)152.2756, (Double)sqrFunction.calculate(symbolTable, getParameterList(expr12_34)), 0.0000001d);
+
+        Assert.assertEquals("numbers are equal", (Double)0.1156, (Double)sqrFunction.calculate(symbolTable, getParameterList(exprNeg0_34)), 0.0000001d);
+        Assert.assertEquals("numbers are equal", (Double)0.9025, (Double)sqrFunction.calculate(symbolTable, getParameterList(exprNeg0_95)), 0.0000001d);
+        Assert.assertEquals("numbers are equal", (Double)152.2756, (Double)sqrFunction.calculate(symbolTable, getParameterList(exprNeg12_34)), 0.0000001d);
+    }
+
+    @Test
+    public void testSqrtFunction() throws Exception {
+        Function sqrtFunction = InstanceManager.getDefault(FunctionManager.class).get("sqrt");
+        Assert.assertEquals("strings matches", "sqrt", sqrtFunction.getName());
+
+        SymbolTable symbolTable = new DefaultSymbolTable(new DefaultConditionalNG("IQC1", null));
+
+        Assert.assertEquals("numbers are equal", (Double)3.4641016151377544, (Double)sqrtFunction.calculate(symbolTable, getParameterList(expr12)), 0.0000001d);
+        Assert.assertEquals("numbers are equal", (Double)4.795831523312719, (Double)sqrtFunction.calculate(symbolTable, getParameterList(expr23)), 0.0000001d);
+
+        Assert.assertEquals("numbers are equal", (Double)0.5830951894845301, (Double)sqrtFunction.calculate(symbolTable, getParameterList(expr0_34)), 0.0000001d);
+        Assert.assertEquals("numbers are equal", (Double)0.9746794344808963, (Double)sqrtFunction.calculate(symbolTable, getParameterList(expr0_95)), 0.0000001d);
+        Assert.assertEquals("numbers are equal", (Double)3.5128336140500593, (Double)sqrtFunction.calculate(symbolTable, getParameterList(expr12_34)), 0.0000001d);
+
+        Assert.assertEquals("numbers are equal", Double.NaN, (Double)sqrtFunction.calculate(symbolTable, getParameterList(exprNeg0_34)), 0.0000001d);
+        Assert.assertEquals("numbers are equal", Double.NaN, (Double)sqrtFunction.calculate(symbolTable, getParameterList(exprNeg0_95)), 0.0000001d);
+        Assert.assertEquals("numbers are equal", Double.NaN, (Double)sqrtFunction.calculate(symbolTable, getParameterList(exprNeg12_34)), 0.0000001d);
     }
 
     // The minimal setup for log4J


### PR DESCRIPTION
Adds the LogixNG functions `cos()`, `tan()`, `atan()`, `sqr()` and `sqrt()` to the `Math` module.

WIP until #12947 has been merged. This PR includes that PR but it's better if that PR is reviewed and merged first.