### PR TITLE
Fix SampleScriptTest

### DIFF
--- a/java/src/jmri/managers/DefaultShutDownManager.java
+++ b/java/src/jmri/managers/DefaultShutDownManager.java
@@ -261,7 +261,7 @@ public class DefaultShutDownManager extends Bean implements ShutDownManager {
      * @param exit   true if System.exit() should be called if all tasks are
      *               executed correctly; false otherwise
      */
-    protected void shutdown(int status, boolean exit) {
+    public void shutdown(int status, boolean exit) {
         Runnable shutdownTask = () -> { doShutdown(status, exit); };
 
         if (!blockingShutdown) {

--- a/java/test/jmri/jmrit/jython/SampleScriptTest.java
+++ b/java/test/jmri/jmrit/jython/SampleScriptTest.java
@@ -119,7 +119,7 @@ public class SampleScriptTest {
 
         // run shutdown task with blocking
         ((jmri.managers.DefaultShutDownManager)InstanceManager.getDefault(ShutDownManager.class)).setBlockingShutdown(true);
-        InstanceManager.getDefault(ShutDownManager.class).shutdown();
+        ((jmri.managers.DefaultShutDownManager)InstanceManager.getDefault(ShutDownManager.class)).shutdown(0, false);
 
         File newTurnoutFile = new File(jmri.util.FileUtil.getUserFilesPath() + "TurnoutState.csv");
         Assertions.assertTrue(newTurnoutFile.exists(),"user TurnoutState.csv exists");


### PR DESCRIPTION
@icklesteve 
@bobjacobsen 
This seems to fix the `SampleScriptTest` and `TurnoutStatePersistence.py`. At least the summary works now. The problem was that `SampleScriptTest` called `ShutdownManager.shutdown()` which in turn called `System.exit(status)`.

One additional note:
`DefaultShutDownManager.doShutdown(int status, boolean exit)` has a Javadoc that's wrong. It says that it returns false if user aborts, but the method is void so it doesn't return any value. I haven't changed this since I'm not exactly sure how the Javadoc should be instead.

Also, there is several `@SuppressFBWarnings()` about DM_EXIT. The one for `doShutdown()` is probably needed but the others can probably be removed.