### PR TITLE
WIP - Move jmri.jmrix.bachrus to the new serial library

### DIFF
--- a/java/src/jmri/jmrix/AbstractSerialPortController.java
+++ b/java/src/jmri/jmrix/AbstractSerialPortController.java
@@ -424,29 +424,7 @@ abstract public class AbstractSerialPortController extends AbstractPortControlle
      */
     final protected void setFlowControl(SerialPort serialPort, FlowControl flow) {
         lastFlowControl = flow;
-
-        boolean result = true;
-
-        if (null == flow) {
-            log.error("Invalid null FlowControl enum member");
-        } else switch (flow) {
-            case RTSCTS:
-                result = serialPort.serialPort.setFlowControl(com.fazecast.jSerialComm.SerialPort.FLOW_CONTROL_RTS_ENABLED
-                        | com.fazecast.jSerialComm.SerialPort.FLOW_CONTROL_CTS_ENABLED );
-                break;
-            case XONXOFF:
-                result = serialPort.serialPort.setFlowControl(com.fazecast.jSerialComm.SerialPort.FLOW_CONTROL_XONXOFF_IN_ENABLED
-                        | com.fazecast.jSerialComm.SerialPort.FLOW_CONTROL_XONXOFF_OUT_ENABLED);
-                break;
-            case NONE:
-                result = serialPort.serialPort.setFlowControl(com.fazecast.jSerialComm.SerialPort.FLOW_CONTROL_DISABLED);
-                break;
-            default:
-                log.error("Invalid FlowControl enum member: {}", flow);
-                break;
-        }
-
-        if (!result) log.error("Port did not accept flow control setting {}", flow);
+        serialPort.setFlowControl(flow);
     }
 
     private FlowControl lastFlowControl = FlowControl.NONE;
@@ -1025,6 +1003,37 @@ abstract public class AbstractSerialPortController extends AbstractPortControlle
 
         public boolean getDCD() {
             return this.serialPort.getDCD();
+        }
+
+        /**
+         * Configure the flow control settings. Keep this in synch with the
+         * FlowControl enum.
+         *
+         * @param flow  set which kind of flow control to use
+         */
+        public final void setFlowControl(FlowControl flow) {
+            boolean result = true;
+
+            if (null == flow) {
+                log.error("Invalid null FlowControl enum member");
+            } else switch (flow) {
+                case RTSCTS:
+                    result = serialPort.setFlowControl(com.fazecast.jSerialComm.SerialPort.FLOW_CONTROL_RTS_ENABLED
+                            | com.fazecast.jSerialComm.SerialPort.FLOW_CONTROL_CTS_ENABLED );
+                    break;
+                case XONXOFF:
+                    result = serialPort.setFlowControl(com.fazecast.jSerialComm.SerialPort.FLOW_CONTROL_XONXOFF_IN_ENABLED
+                            | com.fazecast.jSerialComm.SerialPort.FLOW_CONTROL_XONXOFF_OUT_ENABLED);
+                    break;
+                case NONE:
+                    result = serialPort.setFlowControl(com.fazecast.jSerialComm.SerialPort.FLOW_CONTROL_DISABLED);
+                    break;
+                default:
+                    log.error("Invalid FlowControl enum member: {}", flow);
+                    break;
+            }
+
+            if (!result) log.error("Port did not accept flow control setting {}", flow);
         }
 
         public void setBreak() {

--- a/java/src/jmri/jmrix/AbstractSerialPortController.java
+++ b/java/src/jmri/jmrix/AbstractSerialPortController.java
@@ -991,6 +991,14 @@ abstract public class AbstractSerialPortController extends AbstractPortControlle
             this.serialPort.setNumDataBits(bits);
         }
 
+        public void setNumStopBits(int bits) {
+            this.serialPort.setNumStopBits(bits);
+        }
+
+        public void setParity(Parity parity) {
+            serialPort.setParity(parity.getValue());  // constants are defined with values for the specific port class
+        }
+
         public void setDTR() {
             this.serialPort.setDTR();
         }

--- a/java/src/jmri/jmrix/AbstractSerialPortController.java
+++ b/java/src/jmri/jmrix/AbstractSerialPortController.java
@@ -36,6 +36,23 @@ abstract public class AbstractSerialPortController extends AbstractPortControlle
      * @return Localized message, in case separate presentation to user is
      *         desired
      */
