### PR TITLE
Fix bug in LogixNG formula

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -437,6 +437,8 @@
               floor() rounds down.</li>
           <li>The constant <strong>oblocks</strong> has been added to
               the Layout module.</li>
+          <li>Fixes a bug in LogixNG formula when calling a Java method that
+              takes a boolean as parameter, like <strong>setVisible()</strong>.</li>
           <li></li>
         </ul>
 

--- a/java/src/jmri/jmrit/logixng/util/parser/ExpressionNodeMethod.java
+++ b/java/src/jmri/jmrit/logixng/util/parser/ExpressionNodeMethod.java
@@ -26,6 +26,8 @@ public class ExpressionNodeMethod implements ExpressionNodeWithParameter {
         if (param == null) return true;
         if (type.isAssignableFrom(param.getClass())) return true;
 
+        if ((type == Boolean.TYPE) && (param instanceof Boolean)) return true;
+
         if ((type == Byte.TYPE) && (param instanceof Byte)) return true;
         if ((type == Short.TYPE) && (param instanceof Byte)) return true;
         if ((type == Integer.TYPE) && (param instanceof Byte)) return true;
@@ -81,6 +83,8 @@ public class ExpressionNodeMethod implements ExpressionNodeWithParameter {
             if ((params[i] == null) || (paramTypes[i].isAssignableFrom(params[i].getClass()))) {
                 newParam = params[i];
             }
+
+            else if ((paramTypes[i] == Boolean.TYPE) && (params[i] instanceof Boolean)) newParam = params[i];
 
             else if ((paramTypes[i] == Byte.TYPE) && (params[i] instanceof Byte)) newParam = params[i];
             else if ((paramTypes[i] == Short.TYPE) && (params[i] instanceof Byte)) newParam = (short)(byte)params[i];

--- a/java/src/jmri/jmrit/logixng/util/parser/ExpressionNodeMethod.java
+++ b/java/src/jmri/jmrit/logixng/util/parser/ExpressionNodeMethod.java
@@ -72,7 +72,7 @@ public class ExpressionNodeMethod implements ExpressionNodeWithParameter {
 
     @SuppressWarnings("rawtypes")   // We don't know the generic types of Map.Entry in this method
     private Object callMethod(Method method, Object obj, Object[] params)
-            throws IllegalAccessException, IllegalArgumentException, InvocationTargetException {
+            throws IllegalAccessException, IllegalArgumentException, InvocationTargetException, ReflectionException {
 
         Class<?>[] paramTypes = method.getParameterTypes();
         Object[] newParams = new Object[params.length];
@@ -130,8 +130,12 @@ public class ExpressionNodeMethod implements ExpressionNodeWithParameter {
                     case "toString": return obj.toString();
                     case "getKey": return ((Map.Entry)obj).getKey();
                     case "getValue": return ((Map.Entry)obj).getValue();
-                    default: throw ex;
+                    default:
+                        // Do nothing
                 }
+            }
+            if (!Modifier.isPublic(obj.getClass().getModifiers())) {
+                throw new ReflectionException("Can't call methods on object since it's private", ex);
             }
             throw ex;
         }

--- a/java/test/jmri/jmrit/logixng/util/parser/ExpressionNodeMethodTest.java
+++ b/java/test/jmri/jmrit/logixng/util/parser/ExpressionNodeMethodTest.java
@@ -4,12 +4,14 @@ import java.io.*;
 import java.util.*;
 
 import jmri.JmriException;
+import jmri.jmrit.display.layoutEditor.*;
 import jmri.jmrit.logixng.SymbolTable;
 import jmri.jmrit.logixng.implementation.DefaultConditionalNG;
 import jmri.jmrit.logixng.implementation.DefaultSymbolTable;
 import jmri.util.JUnitUtil;
 
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 /**
  * Test ExpressionNodeMethod.
@@ -51,6 +53,21 @@ public class ExpressionNodeMethodTest {
         testCall(entry, "getKey", "Hello", new Object[]{});
         testCall(entry, "getValue", "World", new Object[]{});
         testCall(entry, "toString", "Hello=World", new Object[]{});
+    }
+
+    @Test
+    @DisabledIfSystemProperty(named = "java.awt.headless", matches = "true")
+    public void testMethodWithBooleanParameter() throws JmriException {
+        var editor = new jmri.jmrit.display.layoutEditor.LayoutEditor("My layout");
+        var trackSegment = new TrackSegment("Id", "A", HitPointType.TRACK, "B", HitPointType.TRACK, false, editor);
+        var trackSegmentView = new TrackSegmentView(trackSegment, editor);
+        editor.addLayoutTrack(trackSegment, trackSegmentView);
+        var segments = editor.getTrackSegmentViews();
+        var segment = segments.get(0);
+        segment.setHidden(false);
+        Assertions.assertFalse(segment.isHidden());
+        testCall(segment, "setHidden", null, new Object[]{true});
+        Assertions.assertTrue(segment.isHidden());
     }
 
     /**

--- a/java/test/jmri/jmrit/logixng/util/parser/ExpressionNodeMethodTest.java
+++ b/java/test/jmri/jmrit/logixng/util/parser/ExpressionNodeMethodTest.java
@@ -44,6 +44,19 @@ public class ExpressionNodeMethodTest {
         testCall("Hello", "substring", "ell", new Object[]{1,4});
     }
 
+    @Test
+    public void testMapEntry() throws JmriException {
+        // HashMap.entrySet() returns a set of classes that are private.
+        // We cannot use reflection to call methods on a class that's private.
+        Map<String, String> map = new HashMap<>();
+        map.put("Hello", "World");
+        var entry = map.entrySet().iterator().next();
+        System.out.format("Key: %s, value: %s%n", entry.getKey(), entry.getValue());
+        testCall(entry, "getKey", "Hello", new Object[]{});
+        testCall(entry, "getValue", "World", new Object[]{});
+        testCall(entry, "toString", "Hello=World", new Object[]{});
+    }
+
     /**
      * This method creates the ExpressionNodeMethodPrimTest.java source file.
      * Uncomment the line "@org.junit.Ignore" and run this test to create the file.

--- a/java/test/jmri/jmrit/logixng/util/parser/ExpressionNodeMethodTest.java
+++ b/java/test/jmri/jmrit/logixng/util/parser/ExpressionNodeMethodTest.java
@@ -9,10 +9,7 @@ import jmri.jmrit.logixng.implementation.DefaultConditionalNG;
 import jmri.jmrit.logixng.implementation.DefaultSymbolTable;
 import jmri.util.JUnitUtil;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.*;
 
 /**
  * Test ExpressionNodeMethod.
@@ -36,7 +33,7 @@ public class ExpressionNodeMethodTest {
         ExpressionNodeMethod t = new ExpressionNodeMethod(method, variables, parameterList);
         Object result = t.calculate(object, symbolTable);
 
-        Assert.assertEquals(expectedResult, result);
+        Assertions.assertEquals(expectedResult, result);
     }
 
     @Test
@@ -51,7 +48,6 @@ public class ExpressionNodeMethodTest {
         Map<String, String> map = new HashMap<>();
         map.put("Hello", "World");
         var entry = map.entrySet().iterator().next();
-        System.out.format("Key: %s, value: %s%n", entry.getKey(), entry.getValue());
         testCall(entry, "getKey", "Hello", new Object[]{});
         testCall(entry, "getValue", "World", new Object[]{});
         testCall(entry, "toString", "Hello=World", new Object[]{});
@@ -217,13 +213,14 @@ public class ExpressionNodeMethodTest {
     }
 
     // The minimal setup for log4J
-    @Before
+    @BeforeEach
     public void setUp() {
         JUnitUtil.setUp();
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 


### PR DESCRIPTION
LogixNG formula uses objects as parameters to Java methods. But some methods uses primitive data types like boolean, int, double. LogixNG formula needs to handle those cases. But it turned out that `boolean` was missing. This PR fixes that.