### PR TITLE
Address issue #13037 - implement Lokommander II CV114, 1115 and 116 based on firmware version

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -268,7 +268,8 @@
 
         <h4>Mistral Train Models</h4>
              <ul>
-                <li></li>
+                <li>Updated Lokommander II definitions. Implement CV114, 115 and 116 according to the firmware version. Firmware V3 : treat as binary and only support up to F8 Firmware V6 : treat as decimal and support up to F28
+</li>
              </ul>
 
         <h4>MTH</h4>

--- a/xml/decoders/TrainOMatic_Lokommander_2.xml
+++ b/xml/decoders/TrainOMatic_Lokommander_2.xml
@@ -19,6 +19,7 @@
 
   <version author="lbijlsma@pobox.com" version="1" lastUpdated="20220729"/>
   <version author="Petr Šídlo sidlo64@hotmail.com" version="2" lastUpdated="20220814"/> <!-- factReset CV30 -->
+  <version author="lbijlsma@pobox.com" version="3" lastUpdated="20240422"/> <!-- CV114-CV116 changes        -->
   <decoder>
     <family name="Lokommander 2 v3" mfg="Tehnologistic (train-O-matic)">
       <model model="Lokommander 2 Micro" numOuts="6" numFns="15" lowVersionID="3" highVersionID="3" connector="Wires/NEM651" productID="2010220,2010221,2010222,2010223,2010227">
@@ -93,6 +94,7 @@
 
       <xi:include href="http://jmri.org/xml/decoders/tOm/commonCVs.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tOm/cv33.47.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tOm/cv114.116.xml"/>
 
     </variables>
 

--- a/xml/decoders/TrainOMatic_Lokommander_2_p22.xml
+++ b/xml/decoders/TrainOMatic_Lokommander_2_p22.xml
@@ -21,6 +21,7 @@
 
   <version author="lbijlsma@pobox.com" version="1" lastUpdated="20220729"/>
   <version author="Petr Šídlo sidlo64@hotmail.com" version="2" lastUpdated="20220814"/> <!-- factReset CV30 -->
+  <version author="lbijlsma@pobox.com" version="3" lastUpdated="20240422"/> <!-- CV114-CV116 changes        -->  
   <decoder>
     <family name="Lokommander 2 v3" mfg="Tehnologistic (train-O-matic)">
        <model model="Lokommander 2 Mini P22" numOuts="12" numFns="15" lowVersionID="3" highVersionID="3" connector="PluX22" productID="2010217">
@@ -71,6 +72,7 @@
 
       <xi:include href="http://jmri.org/xml/decoders/tOm/commonCVs.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tOm/cv33.47_p22.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tOm/cv114.116.xml"/>
 
     </variables>
 

--- a/xml/decoders/TrainOMatic_Lokommander_2_p22_v6.xml
+++ b/xml/decoders/TrainOMatic_Lokommander_2_p22_v6.xml
@@ -22,6 +22,7 @@
   <version author="lbijlsma@pobox.com" version="1" lastUpdated="20230913"/>
   <version author="Petr Šídlo sidlo64@hotmail.com" version="2" lastUpdated="20220814"/> <!-- factReset CV30 -->
   <version author="lbijlsma@pobox.com" version="3" lastUpdated="20230921"/> <!-- v6 firmware specific panes -->
+  <version author="lbijlsma@pobox.com" version="4" lastUpdated="20240422"/> <!-- CV114-CV116 changes        -->
 
   <decoder>
     <family name="Lokommander 2 v6" mfg="Tehnologistic (train-O-matic)">
@@ -73,6 +74,7 @@
 
       <xi:include href="http://jmri.org/xml/decoders/tOm/commonCVs.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tOm/cv33.47_p22.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tOm/cv114.116_v6.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tOm/brakeCVs.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tOm/functionOutputsCVs.xml"/>
 

--- a/xml/decoders/TrainOMatic_Lokommander_2_v6.xml
+++ b/xml/decoders/TrainOMatic_Lokommander_2_v6.xml
@@ -18,6 +18,7 @@
 <!-- Covers all the known versions of the Lokommander II decoder with firmware versions 5 & 6 at this time       -->
 
   <version author="lbijlsma@pobox.com" version="1" lastUpdated="20230913"/>
+  <version author="lbijlsma@pobox.com" version="2" lastUpdated="20240422"/>
   <decoder>
     <family name="Lokommander 2 v6" mfg="Tehnologistic (train-O-matic)">
       <model model="Lokommander 2 Micro" numOuts="6" numFns="15" lowVersionID="5" highVersionID="6" connector="Wires/NEM651" productID="2010220,2010221,2010222,2010223,2010227">
