### PR TITLE
update LinkedWarrantTest

### DIFF
--- a/java/test/jmri/jmrit/logix/LinkedWarrantTest.java
+++ b/java/test/jmri/jmrit/logix/LinkedWarrantTest.java
@@ -4,7 +4,7 @@ import java.io.File;
 import java.util.List;
 import java.util.ArrayList;
 import jmri.*;
-import jmri.jmrit.display.controlPanelEditor.ControlPanelEditor;
+import jmri.util.JmriJFrame;
 import jmri.util.JUnitAppender;
 import jmri.util.JUnitUtil;
 import jmri.util.ThreadingUtil;
@@ -13,8 +13,7 @@ import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.netbeans.jemmy.operators.JFrameOperator;
 
-import static org.assertj.core.api.Assertions.assertThat;
-// import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests for running multiple Warrants
@@ -31,25 +30,25 @@ public class LinkedWarrantTest {
     private WarrantManager _warrantMgr;
 
     // tests a warrant launching itself. (origin, destination the same to make continuous loop)
-//    @Disabled("This test fails on CI")
     @Test
-    public void testLoopedWarrant() throws Exception {
+    public void testLoopedWarrant() {
         // load and display
         File f = new File("java/test/jmri/jmrit/logix/valid/ShortBlocksTest.xml");
-        InstanceManager.getDefault(ConfigureManager.class).load(f);
+
+        assertDoesNotThrow( () -> {
+            InstanceManager.getDefault(ConfigureManager.class).load(f);
+        }, ("Exception loading "+ f));
         JUnitAppender.suppressErrorMessage("Portal elem = null");
 
-        ControlPanelEditor panel = (ControlPanelEditor) jmri.util.JmriJFrame.getFrame("LinkedWarrantsTest");
-
         Sensor sensor1 = _sensorMgr.getBySystemName("IS12");
-        assertThat(sensor1).withFailMessage("Senor IS12 not found").isNotNull();
+        assertNotNull(sensor1,"Senor IS12 not found");
         NXFrameTest.setAndConfirmSensorAction(sensor1, Sensor.ACTIVE, _OBlockMgr.getBySystemName("OB12"));
 
         WarrantTableFrame tableFrame = WarrantTableFrame.getDefault();
-        assertThat(tableFrame).withFailMessage("tableFrame").isNotNull();
+        assertNotNull(tableFrame,"tableFrame");
 
         Warrant warrant = _warrantMgr.getWarrant("LoopDeLoop");
-        assertThat(warrant).withFailMessage("warrant").isNotNull();
+        assertNotNull(warrant,"warrant");
 
         // OBlock of route
         String[] route = {"OB12", "OB1", "OB3", "OB5", "OB6", "OB7", "OB9", "OB11", "OB12"};
@@ -57,7 +56,12 @@ public class LinkedWarrantTest {
 
         // WarrantTable.runTrain() returns a string that is not null if the
         // warrant can't be started
-        assertThat(tableFrame.runTrain(warrant, Warrant.MODE_RUN)).withFailMessage("Warrant starts").isNull(); // start run
+        assertNull(tableFrame.runTrain(warrant, Warrant.MODE_RUN),"Warrant starts"); // start run
+
+        String lookingFor = Bundle.getMessage("warrantStart", warrant.getTrainName(), warrant.getDisplayName(), block.getDisplayName());
+        JUnitUtil.waitFor(() -> {
+            return lookingFor.equals(tableFrame.getStatus());
+        }, "LoopDeLoop started first leg expected \"" + lookingFor + "\" but was \"" + tableFrame.getStatus()+"\"");
 
         JUnitUtil.waitFor(() -> {
             String m =  warrant.getRunningMessage();
@@ -65,26 +69,29 @@ public class LinkedWarrantTest {
         }, "Loopy 1 starts to move at 8th command");
 
         // Run the train, then checks end location
-        assertThat(NXFrameTest.runtimes(route, _OBlockMgr).getDisplayName()).withFailMessage("LoopDeLoop after first leg").isEqualTo(block.getSensor().getDisplayName());
+        assertDoesNotThrow( () -> {
+            assertEquals(block.getSensor(),
+                NXFrameTest.runtimes(route, _OBlockMgr),
+                "LoopDeLoop Completes first Leg");
+        }, ("LoopDeLoop after first leg Exception"));
+
         // It takes 600+ milliseconds per block to execute NXFrameTest.runtimes()
         // i.e. wait at least 600 * route.length for return
-
-        JUnitUtil.waitFor(() -> {
-            String m = tableFrame.getStatus();
-            return m.equals(Bundle.getMessage("warrantStart", warrant.getTrainName(), warrant.getDisplayName(), block.getDisplayName()));
-        }, "LoopDeLoop finished first leg");
 
         JUnitUtil.waitFor(() -> {
             String m =  warrant.getRunningMessage();
             return m.endsWith("Cmd #8.");
         }, "Loopy 2 starts to move at 8th command");
 
-        assertThat(NXFrameTest.runtimes(route, _OBlockMgr).getDisplayName()).withFailMessage("LoopDeLoop after second leg").isEqualTo(block.getSensor().getDisplayName());
+        assertDoesNotThrow( () -> {
+            assertEquals(block.getSensor(),
+                NXFrameTest.runtimes(route, _OBlockMgr),
+                "LoopDeLoop Completes Second Leg");
+        }, ("LoopDeLoop after Second leg Exception"));
 
         String linkMsg = Bundle.getMessage("warrantComplete", warrant.getTrainName(), warrant.getDisplayName(), block.getDisplayName());
         JUnitUtil.waitFor(() -> {
-            String m = tableFrame.getStatus();
-            return m.equals(linkMsg);
+            return linkMsg.equals(tableFrame.getStatus());
         }, "LoopDeLoop finished second leg");
 
         JUnitUtil.waitFor(() -> {
@@ -92,52 +99,57 @@ public class LinkedWarrantTest {
             return m.endsWith("Cmd #8.");
         }, "Loopy 3 starts to move at 8th command");
 
-        assertThat(NXFrameTest.runtimes(route, _OBlockMgr).getDisplayName()).withFailMessage("LoopDeLoop after last leg").isEqualTo(block.getSensor().getDisplayName());
+        assertDoesNotThrow( () -> {
+            assertEquals(block.getSensor(),
+                NXFrameTest.runtimes(route, _OBlockMgr),
+                "LoopDeLoop Completes third Leg");
+        }, ("LoopDeLoop after third leg Exception"));
 
         JUnitUtil.waitFor(() -> {
             String m = tableFrame.getStatus();
             return m.equals(Bundle.getMessage("warrantComplete", warrant.getTrainName(), warrant.getDisplayName(), block.getDisplayName()));
         }, "LoopDeLoop finished third leg");
 
-        JFrameOperator jfo = new JFrameOperator(tableFrame);
+        JFrameOperator jfo = new JFrameOperator(WarrantTableFrame.getDefault());
         jfo.requestClose();
-        // we may want to use jemmy to close the panel as well.
-        assert panel != null;
-        ThreadingUtil.runOnGUI( () -> {
-            panel.dispose();    // disposing this way allows test to be rerun (i.e. reload panel file) multiple times
+        jfo.waitClosed();
+
+        // JFrameOperator requestClose just hides panel, not disposing of it.
+        // disposing this way allows test to be rerun (i.e. reload panel file) multiple times
+        Boolean retVal = ThreadingUtil.runOnGUIwithReturn(() -> {
+            JmriJFrame.getFrame("LinkedWarrantsTest").dispose();
+            return true;
         });
+        assertTrue(retVal);
+
     }
 
     // Tests warrant launching a different warrant with different address. Origin location cannot be destination of the other)
     @Test
-    public void testLinkedWarrant() throws Exception {
+    public void testLinkedWarrant() {
         // load and display
         File f = new File("java/test/jmri/jmrit/logix/valid/ShortBlocksTest.xml");
-        InstanceManager.getDefault(ConfigureManager.class).load(f);
+        assertDoesNotThrow( () -> {
+            InstanceManager.getDefault(ConfigureManager.class).load(f);
+        }, ("Exception loading "+ f));
         JUnitAppender.suppressErrorMessage("Portal elem = null");
 
         final Sensor sensor12 = _sensorMgr.getBySystemName("IS12");
-        assertThat(sensor12).withFailMessage("Sensor IS12 not found").isNotNull();
+        assertNotNull(sensor12,"Sensor IS12 not found");
 
         Sensor sensor1 = _sensorMgr.getBySystemName("IS1");
-        assertThat(sensor1).withFailMessage("Senor IS1 not found").isNotNull();
+        assertNotNull(sensor1,"Senor IS1 not found");
         NXFrameTest.setAndConfirmSensorAction(sensor12, Sensor.ACTIVE, _OBlockMgr.getBySystemName("OB12"));
 
         final Warrant warrant = _warrantMgr.getWarrant("Loop&Fred");
-        assertThat(warrant).withFailMessage("warrant").isNotNull();
+        assertNotNull(warrant,"warrant");
 
         ThreadingUtil.runOnGUI(() -> {
             WarrantTableFrame tableFrame = WarrantTableFrame.getDefault();
             // WarrantTable.runTrain() returns a string that is not null if the
             // warrant can't be started
-            assertThat(tableFrame.runTrain(warrant, Warrant.MODE_RUN)).withFailMessage("Warrant starts").isNull(); // start run
+            assertNull(tableFrame.runTrain(warrant, Warrant.MODE_RUN),"Warrant starts"); // start run
         });
-
-        JFrameOperator jfo = new JFrameOperator(Bundle.getMessage("WarrantTable"));
-        Assertions.assertNotNull(jfo,"WarrantTable not Found");
-
-        JFrameOperator jfoPanel = new JFrameOperator("LinkedWarrantsTest");
-        Assertions.assertNotNull(jfoPanel,"LinkedWarrantsTest panel not Found");
 
         JUnitUtil.waitFor(() -> {
             String m =  warrant.getRunningMessage();
@@ -146,17 +158,23 @@ public class LinkedWarrantTest {
 
        // OBlock of route
         String[] route1 = {"OB12", "OB1", "OB3", "OB5", "OB6", "OB7", "OB9", "OB11", "OB12"};
-        OBlock block = _OBlockMgr.getOBlock("OB12");
+        OBlock lastBlockInRoute1 = _OBlockMgr.getOBlock("OB12");
+        assertNotNull(lastBlockInRoute1);
 
         // Run the train, then checks end location
-        assertThat(NXFrameTest.runtimes(route1, _OBlockMgr)).withFailMessage("Train after first leg").isEqualTo(block.getSensor());
+        assertDoesNotThrow( () -> {
+            assertEquals(lastBlockInRoute1.getSensor(),
+                NXFrameTest.runtimes(route1, _OBlockMgr),
+                "Train after first leg");
+        }, ("Exception running route1"));
+        
         // It takes 500+ milliseconds per block to execute NXFrameTest.runtimes()
 
         // "Loop&Fred" links to "WestToEast". Get start for "WestToEast" occupied quickly
         NXFrameTest.setAndConfirmSensorAction(sensor1, Sensor.ACTIVE, _OBlockMgr.getBySystemName("OB1"));
 
         Warrant ww = _warrantMgr.getWarrant("WestToEast");
-        Assertions.assertNotNull(ww,"warrant WestToEast exists");
+        assertNotNull(ww,"warrant WestToEast exists");
 
         JUnitUtil.waitFor(() -> {
             String m =  ww.getRunningMessage();
@@ -164,43 +182,51 @@ public class LinkedWarrantTest {
         }, "Train Fred starts to move at 8th command");
 
         String[] route2 = {"OB1", "OB3", "OB5", "OB6", "OB7", "OB9", "OB11"};
-        block = _OBlockMgr.getOBlock("OB11");
+        final OBlock block = _OBlockMgr.getOBlock("OB11");
 
-        assertThat(NXFrameTest.runtimes(route2, _OBlockMgr)).withFailMessage("Train after second leg").isEqualTo(block.getSensor());
+        assertDoesNotThrow( () -> {
+            assertEquals(block.getSensor(),
+                NXFrameTest.runtimes(route2, _OBlockMgr),
+                "Train after second leg");
+        }, ("Exception running route2"));
 
-        // passed test - cleanup.  Do it here so failure leaves traces.
+        JFrameOperator jfo = new JFrameOperator(WarrantTableFrame.getDefault());
         jfo.requestClose();
-        jfoPanel.requestClose();
         jfo.waitClosed();
-        jfoPanel.waitClosed();
+
+        // JFrameOperator requestClose just hides panel, not disposing of it.
+        // disposing this way allows test to be rerun (i.e. reload panel file) multiple times
+        Boolean retVal = ThreadingUtil.runOnGUIwithReturn(() -> {
+            JmriJFrame.getFrame("LinkedWarrantsTest").dispose();
+            return true;
+        });
+        assertTrue(retVal);
 
     }
 
     // tests a warrant running a train out and launching a return train
     // Both warrants have the same address and origin of each is destination of the other
-//    @Disabled("This test fails on CI")
     @Test
-    public void testBackAndForth() throws Exception {
+    public void testBackAndForth() {
         // load and display
         File f = new File("java/test/jmri/jmrit/logix/valid/ShortBlocksTest.xml");
-        InstanceManager.getDefault(ConfigureManager.class).load(f);
+        Assertions.assertDoesNotThrow( () -> {
+            InstanceManager.getDefault(ConfigureManager.class).load(f);
+        }, ("Exception loading "+ f));
         JUnitAppender.suppressErrorMessage("Portal elem = null");
 
         WarrantPreferences.getDefault().setShutdown(WarrantPreferences.Shutdown.NO_MERGE);
 
-        ControlPanelEditor panel = (ControlPanelEditor) jmri.util.JmriJFrame.getFrame("LinkedWarrantsTest");
-//        panel.setVisible(false);  // hide panel to prevent repaint.
-
         final Sensor sensor1 = _sensorMgr.getBySystemName("IS1");
-        assertThat(sensor1).withFailMessage("Senor IS1 not found").isNotNull();
+        assertNotNull(sensor1,"Senor IS1 not found");
 
         NXFrameTest.setAndConfirmSensorAction(sensor1, Sensor.ACTIVE, _OBlockMgr.getBySystemName("OB1"));
 
         WarrantTableFrame tableFrame = WarrantTableFrame.getDefault();
-        assertThat(tableFrame).withFailMessage("tableFrame").isNotNull();
+        assertNotNull(tableFrame,"tableFrame");
 
         Warrant outWarrant = _warrantMgr.getWarrant("WestToEastLink");
-        assertThat(outWarrant).withFailMessage("WestWarrant").isNotNull();
+        assertNotNull(outWarrant,"WestWarrant");
         Warrant backWarrant = _warrantMgr.getWarrant("EastToWestLink");
 
         // OBlock of route
@@ -211,7 +237,7 @@ public class LinkedWarrantTest {
 
         // WarrantTable.runTrain() returns a string that is not null if the
         // warrant can't be started
-        assertThat(tableFrame.runTrain(outWarrant, Warrant.MODE_RUN)).withFailMessage("Warrant starts").isNull(); // start run
+        assertNull(tableFrame.runTrain(outWarrant, Warrant.MODE_RUN),"Warrant starts"); // start run
 
         JUnitUtil.waitFor(() -> {
             String m =  outWarrant.getRunningMessage();
@@ -219,7 +245,11 @@ public class LinkedWarrantTest {
         }, "WestToEastLink starts to move at 8th command");
 
         // Run the train, then checks end location
-        assertThat(NXFrameTest.runtimes(routeOut, _OBlockMgr)).withFailMessage("Train after first leg").isEqualTo(outEndSensor);
+        assertDoesNotThrow( () -> {
+            assertEquals(outEndSensor,
+                NXFrameTest.runtimes(routeOut, _OBlockMgr),
+                "Train after first leg");
+        }, ("Exception running routeOut"));
         // It takes 500+ milliseconds per block to execute NXFrameTest.runtimes()
         // i.e. wait at least 600 * (route.length - 1) for return
 
@@ -236,7 +266,11 @@ public class LinkedWarrantTest {
             return m.endsWith("Cmd #8.");
         }, "EastToWestLink starts to move at 8th command");
 
-        assertThat(NXFrameTest.runtimes(routeBack, _OBlockMgr)).withFailMessage("Train after second leg").isEqualTo(backEndSensor);
+        assertDoesNotThrow( () -> {
+            assertEquals(backEndSensor,
+                NXFrameTest.runtimes(routeBack, _OBlockMgr),
+                "Train after second leg");
+        }, ("Exception running routeBack"));
         // It takes 500+ milliseconds per block to execute NXFrameTest.runtimes()
 
         JUnitUtil.waitFor(() -> {
@@ -251,7 +285,11 @@ public class LinkedWarrantTest {
             return m.endsWith("Cmd #8.");
         }, "WestToEastLink starts to move at 8th command");
 
-        assertThat(NXFrameTest.runtimes(routeOut, _OBlockMgr)).withFailMessage("Train after third leg").isEqualTo(outEndSensor);
+        assertDoesNotThrow( () -> {
+            assertEquals(outEndSensor,
+                NXFrameTest.runtimes(routeOut, _OBlockMgr),
+                "Train after third leg");
+        }, ("Exception running routeOut 3"));
         // It takes 500+ milliseconds per block to execute NXFrameTest.runtimes()
 
         JUnitUtil.waitFor(() -> {
@@ -266,60 +304,66 @@ public class LinkedWarrantTest {
             return m.endsWith("Cmd #8.") || m.endsWith("Cmd #9.");
         }, "EastToWestLink starts to move at 8th command");
 
-        assertThat(NXFrameTest.runtimes(routeBack, _OBlockMgr)).withFailMessage("Train after fourth leg").isEqualTo(backEndSensor);
+        assertDoesNotThrow( () -> {
+            assertEquals(backEndSensor,
+                NXFrameTest.runtimes(routeBack, _OBlockMgr),
+                "Train after fourth leg");
+        }, ("Exception running routeBack 4"));
         // It takes 600+ milliseconds per block to execute NXFrameTest.runtimes()
 
         outWarrant.stopWarrant(true, false);
         backWarrant.stopWarrant(true, false);
-            // passed test - cleanup.  Do it here so failure leaves traces.
-            JFrameOperator jfo = new JFrameOperator(tableFrame);
-            jfo.requestClose();
-            // we may want to use jemmy to close the panel as well.
-        assert panel != null;
-        ThreadingUtil.runOnGUI( () -> {
-            panel.dispose();    // disposing this way allows test to be rerun (i.e. reload panel file) multiple times
+
+        JFrameOperator jfo = new JFrameOperator(WarrantTableFrame.getDefault());
+        jfo.requestClose();
+        jfo.waitClosed();
+
+        // JFrameOperator requestClose just hides panel, not disposing of it.
+        // disposing this way allows test to be rerun (i.e. reload panel file) multiple times
+        Boolean retVal = ThreadingUtil.runOnGUIwithReturn(() -> {
+            JmriJFrame.getFrame("LinkedWarrantsTest").dispose();
+            return true;
         });
+        assertTrue(retVal);
+
     }
 
     // Tests warrant launching 3 different warrants mid script - tinker to Evers to Chance (1910 Chicago Cubs)
     @Test
-    public void testLinkedMidScript() throws Exception {
+    public void testLinkedMidScript() {
         // load and display
         File f = new File("java/test/jmri/jmrit/logix/valid/NXWarrantTest.xml");
-        InstanceManager.getDefault(ConfigureManager.class).load(f);
+        assertDoesNotThrow( () -> {
+            InstanceManager.getDefault(ConfigureManager.class).load(f);
+        }, ("Exception loading "+ f));
         JUnitAppender.suppressErrorMessage("Portal elem = null");
 
         // Tinker start block
         Sensor sensor0 = _sensorMgr.getBySystemName("IS0");
-        assertThat(sensor0).withFailMessage("Senor IS0 not found").isNotNull();
+        assertNotNull(sensor0,"Senor IS0 not found");
         // wait block OB0 occupied
         NXFrameTest.setAndConfirmSensorAction(sensor0, Sensor.ACTIVE, _OBlockMgr.getBySystemName("OB0"));
 
         // Evers start block
         Sensor sensor7 = _sensorMgr.getBySystemName("IS7");
-        assertThat(sensor7).withFailMessage("Senor IS7 not found").isNotNull();
+        assertNotNull(sensor7,"Senor IS7 not found");
         // wait block OB7 occupied
         NXFrameTest.setAndConfirmSensorAction(sensor7, Sensor.ACTIVE, _OBlockMgr.getBySystemName("OB7"));
 
         // Chance start block
         Sensor sensor6 = _sensorMgr.getBySystemName("IS6");
-        assertThat(sensor6).withFailMessage("Senor IS6 not found").isNotNull();
+        assertNotNull(sensor6,"Senor IS6 not found");
         NXFrameTest.setAndConfirmSensorAction(sensor6, Sensor.ACTIVE, _OBlockMgr.getBySystemName("OB6"));
 
         Warrant w = _warrantMgr.getWarrant("Tinker");
-        assertThat(w).withFailMessage("warrant").isNotNull();
+        assertNotNull(w,"warrant");
 
         ThreadingUtil.runOnGUI(() -> {
             WarrantTableFrame tableFrame = WarrantTableFrame.getDefault();
             // WarrantTable.runTrain() returns a string that is not null if the
             // warrant can't be started
-            assertThat(tableFrame.runTrain(w, Warrant.MODE_RUN)).withFailMessage("Warrant starts").isNull(); // start run
+            assertNull(tableFrame.runTrain(w, Warrant.MODE_RUN),"Warrant starts"); // start run
         });
-        JFrameOperator jfo = new JFrameOperator(Bundle.getMessage("WarrantTable"));
-        Assertions.assertNotNull(jfo,"WarrantTable not Found");
-
-        JFrameOperator jfoPanel = new JFrameOperator("NXWarrantTest");
-        Assertions.assertNotNull(jfoPanel,"NXWarrantTest panel not Found");
 
         JUnitUtil.waitFor(() -> {
             String m =  w.getRunningMessage();
@@ -328,10 +372,14 @@ public class LinkedWarrantTest {
 
        // OBlock of route
         String[] route1 = {"OB0", "OB1", "OB2", "OB3", "OB4", "OB5", "OB10"};
-        OBlock block = _OBlockMgr.getOBlock("OB10");
+        OBlock block10 = _OBlockMgr.getOBlock("OB10");
 
         // Run the train, then checks end location
-        assertThat(NXFrameTest.runtimes(route1, _OBlockMgr).getDisplayName()).withFailMessage("Tinker after first leg").isEqualTo(block.getSensor().getDisplayName());
+        assertDoesNotThrow( () -> {
+            assertEquals(block10.getSensor(),
+                NXFrameTest.runtimes(route1, _OBlockMgr),
+                "Tinker after first leg");
+        }, ("Exception running route1"));
         // It takes 600+ milliseconds per block to execute NXFrameTest.runtimes()
         // i.e. wait at least 600 * route.length for return
 
@@ -343,9 +391,13 @@ public class LinkedWarrantTest {
         }, "Evers starts to move at 8th command");
 
         String[] route2 = {"OB7", "OB3", "OB2", "OB1"};
-        block = _OBlockMgr.getOBlock("OB1");
+        OBlock block1 = _OBlockMgr.getOBlock("OB1");
 
-        assertThat(NXFrameTest.runtimes(route2, _OBlockMgr).getDisplayName()).withFailMessage("Evers after second leg").isEqualTo(block.getSensor().getDisplayName());
+        assertDoesNotThrow( () -> {
+            assertEquals(block1.getSensor(),
+                NXFrameTest.runtimes(route2, _OBlockMgr),
+                "Evers after second leg");
+        }, ("Exception running route2"));
         // It takes 600+ milliseconds per block to execute NXFrameTest.runtimes()
 
         Warrant www = _warrantMgr.getWarrant("Chance");
@@ -356,19 +408,27 @@ public class LinkedWarrantTest {
         }, "Chance starts to move at 8th command");
 
         String[] route3 = {"OB6", "OB3", "OB4", "OB5"};
-        block = _OBlockMgr.getOBlock("OB5");
+        OBlock block5 = _OBlockMgr.getOBlock("OB5");
 
-        assertThat(NXFrameTest.runtimes(route3, _OBlockMgr).getDisplayName()).withFailMessage("Chance after third leg").isEqualTo(block.getSensor().getDisplayName());
+        assertDoesNotThrow( () -> {
+            assertEquals(block5.getSensor(),
+                NXFrameTest.runtimes(route3, _OBlockMgr),
+                "Chance after third leg");
+        }, ("Exception running route3"));
         // It takes 600+ milliseconds per block to execute NXFrameTest.runtimes()
 
-        // passed test - cleanup.  Do it here so failure leaves traces.
-        
+        JFrameOperator jfo = new JFrameOperator(WarrantTableFrame.getDefault());
         jfo.requestClose();
-        jfoPanel.requestClose();
-
         jfo.waitClosed();
-        jfoPanel.waitClosed();
 
+        // JFrameOperator requestClose just hides panel, not disposing of it.
+        // disposing this way allows test to be rerun (i.e. reload panel file) multiple times
+        Boolean retVal = ThreadingUtil.runOnGUIwithReturn(() -> {
+            JmriJFrame.getFrame("NXWarrantTest").dispose();
+            return true;
+        });
+        assertTrue(retVal);
+        
     }
 
     @BeforeEach
@@ -423,7 +483,6 @@ public class LinkedWarrantTest {
             }
         }
 
-        JUnitUtil.resetWindows(false,false);
         JUnitUtil.tearDown();
     }
 }


### PR DESCRIPTION
ControlPanelEditorPanel cannot be used with JFrameOperator.requestClose repeatedly as the close behaviour for that Frame does not call dispose, which this PR resolves.
Adds various exception assertions.
Update to JUnit5 Assertions for consistency