### PR TITLE
Fixed an issue where MQTT consists might not be enabled.

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -107,7 +107,7 @@
 
         <h4>MQTT</h4>
             <ul>
-                <li>Fixed missing subscription to MQTT Throttle state topics on creation of MQTTtopic.</li>
+                <li>Fixed issue with consists not being activated if created after the controlling throttle was created.</li>
             </ul>
 
         <h4>MRC</h4>

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -107,7 +107,7 @@
 
         <h4>MQTT</h4>
             <ul>
-                <li></li>
+                <li>Fixed missing subscription to MQTT Throttle state topics on creation of MQTTtopic.</li>
             </ul>
 
         <h4>MRC</h4>

--- a/java/src/jmri/jmrix/mqtt/MqttConsist.java
+++ b/java/src/jmri/jmrix/mqtt/MqttConsist.java
@@ -21,12 +21,13 @@ public class MqttConsist extends jmri.implementation.DccConsist {
     private boolean active = false;
 
     // Initialize a consist for the specific address.
-    // The Default consist type is an controller consist
+    // The Default consist type is controller consist
     public MqttConsist(int address, MqttSystemConnectionMemo memo, String sendTopicPrefix) {
         super(address);
         mqttAdapter = memo.getMqttAdapter();
         this.sendTopicPrefix = sendTopicPrefix;
         consistType = Consist.CS_CONSIST;
+        log.debug("Consist {} created.", this.getConsistAddress());
     }
 
     // Initialize a consist for the specific address.
@@ -36,12 +37,14 @@ public class MqttConsist extends jmri.implementation.DccConsist {
         mqttAdapter = memo.getMqttAdapter();
         this.sendTopicPrefix = sendTopicPrefix;
         consistType = Consist.CS_CONSIST;
+        log.debug("Consist {} created.", this.getConsistAddress());
     }
 
     // Clean Up local storage.
     @Override
     public void dispose() {
         super.dispose();
+        log.debug("Consist {} disposed.", this.getConsistAddress());
     }
 
     // Set the Consist Type.
@@ -119,7 +122,7 @@ public class MqttConsist extends jmri.implementation.DccConsist {
      */
     private synchronized void addToConsistList(DccLocoAddress LocoAddress, boolean directionNormal) {
 
-        log.debug("Add to consist list address {} direction{}", LocoAddress, directionNormal);
+        log.debug("Add to consist list address {} direction {}", LocoAddress, directionNormal);
         Boolean Direction = Boolean.valueOf(directionNormal);
         if (!(consistList.contains(LocoAddress))) {
             consistList.add(LocoAddress);
@@ -147,7 +150,7 @@ public class MqttConsist extends jmri.implementation.DccConsist {
      */
     @Override
     public synchronized void add(DccLocoAddress LocoAddress, boolean directionNormal) {
-        log.debug("Add to consist address {} direction{}", LocoAddress, directionNormal);
+        log.debug("Add to consist address {} direction {}", LocoAddress, directionNormal);
         if (consistType == CS_CONSIST) {
             addToConsistList(LocoAddress, directionNormal);
             if (active) publish();
@@ -168,7 +171,7 @@ public class MqttConsist extends jmri.implementation.DccConsist {
      */
     @Override
     public synchronized void restore(DccLocoAddress LocoAddress, boolean directionNormal) {
-        log.debug("Restore to advanced consist address {} direction {}", LocoAddress, directionNormal);
+        log.debug("Restore to consist address {} direction {}", LocoAddress, directionNormal);
 
         if (consistType == CS_CONSIST) {
             addToConsistList(LocoAddress, directionNormal);
@@ -185,7 +188,7 @@ public class MqttConsist extends jmri.implementation.DccConsist {
      */
     @Override
     public synchronized void remove(DccLocoAddress LocoAddress) {
-        log.debug("Remove from advanced consist address {}", LocoAddress);
+        log.debug("Remove from consist address {}", LocoAddress);
 
         if (consistType == CS_CONSIST) {
             removeFromConsistList(LocoAddress);

--- a/java/src/jmri/jmrix/mqtt/MqttConsistManager.java
+++ b/java/src/jmri/jmrix/mqtt/MqttConsistManager.java
@@ -12,6 +12,10 @@ import jmri.DccLocoAddress;
 import jmri.implementation.AbstractConsistManager;
 import javax.annotation.Nonnull;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
 public class MqttConsistManager extends AbstractConsistManager {
 
     protected MqttSystemConnectionMemo adapterMemo;
@@ -37,7 +41,7 @@ public class MqttConsistManager extends AbstractConsistManager {
 
 
     /**
-     * This implementation does not support advanced consists, so return true.
+     * This implementation does support advanced consists, so return true.
      *
      */
     @Override
@@ -88,16 +92,14 @@ public class MqttConsistManager extends AbstractConsistManager {
     }
 
     /**
-     * If a consist exists with the given address, the consist is activated on the controller,
-     * otherwise it does nothing.
-     * This is used by a throttle in case it is controlling a consist.
+     * Consist is activated on the controller for the specified LocoAddress
+     * This is used by MqttThrottle to either publish an existing consist or clear
+     * an old one upon opening the new throttle.
      * @param address Consist address to be activated
      */
     public void activateConsist(LocoAddress address) {
 
-        if (!consistTable.containsKey(address)) return;
-
-        ((MqttConsist)consistTable.get(address)).activate();
+        ((MqttConsist)addConsist(address)).activate();
 
     }
 
@@ -117,6 +119,6 @@ public class MqttConsistManager extends AbstractConsistManager {
 
 
 
-//    private final static Logger log = LoggerFactory.getLogger(MqttConsistManager.class);
+    private final static Logger log = LoggerFactory.getLogger(MqttConsistManager.class);
 
 }

--- a/java/src/jmri/jmrix/mqtt/MqttConsistManager.java
+++ b/java/src/jmri/jmrix/mqtt/MqttConsistManager.java
@@ -12,8 +12,8 @@ import jmri.DccLocoAddress;
 import jmri.implementation.AbstractConsistManager;
 import javax.annotation.Nonnull;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+//import org.slf4j.Logger;
+//import org.slf4j.LoggerFactory;
 
 
 public class MqttConsistManager extends AbstractConsistManager {
@@ -119,6 +119,6 @@ public class MqttConsistManager extends AbstractConsistManager {
 
 
 
-    private final static Logger log = LoggerFactory.getLogger(MqttConsistManager.class);
+//    private final static Logger log = LoggerFactory.getLogger(MqttConsistManager.class);
 
 }

--- a/java/src/jmri/jmrix/mqtt/MqttThrottle.java
+++ b/java/src/jmri/jmrix/mqtt/MqttThrottle.java
@@ -105,6 +105,11 @@ import java.util.regex.*;
 
         this.isForward = true; //loco should default to forward
 
+        // Listen to state topics
+        mqttAdapter.subscribe(this.rcvThrottleTopic.replaceFirst("\\{0\\}", String.valueOf(address)), this);
+        mqttAdapter.subscribe(this.rcvDirectionTopic.replaceFirst("\\{0\\}", String.valueOf(address)), this);
+        mqttAdapter.subscribe(this.rcvFunctionTopic.replaceFirst("\\{0\\}", String.valueOf(address)), this);
+
         log.debug("MqttThrottle constructor called for address {}", address);
     }
 

--- a/java/src/jmri/jmrix/mqtt/MqttThrottle.java
+++ b/java/src/jmri/jmrix/mqtt/MqttThrottle.java
@@ -105,11 +105,6 @@ import java.util.regex.*;
 
         this.isForward = true; //loco should default to forward
 
-        // Listen to state topics
-        mqttAdapter.subscribe(this.rcvThrottleTopic.replaceFirst("\\{0\\}", String.valueOf(address)), this);
-        mqttAdapter.subscribe(this.rcvDirectionTopic.replaceFirst("\\{0\\}", String.valueOf(address)), this);
-        mqttAdapter.subscribe(this.rcvFunctionTopic.replaceFirst("\\{0\\}", String.valueOf(address)), this);
-
         log.debug("MqttThrottle constructor called for address {}", address);
     }
 

--- a/java/src/jmri/jmrix/mqtt/MqttThrottleManager.java
+++ b/java/src/jmri/jmrix/mqtt/MqttThrottleManager.java
@@ -86,7 +86,7 @@ public class MqttThrottleManager extends AbstractThrottleManager {
     }
 
     /**
-     * MQTT based systems DO NOT use the Dispatch Function
+     * MQTT based systems DO use the Dispatch Function
      */
     @Override
     public boolean hasDispatchFunction() {

--- a/java/test/jmri/jmrix/mqtt/MqttThrottleTest.java
+++ b/java/test/jmri/jmrix/mqtt/MqttThrottleTest.java
@@ -46,7 +46,7 @@ public class MqttThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     }
 
     /**
-     * 
+     *
      */
     @Test
     @Override
@@ -66,11 +66,11 @@ public class MqttThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     public void testSpeedSettingAndDirection(){
 
         instance.setSpeedSetting(0.5f);
-        JUnitUtil.waitFor( ()->{ return a.getPublishCount()==4; }, "publish triggered");
+        JUnitUtil.waitFor( ()->{ return a.getPublishCount()==5; }, "publish triggered");
         Assert.assertEquals("cab/3/throttle", a.getLastTopic());
         Assert.assertEquals("50", new String(a.getLastPayload()));
         instance.setIsForward(true);
-        JUnitUtil.waitFor( ()->{ return a.getPublishCount()==5; }, "publish triggered");
+        JUnitUtil.waitFor( ()->{ return a.getPublishCount()==6; }, "publish triggered");
         Assert.assertEquals("cab/3/direction", a.getLastTopic());
         Assert.assertEquals("FORWARD", new String(a.getLastPayload()));
         Assert.assertEquals(instance.getSpeedSetting(), 0.5f, 0.0001);
@@ -78,11 +78,11 @@ public class MqttThrottleTest extends jmri.jmrix.AbstractThrottleTest {
 //        Assert.assertEquals( "t 3 63 1", lm.toString());
 
         instance.setSpeedSetting(0.0f);
-        JUnitUtil.waitFor( ()->{ return a.getPublishCount()==6; }, "publish triggered");
+        JUnitUtil.waitFor( ()->{ return a.getPublishCount()==7; }, "publish triggered");
         Assert.assertEquals("cab/3/throttle", a.getLastTopic());
         Assert.assertEquals("0", new String(a.getLastPayload()));
         instance.setIsForward(false);
-        JUnitUtil.waitFor( ()->{ return a.getPublishCount()==7; }, "publish triggered");
+        JUnitUtil.waitFor( ()->{ return a.getPublishCount()==8; }, "publish triggered");
         Assert.assertEquals("cab/3/direction", a.getLastTopic());
         Assert.assertEquals("REVERSE", new String(a.getLastPayload()));
         Assert.assertEquals(instance.getSpeedSetting(), 0.0f, 0.0001);
@@ -90,11 +90,11 @@ public class MqttThrottleTest extends jmri.jmrix.AbstractThrottleTest {
 //        Assert.assertEquals( "t 3 0 0", lm.toString());
 
         instance.setSpeedSetting(1.0f);
-        JUnitUtil.waitFor( ()->{ return a.getPublishCount()==8; }, "publish triggered");
+        JUnitUtil.waitFor( ()->{ return a.getPublishCount()==9; }, "publish triggered");
         Assert.assertEquals("cab/3/throttle", a.getLastTopic());
         Assert.assertEquals("100", new String(a.getLastPayload()));
         instance.setIsForward(false);
-        JUnitUtil.waitFor( ()->{ return a.getPublishCount()==9; }, "publish triggered");
+        JUnitUtil.waitFor( ()->{ return a.getPublishCount()==10; }, "publish triggered");
         Assert.assertEquals("cab/3/direction", a.getLastTopic());
         Assert.assertEquals("REVERSE", new String(a.getLastPayload()));
         Assert.assertEquals(instance.getSpeedSetting(), 1.0f, 0.0001);
@@ -102,33 +102,33 @@ public class MqttThrottleTest extends jmri.jmrix.AbstractThrottleTest {
 
 
         instance.setSpeedSetting(0.5f);
-        JUnitUtil.waitFor( ()->{ return a.getPublishCount()==10; }, "publish triggered");
+        JUnitUtil.waitFor( ()->{ return a.getPublishCount()==11; }, "publish triggered");
         Assert.assertEquals("cab/3/throttle", a.getLastTopic());
         Assert.assertEquals("50", new String(a.getLastPayload()));
         instance.setIsForward(true);
-        JUnitUtil.waitFor( ()->{ return a.getPublishCount()==11; }, "publish triggered");
+        JUnitUtil.waitFor( ()->{ return a.getPublishCount()==12; }, "publish triggered");
         Assert.assertEquals("cab/3/direction", a.getLastTopic());
         Assert.assertEquals("FORWARD", new String(a.getLastPayload()));
         Assert.assertEquals(instance.getSpeedSetting(), 0.5f, 0.0001);
         Assert.assertTrue(instance.getIsForward());
 
         instance.setSpeedSetting(0.0f);
-        JUnitUtil.waitFor( ()->{ return a.getPublishCount()==12; }, "publish triggered");
+        JUnitUtil.waitFor( ()->{ return a.getPublishCount()==13; }, "publish triggered");
         Assert.assertEquals("cab/3/throttle", a.getLastTopic());
         Assert.assertEquals("0", new String(a.getLastPayload()));
         instance.setIsForward(false);
-        JUnitUtil.waitFor( ()->{ return a.getPublishCount()==13; }, "publish triggered");
+        JUnitUtil.waitFor( ()->{ return a.getPublishCount()==14; }, "publish triggered");
         Assert.assertEquals("cab/3/direction", a.getLastTopic());
         Assert.assertEquals("REVERSE", new String(a.getLastPayload()));
         Assert.assertEquals(instance.getSpeedSetting(), 0.0f, 0.0001);
         Assert.assertFalse(instance.getIsForward());
 
         instance.setSpeedSetting(1.0f);
-        JUnitUtil.waitFor( ()->{ return a.getPublishCount()==14; }, "publish triggered");
+        JUnitUtil.waitFor( ()->{ return a.getPublishCount()==15; }, "publish triggered");
         Assert.assertEquals("cab/3/throttle", a.getLastTopic());
         Assert.assertEquals("100", new String(a.getLastPayload()));
         instance.setIsForward(false);
-        JUnitUtil.waitFor( ()->{ return a.getPublishCount()==15; }, "publish triggered");
+        JUnitUtil.waitFor( ()->{ return a.getPublishCount()==16; }, "publish triggered");
         Assert.assertEquals("cab/3/direction", a.getLastTopic());
         Assert.assertEquals("REVERSE", new String(a.getLastPayload()));
         Assert.assertEquals(instance.getSpeedSetting(), 1.0f, 0.0001);
@@ -144,74 +144,74 @@ public class MqttThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     public void testFunctionFormats(){
         instance.setFunction(0, true);
         Assert.assertTrue(instance.getFunction(0));
-        JUnitUtil.waitFor( ()->{ return a.getPublishCount()==4; }, "publish triggered");
+        JUnitUtil.waitFor( ()->{ return a.getPublishCount()==5; }, "publish triggered");
         Assert.assertEquals("cab/3/function/0", a.getLastTopic());
         Assert.assertEquals("ON", new String(a.getLastPayload()));
         instance.setFunction(0, false);
-        JUnitUtil.waitFor( ()->{ return a.getPublishCount()==5; }, "publish triggered");
+        JUnitUtil.waitFor( ()->{ return a.getPublishCount()==6; }, "publish triggered");
         Assert.assertEquals("cab/3/function/0", a.getLastTopic());
         Assert.assertEquals("OFF", new String(a.getLastPayload()));
 
         instance.setFunction(22, false);
         Assert.assertFalse(instance.getFunction(22));
-        JUnitUtil.waitFor( ()->{ return a.getPublishCount()==6; }, "publish triggered");
+        JUnitUtil.waitFor( ()->{ return a.getPublishCount()==7; }, "publish triggered");
         Assert.assertEquals("cab/3/function/22", a.getLastTopic());
         Assert.assertEquals("OFF", new String(a.getLastPayload()));
 
         instance.setFunction(28, true);
         Assert.assertTrue(instance.getFunction(28));
-        JUnitUtil.waitFor( ()->{ return a.getPublishCount()==7; }, "publish triggered");
+        JUnitUtil.waitFor( ()->{ return a.getPublishCount()==8; }, "publish triggered");
         Assert.assertEquals("cab/3/function/28", a.getLastTopic());
         Assert.assertEquals("ON", new String(a.getLastPayload()));
         instance.setFunction(28, false);
-        JUnitUtil.waitFor( ()->{ return a.getPublishCount()==8; }, "publish triggered");
+        JUnitUtil.waitFor( ()->{ return a.getPublishCount()==9; }, "publish triggered");
         Assert.assertEquals("cab/3/function/28", a.getLastTopic());
         Assert.assertEquals("OFF", new String(a.getLastPayload()));
 
         instance.setFunction(16, true);
         Assert.assertTrue(instance.getFunction(16));
-        JUnitUtil.waitFor( ()->{ return a.getPublishCount()==9; }, "publish triggered");
+        JUnitUtil.waitFor( ()->{ return a.getPublishCount()==10; }, "publish triggered");
         Assert.assertEquals("cab/3/function/16", a.getLastTopic());
         Assert.assertEquals("ON", new String(a.getLastPayload()));
         instance.setFunction(16, false);
         Assert.assertFalse(instance.getFunction(16));
-        JUnitUtil.waitFor( ()->{ return a.getPublishCount()==10; }, "publish triggered");
+        JUnitUtil.waitFor( ()->{ return a.getPublishCount()==11; }, "publish triggered");
         Assert.assertEquals("cab/3/function/16", a.getLastTopic());
         Assert.assertEquals("OFF", new String(a.getLastPayload()));
 
         instance.setFunction(0, true);
         Assert.assertTrue(instance.getFunction(0));
-        JUnitUtil.waitFor( ()->{ return a.getPublishCount()==11; }, "publish triggered");
+        JUnitUtil.waitFor( ()->{ return a.getPublishCount()==12; }, "publish triggered");
         Assert.assertEquals("cab/3/function/0", a.getLastTopic());
         Assert.assertEquals("ON", new String(a.getLastPayload()));
         instance.setFunction(0, false);
-        JUnitUtil.waitFor( ()->{ return a.getPublishCount()==12; }, "publish triggered");
+        JUnitUtil.waitFor( ()->{ return a.getPublishCount()==13; }, "publish triggered");
         Assert.assertEquals("cab/3/function/0", a.getLastTopic());
         Assert.assertEquals("OFF", new String(a.getLastPayload()));
 
         instance.setFunction(21, false);
         Assert.assertFalse(instance.getFunction(21));
-        JUnitUtil.waitFor( ()->{ return a.getPublishCount()==13; }, "publish triggered");
+        JUnitUtil.waitFor( ()->{ return a.getPublishCount()==14; }, "publish triggered");
         Assert.assertEquals("cab/3/function/21", a.getLastTopic());
         Assert.assertEquals("OFF", new String(a.getLastPayload()));
 
         instance.setFunction(4, true);
         Assert.assertTrue(instance.getFunction(4));
-        JUnitUtil.waitFor( ()->{ return a.getPublishCount()==14; }, "publish triggered");
+        JUnitUtil.waitFor( ()->{ return a.getPublishCount()==15; }, "publish triggered");
         Assert.assertEquals("cab/3/function/4", a.getLastTopic());
         Assert.assertEquals("ON", new String(a.getLastPayload()));
         instance.setFunction(4, false);
-        JUnitUtil.waitFor( ()->{ return a.getPublishCount()==15; }, "publish triggered");
+        JUnitUtil.waitFor( ()->{ return a.getPublishCount()==16; }, "publish triggered");
         Assert.assertEquals("cab/3/function/4", a.getLastTopic());
         Assert.assertEquals("OFF", new String(a.getLastPayload()));
 
         instance.setFunction(28, true);
         Assert.assertTrue(instance.getFunction(28));
-        JUnitUtil.waitFor( ()->{ return a.getPublishCount()==16; }, "publish triggered");
+        JUnitUtil.waitFor( ()->{ return a.getPublishCount()==17; }, "publish triggered");
         Assert.assertEquals("cab/3/function/28", a.getLastTopic());
         Assert.assertEquals("ON", new String(a.getLastPayload()));
         instance.setFunction(28, false);
-        JUnitUtil.waitFor( ()->{ return a.getPublishCount()==17; }, "publish triggered");
+        JUnitUtil.waitFor( ()->{ return a.getPublishCount()==18; }, "publish triggered");
         Assert.assertEquals("cab/3/function/28", a.getLastTopic());
         Assert.assertEquals("OFF", new String(a.getLastPayload()));
 


### PR DESCRIPTION
MQTT provides a style of Command Station Assisted Consists where consists are created within the MQTTConsistManager but not published on MQTT until activated by the controlling MqttThrottle when it is created.

A condition can arise where the throttle is created before the consist, and therefore the consist is never activated or published on MQTT.

This patch fixes the issue by creating a consist for a throttle if it does not exist when the throttle is created.  Subsequent requests to create a new consist with the same address will return the previously created one.  Any changes to the consist are automatically published on MQTT when the consist is active.

As new consists are empty, this has the added benefit of clearing out any old consist messages from MQTT as an empty consist is the equivalent of no consist.

Also fixed some comments whilst I was in there.   