+    //@Deprecated(forRemoval=true) // with jmri.jmrix.PureJavaComm
+    public String handlePortBusy(jmri.jmrix.purejavacomm.PortInUseException p, String portName, org.slf4j.Logger log) {
+        log.error("{} port is in use: {}", portName, p.getMessage());
+        ConnectionStatus.instance().setConnectionState(this.getSystemPrefix(), portName, ConnectionStatus.CONNECTION_DOWN);
+        return Bundle.getMessage("SerialPortInUse", portName);
+    }
+
+    /**
+     * Standard error handling for purejavacomm port-busy case.
+     *
+     * @param p        the exception being handled, if additional information
+     *                 from it is desired
+     * @param portName name of the port being accessed
+     * @param log      where to log a status message
+     * @return Localized message, in case separate presentation to user is
+     *         desired
+     */
     //@Deprecated(forRemoval=true) // with PureJavaComm
     @Override
     public String handlePortBusy(purejavacomm.PortInUseException p, String portName, org.slf4j.Logger log) {
@@ -44,6 +61,20 @@ abstract public class AbstractSerialPortController extends AbstractPortControlle
          "Error", JmriJOptionPane.ERROR_MESSAGE);*/
         ConnectionStatus.instance().setConnectionState(this.getSystemPrefix(), portName, ConnectionStatus.CONNECTION_DOWN);
         return Bundle.getMessage("SerialPortInUse", portName);
