### PR TITLE
Improve LogixNG NamedBeanType

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -450,6 +450,8 @@
           <li>The action <strong>Window to front</strong> has been improved and renamed to
               <strong>Window management</strong>. It can now show/hide a window,
               maximize/normalize/minimize a window and move the window to front or back.</li>
+          <li>The class <strong>jmri.jmrit.logixng.actions.NamedBeanType</strong> has been moved to
+              <strong>jmri.jmrit.logixng.NamedBeanType</strong>. It should only affect JMRI developers.</li>
           <li></li>
         </ul>
 

--- a/java/src/jmri/jmrit/logixng/NamedBeanType.java
+++ b/java/src/jmri/jmrit/logixng/NamedBeanType.java
@@ -1,4 +1,4 @@
-package jmri.jmrit.logixng.actions;
+package jmri.jmrit.logixng;
 
 import jmri.*;
 import jmri.jmrit.entryexit.DestinationPoints;
@@ -7,8 +7,6 @@ import jmri.jmrit.logix.OBlock;
 import jmri.jmrit.logix.OBlockManager;
 import jmri.jmrit.logix.Warrant;
 import jmri.jmrit.logix.WarrantManager;
-import jmri.jmrit.logixng.GlobalVariable;
-import jmri.jmrit.logixng.GlobalVariableManager;
 
 /**
  * Defines types of NamedBeans, for example Turnout and Light.

--- a/java/src/jmri/jmrit/logixng/actions/ActionCreateBeansFromTable.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionCreateBeansFromTable.java
@@ -1,5 +1,7 @@
 package jmri.jmrit.logixng.actions;
 
+import jmri.jmrit.logixng.NamedBeanType;
+
 import java.beans.*;
 import java.util.*;
 

--- a/java/src/jmri/jmrit/logixng/actions/ActionListenOnBeans.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionListenOnBeans.java
@@ -1,5 +1,7 @@
 package jmri.jmrit.logixng.actions;
 
+import jmri.jmrit.logixng.NamedBeanType;
+
 import java.beans.*;
 import java.util.*;
 import java.util.stream.Collectors;

--- a/java/src/jmri/jmrit/logixng/actions/ActionListenOnBeansLocalVariable.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionListenOnBeansLocalVariable.java
@@ -1,5 +1,7 @@
 package jmri.jmrit.logixng.actions;
 
+import jmri.jmrit.logixng.NamedBeanType;
+
 import java.beans.*;
 import java.util.*;
 

--- a/java/src/jmri/jmrit/logixng/actions/ActionListenOnBeansTable.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionListenOnBeansTable.java
@@ -1,5 +1,7 @@
 package jmri.jmrit.logixng.actions;
 
+import jmri.jmrit.logixng.NamedBeanType;
+
 import java.beans.*;
 import java.util.*;
 

--- a/java/src/jmri/jmrit/logixng/actions/NamedBeanType.java
+++ b/java/src/jmri/jmrit/logixng/actions/NamedBeanType.java
@@ -26,12 +26,16 @@ public enum NamedBeanType {
             new CreateBean() {
                 @Override
                 public NamedBean createBean(String systemName, String userName) {
-                    return ((BlockManager)NamedBeanType.Block.getManager()).createNewBlock(systemName, userName);
+                    return InstanceManager.getDefault(BlockManager.class)
+                            .createNewBlock(systemName, userName);
                 }
             },
             (NamedBean bean, String property) -> {
-                if (!(bean instanceof Block)) throw new IllegalArgumentException("bean is not a Block");
-                InstanceManager.getDefault(BlockManager.class).deleteBean((Block)bean, property);
+                if (!(bean instanceof Block)) {
+                    throw new IllegalArgumentException("bean is not a Block");
+                }
+                InstanceManager.getDefault(BlockManager.class)
+                        .deleteBean((Block)bean, property);
             }),
 
     GlobalVariable(
@@ -43,12 +47,16 @@ public enum NamedBeanType {
             new CreateBean() {
                 @Override
                 public NamedBean createBean(String systemName, String userName) {
-                    return ((GlobalVariableManager)NamedBeanType.GlobalVariable.getManager()).createGlobalVariable(systemName, userName);
+                    return InstanceManager.getDefault(GlobalVariableManager.class)
+                            .createGlobalVariable(systemName, userName);
                 }
             },
             (NamedBean bean, String property) -> {
-                if (!(bean instanceof GlobalVariable)) throw new IllegalArgumentException("bean is not a GlobalVariable");
-                InstanceManager.getDefault(GlobalVariableManager.class).deleteBean((GlobalVariable)bean, property);
+                if (!(bean instanceof GlobalVariable)) {
+                    throw new IllegalArgumentException("bean is not a GlobalVariable");
+                }
+                InstanceManager.getDefault(GlobalVariableManager.class)
+                        .deleteBean((GlobalVariable)bean, property);
             }),
 
     EntryExit(
@@ -59,8 +67,11 @@ public enum NamedBeanType {
             () -> InstanceManager.getDefault(EntryExitPairs.class),
             null,
             (NamedBean bean, String property) -> {
-                if (!(bean instanceof DestinationPoints)) throw new IllegalArgumentException("bean is not a DestinationPoints");
-                InstanceManager.getDefault(EntryExitPairs.class).deleteBean((DestinationPoints)bean, property);
+                if (!(bean instanceof DestinationPoints)) {
+                    throw new IllegalArgumentException("bean is not a DestinationPoints");
+                }
+                InstanceManager.getDefault(EntryExitPairs.class)
+                        .deleteBean((DestinationPoints)bean, property);
             }),
 
     Light(
@@ -72,11 +83,14 @@ public enum NamedBeanType {
             new CreateBean() {
                 @Override
                 public NamedBean createBean(String systemName, String userName) {
-                    return InstanceManager.getDefault(LightManager.class).newLight(systemName, userName);
+                    return InstanceManager.getDefault(LightManager.class)
+                            .newLight(systemName, userName);
                 }
             },
             (NamedBean bean, String property) -> {
-                if (!(bean instanceof Light)) throw new IllegalArgumentException("bean is not a Light");
+                if (!(bean instanceof Light)) {
+                    throw new IllegalArgumentException("bean is not a Light");
+                }
                 InstanceManager.getDefault(LightManager.class).deleteBean((Light)bean, property);
             }),
 
@@ -89,12 +103,16 @@ public enum NamedBeanType {
             new CreateBean() {
                 @Override
                 public NamedBean createBean(String systemName, String userName) {
-                    return ((MemoryManager)NamedBeanType.Memory.getManager()).newMemory(systemName, userName);
+                    return InstanceManager.getDefault(MemoryManager.class)
+                            .newMemory(systemName, userName);
                 }
             },
             (NamedBean bean, String property) -> {
-                if (!(bean instanceof Memory)) throw new IllegalArgumentException("bean is not a Memory");
-                InstanceManager.getDefault(MemoryManager.class).deleteBean((Memory)bean, property);
+                if (!(bean instanceof Memory)) {
+                    throw new IllegalArgumentException("bean is not a Memory");
+                }
+                InstanceManager.getDefault(MemoryManager.class)
+                        .deleteBean((Memory)bean, property);
             }),
 
     OBlock(
@@ -106,12 +124,16 @@ public enum NamedBeanType {
             new CreateBean() {
                 @Override
                 public NamedBean createBean(String systemName, String userName) {
-                    return InstanceManager.getDefault(OBlockManager.class).createNewOBlock(systemName, userName);
+                    return InstanceManager.getDefault(OBlockManager.class)
+                            .createNewOBlock(systemName, userName);
                 }
             },
             (NamedBean bean, String property) -> {
-                if (!(bean instanceof OBlock)) throw new IllegalArgumentException("bean is not a OBlock");
-                InstanceManager.getDefault(OBlockManager.class).deleteBean((OBlock)bean, property);
+                if (!(bean instanceof OBlock)) {
+                    throw new IllegalArgumentException("bean is not a OBlock");
+                }
+                InstanceManager.getDefault(OBlockManager.class)
+                        .deleteBean((OBlock)bean, property);
             }),
 
     Reporter(
@@ -123,12 +145,16 @@ public enum NamedBeanType {
             new CreateBean() {
                 @Override
                 public NamedBean createBean(String systemName, String userName) {
-                    return InstanceManager.getDefault(ReporterManager.class).newReporter(systemName, userName);
+                    return InstanceManager.getDefault(ReporterManager.class)
+                            .newReporter(systemName, userName);
                 }
             },
             (NamedBean bean, String property) -> {
-                if (!(bean instanceof Reporter)) throw new IllegalArgumentException("bean is not a Reporter");
-                InstanceManager.getDefault(ReporterManager.class).deleteBean((Reporter)bean, property);
+                if (!(bean instanceof Reporter)) {
+                    throw new IllegalArgumentException("bean is not a Reporter");
+                }
+                InstanceManager.getDefault(ReporterManager.class)
+                        .deleteBean((Reporter)bean, property);
             }),
 
     Sensor(
@@ -140,12 +166,16 @@ public enum NamedBeanType {
             new CreateBean() {
                 @Override
                 public NamedBean createBean(String systemName, String userName) {
-                    return InstanceManager.getDefault(SensorManager.class).newSensor(systemName, userName);
+                    return InstanceManager.getDefault(SensorManager.class)
+                            .newSensor(systemName, userName);
                 }
             },
             (NamedBean bean, String property) -> {
-                if (!(bean instanceof Sensor)) throw new IllegalArgumentException("bean is not a Sensor");
-                InstanceManager.getDefault(SensorManager.class).deleteBean((Sensor)bean, property);
+                if (!(bean instanceof Sensor)) {
+                    throw new IllegalArgumentException("bean is not a Sensor");
+                }
+                InstanceManager.getDefault(SensorManager.class)
+                        .deleteBean((Sensor)bean, property);
             }),
 
     SignalHead(
@@ -156,8 +186,11 @@ public enum NamedBeanType {
             () -> InstanceManager.getDefault(SignalHeadManager.class),
             null,
             (NamedBean bean, String property) -> {
-                if (!(bean instanceof SignalHead)) throw new IllegalArgumentException("bean is not a SignalHead");
-                InstanceManager.getDefault(SignalHeadManager.class).deleteBean((SignalHead)bean, property);
+                if (!(bean instanceof SignalHead)) {
+                    throw new IllegalArgumentException("bean is not a SignalHead");
+                }
+                InstanceManager.getDefault(SignalHeadManager.class)
+                        .deleteBean((SignalHead)bean, property);
             }),
 
     SignalMast(
@@ -168,8 +201,11 @@ public enum NamedBeanType {
             () -> InstanceManager.getDefault(SignalMastManager.class),
             null,
             (NamedBean bean, String property) -> {
-                if (!(bean instanceof SignalMast)) throw new IllegalArgumentException("bean is not a SignalMast");
-                InstanceManager.getDefault(SignalMastManager.class).deleteBean((SignalMast)bean, property);
+                if (!(bean instanceof SignalMast)) {
+                    throw new IllegalArgumentException("bean is not a SignalMast");
+                }
+                InstanceManager.getDefault(SignalMastManager.class)
+                        .deleteBean((SignalMast)bean, property);
             }),
 
     Turnout(
@@ -180,12 +216,16 @@ public enum NamedBeanType {
             new CreateBean() {
                 @Override
                 public NamedBean createBean(String systemName, String userName) {
-                    return InstanceManager.getDefault(TurnoutManager.class).newTurnout(systemName, userName);
+                    return InstanceManager.getDefault(TurnoutManager.class)
+                            .newTurnout(systemName, userName);
                 }
             },
             (NamedBean bean, String property) -> {
-                if (!(bean instanceof Turnout)) throw new IllegalArgumentException("bean is not a Turnout");
-                InstanceManager.getDefault(TurnoutManager.class).deleteBean((Turnout)bean, property);
+                if (!(bean instanceof Turnout)) {
+                    throw new IllegalArgumentException("bean is not a Turnout");
+                }
+                InstanceManager.getDefault(TurnoutManager.class)
+                        .deleteBean((Turnout)bean, property);
             }),
 
     Warrant(
@@ -195,8 +235,11 @@ public enum NamedBeanType {
             () -> InstanceManager.getDefault(WarrantManager.class),
             null,
             (NamedBean bean, String property) -> {
-                if (!(bean instanceof Warrant)) throw new IllegalArgumentException("bean is not a Warrant");
-                InstanceManager.getDefault(WarrantManager.class).deleteBean((Warrant)bean, property);
+                if (!(bean instanceof Warrant)) {
+                    throw new IllegalArgumentException("bean is not a Warrant");
+                }
+                InstanceManager.getDefault(WarrantManager.class)
+                        .deleteBean((Warrant)bean, property);
             });
 
 

--- a/java/src/jmri/jmrit/logixng/actions/NamedBeanType.java
+++ b/java/src/jmri/jmrit/logixng/actions/NamedBeanType.java
@@ -23,7 +23,12 @@ public enum NamedBeanType {
             Block.class,
             null,
             () -> InstanceManager.getDefault(BlockManager.class),
-            InstanceManager.getDefault(BlockManager.class)::createNewBlock,
+            new CreateBean() {
+                @Override
+                public NamedBean createBean(String systemName, String userName) {
+                    return ((BlockManager)NamedBeanType.Block.getManager()).createNewBlock(systemName, userName);
+                }
+            },
             (NamedBean bean, String property) -> {
                 if (!(bean instanceof Block)) throw new IllegalArgumentException("bean is not a Block");
                 InstanceManager.getDefault(BlockManager.class).deleteBean((Block)bean, property);
@@ -35,7 +40,12 @@ public enum NamedBeanType {
             GlobalVariable.class,
             "value",
             () -> InstanceManager.getDefault(GlobalVariableManager.class),
-            InstanceManager.getDefault(GlobalVariableManager.class)::createGlobalVariable,
+            new CreateBean() {
+                @Override
+                public NamedBean createBean(String systemName, String userName) {
+                    return ((GlobalVariableManager)NamedBeanType.GlobalVariable.getManager()).createGlobalVariable(systemName, userName);
+                }
+            },
             (NamedBean bean, String property) -> {
                 if (!(bean instanceof GlobalVariable)) throw new IllegalArgumentException("bean is not a GlobalVariable");
                 InstanceManager.getDefault(GlobalVariableManager.class).deleteBean((GlobalVariable)bean, property);
@@ -71,7 +81,12 @@ public enum NamedBeanType {
             Memory.class,
             "value",
             () -> InstanceManager.getDefault(MemoryManager.class),
-            InstanceManager.getDefault(MemoryManager.class)::newMemory,
+            new CreateBean() {
+                @Override
+                public NamedBean createBean(String systemName, String userName) {
+                    return ((MemoryManager)NamedBeanType.Memory.getManager()).newMemory(systemName, userName);
+                }
+            },
             (NamedBean bean, String property) -> {
                 if (!(bean instanceof Memory)) throw new IllegalArgumentException("bean is not a Memory");
                 InstanceManager.getDefault(MemoryManager.class).deleteBean((Memory)bean, property);

--- a/java/src/jmri/jmrit/logixng/actions/NamedBeanType.java
+++ b/java/src/jmri/jmrit/logixng/actions/NamedBeanType.java
@@ -69,7 +69,12 @@ public enum NamedBeanType {
             Light.class,
             "KnownState",
             () -> InstanceManager.getDefault(LightManager.class),
-            InstanceManager.getDefault(LightManager.class)::newLight,
+            new CreateBean() {
+                @Override
+                public NamedBean createBean(String systemName, String userName) {
+                    return InstanceManager.getDefault(LightManager.class).newLight(systemName, userName);
+                }
+            },
             (NamedBean bean, String property) -> {
                 if (!(bean instanceof Light)) throw new IllegalArgumentException("bean is not a Light");
                 InstanceManager.getDefault(LightManager.class).deleteBean((Light)bean, property);
@@ -98,7 +103,12 @@ public enum NamedBeanType {
             OBlock.class,
             "state",
             () -> InstanceManager.getDefault(OBlockManager.class),
-            InstanceManager.getDefault(OBlockManager.class)::createNewOBlock,
+            new CreateBean() {
+                @Override
+                public NamedBean createBean(String systemName, String userName) {
+                    return InstanceManager.getDefault(OBlockManager.class).createNewOBlock(systemName, userName);
+                }
+            },
             (NamedBean bean, String property) -> {
                 if (!(bean instanceof OBlock)) throw new IllegalArgumentException("bean is not a OBlock");
                 InstanceManager.getDefault(OBlockManager.class).deleteBean((OBlock)bean, property);
@@ -110,7 +120,12 @@ public enum NamedBeanType {
             Reporter.class,
             "currentReport",
             () -> InstanceManager.getDefault(ReporterManager.class),
-            InstanceManager.getDefault(ReporterManager.class)::newReporter,
+            new CreateBean() {
+                @Override
+                public NamedBean createBean(String systemName, String userName) {
+                    return InstanceManager.getDefault(ReporterManager.class).newReporter(systemName, userName);
+                }
+            },
             (NamedBean bean, String property) -> {
                 if (!(bean instanceof Reporter)) throw new IllegalArgumentException("bean is not a Reporter");
                 InstanceManager.getDefault(ReporterManager.class).deleteBean((Reporter)bean, property);
@@ -122,7 +137,12 @@ public enum NamedBeanType {
             Sensor.class,
             "KnownState",
             () -> InstanceManager.getDefault(SensorManager.class),
-            InstanceManager.getDefault(SensorManager.class)::newSensor,
+            new CreateBean() {
+                @Override
+                public NamedBean createBean(String systemName, String userName) {
+                    return InstanceManager.getDefault(SensorManager.class).newSensor(systemName, userName);
+                }
+            },
             (NamedBean bean, String property) -> {
                 if (!(bean instanceof Sensor)) throw new IllegalArgumentException("bean is not a Sensor");
                 InstanceManager.getDefault(SensorManager.class).deleteBean((Sensor)bean, property);
@@ -157,7 +177,12 @@ public enum NamedBeanType {
             Bundle.getMessage("BeanNameTurnouts"),
             Turnout.class, "KnownState",
             () -> InstanceManager.getDefault(TurnoutManager.class),
-            InstanceManager.getDefault(TurnoutManager.class)::newTurnout,
+            new CreateBean() {
+                @Override
+                public NamedBean createBean(String systemName, String userName) {
+                    return InstanceManager.getDefault(TurnoutManager.class).newTurnout(systemName, userName);
+                }
+            },
             (NamedBean bean, String property) -> {
                 if (!(bean instanceof Turnout)) throw new IllegalArgumentException("bean is not a Turnout");
                 InstanceManager.getDefault(TurnoutManager.class).deleteBean((Turnout)bean, property);

--- a/java/src/jmri/jmrit/logixng/actions/configurexml/ActionCreateBeansFromTableXml.java
+++ b/java/src/jmri/jmrit/logixng/actions/configurexml/ActionCreateBeansFromTableXml.java
@@ -6,7 +6,7 @@ import jmri.jmrit.logixng.DigitalActionManager;
 import jmri.jmrit.logixng.NamedTable;
 import jmri.jmrit.logixng.TableRowOrColumn;
 import jmri.jmrit.logixng.actions.ActionCreateBeansFromTable;
-import jmri.jmrit.logixng.actions.NamedBeanType;
+import jmri.jmrit.logixng.NamedBeanType;
 import jmri.jmrit.logixng.util.configurexml.LogixNG_SelectNamedBeanXml;
 
 import org.jdom2.Attribute;

--- a/java/src/jmri/jmrit/logixng/actions/configurexml/ActionListenOnBeansLocalVariableXml.java
+++ b/java/src/jmri/jmrit/logixng/actions/configurexml/ActionListenOnBeansLocalVariableXml.java
@@ -5,7 +5,7 @@ import jmri.configurexml.JmriConfigureXmlException;
 import jmri.jmrit.logixng.DigitalActionManager;
 import jmri.jmrit.logixng.MaleSocket;
 import jmri.jmrit.logixng.actions.ActionListenOnBeansLocalVariable;
-import jmri.jmrit.logixng.actions.NamedBeanType;
+import jmri.jmrit.logixng.NamedBeanType;
 
 import org.jdom2.Attribute;
 import org.jdom2.Element;

--- a/java/src/jmri/jmrit/logixng/actions/configurexml/ActionListenOnBeansTableXml.java
+++ b/java/src/jmri/jmrit/logixng/actions/configurexml/ActionListenOnBeansTableXml.java
@@ -6,7 +6,7 @@ import jmri.jmrit.logixng.DigitalActionManager;
 import jmri.jmrit.logixng.NamedTable;
 import jmri.jmrit.logixng.TableRowOrColumn;
 import jmri.jmrit.logixng.actions.ActionListenOnBeansTable;
-import jmri.jmrit.logixng.actions.NamedBeanType;
+import jmri.jmrit.logixng.NamedBeanType;
 import jmri.jmrit.logixng.util.configurexml.LogixNG_SelectNamedBeanXml;
 
 import org.jdom2.Attribute;

--- a/java/src/jmri/jmrit/logixng/actions/configurexml/ActionListenOnBeansXml.java
+++ b/java/src/jmri/jmrit/logixng/actions/configurexml/ActionListenOnBeansXml.java
@@ -6,7 +6,7 @@ import jmri.InstanceManager;
 import jmri.jmrit.logixng.DigitalActionManager;
 import jmri.jmrit.logixng.actions.ActionListenOnBeans;
 import jmri.jmrit.logixng.actions.ActionListenOnBeans.NamedBeanReference;
-import jmri.jmrit.logixng.actions.NamedBeanType;
+import jmri.jmrit.logixng.NamedBeanType;
 
 import org.jdom2.Element;
 

--- a/java/src/jmri/jmrit/logixng/actions/swing/ActionCreateBeansFromTableSwing.java
+++ b/java/src/jmri/jmrit/logixng/actions/swing/ActionCreateBeansFromTableSwing.java
@@ -9,7 +9,7 @@ import javax.swing.*;
 import jmri.*;
 import jmri.jmrit.logixng.*;
 import jmri.jmrit.logixng.actions.ActionCreateBeansFromTable;
-import jmri.jmrit.logixng.actions.NamedBeanType;
+import jmri.jmrit.logixng.NamedBeanType;
 import jmri.util.swing.BeanSelectPanel;
 import jmri.util.swing.JComboBoxUtil;
 

--- a/java/src/jmri/jmrit/logixng/actions/swing/ActionListenOnBeansLocalVariableSwing.java
+++ b/java/src/jmri/jmrit/logixng/actions/swing/ActionListenOnBeansLocalVariableSwing.java
@@ -11,7 +11,7 @@ import javax.swing.*;
 import jmri.*;
 import jmri.jmrit.logixng.*;
 import jmri.jmrit.logixng.actions.ActionListenOnBeansLocalVariable;
-import jmri.jmrit.logixng.actions.NamedBeanType;
+import jmri.jmrit.logixng.NamedBeanType;
 import jmri.util.swing.JComboBoxUtil;
 
 /**

--- a/java/src/jmri/jmrit/logixng/actions/swing/ActionListenOnBeansSwing.java
+++ b/java/src/jmri/jmrit/logixng/actions/swing/ActionListenOnBeansSwing.java
@@ -12,7 +12,7 @@ import javax.swing.table.TableColumn;
 import jmri.InstanceManager;
 import jmri.jmrit.logixng.*;
 import jmri.jmrit.logixng.actions.ActionListenOnBeans;
-import jmri.jmrit.logixng.actions.NamedBeanType;
+import jmri.jmrit.logixng.NamedBeanType;
 import jmri.jmrit.logixng.actions.ActionListenOnBeans.NamedBeanReference;
 import jmri.util.table.ButtonEditor;
 import jmri.util.table.ButtonRenderer;

--- a/java/src/jmri/jmrit/logixng/actions/swing/ActionListenOnBeansTableSwing.java
+++ b/java/src/jmri/jmrit/logixng/actions/swing/ActionListenOnBeansTableSwing.java
@@ -9,7 +9,7 @@ import javax.swing.*;
 import jmri.*;
 import jmri.jmrit.logixng.*;
 import jmri.jmrit.logixng.actions.ActionListenOnBeansTable;
-import jmri.jmrit.logixng.actions.NamedBeanType;
+import jmri.jmrit.logixng.NamedBeanType;
 import jmri.util.swing.BeanSelectPanel;
 import jmri.util.swing.JComboBoxUtil;
 

--- a/java/src/jmri/jmrit/logixng/actions/swing/ListenOnBeansTableModel.java
+++ b/java/src/jmri/jmrit/logixng/actions/swing/ListenOnBeansTableModel.java
@@ -12,7 +12,7 @@ import javax.swing.table.TableCellEditor;
 
 import jmri.Manager;
 import jmri.NamedBean;
-import jmri.jmrit.logixng.actions.NamedBeanType;
+import jmri.jmrit.logixng.NamedBeanType;
 import jmri.jmrit.logixng.actions.ActionListenOnBeans.NamedBeanReference;
 import jmri.swing.NamedBeanComboBox;
 import jmri.util.swing.JComboBoxUtil;

--- a/java/test/jmri/jmrit/logixng/CreateLogixNGTreeScaffold.java
+++ b/java/test/jmri/jmrit/logixng/CreateLogixNGTreeScaffold.java
@@ -5715,7 +5715,7 @@ public class CreateLogixNGTreeScaffold {
     private static final PrimitiveIterator.OfInt iterator =
             JUnitUtil.getRandomConstantSeed().ints('a', 'z'+10).iterator();
 
-    private static String getRandomString(int count) {
+    public static String getRandomString(int count) {
         StringBuilder s = new StringBuilder();
         for (int i=0; i < count; i++) {
             int r = iterator.nextInt();

--- a/java/test/jmri/jmrit/logixng/NamedBeanTypeTest.java
+++ b/java/test/jmri/jmrit/logixng/NamedBeanTypeTest.java
@@ -82,25 +82,25 @@ public class NamedBeanTypeTest {
             }
             Assert.assertNotNull("Manager: "+rootManagerClass.getName(), namedBean);
 
-            NamedBean beanBySystemName =  instanceManagerManager.getBySystemName(namedBeanName);
-            NamedBean beanByUserName =  instanceManagerManager.getByUserName(namedBeanUserName);
-
-            Assert.assertNotNull("Manager: "+rootManagerClass.getName(), beanBySystemName);
-            Assert.assertNotNull("Manager: "+rootManagerClass.getName(), beanByUserName);
-
             try {
-                Assert.assertNotNull(namedBeanType.name()+": "+namedBeanName, namedBeanType.getManager().getBySystemName(namedBeanName));
+                Assert.assertNotNull(namedBeanType.getManager().getBySystemName(namedBeanName));
                 Assert.assertNotNull(namedBeanType.getManager().getByUserName(namedBeanUserName));
+                Assert.assertNotNull(instanceManagerManager.getBySystemName(namedBeanName));
+                Assert.assertNotNull(instanceManagerManager.getByUserName(namedBeanUserName));
 
 //                deleteBean.deleteBean(namedBean, "CanDelete");
 
                 Assert.assertNotNull(namedBeanType.getManager().getBySystemName(namedBeanName));
                 Assert.assertNotNull(namedBeanType.getManager().getByUserName(namedBeanUserName));
+                Assert.assertNotNull(instanceManagerManager.getBySystemName(namedBeanName));
+                Assert.assertNotNull(instanceManagerManager.getByUserName(namedBeanUserName));
 
                 deleteBean.deleteBean(namedBean, "DoDelete");
 
                 Assert.assertNull(namedBeanType.getManager().getBySystemName(namedBeanName));
                 Assert.assertNull(namedBeanType.getManager().getByUserName(namedBeanUserName));
+                Assert.assertNull(instanceManagerManager.getBySystemName(namedBeanName));
+                Assert.assertNull(instanceManagerManager.getByUserName(namedBeanUserName));
             } catch (PropertyVetoException e) {
                 Assert.fail("No exception expected: "+e.toString()+", "+namedBeanType.getManager().getClass().getName());
             }

--- a/java/test/jmri/jmrit/logixng/NamedBeanTypeTest.java
+++ b/java/test/jmri/jmrit/logixng/NamedBeanTypeTest.java
@@ -85,14 +85,8 @@ public class NamedBeanTypeTest {
             NamedBean beanBySystemName =  instanceManagerManager.getBySystemName(namedBeanName);
             NamedBean beanByUserName =  instanceManagerManager.getByUserName(namedBeanUserName);
 
-            // REMOVE THIS!!!
-            if (jmri.BlockManager.class.equals(rootManagerClass)
-                    || jmri.MemoryManager.class.equals(rootManagerClass)
-                    || jmri.jmrit.logix.OBlockManager.class.equals(rootManagerClass)) return;
-
-//            Assert.assertNotNull("Manager: "+rootManagerClass.getName(), beanBySystemName);
-//            Assert.assertNotNull("Manager: "+rootManagerClass.getName(), beanByUserName);
-
+            Assert.assertNotNull("Manager: "+rootManagerClass.getName(), beanBySystemName);
+            Assert.assertNotNull("Manager: "+rootManagerClass.getName(), beanByUserName);
 
             try {
                 Assert.assertNotNull(namedBeanType.name()+": "+namedBeanName, namedBeanType.getManager().getBySystemName(namedBeanName));
@@ -153,8 +147,6 @@ public class NamedBeanTypeTest {
             testNamedBeanType(namedBeanType, rootManagerClass);
         }
 
-        // REMOVE THIS!!!
-        if (1==1) return;
 
         // Ensure we have cleared everything
         setUp();

--- a/java/test/jmri/jmrit/logixng/NamedBeanTypeTest.java
+++ b/java/test/jmri/jmrit/logixng/NamedBeanTypeTest.java
@@ -71,10 +71,6 @@ public class NamedBeanTypeTest {
 
             NamedBean namedBean;
             if (jmri.jmrit.logixng.GlobalVariable.class.isAssignableFrom(namedBeanType.getClazz())) {
-
-                // REMOVE THIS!!!
-                if (1==1) return;
-
                 String sysName = InstanceManager.getDefault(GlobalVariableManager.class).getAutoSystemName();
                 System.out.format("Sys: %s, user: %s%n", sysName, namedBeanName);
                 namedBean = namedBeanType.getCreateBean().createBean(sysName,namedBeanName);
@@ -99,7 +95,7 @@ public class NamedBeanTypeTest {
 
 
             try {
-                Assert.assertNotNull(namedBeanName, namedBeanType.getManager().getBySystemName(namedBeanName));
+                Assert.assertNotNull(namedBeanType.name()+": "+namedBeanName, namedBeanType.getManager().getBySystemName(namedBeanName));
                 Assert.assertNotNull(namedBeanType.getManager().getByUserName(namedBeanUserName));
 
 //                deleteBean.deleteBean(namedBean, "CanDelete");

--- a/java/test/jmri/jmrit/logixng/NamedBeanTypeTest.java
+++ b/java/test/jmri/jmrit/logixng/NamedBeanTypeTest.java
@@ -5,7 +5,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import jmri.*;
-import jmri.jmrit.logixng.actions.NamedBeanType;
 import jmri.util.JUnitUtil;
 
 import org.junit.*;

--- a/java/test/jmri/jmrit/logixng/NamedBeanTypeTest.java
+++ b/java/test/jmri/jmrit/logixng/NamedBeanTypeTest.java
@@ -54,6 +54,7 @@ public class NamedBeanTypeTest {
         return superManagerClass;
     }
 
+    @SuppressWarnings("unchecked")  // Unchecked cast due to type erasure
     private void testNamedBeanType(NamedBeanType namedBeanType, Class<?> rootManagerClass) {
 
         Manager<? extends NamedBean> instanceManagerManager =
@@ -110,6 +111,7 @@ public class NamedBeanTypeTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")  // Static analysis complains despite checked by Assert
     public void testNamedBeanType() {
         Map<NamedBeanType, Class<?>> rootManagerClassMap = new HashMap<>();
 

--- a/java/test/jmri/jmrit/logixng/NamedBeanTypeTest.java
+++ b/java/test/jmri/jmrit/logixng/NamedBeanTypeTest.java
@@ -1,0 +1,203 @@
+package jmri.jmrit.logixng;
+
+import java.beans.PropertyVetoException;
+import java.util.HashMap;
+import java.util.Map;
+
+import jmri.*;
+import jmri.jmrit.logixng.actions.NamedBeanType;
+import jmri.util.JUnitUtil;
+
+import org.junit.*;
+
+/**
+ * Test NamedBeanType.
+ *
+ * @author Daniel Bergqvist (C) 2024
+ */
+public class NamedBeanTypeTest {
+
+    // Find an interface that's a manager for this manager class
+    private Class<?> getSuperManager(Class<?> managerClass) {
+        Map<Integer, Class<?>> classMap = new HashMap<>();
+        Class<?>[] interfaces = managerClass.getInterfaces();
+        for (Class<?> c : interfaces) {
+            if (Manager.class.equals(c)) continue;
+            if (ProvidingManager.class.equals(c)) continue;
+//            System.out.format("%s, %d%n", c.getName(), c.getInterfaces().length);
+            if (Manager.class.isAssignableFrom(c)) {
+                classMap.put(c.getInterfaces().length, c);
+            }
+        }
+        for (int i=0; i < 100; i++) {
+            if (classMap.containsKey(i)) {
+                return classMap.get(i);
+            }
+        }
+        return null;
+    }
+
+    // Find the root manager class for this manager, for example
+    // jmri.SensorManager for jmri.managers.ProxySensorManager
+    private Class<?> getRootManagerClass(Manager<? extends NamedBean> manager) {
+        Class<?> managerClass = manager.getClass();
+        Class<?> superManagerClass = getSuperManager(managerClass);
+        if (superManagerClass == null && managerClass.getSuperclass() != null) {
+            managerClass = managerClass.getSuperclass();
+            superManagerClass = getSuperManager(managerClass);
+        }
+
+        if (superManagerClass == null) {
+            superManagerClass = manager.getClass();
+        }
+
+        return superManagerClass;
+    }
+
+    private void testNamedBeanType(NamedBeanType namedBeanType, Class<?> rootManagerClass) {
+
+        Manager<? extends NamedBean> instanceManagerManager =
+                (Manager<? extends NamedBean>)InstanceManager.getDefault(rootManagerClass);
+
+        NamedBeanType.CreateBean createBean = namedBeanType.getCreateBean();
+        NamedBeanType.DeleteBean deleteBean = namedBeanType.getDeleteBean();
+
+        if (createBean != null) {
+            String namedBeanName = namedBeanType.getManager()
+                    .getSystemNamePrefix()
+                    + CreateLogixNGTreeScaffold.getRandomString(20);
+
+            String namedBeanUserName = "UserName: " + CreateLogixNGTreeScaffold.getRandomString(20);
+
+            NamedBean namedBean;
+            if (jmri.jmrit.logixng.GlobalVariable.class.isAssignableFrom(namedBeanType.getClazz())) {
+
+                // REMOVE THIS!!!
+                if (1==1) return;
+
+                String sysName = InstanceManager.getDefault(GlobalVariableManager.class).getAutoSystemName();
+                System.out.format("Sys: %s, user: %s%n", sysName, namedBeanName);
+                namedBean = namedBeanType.getCreateBean().createBean(sysName,namedBeanName);
+                namedBeanUserName = namedBeanName;
+                namedBeanName = sysName;
+                System.out.format("Sys: %s, user: %s, bean: %s%n", sysName, namedBeanUserName, namedBean);
+             } else {
+                namedBean = createBean.createBean(namedBeanName, namedBeanUserName);
+            }
+            Assert.assertNotNull("Manager: "+rootManagerClass.getName(), namedBean);
+
+            NamedBean beanBySystemName =  instanceManagerManager.getBySystemName(namedBeanName);
+            NamedBean beanByUserName =  instanceManagerManager.getByUserName(namedBeanUserName);
+
+            // REMOVE THIS!!!
+            if (jmri.BlockManager.class.equals(rootManagerClass)
+                    || jmri.MemoryManager.class.equals(rootManagerClass)
+                    || jmri.jmrit.logix.OBlockManager.class.equals(rootManagerClass)) return;
+
+//            Assert.assertNotNull("Manager: "+rootManagerClass.getName(), beanBySystemName);
+//            Assert.assertNotNull("Manager: "+rootManagerClass.getName(), beanByUserName);
+
+
+            try {
+                Assert.assertNotNull(namedBeanName, namedBeanType.getManager().getBySystemName(namedBeanName));
+                Assert.assertNotNull(namedBeanType.getManager().getByUserName(namedBeanUserName));
+
+//                deleteBean.deleteBean(namedBean, "CanDelete");
+
+                Assert.assertNotNull(namedBeanType.getManager().getBySystemName(namedBeanName));
+                Assert.assertNotNull(namedBeanType.getManager().getByUserName(namedBeanUserName));
+
+                deleteBean.deleteBean(namedBean, "DoDelete");
+
+                Assert.assertNull(namedBeanType.getManager().getBySystemName(namedBeanName));
+                Assert.assertNull(namedBeanType.getManager().getByUserName(namedBeanUserName));
+            } catch (PropertyVetoException e) {
+                Assert.fail("No exception expected: "+e.toString()+", "+namedBeanType.getManager().getClass().getName());
+            }
+        }
+
+
+    }
+
+    @Test
+    public void testNamedBeanType() {
+        Map<NamedBeanType, Class<?>> rootManagerClassMap = new HashMap<>();
+
+        Map<NamedBeanType, Manager<? extends NamedBean>> map = new HashMap<>();
+
+        Map<NamedBeanType, Manager<? extends NamedBean>> instanceManagerManagerMap = new HashMap<>();
+
+
+        // Ensure we have cleared everything
+        setUp();
+        setUp();
+        for (NamedBeanType namedBeanType : NamedBeanType.values()) {
+            map.put(namedBeanType, namedBeanType.getManager());
+
+//            Manager<? extends NamedBean> manager = namedBeanType.getManager();
+
+            Class<?> rootManagerClass = getRootManagerClass(namedBeanType.getManager());
+            Assert.assertNotNull(rootManagerClass);
+
+            rootManagerClassMap.put(namedBeanType, rootManagerClass);
+
+            System.out.format("Type: %s, Manager: %s, Super manager: %s%n",
+                    namedBeanType.name(),
+                    namedBeanType.getManager(),
+                    rootManagerClass.getName());
+
+            Object instanceManagerManagerObj = InstanceManager.getDefault(rootManagerClass);
+            Assert.assertNotNull(instanceManagerManagerObj);
+            Assert.assertTrue(instanceManagerManagerObj instanceof Manager);
+            Manager<? extends NamedBean> instanceManagerManager = (Manager<? extends NamedBean>) instanceManagerManagerObj;
+            instanceManagerManagerMap.put(namedBeanType, instanceManagerManager);
+
+            Assert.assertEquals(instanceManagerManager, namedBeanType.getManager());
+
+            testNamedBeanType(namedBeanType, rootManagerClass);
+        }
+
+        // REMOVE THIS!!!
+        if (1==1) return;
+
+        // Ensure we have cleared everything
+        setUp();
+        setUp();
+
+        for (NamedBeanType namedBeanType : NamedBeanType.values()) {
+//            if (!NamedBeanType.Memory.equals(namedBeanType)) continue;
+
+//            System.out.println();
+
+//            NamedBean namedBean = InstanceManager.getDefault(namedBeanType.);
+
+
+            Manager<? extends NamedBean> instanceManagerManager =
+                    instanceManagerManagerMap.get(namedBeanType);
+
+            Assert.assertNotEquals(instanceManagerManager, namedBeanType.getManager());
+
+            testNamedBeanType(namedBeanType, rootManagerClassMap.get(namedBeanType));
+        }
+    }
+
+    // The minimal setup for log4J
+    @Before
+    public void setUp() {
+        JUnitUtil.setUp();
+        JUnitUtil.resetInstanceManager();
+        JUnitUtil.resetProfileManager();
+        JUnitUtil.initConfigureManager();
+        JUnitUtil.initInternalSensorManager();
+        JUnitUtil.initInternalTurnoutManager();
+        JUnitUtil.initLogixNGManager();
+    }
+
+    @After
+    public void tearDown() {
+        jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
+        JUnitUtil.tearDown();
+    }
+
+}

