### PR TITLE
Remove Thread.stop() and ThreadDeath from AbstractAutomaton

### DIFF
--- a/java/src/jmri/jmrit/automat/AbstractAutomaton.java
+++ b/java/src/jmri/jmrit/automat/AbstractAutomaton.java
@@ -148,7 +148,7 @@ public class AbstractAutomaton implements Runnable {
             } else {
                 log.debug("normal termination, handle() returned false");
             }
-        } catch (StopThread e1) {
+        } catch (StopThreadException e1) {
             log.debug("Current thread is stopped()");
         } catch (Exception e2) {
             log.warn("Unexpected Exception ends AbstractAutomaton thread", e2);
@@ -274,7 +274,7 @@ public class AbstractAutomaton implements Runnable {
                 Thread.sleep(stillToGo);
             } catch (InterruptedException e) {
                 if (threadIsStopped) {
-                    throw new StopThread();
+                    throw new StopThreadException();
                 }
                 Thread.currentThread().interrupt(); // retain if needed later
             }
@@ -335,7 +335,7 @@ public class AbstractAutomaton implements Runnable {
                 }
             } catch (InterruptedException e) {
                 if (threadIsStopped) {
-                    throw new StopThread();
+                    throw new StopThreadException();
                 }
                 Thread.currentThread().interrupt(); // retain if needed later
                 log.warn("interrupted in wait");
@@ -891,7 +891,7 @@ public class AbstractAutomaton implements Runnable {
             }
         } catch (InterruptedException e) {
             if (threadIsStopped) {
-                throw new StopThread();
+                throw new StopThreadException();
             }
             Thread.currentThread().interrupt(); // retain if needed later
             log.warn("AbstractAutomaton {} waitChange interrupted", getName());
@@ -1352,7 +1352,7 @@ public class AbstractAutomaton implements Runnable {
             super.wait();
         } catch (InterruptedException e) {
             if (threadIsStopped) {
-                throw new StopThread();
+                throw new StopThreadException();
             }
             Thread.currentThread().interrupt(); // retain if needed later
             log.warn("Interrupted during debugging wait, not expected");
@@ -1363,7 +1363,7 @@ public class AbstractAutomaton implements Runnable {
      * An throwable that's used internally in AbstractAutomation to stop
      * the thread.
      */
-    private static class StopThread extends RuntimeException {
+    private static class StopThreadException extends RuntimeException {
     }
 
     // initialize logging

--- a/java/src/jmri/jmrit/automat/AbstractAutomaton.java
+++ b/java/src/jmri/jmrit/automat/AbstractAutomaton.java
@@ -1360,7 +1360,7 @@ public class AbstractAutomaton implements Runnable {
     }
 
     /**
-     * An throwable that's used internally in AbstractAutomation to stop
+     * An exception that's used internally in AbstractAutomation to stop
      * the thread.
      */
     private static class StopThreadException extends RuntimeException {

--- a/java/src/jmri/jmrit/automat/AbstractAutomaton.java
+++ b/java/src/jmri/jmrit/automat/AbstractAutomaton.java
@@ -379,7 +379,7 @@ public class AbstractAutomaton implements Runnable {
             }
         });
 
-        int now = mSensor.getKnownState();
+        int now;
         while (mState == (now = mSensor.getKnownState())) {
             wait(-1);
         }

--- a/java/test/jmri/jmrit/automat/AbstractAutomatonTest.java
+++ b/java/test/jmri/jmrit/automat/AbstractAutomatonTest.java
@@ -85,7 +85,7 @@ public class AbstractAutomatonTest {
         JUnitUtil.waitFor(()->{return a.isRunning();}, "running");
         a.stop();
         JUnitUtil.waitFor(()->{return ! a.isRunning();}, "stopped");
-        Assert.assertTrue("didn't complete handle", ! done);
+        Assert.assertTrue("completed handle", done);
     }
     
     @Test

--- a/java/test/jmri/jmrit/automat/AbstractAutomatonTest.java
+++ b/java/test/jmri/jmrit/automat/AbstractAutomatonTest.java
@@ -85,7 +85,7 @@ public class AbstractAutomatonTest {
         JUnitUtil.waitFor(()->{return a.isRunning();}, "running");
         a.stop();
         JUnitUtil.waitFor(()->{return ! a.isRunning();}, "stopped");
-        Assert.assertTrue("completed handle", done);
+        Assert.assertTrue("completed handle", !done);
     }
     
     @Test

--- a/java/test/jmri/jmrit/automat/AbstractAutomatonTest.java
+++ b/java/test/jmri/jmrit/automat/AbstractAutomatonTest.java
@@ -85,7 +85,7 @@ public class AbstractAutomatonTest {
         JUnitUtil.waitFor(()->{return a.isRunning();}, "running");
         a.stop();
         JUnitUtil.waitFor(()->{return ! a.isRunning();}, "stopped");
-        Assert.assertTrue("completed handle", !done);
+        Assert.assertTrue("didn't complete handle", ! done);
     }
     
     @Test


### PR DESCRIPTION
`Thread.stop()` and `ThreadDeath` is deprecated and marked for removal. This PR removes Thread.stop() from AbstractAutomaton and replaces it with interrupt(). CI tests succeeds but I don't know if I have got everything right.

Is this change something that should be mentioned in the release notes? If so, how?

Note the change to AbstractAutomatonTest. With this change, the method handle() completes, instead of being aborted. I don't see a way to keep the original behaviour and I don't know if it matters.