+    }
+
+    /**
+     * Specific error handling for purejavacomm port-not-found case.
+     * @param p no such port exception.
+     * @param portName port name.
+     * @param log system log.
+     * @return human readable string with error detail.
+     */
+    //@Deprecated(forRemoval=true) // with jmri.jmrix.PureJavaComm
+    public String handlePortNotFound(jmri.jmrix.purejavacomm.NoSuchPortException p, String portName, org.slf4j.Logger log) {
+        log.error("Serial port {} not found", portName);
+        ConnectionStatus.instance().setConnectionState(this.getSystemPrefix(), portName, ConnectionStatus.CONNECTION_DOWN);
+        return Bundle.getMessage("SerialPortNotFound", portName);
     }
 
     /**
@@ -227,6 +258,35 @@ abstract public class AbstractSerialPortController extends AbstractPortControlle
             portNameVector.addElement(portID.getSystemPortName());
         }
         return portNameVector;
+    }
+
+    /**
+     * Set the control leads and flow control for jmri.jmrix.purejavacomm. This handles any necessary
+     * ordering.
+     *
+     * @param serialPort Port to be updated
+     * @param flow       flow control mode from (@link purejavacomm.SerialPort}
+     * @param rts        set RTS active if true
+     * @param dtr        set DTR active if true
+     */
+    //@Deprecated(forRemoval=true) // Removed with jmri.jmrix.PureJavaComm
+    protected void configureLeadsAndFlowControl(jmri.jmrix.purejavacomm.SerialPort serialPort, int flow, boolean rts, boolean dtr) {
+        // (Jan 2018) PJC seems to mix termios and ioctl access, so it's not clear
+        // what's preserved and what's not. Experimentally, it seems necessary
+        // to write the control leads, set flow control, and then write the control
+        // leads again.
+        serialPort.setRTS(rts);
+        serialPort.setDTR(dtr);
+
+        try {
+            if (flow != jmri.jmrix.purejavacomm.SerialPort.FLOWCONTROL_NONE) {
+                serialPort.setFlowControlMode(flow);
+            }
+        } catch (jmri.jmrix.purejavacomm.UnsupportedCommOperationException e) {
+            log.warn("Could not set flow control, ignoring");
+        }
+        if (flow!=jmri.jmrix.purejavacomm.SerialPort.FLOWCONTROL_RTSCTS_OUT) serialPort.setRTS(rts); // not connected in some serial ports and adapters
+        serialPort.setDTR(dtr);
     }
 
     /**
@@ -447,6 +507,17 @@ abstract public class AbstractSerialPortController extends AbstractPortControlle
      */
     final protected void closeSerialPort(SerialPort serialPort){
         serialPort.serialPort.closePort();
+    }
+
+    /**
+     * Set the flow control for purejavacomm, while also setting RTS and DTR to active.
+     *
+     * @param serialPort Port to be updated
+     * @param flow       flow control mode from (@link jmri.jmrix.purejavacomm.SerialPort}
+     */
+    //@Deprecated(forRemoval=true) // with jmri.jmrix.PureJavaComm
+    final protected void configureLeadsAndFlowControl(jmri.jmrix.purejavacomm.SerialPort serialPort, int flow) {
+        configureLeadsAndFlowControl(serialPort, flow, true, true);
     }
 
     /**
@@ -904,6 +975,10 @@ abstract public class AbstractSerialPortController extends AbstractPortControlle
             this.serialPort.setRTS();
         }
 
+        public void clearRTS() {
+            this.serialPort.clearRTS();
+        }
+
         public void setBaudRate(int baudrate) {
             this.serialPort.setBaudRate(baudrate);
         }
@@ -918,6 +993,10 @@ abstract public class AbstractSerialPortController extends AbstractPortControlle
 
         public void setDTR() {
             this.serialPort.setDTR();
+        }
+
+        public void clearDTR() {
+            this.serialPort.clearDTR();
         }
 
         public boolean getDTR() {

--- a/java/src/jmri/jmrix/bachrus/SpeedoTrafficController.java
+++ b/java/src/jmri/jmrix/bachrus/SpeedoTrafficController.java
@@ -5,8 +5,8 @@ import java.io.OutputStream;
 import java.util.Vector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import purejavacomm.SerialPortEvent;
-import purejavacomm.SerialPortEventListener;
+import jmri.jmrix.purejavacomm.SerialPortEvent;
+import jmri.jmrix.purejavacomm.SerialPortEventListener;
 
 /**
  * Converts Stream-based I/O to/from Speedo messages. The "SpeedoInterface" side

--- a/java/src/jmri/jmrix/bachrus/kpfserialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/bachrus/kpfserialdriver/SerialDriverAdapter.java
@@ -51,7 +51,7 @@ public class SerialDriverAdapter extends SpeedoPortController {
             // get and open the primary port
             CommPortIdentifier portID = CommPortIdentifier.getPortIdentifier(portName);
             try {
-                activeSerialPort = (jmri.jmrix.purejavacomm.SerialPort) portID.open(appName, 2000);  // name of program, msec to wait
+                activeSerialPort = portID.open(appName, 2000);  // name of program, msec to wait
             } catch (PortInUseException p) {
                 return handlePortBusy(p, portName, log);
             }

--- a/java/src/jmri/jmrix/bachrus/kpfserialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/bachrus/kpfserialdriver/SerialDriverAdapter.java
@@ -14,10 +14,10 @@ import jmri.jmrix.bachrus.SpeedoTrafficController;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import purejavacomm.CommPortIdentifier;
-import purejavacomm.NoSuchPortException;
-import purejavacomm.PortInUseException;
-import purejavacomm.UnsupportedCommOperationException;
+import jmri.jmrix.purejavacomm.CommPortIdentifier;
+import jmri.jmrix.purejavacomm.NoSuchPortException;
+import jmri.jmrix.purejavacomm.PortInUseException;
+import jmri.jmrix.purejavacomm.UnsupportedCommOperationException;
 
 /**
  * Implements SerialPortAdapter for the KPF-Zeller speedo.
@@ -42,7 +42,7 @@ public class SerialDriverAdapter extends SpeedoPortController {
         this.getSystemConnectionMemo().setSpeedoTrafficController(new SpeedoTrafficController(this.getSystemConnectionMemo()));
     }
 
-    purejavacomm.SerialPort activeSerialPort = null;
+    jmri.jmrix.purejavacomm.SerialPort activeSerialPort = null;
 
     @Override
     public String openPort(String portName, String appName) {
@@ -51,7 +51,7 @@ public class SerialDriverAdapter extends SpeedoPortController {
             // get and open the primary port
             CommPortIdentifier portID = CommPortIdentifier.getPortIdentifier(portName);
             try {
-                activeSerialPort = (purejavacomm.SerialPort) portID.open(appName, 2000);  // name of program, msec to wait
+                activeSerialPort = (jmri.jmrix.purejavacomm.SerialPort) portID.open(appName, 2000);  // name of program, msec to wait
             } catch (PortInUseException p) {
                 return handlePortBusy(p, portName, log);
             }
@@ -59,9 +59,9 @@ public class SerialDriverAdapter extends SpeedoPortController {
             // try to set it for communication via SerialDriver
             try {
                 activeSerialPort.setSerialPortParams(9600,
-                        purejavacomm.SerialPort.DATABITS_8,
-                        purejavacomm.SerialPort.STOPBITS_1,
-                        purejavacomm.SerialPort.PARITY_NONE);
+                        jmri.jmrix.purejavacomm.SerialPort.DATABITS_8,
+                        jmri.jmrix.purejavacomm.SerialPort.STOPBITS_1,
+                        jmri.jmrix.purejavacomm.SerialPort.PARITY_NONE);
             } catch (UnsupportedCommOperationException e) {
                 log.error("Cannot set serial parameters on port {}: {}", portName, e.getMessage());
                 return "Cannot set serial parameters on port " + portName + ": " + e.getMessage();

--- a/java/src/jmri/jmrix/bachrus/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/bachrus/serialdriver/SerialDriverAdapter.java
@@ -48,7 +48,7 @@ public class SerialDriverAdapter extends SpeedoPortController {
             // get and open the primary port
             CommPortIdentifier portID = CommPortIdentifier.getPortIdentifier(portName);
             try {
-                activeSerialPort = (jmri.jmrix.purejavacomm.SerialPort) portID.open(appName, 2000);  // name of program, msec to wait
+                activeSerialPort = portID.open(appName, 2000);  // name of program, msec to wait
             } catch (PortInUseException p) {
                 return handlePortBusy(p, portName, log);
             }

--- a/java/src/jmri/jmrix/bachrus/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/bachrus/serialdriver/SerialDriverAdapter.java
@@ -11,10 +11,10 @@ import jmri.jmrix.bachrus.SpeedoSystemConnectionMemo;
 import jmri.jmrix.bachrus.SpeedoTrafficController;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import purejavacomm.CommPortIdentifier;
-import purejavacomm.NoSuchPortException;
-import purejavacomm.PortInUseException;
-import purejavacomm.UnsupportedCommOperationException;
+import jmri.jmrix.purejavacomm.CommPortIdentifier;
+import jmri.jmrix.purejavacomm.NoSuchPortException;
+import jmri.jmrix.purejavacomm.PortInUseException;
+import jmri.jmrix.purejavacomm.UnsupportedCommOperationException;
 
 /**
  * Implements SerialPortAdapter for the Bachrus speedo.
@@ -39,7 +39,7 @@ public class SerialDriverAdapter extends SpeedoPortController {
         this.getSystemConnectionMemo().setSpeedoTrafficController(new SpeedoTrafficController(this.getSystemConnectionMemo()));
     }
 
-    purejavacomm.SerialPort activeSerialPort = null;
+    jmri.jmrix.purejavacomm.SerialPort activeSerialPort = null;
 
     @Override
     public String openPort(String portName, String appName) {
@@ -48,7 +48,7 @@ public class SerialDriverAdapter extends SpeedoPortController {
             // get and open the primary port
             CommPortIdentifier portID = CommPortIdentifier.getPortIdentifier(portName);
             try {
-                activeSerialPort = (purejavacomm.SerialPort) portID.open(appName, 2000);  // name of program, msec to wait
+                activeSerialPort = (jmri.jmrix.purejavacomm.SerialPort) portID.open(appName, 2000);  // name of program, msec to wait
             } catch (PortInUseException p) {
                 return handlePortBusy(p, portName, log);
             }
@@ -56,9 +56,9 @@ public class SerialDriverAdapter extends SpeedoPortController {
             // try to set it for communication via SerialDriver
             try {
                 activeSerialPort.setSerialPortParams(9600,
-                        purejavacomm.SerialPort.DATABITS_8,
-                        purejavacomm.SerialPort.STOPBITS_1,
-                        purejavacomm.SerialPort.PARITY_NONE);
+                        jmri.jmrix.purejavacomm.SerialPort.DATABITS_8,
+                        jmri.jmrix.purejavacomm.SerialPort.STOPBITS_1,
+                        jmri.jmrix.purejavacomm.SerialPort.PARITY_NONE);
             } catch (UnsupportedCommOperationException e) {
                 log.error("Cannot set serial parameters on port {}: {}", portName, e.getMessage());
                 return "Cannot set serial parameters on port " + portName + ": " + e.getMessage();

--- a/java/src/jmri/jmrix/purejavacomm/CommPortIdentifier.java
+++ b/java/src/jmri/jmrix/purejavacomm/CommPortIdentifier.java
@@ -19,7 +19,8 @@ public class CommPortIdentifier {
 
     public SerialPort open(String appName, int timeout) throws PortInUseException {
         String systemPrefix = appName;
-        return new SerialPort(AbstractSerialPortController.activatePort(appName, _portName, log, 8, AbstractSerialPortController.Parity.NONE));
+        return new SerialPort(AbstractSerialPortController.activatePort(
+                systemPrefix, _portName, log, 8, AbstractSerialPortController.Parity.NONE));
     }
 
     private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(CommPortIdentifier.class);

--- a/java/src/jmri/jmrix/purejavacomm/CommPortIdentifier.java
+++ b/java/src/jmri/jmrix/purejavacomm/CommPortIdentifier.java
@@ -1,0 +1,26 @@
+package jmri.jmrix.purejavacomm;
+
+import jmri.jmrix.AbstractSerialPortController;
+
+/**
+ * Comm port identifier.
+ */
+public class CommPortIdentifier {
+
+    private final String _portName;
+
+    private CommPortIdentifier(String portName) {
+        this._portName = portName;
+    }
+
+    public static CommPortIdentifier getPortIdentifier(String portName) throws NoSuchPortException {
+        return new CommPortIdentifier(portName);
+    }
+
+    public SerialPort open(String appName, int timeout) throws PortInUseException {
+        String systemPrefix = appName;
+        return new SerialPort(AbstractSerialPortController.activatePort(appName, _portName, log, 8, AbstractSerialPortController.Parity.NONE));
+    }
+
+    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(CommPortIdentifier.class);
+}