@@ -92,6 +93,7 @@
 
       <xi:include href="http://jmri.org/xml/decoders/tOm/commonCVs.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tOm/cv33.47.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/tOm/cv114.116_v6.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tOm/brakeCVs.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/tOm/functionOutputsCVs.xml"/>
 

--- a/xml/decoders/tOm/commonCVs.xml
+++ b/xml/decoders/tOm/commonCVs.xml
@@ -15,6 +15,7 @@
 <!-- Version 1 - Lolke H Bijlsma - Introduction Lokommander II              -->
 <!-- Version 2 - Petr Sidlo - 2022-08-14 - small fix                        -->
 <!-- Version 3 - Lolke H Bijlsma - 2023-09-15  SUSI and Motor frequency fix -->
+<!-- Version 4 - Lolke H Bijlsma - 2024-04-22  Remove CV114-116 (moved to separate file) -->
 
 <variables xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
 
@@ -517,27 +518,6 @@
         <label>Fade OFF effect</label>
         <label xml:lang="cs">Efekt pohasínání Vyp</label>
         <tooltip xml:lang="cs">Efekt pohasínání výstupu při vypnutí, např.: 1 = 8ms, 15 = 120 ms, 125 = 1000 ms</tooltip>
-      </variable>
-
-<!-- CV114 -->
-      <variable item="Shunting Speed Active Function" CV="114" default="3">
-        <xi:include href="http://jmri.org/xml/decoders/parts/enum-F1-F28.xml"/>
-        <label>Shunting Speed Active Function</label>
-        <label xml:lang="cs">Posunvací rychlost aktivuje</label>
-      </variable>
-      
-<!-- CV115 -->
-      <variable item="Switch Off Acceleration Deceleration Function" CV="115" default="4">
-        <xi:include href="http://jmri.org/xml/decoders/parts/enum-F1-F28.xml"/>
-        <label>Switch Off Acceleration Deceleration Function</label>
-        <label xml:lang="cs">Zrychlení zpomalení vypne</label>
-      </variable>
-      
-<!-- CV116 -->
-      <variable item="Disable Constant Braking Distance Function" CV="116" default="5">
-        <xi:include href="http://jmri.org/xml/decoders/parts/enum-F1-F28.xml"/>
-        <label>Disable Constant Braking Distance Function</label>
-        <label xml:lang="cs">Konstantní brzdnou dráhu vypne</label>
       </variable>
 
 <!-- CV117 -->

