### PR TITLE
Accept error when writing TCS CV204; allow access to TCS delay setting

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -326,7 +326,8 @@
 
         <h4>TCS</h4>
             <ul>
-                <li></li>
+                <li>Better handling of an occasional spurious error that
+                can happen when accessing TCS indexed CVs.</li>
             </ul>
 
         <h4>Team Digital</h4>

--- a/java/test/jmri/implementation/TwoIndexTcsProgrammerFacadeTest.java
+++ b/java/test/jmri/implementation/TwoIndexTcsProgrammerFacadeTest.java
@@ -77,10 +77,10 @@ public class TwoIndexTcsProgrammerFacadeTest {
         waitReply();
         Assert.assertEquals("index 1 written", 100 + 10, dp.getCvVal(201));
         Assert.assertEquals("index 2 written", 20, dp.getCvVal(202));
-        Assert.assertEquals("dummy 204 written", 100, dp.getCvVal(204)); // TCS says this is arbitrary, so
+        Assert.assertEquals("dummy 204 written", 0, dp.getCvVal(204)); // TCS says this is arbitrary, so
         // we write the offset value
 
-        Assert.assertEquals("read back", 12 * 256 + 100, readValue);         // We get 100 from the LSB
+        Assert.assertEquals("read back", 12 * 256 + 0, readValue);         // We get 0 from the LSB
         // because we wrote the offset
         // and the test Programmer remembers that
     }


### PR DESCRIPTION
Because of the way that TCS indexed CVs are accessed, the value of CV204 will change between the time the command station writes it, and then reads it to verify the write.  (This is internal to the command station and decoder, not something that JMRI is doing).  It was first seen with the CS-105 command station, but is a general problem.  This accepts the error in the CV204 write and continues.  Errors on other writes and reads are still handled as errors.

Also, makes the TCS-writing time delay accessible from scripts for ease of experimental tuning.