### PR TITLE
Change XSL encoding to UTF-8

### DIFF
--- a/xml/XSLT/CSVsummary.xsl
+++ b/xml/XSLT/CSVsummary.xsl
@@ -27,7 +27,7 @@
 <!-- Need to instruct the XSLT processor to use text output rules.
      See http://www.w3.org/TR/xslt#output for more details
 -->
-<xsl:output method="text" encoding="ISO-8859-1"
+<xsl:output method="text" encoding="UTF-8"
 	indent="no"
 	omit-xml-declaration="yes"
 	standalone="no" />

--- a/xml/XSLT/CVsummary.xsl
+++ b/xml/XSLT/CVsummary.xsl
@@ -27,7 +27,7 @@
 <!-- Need to instruct the XSLT processor to use HTML output rules.
      See http://www.w3.org/TR/xslt#output for more details
 -->
-<xsl:output method="html" encoding="ISO-8859-1"/>
+<xsl:output method="html" encoding="UTF-8"/>
 
 <!-- avoid producing lots of blank lines -->
 <xsl:strip-space elements="*" />

--- a/xml/XSLT/DecoderID.xsl
+++ b/xml/XSLT/DecoderID.xsl
@@ -29,7 +29,7 @@
 <!-- Need to instruct the XSLT processor to use HTML output rules.
      See http://www.w3.org/TR/xslt#output for more details
 -->
-<xsl:output method="html" encoding="ISO-8859-1"/>
+<xsl:output method="html" encoding="UTF-8"/>
 
 
 <!-- This first template matches our root element in the input file.

--- a/xml/XSLT/DecoderMfgIndex.xsl
+++ b/xml/XSLT/DecoderMfgIndex.xsl
@@ -26,7 +26,7 @@
 <!-- Need to instruct the XSLT processor to use HTML output rules.
      See http://www.w3.org/TR/xslt#output for more details
 -->
-<xsl:output method="html" encoding="ISO-8859-1"/>
+<xsl:output method="html" encoding="UTF-8"/>
 
 
 <!-- This first template matches our root element in the input file.

--- a/xml/XSLT/DecoderModelIndex.xsl
+++ b/xml/XSLT/DecoderModelIndex.xsl
@@ -26,7 +26,7 @@
 <!-- Need to instruct the XSLT processor to use HTML output rules.
      See http://www.w3.org/TR/xslt#output for more details
 -->
-<xsl:output method="html" encoding="ISO-8859-1"/>
+<xsl:output method="html" encoding="UTF-8"/>
 
 
 <!-- This first template matches our root element in the input file.

--- a/xml/XSLT/DecoderModelList.xsl
+++ b/xml/XSLT/DecoderModelList.xsl
@@ -26,7 +26,7 @@
 <!-- Need to instruct the XSLT processor to use HTML output rules.
      See http://www.w3.org/TR/xslt#output for more details
 -->
-<xsl:output method="html" encoding="ISO-8859-1"/>
+<xsl:output method="html" encoding="UTF-8"/>
 
 <!-- This first template matches our root element in the input file.
      This will trigger the generation of the HTML skeleton document.

--- a/xml/XSLT/LogixToCode.xsl
+++ b/xml/XSLT/LogixToCode.xsl
@@ -28,7 +28,7 @@
 <!-- Need to instruct the XSLT processor to use HTML output rules.
      See http://www.w3.org/TR/xslt#output for more details
 -->
-<xsl:output method="html" encoding="ISO-8859-1"/>
+<xsl:output method="html" encoding="UTF-8"/>
 
 
 <!-- This first template matches our root element in the input file.

--- a/xml/XSLT/PowerAsCSV.xsl
+++ b/xml/XSLT/PowerAsCSV.xsl
@@ -20,7 +20,7 @@
 <!-- Need to instruct the XSLT processor to use text output rules.
      See http://www.w3.org/TR/xslt#output for more details
 -->
