### PR TITLE
LoadAndStoreTestBase - suppressErrorMessageStartsWith

### DIFF
--- a/java/test/jmri/configurexml/LoadAndStoreTestBase.java
+++ b/java/test/jmri/configurexml/LoadAndStoreTestBase.java
@@ -345,7 +345,8 @@ public class LoadAndStoreTestBase {
         File outFile = storeFile(file, this.saveType);
         checkFile(compFile, outFile);
 
-        JUnitAppender.suppressErrorMessage("systemName is already registered: ");
+        JUnitAppender.suppressErrorMessageStartsWith("systemName is already registered: ");
+
     }
 
     /**


### PR DESCRIPTION
Fixes some test failures when tests are run in a different order to normal CI, eg.

```
JUnit Jupiter:LoadAndStoreTest:loadAndStoreTest(File, boolean):6: java\test\jmri\jmrit\logixng\configurexml\load\LogixNG.5.7.5.xml (pass=true)
     [java]     MethodSource [className = 'jmri.jmrit.logixng.configurexml.LoadAndStoreTest', methodName = 'loadAndStoreTest', methodParameterTypes = 'java.io.File, boolean']
     [java]     => org.opentest4j.AssertionFailedError: Looking for ERROR message "systemName is already registered: " got "systemName is already registered: IHTransitScaffold"
```