### PR TITLE
Handle case of empty OpenLCB/LCC monitor filter

### DIFF
--- a/java/src/jmri/jmrix/openlcb/swing/monitor/MonitorPane.java
+++ b/java/src/jmri/jmrix/openlcb/swing/monitor/MonitorPane.java
@@ -478,7 +478,7 @@ public class MonitorPane extends jmri.jmrix.AbstractMonPane implements CanListen
             String[] filters = filterField.getText().toUpperCase().split(" ");
 
             for (String s : filters) {
-                if (checkRaw.toUpperCase().startsWith(s.toUpperCase())) {
+                if (! s.isEmpty() && checkRaw.toUpperCase().startsWith(s.toUpperCase())) {
                     synchronized (this) {
                         linesBuffer.setLength(0);
                     }


### PR DESCRIPTION
Fixes bug in recent PR where an empty filter string would suppress output erroneously.