--- a/xml/decoders/tOm/cv114.116.xml
+++ b/xml/decoders/tOm/cv114.116.xml
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet type="text/xsl" href="../XSLT/decoder.xsl"?>
+<!-- Copyright (C) JMRI 2024 All rights reserved -->
+<!--                                                                        -->
+<!-- JMRI is free software; you can redistribute it and/or modify it under  -->
+<!-- the terms of version 2 of the GNU General Public License as published  -->
+<!-- by the Free Software Foundation. See the "COPYING" file for a copy     -->
+<!-- of this license.                                                       -->
+<!--                                                                        -->
+<!-- JMRI is distributed in the hope that it will be useful, but WITHOUT    -->
+<!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
+<!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
+<!-- for more details.                                                      -->
+
+<!-- Version 1 - Lolke H Bijlsma - Correct inplementation of CV114-116 per the different Lokommander versions -->
+
+<variables xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+
+<!-- The Lokommander I and II (v3 firmware) implements implements CV114, 115 and 116 as binary values -->
+    
+    
+<!-- CV114 -->
+      <variable item="Shunting Speed Active For F1" CV="114" mask="XXXXXXXV" default="0" minFn="1">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-YesNo.xml"/>
+        <label>Shunting Speed Active For F1</label>
+        <label xml:lang="cs">Posunovací rychlost aktivní na F1</label>
+      </variable>
+      <variable item="Shunting Speed Active For F2" CV="114" mask="XXXXXXVX" default="0" minFn="2">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-YesNo.xml"/>
+        <label>Shunting Speed Active For F2</label>
+        <label xml:lang="cs">Posunovací rychlost aktivní na F2</label>
+      </variable>
+      <variable item="Shunting Speed Active For F3" CV="114" mask="XXXXXVXX" default="1" minFn="3">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-YesNo.xml"/>
+        <label>Shunting Speed Active For F3</label>
+        <label xml:lang="cs">Posunovací rychlost aktivní na F3</label>
+      </variable>
+      <variable item="Shunting Speed Active For F4" CV="114" mask="XXXXVXXX" default="0" minFn="4">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-YesNo.xml"/>
+        <label>Shunting Speed Active For F4</label>
+        <label xml:lang="cs">Posunovací rychlost aktivní na F4</label>
+      </variable>
+      <variable item="Shunting Speed Active For F5" CV="114" mask="XXXVXXXX" default="0" minFn="5">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-YesNo.xml"/>
+        <label>Shunting Speed Active For F5</label>
+        <label xml:lang="cs">Posunovací rychlost aktivní na F5</label>
+      </variable>
+      <variable item="Shunting Speed Active For F6" CV="114" mask="XXVXXXXX" default="0" minFn="6">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-YesNo.xml"/>
+        <label>Shunting Speed Active For F6</label>
+        <label xml:lang="cs">Posunovací rychlost aktivní na F6</label>
+      </variable>
+      <variable item="Shunting Speed Active For F7" CV="114" mask="XVXXXXXX" default="0" minFn="7">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-YesNo.xml"/>
+        <label>Shunting Speed Active For F7</label>
+        <label xml:lang="cs">Posunovací rychlost aktivní na F7</label>
+      </variable>
+      <variable item="Shunting Speed Active For F8" CV="114" mask="VXXXXXXX" default="0" minFn="8">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-YesNo.xml"/>
+        <label>Shunting Speed Active For F8</label>
+        <label xml:lang="cs">Posunovací rychlost aktivní na F8</label>
+      </variable>
+
+
+<!-- CV115 -->
+      <variable item="Switch Off Acceleration Deceleration For F1" CV="115" mask="XXXXXXXV" default="0" minFn="1">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-YesNo.xml"/>
+        <label>Switch Off Acceleration Deceleration For F1</label>
+        <label xml:lang="cs">Vypnutí Zrychlení Zpomalení na F1</label>
+      </variable>
+      <variable item="Switch Off Acceleration Deceleration For F2" CV="115" mask="XXXXXXVX" default="0" minFn="2">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-YesNo.xml"/>
+        <label>Switch Off Acceleration Deceleration For F2</label>
+        <label xml:lang="cs">Vypnutí Zrychlení Zpomalení na F2</label>
+      </variable>
+      <variable item="Switch Off Acceleration Deceleration For F3" CV="115" mask="XXXXXVXX" default="0" minFn="3">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-YesNo.xml"/>
+        <label>Switch Off Acceleration Deceleration For F3</label>
+        <label xml:lang="cs">Vypnutí Zrychlení Zpomalení na F3</label>
+      </variable>
+      <variable item="Switch Off Acceleration Deceleration For F4" CV="115" mask="XXXXVXXX" default="1" minFn="4">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-YesNo.xml"/>
+        <label>Switch Off Acceleration Deceleration For F4</label>
+        <label xml:lang="cs">Vypnutí Zrychlení Zpomalení na F4</label>
+      </variable>
+      <variable item="Switch Off Acceleration Deceleration For F5" CV="115" mask="XXXVXXXX" default="0" minFn="5">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-YesNo.xml"/>
+        <label>Switch Off Acceleration Deceleration For F5</label>
+        <label xml:lang="cs">Vypnutí Zrychlení Zpomalení na F5</label>
+      </variable>
+      <variable item="Switch Off Acceleration Deceleration For F6" CV="115" mask="XXVXXXXX" default="0" minFn="6">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-YesNo.xml"/>
+        <label>Switch Off Acceleration Deceleration For F6</label>
+        <label xml:lang="cs">Vypnutí Zrychlení Zpomalení na F6</label>
+      </variable>
+      <variable item="Switch Off Acceleration Deceleration For F7" CV="115" mask="XVXXXXXX" default="0" minFn="7">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-YesNo.xml"/>
+        <label>Switch Off Acceleration Deceleration For F7</label>
+        <label xml:lang="cs">Vypnutí Zrychlení Zpomalení na F7</label>
+      </variable>
+      <variable item="Switch Off Acceleration Deceleration For F8" CV="115" mask="VXXXXXXX" default="0" minFn="8">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-YesNo.xml"/>
+        <label>Switch Off Acceleration Deceleration For F8</label>
+        <label xml:lang="cs">Vypnutí Zrychlení Zpomalení na F8</label>
+      </variable>
+
+<!-- CV116 -->
+      <variable item="Disable Constant Braking Distance For F1" CV="116" mask="XXXXXXXV" default="0" minFn="1">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-YesNo.xml"/>
+        <label>Disable Constant Braking Distance For F1</label>
+        <label xml:lang="cs">Zakázat Konstantní brzdnou dráhu na F1</label>
+      </variable>
+      <variable item="Disable Constant Braking Distance For F2" CV="116" mask="XXXXXXVX" default="0" minFn="2">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-YesNo.xml"/>
+        <label>Disable Constant Braking Distance For F2</label>
+        <label xml:lang="cs">Zakázat Konstantní brzdnou dráhu na F2</label>
+      </variable>
+      <variable item="Disable Constant Braking Distance For F3" CV="116" mask="XXXXXVXX" default="0" minFn="3">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-YesNo.xml"/>
+        <label>Disable Constant Braking Distance For F3</label>
+        <label xml:lang="cs">Zakázat Konstantní brzdnou dráhu na F3</label>
+      </variable>
+      <variable item="Disable Constant Braking Distance For F4" CV="116" mask="XXXXVXXX" default="0" minFn="4">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-YesNo.xml"/>
+        <label>Disable Constant Braking Distance For F4</label>
+        <label xml:lang="cs">Zakázat Konstantní brzdnou dráhu na F4</label>
+      </variable>
+      <variable item="Disable Constant Braking Distance For F5" CV="116" mask="XXXVXXXX" default="1" minFn="5">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-YesNo.xml"/>
+        <label>Disable Constant Braking Distance For F5</label>
+        <label xml:lang="cs">Zakázat Konstantní brzdnou dráhu na F5</label>
+      </variable>
+      <variable item="Disable Constant Braking Distance For F6" CV="116" mask="XXVXXXXX" default="0" minFn="6">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-YesNo.xml"/>
+        <label>Disable Constant Braking Distance For F6</label>
+        <label xml:lang="cs">Zakázat Konstantní brzdnou dráhu na F6</label>
+      </variable>
+      <variable item="Disable Constant Braking Distance For F7" CV="116" mask="XVXXXXXX" default="0" minFn="7">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-YesNo.xml"/>
+        <label>Disable Constant Braking Distance For F7</label>
+        <label xml:lang="cs">Zakázat Konstantní brzdnou dráhu na F7</label>
+      </variable>
+      <variable item="Disable Constant Braking Distance For F8" CV="116" mask="VXXXXXXX" default="0" minFn="8">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-YesNo.xml"/>
+        <label>Disable Constant Braking Distance For F8</label>
+        <label xml:lang="cs">Zakázat Konstantní brzdnou dráhu na F8</label>
+      </variable>
+    
+</variables>

