### PR TITLE
Disable label value changes

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -412,6 +412,11 @@
             <li>Add the <strong>hidden</strong> attribute to the Layout Editor <strong>Shape</strong>
             item.  The center popup menu has an option to hide the shape when not editing.  The
             <strong>setHidden(boolean)</strong> public method can be used by scripts and LogixNG.</li>
+
+            <li>The <strong>Disable value edit popup when not editing</strong> menu item has been
+            added to the context menus for blocks, memories and global variables.  When the panel
+            is not in edit mode and the option is enabled, the pop-up to the edit the value will
+            not occur.</li>
         </ul>
 
         <h4>NX - Entry/Exit Tool</h4>
@@ -465,13 +470,19 @@
    <h3>Panel Editor</h3>
         <a id="PE" name="PE"></a>
         <ul>
-            <li></li>
+            <li>The <strong>Disable value edit popup when not editing</strong> menu item has been
+            added to the context menus for blocks, memories and global variables.  When the panel
+            is not in edit mode and the option is enabled, the pop-up to the edit the value will
+            not occur. The option does not apply to input and spinner icons.</li>
         </ul>
 
     <h3>Control Panel Editor</h3>
         <a id="CPE" name="CPE"></a>
         <ul>
-            <li></li>
+            <li>The <strong>Disable value edit popup when not editing</strong> menu item has been
+            added to the context menus for memories and global variables.  When the panel
+            is not in edit mode and the option is enabled, the pop-up to the edit the value will
+            not occur. The option does not apply to input, spinner and combo icons.</li>
         </ul>
         <h4>Circuit Builder</h4>
             <a id="CPE-CB" name="CPE-CB"></a>

