### PR TITLE
Log differences as warning instead of info

### DIFF
--- a/java/src/jmri/configurexml/StoreAndCompare.java
+++ b/java/src/jmri/configurexml/StoreAndCompare.java
@@ -317,11 +317,11 @@ public class StoreAndCompare extends AbstractAction {
             }
 
             if (!match && !line1.equals(line2)) {
-                log.info("Match failed in StoreAndCompare:");
-                log.info("    file1:line {}: \"{}\"", lineNumber1, line1);
-                log.info("    file2:line {}: \"{}\"", lineNumber2, line2);
-                log.info("  comparing file1:\"{}\"", inFile1.getPath());
-                log.info("         to file2:\"{}\"", inFile2.getPath());
+                log.warn("Match failed in StoreAndCompare:");
+                log.warn("    file1:line {}: \"{}\"", lineNumber1, line1);
+                log.warn("    file2:line {}: \"{}\"", lineNumber2, line2);
+                log.warn("  comparing file1:\"{}\"", inFile1.getPath());
+                log.warn("         to file2:\"{}\"", inFile2.getPath());
                 result = true;
                 break;
             }

--- a/java/test/jmri/jmrit/logixng/actions/WebRequestTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/WebRequestTest.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import javax.net.ssl.HttpsURLConnection;
 
 import jmri.*;
+import jmri.configurexml.ShutdownPreferences;
 import static jmri.configurexml.StoreAndCompare.checkFile;
 import jmri.jmrit.logixng.*;
 import jmri.jmrit.logixng.expressions.ExpressionTurnout;
@@ -527,6 +528,8 @@ public class WebRequestTest extends AbstractDigitalActionTestBase {
                     new File(FileUtil.getProgramPath() + "help/en/html/tools/logixng/reference/WebRequestExample/" + "WebRequest.xml");
 
             try {
+                // Ignore Timebase changes
+                InstanceManager.getDefault(ShutdownPreferences.class).setIgnoreTimebase(true);
                 // Note: The comparision is made with the first xml file that doesn't have the header comment.
                 dataHasChanged = checkFile(fileInDocumentationFolder, firstFile);
             } catch (FileNotFoundException e) {


### PR DESCRIPTION
Then the message in the log is level warning, it's shown in the output when running tests.