### PR TITLE
Added missing property change event for removeAllocatedSection

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -408,6 +408,7 @@
              <li>Head Only - only the front of the train can be detected.</li>
              <li>Head and Tail - the front and rear are detected but not any bits in between.</li>
              <li>Any TrainInfo files that are edited will be saved in the updated way and cannot be read by older versions.</li>
+             <li>ActiveTrain - now fires property change events when Allocated Section are added and removed.  Previously only fired event on add.
         </ul>
 
     <h3>Dispatcher System</h3>

--- a/java/src/jmri/jmrit/dispatcher/ActiveTrain.java
+++ b/java/src/jmri/jmrit/dispatcher/ActiveTrain.java
@@ -830,6 +830,8 @@ public class ActiveTrain implements PropertyChangeProvider {
                 }
             }
         }
+        // notify anyone interested
+        pcs.firePropertyChange("sectiondeallocated",as , null);
         refreshPanel();
         if (as.getSection() == mLastAllocatedSection) {
             mLastAllocatedSection = null;


### PR DESCRIPTION
In ActveTrain, the method addAllocatedSection fires a property change event but the corresponding removeAllocatedSection didn't.

This PR fixes that oversight.