### PR TITLE
DCCppOverTCP: fix NPE by removing unknown message warning

### DIFF
--- a/java/src/jmri/jmrix/dccpp/DCCppConstants.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppConstants.java
@@ -124,7 +124,7 @@ public final class DCCppConstants {
     public static final String OUTPUT_DELETE_REGEX = "\\s*Z\\s*(\\d+)\\s*"; // <Z ID>
     public static final String OUTPUT_LIST_REGEX = "\\s*Z\\s*"; // <Z>
     public static final String QUERY_SENSOR_STATES_REGEX = "\\s*Q\\s*"; // <Q>
-    public static final String LOCO_STATE_REGEX = "\\s*l\\s*(\\d+)\\s*(\\d+)\\s*(\\d+)\\s*(\\d+)\\s*"; // <l loco slot speedByte functions>
+    public static final String LOCO_STATE_REGEX = "\\s*l\\s*(\\d+)\\s*([-]*\\d+)\\s*(\\d+)\\s*(\\d+)\\s*"; // <l loco slot speedByte functions>
 
     public static final String WRITE_TO_EEPROM_REGEX = "E";
     public static final String CLEAR_EEPROM_REGEX = "e";

--- a/java/src/jmri/jmrix/dccpp/dccppovertcp/ClientRxHandler.java
+++ b/java/src/jmri/jmrix/dccpp/dccppovertcp/ClientRxHandler.java
@@ -99,16 +99,8 @@ public final class ClientRxHandler extends Thread implements DCCppListener {
                         continue;
                     }
 
-                    // BUG FIX: Incoming DCCppOverTCP messages are already formatted for DCC++ and don't
-                    // need to be parsed. Indeed, trying to parse them will screw them up.
-                    // So instead, we de-deprecated the string constructor so that we can
-                    // directly create a DCCppMessage from the incoming string without translation/parsing.
                     DCCppMessage msg = new DCCppMessage(inString.substring(inString.indexOf('<') + 1,
                             inString.lastIndexOf('>')));
-                    if (!msg.isValidMessageFormat()) {
-                        log.warn("Unknown Message Format '{}', forwarding anyway", msg);
-//                        continue;
-                    }
 
                     memo.getDCCppTrafficController().sendDCCppMessage(msg, null);
                     // Keep the message we just sent so we can ACK it when we hear

--- a/java/test/jmri/jmrix/dccpp/DCCppThrottleTest.java
+++ b/java/test/jmri/jmrix/dccpp/DCCppThrottleTest.java
@@ -550,6 +550,9 @@ public class DCCppThrottleTest extends jmri.jmrix.AbstractThrottleTest {
         l = DCCppReply.parseDCCppReply("l 88 3 129 0"); //eStop (forward)
         Assert.assertEquals("Monitor string", "Loco State: LocoId:88 Dir:Forward Speed:-1 F0-28:00000000000000000000000000000", l.toMonitorString());
         Assert.assertTrue("eStop", l.isEStop());
+        l = DCCppReply.parseDCCppReply("l 1225 -1 239 0"); //reg is -1 (ignored)
+        Assert.assertEquals("Monitor string", "Loco State: LocoId:1225 Dir:Forward Speed:110 F0-28:00000000000000000000000000000", l.toMonitorString());
+        Assert.assertFalse("eStop", l.isEStop());
     }
 
     // Test the constructor with an address specified.


### PR DESCRIPTION
also fix: allow negative reg in locostate