### PR TITLE
OpenLCB memory tool: parse space input when doing a put

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -133,7 +133,8 @@
 
         <h4><a href="http://openlcb.org">OpenLCB</a> / LCC</h4>
             <ul>
-                <li></li>
+                <li>Fixed a bug that would cause the Memory Tool to fail
+                    when putting data.</li>
             </ul>
 
         <h4>Powerline</h4>

--- a/java/src/jmri/jmrix/openlcb/swing/memtool/MemoryToolPane.java
+++ b/java/src/jmri/jmrix/openlcb/swing/memtool/MemoryToolPane.java
@@ -290,6 +290,7 @@ public class MemoryToolPane extends jmri.util.swing.JmriPanel
             setRunning(false);
             return;
         }
+
         log.debug("Start get");
         if (fileChooser == null) {
             fileChooser = new jmri.util.swing.JmriJFileChooser();
@@ -399,7 +400,16 @@ public class MemoryToolPane extends jmri.util.swing.JmriPanel
 
     void pushedPutButton(ActionEvent e) {
         farID = nodeSelector.getSelectedItem();
+        try {
+            space = Integer.parseInt(spaceField.getText().trim());
+        } catch (NumberFormatException ex) {
+            log.error("error parsing the space field value \"{}\"", spaceField.getText());
+            statusField.setText("Error parsing the space value");
+            setRunning(false);
+            return;
+        }
         log.debug("Start put");
+
         if (fileChooser == null) {
             fileChooser = new jmri.util.swing.JmriJFileChooser();
         }


### PR DESCRIPTION
Fixes a bug where `put` operations without a prior `get` operation to the same memory space would fail.