### PR TITLE
Limit CI output - Only print failing tests, not successful tests

### DIFF
--- a/.github/workflows/headless-test.yml
+++ b/.github/workflows/headless-test.yml
@@ -25,4 +25,4 @@ jobs:
     - name: Run HeadLessTest with Maven
       run: |
         # run tests using maven with graphics suppressed
-        mvn test "-Djmri.skipTestsRequiringSeparateRunning=true"  "-Djava.awt.headless=true"
+        mvn test "-Djmri.skipTestsRequiringSeparateRunning=true"  "-Djava.awt.headless=true" "-Dsurefire.printSummary=false"

--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Test with Maven
       run: |
         # run all tests using maven
-        mvn test "-Djmri.skipTestsRequiringSeparateRunning=true"
+        mvn test "-Djmri.skipTestsRequiringSeparateRunning=true" "-Dsurefire.printSummary=false"
     - name: Upload generated screenshots artifact
       uses: actions/upload-artifact@v3
       if: ${{ always() }}

--- a/java/test/jmri/jmrit/beantable/AudioTablePanelTest.java
+++ b/java/test/jmri/jmrit/beantable/AudioTablePanelTest.java
@@ -1,5 +1,6 @@
 package jmri.jmrit.beantable;
 
+import jmri.util.JUnitAppender;
 import jmri.util.JUnitUtil;
 
 import org.junit.jupiter.api.*;
