### PR TITLE
WIP - xsl file error that breaks XSLT transformation

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -47,3 +47,5 @@ jobs:
         ./scripts/test_BOM_and_tab.sh
         # Check that the default_lcf.xml and scripts/default.xml files are in synch.
         ./scripts/test_default_lcf.sh
+        # Check XSLT transformations
+        ./scripts/test_decoder_XSLT_transforms.sh

--- a/scripts/test_decoder_XSLT_transforms.sh
+++ b/scripts/test_decoder_XSLT_transforms.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Check that the decoder XSLT transforms work
+
+cd xml/XSLT
+ant clean
+ant
+cd ../..
+

--- a/xml/XSLT/DecoderModelList.xsl
+++ b/xml/XSLT/DecoderModelList.xsl
@@ -21,7 +21,7 @@
      via the build.xml file. We build it by concatenation
      because XPath will evaluate '1997 - 2017' to '20'.
 -->
-<xsl:param name="JmriCopyrightYear" select="concat('1997','-','2024')" />
+<xsl:paAAram name="JmriCopyrightYear" select="concat('1997','-','2024')" />
 
 <!-- Need to instruct the XSLT processor to use HTML output rules.
      See http://www.w3.org/TR/xslt#output for more details


### PR DESCRIPTION
This PR must never be merged. It's only created for demonstration.

This PR changes the `xml/XSLT/DecoderModelList.xsl` file and this change breaks XSLT transformation.
If I remove this file instead, it still breaks XSLT transformation.

So this file is needed for XSLT transformation to work.