### PR TITLE
Linking to /extras/sounds

### DIFF
--- a/help/en/Acknowledgements.shtml
+++ b/help/en/Acknowledgements.shtml
@@ -1121,7 +1121,8 @@
         <li>Todd Wegter, <!-- toddthetrainnut -->
          who improved Bachrus speed matching.</li>
 
-        <li>Jim Wells, who created our logos and the great program icons</li>
+        <li>Jim Wells, who created our logos and the great program icons
+            and provided some great sound files.</li>
 
         <li>Donn Welton, who provided info on configuring a PowerBook for DecoderPro</li>
 

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -470,7 +470,11 @@
     <h3>Resources</h3>
         <a id="Resources" name="Resources"></a>
         <ul>
-            <li></li>
+            <li>Added an 
+                "<a href="https://jmri.org/extras">/extras/</li>"
+                directory to contain large/specialized downloadable resource files.
+            <li>Added Jim Well's coal tipple sound file to 
+                <a href="https://jmri.org/extras/sounds">/extras/sounds</li>
         </ul>
 
     <h3>Roster</h3>

--- a/jython/SampleSound.py
+++ b/jython/SampleSound.py
@@ -9,7 +9,7 @@ import jmri
 snd = jmri.jmrit.Sound("resources/sounds/Crossing.wav")
 
 # play the sound once
-snd.play()
+while (True): snd.play()
 
 # You can also do snd.loop() to start playing the sound
 # as a continuous loop, and snd.stop() to stop it

--- a/jython/SampleSound.py
+++ b/jython/SampleSound.py
@@ -9,7 +9,7 @@ import jmri
 snd = jmri.jmrit.Sound("resources/sounds/Crossing.wav")
 
 # play the sound once
-while (True): snd.play()
+snd.play()
 
 # You can also do snd.loop() to start playing the sound
 # as a continuous loop, and snd.stop() to stop it

--- a/resources/sounds/README.md
+++ b/resources/sounds/README.md
@@ -1,6 +1,9 @@
 This directory contains sound fragments contributed
 for use with JMRI.  
 
+There are also some larger, more detailed sound files in the 
+[/extras/sounds](https://jmri.org/extras/sounds/) directory.
+
 Bell.wav
 Code-receive.wav
 Code-send.wav


### PR DESCRIPTION
Provides links from help to the new /extras/sounds on the web site.

See JMRI/website#548 for the contents there. That PR should probably be merged first.
