### PR TITLE
The method finalize() from the type Object has been deprecated since version 9 and marked for removal

### DIFF
--- a/java/src/jmri/ConditionalAction.java
+++ b/java/src/jmri/ConditionalAction.java
@@ -122,4 +122,10 @@ public interface ConditionalAction {
     public NamedBeanHandle<?> getNamedBean();
 
     public NamedBean getBean();
+
+    /**
+     * Dispose this ConditionalAction.
+     */
+    public void dispose();
+
 }

--- a/java/src/jmri/implementation/DefaultConditional.java
+++ b/java/src/jmri/implementation/DefaultConditional.java
@@ -8,6 +8,7 @@ import java.util.BitSet;
 import java.util.List;
 
 import javax.annotation.Nonnull;
+import javax.annotation.OverridingMethodsMustInvokeSuper;
 import javax.swing.*;
 
 import jmri.*;
@@ -993,6 +994,16 @@ public class DefaultConditional extends AbstractNamedBean
             int oldState = _currentState;
             _currentState = state;
             firePropertyChange("KnownState", oldState, _currentState);  // NOI18N
+        }
+    }
+
+    /**
+     * Dispose this DefaultConditional.
+     */
+    @Override
+    public void dispose() {
+        for (int i = 0; i < _actionList.size(); i++) {
+            _actionList.get(i).dispose();
         }
     }
 

--- a/java/src/jmri/implementation/DefaultConditional.java
+++ b/java/src/jmri/implementation/DefaultConditional.java
@@ -8,7 +8,6 @@ import java.util.BitSet;
 import java.util.List;
 
 import javax.annotation.Nonnull;
-import javax.annotation.OverridingMethodsMustInvokeSuper;
 import javax.swing.*;
 
 import jmri.*;

--- a/java/src/jmri/implementation/DefaultConditional.java
+++ b/java/src/jmri/implementation/DefaultConditional.java
@@ -1001,6 +1001,7 @@ public class DefaultConditional extends AbstractNamedBean
      */
     @Override
     public void dispose() {
+        super.dispose();
         for (int i = 0; i < _actionList.size(); i++) {
             _actionList.get(i).dispose();
         }

--- a/java/src/jmri/implementation/DefaultConditionalAction.java
+++ b/java/src/jmri/implementation/DefaultConditionalAction.java
@@ -994,6 +994,14 @@ public class DefaultConditionalAction implements ConditionalAction {
         return str;
     }
 
+    /** {@inheritDoc} */
+    @Override
+    public void dispose() {
+        if (_sound != null) {
+            _sound.dispose();
+        }
+    }
+
     private final static Logger log = LoggerFactory.getLogger(DefaultConditionalAction.class);
 
 }

--- a/java/src/jmri/implementation/DefaultLogix.java
+++ b/java/src/jmri/implementation/DefaultLogix.java
@@ -4,7 +4,9 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.regex.Pattern;
+
 import javax.annotation.Nonnull;
+import javax.annotation.OverridingMethodsMustInvokeSuper;
 
 import jmri.*;
 import jmri.jmrit.beantable.LRouteTableAction;
@@ -1105,6 +1107,17 @@ public class DefaultLogix extends AbstractNamedBean
             }
         }
         return report;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    @OverridingMethodsMustInvokeSuper
+    public void dispose() {
+        super.dispose();
+        for (int i = 0; i < getNumConditionals(); i++) {
+            Conditional c = getConditional(getConditionalByNumberOrder(i));
+            c.dispose();
+        }
     }
 
     private final static Logger log = LoggerFactory.getLogger(DefaultLogix.class);

