### PR TITLE
Let Static Analysis CI test XSLT transformations

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -47,3 +47,5 @@ jobs:
         ./scripts/test_BOM_and_tab.sh
         # Check that the default_lcf.xml and scripts/default.xml files are in synch.
         ./scripts/test_default_lcf.sh
+        # Check XSLT transformations
+        ./scripts/test_decoder_XSLT_transforms.sh

--- a/scripts/test_decoder_XSLT_transforms.sh
+++ b/scripts/test_decoder_XSLT_transforms.sh
@@ -3,7 +3,14 @@
 # Check that the decoder XSLT transforms work
 
 cd xml/XSLT
-ant clean
-ant
+
+ant clean && ant
+
+result=$?
+
 cd ../..
 
+if [[ $result != 0 ]]; then
+    echo "decoder XSLT transformations failed"
+    exit 1
+fi

--- a/scripts/test_decoder_XSLT_transforms.sh
+++ b/scripts/test_decoder_XSLT_transforms.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Check that the decoder XSLT transforms work
+
+cd xml/XSLT
+ant clean
+ant
+cd ../..
+


### PR DESCRIPTION
@bobjacobsen 
This PR adds a test to Static Analysis that runs `ant clean && ant` in `xml/XSLT`. And I have found some interesting results.

PR #13353 shows that if I break or remove `xml/XSLT/DecoderModelList.xsl`, XSLT transformation fails.

PR #13354 shows that I can remove most, but not all, of the xsl files in xml/XSLT without breaking XSLT transformation, or at least not breaking `ant clean && ant` in `xml/XSLT` folder.

Am I missing something or could we have a potential problem here?