### PR TITLE
Make the STL Editor parser a little more accepting of node input

### DIFF
--- a/java/src/jmri/jmrix/openlcb/swing/stleditor/StlEditorPane.java
+++ b/java/src/jmri/jmrix/openlcb/swing/stleditor/StlEditorPane.java
@@ -751,7 +751,7 @@ public class StlEditorPane extends jmri.util.swing.JmriPanel
                 // Get name
                 if (oper != null) {
                     if (!name.isEmpty()) {
-                        log.warn("Skipping superfluous input \"{}\" in line \"{}\", missing newline?", token, lines[i]);
+                        log.warn("Skipping superfluous input \"{}\" in line \"{}\". Perhaps a missing newline?", token, lines[i]);
                         continue;
                     }
                     if (oper.name().startsWith("J")) {   // Jump label
@@ -796,8 +796,8 @@ public class StlEditorPane extends jmri.util.swing.JmriPanel
         //
         // This implementation will parse "SET0" as a 
         // "SET" command with an argument of "0", even though
-        // it might be intended to be an "SE" with an argument of "T0"".
-        // ("SET" takes no argument, which is how you tell these apart)
+        // it is intended to be an "SE" with an argument of "T0"".
+        // ("SET" takes no argument, which is how the parser should tell these apart)
         // Perhaps "SET" vs "SE" should be added as a special case.
         for (int i = name.length(); i > 0; i--) {
             String opCandidate = name.substring(0,i);

--- a/java/src/jmri/jmrix/openlcb/swing/stleditor/StlEditorPane.java
+++ b/java/src/jmri/jmrix/openlcb/swing/stleditor/StlEditorPane.java
@@ -784,6 +784,7 @@ public class StlEditorPane extends jmri.util.swing.JmriPanel
     /**
      * Handle an operator and operand without
      * an intervening space.
+     * @param name operand or concatenated operand and argument
      * @return index between operator and operand
      *          or -1
      */

--- a/java/src/jmri/jmrix/openlcb/swing/stleditor/StlEditorPane.java
+++ b/java/src/jmri/jmrix/openlcb/swing/stleditor/StlEditorPane.java
@@ -742,9 +742,14 @@ public class StlEditorPane extends jmri.util.swing.JmriPanel
                 }
 
                 // Get comment
-                if (token.equals("//")) {
+                if (token.startsWith("//")) {
+                    // Accept either "// comment" or "//comment". In the first case,
+                    // the token is "//" with a separating space that needs to be skipped.
+                    // In the second, the comment text starts directly after the //
+                    int offset = 3;
+                    if (token.length() > 2) offset = 2;
                     int commentPosition = lines[i].indexOf("//");
-                    comment = lines[i].substring(commentPosition + 3);
+                    comment = lines[i].substring(commentPosition + offset);
                     break;
                 }
 

--- a/java/test/jmri/jmrix/openlcb/swing/stleditor/StlEditorPaneTest.java
+++ b/java/test/jmri/jmrix/openlcb/swing/stleditor/StlEditorPaneTest.java
@@ -1,0 +1,39 @@
+package jmri.jmrix.openlcb.swing.stleditor;
+
+import java.util.Locale;
+import org.junit.Assert;
+import org.junit.jupiter.api.*;
+
+/**
+ * Tests for the Bundle class
+ *
+ * @author Bob Jacobsen Copyright (C) 2012
+ */
+public class StlEditorPaneTest  {
+
+    @Test public void testSeveralGetEnum() {
+        Assert.assertEquals(StlEditorPane.Operator.AN, StlEditorPane.getEnum("AN"));
+
+        Assert.assertEquals(StlEditorPane.Operator.Cp, StlEditorPane.getEnum(")"));
+
+        Assert.assertEquals(StlEditorPane.Operator.ANp, StlEditorPane.getEnum("AN("));
+
+        Assert.assertEquals(StlEditorPane.Operator.AN, StlEditorPane.getEnum("An"));
+
+        Assert.assertEquals(StlEditorPane.Operator.ANp, StlEditorPane.getEnum("An("));
+    }
+    
+    @Test public void testSeveralFindOperatorBoundary() {
+        Assert.assertEquals(2, StlEditorPane.findOperatorBoundary("AN"));
+
+        Assert.assertEquals(2, StlEditorPane.findOperatorBoundary("A("));
+
+        Assert.assertEquals(2, StlEditorPane.findOperatorBoundary("A(O1.0"));
+
+        Assert.assertEquals(1, StlEditorPane.findOperatorBoundary("AI2.4"));
+
+        Assert.assertEquals(1, StlEditorPane.findOperatorBoundary("L#0#50"));
+
+        Assert.assertEquals(-1, StlEditorPane.findOperatorBoundary("//"));
+    }
+}

--- a/java/test/jmri/jmrix/openlcb/swing/stleditor/StlEditorPaneTest.java
+++ b/java/test/jmri/jmrix/openlcb/swing/stleditor/StlEditorPaneTest.java
@@ -1,6 +1,5 @@
 package jmri.jmrix.openlcb.swing.stleditor;
 
-import java.util.Locale;
 import org.junit.Assert;
 import org.junit.jupiter.api.*;
 


### PR DESCRIPTION
This PR is intended to make the STL Editor better handle a broader range of input from a node's configuration, making it easier to import content that was first created by hand.

1) Accept lower case for commands, e.g. `An` in addition to `AN`
2) In many cases, accept a missing space between command and operand, e.g. "ANI1.0" will be interpreted as "AN I1.0"
3) Add WARN-level diagnostic information for various parse failures that will let people track down and fix them.

The input is converted to canonical form before being used by the STL editor, so a load-store cycle will update the content.

Note that (2) is not 100%.  It's an improvement, but it's not 100% Some inputs, like "SET2" as an input and perhaps others, will later need to be treated as a special case. 

The main thing that's missing is handling multiple command/operand pairs on a single line.  That may come later.