### PR TITLE
Let LogixNG log what it's doing

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -436,6 +436,11 @@
               floor() rounds down.</li>
           <li>The constant <strong>oblocks</strong> has been added to
               the Layout module.</li>
+          <li>Two new preferences have been added. <strong>Log all before</strong>
+              and <strong>Log all after</strong>. If these are selected,
+              LogixNG will log every action that's executed and every
+              expression that's evaluated. For this to work, the LogixNG
+              debugger must be installed (which it is by default).</li>
           <li></li>
         </ul>
 

--- a/java/src/jmri/jmrit/logixng/LogixNGPreferences.java
+++ b/java/src/jmri/jmrit/logixng/LogixNGPreferences.java
@@ -146,4 +146,28 @@ public interface LogixNGPreferences {
      */
     IfThenElse.ExecuteType getIfThenElseExecuteTypeDefault();
 
+    /**
+     * Set log all before.
+     * @param value true if log all before, false otherwise
+     */
+    void setLogAllBefore(boolean value);
+
+    /**
+     * Get log all before.
+     * @return true if log all before, false otherwise
+     */
+    boolean getLogAllBefore();
+
+    /**
+     * Set log all after.
+     * @param value true if log all after, false otherwise
+     */
+    void setLogAllAfter(boolean value);
+
+    /**
+     * Get log all after.
+     * @return true if log all after, false otherwise
+     */
+    boolean getLogAllAfter();
+
 }

--- a/java/src/jmri/jmrit/logixng/implementation/DefaultLogixNGPreferences.java
+++ b/java/src/jmri/jmrit/logixng/implementation/DefaultLogixNGPreferences.java
@@ -25,6 +25,8 @@ public final class DefaultLogixNGPreferences extends PreferencesBean implements 
     private static final String STRICT_TYPING_GLOBAL_VARIABLES = "strictTypingGlobalVariables";
     private static final String STRICT_TYPING_LOCAL_VARIABLES = "strictTypingLocalVariables";
     private static final String IF_THEN_ELSE_EXECUTE_TYPE_DEFAULT = "ifThenElseExecuteTypeDefault";
+    private static final String LOG_ALL_BEFORE = "logAllBefore";
+    private static final String LOG_ALL_AFTER = "logAllAfter";
 
     private boolean _startLogixNGOnLoad = true;
     private boolean _showSystemUserNames = false;
@@ -35,6 +37,8 @@ public final class DefaultLogixNGPreferences extends PreferencesBean implements 
     private boolean _strictTypingGlobalVariables = false;
     private boolean _strictTypingLocalVariables = false;
     private IfThenElse.ExecuteType _ifThenElseExecuteTypeDefault = IfThenElse.ExecuteType.ExecuteOnChange;
+    private boolean _logAllBefore = false;
+    private boolean _logAllAfter = false;
 
 
     public DefaultLogixNGPreferences() {
@@ -57,6 +61,8 @@ public final class DefaultLogixNGPreferences extends PreferencesBean implements 
         _strictTypingLocalVariables = sharedPreferences.getBoolean(STRICT_TYPING_LOCAL_VARIABLES, _strictTypingLocalVariables);
         _ifThenElseExecuteTypeDefault = IfThenElse.ExecuteType.valueOf(
                 sharedPreferences.get(IF_THEN_ELSE_EXECUTE_TYPE_DEFAULT, _ifThenElseExecuteTypeDefault.name()));
+        _logAllBefore = sharedPreferences.getBoolean(LOG_ALL_BEFORE, _logAllBefore);
+        _logAllAfter = sharedPreferences.getBoolean(LOG_ALL_AFTER, _logAllAfter);
 
         setIsDirty(false);
     }
@@ -87,6 +93,12 @@ public final class DefaultLogixNGPreferences extends PreferencesBean implements 
         if (getIfThenElseExecuteTypeDefault() != prefs.getIfThenElseExecuteTypeDefault()) {
             return true;
         }
+        if (getLogAllBefore() != prefs.getLogAllBefore()) {
+            return true;
+        }
+        if (getLogAllAfter() != prefs.getLogAllAfter()) {
+            return true;
+        }
         return (getErrorHandlingType() != prefs.getErrorHandlingType());
     }
 
@@ -101,6 +113,8 @@ public final class DefaultLogixNGPreferences extends PreferencesBean implements 
         setStrictTypingGlobalVariables(prefs.getStrictTypingGlobalVariables());
         setStrictTypingLocalVariables(prefs.getStrictTypingLocalVariables());
         setIfThenElseExecuteTypeDefault(prefs.getIfThenElseExecuteTypeDefault());
+        setLogAllBefore(prefs.getLogAllBefore());
+        setLogAllAfter(prefs.getLogAllAfter());
     }
 
     @Override