--- a/java/src/jmri/implementation/DefaultRoute.java
+++ b/java/src/jmri/implementation/DefaultRoute.java
@@ -1247,7 +1247,7 @@ public class DefaultRoute extends AbstractNamedBean implements Route, java.beans
             // play sound defined for start of route set
             if ((r.getOutputSoundName() != null) && (!r.getOutputSoundName().isEmpty())) {
                 try {
-                    (new Sound(r.getOutputSoundName())).play();
+                    (new Sound(r.getOutputSoundName())).play(true);
                 } catch (NullPointerException ex) {
                     log.error("Cannot find file {}", r.getOutputSoundName());
                 }

--- a/java/src/jmri/jmrit/Sound.java
+++ b/java/src/jmri/jmrit/Sound.java
@@ -155,7 +155,20 @@ public class Sound {
      * Play the sound once.
      */
     public void play() {
+        play(false);
+    }
+
+    /**
+     * Play the sound once.
+     * @param autoClose true if auto close clip, false otherwise. Only
+     *                  valid for clips. For streams, autoClose must be false.
+     * @throws IllegalArgumentException if streaming and autoClose is true
+     */
+    public void play(boolean autoClose) {
         if (streaming) {
+            if (autoClose) {
+                throw new IllegalArgumentException("autoClose is supported only for clips, not streams");
+            }
             Runnable streamSound = new StreamingSound(this.url);
             Thread tStream = jmri.util.ThreadingUtil.newThread(streamSound);
             tStream.start();
@@ -165,6 +178,13 @@ public class Sound {
                     clip = openClip();
                 }
                 if (clip != null) {
+                    if (autoClose) {
+                        clip.addLineListener((event)->{
+                            if (event.getType() == LineEvent.Type.STOP) {
+                                event.getLine().close();
+                            }
+                        });
+                    }
                     clip.start();
                 }
                 return clip;

--- a/java/src/jmri/jmrit/Sound.java
+++ b/java/src/jmri/jmrit/Sound.java
@@ -161,14 +161,10 @@ public class Sound {
     /**
      * Play the sound once.
      * @param autoClose true if auto close clip, false otherwise. Only
-     *                  valid for clips. For streams, autoClose must be false.
-     * @throws IllegalArgumentException if streaming and autoClose is true
+     *                  valid for clips. For streams, autoClose is ignored.
      */
     public void play(boolean autoClose) {
         if (streaming) {
-            if (autoClose) {
-                throw new IllegalArgumentException("autoClose is supported only for clips, not streams");
-            }
             Runnable streamSound = new StreamingSound(this.url);
             Thread tStream = jmri.util.ThreadingUtil.newThread(streamSound);
             tStream.start();

--- a/java/src/jmri/jmrit/Sound.java
+++ b/java/src/jmri/jmrit/Sound.java
@@ -175,7 +175,7 @@ public class Sound {
                 }
                 if (clip != null) {
                     if (autoClose) {
-                        clip.addLineListener((event)->{
+                        clip.addLineListener((event) -> {
                             if (event.getType() == LineEvent.Type.STOP) {
                                 event.getLine().close();
                             }

--- a/java/src/jmri/jmrit/Sound.java
+++ b/java/src/jmri/jmrit/Sound.java
@@ -151,24 +151,6 @@ public class Sound {
         }
     }
 
-    /** {@inheritDoc} */
-    @Override
-    @SuppressWarnings("deprecation") // Object.finalize
-    protected void finalize() throws Throwable {
-        try {
-            if (!streaming) {
-                clipRef.updateAndGet(clip -> {
-                    if (clip != null) {
-                        clip.close();
-                    }
-                    return null;
-                });
-            }
-        } finally {
-            super.finalize();
-        }
-    }
-
     /**
      * Play the sound once.
      */
@@ -284,6 +266,20 @@ public class Sound {
         // write(byte[] b, int off, int len)
         line.write(wavData, 0, wavData.length);
 
+    }
+
+    /**
+     * Dispose this sound.
+     */
+    public void dispose() {
+        if (!streaming) {
+            clipRef.updateAndGet(clip -> {
+                if (clip != null) {
+                    clip.close();
+                }
+                return null;
+            });
+        }
     }
 
     public static class WavBuffer {

--- a/java/src/jmri/jmrit/logixng/actions/ActionSound.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionSound.java
@@ -161,7 +161,7 @@ public class ActionSound extends AbstractDigitalAction
                 case Play:
                     if (!path.equals("")) {
                         try {
-                            new Sound(path).play();
+                            new Sound(path).play(true);
                         } catch (NullPointerException ex) {
                             throw new JmriException(Bundle.getMessage("ActionSound_Error_SoundNotFound", path));
                         }


### PR DESCRIPTION
```
1. ERROR in /home/runner/work/JMRI/JMRI/java/src/jmri/jmrit/Sound.java (at line 168)
	super.finalize();
	      ^^^^^^^^^^
The method finalize() from the type Object has been deprecated since version 9 and marked for removal
```

Of the classes that uses `Sound`, I have fixed the classes related to Logix, Route and LogixNG in this PR but I haven't tested Logix and Route.

@icklesteve 
`jmri.jmrit.etcs.ResourceUtil` uses Sound. I'm not sure what to do with it.

@bobjacobsen 
`jmri.jmrit.ussctc.ComputerBell` and `jmri.jmrit.ussctc.PhysicalBell` uses Sound.
I'm not sure what to do with these.

---

There is one `finalize()` method still in JMRI. `jmri.util.MenuScroller` has it and that class is only used by `jmri.jmrit.display.PositionablePopupUtil`.

It's easy to change that `finalize()` method to `dispose()` instead, but I'm not sure how I should get `PositionablePopupUtil` to call it.