### PR TITLE
Fixed issue with MQTT Client Id

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -108,6 +108,7 @@
         <h4>MQTT</h4>
             <ul>
                 <li>Fixed issue with consists not being activated if created after the controlling throttle was created.</li>
+                <li>Fixed issue where JRMI may generate a non-unique client id when connecting to the MQTT broker - see Warnings.</li>
             </ul>
 
         <h4>MRC</h4>

--- a/help/en/releasenotes/current-draft-warnings.shtml
+++ b/help/en/releasenotes/current-draft-warnings.shtml
@@ -1,6 +1,5 @@
 
     <!-- contains new warnings for the release under development -->
-    <li>
-    </li>
+    <li>Multiple MQTT connections from a single JMRI instance to a single MQTT broker will suffer degraded performance due to clashing client ids.</li>
     <li>
     </li>

--- a/java/src/jmri/jmrix/mqtt/MqttAdapter.java
+++ b/java/src/jmri/jmrix/mqtt/MqttAdapter.java
@@ -162,12 +162,11 @@ public class MqttAdapter extends jmri.jmrix.AbstractNetworkPortController implem
             }
 
             // generate a unique client ID based on the network ID and the system prefix of the MQTT connection.
-            String clientID = jmri.InstanceManager.getDefault(jmri.web.server.WebServerPreferences.class).getRailroadName()
-                                + getSystemPrefix() + jmri.util.node.NodeIdentity.networkIdentity();
+            String clientID = jmri.util.node.NodeIdentity.networkIdentity();
             
             // ensure that only guaranteed valid characters are included in the client ID
             clientID = clientID.replaceAll("[^A-Za-z0-9]", "");
-            
+
             // ensure the length of the client ID doesn't exceed the guaranteed acceptable length of 23
             if (clientID.length() > 23) {
                 clientID = clientID.substring(0, 23);

--- a/java/src/jmri/jmrix/mqtt/MqttAdapter.java
+++ b/java/src/jmri/jmrix/mqtt/MqttAdapter.java
@@ -162,15 +162,19 @@ public class MqttAdapter extends jmri.jmrix.AbstractNetworkPortController implem
             }
 
             // generate a unique client ID based on the network ID and the system prefix of the MQTT connection.
-            String clientID = jmri.util.node.NodeIdentity.networkIdentity();
-            
+            String clientID = jmri.InstanceManager.getDefault(jmri.web.server.WebServerPreferences.class).getRailroadName();
+
             // ensure that only guaranteed valid characters are included in the client ID
             clientID = clientID.replaceAll("[^A-Za-z0-9]", "");
 
-            // ensure the length of the client ID doesn't exceed the guaranteed acceptable length of 23
-            if (clientID.length() > 23) {
-                clientID = clientID.substring(0, 23);
-            }
+            String clientIDsuffix = "JMRI" + Integer.toHexString(jmri.util.node.NodeIdentity.networkIdentity().hashCode()) .toUpperCase() + getSystemPrefix();
+
+            // Trim railroad name to fit within MQTT client id 23 character limit.
+            if (clientID.length() > 23 - clientIDsuffix.length())
+                clientID = clientID.substring(0,23 - clientIDsuffix.length());
+
+            clientID = clientID + clientIDsuffix;
+
             log.info("Connection {} is using a clientID of \"{}\"", getSystemPrefix(), clientID);
             
             String tempdirName = jmri.util.FileUtil.getExternalFilename(jmri.util.FileUtil.PROFILE);


### PR DESCRIPTION
MQTT requires a unique client id for each connection to a MQTT broker.  Clients connecting with a non-unique client id cause the previous client with that id to be disconnected.

JRMI was using a combination of the railroad name, connection system prefix, and JMRI network identity (a combination of the machine's MAC address and the profile id).  The intent is that this would handle every possible situation including multiple JMRI railways/profiles on one machine, the same JMRI profile running on multiple machines, and multiple MQTT connections from the one JMRI profile to the same broker.

The issue is that the JMRI network id alone is 24 characters but the standard MQTT client id is  23 characters.  JRMI truncates the combined client id to 23 characters, which defeats the intent of being unique in all conditions.  This is especially the case when the railroad name is greater than 23 characters, such as 'Tarlington District Mountain Railway', which causes a problem if this railroad is using multiple computers (such as a development machine and operational machine, which is how I hit the issue).

The fix is to just use the JMRI network identity as the client id. 

This fix will work for all situations except for when a profile has more than one MQTT connection to the same broker.  Whilst having more than one connection is unnecessary, I can see a situation where this may happen - someone may create more than one connection to create some sort of separation of signals, such as for a multi-segment layout where they want to be able to disable entire segments.   In this case, the configuration would still work but the connections would fight with each other to maintain their connections to the broker.

However, the documentation says:

> Currently, JMRI can handle only one MQTT connection at a time. [Advanced Usage: The ability to change the connection name will be required at some point in the future when more than one MQTT Connection is allowed.]

I'm not entirely sure that is true as I haven't seen anything that would prevent multiple connections, but then I haven't really looked specifically or tried it out.

 
 