### PR TITLE
JUnitUtil reset ZeroConf ServiceManager / JsonHttpService Test Base

### DIFF
--- a/java/src/jmri/util/zeroconf/ZeroConfServiceManager.java
+++ b/java/src/jmri/util/zeroconf/ZeroConfServiceManager.java
@@ -15,12 +15,14 @@ import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
+
 import javax.annotation.Nonnull;
 import javax.jmdns.JmDNS;
 import javax.jmdns.JmmDNS;
 import javax.jmdns.NetworkTopologyEvent;
 import javax.jmdns.NetworkTopologyListener;
 import javax.jmdns.ServiceInfo;
+
 import jmri.Disposable;
 import jmri.InstanceManager;
 import jmri.InstanceManagerAutoDefault;
@@ -29,8 +31,6 @@ import jmri.profile.ProfileManager;
 import jmri.util.SystemType;
 import jmri.util.node.NodeIdentity;
 import jmri.web.server.WebServerPreferences;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * A ZeroConfServiceManager object manages zeroConf network service
@@ -88,11 +88,13 @@ public class ZeroConfServiceManager implements InstanceManagerAutoDefault, Dispo
      * {@link #getDNSes() } to ensure this is populated correctly.
      */
     static final HashMap<InetAddress, JmDNS> JMDNS_SERVICES = new HashMap<>();
-    private static final Logger log = LoggerFactory.getLogger(ZeroConfServiceManager.class);
+
     // class data objects
     protected final HashMap<String, ZeroConfService> services = new HashMap<>();
     protected final NetworkListener networkListener = new NetworkListener(this);
     protected final Runnable shutDownTask = () -> dispose(this);
+
+    public static final String DNS_CLOSE_THREAD_NAME = "dns.close in ZerConfServiceManager#stopAll";
 
     protected final ZeroConfPreferences preferences = new ZeroConfPreferences(ProfileManager.getDefault().getActiveProfile());
 
@@ -315,7 +317,7 @@ public class ZeroConfServiceManager implements InstanceManagerAutoDefault, Dispo
                 }
                 nsLatch.countDown();
             });
-            t.setName("dns.close in ZerConfServiceManager#stopAll");
+            t.setName(DNS_CLOSE_THREAD_NAME);
             t.start();
         });
         try {
@@ -616,4 +618,7 @@ public class ZeroConfServiceManager implements InstanceManagerAutoDefault, Dispo
         }
 
     }
+
+    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ZeroConfServiceManager.class);
+
 }

--- a/java/test/jmri/util/JUnitUtil.java
+++ b/java/test/jmri/util/JUnitUtil.java
@@ -199,10 +199,13 @@ public class JUnitUtil {
     static private String initPrefsDir = null;
 
     /**
-     * JMRI standard setUp for tests that mock the InstanceManager. This should be the first line in the {@code @Before}
+     * JMRI standard setUp for tests that mock the InstanceManager.
+     * This should be the first line in the {@code @BeforeEach}
      * annotated method if the tests mock the InstanceManager.
+     * <p>
      * One or the other of {@link #setUp()} or {@link #setUpLoggingAndCommonProperties()} must
-     * be present in the {@code @Before} routine.
+     * be present in the {@code @BeforeEach} routine.
+     * <p>
      */
     public static void setUpLoggingAndCommonProperties() {
         if (!isLoggingInitialized) {
@@ -287,10 +290,15 @@ public class JUnitUtil {
     }
 
     /**
-     * JMRI standard setUp for tests. This should be the first line in the {@code @Before}
+     * JMRI standard setUp for tests.
+     * This should be the first line in the {@code @BeforeEach}
      * annotated method if the tests do not mock the InstanceManager.
+     * <p>
      * One or the other of {@link #setUp()} or {@link #setUpLoggingAndCommonProperties()} must
-     * be present in the {@code @Before} routine.
+     * be present in the {@code @BeforeEach} routine.
+     * <p>
+     * Calls {@link #setUpLoggingAndCommonProperties()}, {@link #resetInstanceManager()}
+     * and sets the jmri.configurexml.ShutdownPreferences setEnableStoreCheck to false.
      */
     public static void setUp() {
         WAITFOR_DELAY_STEP = DEFAULT_WAITFOR_DELAY_STEP;
@@ -727,6 +735,15 @@ public class JUnitUtil {
         }, "setAndWait " + bean.getSystemName() + ": " + state);
     }
 
+    /**
+     * Reset the Instance Manager.
+     * Clears all instances from the static InstanceManager.
+     * <p>
+     * Ensures the auto-default UserPreferencesManager is not created
+     * by installing a test one.
+     * <p>
+     * Sets the jmri.configurexml.ShutdownPreferences setEnableStoreCheck to false.
+     */
     public static void resetInstanceManager() {
         // clear all instances from the static InstanceManager
         InstanceManager.getDefault().clearAll();
@@ -1050,18 +1067,25 @@ public class JUnitUtil {
      * Ensure that any existing
      * {@link jmri.util.zeroconf.ZeroConfServiceManager} (real or mocked) has
      * stopped all services it is managing.
+     * @return true when complete.
      */
-    public static void resetZeroConfServiceManager() {
-        if (! InstanceManager.containsDefault(ZeroConfServiceManager.class)) return; // not present, don't create on by asking for it.
+    public static boolean resetZeroConfServiceManager() {
+        if (! InstanceManager.containsDefault(ZeroConfServiceManager.class)) {
+            return true; // not present, don't create one by asking for it.
+        }
 
         ZeroConfServiceManager manager = InstanceManager.getDefault(ZeroConfServiceManager.class);
         manager.stopAll();
 
-        JUnitUtil.waitFor(() -> {
-            return (manager.allServices().isEmpty());
-        }, "Stopping all ZeroConf Services");
+        waitFor( () -> manager.allServices().isEmpty(), "Stopping all ZeroConf Services");
 
         manager.dispose();
+
+        Thread t = getThreadByName( ZeroConfServiceManager.DNS_CLOSE_THREAD_NAME );
+        if ( t != null ) {
+            waitFor( () -> !t.isAlive(), "dns.close thread did not complete");
+        }
+        return true;
     }
 
     /**


### PR DESCRIPTION
**JUnitUtil** -
Add boolean return value for resetZeroConfServiceManager
Wait for dns close thread to complete before returning.
Javadoc

**ZeroConfServiceManager** - access to DNS_CLOSE_THREAD_NAME

**JsonHttpServiceTestBase** -
ln 118-126 assertEquals on schema1 vs schema2 , not schema1 vs schema 1, 
assert ZeroConf ServiceManager DNS close thread complete