### PR TITLE
Move test to Separate CI test since it fails on Headless CI

### DIFF
--- a/java/test/jmri/jmrit/logixng/actions/WebRequestTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/WebRequestTest.java
@@ -488,6 +488,9 @@ public class WebRequestTest extends AbstractDigitalActionTestBase {
 
     @Test
     public void testStoreFile() throws Exception {
+        // This test fails for unknown reason on Headless CI
+        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
+
         // Ensure the fast clock is started at a specified time so it doesn't vary.
         // Otherwise the WebRequest.xml will be changed on every run.
         Timebase clock = InstanceManager.getDefault(jmri.Timebase.class);


### PR DESCRIPTION
This test fails often on Headless CI and I have no idea of why.

There is a setting `ShutdownPreferences.setIgnoreTimebase(true)` that should fix this and this test sets that setting, but it's not working. Maybe some other test interfere with this test.