### PR TITLE
Fix deprecations java21

### DIFF
--- a/java/src/apps/CheckForUpdateAction.java
+++ b/java/src/apps/CheckForUpdateAction.java
@@ -64,8 +64,8 @@ public class CheckForUpdateAction extends jmri.util.swing.JmriAbstractAction {
 
         URL url;
         try {
-            url = new URL(urlname);
-        } catch (MalformedURLException e){
+            url = new URI(urlname).toURL();
+        } catch (MalformedURLException | URISyntaxException e){
             log.error("Unexpected failure in URL parsing", e);
             return;
         }

--- a/java/src/apps/SystemConsole.java
+++ b/java/src/apps/SystemConsole.java
@@ -520,6 +520,8 @@ public final class SystemConsole extends JTextArea {
 
     private Map<Thread, StackTraceElement[]> traces;
 
+    @SuppressWarnings("deprecation")    // The method getId() from the type Thread is deprecated since version 19
+                                        // The replacement Thread.threadId() isn't available before version 19
     private void performStackTrace() {
         System.out.println("----------- Begin Stack Trace -----------"); //NO18N
         System.out.println("-----------------------------------------"); //NO18N

--- a/java/src/apps/TrainCrew/InstallFromURL.java
+++ b/java/src/apps/TrainCrew/InstallFromURL.java
@@ -3,6 +3,7 @@ package apps.TrainCrew;
 import java.awt.event.ActionEvent;
 import java.io.File;
 import java.io.InputStream;
+import java.net.URI;
 import java.net.URL;
 import javax.swing.Icon;
 import javax.swing.JPanel;
@@ -52,7 +53,7 @@ public class InstallFromURL extends JmriAbstractAction {
         
         try {
             // create URL
-            URL url = new URL(urlString);
+            URL url = new URI(urlString).toURL();
 
             try {
                 // open connection
@@ -65,7 +66,7 @@ public class InstallFromURL extends JmriAbstractAction {
             } catch (java.io.IOException ex) {
                 log.error("Error in transfer", ex);
             }
-        } catch (java.net.MalformedURLException ex) {
+        } catch (java.net.MalformedURLException | java.net.URISyntaxException ex) {
             log.error("Invalid URL", ex);
         }
     }

--- a/java/src/jmri/Block.java
+++ b/java/src/jmri/Block.java
@@ -472,6 +472,8 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
      *
      * @param v the new state
      */
+    @SuppressWarnings("deprecation")    // The method getId() from the type Thread is deprecated since version 19
+                                        // The replacement Thread.threadId() isn't available before version 19
     @Override
     public void setState(int v) {
         int old = _current;

--- a/java/src/jmri/jmrit/decoderdefn/InstallDecoderFileAction.java
+++ b/java/src/jmri/jmrit/decoderdefn/InstallDecoderFileAction.java
@@ -1,6 +1,7 @@
 package jmri.jmrit.decoderdefn;
 
 import java.io.File;
+import java.net.URI;
 import java.net.URL;
 import javax.swing.Icon;
 import javax.swing.JFileChooser;
@@ -50,7 +51,7 @@ public class InstallDecoderFileAction extends InstallDecoderURLAction {
                 log.debug("located file {} for XML processing", file);
             }
             try {
-                return new URL("file:" + file.getCanonicalPath());
+                return new URI("file:" + file.getCanonicalPath()).toURL();
             } catch (Exception e) {
                 log.error("Unexpected exception in new URL", e);
                 return null;

--- a/java/src/jmri/jmrit/decoderdefn/InstallDecoderURLAction.java
+++ b/java/src/jmri/jmrit/decoderdefn/InstallDecoderURLAction.java
@@ -8,6 +8,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.URI;
 import java.net.URL;
 import javax.swing.Icon;
 import javax.swing.JPanel;
@@ -53,8 +54,8 @@ public class InstallDecoderURLAction extends JmriAbstractAction {
             return null;
         }
         try {
-            return new URL(urlname);
-        } catch (java.net.MalformedURLException e) {
+            return new URI(urlname).toURL();
+        } catch (java.net.MalformedURLException | java.net.URISyntaxException e) {
             JmriJOptionPane.showMessageDialog(who, Bundle.getMessage("MalformedURL"));
         }
         return null;

--- a/java/src/jmri/jmrit/display/IndicatorTrackPaths.java
+++ b/java/src/jmri/jmrit/display/IndicatorTrackPaths.java
@@ -125,6 +125,8 @@ public class IndicatorTrackPaths {
      * Each wraps this method with ThreadingUtil.runOnLayoutEventually, so there is
      * a time lag for when track icon changes and display of the change.
      */
+    @SuppressWarnings("deprecation")    // The method getId() from the type Thread is deprecated since version 19
+                                        // The replacement Thread.threadId() isn't available before version 19
     @jmri.InvokeOnLayoutThread
     synchronized protected void setLocoIcon(OBlock block, Point pt, Dimension size, Editor ed) {
         if (!_showTrain) {

--- a/java/src/jmri/jmrit/logixng/actions/WebRequest.java
+++ b/java/src/jmri/jmrit/logixng/actions/WebRequest.java
@@ -4,6 +4,8 @@ import java.beans.*;
 import java.io.*;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.charset.Charset;
@@ -210,12 +212,12 @@ public class WebRequest extends AbstractDigitalAction
 //                System.out.format("Param string: \"%s\". URL: \"%s\"%n", paramString, urlString);
             }
 
-            url = new URL(urlString);
+            url = new URI(urlString).toURL();
 //            System.out.format("URL: %s, query: %s, userInfo: %s%n", url.toString(), url.getQuery(), url.getUserInfo());
 //            if (!urlString.contains("LogixNG_WebRequest_Test.php") && !urlString.contains("https://www.modulsyd.se/")) return;
 //            if (!urlString.contains("LogixNG_WebRequest_Test.php")) return;
 //            if (!urlString.contains("https://www.modulsyd.se/")) return;
-        } catch (MalformedURLException ex) {
+        } catch (MalformedURLException | URISyntaxException ex) {
             throw new JmriException(ex.getMessage(), ex);
         }
 

--- a/java/src/jmri/jmrit/mailreport/ReportPanel.java
+++ b/java/src/jmri/jmrit/mailreport/ReportPanel.java
@@ -9,6 +9,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.zip.ZipEntry;
@@ -268,7 +269,7 @@ public class ReportPanel extends JPanel {
                 sendButton.setEnabled(true);
             }
 
-        } catch (IOException ex) {
+        } catch (IOException | URISyntaxException ex) {
             log.error("Error when attempting to send report", ex);
             sendButton.setEnabled(true);
         } catch (AddressException ex) {

--- a/java/src/jmri/jmrix/lenz/XNetTurnout.java
+++ b/java/src/jmri/jmrix/lenz/XNetTurnout.java
@@ -534,6 +534,8 @@ public class XNetTurnout extends AbstractTurnout implements XNetListener {
     /**
      * Send an "Off" message to the decoder for this output. 
      */
+    @SuppressWarnings("deprecation")    // The method getId() from the type Thread is deprecated since version 19
+                                        // The replacement Thread.threadId() isn't available before version 19
     protected synchronized void sendOffMessage() {
         // We need to tell the turnout to shut off the output.
         if (log.isDebugEnabled()) {

--- a/java/src/jmri/jmrix/roco/z21/Z21XNetTurnout.java
+++ b/java/src/jmri/jmrix/roco/z21/Z21XNetTurnout.java
@@ -146,6 +146,8 @@ public class Z21XNetTurnout extends XNetTurnout {
        sendOffMessage(getCommandedState());
     }
 
+    @SuppressWarnings("deprecation")    // The method getId() from the type Thread is deprecated since version 19
+                                        // The replacement Thread.threadId() isn't available before version 19
     protected synchronized void sendOffMessage(int state) {
         // We need to tell the turnout to shut off the output.
         if (log.isDebugEnabled()) {

--- a/java/src/jmri/server/web/app/WebAppServlet.java
+++ b/java/src/jmri/server/web/app/WebAppServlet.java
@@ -170,6 +170,8 @@ public class WebAppServlet extends HttpServlet {
         response.getWriter().print(FileUtil.readFile(script));
     }
 
+    @SuppressWarnings("deprecation")    // The constructor Locale(String) is deprecated since version 19
+                                        // The replacement Locale.of(String) isn't available before version 19
     private void processLocale(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
         response.setContentType(UTF8_APPLICATION_JSON);
         Profile profile = ProfileManager.getDefault().getActiveProfile();

--- a/java/src/jmri/util/MultipartMessage.java
+++ b/java/src/jmri/util/MultipartMessage.java
@@ -9,6 +9,8 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.util.ArrayList;
@@ -52,13 +54,16 @@ public class MultipartMessage {
      * @param requestURL URL to which this request should be sent
      * @param charSet    character set encoding of this message
      * @throws IOException if {@link OutputStream} cannot be created
+     * @throws URISyntaxException if the requestURL has wrong syntax
      */
-    public MultipartMessage(String requestURL, String charSet) throws IOException {
+    public MultipartMessage(String requestURL, String charSet)
+            throws IOException, URISyntaxException {
+
         this.charSet = charSet;
 
         // create unique multi-part message boundary
         boundary = "===" + System.currentTimeMillis() + "===";
-        URL url = new URL(requestURL);
+        URL url = new URI(requestURL).toURL();
         httpConn = (HttpURLConnection) url.openConnection();
         httpConn.setUseCaches(false);
         httpConn.setDoOutput(true);

--- a/java/src/jmri/util/ThreadingUtil.java
+++ b/java/src/jmri/util/ThreadingUtil.java
@@ -449,6 +449,8 @@ public class ThreadingUtil {
     /**
      * Warn if a thread is holding locks. Used when transitioning to another context.
      */
+    @SuppressWarnings("deprecation")    // The method getId() from the type Thread is deprecated since version 19
+                                        // The replacement Thread.threadId() isn't available before version 19
     static public void warnLocks() {
         if ( log.isDebugEnabled() ) {
             try {

--- a/java/src/jmri/util/gui/GuiLafPreferencesManager.java
+++ b/java/src/jmri/util/gui/GuiLafPreferencesManager.java
@@ -570,6 +570,8 @@ public class GuiLafPreferencesManager extends Bean implements PreferencesManager
      *
      * @param profile The profile to get the locale from
      */
+    @SuppressWarnings("deprecation")    // The constructor Locale(String) is deprecated since version 19
+                                        // The replacement Locale.of(String) isn't available before version 19
     public static void setLocaleMinimally(Profile profile) {
         // en is default if a locale preference has not been set
         String name = ProfileUtils.getPreferences(profile, GuiLafPreferencesManager.class, true).get("locale", "en");

--- a/java/test/jmri/jmrix/can/cbus/CbusTurnoutTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusTurnoutTest.java
@@ -92,7 +92,12 @@ public class CbusTurnoutTest extends jmri.implementation.AbstractTurnoutTestBase
     @Test
     public void testNullEvent() throws Exception {
         Exception ex = Assertions.assertThrows(NullPointerException.class, () -> { t = new CbusTurnout("MT",null,tcis); });
-        Assertions.assertEquals(null, ex.getMessage());
+        
+        // On Java 11 and below, the message is null.
+        // On Java 17 and above, the message is text.
+        boolean messageIsCorrect = ex.getMessage() == null
+                || "Cannot invoke \"java.lang.CharSequence.length()\" because \"this.text\" is null".equals(ex.getMessage());
+        Assertions.assertTrue(messageIsCorrect);
     }
     
     @Test

--- a/java/test/jmri/util/MultipartMessageTest.java
+++ b/java/test/jmri/util/MultipartMessageTest.java
@@ -19,7 +19,7 @@ public class MultipartMessageTest {
     private WebServer server = null;
 
     @Test
-    public void testCTor() throws java.io.IOException {
+    public void testCTor() throws java.io.IOException, java.net.URISyntaxException {
         MultipartMessage t = new MultipartMessage("http://localhost:12080",StandardCharsets.UTF_8.name());
         Assert.assertNotNull("exists",t);
         t.finish(); // make sure the port closes.


### PR DESCRIPTION
@bobjacobsen 
This PR fixes some of the deprecations that will hit us with Java 21. In some cases, I have chosen to suppress the warnings since the replacements isn't available until we move to Java 21. Once we have done the move to Java21, it's easy to fix these.

I have changed the public constructor of `jmri.util.MultipartMessage` so that it throws an additional exception. I thought it would be better if the caller handled the original `URISyntaxException`, than to have this class throw an `IOException` with the URISyntaxException as cause. But it might affect people that are using JMRI as a library.