### PR TITLE
Fix screen size for DIALOG EditConnectionPreference

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -464,7 +464,7 @@
     <h3>Preferences</h3>
         <a id="Preferences" name="Preferences"></a>
         <ul>
-            <li></li>
+            <li>Set the bounds on the dialog when going into EditPreferences after profile connection fail.</li>
         </ul>
 
     <h3>Resources</h3>

--- a/java/src/apps/gui3/tabbedpreferences/EditConnectionPreferencesDialog.java
+++ b/java/src/apps/gui3/tabbedpreferences/EditConnectionPreferencesDialog.java
@@ -40,8 +40,12 @@ public final class EditConnectionPreferencesDialog extends JDialog implements Wi
     public static boolean showDialog() {
         EditConnectionPreferencesDialog dialog = new EditConnectionPreferencesDialog();
         SwingUtilities.updateComponentTreeUI(dialog);  // hack because sometimes this was created before L&F was set?
-        
         dialog.pack();
+        dialog.setBounds(
+                (int) ( jmri.util.JmriJFrame.getScreenDimensions().get(0).getBounds().getSize().getWidth() * 0.10 ),
+                (int) ( jmri.util.JmriJFrame.getScreenDimensions().get(0).getBounds().getSize().getHeight() * 0.10 ),
+                (int) ( jmri.util.JmriJFrame.getScreenDimensions().get(0).getBounds().getSize().getWidth() * 0.80 ),
+                (int) (jmri.util.JmriJFrame.getScreenDimensions().get(0).getBounds().getSize().getHeight()* 0.80 ));
         dialog.setVisible(true);
         return dialog.restartProgram;
     }


### PR DESCRIPTION
Someone with a tiny screen needs to check this on a Mac. 
I tested on a Acer One under Qos with Trinity desktop, 32bit, its the minimilistic gui, also dual 4K with Fedora 64bit., and single screen Windows 11.

