### PR TITLE
Disable read and write for roster entries without a decoder

### DIFF
--- a/java/src/jmri/jmrit/symbolicprog/CvTableModel.java
+++ b/java/src/jmri/jmrit/symbolicprog/CvTableModel.java
@@ -72,6 +72,18 @@ public class CvTableModel extends javax.swing.table.AbstractTableModel implement
         //addCV("1", false, false, false);
     }
 
+    public void setNoDecoder() {
+        for (var b : _readButtons) {
+            b.setEnabled(false);
+        }
+        for (var b : _writeButtons) {
+            b.setEnabled(false);
+        }
+        for (var b : _compareButtons) {
+            b.setEnabled(false);
+        }
+    }
+
     /**
      * Gives access to the programmer used to reach these CVs, so you can check
      * on mode, capabilities, etc.

--- a/java/src/jmri/jmrit/symbolicprog/tabbedframe/PaneProgFrame.java
+++ b/java/src/jmri/jmrit/symbolicprog/tabbedframe/PaneProgFrame.java
@@ -307,7 +307,10 @@ abstract public class PaneProgFrame extends JmriJFrame
 
     void setProgrammingGui(JPanel bottom) {
         // see if programming mode is available
-        var tempModePane = getModePane();
+        JPanel tempModePane = null;
+        if (!noDecoder) {
+            tempModePane = getModePane();
+        }
         if (tempModePane != null) {
             // if so, configure programming part of GUI
             // add buttons

--- a/java/src/jmri/jmrit/symbolicprog/tabbedframe/PaneProgPane.java
+++ b/java/src/jmri/jmrit/symbolicprog/tabbedframe/PaneProgPane.java
@@ -453,6 +453,15 @@ public class PaneProgPane extends javax.swing.JPanel
         }
     }
 
+    public void setNoDecoder() {
+        readChangesButton.setEnabled(false);
+        readAllButton.setEnabled(false);
+        writeChangesButton.setEnabled(false);
+        writeAllButton.setEnabled(false);
+        confirmChangesButton.setEnabled(false);
+        confirmAllButton.setEnabled(false);
+    }
+
     @Override
     public String getName() {
         return mName;

--- a/xml/decoders/0NoDecoder.xml
+++ b/xml/decoders/0NoDecoder.xml
@@ -34,9 +34,25 @@
     <family name="No Decoder" mfg="No Decoder">
       <model model="No Decoder"/>
     </family>
-    <programming direct="no" paged="no" register="no" ops="no"/>
+    <programming nodecoder="yes" direct="no" paged="no" register="no" ops="no"/>
     <variables>
-      <xi:include href="http://jmri.org/xml/decoders/nmra/shortAddressOnly.xml"/>
+      <variable CV="1" comment="Short address" item="Short Address" default="0">
+        <shortAddressVal/>
+        <label>Primary Address</label>
+        <label xml:lang="cs">Základní adresa</label>
+        <label xml:lang="it">Indirizzo Primario</label>
+        <label xml:lang="fr">Adresse décodeur</label>
+        <label xml:lang="de">Basisadresse</label>
+        <label xml:lang="nl">Basisadres</label>
+        <label xml:lang="es">Dirección primaria</label>
+        <tooltip xml:lang="cs">Krátká adresa</tooltip>
+        <tooltip xml:lang="it">Indirizzo Corto</tooltip>
+        <tooltip xml:lang="fr">Adresse courte</tooltip>
+        <tooltip xml:lang="de">Kurze Adresse</tooltip>
+        <tooltip xml:lang="nl">Kort Adres</tooltip>
+        <tooltip xml:lang="es">Dirección corta</tooltip>
+        <tooltip xml:lang="de">Kurze Adresse</tooltip>
+      </variable>
     </variables>
   </decoder>
 </decoder-config>

--- a/xml/schema/decoder-4-15-2.xsd
+++ b/xml/schema/decoder-4-15-2.xsd
@@ -130,6 +130,12 @@
               </xs:restriction>
             </xs:simpleType>
           </xs:attribute>
+          <xs:attribute name="nodecoder" type="yesNoType" default="no">
+            <xs:annotation><xs:documentation>
+                Yes indicates no decoder in loco. If so, it's
+                recommended that the other modes are all "no".
+            </xs:documentation></xs:annotation>
+          </xs:attribute>
           <xs:attribute name="paged" type="yesNoType" default="yes">
             <xs:annotation><xs:documentation>
                 Yes indicates programmer supports Paged mode,


### PR DESCRIPTION
This PR is an add-on to PR #13181. It changes the default address to 0 and it disables the read, write and compare buttons for "No decoder" roster items.