### PR TITLE
Don't use deprecated method Runtime.exec(String)

### DIFF
--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionLinuxLinePower.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionLinuxLinePower.java
@@ -64,7 +64,7 @@ public class ExpressionLinuxLinePower extends AbstractDigitalExpression
     private List<String> getLinuxPowerSupplies() throws IOException, NoPowerSuppliesException {
         List<String> powerSupplies = new ArrayList<>();
 
-        Process process = Runtime.getRuntime().exec("upower -e");
+        Process process = Runtime.getRuntime().exec(new String[]{"upower","-e"});
         try (BufferedReader buffer = new BufferedReader(new InputStreamReader(process.getInputStream())))  {
             String line;
             while ((line = buffer.readLine()) != null) {
@@ -83,7 +83,7 @@ public class ExpressionLinuxLinePower extends AbstractDigitalExpression
         boolean isPowerOnline = false;
 
         for (String powerSupply : getLinuxPowerSupplies()) {
-            Process process = Runtime.getRuntime().exec("upower -i " + powerSupply);
+            Process process = Runtime.getRuntime().exec(new String[]{"upower", "-i", powerSupply});
             try (BufferedReader buffer = new BufferedReader(new InputStreamReader(process.getInputStream())))  {
                 String line;
                 boolean linePowerFound = false;
@@ -139,7 +139,7 @@ public class ExpressionLinuxLinePower extends AbstractDigitalExpression
     /** {@inheritDoc} */
     @Override
     public boolean evaluate() throws JmriException {
-
+        
         if (_thrownException != null) {
             JmriException e = _thrownException;
             _thrownException = null;

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionLinuxLinePower.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionLinuxLinePower.java
@@ -139,7 +139,7 @@ public class ExpressionLinuxLinePower extends AbstractDigitalExpression
     /** {@inheritDoc} */
     @Override
     public boolean evaluate() throws JmriException {
-        
+
         if (_thrownException != null) {
             JmriException e = _thrownException;
             _thrownException = null;

--- a/java/src/jmri/jmrit/operations/trains/excel/TrainCustomCommon.java
+++ b/java/src/jmri/jmrit/operations/trains/excel/TrainCustomCommon.java
@@ -146,7 +146,7 @@ public abstract class TrainCustomCommon {
         // Excel spreadsheets
         // It should work OK with actual programs.
         if (SystemType.isWindows()) {
-            String cmd = "cmd /c start " + getFileName() + " " + mcAppArg; // NOI18N
+            String[] cmd = {"cmd", "/c", "start", getFileName(), mcAppArg}; // NOI18N
             try {
                 process = Runtime.getRuntime().exec(cmd, null,
                         InstanceManager.getDefault(OperationsManager.class).getFile(getDirectoryName()));
@@ -154,7 +154,7 @@ public abstract class TrainCustomCommon {
                 log.error("Unable to execute {}", getFileName(), e);
             }
         } else {
-            String cmd = "open " + getFileName() + " " + mcAppArg; // NOI18N
+            String[] cmd = {"open", getFileName(), mcAppArg}; // NOI18N
             try {
                 process = Runtime.getRuntime().exec(cmd, null,
                         InstanceManager.getDefault(OperationsManager.class).getFile(getDirectoryName()));

--- a/java/src/jmri/util/JmriInsets.java
+++ b/java/src/jmri/util/JmriInsets.java
@@ -80,7 +80,7 @@ public class JmriInsets {
         if (!SystemType.isWindows()
                 && !OS_NAME.toLowerCase().startsWith("mac")) { // NOI18N
             try {
-                Process p = Runtime.getRuntime().exec("ps ax"); // NOI18N
+                Process p = Runtime.getRuntime().exec(new String[]{"ps","ax"}); // NOI18N
                 BufferedReader r = new BufferedReader(new InputStreamReader(p.getInputStream()));
 
                 try {


### PR DESCRIPTION
@DanielBoudreau 
I have started looking at deprecations in Java 21 to see what's easy to fix.

The method [Runtime.exec(String)](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/Runtime.html#exec(java.lang.String)
) is deprecated in Java 18. This PR replaces it with [Runtime.exec(String[])](https://docs.oracle.com/en%2Fjava%2Fjavase%2F11%2Fdocs%2Fapi%2F%2F/java.base/java/lang/Runtime.html#exec(java.lang.String%5B%5D)).

I have tested `ExpressionLinuxLinePower` and `JmriInsets` but not `TrainCustomCommon`.