@@ -115,6 +129,8 @@ public final class DefaultLogixNGPreferences extends PreferencesBean implements 
         sharedPreferences.putBoolean(STRICT_TYPING_GLOBAL_VARIABLES, this.getStrictTypingGlobalVariables());
         sharedPreferences.putBoolean(STRICT_TYPING_LOCAL_VARIABLES, this.getStrictTypingLocalVariables());
         sharedPreferences.put(IF_THEN_ELSE_EXECUTE_TYPE_DEFAULT, this.getIfThenElseExecuteTypeDefault().name());
+        sharedPreferences.putBoolean(LOG_ALL_BEFORE, this.getLogAllBefore());
+        sharedPreferences.putBoolean(LOG_ALL_AFTER, this.getLogAllAfter());
         setIsDirty(false);
     }
 
@@ -215,6 +231,28 @@ public final class DefaultLogixNGPreferences extends PreferencesBean implements 
     @Override
     public IfThenElse.ExecuteType getIfThenElseExecuteTypeDefault() {
         return _ifThenElseExecuteTypeDefault;
+    }
+
+    @Override
+    public void setLogAllBefore(boolean value) {
+        _logAllBefore = value;
+        setIsDirty(true);
+    }
+
+    @Override
+    public boolean getLogAllBefore() {
+        return _logAllBefore;
+    }
+
+    @Override
+    public void setLogAllAfter(boolean value) {
+        _logAllAfter = value;
+        setIsDirty(true);
+    }
+
+    @Override
+    public boolean getLogAllAfter() {
+        return _logAllAfter;
     }
 
 //    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LogixNGPreferences.class);

