### PR TITLE
Run separate-tests CI on macOS 14

### DIFF
--- a/.github/workflows/run-separate.yml
+++ b/.github/workflows/run-separate.yml
@@ -12,7 +12,7 @@ on: [ push, pull_request ]
 jobs:
   build:
 
-    runs-on: macos-11
+    runs-on: macos-14
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
GitHub is retiring the macos-11 workflow servers, so this PR updates the Separate Tests CI to run on macOS 14.