### PR TITLE
prevent PipeListener NPE

### DIFF
--- a/java/src/jmri/util/PipeListener.java
+++ b/java/src/jmri/util/PipeListener.java
@@ -43,7 +43,7 @@ public class PipeListener extends Thread {
                     });
 
                 } catch (IOException ex) {
-                    if (ex.getMessage().equals("Write end dead") || ex.getMessage().equals("Pipe broken")) {
+                    if ( "Write end dead".equals(ex.getMessage()) || "Pipe broken".equals(ex.getMessage())) {
                         // happens when the writer thread, possibly a script, terminates
                         synchronized (this) {
                             try {


### PR DESCRIPTION
prevent NPE if #getMessage is null