### PR TITLE
Add "hint" on GUI to 'Startup' options

### DIFF
--- a/help/en/package/apps/TabbedPreferences.shtml
+++ b/help/en/package/apps/TabbedPreferences.shtml
@@ -217,9 +217,11 @@
         <p>Click the <strong>Add &#9662;</strong> button and select the type of start up action to add.
         The new action will be added last.</p>
 
-        <p>Start up action order is important. In most cases, scripts should be the last items in
-        the start up order. Start up order can be changed by selecting a start up item and moving
-        it <em>up</em> or <em>down</em> in the list.</p>
+        <p>Start up action order is important, and can be changed by selecting a start up item and 
+        moving it <em>up</em> or <em>down</em> in the list.  For the best performance when loading 
+        an XML file, ensure that "Load table content and panels..." occurs <u>before any<u> "Perform 
+        Action..." to "Open" <em>any</em> "Table".  And, in most cases, scripts should be the last 
+        items in the start up order.</p>
 
         <p>Individual start up actions can be enabled or disabled.  The default is
         <strong>Enabled</strong>.<span class="since">since 5.5.6</span></p>
@@ -242,7 +244,8 @@
           <dt>Load table content and panels...</dt>
 
           <dd>Automatically load a PanelPro xml data file or Configuration file when the program
-          starts up.</dd>
+              starts up.  Generally, "Load table content and panels..." runs more quickly when it 
+              is found <em>before</em> any "Perform Action..." item which "Opens" a JMRI "Table".</dd>
 
           <dt>Pause...</dt>
 
@@ -259,7 +262,9 @@
 
           <dd>Automatically run a scripts when the program starts up. You can run as many scripts
           as you'd like; each will be run to completion before the next is started. Note that any
-          files the script depends upon need to be loaded before running the script.</dd>
+          files the script depends upon need to be loaded before running the script.  In most 
+          cases, "Run Script..." actions should be run "last" in the set of items in the 
+          "Start Up" list.</dd>
 
           <dt>Set route...</dt>
 

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -465,7 +465,9 @@
     <h3>Preferences</h3>
         <a id="Preferences" name="Preferences"></a>
         <ul>
-            <li></li>
+            <li>Added text to "start Up" Preferences to note that optimal XML file 
+                loading should be done <em>before</em> "Opening" <u>any</u> 
+                "Table".</li>
         </ul>
 
     <h3>Resources</h3>
@@ -603,4 +605,3 @@
         <ul>
             <li></li>
         </ul>
-

--- a/java/src/apps/startup/Bundle.properties
+++ b/java/src/apps/startup/Bundle.properties
@@ -8,7 +8,7 @@ StartupActionsPreferencesPanel.upBtn.text=Up
 StartupActionsPreferencesPanel.startupLbl.text=<html>Add items to be executed or opened when the application starts.<br>Items will be executed or opened in the order listed.</html>
 StartupActionsPreferencesPanel.removeBtn.text=Remove
 StartupActionsPreferencesPanel.moveLbl.text=Move
-StartupActionsPreferencesPanel.recommendationsLbl.text=<html>Scripts should be run last in most cases.</html>
+StartupActionsPreferencesPanel.recommendationsLbl.text=<html>For speediest loading of XML files, 'Load table content and panels...', should be loaded before <em>any</em> action to 'Open <em>{type}</em> Table'.<p>Scripts should be run last in most cases.</html>
 
 # Descriptions of the Startup Models included in JMRI
 apps.CreateButtonModel=Add button to main window

--- a/java/src/apps/startup/Bundle.properties
+++ b/java/src/apps/startup/Bundle.properties
@@ -8,7 +8,10 @@ StartupActionsPreferencesPanel.upBtn.text=Up
 StartupActionsPreferencesPanel.startupLbl.text=<html>Add items to be executed or opened when the application starts.<br>Items will be executed or opened in the order listed.</html>
 StartupActionsPreferencesPanel.removeBtn.text=Remove
 StartupActionsPreferencesPanel.moveLbl.text=Move
-StartupActionsPreferencesPanel.recommendationsLbl.text=<html>For speediest loading of XML files, 'Load table content and panels...', should be loaded before <em>any</em> action to 'Open <em>{type}</em> Table'.<p>Scripts should be run last in most cases.</html>
+StartupActionsPreferencesPanel.recommendationsLbl.text=<html>Notes:<ul><li>For fastest \
+loading of XML files, 'Load table content and panels...', should be loaded before \
+<em>any</em> action to open <u>any type</u> of "Table".</li><li>Scripts should be run last \
+in most cases.</li></ul></html>
 
 # Descriptions of the Startup Models included in JMRI
 apps.CreateButtonModel=Add button to main window


### PR DESCRIPTION
Add a hint to the "Preferences"->"Start Up" GUI to encourage "Load table content and panels..." _before_ opening bean's "GUI "Table".  This would avoid the JMRI slow-down encountered when adding beans from the XML to the GUI table _when that table is ordered in a way that does not match the order in the XML_.

Since the GUI table's ordering usually can be changed by the user, and its ordering can be changed when JMRI was last run, the speed can change radically in this case, _if_ the table is already opened when the "Start Up" list's item "loads" the XML.

But when the XML is loaded _before_ the tables are opened, JMRI will only "sort" each table's data once.  This can allow a significant savings in amount of JMRI start-up time.

See also #13390 for related info.
