### PR TITLE
JmriJFileChooser to document modal

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -617,6 +617,6 @@
     <h3>Miscellaneous</h3>
         <a id="Misc" name="Misc"></a>
         <ul>
-            <li></li>
+            <li>Improvements to File Selection Dialog boxes when displayed with "Always On Top" window frames present.</li>
         </ul>
 

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -617,6 +617,6 @@
     <h3>Miscellaneous</h3>
         <a id="Misc" name="Misc"></a>
         <ul>
-            <li>Improvements to File Selection Dialog boxes when displayed with "Always On Top" window frames present.</li>
+            <li>Improvements to File Selection Dialog boxes when displayed with &quot;Always On Top&quot; window frames present.</li>
         </ul>
 

--- a/java/src/jmri/configurexml/LoadXmlConfigAction.java
+++ b/java/src/jmri/configurexml/LoadXmlConfigAction.java
@@ -100,6 +100,7 @@ public class LoadXmlConfigAction extends LoadStoreBaseAction {
 
     /**
      * Get the File from a given JFileChooser.
+     * @return the selected File.
      * @deprecated use {@link #getFile(JFileChooser fileChooser, Component component)}
      * @param fileChooser the JFileChooser for the file.
      */
@@ -124,6 +125,7 @@ public class LoadXmlConfigAction extends LoadStoreBaseAction {
     }
 
     /**
+     * @return the selected File.
      * @deprecated use {@link #getFile(JFileChooser fileChooser, Component component)}
      * @param fileChooser the FileChooser to get from.
      */

--- a/java/src/jmri/configurexml/LoadXmlConfigAction.java
+++ b/java/src/jmri/configurexml/LoadXmlConfigAction.java
@@ -115,7 +115,8 @@ public class LoadXmlConfigAction extends LoadStoreBaseAction {
      * If a Component is provided, this helps the JFileChooser to not get stuck
      * behind an Always On Top Window.
      * @param fileChooser the FileChooser to get from.
-     * @param component a Component within a JFrame / Window / Popup Menu.
+     * @param component a Component within a JFrame / Window / Popup Menu,
+     *                  or the JFrame or Window itself.
      * @return the File, may be null if none selected.
      */
     @CheckForNull
@@ -140,7 +141,8 @@ public class LoadXmlConfigAction extends LoadStoreBaseAction {
      * If a Component is provided, this helps the JFileChooser to not get stuck
      * behind an Always On Top Window.
      * @param fileChooser the FileChooser to get from.
-     * @param component a Component within a JFrame / Window / Popup Menu.
+     * @param component a Component within a JFrame / Window / Popup Menu,
+     *                  or the JFrame or Window itself.
      * @return the File, may be null if none selected.
      */
     @CheckForNull

--- a/java/src/jmri/configurexml/LoadXmlConfigAction.java
+++ b/java/src/jmri/configurexml/LoadXmlConfigAction.java
@@ -1,8 +1,12 @@
 package jmri.configurexml;
 
+import java.io.File;
 import java.util.Set;
+import java.awt.Component;
 import java.awt.event.ActionEvent;
 
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
 import javax.swing.JFileChooser;
 
 import jmri.ConfigureManager;
@@ -12,9 +16,7 @@ import jmri.JmriException;
 import jmri.jmrit.display.Editor;
 import jmri.jmrit.display.EditorManager;
 import jmri.jmrit.logixng.LogixNG_Manager;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import jmri.util.swing.JmriJOptionPane;
 
 /**
  * Load configuration information from an XML file.
@@ -40,15 +42,16 @@ public class LoadXmlConfigAction extends LoadStoreBaseAction {
 
     @Override
     public void actionPerformed(ActionEvent e) {
-        loadFile(getConfigFileChooser());
+        loadFile(getConfigFileChooser(), JmriJOptionPane.findWindowForObject( e == null ? null : e.getSource()));
     }
 
     /**
-     *
+     * Load a File from a given JFileChooser.
      * @param fileChooser {@link JFileChooser} to use for file selection
+     * @param component a Component which has called the File Chooser.
      * @return true if successful
      */
-    protected boolean loadFile(JFileChooser fileChooser) {
+    protected boolean loadFile(@Nonnull JFileChooser fileChooser, @CheckForNull Component component ) {
         Set<Editor> editors = InstanceManager.getDefault(EditorManager.class).getAll();
         if (!editors.isEmpty()) {
             InstanceManager.getDefault(jmri.UserPreferencesManager.class).showWarningMessage(
@@ -59,7 +62,7 @@ public class LoadXmlConfigAction extends LoadStoreBaseAction {
         }
 
         boolean results = false;
-        java.io.File file = getFile(fileChooser);
+        File file = getFile(fileChooser, component);
         if (file != null) {
             log.info("Loading selected file: {}", file); // NOI18N
             try {
@@ -95,24 +98,60 @@ public class LoadXmlConfigAction extends LoadStoreBaseAction {
         return results;
     }
 
-    static public java.io.File getFile(JFileChooser fileChooser) {
-        fileChooser.setDialogType(javax.swing.JFileChooser.OPEN_DIALOG);
-        return getFileCustom(fileChooser);
+    /**
+     * Get the File from a given JFileChooser.
+     * @deprecated use {@link #getFile(JFileChooser fileChooser, Component component)}
+     * @param fileChooser the JFileChooser for the file.
+     */
+    @CheckForNull
+    @Deprecated (since="5.7.8",forRemoval=true)
+    public static File getFile(@Nonnull JFileChooser fileChooser) {
+        return getFile(fileChooser, null);
     }
 
-    static public java.io.File getFileCustom(JFileChooser fileChooser) {
+    /**
+     * Get the File from an Open File JFileChooser.
+     * If a Component is provided, this helps the JFileChooser to not get stuck
+     * behind an Always On Top Window.
+     * @param fileChooser the FileChooser to get from.
+     * @param component a Component within a JFrame / Window / Popup Menu.
+     * @return the File, may be null if none selected.
+     */
+    @CheckForNull
+    public static File getFile(@Nonnull JFileChooser fileChooser, @CheckForNull Component component) {
+        fileChooser.setDialogType(javax.swing.JFileChooser.OPEN_DIALOG);
+        return getFileCustom(fileChooser, component);
+    }
+
+    /**
+     * @deprecated use {@link #getFile(JFileChooser fileChooser, Component component)}
+     * @param fileChooser the FileChooser to get from.
+     */
+    @CheckForNull
+    @Deprecated (since="5.7.8",forRemoval=true)
+    public static File getFileCustom(@Nonnull JFileChooser fileChooser) {
+        return getFileCustom(fileChooser, null);
+    }
+
+    /**
+     * Get the File from a JFileChooser.
+     * If a Component is provided, this helps the JFileChooser to not get stuck
+     * behind an Always On Top Window.
+     * @param fileChooser the FileChooser to get from.
+     * @param component a Component within a JFrame / Window / Popup Menu.
+     * @return the File, may be null if none selected.
+     */
+    @CheckForNull
+    public static File getFileCustom(@Nonnull JFileChooser fileChooser, @CheckForNull Component component){
         fileChooser.rescanCurrentDirectory();
-        int retVal = fileChooser.showDialog(null, Bundle.getMessage("MenuItemLoad"));  // NOI18N
+        int retVal = fileChooser.showDialog(component, Bundle.getMessage("MenuItemLoad"));  // NOI18N
         if (retVal != JFileChooser.APPROVE_OPTION) {
             return null;  // give up if no file selected
         }
-        if (log.isDebugEnabled()) {
-            log.debug("Open file: {}", fileChooser.getSelectedFile().getPath());  // NOI18N
-        }
+        log.debug("Open file: {}", fileChooser.getSelectedFile().getPath());
         return fileChooser.getSelectedFile();
     }
 
-    // initialize logging
-    private final static Logger log = LoggerFactory.getLogger(LoadXmlConfigAction.class);
+    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LoadXmlConfigAction.class);
 
 }

--- a/java/src/jmri/configurexml/LoadXmlUserAction.java
+++ b/java/src/jmri/configurexml/LoadXmlUserAction.java
@@ -2,6 +2,7 @@ package jmri.configurexml;
 
 import java.awt.event.ActionEvent;
 import java.io.File;
+
 import javax.swing.JFileChooser;
 
 import jmri.util.swing.JmriJOptionPane;
@@ -20,7 +21,7 @@ import jmri.util.swing.JmriJOptionPane;
  */
 public class LoadXmlUserAction extends LoadXmlConfigAction {
 
-    static private File currentFile = null;
+    private static File currentFile = null;
 
     public LoadXmlUserAction() {
         this(Bundle.getMessage("MenuItemLoad"));
@@ -38,13 +39,14 @@ public class LoadXmlUserAction extends LoadXmlConfigAction {
         // Cancel button can't be localized like userFileChooser.setCancelButtonText() TODO
         userFileChooser.setDialogTitle(Bundle.getMessage("LoadTitle"));
 
-        boolean results = loadFile(userFileChooser);
+        java.awt.Window window = JmriJOptionPane.findWindowForObject( e == null ? null : e.getSource());
+        boolean results = loadFile(userFileChooser, window);
         if (results) {
             log.debug("load was successful");
             setCurrentFile(userFileChooser.getSelectedFile());
         } else {
             log.debug("load failed");
-            JmriJOptionPane.showMessageDialog(null,
+            JmriJOptionPane.showMessageDialog(window,
                     Bundle.getMessage("LoadHasErrors") + "\n"
                     + Bundle.getMessage("CheckPreferences") + "\n"
                     + Bundle.getMessage("ConsoleWindowHasInfo"),

--- a/java/src/jmri/jmrit/throttle/ThrottleFrame.java
+++ b/java/src/jmri/jmrit/throttle/ThrottleFrame.java
@@ -238,7 +238,7 @@ public class ThrottleFrame extends JDesktopPane implements ComponentListener, Ad
         JFileChooser fileChooser = jmri.jmrit.XmlFile.userFileChooser(Bundle.getMessage("PromptXmlFileTypes"), "xml");
         fileChooser.setCurrentDirectory(new File(getDefaultThrottleFolder()));
         fileChooser.setDialogType(JFileChooser.OPEN_DIALOG);
-        java.io.File file = LoadXmlConfigAction.getFile(fileChooser);
+        java.io.File file = LoadXmlConfigAction.getFile(fileChooser, this);
         if (file == null) {
             return ;
         }

--- a/java/src/jmri/util/swing/JmriJFileChooser.java
+++ b/java/src/jmri/util/swing/JmriJFileChooser.java
@@ -47,4 +47,15 @@ public class JmriJFileChooser extends JFileChooser {
             details.actionPerformed(null);
         }
     }
+
+    // set ModalityType.DOCUMENT_MODAL so does not clash with Always On Top windows.
+    @Override
+    protected javax.swing.JDialog createDialog(java.awt.Component parent) throws java.awt.HeadlessException {
+        javax.swing.JDialog dialog = super.createDialog(parent);
+        if ( parent != null ) {
+            dialog.setModalityType(java.awt.Dialog.ModalityType.DOCUMENT_MODAL);
+        }
+        return dialog;
+    }
+
 }

--- a/java/src/jmri/util/swing/JmriJOptionPane.java
+++ b/java/src/jmri/util/swing/JmriJOptionPane.java
@@ -317,14 +317,37 @@ public class JmriJOptionPane {
     }
 
     @CheckForNull
-    private static Window findWindowForComponent(Component component){
+    private static Window findWindowForComponent(@CheckForNull Component component){
         if (component == null) {
             return null;
+        }
+        if (component instanceof JPopupMenu ) {
+            return findWindowForComponent(((JPopupMenu)component).getInvoker());
+        }
+        if (component instanceof JFrame ) {
+            return (JFrame)component;
         }
         if (component instanceof Window) {
             return (Window) component;
         }
         return findWindowForComponent(component.getParent());
+    }
+
+    /**
+     * Find the parent Window, normally from a java.awt.Component .
+     * <p>
+     * If the component is within a JPopupMenu,
+     * the parent Window of the Popup Menu will be returned, not the Frame of
+     * the Popup Menu itself ( which may no longer be visible ).
+     * @param object a child component of the Window.
+     * @return the parent Window, or null if none found.
+     */
+    @CheckForNull
+    public static Window findWindowForObject( @CheckForNull Object object ){
+        if ( object instanceof Component ) {
+            return JmriJOptionPane.findWindowForComponent((Component)object);
+        }
+        return null;
     }
 
     private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(JmriJOptionPane.class);


### PR DESCRIPTION
See #13111 

JmriJFileChooser -
Set Document Modal if parent exists.

JmriJOptionPane -
Add public method to locate Windows from components.
If component is a JPopupMenu locate the invoker Window.

LoadXmlConfigAction -
Pass the Window Component through to the fileChooser showDialog .
Deprecates loadFile(JFileChooser), getFile(JFileChooser) and getFileCustom(JFileChooser) in favour of methods with the additional Component field.

LoadXmlUserAction -
Find any potential Component through from the ActionEvent source and use it for FileChooser and Error dialogs.