### PR TITLE
Improve process for shutting down receive threads in jmrix

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -86,7 +86,8 @@
 
         <h4>LocoNet</h4>
             <ul>
-                <li></li>
+                <li>Improved how threads are shutdown when changing connections
+                    in the settings.</li>
             </ul>
 
         <h4>Maple</h4>

--- a/java/src/jmri/jmrix/AbstractMRTrafficController.java
+++ b/java/src/jmri/jmrix/AbstractMRTrafficController.java
@@ -983,6 +983,13 @@ public abstract class AbstractMRTrafficController {
         }
         while (true) { // loop will repeat until character found
             int nchars;
+            // The istream should be configured so that the following
+            // read(..) call only blocks for a short time, e.g. 100msec, if no
+            // data is available.  It's OK if it 
+            // throws e.g. java.io.InterruptedIOException
+            // in that case, as the calling loop should just go around
+            // and request input again.  This semi-blocking behavior will
+            // let the terminateThreads() method end this thread cleanly.
             nchars = istream.read(rcvBuffer, 0, 1);
             if (nchars == -1) {
                 // No more bytes can be read from the channel
@@ -1304,7 +1311,7 @@ public abstract class AbstractMRTrafficController {
         if (xmtThread != null) {
             xmtThread.interrupt();
             try {
-                xmtThread.join();
+                xmtThread.join(150);
             } catch (InterruptedException ie){
                 // interrupted during cleanup.
             }
@@ -1313,7 +1320,7 @@ public abstract class AbstractMRTrafficController {
         if (rcvThread != null) {
             rcvThread.interrupt();
             try {
-                rcvThread.join();
+                rcvThread.join(150);
             } catch (InterruptedException ie){
                 // interrupted during cleanup.
             }

--- a/java/src/jmri/jmrix/AbstractMRTrafficController.java
+++ b/java/src/jmri/jmrix/AbstractMRTrafficController.java
@@ -970,7 +970,8 @@ public abstract class AbstractMRTrafficController {
      * Read a single byte, protecting against various timeouts, etc.
      * <p>
      * When a port is set to have a receive timeout, some will return
-     * zero bytes or an EOFException at the end of the timeout. In that case, the read
+     * zero bytes, an EOFException or a InterruptedIOException at the end of the timeout. 
+     * In that case, the read()
      * should be repeated to get the next real character.
      *
      * @param istream stream to read

--- a/java/src/jmri/jmrix/loconet/LnPacketizer.java
+++ b/java/src/jmri/jmrix/loconet/LnPacketizer.java
@@ -479,7 +479,7 @@ public class LnPacketizer extends LnTrafficController {
     /**
      * {@inheritDoc}
      */
-    // The join(150) is using a timeout become some receive threads
+    // The join(150) is using a timeout because some receive threads
     // (and maybe some day transmit threads) use calls that block 
     // even when interrupted.  We wait 150 msec and proceed.
     // Threads that do that are responsible for ending cleanly 
@@ -506,7 +506,7 @@ public class LnPacketizer extends LnTrafficController {
      * <p>
      * This is intended to be used only by testing subclasses.
      */
-    // The join(150) is using a timeout become some receive threads
+    // The join(150) is using a timeout because some receive threads
     // (and maybe some day transmit threads) use calls that block 
     // even when interrupted.  We wait 150 msec and proceed.
     // Threads that do that are responsible for ending cleanly 

--- a/java/src/jmri/jmrix/loconet/LnPacketizer.java
+++ b/java/src/jmri/jmrix/loconet/LnPacketizer.java
@@ -181,6 +181,13 @@ public class LnPacketizer extends LnTrafficController {
     protected byte readByteProtected(DataInputStream istream) throws java.io.IOException {
         while (true) { // loop will repeat until character found
             int nchars;
+            // The istream should be configured so that the following
+            // read(..) call only blocks for a short time, e.g. 100msec, if no
+            // data is available.  It's OK if it 
+            // throws e.g. java.io.InterruptedIOException
+            // in that case, as the calling loop should just go around
+            // and request input again.  This semi-blocking behavior will
+            // let the terminateThreads() method end this thread cleanly.
             nchars = istream.read(rcvBuffer, 0, 1);
             if (nchars > 0) {
                 return rcvBuffer[0];
@@ -308,18 +315,22 @@ public class LnPacketizer extends LnTrafficController {
                 } catch (LocoNetMessageException e) {
                     // just let it ride for now
                     log.warn("run: unexpected LocoNetMessageException", e); // NOI18N
-                } catch (java.io.EOFException | com.fazecast.jSerialComm.SerialPortTimeoutException e) {
+                    continue;
+                } catch (java.io.EOFException | java.io.InterruptedIOException e) {
                     // posted from idle port when enableReceiveTimeout used
+                    // Normal condition, go around the loop again
+                    continue;
                 } catch (java.io.IOException e) {
                     // fired when write-end of HexFile reaches end
                     log.debug("IOException, should only happen with HexFile", e); // NOI18N
                     log.info("End of file"); // NOI18N
                     disconnectPort(controller);
                     return;
-                } // normally, we don't catch RuntimeException, but in this
-                  // permanently running loop it seems wise.
-                catch (RuntimeException e) {
+                } catch (RuntimeException e) {
+                    // normally, we don't catch RuntimeException, but in this
+                    // permanently running loop it seems wise.
                     log.warn("run: unexpected Exception", e); // NOI18N
+                    continue;
                 }
             } // end of permanent loop
         }
@@ -440,7 +451,7 @@ public class LnPacketizer extends LnTrafficController {
         if (rcvHandler == null) {
             rcvHandler = new RcvHandler(this);
         }
-        rcvThread = new Thread(rcvHandler, "LocoNet receive handler"); // NOI18N
+        rcvThread = jmri.util.ThreadingUtil.newThread(rcvHandler, "LocoNet receive handler"); // NOI18N
         rcvThread.setDaemon(true);
         rcvThread.setPriority(Thread.MAX_PRIORITY);
         rcvThread.start();
@@ -452,7 +463,7 @@ public class LnPacketizer extends LnTrafficController {
         int xmtpriority = (Thread.MAX_PRIORITY - 1 > priority ? Thread.MAX_PRIORITY - 1 : Thread.MAX_PRIORITY);
         // start the XmtHandler in a thread of its own
         if (xmtThread == null) {
-            xmtThread = new Thread(xmtHandler, "LocoNet transmit handler"); // NOI18N
+            xmtThread = jmri.util.ThreadingUtil.newThread(xmtHandler, "LocoNet transmit handler"); // NOI18N
         }
         log.debug("Xmt thread starts at priority {}", xmtpriority); // NOI18N
         xmtThread.setDaemon(true);
@@ -468,19 +479,23 @@ public class LnPacketizer extends LnTrafficController {
     /**
      * {@inheritDoc}
      */
-    @SuppressWarnings("deprecation") // Thread.stop()
+    // The join(150) is using a timeout become some receive threads
+    // (and maybe some day transmit threads) use calls that block 
+    // even when interrupted.  We wait 150 msec and proceed.
+    // Threads that do that are responsible for ending cleanly 
+    // when the blocked call eventually returns.
     @Override
     public void dispose() {
         if (xmtThread != null) {
             xmtThread.interrupt();
             try {
-                xmtThread.join();
+                xmtThread.join(150);
             } catch (InterruptedException e) { log.warn("unexpected InterruptedException", e);}
         }
         if (rcvThread != null) {
             rcvThread.interrupt();
             try {
-                rcvThread.join();
+                rcvThread.join(150);
             } catch (InterruptedException e) { log.warn("unexpected InterruptedException", e);}
         }
         super.dispose();
@@ -491,12 +506,17 @@ public class LnPacketizer extends LnTrafficController {
      * <p>
      * This is intended to be used only by testing subclasses.
      */
+    // The join(150) is using a timeout become some receive threads
+    // (and maybe some day transmit threads) use calls that block 
+    // even when interrupted.  We wait 150 msec and proceed.
+    // Threads that do that are responsible for ending cleanly 
+    // when the blocked call eventually returns.
     public void terminateThreads() {
         threadStopRequest = true;
         if (xmtThread != null) {
             xmtThread.interrupt();
             try {
-                xmtThread.join();
+                xmtThread.join(150);
             } catch (InterruptedException ie){
                 // interrupted during cleanup.
             }
@@ -505,7 +525,7 @@ public class LnPacketizer extends LnTrafficController {
         if (rcvThread != null) {
             rcvThread.interrupt();
             try {
-                rcvThread.join();
+                rcvThread.join(150);
             } catch (InterruptedException ie){
                 // interrupted during cleanup.
             }

--- a/java/src/jmri/jmrix/loconet/LnPacketizerStrict.java
+++ b/java/src/jmri/jmrix/loconet/LnPacketizerStrict.java
@@ -181,19 +181,22 @@ public class LnPacketizerStrict extends LnPacketizer {
                 } catch (LocoNetMessageException e) {
                     // just let it ride for now
                     log.warn("run: unexpected LocoNetMessageException", e); // NOI18N
-                } catch (java.io.EOFException e) {
+                    continue;
+                } catch (java.io.EOFException | java.io.InterruptedIOException e) {
                     // posted from idle port when enableReceiveTimeout used
-                    log.trace("EOFException, is LocoNet serial I/O using timeouts?"); // NOI18N
+                    // Normal condition, go around the loop again
+                    continue;
                 } catch (java.io.IOException e) {
                     // fired when write-end of HexFile reaches end
                     log.debug("IOException, should only happen with HexFile", e); // NOI18N
                     log.info("End of file"); // NOI18N
                     disconnectPort(controller);
                     return;
-                } // normally, we don't catch RuntimeException, but in this
-                // permanently running loop it seems wise.
-                catch (RuntimeException e) {
+                } catch (RuntimeException e) {
+                    // normally, we don't catch RuntimeException, but in this
+                    // permanently running loop it seems wise.
                     log.warn("run: unexpected Exception", e); // NOI18N
+                    continue;
                 }
             } // end of permanent loop
         }
@@ -361,7 +364,7 @@ public class LnPacketizerStrict extends LnPacketizer {
         if (xmtHandler == null) {
             xmtHandler = new XmtHandlerStrict();
         }
-        xmtThread = new Thread(xmtHandler, "LocoNet transmit handler"); // NOI18N
+        xmtThread = jmri.util.ThreadingUtil.newThread(xmtHandler, "LocoNet transmit handler"); // NOI18N
         log.debug("Xmt thread starts at priority {}", xmtpriority); // NOI18N
         xmtThread.setDaemon(true);
         xmtThread.setPriority(Thread.MAX_PRIORITY - 1);
@@ -371,7 +374,7 @@ public class LnPacketizerStrict extends LnPacketizer {
         if (rcvHandler == null) {
             rcvHandler = new RcvHandlerStrict(this);
         }
-        rcvThread = new Thread(rcvHandler, "LocoNet receive handler"); // NOI18N
+        rcvThread = jmri.util.ThreadingUtil.newThread(rcvHandler, "LocoNet receive handler"); // NOI18N
         rcvThread.setDaemon(true);
         rcvThread.setPriority(Thread.MAX_PRIORITY);
         rcvThread.start();

--- a/java/src/jmri/jmrix/loconet/hexfile/HexFileFrame.java
+++ b/java/src/jmri/jmrix/loconet/hexfile/HexFileFrame.java
@@ -261,7 +261,7 @@ public class HexFileFrame extends JmriJFrame implements LocoNetListener {
 
         // start operation of packetizer
         packets.startThreads();
-        sourceThread = new Thread(port, "LocoNet HexFileFrame");
+        sourceThread = jmri.util.ThreadingUtil.newThread(port, "LocoNet HexFileFrame");
         sourceThread.start();
     }
 

--- a/java/src/jmri/jmrix/loconet/hexfile/LnHexFilePort.java
+++ b/java/src/jmri/jmrix/loconet/hexfile/LnHexFilePort.java
@@ -101,7 +101,7 @@ public class LnHexFilePort extends LnPortController implements Runnable {
                 // until we are interrupted
                 try {
                     synchronized (this) {
-                        wait(1000);
+                        wait(100);
                     }
                 } catch (InterruptedException e) {
                     log.info("LnHexFilePort.run: woken from sleep"); // NOI18N

--- a/java/src/jmri/jmrix/loconet/loconetovertcp/LnOverTcpPacketizer.java
+++ b/java/src/jmri/jmrix/loconet/loconetovertcp/LnOverTcpPacketizer.java
@@ -109,10 +109,18 @@ public class LnOverTcpPacketizer extends LnPacketizer {
         public void run() {
 
             String rxLine;
-            while (true) {  // loop permanently, program close will exit
+            while (! Thread.interrupted()) {  // loop permanently, program close will exit
                 try {
-                    // start by looking for a complete line
+                    // Start by looking for a complete line.
+                    // This will block until input is returned, even if the thread is interrupted.
                     rxLine = istream.readLine();
+                    if (Thread.interrupted()) {
+                        // This indicates normal termination of the thread
+                        // followed by some input being provided by readLine above.
+                        // We return immediately to end the thread, rather than
+                        // processing the no-long-relevant input.
+                        return;
+                    }
                     if (rxLine == null) {
                         log.warn("run: input stream returned null, exiting loop");
                         return;

--- a/java/src/jmri/jmrix/loconet/streamport/LnStreamPortPacketizer.java
+++ b/java/src/jmri/jmrix/loconet/streamport/LnStreamPortPacketizer.java
@@ -133,7 +133,7 @@ public class LnStreamPortPacketizer extends LnPacketizer {
         if (xmtHandler == null) {
             xmtHandler = new XmtHandler();
         }
-        xmtThread = new Thread(xmtHandler, "LocoNet transmit handler"); // NOI18N
+        xmtThread = jmri.util.ThreadingUtil.newThread(xmtHandler, "LocoNet transmit handler"); // NOI18N
         log.debug("Xmt thread starts at priority {}", xmtpriority); // NOI18N
         xmtThread.setDaemon(true);
         xmtThread.setPriority(Thread.MAX_PRIORITY - 1);
@@ -143,7 +143,7 @@ public class LnStreamPortPacketizer extends LnPacketizer {
         if (rcvHandler == null) {
             rcvHandler = new RcvHandler(this);
         }
-        rcvThread = new Thread(rcvHandler, "LocoNet receive handler"); // NOI18N
+        rcvThread = jmri.util.ThreadingUtil.newThread(rcvHandler, "LocoNet receive handler"); // NOI18N
         rcvThread.setDaemon(true);
         rcvThread.setPriority(Thread.MAX_PRIORITY);
         rcvThread.start();

--- a/java/src/jmri/jmrix/loconet/uhlenbrock/UhlenbrockPacketizer.java
+++ b/java/src/jmri/jmrix/loconet/uhlenbrock/UhlenbrockPacketizer.java
@@ -222,19 +222,21 @@ public class UhlenbrockPacketizer extends LnPacketizer {
                 } catch (LocoNetMessageException e) {
                     // just let it ride for now
                     log.warn("run: unexpected LocoNetMessageException: ", e);
-                } catch (java.io.EOFException e) {
+                } catch (java.io.EOFException | java.io.InterruptedIOException e) {
                     // posted from idle port when enableReceiveTimeout used
-                    log.debug("EOFException, is LocoNet serial I/O using timeouts?");
+                    // Normal condition, go around the loop again
+                    continue;
                 } catch (java.io.IOException e) {
                     // fired when write-end of HexFile reaches end
                     log.debug("IOException, should only happen with HexFile", e);
                     log.debug("End of file");
                     disconnectPort(controller);
                     return;
-                } // normally, we don't catch the unnamed Exception, but in this
-                // permanently running loop it seems wise.
-                catch (RuntimeException e) {
-                    log.warn("run: unexpected Exception", e);
+                } catch (RuntimeException e) {
+                    // normally, we don't catch RuntimeException, but in this
+                    // permanently running loop it seems wise.
+                    log.warn("run: unexpected Exception", e); // NOI18N
+                    continue;
                 }
             } // end of permanent loop
         }


### PR DESCRIPTION
This is a solution for #1362. It supersedes #13060, #13064, #13065.

This adds
 - Create a few threads in the JMRI group to help debugging
 - Add comments on why/how the serial `istream` has to timeout
 - Use a java.io exception instead of a com.fazecast one
 - Protect against untimely end of `readLine` call on TCP socket

