### PR TITLE
Remove unnecessary method stopHubThread()

### DIFF
--- a/java/src/jmri/jmrix/openlcb/swing/hub/HubPane.java
+++ b/java/src/jmri/jmrix/openlcb/swing/hub/HubPane.java
@@ -211,15 +211,6 @@ public class HubPane extends jmri.util.swing.JmriPanel implements CanListener, C
         advertise(port);
     }
 
-    // For testing
-    @SuppressWarnings("deprecation") // Thread.stop
-    void stopHubThread() {
-        if (t != null) {
-            t.stop();
-            t = null;
-        }
-    }
-
     ArrayList<CanReply> workingReplySet = new ArrayList<>(); // collection of self-sent replies
     ArrayList<CanMessage> workingMessageSet = new ArrayList<>(); // collection of self-sent messages
 
@@ -304,7 +295,6 @@ public class HubPane extends jmri.util.swing.JmriPanel implements CanListener, C
         if ( _zero_conf_service != null ) { // set on void advertise(int port)
             _zero_conf_service.stop();
         }
-        stopHubThread();
         hub.dispose();
     }
 


### PR DESCRIPTION
The `dispose()` method calls `stopHubThread()` and then `hub.dispose()`. But `hub.dispose()` sets `disposed` to true which will eventually stop the Hub thread. Maybe `Hub.dispose()` should also close the input streams to stop the thread earlier, but that change will in that case need to be done to the OpenLCB library.
https://github.com/openlcb/OpenLCB_Java/blob/master/src/org/openlcb/hub/Hub.java

The commit that added the stopHubThread() method: https://github.com/JMRI/JMRI/commit/058957ca4ca142cab01f2a5090a7701f35455e04

The background for this PR is that I'm working on cleaning up the deprecations that will hit us with Java 21, in this case `Thread.stop()`.