--- a/xml/decoders/tOm/cv114.116_v6.xml
+++ b/xml/decoders/tOm/cv114.116_v6.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet type="text/xsl" href="../XSLT/decoder.xsl"?>
+<!-- Copyright (C) JMRI 2024 All rights reserved -->
+<!--                                                                        -->
+<!-- JMRI is free software; you can redistribute it and/or modify it under  -->
+<!-- the terms of version 2 of the GNU General Public License as published  -->
+<!-- by the Free Software Foundation. See the "COPYING" file for a copy     -->
+<!-- of this license.                                                       -->
+<!--                                                                        -->
+<!-- JMRI is distributed in the hope that it will be useful, but WITHOUT    -->
+<!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
+<!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
+<!-- for more details.                                                      -->
+
+<!-- Version 1 - Lolke H Bijlsma - Correct inplementation of CV114-116 per the different Lokommander versions -->
+
+<variables xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+
+<!-- The V6 firmware implements CV114, 115 and 116 as decimal values representing the function number -->
+    
+<!-- CV114 -->
+      <variable item="Shunting Speed Active Function" CV="114" default="3">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-F1-F28.xml"/>
+        <label>Shunting Speed Active Function</label>
+        <label xml:lang="cs">Posunvací rychlost aktivuje</label>
+      </variable>
+      
+<!-- CV115 -->
+      <variable item="Switch Off Acceleration Deceleration Function" CV="115" default="4">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-F1-F28.xml"/>
+        <label>Switch Off Acceleration Deceleration Function</label>
+        <label xml:lang="cs">Zrychlení zpomalení vypne</label>
+      </variable>
+      
+<!-- CV116 -->
+      <variable item="Disable Constant Braking Distance Function" CV="116" default="5">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-F1-F28.xml"/>
+        <label>Disable Constant Braking Distance Function</label>
+        <label xml:lang="cs">Konstantní brzdnou dráhu vypne</label>
+      </variable>
+  
+</variables>

