### PR TITLE
Add "No Decoder" mfg, family and definition to allow people to track non-decoder equipped (DC) trains in the roster

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -181,7 +181,8 @@
 
     <h3>New / Updated decoder definitions</h3>
         <ul>
-          <li></li>
+          <li>Added a new "No Decoder" listing in the New Loco selection to allow people
+              to track DC locomotives in the roster.</li>
         </ul>
 
         <h4>Arnold</h4>

--- a/xml/decoderIndex.xml
+++ b/xml/decoderIndex.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet href="/xml/XSLT/DecoderID.xsl" type="text/xsl"?>
 <decoderIndex-config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
-  <!--Written by JMRI version 5.7.6plus+jake+20240509T1458Z+Rfd628fd8472 on Thu May 09 10:59:14 EDT 2024-->
-  <decoderIndex version="585">
+  <!--Written by JMRI version 5.7.7plus+jake+20240608T1221Z+R216e38cd207 on Sat Jun 08 08:21:07 EDT 2024-->
+  <decoderIndex version="591">
     <!--The manufacturer list is from the nmra_mfg_list.xml file-->
     <mfgList nmraListDate="2021-03-06" updated="2023-01-25" lastadd="169">
       <manufacturer mfg="NMRA" mfgID="999" />
@@ -114,6 +114,7 @@
       <manufacturer mfg="Nagoden" mfgID="108" />
       <manufacturer mfg="New York Byano Limited" mfgID="71" />
       <manufacturer mfg="Ngineering" mfgID="43" />
+      <manufacturer mfg="No Decoder" mfgID="1000" />
       <manufacturer mfg="Noarail" mfgID="63" />
       <manufacturer mfg="North Coast Engineering" mfgID="11" />
       <manufacturer mfg="Nucky" mfgID="156" />
@@ -221,6 +222,9 @@
       </family>
       <family name="Raw CVs 1-1024" mfg="NMRA" file="0NMRA_test_1024.xml">
         <model model="Raw CVs 1-1024" />
+      </family>
+      <family name="DC" mfg="No Decoder" file="0NoDecoder.xml">
+        <model model="DC" />
       </family>
       <family name="LocoCruiser" mfg="ANE Model Co, Ltd" lowVersionID="201" highVersionID="201" file="ANE_LC201.xml">
         <model model="LC201" numOuts="5" numFns="5">
@@ -15518,6 +15522,11 @@
         </functionlabels>
       </family>
       <family name="Blunami Diesel" mfg="SoundTraxx (Throttle-Up)" lowVersionID="72" file="SoundTraxx_Blu_Diesel.xml">
+        <model model="BLU-21PNEM8 Alco Diesels" numOuts="6" numFns="30" productID="2160" />
+        <model model="BLU-21PNEM8 Baldwin Diesels" numOuts="6" numFns="30" productID="2161" />
+        <model model="BLU-21PNEM8 EMD Diesels" numOuts="6" numFns="30" productID="2158" />
+        <model model="BLU-21PNEM8 EMD-2 Diesels" numOuts="6" numFns="30" productID="2162" />
+        <model model="BLU-21PNEM8 GE Diesels" numOuts="6" numFns="30" productID="2159" />
         <model model="BLU-2200 Alco Diesels" numOuts="6" numFns="30" productID="2141" />
         <model model="BLU-2200 Baldwin Diesels" numOuts="6" numFns="30" productID="2142" />
         <model model="BLU-2200 EMD Diesels" numOuts="6" numFns="30" productID="2139" />
@@ -15594,6 +15603,7 @@
         </functionlabels>
       </family>
       <family name="Blunami Electric" mfg="SoundTraxx (Throttle-Up)" lowVersionID="72" file="SoundTraxx_Blu_Electric.xml">
+        <model model="BLU-21PNEM8 Electric" numOuts="6" numFns="30" productID="2163" />
         <model model="BLU-2200 Electric" numOuts="6" numFns="30" productID="2144" />
         <model model="BLU-4408 Electric" numOuts="8" numFns="30" productID="2151" />
         <output name="3" label="  FX3  " />
@@ -15657,6 +15667,7 @@
         </functionlabels>
       </family>
       <family name="Blunami Steam" mfg="SoundTraxx (Throttle-Up)" lowVersionID="72" file="SoundTraxx_Blu_Steam.xml">
+        <model model="BLU-21PNEM8 Steam-2" numOuts="6" numFns="30" productID="2157" />
         <model model="BLU-2200 Steam-2" numOuts="6" numFns="30" productID="2138" />
         <model model="BLU-4408 Steam-2" numOuts="8" numFns="30" productID="2145" />
         <output name="3" label="  FX3  " />

