### PR TITLE
Drop java3d packagelist no longer available to Javadoc

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -2076,9 +2076,6 @@
 
             <link href="https://fazecast.github.io/jSerialComm/javadoc" />
             
-            <!-- <link href="http://download.java.net/media/java3d/javadoc/1.3.2/"/>  redirected to next line -->
-            <link href="https://download.java.net/media/java3d/javadoc/1.3.2/" />
-
             <!-- <link href="https://static.javadoc.io/org.openlcb/openlcb/0.7.23/"/>  redirected to next line -->
             <link href="https://www.javadoc.io/doc/org.openlcb/openlcb/0.7.23/" />
 
@@ -2186,9 +2183,6 @@
             <link href="https://docs.oracle.com/cd/E17802_01/products/products/javacomm/reference/api/" />
 
             <link href="https://fazecast.github.io/jSerialComm/javadoc" />
-
-            <!-- <link href="http://download.java.net/media/java3d/javadoc/1.3.2/"/>  redirected to next line -->
-            <link href="https://download.java.net/media/java3d/javadoc/1.3.2/" />
 
             <link href="http://docs.oracle.com/en/java/javase/11/docs/api/"/>
             <link href="http://www.jdom.org/docs/apidocs/"/>

--- a/pom.xml
+++ b/pom.xml
@@ -716,7 +716,6 @@
                         <link>https://commons.apache.org/proper/commons-csv/apidocs/</link>
                         <link>https://static.javadoc.io/com.fasterxml.jackson.core/jackson-databind/${jackson-databind.version}/</link>
                         <link>http://logging.apache.org/log4j/1.2/apidocs/</link>
-                        <link>http://download.java.net/media/java3d/javadoc/1.3.2/</link>
                         <link>https://static.javadoc.io/org.openlcb/openlcb/${openlcb.version}/</link>
                         <link>https://commons.apache.org/proper/commons-lang/javadocs/api-release/</link>
                         <link>https://javadoc.io/static/com.github.spotbugs/spotbugs-annotations/4.7.3/</link>


### PR DESCRIPTION
When building Javadoc, JMRI references a few external packages from the web.  Oracle has removed the documentation for Java3D and that reference is no longer valid. It gives an error when building full Javadoc.  This PR removed the references to Java3D when building Javadoc.  The only effect this has is making the references to Java3D API no longer live links.