--- a/xml/decoders/tOm/functionsPane.xml
+++ b/xml/decoders/tOm/functionsPane.xml
@@ -13,6 +13,7 @@
 
 <!-- Version 1 - Lolke H Bijlsma - Introduction Lokommander II              -->
 <!-- Version 2 - Lolke H Bijlsma (2023-09-15) - Function selection updated  -->
+<!-- Version 3 - Lolke H Bijlsma (2024-04-22) - Correct implementation      -->
 
   <pane xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/programmer.xsd">
     <name>tOm Function Map</name>
@@ -22,16 +23,77 @@
       <label>
         <text> </text>
       </label>
-      <grid gridx="0" gridy="NEXT" weightx="1" anchor="LINE_END">
-        <griditem>
-           <display item="Shunting Speed Active Function" />
-        </griditem>
-        <griditem>
-           <display item="Switch Off Acceleration Deceleration Function" />
-        </griditem>
-        <griditem>
-           <display item="Disable Constant Braking Distance Function" />
-        </griditem>
-      </grid>
+      <label>
+        <text>Select which function</text>
+        <text xml:lang="cs">Vyberte která funkce</text>
+      </label>
+      <label>
+        <text>enables Shunting Speed</text>
+        <text xml:lang="cs">povolí posunovací rychlost</text>
+      </label>
+      <label>
+        <text> </text>
+      </label>
+      <display item="Shunting Speed Active For F1" format="checkbox" />
+      <display item="Shunting Speed Active For F2" format="checkbox" />
+      <display item="Shunting Speed Active For F3" format="checkbox" />
+      <display item="Shunting Speed Active For F4" format="checkbox" />
+      <display item="Shunting Speed Active For F5" format="checkbox" />
+      <display item="Shunting Speed Active For F6" format="checkbox" />
+      <display item="Shunting Speed Active For F7" format="checkbox" />
+      <display item="Shunting Speed Active For F8" format="checkbox" />
     </column>
+
+    <column>
+      <separator/>
+      <label>
+        <text> </text>
+      </label>
+      <label>
+        <text>Select which function</text>
+        <text xml:lang="cs">Vyberte která funkce</text>
+      </label>
+      <label>
+        <text>switches off Acceleration, Deceleration</text>
+        <text xml:lang="cs">vypne Zrychlení a Zpomalení</text>
+      </label>
+      <label>
+        <text> </text>
+      </label>
+      <display item="Switch Off Acceleration Deceleration For F1" format="checkbox" />
+      <display item="Switch Off Acceleration Deceleration For F2" format="checkbox" />
+      <display item="Switch Off Acceleration Deceleration For F3" format="checkbox" />
+      <display item="Switch Off Acceleration Deceleration For F4" format="checkbox" />
+      <display item="Switch Off Acceleration Deceleration For F5" format="checkbox" />
+      <display item="Switch Off Acceleration Deceleration For F6" format="checkbox" />
+      <display item="Switch Off Acceleration Deceleration For F7" format="checkbox" />
+      <display item="Switch Off Acceleration Deceleration For F8" format="checkbox" />
+    </column>
+
+    <column>
+      <separator/>
+      <label>
+        <text> </text>
+      </label>
+      <label>
+        <text>Select which function</text>
+        <text xml:lang="cs">Vyberte která funkce</text>
+      </label>
+      <label>
+        <text>disables Constant Braking Distance</text>
+        <text xml:lang="cs">zakáže Konstantní brzdnou vzdálenost</text>
+      </label>
+      <label>
+        <text> </text>
+      </label>
+      <display item="Disable Constant Braking Distance For F1" format="checkbox" />
+      <display item="Disable Constant Braking Distance For F2" format="checkbox" />
+      <display item="Disable Constant Braking Distance For F3" format="checkbox" />
+      <display item="Disable Constant Braking Distance For F4" format="checkbox" />
+      <display item="Disable Constant Braking Distance For F5" format="checkbox" />
+      <display item="Disable Constant Braking Distance For F6" format="checkbox" />
+      <display item="Disable Constant Braking Distance For F7" format="checkbox" />
+      <display item="Disable Constant Braking Distance For F8" format="checkbox" />
+    </column>
+    
   </pane>


### PR DESCRIPTION
Issue #13037 describes a problem with CV114, 115 and 116 for the Train-O-Matic Lokommander II decoders. 
The implementation of these CVs changed from firmware v3 to v6 significantly. These changes are to handle them correctly:

v3 firmware : handle as binary and support up to F8 
v6 firmware: handle as decimal and support up to F28