-<xsl:output method="text" encoding="ISO-8859-1" 
+<xsl:output method="text" encoding="UTF-8" 
 	indent="no"
 	omit-xml-declaration="yes"
 	standalone="no" />

--- a/xml/XSLT/PropertiesFiles.xsl
+++ b/xml/XSLT/PropertiesFiles.xsl
@@ -19,7 +19,7 @@
 <!-- Need to instruct the XSLT processor to use text output rules.
      See http://www.w3.org/TR/xslt#output for more details
 -->
-<xsl:output method="text" encoding="ISO-8859-1" 
+<xsl:output method="text" encoding="UTF-8" 
         indent="no"
         omit-xml-declaration="yes"
         standalone="no" />

--- a/xml/XSLT/SelectionGuide.xsl
+++ b/xml/XSLT/SelectionGuide.xsl
@@ -27,7 +27,7 @@
 <!-- Need to instruct the XSLT processor to use HTML output rules.
      See http://www.w3.org/TR/xslt#output for more details
 -->
-<xsl:output method="html" encoding="ISO-8859-1"/>
+<xsl:output method="html" encoding="UTF-8"/>
 
 
 <!-- This first template matches our root element in the input file.

--- a/xml/XSLT/SizeAsCSV.xsl
+++ b/xml/XSLT/SizeAsCSV.xsl
@@ -20,7 +20,7 @@
 <!-- Need to instruct the XSLT processor to use text output rules.
      See http://www.w3.org/TR/xslt#output for more details
 -->
-<xsl:output method="text" encoding="ISO-8859-1" 
+<xsl:output method="text" encoding="UTF-8" 
 	indent="no"
 	omit-xml-declaration="yes"
 	standalone="no" />

--- a/xml/XSLT/appearancetable.xsl
+++ b/xml/XSLT/appearancetable.xsl
@@ -30,7 +30,7 @@
 <!-- Need to instruct the XSLT processor to use HTML output rules.
      See http://www.w3.org/TR/xslt#output for more details
 -->
-<xsl:output method="html" encoding="ISO-8859-1"/>
+<xsl:output method="html" encoding="UTF-8"/>
 
 <!-- Overide basic default template rule to
      copy nodes to the output.  This lets e.g.

--- a/xml/XSLT/aspecttable.xsl
+++ b/xml/XSLT/aspecttable.xsl
@@ -31,7 +31,7 @@
 <!-- Need to instruct the XSLT processor to use HTML output rules.
      See http://www.w3.org/TR/xslt#output for more details
 -->
-<xsl:output method="html" encoding="ISO-8859-1"/>
+<xsl:output method="html" encoding="UTF-8"/>
 
 
 <!-- Overide basic default template rule to

--- a/xml/XSLT/consistRoster.xsl
+++ b/xml/XSLT/consistRoster.xsl
@@ -29,7 +29,7 @@
 	<!-- Need to instruct the XSLT processor to use HTML output rules.
 		See http://www.w3.org/TR/xslt#output for more details
 	-->
-	<xsl:output method="html" encoding="ISO-8859-1" />
+	<xsl:output method="html" encoding="UTF-8" />
 
 
 	<!-- This first template matches our root element in the input file.

--- a/xml/XSLT/decoder-with-form.xsl
+++ b/xml/XSLT/decoder-with-form.xsl
@@ -27,7 +27,7 @@
 <!-- Need to instruct the XSLT processor to use HTML output rules.
      See http://www.w3.org/TR/xslt#output for more details
 -->
-<xsl:output method="html" encoding="ISO-8859-1"/>
+<xsl:output method="html" encoding="UTF-8"/>
 
 
 <!-- This first template matches our root element in the input file.

--- a/xml/XSLT/decoder.xsl
+++ b/xml/XSLT/decoder.xsl
@@ -22,7 +22,7 @@
 <!-- Need to instruct the XSLT processor to use HTML output rules.
      See http://www.w3.org/TR/xslt#output for more details
 -->
