### PR TITLE
add Architecture checks for java.util.logging

### DIFF
--- a/java/test/jmri/ArchitectureTest.java
+++ b/java/test/jmri/ArchitectureTest.java
@@ -276,6 +276,14 @@ public class ArchitectureTest {
             .should().dependOnClassesThat().resideInAPackage("org.apache.logging.log4j");
 
     /**
+     * JMRI (but not apps) should use org.slf4j.Logger instead of JUL.
+     */
+    @ArchTest
+    public static final ArchRule noJULinJmri = noClasses()
+        .that().resideInAPackage("jmri..")
+        .should().dependOnClassesThat().resideInAPackage("java.util.logging");
+
+    /**
      * Confine JDOM to configurexml packages.
      */
     @ArchTest

--- a/java/test/jmri/TestArchitectureTest.java
+++ b/java/test/jmri/TestArchitectureTest.java
@@ -90,6 +90,17 @@ public class TestArchitectureTest {
         .should().dependOnClassesThat().resideInAPackage("org.apache.logging.log4j");
 
     /**
+     * JMRI tests should use org.slf4j.Logger instead of JUL.
+     */
+    @ArchTest
+    public static final ArchRule minimalJULinJmriTests = noClasses()
+        .that().resideInAPackage("jmri..")
+        .and().doNotHaveFullyQualifiedName("jmri.util.TestingLoggerConfiguration")
+        .and().doNotHaveFullyQualifiedName("jmri.util.web.BrowserFactory")
+        .and().doNotHaveFullyQualifiedName("jmri.web.WebServerAcceptanceSteps")
+        .should().dependOnClassesThat().resideInAPackage("java.util.logging");
+
+    /**
      * setUp methods should normally use the org.junit.jupiter.api.BeforeEach annotation.
      */
     @ArchTest

--- a/java/test/jmri/TestArchitectureTest.java
+++ b/java/test/jmri/TestArchitectureTest.java
@@ -95,9 +95,9 @@ public class TestArchitectureTest {
     @ArchTest
     public static final ArchRule minimalJULinJmriTests = noClasses()
         .that().resideInAPackage("jmri..")
-        .and().doNotHaveFullyQualifiedName("jmri.util.TestingLoggerConfiguration")
-        .and().doNotHaveFullyQualifiedName("jmri.util.web.BrowserFactory")
-        .and().doNotHaveFullyQualifiedName("jmri.web.WebServerAcceptanceSteps")
+        .and().doNotHaveFullyQualifiedName("jmri.util.TestingLoggerConfiguration") // tests jul routed to l4j OK
+        .and().doNotHaveFullyQualifiedName("jmri.util.web.BrowserFactory") // 3rd party lib setup
+        .and().doNotHaveFullyQualifiedName("jmri.web.WebServerAcceptanceSteps") // testing output from lib
         .should().dependOnClassesThat().resideInAPackage("java.util.logging");
 
     /**

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorToolsTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorToolsTest.java
@@ -2,7 +2,6 @@ package jmri.jmrit.display.layoutEditor;
 
 import java.awt.geom.Point2D;
 import java.util.List;
-import java.util.logging.*;
 import java.util.stream.Collectors;
 
 import javax.annotation.Nonnull;
@@ -280,7 +279,7 @@ public class LayoutEditorToolsTest {
         try {
             layoutTurnout.setConnection(types[idx], trackSegment, HitPointType.TRACK);
         } catch (JmriException ex) {
-            Logger.getLogger(LayoutEditorToolsTest.class.getName()).log(Level.SEVERE, null, ex);
+            Assertions.fail("Could not set LayoutTurnout Connection", ex);
         }
 
         //pressing "Done" should throw up a "the next signal... apparently is not yet defined."  (InfoMessage5)


### PR DESCRIPTION
Checks for usages of java.util.logging
Tweaks the one test where JUL was used without due cause.