--- a/xml/decoderIndex.xml
+++ b/xml/decoderIndex.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet href="/xml/XSLT/DecoderID.xsl" type="text/xsl"?>
 <decoderIndex-config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
-  <!--Written by JMRI version 5.7.7plus+jake+20240608T1221Z+R216e38cd207 on Sat Jun 08 08:21:07 EDT 2024-->
-  <decoderIndex version="591">
+  <!--Written by JMRI version 5.7.7plus+jake+20240608T2103Z+R070f1f537e3 on Sat Jun 08 17:03:21 EDT 2024-->
+  <decoderIndex version="593">
     <!--The manufacturer list is from the nmra_mfg_list.xml file-->
     <mfgList nmraListDate="2021-03-06" updated="2023-01-25" lastadd="169">
       <manufacturer mfg="NMRA" mfgID="999" />
@@ -223,8 +223,8 @@
       <family name="Raw CVs 1-1024" mfg="NMRA" file="0NMRA_test_1024.xml">
         <model model="Raw CVs 1-1024" />
       </family>
-      <family name="DC" mfg="No Decoder" file="0NoDecoder.xml">
-        <model model="DC" />
+      <family name="No Decoder" mfg="No Decoder" file="0NoDecoder.xml">
+        <model model="No Decoder" />
       </family>
       <family name="LocoCruiser" mfg="ANE Model Co, Ltd" lowVersionID="201" highVersionID="201" file="ANE_LC201.xml">
         <model model="LC201" numOuts="5" numFns="5">

--- a/xml/decoders/0NoDecoder.xml
+++ b/xml/decoders/0NoDecoder.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet type="text/xsl" href="../XSLT/decoder.xsl"?>
+<!-- Copyright (C) JMRI 2024 All rights reserved -->
+<!--                                                                        -->
+<!-- JMRI is free software; you can redistribute it and/or modify it under  -->
+<!-- the terms of version 2 of the GNU General Public License as published  -->
+<!-- by the Free Software Foundation. See the "COPYING" file for a copy     -->
+<!-- of this license.                                                       -->
+<!--                                                                        -->
+<!-- JMRI is distributed in the hope that it will be useful, but WITHOUT    -->
+<!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
+<!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
+<!-- for more details.                                                      -->
+<decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" 
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+    xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd"
+    showEmptyPanes="no">
+  <copyright xmlns="http://docbook.org/ns/docbook">
+    <year>2024</year>
+    <holder>JMRI</holder>
+  </copyright>
+  <authorgroup xmlns="http://docbook.org/ns/docbook">
+    <author>
+      <personname><firstname>Bob</firstname><surname>Jacobsen</surname></personname>
+    </author>
+  </authorgroup>
+  <revhistory xmlns="http://docbook.org/ns/docbook">
+    <revision>
+      <revnumber>0</revnumber><date>2024-06-08</date><authorinitials>BJ</authorinitials>
+      <revremark>Initial version</revremark>
+    </revision>
+  </revhistory>
+  <decoder>
+    <family name="DC" mfg="No Decoder">
+      <model model="DC"/>
+    </family>
+    <programming direct="no" paged="no" register="no" ops="no"/>
+    <variables>
+      <xi:include href="http://jmri.org/xml/decoders/nmra/shortAddressOnly.xml"/>
+    </variables>
+  </decoder>
+</decoder-config>

--- a/xml/decoders/0NoDecoder.xml
+++ b/xml/decoders/0NoDecoder.xml
@@ -31,8 +31,8 @@
     </revision>
   </revhistory>
   <decoder>
-    <family name="DC" mfg="No Decoder">
-      <model model="DC"/>
+    <family name="No Decoder" mfg="No Decoder">
+      <model model="No Decoder"/>
     </family>
     <programming direct="no" paged="no" register="no" ops="no"/>
     <variables>

--- a/xml/nmra_mfg_list.xml
+++ b/xml/nmra_mfg_list.xml
@@ -215,11 +215,15 @@
       <manufacturer mfg="Zimo" mfgID="145" />
       <manufacturer mfg="ZTC" mfgID="132" />
 
+      <!-- Special case for no decoder, e.g. DC operation -->
+      <manufacturer mfg="No Decoder" mfgID="1000" />
+
       <!-- we include Lionel as a special case to support TMCC -->
       <manufacturer mfg="Lionel" mfgID="1001" />
 
       <!-- not registered, provide custom numbers -->
       <manufacturer mfg="LEB" mfgID="1002" />
       <manufacturer mfg="Logic Rail Technologies" mfgID="1003" />
+      
 
 </mfgList>


### PR DESCRIPTION
See Issue #13179 for request and background information