-<xsl:output method="html" encoding="ISO-8859-1"/>
+<xsl:output method="html" encoding="UTF-8"/>
 
 <!-- Define the copyright year for the output page
      In batch work via running Ant, this is defined

--- a/xml/XSLT/idtags.xsl
+++ b/xml/XSLT/idtags.xsl
@@ -30,7 +30,7 @@
 <!-- Need to instruct the XSLT processor to use HTML output rules.
      See http://www.w3.org/TR/xslt#output for more details
 -->
-<xsl:output method="html" encoding="ISO-8859-1"/>
+<xsl:output method="html" encoding="UTF-8"/>
 
 
 <!-- This first template matches our root element in the input file.

--- a/xml/XSLT/interestingCVs.xml
+++ b/xml/XSLT/interestingCVs.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <CVs>
 	<CV num="1" />

--- a/xml/XSLT/locomotive.xsl
+++ b/xml/XSLT/locomotive.xsl
@@ -28,7 +28,7 @@
 <!-- Need to instruct the XSLT processor to use HTML output rules.
      See http://www.w3.org/TR/xslt#output for more details
 -->
-<xsl:output method="html" encoding="ISO-8859-1"/>
+<xsl:output method="html" encoding="UTF-8"/>
 
 
 <!-- This first template matches our root element in the input file.

--- a/xml/XSLT/mfgID.xsl
+++ b/xml/XSLT/mfgID.xsl
@@ -29,7 +29,7 @@
 <!-- Need to instruct the XSLT processor to use HTML output rules.
      See http://www.w3.org/TR/xslt#output for more details
 -->
-<xsl:output method="html" encoding="ISO-8859-1"/>
+<xsl:output method="html" encoding="UTF-8"/>
 
 
 <!-- This first template matches our root element in the input file.

--- a/xml/XSLT/panelfile-2-9-6.xsl
+++ b/xml/XSLT/panelfile-2-9-6.xsl
@@ -18,7 +18,7 @@
 <!-- Need to instruct the XSLT processor to use HTML output rules.
      See http://www.w3.org/TR/xslt#output for more details
 -->
-<xsl:output method="html" encoding="ISO-8859-1"/>
+<xsl:output method="html" encoding="UTF-8"/>
 
 
 <!-- Define variables for translation -->

--- a/xml/XSLT/panelfile-4-19-2.xsl
+++ b/xml/XSLT/panelfile-4-19-2.xsl
@@ -41,7 +41,7 @@
 <!-- Need to instruct the XSLT processor to use HTML output rules.
      See http://www.w3.org/TR/xslt#output for more details
 -->
-<xsl:output method="html" encoding="ISO-8859-1"/>
+<xsl:output method="html" encoding="UTF-8"/>
 
 
 <!-- Define variables for translation -->

--- a/xml/XSLT/panelfile-5-5-5.xsl
+++ b/xml/XSLT/panelfile-5-5-5.xsl
@@ -49,7 +49,7 @@
 <!-- Need to instruct the XSLT processor to use HTML output rules.
      See http://www.w3.org/TR/xslt#output for more details
 -->
-<xsl:output method="html" encoding="ISO-8859-1"/>
+<xsl:output method="html" encoding="UTF-8"/>
 
 
 <!-- Define variables for translation -->

--- a/xml/XSLT/panelfile.xsl
+++ b/xml/XSLT/panelfile.xsl
@@ -16,7 +16,7 @@
 <!-- Need to instruct the XSLT processor to use HTML output rules.
      See http://www.w3.org/TR/xslt#output for more details
 -->
-<xsl:output method="html" encoding="ISO-8859-1"/>
+<xsl:output method="html" encoding="UTF-8"/>
 
 
 <!-- Define variables for translation -->

--- a/xml/XSLT/reservedCSV.xsl
+++ b/xml/XSLT/reservedCSV.xsl
@@ -23,7 +23,7 @@
 <!-- Need to instruct the XSLT processor to use text output rules.
      See http://www.w3.org/TR/xslt#output for more details
 -->
