### PR TITLE
Print summary to find failing Headless CI test

### DIFF
--- a/.github/workflows/headless-test.yml
+++ b/.github/workflows/headless-test.yml
@@ -25,4 +25,4 @@ jobs:
     - name: Run HeadLessTest with Maven
       run: |
         # run tests using maven with graphics suppressed
-        mvn test "-Djmri.skipTestsRequiringSeparateRunning=true"  "-Djava.awt.headless=true" "-Dsurefire.printSummary=false"
+        mvn test "-Djmri.skipTestsRequiringSeparateRunning=true"  "-Djava.awt.headless=true" "-Dsurefire.printSummary=true"


### PR DESCRIPTION
@bobjacobsen 
`jmri.configurexml.LoadAndStoreTest` currently fails almost every time on Headless CI. I know how to move a standard test to Separate CI test, see #13295, but how to move a parameterized test?