### PR TITLE
ThreadDeath is deprecated and cannot be suppressed in Java 21

### DIFF
--- a/java/src/jmri/jmrix/AbstractMRTrafficController.java
+++ b/java/src/jmri/jmrix/AbstractMRTrafficController.java
@@ -803,12 +803,20 @@ public abstract class AbstractMRTrafficController {
                     public void run() {
                         try {
                             transmitLoop();
-                        } catch (ThreadDeath td) {
-                            if (!threadStopRequest) log.error("Transmit thread terminated prematurely by: {}", td, td);
-                            // ThreadDeath must be thrown per Java API Javadocs
-                            throw td;
                         } catch (Throwable e) {
-                            if (!threadStopRequest) log.error("Transmit thread terminated prematurely by: {}", e, e);
+                            if (!threadStopRequest) {
+                                log.error("Transmit thread terminated prematurely by: {}", e, e);
+                            }
+                            // see http://docs.oracle.com/javase/7/docs/api/java/lang/ThreadDeath.html
+                            // ThreadDeath must be thrown per Java API Javadocs
+                            // 
+                            // The type ThreadDeath has been deprecated since version 20 and marked for removal
+                            // and the warning cannot be suppressed in Java 21. But external libraries might
+                            // throw the exception outside of JMRI control. So check the name of the exception
+                            // instead of using "instanceof".
+                            if ("java.lang.ThreadDeath".equals(e.getClass().getName())) {
+                                throw e;
+                            }
                         }
                 }
             });

--- a/java/src/jmri/util/exceptionhandler/UncaughtExceptionHandler.java
+++ b/java/src/jmri/util/exceptionhandler/UncaughtExceptionHandler.java
@@ -23,7 +23,12 @@ public class UncaughtExceptionHandler implements Thread.UncaughtExceptionHandler
     public void uncaughtException(Thread t, Throwable e) {
 
         // see http://docs.oracle.com/javase/7/docs/api/java/lang/ThreadDeath.html
-        if (e instanceof java.lang.ThreadDeath) {
+        // 
+        // The type ThreadDeath has been deprecated since version 20 and marked for removal
+        // and the warning cannot be suppressed in Java 21. But external libraries might
+        // throw the exception outside of JMRI control. So check the name of the exception
+        // instead of using "instanceof".
+        if ("java.lang.ThreadDeath".equals(e.getClass().getName())) {
             log.info("Thread has stopped: {}", t.getName());
             return;
         }


### PR DESCRIPTION
@bobjacobsen 

After #13229 is merged, there are four classes which still uses Thread.stop():
```
jmri.jmrix.pricom.downloader.LoaderPane
jmri.jmrix.pricom.pockettester.DataSource
jmri.jmrix.roco.z21.Z21LocoNetTunnel
jmri.jmrix.roco.z21.Z21XPressNetTunnel
```

But even after we have fixed those, I think there is a risk of ThreadDeath anyway due to external libraries. What's your thought about that? This PR solves the deprecation issue while still handle ThreadDeath. Or is it better to wait until all cases of Thread.stop() has been fixed and then remove the handling of ThreadDeath?