### PR TITLE
Check that the default_lcf.xml and scripts/default.xml files are in synch

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -45,3 +45,5 @@ jobs:
         ./scripts/test_stale_sources.sh
         # Test if  if there are any files with with multiple UTF-8 Byte-Order-Marks (BOM) or TABs
         ./scripts/test_BOM_and_tab.sh
+        # Check that the default_lcf.xml and scripts/default.xml files are in synch.
+        ./scripts/test_default_lcf.sh

--- a/default_lcf.xml
+++ b/default_lcf.xml
@@ -3,8 +3,6 @@
 # default_lcf.xml
 # Default logging configuration file for JMRI project development.
 #
-# Test line of Static Analysis CI /DanielB
-#
 # If making changes here that should be included in the distribution
 # please also update the file for distribution at 'scripts/default_lcf.xml'
 

--- a/default_lcf.xml
+++ b/default_lcf.xml
@@ -3,6 +3,8 @@
 # default_lcf.xml
 # Default logging configuration file for JMRI project development.
 #
+# Test line of Static Analysis CI /DanielB
+#
 # If making changes here that should be included in the distribution
 # please also update the file for distribution at 'scripts/default_lcf.xml'
 

--- a/scripts/test_default_lcf.sh
+++ b/scripts/test_default_lcf.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Check that the default_lcf.xml and scripts/default.xml files are in synch.
+
+
+sed '0,/development/{s/development/distribution/}' default_lcf.xml | diff - scripts/default_lcf.xml
+
+result=$?
+
+if [[ $result == 1 ]]; then
+    echo ""
+    echo ""
+    echo "default_lcf.xml and scripts/default_lcf.xml differs."
+    echo "Run \"diff default_lcf.xml scripts/default_lcf.xml\" to check the differences"
+    echo ""
+    echo "There is one difference that should be keept:"
+    echo ""
+    echo "default_lcf.xml has the line:"
+    echo "Default logging configuration file for JMRI project development."
+    echo ""
+    echo "scripts/default_lcf.xml has the line:"
+    echo "Default logging configuration file for JMRI project distribution."
+    exit 1
+fi
+
+if [[ $result != 0 ]]; then
+    echo "sed or diff failed to execute properly."
+    exit 1
+fi
+


### PR DESCRIPTION
Example of failure:
https://github.com/danielb987/JMRI/actions/runs/10431274958/job/28890754389
```
6,7d5
< # Test line of Static Analysis CI /DanielB
< #


default_lcf.xml and scripts/default_lcf.xml differs.
Run "diff default_lcf.xml scripts/default_lcf.xml" to check the differences

There is one difference that should be keept:

default_lcf.xml has the line:
Default logging configuration file for JMRI project development.

scripts/default_lcf.xml has the line:
Default logging configuration file for JMRI project distribution.
```