### PR TITLE
Call a LogixNG Module directly

### DIFF
--- a/java/src/jmri/jmrit/logixng/LogixNG_Manager.java
+++ b/java/src/jmri/jmrit/logixng/LogixNG_Manager.java
@@ -2,6 +2,7 @@ package jmri.jmrit.logixng;
 
 import java.io.PrintWriter;
 import java.util.Locale;
+import java.util.Map;
 
 import jmri.Manager;
 import jmri.jmrit.logixng.Base.PrintTreeSettings;
@@ -272,5 +273,16 @@ public interface LogixNG_Manager extends Manager<LogixNG> {
      * @param task the task
      */
     void registerSetupTask(Runnable task);
+
+    /**
+     * Executes a LogixNG Module.
+     * Note that the module must be a Digital Action Module.
+     * @param module      The module to be executed
+     * @param parameters  The parameters. The module must have exactly one parameter.
+     * @throws IllegalArgumentException if module or parameters is null or if module
+     *                    is not a DigitalActionModule.
+     */
+    void executeModule(Module module, Map<String, Object> parameters)
+            throws IllegalArgumentException;
 
 }

--- a/java/src/jmri/jmrit/logixng/LogixNG_Manager.java
+++ b/java/src/jmri/jmrit/logixng/LogixNG_Manager.java
@@ -277,9 +277,20 @@ public interface LogixNG_Manager extends Manager<LogixNG> {
     /**
      * Executes a LogixNG Module.
      * Note that the module must be a Digital Action Module.
+     * @param module     The module to be executed
+     * @param parameter  The parameter. The module must have exactly one parameter.
+     * @throws IllegalArgumentException If module is null or if module is not a
+     *                   DigitalActionModule.
+     */
+    void executeModule(Module module, Object parameter)
+            throws IllegalArgumentException;
+
+    /**
+     * Executes a LogixNG Module.
+     * Note that the module must be a Digital Action Module.
      * @param module      The module to be executed
-     * @param parameters  The parameters. The module must have exactly one parameter.
-     * @throws IllegalArgumentException if module or parameters is null or if module
+     * @param parameters  The parameters
+     * @throws IllegalArgumentException If module or parameters is null or if module
      *                    is not a DigitalActionModule.
      */
     void executeModule(Module module, Map<String, Object> parameters)

--- a/java/src/jmri/jmrit/logixng/implementation/DefaultConditionalNG.java
+++ b/java/src/jmri/jmrit/logixng/implementation/DefaultConditionalNG.java
@@ -144,7 +144,7 @@ public class DefaultConditionalNG extends AbstractBase
     /**
      * Executes a LogixNG Module.
      * @param module      The module to be executed
-     * @param parameters  The parameters. The module must have exactly one parameter.
+     * @param parameters  The parameters
      */
     public static void executeModule(Module module, Map<String, Object> parameters)
             throws IllegalArgumentException {

--- a/java/src/jmri/jmrit/logixng/implementation/DefaultConditionalNG.java
+++ b/java/src/jmri/jmrit/logixng/implementation/DefaultConditionalNG.java
@@ -162,7 +162,7 @@ public class DefaultConditionalNG extends AbstractBase
         LogixNG_Thread thread = LogixNG_Thread.getThread(LogixNG_Thread.DEFAULT_LOGIXNG_THREAD);
         ConditionalNG conditionalNG = new DefaultConditionalNG("IQC0000000", null);
         InternalFemaleSocket socket = new InternalFemaleSocket(conditionalNG, module, parameters);
-        thread.runOnLogixNGEventually(() -> {internalExecute(conditionalNG, (FemaleDigitalActionSocket)socket);});
+        thread.runOnLogixNGEventually(() -> { internalExecute(conditionalNG, socket); });
     }
 
     private static class InternalFemaleSocket extends DefaultFemaleDigitalActionSocket {
@@ -196,9 +196,15 @@ public class DefaultConditionalNG extends AbstractBase
             }
 
             synchronized(this) {
-                SymbolTable newSymbolTable;
                 SymbolTable oldSymbolTable = _conditionalNG.getSymbolTable();
-                newSymbolTable = new DefaultSymbolTable(oldSymbolTable);
+                DefaultSymbolTable newSymbolTable = new DefaultSymbolTable(_conditionalNG);
+                List<Module.ParameterData> _parameterData = new ArrayList<>();
+                for (Module.Parameter p : _module.getParameters()) {
+                    _parameterData.add(new Module.ParameterData(
+                            p.getName(), SymbolTable.InitialValueType.None, "",
+                            Module.ReturnValueType.None, ""));
+                }
+                newSymbolTable.createSymbols(_conditionalNG.getSymbolTable(), _parameterData);
                 for (var entry : _parameters.entrySet()) {
                     newSymbolTable.setValue(entry.getKey(), entry.getValue());
                 }
@@ -219,7 +225,11 @@ public class DefaultConditionalNG extends AbstractBase
 
                 conditionalNG.setSymbolTable(newSymbolTable);
 
-                InlineLogixNG inlineLogixNG = conditionalNG.getLogixNG().getInlineLogixNG();
+                LogixNG logixNG = conditionalNG.getLogixNG();
+                InlineLogixNG inlineLogixNG = null;
+                if (logixNG != null) {
+                    inlineLogixNG = logixNG.getInlineLogixNG();
+                }
                 if (inlineLogixNG != null) {
                     List<SymbolTable.VariableData> localVariables = new ArrayList<>();
                     localVariables.add(new SymbolTable.VariableData(

--- a/java/src/jmri/jmrit/logixng/implementation/DefaultLogixNGManager.java
+++ b/java/src/jmri/jmrit/logixng/implementation/DefaultLogixNGManager.java
@@ -501,6 +501,17 @@ public class DefaultLogixNGManager extends AbstractManager<LogixNG>
     }
 
     /**
+     * Executes a LogixNG Module.
+     * @param module      The module to be executed
+     * @param parameters  The parameters. The module must have exactly one parameter.
+     */
+    @Override
+    public void executeModule(Module module, Map<String, Object> parameters)
+            throws IllegalArgumentException {
+        DefaultConditionalNG.executeModule(module, parameters);
+    }
+
+    /**
      * The PropertyChangeListener interface in this class is intended to keep
      * track of user name changes to individual NamedBeans. It is not completely
      * implemented yet. In particular, listeners are not added to newly

--- a/java/src/jmri/jmrit/logixng/implementation/DefaultLogixNGManager.java
+++ b/java/src/jmri/jmrit/logixng/implementation/DefaultLogixNGManager.java
@@ -500,11 +500,37 @@ public class DefaultLogixNGManager extends AbstractManager<LogixNG>
         _setupTasks.add(task);
     }
 
-    /**
-     * Executes a LogixNG Module.
-     * @param module      The module to be executed
-     * @param parameters  The parameters. The module must have exactly one parameter.
-     */
+    /** {@inheritDoc} */
+    @Override
+    public void executeModule(Module module, Object parameter)
+            throws IllegalArgumentException {
+
+        if (module == null) {
+            throw new IllegalArgumentException("The parameter \"module\" is null");
+        }
+        // Get the parameters for the module
+        Collection<Module.Parameter> parameterNames = module.getParameters();
+
+        // Ensure that there is only one parameter
+        if (parameterNames.size() != 1) {
+            throw new IllegalArgumentException("The module doesn't take exactly one parameter");
+        }
+
+        // Get the parameter
+        Module.Parameter param = parameterNames.toArray(Module.Parameter[]::new)[0];
+        if (!param.isInput()) {
+            throw new IllegalArgumentException("The module's parameter is not an input parameter");
+        }
+
+        // Set the value of the parameter
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put(param.getName(), parameter);
+
+        // Execute the module
+        executeModule(module, parameters);
+    }
+
+    /** {@inheritDoc} */
     @Override
     public void executeModule(Module module, Map<String, Object> parameters)
             throws IllegalArgumentException {

--- a/java/test/jmri/jmrit/logixng/CallModuleTest.java
+++ b/java/test/jmri/jmrit/logixng/CallModuleTest.java
@@ -20,7 +20,8 @@ public class CallModuleTest {
 
     @Test
     public void testCallModuleWithOneParameter() throws JmriException {
-        // Get the module
+        // Get the module. Note that the module must have exactly one
+        // parameter and that the parameter must have "input" selected.
         Module module = InstanceManager.getDefault(ModuleManager.class).getModule("My module");
 
         // The parameter to the module

--- a/java/test/jmri/jmrit/logixng/CallModuleTest.java
+++ b/java/test/jmri/jmrit/logixng/CallModuleTest.java
@@ -1,0 +1,138 @@
+package jmri.jmrit.logixng;
+
+import java.util.*;
+
+import jmri.*;
+import jmri.jmrit.logixng.actions.*;
+import jmri.jmrit.logixng.util.parser.ParserException;
+import jmri.util.JUnitUtil;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Test call module from JMRI
+ *
+ * @author Daniel Bergqvist 2024
+ */
+public class CallModuleTest {
+
+    @Test
+    public void testCallModuleWithOneParameter() throws JmriException {
+        // Get the module
+        Module module = InstanceManager.getDefault(ModuleManager.class).getModule("My module");
+
+        // The parameter to the module
+        Object parameter = "My sensor";
+
+        // Execute the module
+        InstanceManager.getDefault(LogixNG_Manager.class).executeModule(module, parameter);
+
+        // Ensure that the module has been executed and has set the sensor
+        Sensor sensor = InstanceManager.getDefault(SensorManager.class)
+                .newSensor("IS1", "My sensor");  // NOI18N
+
+        JUnitUtil.waitFor(() -> sensor.getState() == Sensor.ACTIVE,
+                "Sensor did not go active: " + sensor.getDisplayName());
+    }
+
+    @Test
+    public void testCallModuleWithTwoParameters() throws JmriException {
+        // Get the module
+        Module module = InstanceManager.getDefault(ModuleManager.class).getModule("My other module");
+
+        // Get the parameters for the module
+        Collection<Module.Parameter> parameterNames = module.getParameters();
+
+        // Get the parameter
+        Module.Parameter[] params = parameterNames.toArray(Module.Parameter[]::new);
+
+        // Set the value of the parameters
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put(params[0].getName(), "My sensor");
+        parameters.put(params[1].getName(), "My turnout");
+
+        // Execute the module
+        InstanceManager.getDefault(LogixNG_Manager.class).executeModule(module, parameters);
+
+        // Ensure that the module has been executed and has set the sensor and the turnout
+        Sensor sensor = InstanceManager.getDefault(SensorManager.class)
+                .newSensor("IS1", "My sensor");  // NOI18N
+        Turnout turnout = InstanceManager.getDefault(TurnoutManager.class)
+                .newTurnout("IT1", "My turnout");  // NOI18N
+
+        JUnitUtil.waitFor(() -> sensor.getState() == Sensor.ACTIVE,
+                "Sensor did not go active: " + sensor.getDisplayName());
+        JUnitUtil.waitFor(() -> turnout.getState() == Turnout.THROWN,
+                "Turnout did not go thrown: " + turnout.getDisplayName());
+    }
+
+    // The minimal setup for log4J
+    @Before
+    public void setUp() throws SocketAlreadyConnectedException, ParserException, JmriException {
+        JUnitUtil.setUp();
+        JUnitUtil.resetInstanceManager();
+        JUnitUtil.resetProfileManager();
+        JUnitUtil.initConfigureManager();
+        JUnitUtil.initInternalSensorManager();
+        JUnitUtil.initInternalTurnoutManager();
+        JUnitUtil.initLogixNGManager();
+
+        DigitalActionManager digitalActionManager =
+                InstanceManager.getDefault(DigitalActionManager.class);
+
+        Sensor sensor = InstanceManager.getDefault(SensorManager.class)
+                .newSensor("IS1", "My sensor");  // NOI18N
+        sensor.setState(Sensor.INACTIVE);
+
+        Turnout turnout = InstanceManager.getDefault(TurnoutManager.class)
+                .newTurnout("IT1", "My turnout");  // NOI18N
+        turnout.setState(Turnout.CLOSED);
+
+        FemaleSocketManager.SocketType socketType = InstanceManager.getDefault(FemaleSocketManager.class)
+                .getSocketTypeByType("DefaultFemaleDigitalActionSocket");
+
+        Module myModule = InstanceManager.getDefault(ModuleManager.class)
+                .createModule("My module", socketType);  // NOI18N
+
+        myModule.addParameter("sensor", true, false);
+
+        ActionSensor actionSensor = new ActionSensor(digitalActionManager.getAutoSystemName(), null);
+        actionSensor.getSelectNamedBean().setAddressing(NamedBeanAddressing.LocalVariable);
+        actionSensor.getSelectNamedBean().setLocalVariable("sensor");
+        actionSensor.getSelectEnum().setEnum(ActionSensor.SensorState.Active);
+        myModule.getRootSocket().connect(digitalActionManager.registerAction(actionSensor));
+
+        Module myOtherModule = InstanceManager.getDefault(ModuleManager.class)
+                .createModule("My other module", socketType);  // NOI18N
+
+        myOtherModule.addParameter("sensor", true, false);
+        myOtherModule.addParameter("turnout", true, false);
+
+        DigitalMany many = new DigitalMany(digitalActionManager.getAutoSystemName(), null);
+        myOtherModule.getRootSocket().connect(digitalActionManager.registerAction(many));
+
+        ActionSensor otherActionSensor = new ActionSensor(digitalActionManager.getAutoSystemName(), null);
+        otherActionSensor.getSelectNamedBean().setAddressing(NamedBeanAddressing.LocalVariable);
+        otherActionSensor.getSelectNamedBean().setLocalVariable("sensor");
+        otherActionSensor.getSelectEnum().setEnum(ActionSensor.SensorState.Active);
+        many.getChild(0).connect(digitalActionManager.registerAction(otherActionSensor));
+
+        ActionTurnout actionTurnout = new ActionTurnout(digitalActionManager.getAutoSystemName(), null);
+        actionTurnout.getSelectNamedBean().setAddressing(NamedBeanAddressing.LocalVariable);
+        actionTurnout.getSelectNamedBean().setLocalVariable("turnout");
+        actionTurnout.getSelectEnum().setEnum(ActionTurnout.TurnoutState.Thrown);
+        many.getChild(1).connect(digitalActionManager.registerAction(actionTurnout));
+    }
+
+    @After
+    public void tearDown() {
+        jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
+        JUnitUtil.tearDown();
+    }
+
+//     private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LogixNGTest.class);
+
+}


### PR DESCRIPTION
This PR allows JMRI to call a LogixNG Module directly with parameters. It might be useful for PR #13234.

See `CallModuleTest`, method `testCallModuleWithOneParameter()` for an example on how to use it if the module is known to have exactly one parameter and method `testCallModuleWithTwoParameters()` for the general solution with any number of parameters.