### PR TITLE
Store the outer bean in the manager

### DIFF
--- a/java/src/jmri/jmrit/logixng/implementation/AbstractBaseManager.java
+++ b/java/src/jmri/jmrit/logixng/implementation/AbstractBaseManager.java
@@ -134,6 +134,23 @@ public abstract class AbstractBaseManager<E extends NamedBean> extends AbstractM
         _maleSocketFactories.add(factory);
     }
     
+    /** {@inheritDoc} */
+    @Override
+    @SuppressWarnings("unchecked")   // Can't check generic types
+    protected E getOuterBean(E bean) {
+        if (bean == null) {
+            return null;
+        }
+        if (bean instanceof Base) {
+            Base b = (Base) bean;
+            while (b.getParent() instanceof MaleSocket) {
+                b = b.getParent();
+            }
+            return (E) b;
+        }
+        return bean;
+    }
+
 //    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(AbstractBaseManager.class);
     
 }

--- a/java/src/jmri/managers/AbstractManager.java
+++ b/java/src/jmri/managers/AbstractManager.java
@@ -307,6 +307,18 @@ public abstract class AbstractManager<E extends NamedBean> extends VetoableChang
     }
 
     /**
+     * Get the outer bean of an encapsulated bean.
+     * Some managers encapsulates the beans and those managers needs to
+     * override this method.
+     * @param  bean the bean
+     * @return the most outer bean or the bean itself if there is no
+     *         outer bean
+     */
+    protected E getOuterBean(E bean) {
+        return bean;
+    }
+
+    /**
      * The PropertyChangeListener interface in this class is intended to keep
      * track of user name changes to individual NamedBeans. It is not completely
      * implemented yet. In particular, listeners are not added to newly
@@ -322,7 +334,7 @@ public abstract class AbstractManager<E extends NamedBean> extends VetoableChang
             String old = (String) e.getOldValue();  // previous user name
             String now = (String) e.getNewValue();  // current user name
             try { // really should always succeed
-                E t = (E) e.getSource();
+                E t = getOuterBean((E) e.getSource());
                 if (old != null) {
                     _tuser.remove(old); // remove old name for this bean
                 }


### PR DESCRIPTION
@bobjacobsen 
Each action and expression in LogixNG is encapsulated in one or more male sockets. The male socket, not the action/expression, is stored in the manager.

This works very well, with one important exception. If the user changes the user name of an action/expression, the action/expression itself is stored in the `_tuser` map in AbstractManager, instead of the male socket that should be stored.

This PR ensures that the outer male socket is stored in the manager, instead of the action/expression itself.