### PR TITLE
Test that scripts can access LogixNG local variables

### DIFF
--- a/java/src/jmri/jmrit/logixng/SymbolTable.java
+++ b/java/src/jmri/jmrit/logixng/SymbolTable.java
@@ -289,7 +289,7 @@ public interface SymbolTable {
         }
     }
 
-    private static Object runScriptExpression(String initialData) {
+    private static Object runScriptExpression(SymbolTable symbolTable, String initialData) {
         String script =
                 "import jmri\n" +
                 "variable.set(" + initialData + ")";
@@ -302,6 +302,8 @@ public interface SymbolTable {
         var variable = new Reference<Object>();
         bindings.put("variable", variable);
 
+        bindings.put("symbolTable", symbolTable);    // Give the script access to the local variables in the symbol table
+
         try {
             String theScript = String.format("import jmri%n") + script;
             scriptEngineManager.getEngineByName(JmriScriptEngineManager.JYTHON)
@@ -313,7 +315,7 @@ public interface SymbolTable {
         return variable.get();
     }
 
-    private static Object runScriptFile(String initialData) {
+    private static Object runScriptFile(SymbolTable symbolTable, String initialData) {
 
         JmriScriptEngineManager scriptEngineManager = jmri.script.JmriScriptEngineManager.getDefault();
 
@@ -322,6 +324,8 @@ public interface SymbolTable {
 
         var variable = new Reference<Object>();
         bindings.put("variable", variable);
+
+        bindings.put("symbolTable", symbolTable);    // Give the script access to the local variables in the symbol table
 
         try (InputStreamReader reader = new InputStreamReader(
                 new FileInputStream(jmri.util.FileUtil.getExternalFilename(initialData)),
@@ -482,11 +486,11 @@ public interface SymbolTable {
 
             case ScriptExpression:
                 validateValue(type, name, initialData, "from script expression");
-                return runScriptExpression(initialData);
+                return runScriptExpression(symbolTable, initialData);
 
             case ScriptFile:
                 validateValue(type, name, initialData, "from script file");
-                return runScriptFile(initialData);
+                return runScriptFile(symbolTable, initialData);
 
             case LogixNG_Table:
                 validateValue(type, name, initialData, "from logixng table");

--- a/java/src/jmri/jmrit/logixng/actions/ActionScript.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionScript.java
@@ -265,7 +265,7 @@ public class ActionScript extends AbstractDigitalAction {
         LogixNG_ScriptBindings.addScriptBindings(bindings);
 
         SymbolTable symbolTable = getConditionalNG().getSymbolTable();
-        bindings.put("symbolTable", symbolTable);    // Give the script access to the local variable 'symbolTable'
+        bindings.put("symbolTable", symbolTable);    // Give the script access to the local variables in the symbol table
 
         ThreadingUtil.runOnLayoutWithJmriException(() -> {
             ScriptEngineSelector.Engine engine =

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionScript.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionScript.java
@@ -296,7 +296,7 @@ public class ExpressionScript extends AbstractDigitalExpression
         LogixNG_ScriptBindings.addScriptBindings(bindings);
 
         SymbolTable symbolTable = getConditionalNG().getSymbolTable();
-        bindings.put("symbolTable", symbolTable);    // Give the script access to the local variable 'symbolTable'
+        bindings.put("symbolTable", symbolTable);    // Give the script access to the local variables in the symbol table
 
         bindings.put("result", result);     // Give the script access to the local variable 'result'
 

--- a/java/test/jmri/jmrit/logixng/actions/ActionScriptTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ActionScriptTest.java
@@ -362,6 +362,24 @@ public class ActionScriptTest extends AbstractDigitalActionTestBase {
     }
 
     @Test
+    public void testAction_GetAndSetLocalVariables() throws Exception {
+
+        ((MaleSocket)ifThenElse.getParent()).addLocalVariable("in", SymbolTable.InitialValueType.Integer, "10");
+        var globalVariable = InstanceManager.getDefault(GlobalVariableManager.class).createGlobalVariable("out");
+
+        actionScript.setScript("symbolTable.setValue(\"out\",symbolTable.getValue(\"in\")*15)");
+
+        // Enable the conditionalNG and all its children.
+        conditionalNG.setEnabled(true);
+        // Set the sensor to execute the conditionalNG
+        sensor.setState(Sensor.ACTIVE);
+
+        // The action should now be executed so the global variable should have the correct value
+        Assert.assertEquals("global variable has the correct value", 150,
+                ((java.math.BigInteger)globalVariable.getValue()).longValue());
+    }
+
+    @Test
     public void testSetScript() {
         // Disable the conditionalNG. This will unregister the listeners
         conditionalNG.setEnabled(false);

--- a/java/test/jmri/jmrit/logixng/expressions/ExpressionScriptTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/ExpressionScriptTest.java
@@ -295,6 +295,24 @@ public class ExpressionScriptTest extends AbstractDigitalExpressionTestBase {
     }
 
     @Test
+    public void testAction_GetAndSetLocalVariables() throws Exception {
+
+        ((MaleSocket)ifThenElse.getParent()).addLocalVariable("in", SymbolTable.InitialValueType.Integer, "10");
+        var globalVariable = InstanceManager.getDefault(GlobalVariableManager.class).createGlobalVariable("out");
+
+        expressionScript.setScript("symbolTable.setValue(\"out\",symbolTable.getValue(\"in\")*15)");
+
+        // Enable the conditionalNG and all its children.
+        conditionalNG.setEnabled(true);
+        // Execute the conditionalNG
+        conditionalNG.execute();
+
+        // The expression should now be evaluated so the global variable should have the correct value
+        Assert.assertEquals("global variable has the correct value", 150,
+                ((java.math.BigInteger)globalVariable.getValue()).longValue());
+    }
+
+    @Test
     public void testSetScript() {
         // Disable the conditionalNG. This will unregister the listeners
         conditionalNG.setEnabled(false);


### PR DESCRIPTION
@dsand47 
This PR ensures that a script executed by the LogixNG action `Script` or the LogixNG expression `Script` can get and set the value of a local or global variable.

I suggest that something like the text below is added to the documentation of the LogixNG action `Script` and the expression `Script`:
```
The script can access local and global variables using the symbol table.

To get the value of the variable "myVar":
symbolTable.getValue("myVar")

To set the value of the variable "myVar" to "Some value":
symbolTable.setValue("myVar", "Some value")

Note that the symbol table and the local variables only exists during
the execution of the ConditionalNG the script action belongs to.
```

Background:
https://jmri-developers.groups.io/g/jmri/message/9925
https://jmri-developers.groups.io/g/jmri/message/9927