@@ -13,20 +14,20 @@ public class AudioTablePanelTest {
 
     @Test
     public void testCTor() {
-        // The Table Data Models required to create an AudioTablePanel are 
+        // The Table Data Models required to create an AudioTablePanel are
         // internal classes in the AudioTableAction.
         AudioTableAction a = new AudioTableAction();
-        // the getPanel() method of the AudioTableAction calls the 
+        // the getPanel() method of the AudioTableAction calls the
         // constructor for AudioTablePanel. We need to seperate the
         // Table Data Model objects from the AudioTableAction to be
-        // able to create this directly. 
+        // able to create this directly.
         AudioTablePanel t = (AudioTablePanel) a.getPanel();
         Assert.assertNotNull("exists",t);
     }
 
     @BeforeEach
     public void setUp() {
-        JUnitUtil.setUp();        
+        JUnitUtil.setUp();
         JUnitUtil.initDefaultUserMessagePreferences();
     }
 
@@ -34,6 +35,8 @@ public class AudioTablePanelTest {
     public void tearDown() {
         // this created an audio manager, clean that up
         jmri.InstanceManager.getDefault(jmri.AudioManager.class).cleanup();
+        JUnitAppender.suppressWarnMessage("Error initialising JOAL");
+        JUnitAppender.suppressWarnMessage("Error loading OpenAL libraries: Could not initialize class jogamp.openal.ALImpl");
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/jython/SampleScriptTest.java
+++ b/java/test/jmri/jmrit/jython/SampleScriptTest.java
@@ -166,7 +166,7 @@ public class SampleScriptTest {
         // include a comprehensive set here.
         JUnitUtil.resetInstanceManager();
         JUnitUtil.resetProfileManager( new jmri.profile.NullProfile( tempDir.toFile()));
-        
+
         JUnitUtil.initConfigureManager();
         JUnitUtil.initDefaultUserMessagePreferences();
         JUnitUtil.initDebugPowerManager();
@@ -183,6 +183,7 @@ public class SampleScriptTest {
 
         JUnitUtil.resetWindows(false, false);
         JUnitUtil.deregisterBlockManagerShutdownTask();
+        JUnitAppender.suppressWarnMessageStartsWith("Turnout state file "); // Turnout state file '/tmp/junit15888088443980290405/TurnoutState.csv' does not exist
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/NamedBeanTypeTest.java
+++ b/java/test/jmri/jmrit/logixng/NamedBeanTypeTest.java
@@ -67,19 +67,13 @@ public class NamedBeanTypeTest {
                     .getSystemNamePrefix()
                     + CreateLogixNGTreeScaffold.getRandomString(20);
 
-            String namedBeanUserName = "UserName: " + CreateLogixNGTreeScaffold.getRandomString(20);
+            String namedBeanUserName = "UserName_" + CreateLogixNGTreeScaffold.getRandomString(20);
 
             NamedBean namedBean;
             if (jmri.jmrit.logixng.GlobalVariable.class.isAssignableFrom(namedBeanType.getClazz())) {
-                String sysName = InstanceManager.getDefault(GlobalVariableManager.class).getAutoSystemName();
-                System.out.format("Sys: %s, user: %s%n", sysName, namedBeanName);
-                namedBean = namedBeanType.getCreateBean().createBean(sysName,namedBeanName);
-                namedBeanUserName = namedBeanName;
-                namedBeanName = sysName;
-                System.out.format("Sys: %s, user: %s, bean: %s%n", sysName, namedBeanUserName, namedBean);
-             } else {
-                namedBean = createBean.createBean(namedBeanName, namedBeanUserName);
+                namedBeanName = InstanceManager.getDefault(GlobalVariableManager.class).getAutoSystemName();
             }
+            namedBean = createBean.createBean(namedBeanName, namedBeanUserName);
             Assert.assertNotNull("Manager: "+rootManagerClass.getName(), namedBean);
 
             try {

--- a/java/test/jmri/jmrit/logixng/actions/WebRequestTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/WebRequestTest.java
@@ -601,6 +601,7 @@ public class WebRequestTest extends AbstractDigitalActionTestBase {
     public void tearDown() {
         JUnitUtil.deregisterBlockManagerShutdownTask();
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitAppender.suppressWarnMessage("loading of HID System failed");
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/WebRequestTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/WebRequestTest.java
@@ -19,11 +19,7 @@ import jmri.jmrit.logixng.util.LineEnding;
 import jmri.jmrit.logixng.util.parser.ParserException;
 import jmri.util.*;
 
-import org.junit.After;
-import org.junit.Assume;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.*;
 
 /**
  * Test WebRequest
@@ -208,16 +204,16 @@ public class WebRequestTest extends AbstractDigitalActionTestBase {
         torontoFirst.setState(Turnout.THROWN);
         Assert.assertEquals(200, (int)_responseCodeVariable.getValue());
         Assert.assertEquals("Turnout TorontoFirst is thrown", _replyVariable.getValue());
-/*
-        JUnitAppender.assertWarnMessageStartsWith("Log local variables:");
-        JUnitAppender.assertWarnMessageStartsWith("Name: turnout, Value: TorontoFirst");
-        JUnitAppender.assertWarnMessageStartsWith("Name: bean, Value: IT3");
-        JUnitAppender.assertWarnMessageStartsWith("Global variables:");
-        JUnitAppender.assertWarnMessageStartsWith("Global Name: responseCode, value: 200");
-        JUnitAppender.assertWarnMessageStartsWith("Global Name: reply, value: Turnout TorontoFirst is thrown");
-        JUnitAppender.assertWarnMessageStartsWith("Global Name: cookies, value: null");
-        JUnitAppender.assertWarnMessageStartsWith("Log local variables done");
-*/
+
+        // Suppress instead of assert these messages since they will not be there if the JMRI web server is down
+        JUnitAppender.suppressWarnMessageStartsWith("Log local variables:");
+        JUnitAppender.suppressWarnMessageStartsWith("Name: turnout, Value: TorontoFirst");
+        JUnitAppender.suppressWarnMessageStartsWith("Name: bean, Value: IT3");
+        JUnitAppender.suppressWarnMessageStartsWith("Global variables:");
+        JUnitAppender.suppressWarnMessageStartsWith("Global Name: responseCode, value: 200");
+        JUnitAppender.suppressWarnMessageStartsWith("Global Name: reply, value: Turnout TorontoFirst is thrown");
+        JUnitAppender.suppressWarnMessageStartsWith("Global Name: cookies, value: null");
+        JUnitAppender.suppressWarnMessageStartsWith("Log local variables done");
     }
 
     private void setupThrowTurnoutsConditionalNG() throws SocketAlreadyConnectedException, ParserException {

--- a/java/test/jmri/jmrit/logixng/actions/WebRequestTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/WebRequestTest.java
@@ -601,7 +601,6 @@ public class WebRequestTest extends AbstractDigitalActionTestBase {
     public void tearDown() {
         JUnitUtil.deregisterBlockManagerShutdownTask();
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
-        JUnitAppender.suppressWarnMessage("loading of HID System failed");
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/vsdecoder/Diesel3SoundTest.java
+++ b/java/test/jmri/jmrit/vsdecoder/Diesel3SoundTest.java
@@ -1,6 +1,7 @@
 package jmri.jmrit.vsdecoder;
 
 import jmri.*;
+import jmri.util.JUnitAppender;
 import jmri.util.JUnitUtil;
 
 import org.junit.Assert;
@@ -30,6 +31,7 @@ public class Diesel3SoundTest {
     public void tearDown() {
         JUnitUtil.removeMatchingThreads("VSDecoderManagerThread");
         JUnitUtil.deregisterBlockManagerShutdownTask();
+        JUnitAppender.suppressWarnMessage("Error loading OpenAL libraries: Could not initialize class jogamp.openal.ALImpl");
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrix/jinput/treecontrol/TreePanelTest.java
+++ b/java/test/jmri/jmrix/jinput/treecontrol/TreePanelTest.java
@@ -1,6 +1,7 @@
 package jmri.jmrix.jinput.treecontrol;
 
 import jmri.jmrix.jinput.TreeModel;
+import jmri.util.JUnitAppender;
 import jmri.util.JUnitUtil;
 
 import org.junit.Assert;
@@ -41,6 +42,7 @@ public class TreePanelTest {
 
     @AfterEach
     public void tearDown() {
+        JUnitAppender.suppressWarnMessage("loading of HID System failed");
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrix/jinput/treecontrol/TreePanelTest.java
+++ b/java/test/jmri/jmrix/jinput/treecontrol/TreePanelTest.java
@@ -42,6 +42,7 @@ public class TreePanelTest {
 
     @AfterEach
     public void tearDown() {
+        JUnitAppender.suppressWarnMessage("unable to show help page package.jmri.jmrix.jinput.treemodel.TreeFrame due to:");
         JUnitAppender.suppressWarnMessage("loading of HID System failed");
         JUnitUtil.tearDown();
     }

--- a/java/test/jmri/jmrix/loconet/LocoNetSlotTest.java
+++ b/java/test/jmri/jmrix/loconet/LocoNetSlotTest.java
@@ -1,6 +1,7 @@
 package jmri.jmrix.loconet;
 
 import jmri.jmrix.loconet.SlotMapEntry.SlotType;
+import jmri.util.JUnitAppender;
 import jmri.util.JUnitUtil;
 
 import org.junit.Assert;
@@ -36,6 +37,7 @@ public class LocoNetSlotTest {
         LocoNetMessage lm = new LocoNetMessage(ia);
         LocoNetSlot t = new LocoNetSlot(new LocoNetMessage(lm));
         Assert.assertNotNull("exists", t);
+        JUnitAppender.assertWarnMessage("Slot [1] not in map but reports loco, check command station type");
     }
 
     @Test
@@ -297,6 +299,7 @@ public class LocoNetSlotTest {
         LocoNetMessage lm = new LocoNetMessage(ia);
         LocoNetSlot t = new LocoNetSlot(new LocoNetMessage(lm));
         Assert.assertEquals("decoder type", LnConstants.DEC_MODE_128, t.decoderType());
+        JUnitAppender.assertWarnMessage("Slot [1] not in map but reports loco, check command station type");
     }
 
     @Test
@@ -306,6 +309,7 @@ public class LocoNetSlotTest {
         LocoNetMessage lm = new LocoNetMessage(ia);
         LocoNetSlot t = new LocoNetSlot(new LocoNetMessage(lm));
         Assert.assertEquals("Slot Status", LnConstants.LOCO_IN_USE, t.slotStatus());
+        JUnitAppender.assertWarnMessage("Slot [1] not in map but reports loco, check command station type");
     }
 
     @Test
@@ -315,6 +319,7 @@ public class LocoNetSlotTest {
         LocoNetMessage lm = new LocoNetMessage(ia);
         LocoNetSlot t = new LocoNetSlot(new LocoNetMessage(lm));
         Assert.assertEquals("Slot Status", 0x00, t.ss2());
+        JUnitAppender.assertWarnMessage("Slot [1] not in map but reports loco, check command station type");
     }
 
     @Test
@@ -324,6 +329,7 @@ public class LocoNetSlotTest {
         LocoNetMessage lm = new LocoNetMessage(ia);
         LocoNetSlot t = new LocoNetSlot(new LocoNetMessage(lm));
         Assert.assertEquals("Consist Status", LnConstants.CONSIST_NO, t.consistStatus());
+        JUnitAppender.assertWarnMessage("Slot [1] not in map but reports loco, check command station type");
     }
 
     @Test
@@ -333,6 +339,7 @@ public class LocoNetSlotTest {
         LocoNetMessage lm = new LocoNetMessage(ia);
         LocoNetSlot t = new LocoNetSlot(new LocoNetMessage(lm));
         Assert.assertTrue("is Forward", t.isForward());
+        JUnitAppender.assertWarnMessage("Slot [1] not in map but reports loco, check command station type");
     }
 
     @Test
@@ -342,6 +349,7 @@ public class LocoNetSlotTest {
         LocoNetMessage lm = new LocoNetMessage(ia);
         LocoNetSlot t = new LocoNetSlot(new LocoNetMessage(lm));
         Assert.assertFalse("is F0", t.isF0());
+        JUnitAppender.assertWarnMessage("Slot [1] not in map but reports loco, check command station type");
     }
 
     @Test
@@ -351,6 +359,7 @@ public class LocoNetSlotTest {
         LocoNetMessage lm = new LocoNetMessage(ia);
         LocoNetSlot t = new LocoNetSlot(new LocoNetMessage(lm));
         Assert.assertFalse("is F1", t.isF1());
+        JUnitAppender.assertWarnMessage("Slot [1] not in map but reports loco, check command station type");
     }
 
     @Test
@@ -360,6 +369,7 @@ public class LocoNetSlotTest {
         LocoNetMessage lm = new LocoNetMessage(ia);
         LocoNetSlot t = new LocoNetSlot(new LocoNetMessage(lm));
         Assert.assertFalse("is F2", t.isF2());
+        JUnitAppender.assertWarnMessage("Slot [1] not in map but reports loco, check command station type");
     }
 
     @Test
@@ -369,6 +379,7 @@ public class LocoNetSlotTest {
         LocoNetMessage lm = new LocoNetMessage(ia);
         LocoNetSlot t = new LocoNetSlot(new LocoNetMessage(lm));
         Assert.assertFalse("is F3", t.isF3());
+        JUnitAppender.assertWarnMessage("Slot [1] not in map but reports loco, check command station type");
     }
 
     @Test
@@ -378,6 +389,7 @@ public class LocoNetSlotTest {
         LocoNetMessage lm = new LocoNetMessage(ia);
         LocoNetSlot t = new LocoNetSlot(new LocoNetMessage(lm));
         Assert.assertFalse("is F4", t.isF4());
+        JUnitAppender.assertWarnMessage("Slot [1] not in map but reports loco, check command station type");
     }
 
     @Test
@@ -387,6 +399,7 @@ public class LocoNetSlotTest {
         LocoNetMessage lm = new LocoNetMessage(ia);
         LocoNetSlot t = new LocoNetSlot(new LocoNetMessage(lm));
         Assert.assertFalse("is F5", t.isF5());
+        JUnitAppender.assertWarnMessage("Slot [1] not in map but reports loco, check command station type");
     }
 
     @Test
@@ -396,6 +409,7 @@ public class LocoNetSlotTest {
         LocoNetMessage lm = new LocoNetMessage(ia);
         LocoNetSlot t = new LocoNetSlot(new LocoNetMessage(lm));
         Assert.assertFalse("is F6", t.isF6());
+        JUnitAppender.assertWarnMessage("Slot [1] not in map but reports loco, check command station type");
     }
 
     @Test
@@ -405,6 +419,7 @@ public class LocoNetSlotTest {
         LocoNetMessage lm = new LocoNetMessage(ia);
         LocoNetSlot t = new LocoNetSlot(new LocoNetMessage(lm));
         Assert.assertFalse("is F7", t.isF7());
+        JUnitAppender.assertWarnMessage("Slot [1] not in map but reports loco, check command station type");
     }
 
     @Test
@@ -414,6 +429,7 @@ public class LocoNetSlotTest {
         LocoNetMessage lm = new LocoNetMessage(ia);
         LocoNetSlot t = new LocoNetSlot(new LocoNetMessage(lm));
         Assert.assertFalse("is F8", t.isF8());
+        JUnitAppender.assertWarnMessage("Slot [1] not in map but reports loco, check command station type");
     }
 
     @Test
@@ -423,6 +439,7 @@ public class LocoNetSlotTest {
         LocoNetMessage lm = new LocoNetMessage(ia);
         LocoNetSlot t = new LocoNetSlot(new LocoNetMessage(lm));
         Assert.assertFalse("is F9", t.isF9());
+        JUnitAppender.assertWarnMessage("Slot [1] not in map but reports loco, check command station type");
     }
 
     @Test
@@ -432,6 +449,7 @@ public class LocoNetSlotTest {
         LocoNetMessage lm = new LocoNetMessage(ia);
         LocoNetSlot t = new LocoNetSlot(new LocoNetMessage(lm));
         Assert.assertFalse("is F10", t.isF10());
+        JUnitAppender.assertWarnMessage("Slot [1] not in map but reports loco, check command station type");
     }
 
     @Test
@@ -441,6 +459,7 @@ public class LocoNetSlotTest {
         LocoNetMessage lm = new LocoNetMessage(ia);
         LocoNetSlot t = new LocoNetSlot(new LocoNetMessage(lm));
         Assert.assertFalse("is F11", t.isF11());
+        JUnitAppender.assertWarnMessage("Slot [1] not in map but reports loco, check command station type");
     }
 
     @Test
@@ -450,6 +469,7 @@ public class LocoNetSlotTest {
         LocoNetMessage lm = new LocoNetMessage(ia);
         LocoNetSlot t = new LocoNetSlot(new LocoNetMessage(lm));
         Assert.assertFalse("is F12", t.isF12());
+        JUnitAppender.assertWarnMessage("Slot [1] not in map but reports loco, check command station type");
     }
 
     @Test
@@ -459,6 +479,7 @@ public class LocoNetSlotTest {
         LocoNetMessage lm = new LocoNetMessage(ia);
         LocoNetSlot t = new LocoNetSlot(new LocoNetMessage(lm));
         Assert.assertFalse("is F13", t.isF13());
+        JUnitAppender.assertWarnMessage("Slot [1] not in map but reports loco, check command station type");
     }
 
     @Test
@@ -468,6 +489,7 @@ public class LocoNetSlotTest {
         LocoNetMessage lm = new LocoNetMessage(ia);
         LocoNetSlot t = new LocoNetSlot(new LocoNetMessage(lm));
         Assert.assertFalse("is F14", t.isF14());
+        JUnitAppender.assertWarnMessage("Slot [1] not in map but reports loco, check command station type");
     }
 
     @Test
@@ -477,6 +499,7 @@ public class LocoNetSlotTest {
         LocoNetMessage lm = new LocoNetMessage(ia);
         LocoNetSlot t = new LocoNetSlot(new LocoNetMessage(lm));
         Assert.assertFalse("is F15", t.isF15());
+        JUnitAppender.assertWarnMessage("Slot [1] not in map but reports loco, check command station type");
     }
 
     @Test
@@ -486,6 +509,7 @@ public class LocoNetSlotTest {
         LocoNetMessage lm = new LocoNetMessage(ia);
         LocoNetSlot t = new LocoNetSlot(new LocoNetMessage(lm));
         Assert.assertFalse("is F16", t.isF16());
+        JUnitAppender.assertWarnMessage("Slot [1] not in map but reports loco, check command station type");
     }
 
     @Test
@@ -495,6 +519,7 @@ public class LocoNetSlotTest {
         LocoNetMessage lm = new LocoNetMessage(ia);
         LocoNetSlot t = new LocoNetSlot(new LocoNetMessage(lm));
         Assert.assertFalse("is F17", t.isF17());
+        JUnitAppender.assertWarnMessage("Slot [1] not in map but reports loco, check command station type");
     }
 
     @Test
@@ -504,6 +529,7 @@ public class LocoNetSlotTest {
         LocoNetMessage lm = new LocoNetMessage(ia);
         LocoNetSlot t = new LocoNetSlot(new LocoNetMessage(lm));
         Assert.assertFalse("is F18", t.isF18());
+        JUnitAppender.assertWarnMessage("Slot [1] not in map but reports loco, check command station type");
     }
 
     @Test
@@ -513,6 +539,7 @@ public class LocoNetSlotTest {
         LocoNetMessage lm = new LocoNetMessage(ia);
         LocoNetSlot t = new LocoNetSlot(new LocoNetMessage(lm));
         Assert.assertFalse("is F19", t.isF19());
+        JUnitAppender.assertWarnMessage("Slot [1] not in map but reports loco, check command station type");
     }
 
     @Test
@@ -522,6 +549,7 @@ public class LocoNetSlotTest {
         LocoNetMessage lm = new LocoNetMessage(ia);
         LocoNetSlot t = new LocoNetSlot(new LocoNetMessage(lm));
         Assert.assertFalse("is F20", t.isF20());
+        JUnitAppender.assertWarnMessage("Slot [1] not in map but reports loco, check command station type");
     }
 
     @Test
@@ -531,6 +559,7 @@ public class LocoNetSlotTest {
         LocoNetMessage lm = new LocoNetMessage(ia);
         LocoNetSlot t = new LocoNetSlot(new LocoNetMessage(lm));
         Assert.assertFalse("is F21", t.isF21());
+        JUnitAppender.assertWarnMessage("Slot [1] not in map but reports loco, check command station type");
     }
 
     @Test
@@ -540,6 +569,7 @@ public class LocoNetSlotTest {
         LocoNetMessage lm = new LocoNetMessage(ia);
         LocoNetSlot t = new LocoNetSlot(new LocoNetMessage(lm));
         Assert.assertFalse("is F22", t.isF22());
+        JUnitAppender.assertWarnMessage("Slot [1] not in map but reports loco, check command station type");
     }
 
     @Test
@@ -549,6 +579,7 @@ public class LocoNetSlotTest {
         LocoNetMessage lm = new LocoNetMessage(ia);
         LocoNetSlot t = new LocoNetSlot(new LocoNetMessage(lm));
         Assert.assertFalse("is F23", t.isF23());
+        JUnitAppender.assertWarnMessage("Slot [1] not in map but reports loco, check command station type");
     }
 
     @Test
@@ -558,6 +589,7 @@ public class LocoNetSlotTest {
         LocoNetMessage lm = new LocoNetMessage(ia);
         LocoNetSlot t = new LocoNetSlot(new LocoNetMessage(lm));
         Assert.assertFalse("is F24", t.isF24());
+        JUnitAppender.assertWarnMessage("Slot [1] not in map but reports loco, check command station type");
     }
 
     @Test
@@ -567,6 +599,7 @@ public class LocoNetSlotTest {
         LocoNetMessage lm = new LocoNetMessage(ia);
         LocoNetSlot t = new LocoNetSlot(new LocoNetMessage(lm));
         Assert.assertFalse("is F25", t.isF25());
+        JUnitAppender.assertWarnMessage("Slot [1] not in map but reports loco, check command station type");
     }
 
     @Test
@@ -576,6 +609,7 @@ public class LocoNetSlotTest {
         LocoNetMessage lm = new LocoNetMessage(ia);
         LocoNetSlot t = new LocoNetSlot(new LocoNetMessage(lm));
         Assert.assertFalse("is F26", t.isF26());
+        JUnitAppender.assertWarnMessage("Slot [1] not in map but reports loco, check command station type");
     }
 
     @Test
@@ -585,6 +619,7 @@ public class LocoNetSlotTest {
         LocoNetMessage lm = new LocoNetMessage(ia);
         LocoNetSlot t = new LocoNetSlot(new LocoNetMessage(lm));
         Assert.assertFalse("is F27", t.isF27());
+        JUnitAppender.assertWarnMessage("Slot [1] not in map but reports loco, check command station type");
     }
 
     @Test
@@ -594,6 +629,7 @@ public class LocoNetSlotTest {
         LocoNetMessage lm = new LocoNetMessage(ia);
         LocoNetSlot t = new LocoNetSlot(new LocoNetMessage(lm));
         Assert.assertFalse("is F28", t.isF28());
+        JUnitAppender.assertWarnMessage("Slot [1] not in map but reports loco, check command station type");
     }
 
     @Test
@@ -616,6 +652,7 @@ public class LocoNetSlotTest {
         LocoNetMessage lm = new LocoNetMessage(ia);
         LocoNetSlot t = new LocoNetSlot(new LocoNetMessage(lm));
         Assert.assertEquals("address", 5544, t.locoAddr());
+        JUnitAppender.assertWarnMessage("Slot [1] not in map but reports loco, check command station type");
     }
 
     @Test
@@ -625,6 +662,7 @@ public class LocoNetSlotTest {
         LocoNetMessage lm = new LocoNetMessage(ia);
         LocoNetSlot t = new LocoNetSlot(new LocoNetMessage(lm));
         Assert.assertEquals("speed", 0, t.speed());
+        JUnitAppender.assertWarnMessage("Slot [1] not in map but reports loco, check command station type");
     }
 
     @Test
@@ -634,6 +672,7 @@ public class LocoNetSlotTest {
         LocoNetMessage lm = new LocoNetMessage(ia);
         LocoNetSlot t = new LocoNetSlot(new LocoNetMessage(lm));
         Assert.assertEquals("directions and Functions", 0x00, t.dirf());
+        JUnitAppender.assertWarnMessage("Slot [1] not in map but reports loco, check command station type");
     }
 
     @Test
@@ -643,6 +682,7 @@ public class LocoNetSlotTest {
         LocoNetMessage lm = new LocoNetMessage(ia);
         LocoNetSlot t = new LocoNetSlot(new LocoNetMessage(lm));
         Assert.assertEquals("snd", 0x00, t.snd());
+        JUnitAppender.assertWarnMessage("Slot [1] not in map but reports loco, check command station type");
     }
 
     @Test
@@ -652,6 +692,7 @@ public class LocoNetSlotTest {
         LocoNetMessage lm = new LocoNetMessage(ia);
         LocoNetSlot t = new LocoNetSlot(new LocoNetMessage(lm));
         Assert.assertEquals("ID", 0x00, t.id());
+        JUnitAppender.assertWarnMessage("Slot [1] not in map but reports loco, check command station type");
     }
 
     @Test
@@ -665,6 +706,7 @@ public class LocoNetSlotTest {
         for (int i = 1; i <= 12; i++) {
             Assert.assertEquals("Element " + i, lm.getElement(i), lm2.getElement(i));
         }
+        JUnitAppender.assertWarnMessage("Slot [1] not in map but reports loco, check command station type");
     }
 
     @Test
@@ -678,6 +720,7 @@ public class LocoNetSlotTest {
         for (int i = 1; i <= 19; i++) {
             Assert.assertEquals("Element " + i, lm.getElement(i), lm2.getElement(i));
         }
+        JUnitAppender.assertWarnMessage("Slot [128] not in map but reports loco, check command station type");
     }
 
     @Test
@@ -693,6 +736,7 @@ public class LocoNetSlotTest {
         }
         Assert.assertEquals("Element 11", 0x71, lm2.getElement(11));
         Assert.assertEquals("Element 12", 0x02, lm2.getElement(12));
+        JUnitAppender.assertWarnMessage("Slot [1] not in map but reports loco, check command station type");
     }
 
     @Test
@@ -708,6 +752,7 @@ public class LocoNetSlotTest {
         }
         Assert.assertEquals("Element 18",0x71,lm2.getElement(18));
         Assert.assertEquals("Element 19",0x02,lm2.getElement(19));
+        JUnitAppender.assertWarnMessage("Slot [130] not in map but reports loco, check command station type");
     }
 
     @Test
@@ -809,6 +854,7 @@ public class LocoNetSlotTest {
         t.setSlot(lm);
         Assert.assertEquals("Change F0, F4-F1, for consist-sub slot", 0x3F, t.dirf());
 
+        JUnitAppender.assertWarnMessage("Slot [1] not in map but reports loco, check command station type");
     }
 
     @Test
@@ -917,6 +963,7 @@ public class LocoNetSlotTest {
         t.setSlot(lm);
         Assert.assertEquals("Change F0, F4-F3, F1 for consist-sub slot", 0x22, t.dirf());
 
+        JUnitAppender.assertWarnMessage("Slot [130] not in map but reports loco, check command station type");
     }
 
     @Test

--- a/java/test/jmri/util/JUnitUtil.java
+++ b/java/test/jmri/util/JUnitUtil.java
@@ -423,7 +423,8 @@ public class JUnitUtil {
 
         // Check final status of logging in the test just completed
         JUnitAppender.end();
-        Level severity = Level.ERROR; // level at or above which we'll complain
+//        Level severity = Level.ERROR; // level at or above which we'll complain
+        Level severity = Level.WARN; // level at or above which we'll complain
         boolean unexpectedMessageSeen = JUnitAppender.unexpectedMessageSeen(severity);
         String unexpectedMessageContent = JUnitAppender.unexpectedMessageContent(severity);
         JUnitAppender.verifyNoBacklog();

--- a/java/test/jmri/util/JUnitUtil.java
+++ b/java/test/jmri/util/JUnitUtil.java
@@ -423,8 +423,7 @@ public class JUnitUtil {
 
         // Check final status of logging in the test just completed
         JUnitAppender.end();
-//        Level severity = Level.ERROR; // level at or above which we'll complain
-        Level severity = Level.WARN; // level at or above which we'll complain
+        Level severity = Level.ERROR; // level at or above which we'll complain
         boolean unexpectedMessageSeen = JUnitAppender.unexpectedMessageSeen(severity);
         String unexpectedMessageContent = JUnitAppender.unexpectedMessageContent(severity);
         JUnitAppender.verifyNoBacklog();


### PR DESCRIPTION
@bobjacobsen 
This PR, which replaces #13042, changes headless-test.yml and windows-test.yml so that only failing tests are printed.

Headless CI that succeeds:
https://github.com/danielb987/JMRI/actions/runs/8744286915/job/23996798776

Headless CI that fails (due to a deliberate failure in two of the LogixNG tests):
https://github.com/danielb987/JMRI/actions/runs/8744307738/job/23996865897