--- a/java/src/jmri/jmrit/display/BlockContentsIcon.java
+++ b/java/src/jmri/jmrit/display/BlockContentsIcon.java
@@ -297,6 +297,10 @@ public class BlockContentsIcon extends MemoryIcon {
     @Override
     public void doMouseClicked(JmriMouseEvent e) {
         if (e.getClickCount() == 2) { // double click?
+            if (!getEditor().isEditable() && isValueEditDisabled()) {
+                log.debug("Double click block value edit disabled");
+                return;
+            }
             editBlockValue();
         }
     }

--- a/java/src/jmri/jmrit/display/DisplayBundle.properties
+++ b/java/src/jmri/jmrit/display/DisplayBundle.properties
@@ -178,6 +178,7 @@ SetCustomTooltip = Set Custom Tooltip{0}
 PrependTooltipWithDisplayName    = Prepend Display Name to custom tooltip
 SetHidden       = Hide when not editing
 SetEmptyHidden  = Hide when empty and not editing
+SetValueEditDisabled = Disable value edit popup when not editing
 EditId          = Edit Id
 EditClasses     = Edit Classes
 LogixNG         = LogixNG

--- a/java/src/jmri/jmrit/display/Editor.java
+++ b/java/src/jmri/jmrit/display/Editor.java
@@ -1387,6 +1387,39 @@ abstract public class Editor extends JmriJFrame implements JmriMouseListener, Jm
     }
 
     /**
+     * Add a menu entry to disable double click value edits.  This applies when not in panel edit mode.
+     * This is applicable to memory,  block content and LogixNG global variable labels.
+     *
+     * @param p     the item
+     * @param popup the menu to add the entry to
+     */
+    public void setValueEditDisabledMenu(Positionable p, JPopupMenu popup) {
+        if (p.getDisplayLevel() == BKG) {
+            return;
+        }
+        if (p instanceof BlockContentsIcon || p instanceof MemoryIcon || p instanceof GlobalVariableIcon) {
+            JCheckBoxMenuItem valueEditDisableItem = new JCheckBoxMenuItem(Bundle.getMessage("SetValueEditDisabled"));
+            valueEditDisableItem.setSelected(p.isValueEditDisabled());
+            valueEditDisableItem.addActionListener(new ActionListener() {
+                Positionable comp;
+                JCheckBoxMenuItem checkBox;
+
+                @Override
+                public void actionPerformed(ActionEvent e) {
+                    comp.setValueEditDisabled(checkBox.isSelected());
+                }
+
+                ActionListener init(Positionable pos, JCheckBoxMenuItem cb) {
+                    comp = pos;
+                    checkBox = cb;
+                    return this;
+                }
+            }.init(p, valueEditDisableItem));
+            popup.add(valueEditDisableItem);
+        }
+    }
+
+    /**
      * Add a menu entry to edit Id of the Positionable item
      *
      * @param p     the item

--- a/java/src/jmri/jmrit/display/GlobalVariableIcon.java
+++ b/java/src/jmri/jmrit/display/GlobalVariableIcon.java
@@ -463,6 +463,10 @@ public class GlobalVariableIcon extends MemoryOrGVIcon implements java.beans.Pro
     @Override
     public void doMouseClicked(JmriMouseEvent e) {
         if (e.getClickCount() == 2) { // double click?
+            if (!getEditor().isEditable() && isValueEditDisabled()) {
+                log.debug("Double click global variable value edit is disabled");
+                return;
+            }
             editGlobalVariableValue();
         }
     }

--- a/java/src/jmri/jmrit/display/MemoryIcon.java
+++ b/java/src/jmri/jmrit/display/MemoryIcon.java
@@ -577,6 +577,10 @@ public class MemoryIcon extends MemoryOrGVIcon implements java.beans.PropertyCha
     @Override
     public void doMouseClicked(JmriMouseEvent e) {
         if (e.getClickCount() == 2) { // double click?
+            if (!getEditor().isEditable() && isValueEditDisabled()) {
+                log.debug("Double click memory value edit is disabled");
+                return;
+            }
             editMemoryValue();
         }
     }

--- a/java/src/jmri/jmrit/display/Positionable.java
+++ b/java/src/jmri/jmrit/display/Positionable.java
@@ -117,6 +117,10 @@ public interface Positionable extends Cloneable, InlineLogixNG {
 
     boolean isEmptyHidden();
 
+    void setValueEditDisabled(boolean disabled);
+
+    boolean isValueEditDisabled();
+
     int getDisplayLevel();
 
     void setDisplayLevel(int l);

--- a/java/src/jmri/jmrit/display/PositionableJComponent.java
+++ b/java/src/jmri/jmrit/display/PositionableJComponent.java
@@ -195,6 +195,15 @@ public class PositionableJComponent extends JComponent implements Positionable {
         return _emptyHidden;
     }
 
+    @Override
+    public void setValueEditDisabled(boolean isDisabled) {
+    }
+
+    @Override
+    public boolean isValueEditDisabled() {
+        return false;
+    }
+
     /**
      * Delayed setDisplayLevel for DnD.
      *

--- a/java/src/jmri/jmrit/display/PositionableJPanel.java
+++ b/java/src/jmri/jmrit/display/PositionableJPanel.java
@@ -199,6 +199,15 @@ public class PositionableJPanel extends JPanel implements Positionable, JmriMous
         return _emptyHidden;
     }
 
+    @Override
+    public void setValueEditDisabled(boolean isDisabled) {
+    }
+
+    @Override
+    public boolean isValueEditDisabled() {
+        return false;
+    }
+
     public void setLevel(int l) {
         _displayLevel = l;
     }

--- a/java/src/jmri/jmrit/display/PositionableLabel.java
+++ b/java/src/jmri/jmrit/display/PositionableLabel.java
@@ -71,6 +71,7 @@ public class PositionableLabel extends JLabel implements Positionable {
     protected boolean _controlling = true;
     protected boolean _hidden = false;
     protected boolean _emptyHidden = false;
+    protected boolean _valueEditDisabled = false;
     protected int _displayLevel;
 
     protected String _unRotatedText;
@@ -242,6 +243,16 @@ public class PositionableLabel extends JLabel implements Positionable {
     @Override
     public boolean isEmptyHidden() {
         return _emptyHidden;
+    }
+
+    @Override
+    public void setValueEditDisabled(boolean isDisabled) {
+        _valueEditDisabled = isDisabled;
+    }
+
+    @Override
+    public boolean isValueEditDisabled() {
+        return _valueEditDisabled;
     }
 
     /**

--- a/java/src/jmri/jmrit/display/configurexml/PositionableLabelXml.java
+++ b/java/src/jmri/jmrit/display/configurexml/PositionableLabelXml.java
@@ -183,6 +183,9 @@ public class PositionableLabelXml extends AbstractXmlAdapter {
         if (p.isEmptyHidden()) {
             element.setAttribute("emptyHidden", "yes");
         }
+        if (p.isValueEditDisabled()) {
+            element.setAttribute("valueEditDisabled", "yes");
+        }
         element.setAttribute("positionable", p.isPositionable() ? "true" : "false");
         element.setAttribute("showtooltip", p.showToolTip() ? "true" : "false");
         element.setAttribute("editable", p.isEditable() ? "true" : "false");
@@ -538,6 +541,15 @@ public class PositionableLabelXml extends AbstractXmlAdapter {
             l.setEmptyHidden(value);
         } catch (DataConversionException e) {
             log.warn("unable to convert positionable label emptyHidden attribute");
+        } catch (NullPointerException e) {
+            // considered normal if the attribute not present
+        }
+
+        try {
+            boolean value = element.getAttribute("valueEditDisabled").getBooleanValue();
+            l.setValueEditDisabled(value);
+        } catch (DataConversionException e) {
+            log.warn("unable to convert positionable label valueEditDisabled attribute");
         } catch (NullPointerException e) {
             // considered normal if the attribute not present
         }

--- a/java/src/jmri/jmrit/display/controlPanelEditor/ControlPanelEditor.java
+++ b/java/src/jmri/jmrit/display/controlPanelEditor/ControlPanelEditor.java
@@ -1592,6 +1592,7 @@ public class ControlPanelEditor extends Editor implements DropTargetListener, Cl
                 setDisplayLevelMenu(p, popup);
                 setHiddenMenu(p, popup);
                 setEmptyHiddenMenu(p, popup);
+                setValueEditDisabledMenu(p, popup);
                 setEditIdMenu(p, popup);
                 setEditClassesMenu(p, popup);
                 popup.addSeparator();

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
@@ -3969,6 +3969,7 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
                 if (p.doViemMenu()) {
                     setHiddenMenu(p, popup);
                     setEmptyHiddenMenu(p, popup);
+                    setValueEditDisabledMenu(p, popup);
                     setEditIdMenu(p, popup);
                     setEditClassesMenu(p, popup);
                     popup.addSeparator();

--- a/java/src/jmri/jmrit/display/panelEditor/PanelEditor.java
+++ b/java/src/jmri/jmrit/display/panelEditor/PanelEditor.java
@@ -617,6 +617,7 @@ public class PanelEditor extends Editor implements ItemListener {
                 setDisplayLevelMenu(p, popup);
                 setHiddenMenu(p, popup);
                 setEmptyHiddenMenu(p, popup);
+                setValueEditDisabledMenu(p, popup);
                 setEditIdMenu(p, popup);
                 setEditClassesMenu(p, popup);
                 popup.addSeparator();

--- a/xml/schema/types/editors.xsd
+++ b/xml/schema/types/editors.xsd
@@ -117,6 +117,7 @@
       <xs:attribute name="forcecontroloff" type="trueFalseType" default="false"></xs:attribute>
       <xs:attribute name="hidden" type="yesNoType" default="no"></xs:attribute>
       <xs:attribute name="emptyHidden" type="yesNoType"></xs:attribute>
+      <xs:attribute name="valueEditDisabled" type="yesNoType"></xs:attribute>
       <xs:attribute name="positionable" type="trueFalseType"></xs:attribute>
       <xs:attribute name="showtooltip" type="trueFalseType" default="true"></xs:attribute>
       <xs:attribute name="editable" type="trueFalseType" default="true"></xs:attribute>


### PR DESCRIPTION
An option is added to the context menus for blocks, memories and global variables to disable the double click pop-up that can be used to change values.  