### PR TITLE
Rename AudioThread.alive() to isThreadAlive()

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -615,5 +615,7 @@
         <a id="Misc" name="Misc"></a>
         <ul>
             <li>Updated LauchJMRI.exe to display the console when the /noisy is used. No more return code 1, but and actual explanation</li>
+            <li>The method <strong>jmri.jmrit.audio.AudioThread.alive()</strong> has been renamed to <strong>isThreadAlive()</strong>.
+                It should only affect developers and people using JMRI as a library.</li>
         </ul>
 

--- a/java/src/jmri/jmrit/audio/AbstractAudioFactory.java
+++ b/java/src/jmri/jmrit/audio/AbstractAudioFactory.java
@@ -84,7 +84,7 @@ public abstract class AbstractAudioFactory implements AudioFactory {
         if (!dieException) {
             // wait for up to 5 seconds for thread to end
             for (int i = 0; i < 50; i++) {
-                if (!audioCommandThread.alive()) {
+                if (!audioCommandThread.isThreadAlive()) {
                     break;
                 }
                 AbstractAudioThread.snooze(100);

--- a/java/src/jmri/jmrit/audio/AbstractAudioSource.java
+++ b/java/src/jmri/jmrit/audio/AbstractAudioSource.java
@@ -95,7 +95,7 @@ public abstract class AbstractAudioSource extends AbstractAudio implements Audio
     }
 
     public boolean isAudioAlive() {
-        return ((AudioThread) activeAudioFactory.getCommandThread()).alive();
+        return ((AudioThread) activeAudioFactory.getCommandThread()).isThreadAlive();
     }
 
     @Override

--- a/java/src/jmri/jmrit/audio/AbstractAudioThread.java
+++ b/java/src/jmri/jmrit/audio/AbstractAudioThread.java
@@ -58,7 +58,7 @@ public abstract class AbstractAudioThread extends Thread implements AudioThread 
     }
 
     @Override
-    public boolean alive() {
+    public boolean isThreadAlive() {
         return alive(GET, NA);
     }
 

--- a/java/src/jmri/jmrit/audio/AudioThread.java
+++ b/java/src/jmri/jmrit/audio/AudioThread.java
@@ -39,7 +39,7 @@ public interface AudioThread extends Runnable {
      *
      * @return true, while thread is alive; false, when all cleanup has finished
      */
-    boolean alive();
+    boolean isThreadAlive();
 
     /**
      * Method used to tell the thread that it should shutdown

--- a/java/src/jmri/jmrit/vsdecoder/AudioUtil.java
+++ b/java/src/jmri/jmrit/vsdecoder/AudioUtil.java
@@ -145,7 +145,7 @@ public class AudioUtil {
         if (af == null) {
             return false;
         } else {
-            return ((jmri.jmrit.audio.AudioThread) af.getCommandThread()).alive();
+            return ((jmri.jmrit.audio.AudioThread) af.getCommandThread()).isThreadAlive();
         }
     }
 


### PR DESCRIPTION
The method `alive()` is package private in Thread in Java 21. We don't use the Thread implementation of this method, but Static analysis with Java21 fails with the message:
```
 2. ERROR in /home/runner/work/JMRI/JMRI/java/src/jmri/jmrit/audio/AbstractAudioThread.java (at line 61)
	public boolean alive() {
	               ^^^^^^^
The method AbstractAudioThread.alive() does not override the inherited method from Thread since it is private to a different package
```

For more information about the warning, see:
https://stackoverflow.com/questions/7569548/suppress-the-method-does-not-override-the-inherited-method-since-it-is-private