### PR TITLE
WIP - Fix missing MQTT Throttle state subscribes at time of throttle creation

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -107,7 +107,7 @@
 
         <h4>MQTT</h4>
             <ul>
-                <li></li>
+                <li>Fixed missing subscription to MQTT Throttle state topics on creation of MQTTtopic.</li>
             </ul>
 
         <h4>MRC</h4>

--- a/java/src/jmri/jmrix/mqtt/MqttThrottle.java
+++ b/java/src/jmri/jmrix/mqtt/MqttThrottle.java
@@ -105,6 +105,11 @@ import java.util.regex.*;
 
         this.isForward = true; //loco should default to forward
 
+        // Listen to state topics
+        mqttAdapter.subscribe(this.rcvThrottleTopic.replaceFirst("\\{0\\}", String.valueOf(address)), this);
+        mqttAdapter.subscribe(this.rcvDirectionTopic.replaceFirst("\\{0\\}", String.valueOf(address)), this);
+        mqttAdapter.subscribe(this.rcvFunctionTopic.replaceFirst("\\{0\\}", String.valueOf(address)), this);
+
         log.debug("MqttThrottle constructor called for address {}", address);
     }
 


### PR DESCRIPTION
Omitted to subscribe to MQTT Throttle state topics on creation of a MQTT throttle.  State topic subscriptions would occur if you changed the DCC address but not at time of creation.
