### PR TITLE
disable some empty Throttle tests

### DIFF
--- a/java/test/jmri/jmrix/bidib/BiDiBThrottleTest.java
+++ b/java/test/jmri/jmrix/bidib/BiDiBThrottleTest.java
@@ -1,13 +1,11 @@
 package jmri.jmrix.bidib;
 
-import org.junit.Assert;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-
 import jmri.DccLocoAddress;
 import jmri.SpeedStepMode;
 import jmri.util.JUnitUtil;
+
+import org.junit.Assert;
+import org.junit.jupiter.api.*;
 
 /**
  * Tests for the BiDiBThrottle class
@@ -347,6 +345,7 @@ public class BiDiBThrottleTest  extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup1() {
     }
 
@@ -355,6 +354,7 @@ public class BiDiBThrottleTest  extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup2() {
     }
 
@@ -363,6 +363,7 @@ public class BiDiBThrottleTest  extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup3() {
     }
 
@@ -371,6 +372,7 @@ public class BiDiBThrottleTest  extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup4() {
     }
 
@@ -379,6 +381,7 @@ public class BiDiBThrottleTest  extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup5() {
     }
 
@@ -395,6 +398,9 @@ public class BiDiBThrottleTest  extends jmri.jmrix.AbstractThrottleTest {
     @Override
     @AfterEach
     public void tearDown() {
+        memo.dispose();
+        memo = null;
+        instance = null;
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrix/dccpp/DCCppThrottleTest.java
+++ b/java/test/jmri/jmrix/dccpp/DCCppThrottleTest.java
@@ -479,6 +479,7 @@ public class DCCppThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup1() {
     }
 
@@ -487,6 +488,7 @@ public class DCCppThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup2() {
     }
 
@@ -495,6 +497,7 @@ public class DCCppThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup3() {
     }
 
@@ -503,6 +506,7 @@ public class DCCppThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup4() {
     }
 
@@ -511,6 +515,7 @@ public class DCCppThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup5() {
     }
 

--- a/java/test/jmri/jmrix/debugthrottle/DebugThrottleTest.java
+++ b/java/test/jmri/jmrix/debugthrottle/DebugThrottleTest.java
@@ -3,6 +3,7 @@ package jmri.jmrix.debugthrottle;
 import jmri.SpeedStepMode;
 import jmri.SystemConnectionMemo;
 import jmri.util.JUnitUtil;
+import jmri.util.junit.annotations.NotApplicable;
 
 import org.mockito.Mockito;
 import org.junit.jupiter.api.*;
@@ -188,6 +189,7 @@ public class DebugThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @NotApplicable("DebugThrottle does not send Functions")
     public void testSendFunctionGroup1() {
     }
 
@@ -196,6 +198,7 @@ public class DebugThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @NotApplicable("DebugThrottle does not send Functions")
     public void testSendFunctionGroup2() {
     }
 
@@ -204,6 +207,7 @@ public class DebugThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @NotApplicable("DebugThrottle does not send Functions")
     public void testSendFunctionGroup3() {
     }
 

--- a/java/test/jmri/jmrix/direct/ThrottleTest.java
+++ b/java/test/jmri/jmrix/direct/ThrottleTest.java
@@ -322,6 +322,7 @@ public class ThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup1() {
     }
 
@@ -330,6 +331,7 @@ public class ThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup2() {
     }
 
@@ -338,6 +340,7 @@ public class ThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup3() {
     }
 
@@ -346,6 +349,7 @@ public class ThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup4() {
     }
 
@@ -354,6 +358,7 @@ public class ThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup5() {
     }
 

--- a/java/test/jmri/jmrix/easydcc/EasyDccThrottleTest.java
+++ b/java/test/jmri/jmrix/easydcc/EasyDccThrottleTest.java
@@ -189,6 +189,7 @@ public class EasyDccThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup1() {
     }
 
@@ -197,6 +198,7 @@ public class EasyDccThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup2() {
     }
 
@@ -205,6 +207,7 @@ public class EasyDccThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup3() {
     }
 

--- a/java/test/jmri/jmrix/ecos/EcosDccThrottleTest.java
+++ b/java/test/jmri/jmrix/ecos/EcosDccThrottleTest.java
@@ -462,6 +462,7 @@ public class EcosDccThrottleTest extends AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup1() {
     }
 
@@ -470,6 +471,7 @@ public class EcosDccThrottleTest extends AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup2() {
     }
 
@@ -478,6 +480,7 @@ public class EcosDccThrottleTest extends AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup3() {
     }
 
@@ -486,6 +489,7 @@ public class EcosDccThrottleTest extends AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup4() {
     }
 
@@ -494,6 +498,7 @@ public class EcosDccThrottleTest extends AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup5() {
     }
 

--- a/java/test/jmri/jmrix/lenz/hornbyelite/EliteXNetThrottleTest.java
+++ b/java/test/jmri/jmrix/lenz/hornbyelite/EliteXNetThrottleTest.java
@@ -341,6 +341,7 @@ public class EliteXNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup1() {
     }
 
@@ -349,6 +350,7 @@ public class EliteXNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup2() {
     }
 
@@ -357,6 +359,7 @@ public class EliteXNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup3() {
     }
 
@@ -365,6 +368,7 @@ public class EliteXNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup4() {
     }
 
@@ -373,6 +377,7 @@ public class EliteXNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup5() {
     }
 
@@ -393,6 +398,8 @@ public class EliteXNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     public void tearDown() {
         memo.getXNetTrafficController().terminateThreads();
         memo.dispose();
+        memo = null;
+        instance = null;
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrix/loconet/Ib1ThrottleTest.java
+++ b/java/test/jmri/jmrix/loconet/Ib1ThrottleTest.java
@@ -358,6 +358,7 @@ public class Ib1ThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup1() {
     }
 
@@ -366,6 +367,7 @@ public class Ib1ThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup2() {
     }
 
@@ -374,6 +376,7 @@ public class Ib1ThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup3() {
     }
 
@@ -382,6 +385,7 @@ public class Ib1ThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup4() {
     }
 
@@ -390,6 +394,7 @@ public class Ib1ThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup5() {
     }
 

--- a/java/test/jmri/jmrix/loconet/Ib2ThrottleTest.java
+++ b/java/test/jmri/jmrix/loconet/Ib2ThrottleTest.java
@@ -358,6 +358,7 @@ public class Ib2ThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup1() {
     }
 
@@ -366,6 +367,7 @@ public class Ib2ThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup2() {
     }
 
@@ -374,6 +376,7 @@ public class Ib2ThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup3() {
     }
 
@@ -382,6 +385,7 @@ public class Ib2ThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup4() {
     }
 
@@ -390,6 +394,7 @@ public class Ib2ThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup5() {
     }
 
@@ -422,6 +427,7 @@ public class Ib2ThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     public void tearDown() {
         ((Ib2ThrottleManager)jmri.InstanceManager.getDefault(jmri.ThrottleManager.class)).dispose();
         memo.dispose();
+        memo = null;
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrix/loconet/Pr2ThrottleTest.java
+++ b/java/test/jmri/jmrix/loconet/Pr2ThrottleTest.java
@@ -373,6 +373,7 @@ public class Pr2ThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup1() {
     }
 
@@ -381,6 +382,7 @@ public class Pr2ThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup2() {
     }
 
@@ -389,6 +391,7 @@ public class Pr2ThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup3() {
     }
 
@@ -397,6 +400,7 @@ public class Pr2ThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup4() {
     }
 
@@ -405,6 +409,7 @@ public class Pr2ThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup5() {
     }
 
@@ -424,6 +429,7 @@ public class Pr2ThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     @Override
     public void tearDown() {
         memo.dispose();
+        memo = null;
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrix/marklin/MarklinThrottleTest.java
+++ b/java/test/jmri/jmrix/marklin/MarklinThrottleTest.java
@@ -346,6 +346,7 @@ public class MarklinThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup1() {
     }
 
@@ -354,6 +355,7 @@ public class MarklinThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup2() {
     }
 
@@ -362,6 +364,7 @@ public class MarklinThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup3() {
     }
 
@@ -370,6 +373,7 @@ public class MarklinThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup4() {
     }
 
@@ -378,6 +382,7 @@ public class MarklinThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup5() {
     }
 

--- a/java/test/jmri/jmrix/mqtt/MqttThrottleTest.java
+++ b/java/test/jmri/jmrix/mqtt/MqttThrottleTest.java
@@ -600,6 +600,7 @@ public class MqttThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup1() {
     }
 
@@ -608,6 +609,7 @@ public class MqttThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup2() {
     }
 
@@ -616,6 +618,7 @@ public class MqttThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup3() {
     }
 
@@ -624,6 +627,7 @@ public class MqttThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup4() {
     }
 
@@ -632,6 +636,7 @@ public class MqttThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup5() {
     }
 

--- a/java/test/jmri/jmrix/mrc/MrcThrottleTest.java
+++ b/java/test/jmri/jmrix/mrc/MrcThrottleTest.java
@@ -345,6 +345,7 @@ public class MrcThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup1() {
     }
 
@@ -353,6 +354,7 @@ public class MrcThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup2() {
     }
 
@@ -361,6 +363,7 @@ public class MrcThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup3() {
     }
 
@@ -369,6 +372,7 @@ public class MrcThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup4() {
     }
 
@@ -377,14 +381,17 @@ public class MrcThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup5() {
     }
+
+    private MrcSystemConnectionMemo memo;
 
     @BeforeEach
     @Override
     public void setUp() {
         JUnitUtil.setUp();
-        MrcSystemConnectionMemo memo = new MrcSystemConnectionMemo();
+        memo = new MrcSystemConnectionMemo();
         MrcInterfaceScaffold tc = new MrcInterfaceScaffold();
         memo.setMrcTrafficController(tc);
         jmri.InstanceManager.store(memo, MrcSystemConnectionMemo.class);
@@ -395,6 +402,9 @@ public class MrcThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     @AfterEach
     @Override
     public void tearDown() {
+        memo.dispose();
+        memo = null;
+        instance = null;
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrix/nce/NceThrottleTest.java
+++ b/java/test/jmri/jmrix/nce/NceThrottleTest.java
@@ -349,6 +349,7 @@ public class NceThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup1() {
     }
 
@@ -357,6 +358,7 @@ public class NceThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup2() {
     }
 
@@ -365,6 +367,7 @@ public class NceThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup3() {
     }
 
@@ -373,6 +376,7 @@ public class NceThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup4() {
     }
 
@@ -381,6 +385,7 @@ public class NceThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup5() {
     }
 

--- a/java/test/jmri/jmrix/openlcb/OlcbThrottleTest.java
+++ b/java/test/jmri/jmrix/openlcb/OlcbThrottleTest.java
@@ -337,6 +337,7 @@ public class OlcbThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup1() {
     }
 
@@ -345,6 +346,7 @@ public class OlcbThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup2() {
     }
 
@@ -353,6 +355,7 @@ public class OlcbThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup3() {
     }
 
@@ -361,6 +364,7 @@ public class OlcbThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup4() {
     }
 
@@ -369,6 +373,7 @@ public class OlcbThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup5() {
     }
 

--- a/java/test/jmri/jmrix/roco/RocoXNetThrottleTest.java
+++ b/java/test/jmri/jmrix/roco/RocoXNetThrottleTest.java
@@ -68,30 +68,35 @@ public class RocoXNetThrottleTest extends jmri.jmrix.lenz.XNetThrottleTest {
     @Override
     @Test
     @Timeout(1000)
+    @Disabled("Test requires further development")
     public void testInitSequenceNormalUnitSpeedStep128() throws Exception {
     }
 
     @Override
     @Test
     @Timeout(1000)
+    @Disabled("Test requires further development")
     public void initSequenceNormalUnitSpeedStep14() throws Exception {
     }
 
     @Override
     @Test
     @Timeout(1000)
+    @Disabled("Test requires further development")
     public void initSequenceMUAddress28SpeedStep() throws Exception {
     }
 
     @Override
     @Test
     @Timeout(1000)
+    @Disabled("Test requires further development")
     public void initSequenceMuedUnitSpeedStep128() throws Exception {
     }
 
     @Override
     @Test
     @Timeout(1000)
+    @Disabled("Test requires further development")
     public void initSequenceDHUnitSpeedStep27() throws Exception {
     }
 

--- a/java/test/jmri/jmrix/sprog/SprogCSThrottleTest.java
+++ b/java/test/jmri/jmrix/sprog/SprogCSThrottleTest.java
@@ -338,6 +338,7 @@ public class SprogCSThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup1() {
     }
 
@@ -346,6 +347,7 @@ public class SprogCSThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup2() {
     }
 
@@ -354,6 +356,7 @@ public class SprogCSThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup3() {
     }
 
@@ -362,6 +365,7 @@ public class SprogCSThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup4() {
     }
 
@@ -370,6 +374,7 @@ public class SprogCSThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup5() {
     }
 
@@ -417,7 +422,7 @@ public class SprogCSThrottleTest extends jmri.jmrix.AbstractThrottleTest {
         try {
             m.getSlotThread().interrupt();
             m.dispose();
-            JUnitUtil.waitFor(() -> { return !m.getSlotThread().isAlive(); });
+            JUnitUtil.waitFor(() -> { return !m.getSlotThread().isAlive(); },"SPROG Slot Thread still alive");
             stcs.dispose();
         } finally {
             JUnitUtil.tearDown();

--- a/java/test/jmri/jmrix/sprog/SprogThrottleTest.java
+++ b/java/test/jmri/jmrix/sprog/SprogThrottleTest.java
@@ -338,6 +338,7 @@ public class SprogThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup1() {
     }
 
@@ -346,6 +347,7 @@ public class SprogThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup2() {
     }
 
@@ -354,6 +356,7 @@ public class SprogThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup3() {
     }
 
@@ -362,6 +365,7 @@ public class SprogThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup4() {
     }
 
@@ -370,6 +374,7 @@ public class SprogThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup5() {
     }
 

--- a/java/test/jmri/jmrix/srcp/SRCPThrottleTest.java
+++ b/java/test/jmri/jmrix/srcp/SRCPThrottleTest.java
@@ -350,6 +350,7 @@ public class SRCPThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup1() {
     }
 
@@ -358,6 +359,7 @@ public class SRCPThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup2() {
     }
 
@@ -366,6 +368,7 @@ public class SRCPThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup3() {
     }
 
@@ -374,6 +377,7 @@ public class SRCPThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup4() {
     }
 
@@ -382,6 +386,7 @@ public class SRCPThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup5() {
     }
 

--- a/java/test/jmri/jmrix/tams/TamsThrottleTest.java
+++ b/java/test/jmri/jmrix/tams/TamsThrottleTest.java
@@ -349,6 +349,7 @@ public class TamsThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup1() {
     }
 
@@ -357,6 +358,7 @@ public class TamsThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup2() {
     }
 
@@ -365,6 +367,7 @@ public class TamsThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup3() {
     }
 
@@ -373,6 +376,7 @@ public class TamsThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup4() {
     }
 
@@ -381,6 +385,7 @@ public class TamsThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup5() {
     }
 

--- a/java/test/jmri/jmrix/xpa/XpaThrottleTest.java
+++ b/java/test/jmri/jmrix/xpa/XpaThrottleTest.java
@@ -188,6 +188,7 @@ public class XpaThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup1() {
     }
 
@@ -196,6 +197,7 @@ public class XpaThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup2() {
     }
 
@@ -204,6 +206,7 @@ public class XpaThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup3() {
     }
 

--- a/java/test/jmri/jmrix/zimo/Mx1ThrottleTest.java
+++ b/java/test/jmri/jmrix/zimo/Mx1ThrottleTest.java
@@ -347,6 +347,7 @@ public class Mx1ThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup1() {
     }
 
@@ -355,6 +356,7 @@ public class Mx1ThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup2() {
     }
 
@@ -363,6 +365,7 @@ public class Mx1ThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup3() {
     }
 
@@ -371,6 +374,7 @@ public class Mx1ThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup4() {
     }
 
@@ -379,6 +383,7 @@ public class Mx1ThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      */
     @Test
     @Override
+    @Disabled("Test requires further development")
     public void testSendFunctionGroup5() {
     }
 


### PR DESCRIPTION
Adds Disabled / NotApplicable annotation to empty Throttle tests.
Prevents a call to BeforeEach / AfterEach for each test that is not required.