### PR TITLE
OBlock Manager / test tweaks

### DIFF
--- a/java/src/jmri/jmrit/logix/OBlockManager.java
+++ b/java/src/jmri/jmrit/logix/OBlockManager.java
@@ -113,7 +113,7 @@ public class OBlockManager extends AbstractManager<OBlock>
     @Nonnull
     public OBlock provideOBlock(@Nonnull String name) {
         if (name.trim().length() == 0) {
-            throw new IllegalArgumentException("name \"" + name + "\" invalid");
+            throw new IllegalArgumentException("No name given for OBlock");
         }
         OBlock ob = getByUserName(name);
         if (ob == null) {

--- a/java/test/jmri/jmrit/logix/OBlockManagerTest.java
+++ b/java/test/jmri/jmrit/logix/OBlockManagerTest.java
@@ -4,10 +4,9 @@ import jmri.Block;
 import jmri.InstanceManager;
 import jmri.util.JUnitUtil;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.*;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests for the OBlockManager class.
@@ -17,41 +16,38 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 public class OBlockManagerTest {
 
-    OBlockManager l;
+    private OBlockManager l;
     
     @Test
     public void testProvide() {
         // original create with systemname
         OBlock b1 = l.provide("OB101");
-        Assert.assertNotNull(b1);
-        assertThat(b1.getSystemName()).withFailMessage("system name").isEqualTo("OB101");
+        assertNotNull(b1);
+        assertEquals("OB101", b1.getSystemName(), "system name");
     }
 
     @Test
     public void testProvideWorksTwice() {
         Block b1 = l.provide("OB102");
         Block b2 = l.provide("OB102");
-        Assert.assertNotNull(b1);
-        Assert.assertNotNull(b2);
-        Assert.assertEquals(b1, b2);
+        assertNotNull(b1);
+        assertNotNull(b2);
+        assertEquals(b1, b2);
     }
 
     @Test
     public void testProvideFailure() {
-        boolean correct = false;
-        try {
-            l.provide("");
-            Assert.fail("didn't throw");
-        } catch (IllegalArgumentException ex) {
-            correct = true;
-        }
-        assertThat(correct).withFailMessage("Exception thrown properly").isTrue();
+        
+        Exception ex = assertThrows( IllegalArgumentException.class,
+            () -> { l.provide("");}, "Exception thrown");
+        assertNotNull(ex);
+        assertTrue( ex.getMessage().toLowerCase().contains("oblock") , "no oblock string in " + ex.getMessage() );
     }
-    
+
     @Test
     public void testCreateNewOBlock() {
-        Assert.assertNull("createNewOBlock", l.createNewOBlock("", "user"));
-        Assert.assertNull("createNewOBlock", l.createNewOBlock("OB", "user"));
+        assertNull( l.createNewOBlock("", "user"), "createNewOBlock no sysname");
+        assertNull( l.createNewOBlock("OB", "user"), "createNewOBlock OB");
     }
 
     @Test
@@ -63,19 +59,22 @@ public class OBlockManagerTest {
         OBlock bEast = _OBlockMgr.createNewOBlock("OB2", "East");
         OBlock bNorth = _OBlockMgr.createNewOBlock("OB3", "North");
         OBlock bSouth = _OBlockMgr.createNewOBlock("OB4", "South");
-        assertThat(_OBlockMgr.getOBlock("West")).withFailMessage("OBlock").isEqualTo(bWest);
-        assertThat(_OBlockMgr.getOBlock("OB2")).withFailMessage("OBlock").isEqualTo(bEast);
-        assertThat(_OBlockMgr.getOBlock("North")).withFailMessage("OBlock").isEqualTo(bNorth);
-        assertThat(_OBlockMgr.getOBlock("OB4")).withFailMessage("OBlock").isEqualTo(bSouth);
+        assertEquals( bWest, _OBlockMgr.getOBlock("West"), "OBlock W");
+        assertEquals( bEast, _OBlockMgr.getOBlock("OB2"), "OBlock 2");
+        assertEquals( bNorth, _OBlockMgr.getOBlock("North"), "OBlock N");
+        assertEquals( bSouth, _OBlockMgr.getOBlock("OB4"), "OBlock 4");
     }
 
     @BeforeEach
     public void setUp() {
-        JUnitUtil.setUp();        l = new OBlockManager();
+        JUnitUtil.setUp();
+        l = new OBlockManager();
     }
 
     @AfterEach
     public void tearDown() {
+        l.dispose();
+        l = null;
         JUnitUtil.tearDown();
     }
 


### PR DESCRIPTION
Tweak exception text for empty string in provide.

Improve exception confirmation in test.
Dispose of manager after each test.