--- a/java/test/jmri/jmrit/logixng/NamedBeanTypeTest.java
+++ b/java/test/jmri/jmrit/logixng/NamedBeanTypeTest.java
@@ -124,17 +124,15 @@ public class NamedBeanTypeTest {
         for (NamedBeanType namedBeanType : NamedBeanType.values()) {
             map.put(namedBeanType, namedBeanType.getManager());
 
-//            Manager<? extends NamedBean> manager = namedBeanType.getManager();
-
             Class<?> rootManagerClass = getRootManagerClass(namedBeanType.getManager());
             Assert.assertNotNull(rootManagerClass);
 
             rootManagerClassMap.put(namedBeanType, rootManagerClass);
 
-            System.out.format("Type: %s, Manager: %s, Super manager: %s%n",
-                    namedBeanType.name(),
-                    namedBeanType.getManager(),
-                    rootManagerClass.getName());
+//            System.out.format("Type: %s, Manager: %s, Super manager: %s%n",
+//                    namedBeanType.name(),
+//                    namedBeanType.getManager(),
+//                    rootManagerClass.getName());
 
             Object instanceManagerManagerObj = InstanceManager.getDefault(rootManagerClass);
             Assert.assertNotNull(instanceManagerManagerObj);
@@ -153,13 +151,6 @@ public class NamedBeanTypeTest {
         setUp();
 
         for (NamedBeanType namedBeanType : NamedBeanType.values()) {
-//            if (!NamedBeanType.Memory.equals(namedBeanType)) continue;
-
-//            System.out.println();
-
-//            NamedBean namedBean = InstanceManager.getDefault(namedBeanType.);
-
-
             Manager<? extends NamedBean> instanceManagerManager =
                     instanceManagerManagerMap.get(namedBeanType);
 

--- a/java/test/jmri/jmrit/logixng/RecursiveModuleTest.java
+++ b/java/test/jmri/jmrit/logixng/RecursiveModuleTest.java
@@ -11,7 +11,6 @@ import jmri.jmrit.logixng.actions.DigitalMany;
 import jmri.jmrit.logixng.Module.ReturnValueType;
 import jmri.jmrit.logixng.SymbolTable.InitialValueType;
 import jmri.jmrit.logixng.actions.ActionListenOnBeans.NamedBeanReference;
-import jmri.jmrit.logixng.actions.NamedBeanType;
 import jmri.jmrit.logixng.expressions.ExpressionLocalVariable;
 import jmri.jmrit.logixng.implementation.DefaultConditionalNGScaffold;
 import jmri.util.JUnitUtil;

--- a/java/test/jmri/jmrit/logixng/actions/WebRequestTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/WebRequestTest.java
@@ -1,5 +1,7 @@
 package jmri.jmrit.logixng.actions;
 
+import jmri.jmrit.logixng.NamedBeanType;
+
 import java.io.*;
 import java.net.*;
 import java.nio.charset.StandardCharsets;
@@ -580,7 +582,7 @@ public class WebRequestTest extends AbstractDigitalActionTestBase {
         JUnitUtil.initInternalSensorManager();
         JUnitUtil.initInternalLightManager();
         JUnitUtil.initLogixNGManager();
-        jmri.jmrit.logixng.actions.NamedBeanType.reset();
+        jmri.jmrit.logixng.NamedBeanType.reset();
 
         _category = Category.ITEM;
         _isExternal = true;

--- a/java/test/jmri/util/JUnitUtil.java
+++ b/java/test/jmri/util/JUnitUtil.java
@@ -997,7 +997,7 @@ public class JUnitUtil {
         }
         InstanceManager.setDefault(StringExpressionManager.class, m9);
 
-        jmri.jmrit.logixng.actions.NamedBeanType.reset();
+        jmri.jmrit.logixng.NamedBeanType.reset();
         jmri.jmrit.logixng.actions.CommonManager.reset();
 
         if (activate) m1.activateAllLogixNGs(false, false);


### PR DESCRIPTION
This PR fixes some bugs in `NamedBeanType` that only occurs during testing. It failed when the InstanceManager was replaced.

Most of the changes in this PR is because I have moved `jmri.jmrit.logixng.actions.NamedBeanType` to package `jmri.jmrit.logixng`.