### PR TITLE
Move testLogixAction() in jmri.jmrit.logix.LogixActionTest to Separate CI tests

### DIFF
--- a/java/test/jmri/jmrit/logix/LogixActionTest.java
+++ b/java/test/jmri/jmrit/logix/LogixActionTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 public class LogixActionTest {
 
+    @Disabled
     @Test
     public void testLogixAction() throws Exception {
         jmri.configurexml.ConfigXmlManager cm = new jmri.configurexml.ConfigXmlManager() {

--- a/java/test/jmri/jmrit/logix/LogixActionTest.java
+++ b/java/test/jmri/jmrit/logix/LogixActionTest.java
@@ -19,8 +19,8 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 public class LogixActionTest {
 
-    @Disabled
     @Test
+    @DisabledIfSystemProperty(named ="jmri.skipTestsRequiringSeparateRunning", matches ="true")
     public void testLogixAction() throws Exception {
         jmri.configurexml.ConfigXmlManager cm = new jmri.configurexml.ConfigXmlManager() {
         };

--- a/java/test/jmri/jmrit/logix/LogixActionTest.java
+++ b/java/test/jmri/jmrit/logix/LogixActionTest.java
@@ -9,6 +9,7 @@ import jmri.util.JUnitUtil;
 
 import org.junit.Assert;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import static org.assertj.core.api.Assertions.assertThat;
 


### PR DESCRIPTION
This PR fixes the Headless CI problem we are currently seeing. I don't know the exact cause, but this test loads the xml file `java/test/jmri/jmrit/logix/valid/LogixActionTest.xml` and that file interfers with the LoadAndStoreTest that currently fails on Headless CI.

See PR #13306 and #13300.