--- a/java/src/jmri/jmrix/purejavacomm/NoSuchPortException.java
+++ b/java/src/jmri/jmrix/purejavacomm/NoSuchPortException.java
@@ -1,0 +1,14 @@
+package jmri.jmrix.purejavacomm;
+
+/**
+ * This exception is thrown when there is no such port.
+ */
+public class NoSuchPortException extends Exception {
+
+    /**
+     * Creates a new instance of <code>NoSuchPortException</code> without detail message.
+     */
+    public NoSuchPortException() {
+    }
+
+}

--- a/java/src/jmri/jmrix/purejavacomm/PortInUseException.java
+++ b/java/src/jmri/jmrix/purejavacomm/PortInUseException.java
@@ -1,0 +1,14 @@
+package jmri.jmrix.purejavacomm;
+
+/**
+ * This exception is thrown when the port is in use.
+ */
+public class PortInUseException extends Exception {
+
+    /**
+     * Creates a new instance of <code>PortInUseException</code> without detail message.
+     */
+    public PortInUseException() {
+    }
+
+}

--- a/java/src/jmri/jmrix/purejavacomm/SerialPort.java
+++ b/java/src/jmri/jmrix/purejavacomm/SerialPort.java
@@ -3,6 +3,8 @@ package jmri.jmrix.purejavacomm;
 import java.io.InputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.TooManyListenersException;
 
 import jmri.jmrix.AbstractSerialPortController;
