### PR TITLE
Fix TwoColumnMachineTest.py for Java17

### DIFF
--- a/jython/ctc/TwoColumnMachineTest.py
+++ b/jython/ctc/TwoColumnMachineTest.py
@@ -6,8 +6,19 @@
 # Part of the JMRI distribution
 import java
 import jmri
-from jmri.jmrit.ussctc import *
 from jmri.jmrit import Sound
+from jmri.jmrit.ussctc import CodeButton
+from jmri.jmrit.ussctc import CodeLine
+from jmri.jmrit.ussctc import OccupancyLock
+from jmri.jmrit.ussctc import PhysicalBell
+from jmri.jmrit.ussctc import RouteLock
+from jmri.jmrit.ussctc import SignalHeadSection
+from jmri.jmrit.ussctc import Station
+from jmri.jmrit.ussctc import TimeLock
+from jmri.jmrit.ussctc import TrackCircuitSection
+from jmri.jmrit.ussctc import TrafficLock
+from jmri.jmrit.ussctc import TurnoutSection
+from jmri.jmrit.ussctc import VetoedBell
 
 # First, we define Turnouts and Sensors used by this example
 # These are normally defined in a panel file with names specific


### PR DESCRIPTION
 @bobjacobsen 
If `project.properties` has the property `sdk_version=17`, then `TwoColumnMachineTest.py` fails. This PR fixes that.

For some reason, `from jmri.jmrit.ussctc import *` fails to import the needed classes on Java17. It's not a problem when compiling and running on Java17, but it fails if `sdk_version=17`. I don't know why.

Note that `jython/ctc/TwoColumnMachine.py` also has `from jmri.jmrit.ussctc import *` but the `SampleScriptTest` doesn't fail on that.

To test this, I run:
```
ant realclean
export JMRI_OPTIONS="-Duser.language=en -Duser.country=us" && ant tests && ./runtest.csh jmri.jmrit.jython.SampleScriptTest
```

If you have a better solution than this PR, then I'm happy to close this PR.