### PR TITLE
Fix Javadoc warnings

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -2039,7 +2039,7 @@
                 <include name="jmri/**"/>
             </packageset>
 
-            <arg value="-Xdoclint:all"/><!-- remove -missing to get warnings about missing javadoc tags -->
+            <arg value="-Xdoclint:all,-missing,-html"/>
             <arg value="-Xmaxwarns"/>
             <arg value="100"/><!-- default is 100; keep synced with pom.xml, other javadoc targets -->
 

--- a/build.xml
+++ b/build.xml
@@ -2076,7 +2076,7 @@
 
             <link href="https://fazecast.github.io/jSerialComm/javadoc" />
             
-            <link href="https://www.javadoc.io/doc/org.openlcb/openlcb/latest/" />
+            <link href="https://www.javadoc.io/doc/org.openlcb/openlcb/0.7.37/" />
 
             <!-- <link href="https://static.javadoc.io/com.github.purejavacomm/purejavacomm/1.0.1.RELEASE/" packagelistLoc="lib/purejavacomm-1.0.1-package-list"/>  redirected to next line -->
             <link href="https://www.javadoc.io/doc/com.github.purejavacomm/purejavacomm/1.0.1.RELEASE/" packagelistLoc="lib/purejavacomm-1.0.1-package-list"/>
@@ -2084,10 +2084,10 @@
             <!-- <link href="https://static.javadoc.io/com.alexandriasoftware.swing/jsplitbutton/1.3.1/" packagelistLoc="lib/jsplitbutton-1.3.1-package-list"/>  redirected to next line -->
             <link href="https://www.javadoc.io/doc/com.alexandriasoftware.swing/jsplitbutton/1.3.1/" packagelistLoc="lib/jsplitbutton-1.3.1-package-list"/>
 
-            <link href="http://docs.oracle.com/en/java/javase/11/docs/api/"/>
+            <link href="https://docs.oracle.com/en/java/javase/11/docs/api/"/>
             <link href="http://www.jdom.org/docs/apidocs/"/>
             <link href="https://commons.apache.org/proper/commons-csv/apidocs/"/>
-            <link href="http://logging.apache.org/log4j/1.2/apidocs/"/>
+            <link href="https://logging.apache.org/log4j/1.x/apidocs/"/>
             <link href="https://commons.apache.org/proper/commons-lang/javadocs/api-release"/>
             <link href="https://javadoc.io/static/com.github.spotbugs/spotbugs-annotations/4.7.3/"/>
             <link href="https://javadoc.io/doc/com.google.code.findbugs/jsr305/3.0.1/"/>

--- a/java/src/jmri/jmrit/beantable/oblock/TableFrames.java
+++ b/java/src/jmri/jmrit/beantable/oblock/TableFrames.java
@@ -56,6 +56,7 @@ import jmri.util.table.ToggleButtonRenderer;
  * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
  *
  * @author Pete Cressman (C) 2010
+ * @author Egbert Broerse (C) 2019
  * @author Egbert Broerse (C) 2020
  */
 public class TableFrames implements InternalFrameListener {
@@ -350,7 +351,6 @@ public class TableFrames implements InternalFrameListener {
      * Convert a copy of your current JMRI Blocks to OBlocks and connect them with Portals and Paths.
      * Accessed from the Options menu.
      * @throws IllegalArgumentException exception
-     * @author Egbert Broerse 2019
      */
     protected void importBlocks() throws IllegalArgumentException {
         Manager<Block> bm = InstanceManager.getDefault(jmri.BlockManager.class);

--- a/java/src/jmri/jmrix/bachrus/SpeedoTrafficController.java
+++ b/java/src/jmri/jmrix/bachrus/SpeedoTrafficController.java
@@ -146,8 +146,6 @@ public class SpeedoTrafficController implements SpeedoInterface, SerialPortEvent
      * Respond to an event triggered by RXTX. In this case we are
      * only dealing with DATA_AVAILABLE but the other events are left here for
      * reference.
-     *
-     * @author Andrew Berridge Jan 2010
      */
     @Override
     public void serialEvent(SerialPortEvent event) {

--- a/java/src/jmri/util/davidflanagan/HardcopyWriter.java
+++ b/java/src/jmri/util/davidflanagan/HardcopyWriter.java
@@ -22,6 +22,7 @@ import jmri.util.JmriJFrame;
  * alligator on the front.
  *
  * @author David Flanagan
+ * @author Dennis Miller
  */
 public class HardcopyWriter extends Writer {
 
@@ -181,8 +182,6 @@ public class HardcopyWriter extends Writer {
 
     /**
      * Create a print preview toolbar.
-     *
-     * @author Dennis Miller
      */
     protected void toolBarInit() {
         previousButton = new JButton(Bundle.getMessage("ButtonPreviousPage"));
@@ -214,8 +213,6 @@ public class HardcopyWriter extends Writer {
      * Display a page image in the preview pane.
      * <p>
      * Not part of the original HardcopyWriter class.
-     *
-     * @author Dennis Miller
      */
     protected void displayPage() {
         // limit the pages to the actual range
@@ -355,8 +352,6 @@ public class HardcopyWriter extends Writer {
     /**
      * Handle close event of pane. Modified to clean up the added preview
      * capability.
-     *
-     * @author David Flanagan, modified by Dennis Miller
      */
     @Override
     public void close() {


### PR DESCRIPTION
The section [Running JMRI 5 on Java 17 or later](https://www.jmri.org/help/en/html/doc/Technical/JVMCapabilities.shtml) has the comment:

> 5. (Development only) Improved error checking in the Javadoc process generates hundreds of warnings that can hide real problems. These will need to be cleaned up.

There was three warnings about redirection of Javadoc, for example `openlcb/latest` to `openlcb/0.7.37`. These are fixed.

There was some warnings about `@author` in places not allowed. These are fixed.

There was 46977 warnings about missing Javadoc. It's not reasonable that we will track down and fix these so this PR suppresses that warning.

There was 10 warnings about `empty <p> tag`. In my view, fixing these makes the Java code ugly and difficult to read so this PR suppresses these too. An example of the problem is jmri.jmrix.bidib.BiDiBConnectionTypeList

Before the fix:

```
/**
 * Returns a list of valid BiDiB Connection Types
 * <p>
 * @author Bob Jacobsen Copyright (C) 2010
 * @author Kevin Dickerson Copyright (C) 2010
 * @author Mark Underwood Copyright (C) 2015
 * @author Eckart Meyer Copyright (C) 2019-2023
 *
 * Based on DCCppConnectionTypeList
 */
```

After the fix:

```
> /**
>  * Returns a list of valid BiDiB Connection Types
>  *
>  * <p>@author Bob Jacobsen Copyright (C) 2010
>  * @author Kevin Dickerson Copyright (C) 2010
>  * @author Mark Underwood Copyright (C) 2015
>  * @author Eckart Meyer Copyright (C) 2019-2023
>  *
>  * Based on DCCppConnectionTypeList
>  */
```

Note the line:
` * <p>@author Bob Jacobsen Copyright (C) 2010`