@@ -14,23 +16,49 @@ public class SerialPort {
 
     public static final int DATABITS_8 = 8;
     public static final int PARITY_NONE = 0;
+    public static final int PARITY_ODD = 1;
+    public static final int PARITY_EVEN = 2;
     public static final int STOPBITS_1 = 1;
+    public static final int STOPBITS_2 = 2;
     public static final int FLOWCONTROL_NONE = 0;
     public static final int FLOWCONTROL_RTSCTS_IN = 1;
     public static final int FLOWCONTROL_RTSCTS_OUT = 2;
 
     private AbstractSerialPortController.SerialPort _serialPort;
+    private final List<SerialPortEventListener> listeners = new ArrayList<>();
 
     public SerialPort(AbstractSerialPortController.SerialPort serialPort) {
         this._serialPort = serialPort;
     }
 
+    private void setParity(int parity) {
+        switch (parity) {
+            case PARITY_NONE:
+                _serialPort.setParity(AbstractSerialPortController.Parity.NONE);
+                break;
+                
+            case PARITY_EVEN:
+                _serialPort.setParity(AbstractSerialPortController.Parity.EVEN);
+                break;
+                
+            case PARITY_ODD:
+                _serialPort.setParity(AbstractSerialPortController.Parity.ODD);
+                break;
+            
+            default:
+                throw new IllegalArgumentException("Unknown parity: "+Integer.toString(parity));
+        }
+    }
+
     public void setSerialPortParams(int baudRate, int dataBits, int stopBits, int parity) throws UnsupportedCommOperationException {
-        throw new UnsupportedOperationException("Not implemented");
+        _serialPort.setBaudRate(baudRate);
+        _serialPort.setNumDataBits(dataBits);
+        _serialPort.setNumStopBits(stopBits);
+        setParity(parity);
     }
 
     public void addEventListener(SerialPortEventListener listener) throws TooManyListenersException {
-        throw new UnsupportedOperationException("Not implemented");
+        listeners.add(listener);
     }
 
     public void notifyOnDataAvailable(boolean value) {

--- a/java/src/jmri/jmrix/purejavacomm/SerialPort.java
+++ b/java/src/jmri/jmrix/purejavacomm/SerialPort.java
@@ -21,9 +21,6 @@ public class SerialPort {
 
     private AbstractSerialPortController.SerialPort _serialPort;
 
-    /**
-     * Creates a new instance of <code>SerialPort</code>.
-     */
     public SerialPort(AbstractSerialPortController.SerialPort serialPort) {
         this._serialPort = serialPort;
     }

--- a/java/src/jmri/jmrix/purejavacomm/SerialPort.java
+++ b/java/src/jmri/jmrix/purejavacomm/SerialPort.java
@@ -26,10 +26,7 @@ public class SerialPort {
     private SerialPortEventListener _eventListener;
     private boolean _threadStarted = false;
     private Thread _inputThread;
-    private boolean _notifyOnDataAvailable;
-    private boolean _dataAvailableNotified;
-    private boolean _notifyOnOutputEmpty;
-    private boolean _outputEmptyNotified;
+    private volatile boolean _notifyOnDataAvailable;
 
     public SerialPort(AbstractSerialPortController.SerialPort serialPort) {
         this._serialPort = serialPort;
@@ -40,7 +37,8 @@ public class SerialPort {
             
             while (true) {
                 try {
-                    while ((_eventListener != null) && (inputStream.available() > 0)) {
+                    while (_notifyOnDataAvailable && (_eventListener != null)
+                            && (inputStream.available() > 0)) {
                         _eventListener.serialEvent(new SerialPortEvent(
                                 this, SerialPortEvent.DATA_AVAILABLE, false, true));
                     }

--- a/java/src/jmri/jmrix/purejavacomm/SerialPort.java
+++ b/java/src/jmri/jmrix/purejavacomm/SerialPort.java
@@ -1,0 +1,103 @@
+package jmri.jmrix.purejavacomm;
+
+import java.io.InputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.TooManyListenersException;
+
+import jmri.jmrix.AbstractSerialPortController;
+
+/**
+ * Serial port.
+ */
+public class SerialPort {
+
+    public static final int DATABITS_8 = 8;
+    public static final int PARITY_NONE = 0;
+    public static final int STOPBITS_1 = 1;
+    public static final int FLOWCONTROL_NONE = 0;
+    public static final int FLOWCONTROL_RTSCTS_IN = 1;
+    public static final int FLOWCONTROL_RTSCTS_OUT = 2;
+
+    private AbstractSerialPortController.SerialPort _serialPort;
+
+    /**
+     * Creates a new instance of <code>SerialPort</code>.
+     */
+    public SerialPort(AbstractSerialPortController.SerialPort serialPort) {
+        this._serialPort = serialPort;
+    }
+
+    public void setSerialPortParams(int baudRate, int dataBits, int stopBits, int parity) throws UnsupportedCommOperationException {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
+    public void addEventListener(SerialPortEventListener listener) throws TooManyListenersException {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
+    public void notifyOnDataAvailable(boolean value) {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
+    public void setFlowControlMode(int mode) throws UnsupportedCommOperationException {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
+    public InputStream getInputStream() throws IOException {
+        return _serialPort.getInputStream();
+    }
+
+    public OutputStream getOutputStream() throws IOException {
+        return _serialPort.getOutputStream();
+    }
+
+    public int getBaudRate() {
+        return _serialPort.getBaudRate();
+    }
+
+    public void setDTR(boolean value) {
+        if (value) {
+            _serialPort.setDTR();
+        } else {
+            _serialPort.clearDTR();
+        }
+    }
+
+    public void setRTS(boolean value) {
+        if (value) {
+            _serialPort.setRTS();
+        } else {
+            _serialPort.clearRTS();
+        }
+    }
+
+    public boolean isDTR() {
+        return _serialPort.getDTR();
+    }
+
+    public boolean isRTS() {
+        return _serialPort.getRTS();
+    }
+
+    public boolean isDSR() {
+        return _serialPort.getDSR();
+    }
+
+    public boolean isCTS() {
+        return _serialPort.getCTS();
+    }
+
+    public boolean isCD() {
+        return _serialPort.getDCD();
+    }
+
+    public boolean isReceiveTimeoutEnabled() {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
+    public int getReceiveTimeout() {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
+}

--- a/java/src/jmri/jmrix/purejavacomm/SerialPortEvent.java
+++ b/java/src/jmri/jmrix/purejavacomm/SerialPortEvent.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2011, Kustaa Nyholm / SpareTimeLabs
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, 
+ * are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this list 
+ * of conditions and the following disclaimer.
+ * 
+ * Redistributions in binary form must reproduce the above copyright notice, this 
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *  
+ * Neither the name of the Kustaa Nyholm or SpareTimeLabs nor the names of its 
+ * contributors may be used to endorse or promote products derived from this software 
+ * without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, 
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ */
+
+package jmri.jmrix.purejavacomm;
+
+import java.util.EventObject;
+
+public class SerialPortEvent extends EventObject {
+	/**
+	 * Data available at the serial port.
+	 */
+	public static final int DATA_AVAILABLE = 1;
+	/**
+	 * Output buffer is empty.
+	 */
+	public static final int OUTPUT_BUFFER_EMPTY = 2;
+	/**
+	 * Clear to send.
+	 */
+	public static final int CTS = 3;
+	/**
+	 * Data set ready.
+	 */
+	public static final int DSR = 4;
+	/**
+	 * Ring indicator.
+	 */
+	public static final int RI = 5;
+	/**
+	 * Carrier detect.
+	 */
+	public static final int CD = 6;
+	/**
+	 * Overrun error.
+	 */
+	public static final int OE = 7;
+	/**
+	 * Parity error.
+	 */
+	public static final int PE = 8;
+	/**
+	 * Framing error.
+	 */
+	public static final int FE = 9;
+	/**
+	 * Break interrupt.
+	 */
+	public static final int BI = 10;
+
+	private final int eventType;
+	private final boolean newValue;
+	private final boolean oldValue;
+
+	/**
+	 * Constructs a <CODE>SerialPortEvent</CODE> with the specified serial port,
+	 * event type, old and new values. Application programs should not directly
+	 * create <CODE>SerialPortEvent</CODE> objects.
+	 * 
+	 * @param source
+	 * @param eventType
+	 * @param oldValue
+	 * @param newValue
+	 */
+	public SerialPortEvent(SerialPort source, int eventType, boolean oldValue, boolean newValue) {
+		super(source);
+		this.eventType = eventType;
+		this.newValue = newValue;
+		this.oldValue = oldValue;
+	}
+
+	/**
+	 * Returns the type of this event.
+	 * 
+	 * @return The type of this event.
+	 */
+	public int getEventType() {
+		return this.eventType;
+	}
+
+	/**
+	 * Returns the new value of the state change that caused the
+	 * <CODE>SerialPortEvent</CODE> to be propagated.
+	 * 
+	 * @return The new value of the state change.
+	 */
+	public boolean getNewValue() {
+		return this.newValue;
+	}
+
+	/**
+	 * Returns the old value of the state change that caused the
+	 * <CODE>SerialPortEvent</CODE> to be propagated.
+	 * 
+	 * @return The old value of the state change.
+	 */
+	public boolean getOldValue() {
+		return this.oldValue;
+	}
+}

--- a/java/src/jmri/jmrix/purejavacomm/SerialPortEvent.java
+++ b/java/src/jmri/jmrix/purejavacomm/SerialPortEvent.java
@@ -33,94 +33,94 @@ package jmri.jmrix.purejavacomm;
 import java.util.EventObject;
 
 public class SerialPortEvent extends EventObject {
-	/**
-	 * Data available at the serial port.
-	 */
-	public static final int DATA_AVAILABLE = 1;
-	/**
-	 * Output buffer is empty.
-	 */
-	public static final int OUTPUT_BUFFER_EMPTY = 2;
-	/**
-	 * Clear to send.
-	 */
-	public static final int CTS = 3;
-	/**
-	 * Data set ready.
-	 */
-	public static final int DSR = 4;
-	/**
-	 * Ring indicator.
-	 */
-	public static final int RI = 5;
-	/**
-	 * Carrier detect.
-	 */
-	public static final int CD = 6;
-	/**
-	 * Overrun error.
-	 */
-	public static final int OE = 7;
-	/**
-	 * Parity error.
-	 */
-	public static final int PE = 8;
-	/**
-	 * Framing error.
-	 */
-	public static final int FE = 9;
-	/**
-	 * Break interrupt.
-	 */
-	public static final int BI = 10;
+    /**
+     * Data available at the serial port.
+     */
+    public static final int DATA_AVAILABLE = 1;
+    /**
+     * Output buffer is empty.
+     */
+    public static final int OUTPUT_BUFFER_EMPTY = 2;
+    /**
+     * Clear to send.
+     */
+    public static final int CTS = 3;
+    /**
+     * Data set ready.
+     */
+    public static final int DSR = 4;
+    /**
+     * Ring indicator.
+     */
+    public static final int RI = 5;
+    /**
+     * Carrier detect.
+     */
+    public static final int CD = 6;
+    /**
+     * Overrun error.
+     */
+    public static final int OE = 7;
+    /**
+     * Parity error.
+     */
+    public static final int PE = 8;
+    /**
+     * Framing error.
+     */
+    public static final int FE = 9;
+    /**
+     * Break interrupt.
+     */
+    public static final int BI = 10;
 
-	private final int eventType;
-	private final boolean newValue;
-	private final boolean oldValue;
+    private final int eventType;
+    private final boolean newValue;
+    private final boolean oldValue;
 
-	/**
-	 * Constructs a <CODE>SerialPortEvent</CODE> with the specified serial port,
-	 * event type, old and new values. Application programs should not directly
-	 * create <CODE>SerialPortEvent</CODE> objects.
-	 * 
-	 * @param source
-	 * @param eventType
-	 * @param oldValue
-	 * @param newValue
-	 */
-	public SerialPortEvent(SerialPort source, int eventType, boolean oldValue, boolean newValue) {
-		super(source);
-		this.eventType = eventType;
-		this.newValue = newValue;
-		this.oldValue = oldValue;
-	}
+    /**
+     * Constructs a <CODE>SerialPortEvent</CODE> with the specified serial port,
+     * event type, old and new values. Application programs should not directly
+     * create <CODE>SerialPortEvent</CODE> objects.
+     * 
+     * @param source
+     * @param eventType
+     * @param oldValue
+     * @param newValue
+     */
+    public SerialPortEvent(SerialPort source, int eventType, boolean oldValue, boolean newValue) {
+        super(source);
+        this.eventType = eventType;
+        this.newValue = newValue;
+        this.oldValue = oldValue;
+    }
 
-	/**
-	 * Returns the type of this event.
-	 * 
-	 * @return The type of this event.
-	 */
-	public int getEventType() {
-		return this.eventType;
-	}
+    /**
+     * Returns the type of this event.
+     * 
+     * @return The type of this event.
+     */
+    public int getEventType() {
+        return this.eventType;
+    }
 
-	/**
-	 * Returns the new value of the state change that caused the
-	 * <CODE>SerialPortEvent</CODE> to be propagated.
-	 * 
-	 * @return The new value of the state change.
-	 */
-	public boolean getNewValue() {
-		return this.newValue;
-	}
+    /**
+     * Returns the new value of the state change that caused the
+     * <CODE>SerialPortEvent</CODE> to be propagated.
+     * 
+     * @return The new value of the state change.
+     */
+    public boolean getNewValue() {
+        return this.newValue;
+    }
 
-	/**
-	 * Returns the old value of the state change that caused the
-	 * <CODE>SerialPortEvent</CODE> to be propagated.
-	 * 
-	 * @return The old value of the state change.
-	 */
-	public boolean getOldValue() {
-		return this.oldValue;
-	}
+    /**
+     * Returns the old value of the state change that caused the
+     * <CODE>SerialPortEvent</CODE> to be propagated.
+     * 
+     * @return The old value of the state change.
+     */
+    public boolean getOldValue() {
+        return this.oldValue;
+    }
 }

--- a/java/src/jmri/jmrix/purejavacomm/SerialPortEvent.java
+++ b/java/src/jmri/jmrix/purejavacomm/SerialPortEvent.java
@@ -83,10 +83,10 @@ public class SerialPortEvent extends EventObject {
      * event type, old and new values. Application programs should not directly
      * create <CODE>SerialPortEvent</CODE> objects.
      * 
-     * @param source
-     * @param eventType
-     * @param oldValue
-     * @param newValue
+     * @param source     the source
+     * @param eventType  the event type
+     * @param oldValue   the old value
+     * @param newValue   the new value
      */
     public SerialPortEvent(SerialPort source, int eventType, boolean oldValue, boolean newValue) {
         super(source);

--- a/java/src/jmri/jmrix/purejavacomm/SerialPortEventListener.java
+++ b/java/src/jmri/jmrix/purejavacomm/SerialPortEventListener.java
@@ -1,0 +1,10 @@
+package jmri.jmrix.purejavacomm;
+
+/**
+ * Serial port listener.
+ */
+public interface SerialPortEventListener {
+
+    public void serialEvent(SerialPortEvent event);
+
+}

--- a/java/src/jmri/jmrix/purejavacomm/UnsupportedCommOperationException.java
+++ b/java/src/jmri/jmrix/purejavacomm/UnsupportedCommOperationException.java
@@ -1,0 +1,14 @@
+package jmri.jmrix.purejavacomm;
+
+/**
+ * This exception is thrown when the operation is not supported.
+ */
+public class UnsupportedCommOperationException extends Exception {
+
+    /**
+     * Creates a new instance of <code>UnsupportedCommOperationException</code> without detail message.
+     */
+    public UnsupportedCommOperationException() {
+    }
+
+}

--- a/java/test/jmri/ArchitectureTest.java
+++ b/java/test/jmri/ArchitectureTest.java
@@ -305,9 +305,6 @@ public class ArchitectureTest {
         .doNotHaveFullyQualifiedName("jmri.jmrix.AbstractSerialPortController$2").and()
 
         // non-typical systems that are not (yet) migrated
-        .doNotHaveFullyQualifiedName("jmri.jmrix.bachrus.SpeedoTrafficController").and()
-        .doNotHaveFullyQualifiedName("jmri.jmrix.bachrus.kpfserialdriver.SerialDriverAdapter").and()
-        .doNotHaveFullyQualifiedName("jmri.jmrix.bachrus.serialdriver.SerialDriverAdapter").and()
         .doNotHaveFullyQualifiedName("jmri.jmrix.dcc4pc.Dcc4PcTrafficController").and()
         .doNotHaveFullyQualifiedName("jmri.jmrix.dcc4pc.serialdriver.SerialDriverAdapter").and()
         .doNotHaveFullyQualifiedName("jmri.jmrix.pricom.downloader.LoaderPane").and()


### PR DESCRIPTION
This PR adds a PureJavaComm emulator that uses `jmri.jmrix.AbstractSerialPortController` for the serial port communication.