### PR TITLE
OLCB Turnout Manager 2 part address validation

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -127,7 +127,7 @@
 
         <h4><a href="http://openlcb.org">OpenLCB</a> / LCC</h4>
             <ul>
-                <li></li>
+                <li>Improved new Turnout address validation.</li>
             </ul>
 
         <h4>Powerline</h4>

--- a/java/src/jmri/jmrix/openlcb/Bundle.properties
+++ b/java/src/jmri/jmrix/openlcb/Bundle.properties
@@ -37,7 +37,7 @@ OlcbClockAlt2 = Alternate Clock 2
 # {0} will be a node ID like 05:02:01:00:00:F0
 OlcbClockCustom = Custom Clock {0}
 
-AddTurnoutEntryToolTip = <html>Pair of 8 byte events, Thrown;Closed<br>02.01.57.00.00.54.00.72;02.01.57.00.00.54.00.73<br>Bridged DCC Turnouts: T123</html>
+AddTurnoutEntryToolTip = <html>Pair of 8 byte events, Thrown;Closed<br>02.01.57.00.00.54.00.72;02.01.57.00.00.54.00.73<br>Or you can use bridged DCC Turnouts: T123</html>
 AddSensorEntryToolTip = <html>Pair of 8 byte events, Active;Inactive<br>02.01.57.00.00.54.00.72;02.01.57.00.00.54.00.73</html>
 AddLightEntryToolTip = <html>Pair of 8 byte events, On;Off<br>02.01.57.00.00.54.00.72;02.01.57.00.00.54.00.73</html>
 AddReporterEntryToolTip = <html>06.xM.MM.LL.LL.LL.00.00<br>One 8 byte event, ends with two zero bytes, MMM is manufacturer, LLLLLL is a unique number, x is 4 or 5.</html>

--- a/java/src/jmri/jmrix/openlcb/Bundle.properties
+++ b/java/src/jmri/jmrix/openlcb/Bundle.properties
@@ -37,7 +37,7 @@ OlcbClockAlt2 = Alternate Clock 2
 # {0} will be a node ID like 05:02:01:00:00:F0
 OlcbClockCustom = Custom Clock {0}
 
-AddTurnoutEntryToolTip = <html>Pair of 8 byte events, Thrown;Closed<br>02.01.57.00.00.54.00.72;02.01.57.00.00.54.00.73</html>
+AddTurnoutEntryToolTip = <html>Pair of 8 byte events, Thrown;Closed<br>02.01.57.00.00.54.00.72;02.01.57.00.00.54.00.73<br>Bridged DCC Turnouts: T123</html>
 AddSensorEntryToolTip = <html>Pair of 8 byte events, Active;Inactive<br>02.01.57.00.00.54.00.72;02.01.57.00.00.54.00.73</html>
 AddLightEntryToolTip = <html>Pair of 8 byte events, On;Off<br>02.01.57.00.00.54.00.72;02.01.57.00.00.54.00.73</html>
 AddReporterEntryToolTip = <html>06.xM.MM.LL.LL.LL.00.00<br>One 8 byte event, ends with two zero bytes, MMM is manufacturer, LLLLLL is a unique number, x is 4 or 5.</html>

--- a/java/src/jmri/jmrix/openlcb/OlcbAddress.java
+++ b/java/src/jmri/jmrix/openlcb/OlcbAddress.java
@@ -5,6 +5,7 @@ import java.util.regex.Pattern;
 
 import javax.annotation.CheckReturnValue;
 
+import jmri.NamedBean.BadSystemNameException;
 import jmri.jmrix.can.CanMessage;
 import jmri.jmrix.can.CanReply;
 
@@ -317,21 +318,45 @@ public class OlcbAddress {
      * @throws jmri.NamedBean.BadSystemNameException if provided name is an invalid format.
      */
     @Nonnull
-    public static String validateSystemNameFormat(@Nonnull String name, @Nonnull java.util.Locale locale, @Nonnull String prefix) throws jmri.NamedBean.BadSystemNameException {
+    public static String validateSystemNameFormat(@Nonnull String name, @Nonnull java.util.Locale locale,
+        @Nonnull String prefix) throws BadSystemNameException {
         String oAddr = name.substring(prefix.length());
         OlcbAddress a = new OlcbAddress(oAddr);
         OlcbAddress[] v = a.split();
         if (v == null) {
-            throw new jmri.NamedBean.BadSystemNameException(locale,"InvalidSystemNameCustom","Did not find usable system name: " + name + " to a valid Olcb address");
+            throw new BadSystemNameException(locale,"InvalidSystemNameCustom","Did not find usable system name: " + name + " to a valid Olcb address");
         }
         switch (v.length) {
             case 1:
             case 2:
                 break;
             default:
-                throw new jmri.NamedBean.BadSystemNameException(locale,"InvalidSystemNameCustom","Wrong number of events in address: " + name);
+                throw new BadSystemNameException(locale,"InvalidSystemNameCustom","Wrong number of events in address: " + name);
         }
         return name;
+    }
+
+    /**
+     * Validates 2 part Hardware Address Strings for OpenLCB format.
+     * @param name   the system name to validate.
+     * @param locale the locale for a localized exception.
+     * @param prefix system prefix, eg. MT for OpenLcb turnout.
+     * @return the unchanged value of the name parameter.
+     * @throws jmri.NamedBean.BadSystemNameException if provided name is an invalid format.
+     */
+    @Nonnull
+    public static String validateSystemNameFormat2Part(@Nonnull String name, @Nonnull java.util.Locale locale,
+        @Nonnull String prefix) throws BadSystemNameException {
+        String oAddr = name.substring(prefix.length());
+        OlcbAddress a = new OlcbAddress(oAddr);
+        OlcbAddress[] v = a.split();
+        if (v == null) {
+            throw new BadSystemNameException(locale,"InvalidSystemNameCustom","Did not find usable system name: " + name + " to a valid Olcb address");
+        }
+        if ( v.length == 2 ) {
+            return name;
+        }
+        throw new BadSystemNameException(locale,"InvalidSystemNameCustom","Address requires 2 Events: " + name);
     }
 
     /**

--- a/java/src/jmri/jmrix/openlcb/OlcbTurnoutManager.java
+++ b/java/src/jmri/jmrix/openlcb/OlcbTurnoutManager.java
@@ -144,14 +144,15 @@ public class OlcbTurnoutManager extends AbstractTurnoutManager {
     }
 
     /**
-     * Validates to OpenLCB format.
+     * Validates to OpenLCB 2 part address format.
      * {@inheritDoc}
      */
     @Override
     @Nonnull
-    public String validateSystemNameFormat(@Nonnull String name, @Nonnull java.util.Locale locale) throws jmri.NamedBean.BadSystemNameException {
-        name = super.validateSystemNameFormat(name,locale);
-        return OlcbAddress.validateSystemNameFormat(name,locale,getSystemNamePrefix());
+    public String validateSystemNameFormat(@Nonnull String name, @Nonnull java.util.Locale locale)
+        throws jmri.NamedBean.BadSystemNameException {
+        return OlcbAddress.validateSystemNameFormat2Part(super.validateSystemNameFormat(
+            name,locale),locale,getSystemNamePrefix());
     }
 
     /**


### PR DESCRIPTION
OlcbTurnoutManager - use 2 part address string validation
adds method validateSystemNameFormat2Part to OlcbAddress
fixes #12960 