-<xsl:output method="text" encoding="ISO-8859-1"
+<xsl:output method="text" encoding="UTF-8"
 	indent="no"
 	omit-xml-declaration="yes"
 	standalone="no" />

--- a/xml/XSLT/roster.xsl
+++ b/xml/XSLT/roster.xsl
@@ -21,7 +21,7 @@
 <!-- Need to instruct the XSLT processor to use HTML output rules.
      See http://www.w3.org/TR/xslt#output for more details
 -->
-<xsl:output method="html" encoding="ISO-8859-1"/>
+<xsl:output method="html" encoding="UTF-8"/>
 
 <!-- Define the copyright year for the output page
      In batch work via running Ant, this is defined

--- a/xml/XSLT/roster2array.xsl
+++ b/xml/XSLT/roster2array.xsl
@@ -21,7 +21,7 @@
 
 	<!-- Need to instruct the XSLT processor to use HTML output rules. See http://www.w3.org/TR/xslt#output
 		for more details -->
-	<xsl:output method="html" encoding="ISO-8859-1" />
+	<xsl:output method="html" encoding="UTF-8" />
 
 
 	<!-- This first template matches our root element in the input file. This

--- a/xml/XSLT/roster2text.xsl
+++ b/xml/XSLT/roster2text.xsl
@@ -28,7 +28,7 @@
 <!-- Need to instruct the XSLT processor to use HTML output rules.
      See http://www.w3.org/TR/xslt#output for more details
 -->
-<xsl:output method="html" encoding="ISO-8859-1"/>
+<xsl:output method="html" encoding="UTF-8"/>
 
 
 <!-- This first template matches our root element in the input file.

--- a/xml/XSLT/rpsfile.xsl
+++ b/xml/XSLT/rpsfile.xsl
@@ -21,7 +21,7 @@
 <!-- Need to instruct the XSLT processor to use HTML output rules.
      See http://www.w3.org/TR/xslt#output for more details
 -->
-<xsl:output method="html" encoding="ISO-8859-1"/>
+<xsl:output method="html" encoding="UTF-8"/>
 
 <!-- Define the copyright year for the output page
      In batch work via running Ant, this is defined

--- a/xml/XSLT/speedometer.xsl
+++ b/xml/XSLT/speedometer.xsl
@@ -25,7 +25,7 @@
 <!-- Need to instruct the XSLT processor to use HTML output rules.
      See http://www.w3.org/TR/xslt#output for more details
 -->
-<xsl:output method="html" encoding="ISO-8859-1"/>
+<xsl:output method="html" encoding="UTF-8"/>
 
 <!-- Define the copyright year for the output page
      In batch work via running Ant, this is defined

--- a/xml/XSLT/timetable.xsl
+++ b/xml/XSLT/timetable.xsl
@@ -3,7 +3,7 @@
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
 <xsl:param name="JmriCopyrightYear" select="concat('1997','-','2024')" />
-<xsl:output method="html" encoding="ISO-8859-1"/>
+<xsl:output method="html" encoding="UTF-8"/>
 
 
 <xsl:template match='timetable-data'>

--- a/xml/XSLT/vsdecoder-config.xsl
+++ b/xml/XSLT/vsdecoder-config.xsl
@@ -24,7 +24,7 @@
 <!-- Need to instruct the XSLT processor to use HTML output rules.
      See http://www.w3.org/TR/xslt#output for more details
 -->
-<xsl:output method="html" encoding="ISO-8859-1"/>
+<xsl:output method="html" encoding="UTF-8"/>
 
 <!-- Define the copyright year for the output page
      In batch work via running Ant, this is defined


### PR DESCRIPTION
@bobjacobsen 
When I run
```
        cd xml/XSLT
        ant
        cd ../..
```
I get a huge number of errors or warnings:
```
[xslt] Attempt to output character of integral value 283 that is not represented in specified output encoding of ISO-8859-1.
```

This PR fixes that by changing the encoding to UTF-8. But I don't know how to test this PR.