--- a/java/src/jmri/jmrit/logixng/tools/debugger/AbstractDebuggerMaleSocket.java
+++ b/java/src/jmri/jmrit/logixng/tools/debugger/AbstractDebuggerMaleSocket.java
@@ -9,41 +9,58 @@ import jmri.jmrit.logixng.implementation.AbstractMaleSocket;
  * @author Daniel Bergqvist 2020
  */
 public abstract class AbstractDebuggerMaleSocket extends AbstractMaleSocket {
-    
+
     private final Debugger _debugger = InstanceManager.getDefault(Debugger.class);
-//    protected final MaleSocket ((MaleSocket)getObject());
-    
+
     private boolean _breakpointBefore = false;
     private boolean _breakpointAfter = false;
-    
+
     private boolean _stepInto = true;
     private boolean _lastDoBreak = true;
-    
-    
+
+    private boolean _logBefore = false;
+    private boolean _logAfter = false;
+
+
     public AbstractDebuggerMaleSocket(BaseManager<? extends MaleSocket> manager, MaleSocket maleSocket) {
         super(manager, maleSocket);
     }
-    
+
     /**
      * Get information about this action/expression before it is executed or
      * evaluated.
      * @return an information string
      */
     public abstract String getBeforeInfo();
-    
+
     /**
      * Get information about this action/expression after it is executed or
      * evaluated.
      * @return an information string
      */
     public abstract String getAfterInfo();
-    
+
+    protected boolean isLogAllBefore() {
+        return InstanceManager.getDefault(LogixNGPreferences.class).getLogAllBefore();
+    }
+
+    protected boolean isLogAllAfter() {
+        return InstanceManager.getDefault(LogixNGPreferences.class).getLogAllAfter();
+    }
+
     protected boolean isDebuggerActive() {
         return _debugger.isDebuggerActive()
                 && (_debugger.getDebugConditionalNG() == this.getConditionalNG());
     }
-    
+
     protected void before() {
+        if (isLogAllBefore() || _logBefore) {
+            String info = getBeforeInfo();
+            if (!info.isBlank()) {
+                info = " --- " + info;
+            }
+            log.warn("LogixNG Before: {}{}", getLongDescription(), info);
+        }
         _lastDoBreak = _debugger.getBreak();
         if (isDebuggerActive() && (_debugger.getBreak() || _breakpointBefore)) {
 //            System.out.format("Before: %s%n", getLongDescription());
@@ -51,7 +68,7 @@ public abstract class AbstractDebuggerMaleSocket extends AbstractMaleSocket {
             _debugger.setBreak(_stepInto);
         }
     }
-    
+
     protected void after() {
         if (isDebuggerActive()) {
             _debugger.setBreak(_lastDoBreak);
@@ -60,28 +77,51 @@ public abstract class AbstractDebuggerMaleSocket extends AbstractMaleSocket {
                 _debugger.firePropertyChange(Debugger.STEP_AFTER, null, this);
             }
         }
+        if (isLogAllAfter() || _logAfter) {
+            String info = getAfterInfo();
+            if (!info.isBlank()) {
+                info = " --- " + info;
+            }
+            log.warn("LogixNG After: {}{}", getLongDescription(), info);
+        }
     }
-    
+
     public void setStepInto(boolean value) {
         _stepInto = value;
     }
-    
+
     public void setBreakpointBefore(boolean value) {
         _breakpointBefore = value;
     }
-    
+
     public boolean getBreakpointBefore() {
         return _breakpointBefore;
     }
-    
+
     public void setBreakpointAfter(boolean value) {
         _breakpointAfter = value;
     }
-    
+
     public boolean getBreakpointAfter() {
         return _breakpointAfter;
     }
-    
+
+    public void setLogBefore(boolean value) {
+        _logBefore = value;
+    }
+
+    public boolean getLogBefore() {
+        return _logBefore;
+    }
+
+    public void setLogAfter(boolean value) {
+        _logAfter = value;
+    }
+
+    public boolean getLogAfter() {
+        return _logAfter;
+    }
+
     @Override
     protected final void registerListenersForThisClass() {
         ((MaleSocket)getObject()).registerListeners();
@@ -143,4 +183,5 @@ public abstract class AbstractDebuggerMaleSocket extends AbstractMaleSocket {
         ((MaleSocket)getObject()).setParent(this);
     }
 
+    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(AbstractDebuggerMaleSocket.class);
 }

--- a/java/src/jmri/jmrit/logixng/tools/debugger/AbstractDebuggerMaleSocket.java
+++ b/java/src/jmri/jmrit/logixng/tools/debugger/AbstractDebuggerMaleSocket.java
@@ -55,11 +55,12 @@ public abstract class AbstractDebuggerMaleSocket extends AbstractMaleSocket {
 
     protected void before() {
         if (isLogAllBefore() || _logBefore) {
+            ConditionalNG cng = getConditionalNG();
             String info = getBeforeInfo();
             if (!info.isBlank()) {
                 info = " --- " + info;
             }
-            log.warn("LogixNG Before: {}{}", getLongDescription(), info);
+            log.warn("LogixNG Before: {}, {}: {}{}", cng.getLogixNG().getSystemName(), cng.getSystemName(), getLongDescription(), info);
         }
         _lastDoBreak = _debugger.getBreak();
         if (isDebuggerActive() && (_debugger.getBreak() || _breakpointBefore)) {
@@ -78,11 +79,12 @@ public abstract class AbstractDebuggerMaleSocket extends AbstractMaleSocket {
             }
         }
         if (isLogAllAfter() || _logAfter) {
+            ConditionalNG cng = getConditionalNG();
             String info = getAfterInfo();
             if (!info.isBlank()) {
                 info = " --- " + info;
             }
-            log.warn("LogixNG After: {}{}", getLongDescription(), info);
+            log.warn("LogixNG After: {}, {}: {}{}", cng.getLogixNG().getSystemName(), cng.getSystemName(), getLongDescription(), info);
         }
     }
 

--- a/java/src/jmri/jmrit/logixng/tools/debugger/AbstractDebuggerMaleSocket.java
+++ b/java/src/jmri/jmrit/logixng/tools/debugger/AbstractDebuggerMaleSocket.java
@@ -84,7 +84,7 @@ public abstract class AbstractDebuggerMaleSocket extends AbstractMaleSocket {
             if (!info.isBlank()) {
                 info = " --- " + info;
             }
-            log.warn("LogixNG After: {}, {}: {}{}", cng.getLogixNG().getSystemName(), cng.getSystemName(), getLongDescription(), info);
+            log.warn("LogixNG  After: {}, {}: {}{}", cng.getLogixNG().getSystemName(), cng.getSystemName(), getLongDescription(), info);
         }
     }
 

--- a/java/src/jmri/jmrit/logixng/tools/swing/LogixNGPreferencesPanel.java
+++ b/java/src/jmri/jmrit/logixng/tools/swing/LogixNGPreferencesPanel.java
@@ -29,6 +29,8 @@ public class LogixNGPreferencesPanel extends JPanel implements PreferencesPanel 
 
     JCheckBox _startLogixNGOnLoadCheckBox;
     JCheckBox _installDebuggerCheckBox;
+    JCheckBox _logAllBeforeCheckBox;
+    JCheckBox _logAllAfterCheckBox;
     JCheckBox _showSystemUserNamesCheckBox;
     JCheckBox _treeEditorHighlightRow;
     JCheckBox _showSystemNameInException;
@@ -63,6 +65,8 @@ public class LogixNGPreferencesPanel extends JPanel implements PreferencesPanel 
         boolean didSet = true;
         preferences.setStartLogixNGOnStartup(_startLogixNGOnLoadCheckBox.isSelected());
         preferences.setInstallDebugger(_installDebuggerCheckBox.isSelected());
+        preferences.setLogAllBefore(_logAllBeforeCheckBox.isSelected());
+        preferences.setLogAllAfter(_logAllAfterCheckBox.isSelected());
         preferences.setShowSystemUserNames(_showSystemUserNamesCheckBox.isSelected());
         preferences.setTreeEditorHighlightRow(_treeEditorHighlightRow.isSelected());
         preferences.setErrorHandlingType(_errorHandlingComboBox.getItemAt(
@@ -84,6 +88,12 @@ public class LogixNGPreferencesPanel extends JPanel implements PreferencesPanel 
         _installDebuggerCheckBox = new JCheckBox(Bundle.getMessage("LabelInstallDebugger"));
         _installDebuggerCheckBox.setToolTipText(Bundle.getMessage("ToolTipLabelInstallDebugger"));
 
+        _logAllBeforeCheckBox = new JCheckBox(Bundle.getMessage("LabelLogAllBefore"));
+        _logAllBeforeCheckBox.setToolTipText(Bundle.getMessage("ToolTipLabelLogAllBefore"));
+
+        _logAllAfterCheckBox = new JCheckBox(Bundle.getMessage("LabelLogAllAfter"));
+        _logAllAfterCheckBox.setToolTipText(Bundle.getMessage("ToolTipLabelLogAllAfter"));
+
         _showSystemUserNamesCheckBox = new JCheckBox(Bundle.getMessage("LabelShowSystemUserNames"));
         _showSystemUserNamesCheckBox.setToolTipText(Bundle.getMessage("ToolTipLabeShowSystemUserNames"));
 
@@ -103,6 +113,8 @@ public class LogixNGPreferencesPanel extends JPanel implements PreferencesPanel 
 
         gridPanel.add(_startLogixNGOnLoadCheckBox);
         gridPanel.add(_installDebuggerCheckBox);
+        gridPanel.add(_logAllBeforeCheckBox);
+        gridPanel.add(_logAllAfterCheckBox);
         gridPanel.add(_showSystemUserNamesCheckBox);
         gridPanel.add(_treeEditorHighlightRow);
         gridPanel.add(Box.createVerticalStrut(2));
@@ -113,6 +125,8 @@ public class LogixNGPreferencesPanel extends JPanel implements PreferencesPanel 
 
         _startLogixNGOnLoadCheckBox.setSelected(preferences.getStartLogixNGOnStartup());
         _installDebuggerCheckBox.setSelected(preferences.getInstallDebugger());
+        _logAllBeforeCheckBox.setSelected(preferences.getLogAllBefore());
+        _logAllAfterCheckBox.setSelected(preferences.getLogAllAfter());
         _showSystemUserNamesCheckBox.setSelected(preferences.getShowSystemUserNames());
         _treeEditorHighlightRow.setSelected(preferences.getTreeEditorHighlightRow());
         _showSystemNameInException.setSelected(preferences.getShowSystemNameInException());

--- a/java/src/jmri/jmrit/logixng/tools/swing/LogixNGSwingBundle.properties
+++ b/java/src/jmri/jmrit/logixng/tools/swing/LogixNGSwingBundle.properties
@@ -29,6 +29,8 @@ TitleInlineLogixNGs         = Inline LogixNGs
 
 LabelStartLogixNGOnLoad     = Start LogixNGs on load
 LabelInstallDebugger        = Install debugger
+LabelLogAllBefore           = Log all before
+LabelLogAllAfter            = Log all after
 LabelShowSystemUserNames    = Show system names and user names
 LabelTreeEditorHighlightRow = Highlight row in ConditionalNG editor
 LabelStrictTypingGlobalVariables = Use strict typing of global variables
@@ -39,6 +41,8 @@ LabelDefaultIfThenElseExecution = If Then Else - Default execution:
 
 ToolTipStartLogixNGOnLoad   = Should LogixNG start when the panels are loaded?
 ToolTipLabelInstallDebugger = Install the debugger?
+ToolTipLabelLogAllBefore    = Log before every action is executed or expression is evaluated?
+ToolTipLabelLogAllAfter     = Log after every action is executed or expression is evaluated?
 ToolTipLabeShowSystemUserNames  = Should system names and user names be visible for actions and expressions?
 ToolTipTreeEditorHighlightRow = Should highlight row in ConditionalNG editor?
 ToolTipStrictTypingGlobalVariables = If set, a global variable cannot change it's type during execution


### PR DESCRIPTION
See: https://groups.io/g/jmriusers/message/230055

This PR adds two new options to LogixNG preferences:

`Log all before` - If selected, the long description of every action and expression will be printed to the log before it's executed or evaluated.

`Log all after` - If selected, the long description of every action and expression will be printed to the log after it's executed or evaluated.

If there is additional information, it's printed at the end of the line after `---`. Example:
`LogixNG After: Sensor ISCLOCKRUNNING is Active --- Return value False`

In this case, the sensor expression returned False.

Note: For this to work, the LogixNG debugger must be installed. Se LogixNG preferences. The default is that it's installed.