### PR TITLE
ESU decoder definition update

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -243,7 +243,12 @@
 
         <h4>ESU</h4>
             <ul>
-                <li></li>
+                <li>Added LokPilot 5 micro DCC Direct</li>
+                <li>Added LokPilot 5 nano DCC</li>
+                <li>Added LokSound 5 micro DCC Direct Atlas S2</li>
+                <li>Added LokSound 5 nano DCC Next18</li>
+                <li>Updated LokPilot 5 L and 5L DCC productIDs</li>
+              
             </ul>
 
         <h4>Hornby</h4>

--- a/xml/decoders/ESU_LokPilot5.xml
+++ b/xml/decoders/ESU_LokPilot5.xml
@@ -26,6 +26,8 @@
     <version author="Dave Heap" version="5" lastUpdated="20200924"/>
     <!-- ver6 add some new productIDs -->
     <version author="Dave Heap" version="6" lastUpdated="20211203"/>
+    <!-- ver7 add "LokPilot 5 micro DCC Direct", "LokPilot 5 nano DCC" and a few more productIDs -->
+    <version author="Heiko Rosemann" version="7" lastUpdated="20240901"/>
     <decoder>
         <family name="ESU LokPilot 5" mfg="Electronic Solutions Ulm GmbH" lowVersionID="255" highVersionID="255">
             <model model="LokPilot 5" maxFnNum="31" numOuts="20" maxMotorCurrent="1.5A" extFnsESU="V5" productID="33554600,33554636">
@@ -76,6 +78,9 @@
                 <output name="2,20" label="|"/> <!-- suppress unused item -->
                 <size length="25.5" width="10.6" height="4.5" units="mm"/>
             </model>
+            <model model="LokPilot 5 micro DCC Direct" maxFnNum="31" numOuts="10" maxMotorCurrent="0.75A" extFnsESU="V5" productID="16777370">
+                <size length="66.0" width="8.5" height="3.0" units="mm"/>
+            </model>
             <model model="LokPilot 5 micro Next18" maxFnNum="31" numOuts="20" maxMotorCurrent="0.75A" extFnsESU="V5" productID="33554604">
                 <output name="1,35" label="|"/> <!-- suppress unused item -->
                 <size length="21.0" width="10.6" height="4.0" units="mm"/>
@@ -84,10 +89,13 @@
                 <output name="1,35" label="|"/> <!-- suppress unused item -->
                 <size length="21.0" width="10.6" height="4.0" units="mm"/>
             </model>
-            <model model="LokPilot 5 L" maxFnNum="31" numOuts="20" maxMotorCurrent="3A" extFnsESU="V5" productID="33554609,33554639">
+            <model model="LokPilot 5 nano DCC" maxFnNum="31" numOuts="20" maxMotorCurrent="0.75A" extFnsESU="V5" productID="16777468">
+                <size length="19.6" width="8.5" height="3.2" units="mm"/>
+            </model>
+            <model model="LokPilot 5 L" maxFnNum="31" numOuts="20" maxMotorCurrent="3A" extFnsESU="V5" productID="33554609,33554639,33554672">
                 <size length="51.8" width="25.4" height="14" units="mm"/>
             </model>
-            <model model="LokPilot 5 L DCC" maxFnNum="31" numOuts="20" maxMotorCurrent="3A" extFnsESU="V5" productID="33554610,33554640">
+            <model model="LokPilot 5 L DCC" maxFnNum="31" numOuts="20" maxMotorCurrent="3A" extFnsESU="V5" productID="33554610,33554640,33554673">
                 <size length="51.8" width="25.4" height="14" units="mm"/>
             </model>
             <model model="LokPilot 5 Fx" maxFnNum="31" numOuts="20" maxMotorCurrent="5A" extFnsESU="V5" productID="16777406,16777425">

--- a/xml/decoders/ESU_LokSound5.xml
+++ b/xml/decoders/ESU_LokSound5.xml
@@ -23,6 +23,7 @@
     <!-- ver7 renamed "LokSound 5 micro E24 DCC" to "LokSound 5 nano DCC" -->
     <!-- ver8 add "LokSound 5 micro DCC Direct Atlas Legacy -->
     <!-- ver9 add additional productIDs -->
+    <!-- ver10 add "LokSound 5 micro DCC Direct Atlas S2" and "LokSound 5 nano DCC Next18" -->
     <version author="Dave Heap" version="1" lastUpdated="20190507"/>
     <version author="Dave Heap" version="2" lastUpdated="20200410"/>
     <version author="Dave Heap" version="3" lastUpdated="20200726"/>
@@ -32,6 +33,7 @@
     <version author="Dave Heap" version="7" lastUpdated="20210930"/>
     <version author="Heiko Rosemann" version="8" lastUpdated="20230123"/>
     <version author="Michael Mosher" version="9" lastUpdated="20240321"/>
+    <version author="Heiko Rosemann" version="10" lastUpdated="20240901"/>
     <decoder>
         <family name="ESU LokSound 5" mfg="Electronic Solutions Ulm GmbH" lowVersionID="255" highVersionID="255">
             <model model="LokSound 5" maxFnNum="31" numOuts="20" maxMotorCurrent="1.5A" extFnsESU="V5" productID="33554582,33554679,33554650">
@@ -66,11 +68,19 @@
                 <output name="2,20" label="|"/> <!-- suppress unused item -->
                 <size length="21.0" width="10.6" height="4.0" units="mm"/>
             </model>
+            <model model="LokSound 5 micro DCC Direct Atlas Legacy" maxFnNum="31" numOuts="6" maxMotorCurrent="0.75A" extFnsESU="V5" productID="16777432">
+                <size length="66.0" width="8.2" height="3.0" units="mm"/>
+            </model>
+            <model model="LokSound 5 micro DCC Direct Atlas S2" maxFnNum="31" numOuts="3" maxMotorCurrent="0.75A" extFnsESU="V5" productID="16777467">
+            </model>
             <model show="no" model="LokSound 5 micro E24 DCC" replacementModel="LokSound 5 nano DCC" maxFnNum="31" numOuts="20" maxMotorCurrent="0.75A" extFnsESU="V5" productID="16777404">
                 <size length="21.0" width="10.6" height="4.0" units="mm"/>
             </model>
             <model model="LokSound 5 nano DCC" maxFnNum="31" numOuts="20" maxMotorCurrent="0.75A" extFnsESU="V5" productID="16777404">
-                <size length="21.0" width="10.6" height="4.0" units="mm"/>
+                <size length="19.6" width="8.5" height="5.3" units="mm"/>
+            </model>
+            <model model="LokSound 5 nano DCC Next18" maxFnNum="31" numOuts="20" maxMotorCurrent="0.75A" extFnsESU="V5" productID="16777444">
+                <size length="15" width="9.5" height="3.5" units="mm"/>
             </model>
             <model model="LokSound 5 L" maxFnNum="31" numOuts="20" maxMotorCurrent="3A" extFnsESU="V5" productID="33554589,16777442,33554653">
                 <size length="51.8" width="25.4" height="14" units="mm"/>
@@ -112,9 +122,6 @@
             </model>
             <model model="LokSound 5 micro KATO" maxFnNum="31" numOuts="20" maxMotorCurrent="0.75A" extFnsESU="V5" productID="16777405">
                 <size length="21.0" width="10.6" height="4.0" units="mm"/>
-            </model>
-            <model model="LokSound 5 micro DCC Direct Atlas Legacy" maxFnNum="31" numOuts="6" maxMotorCurrent="0.75A" extFnsESU="V5" productID="16777432">
-                <size length="66.0" width="8.2" height="3.0" units="mm"/>
             </model>
             <xi:include href="http://jmri.org/xml/decoders/esu/v5lsOutputLabels.xml"/>
             <functionlabels>

--- a/xml/decoders/esu/susiMapPane.xml
+++ b/xml/decoders/esu/susiMapPane.xml
@@ -7,7 +7,7 @@
       xmlns:docbook="http://docbook.org/ns/docbook"
       xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd"
       include="ESU LokSound V4.0,LokSound Select direct / micro,ESU LokSound 5,ESU LokPilot 5"
-      exclude="Essential Sound Unit,LokPilot 5 Fx micro,LokPilot 5 Fx micro DCC,LokPilot 5 micro,LokPilot 5 micro DCC,LokSound 5 micro DCC Direct">
+      exclude="Essential Sound Unit,LokPilot 5 Fx micro,LokPilot 5 Fx micro DCC,LokPilot 5 micro,LokPilot 5 micro DCC,LokPilot 5 micro DCC Direct,LokSound 5 micro DCC Direct,LokSound 5 micro DCC Direct Atlas Legacy,LokSound 5 micro DCC Direct Atlas S2">
     <name>SUSI Map</name>
     <column>
         <label>

--- a/xml/decoders/esu/v5fnOutCVs.xml
+++ b/xml/decoders/esu/v5fnOutCVs.xml
@@ -923,6 +923,8 @@
         </qualifier>
         <decVal max="127"/>
     </variable>
+    <!-- exclude AUX2 [1] to AUX18 -->
+    <variables exclude="LokSound 5 micro DCC Direct Atlas S2">
     <!-- AUX2 [1] Mode -->
     <variable label="AUX2 [1] Mode" CV="16.0.283" default="1" item="ESU FnOut A2-1 Mode">
         <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
@@ -3075,7 +3077,7 @@
                     </variable>
                 </variables>
                 <!-- exclude AUX9 to AUX18 -->
-                <variables exclude="LokSound 5 micro DCC Direct">
+                <variables exclude="LokPilot 5 micro DCC Direct,LokSound 5 micro DCC Direct">
                     <!-- AUX9 Mode -->
                     <variable label="AUX9 Mode" CV="16.0.339" default="1" item="ESU FnOut A9 Mode">
                         <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
@@ -6257,6 +6259,7 @@
             </variables>
         </variables>
     </variables>
+    </variables>
     <!-- Exclude [2] outputs to avoid tripping over a firmware bug -->
     <!-- At least up to 5.8.156 (current as of writing this) these functions are not -->
     <!-- accessible through standard CV programming on ESU 58751 -->
@@ -7180,6 +7183,8 @@
 	    </qualifier>
 	    <decVal max="127"/>
 	</variable>
+        <!-- exclude AUX2 [2] -->
+        <variables exclude="LokSound 5 micro DCC Direct Atlas S2">
 	<!-- AUX2 [2] Mode -->
 	<variable label="AUX2 [2] Mode" CV="16.0.443" default="1" item="ESU FnOut A2-2 Mode">
 	    <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
@@ -7487,4 +7492,5 @@
 	    <decVal max="127"/>
 	</variable>
     </variables>
+</variables>
 </variables>

--- a/xml/decoders/esu/v5fnOutCVs.xml
+++ b/xml/decoders/esu/v5fnOutCVs.xml
@@ -923,380 +923,74 @@
         </qualifier>
         <decVal max="127"/>
     </variable>
-    <!-- AUX2 [1] Mode -->
-    <variable label="AUX2 [1] Mode" CV="16.0.283" default="1" item="ESU FnOut A2-1 Mode">
-        <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
-    </variable>
-    <variable label="Function Switch On Delay" CV="16.0.284" default="0" item="ESU FnOut A2-1 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>gt</relation>
-            <value>0</value>
-        </qualifier>
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>ne</relation>
-            <value>27</value>
-        </qualifier>
-        <decVal max="15"/>
-        <label xml:lang="de">Verzögerung beim Einschalten</label>
-    </variable>
-    <variable label="Function Switch Off Delay" CV="16.0.284" default="0" mask="VVVVXXXX" item="ESU FnOut A2-1 Slider 2" tooltip="Units = 0.4 sec">
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>gt</relation>
-            <value>0</value>
-        </qualifier>
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>ne</relation>
-            <value>27</value>
-        </qualifier>
-        <decVal max="15"/>
-        <label xml:lang="de">Verzögerung beim Ausschalten</label>
-    </variable>
-    <variable label="Function Auto Switch Off" CV="16.0.285" default="0" item="ESU FnOut A2-1 Slider 3" tooltip="Units = 0.4 sec">
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>gt</relation>
-            <value>0</value>
-        </qualifier>
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>ne</relation>
-            <value>27</value>
-        </qualifier>
-        <decVal/>
-        <label xml:lang="de">Ausgang automatisch Ausschalten</label>
-    </variable>
-    <variable item="Brightness CV286" label="Brightness CV" CV="16.0.286" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
-        <decVal/>
-    </variable>
-    <variable label="Brightness" CV="16.0.286" default="31" item="ESU FnOut A2-1 Slider 5" mask="XXXVVVVV">
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>gt</relation>
-            <value>0</value>
-        </qualifier>
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>le</relation>
-            <value>18</value>
-        </qualifier>
-        <decVal max="31"/>
-        <label xml:lang="de">Helligkeit</label>
-    </variable>
-    <variable label="Mode" CV="16.0.286" default="0" item="ESU FnOut A2-1 Option 1" mask="XXXXXXXV">
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>eq</relation>
-            <value>22</value>
-        </qualifier>
-        <enumVal>
-            <enumChoice choice="Heating control">
-                <choice>Heating control</choice>
-                <choice xml:lang="de">Heizungssteuerung</choice>
-            </enumChoice>
-            <enumChoice choice="Fan control">
-                <choice>Fan control</choice>
-                <choice xml:lang="de">Lüftersteuerung</choice>
-            </enumChoice>
-        </enumVal>
-        <label xml:lang="de">Modus</label>
-    </variable>
-    <variable label="Coupler Force" CV="16.0.286" default="31" item="ESU FnOut A2-1 Slider 7" mask="XXXVVVVV">
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>ge</relation>
-            <value>28</value>
-        </qualifier>
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>ne</relation>
-            <value>29</value>
-        </qualifier>
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>ne</relation>
-            <value>30</value>
-        </qualifier>
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>ne</relation>
-            <value>31</value>
-        </qualifier>
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>ne</relation>
-            <value>32</value>
-        </qualifier>
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>le</relation>
-            <value>33</value>
-        </qualifier>
-        <decVal max="31"/>
-        <label xml:lang="de">Stärke des Kupplers</label>
-    </variable>
-    <variable label="Fan Speed" CV="16.0.286" default="31" item="ESU FnOut A2-1 Slider 11" mask="XXXVVVVV">
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>eq</relation>
-            <value>23</value>
-        </qualifier>
-        <decVal max="31"/>
-        <label xml:lang="de">Geschwindigkeit</label>
-    </variable>
-    <variable label="Standing heat" CV="16.0.286" default="31" item="ESU FnOut A2-1 Slider 14" mask="XXXVVVVV">
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>eq</relation>
-            <value>24</value>
-        </qualifier>
-        <decVal max="31"/>
-        <label xml:lang="de">Heizstufe im Stand</label>
-    </variable>
-    <variable label="Chuff power" CV="16.0.286" default="31" item="ESU FnOut A2-1 Slider 8" mask="XXXVVVVV">
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>eq</relation>
-            <value>25</value>
-        </qualifier>
-        <decVal max="31"/>
-        <label xml:lang="de">Dampfstoßstärke</label>
-    </variable>
-    <variable item="Special Function CV287" label="Special Function CV 1" CV="16.0.287" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
-        <decVal/>
-    </variable>
-    <variable label="Fan Acceleration rate" CV="16.0.287" default="0" item="ESU FnOut A2-1 Slider 12" mask="XXXVVVVV">
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>eq</relation>
-            <value>23</value>
-        </qualifier>
-        <decVal max="31"/>
-        <label xml:lang="de">Beschleunigungszeit</label>
-    </variable>
-    <variable label="Minimum driving heat" CV="16.0.287" default="0" item="ESU FnOut A2-1 Slider 15" mask="XXXVVVVV">
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>eq</relation>
-            <value>24</value>
-        </qualifier>
-        <decVal max="31"/>
-        <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
-    </variable>
-    <variable label="Fan power" CV="16.0.287" default="0" item="ESU FnOut A2-1 Slider 9" mask="XXXVVVVV">
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>eq</relation>
-            <value>25</value>
-        </qualifier>
-        <decVal max="31"/>
-        <label xml:lang="de">Stäke des Bläsers</label>
-    </variable>
-    <variable label="Phase Reverse" CV="16.0.287" default="0" item="ESU FnOut A2-1 Check 6" mask="XXXXXXXV">
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>gt</relation>
-            <value>0</value>
-        </qualifier>
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>le</relation>
-            <value>15</value>
-        </qualifier>
-        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-        <label xml:lang="de">Phase tauschen</label>
-    </variable>
-    <variable label="Grade Crossing" CV="16.0.287" default="0" item="ESU FnOut A2-1 Check 1" mask="XXXXXXVX">
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>gt</relation>
-            <value>0</value>
-        </qualifier>
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>le</relation>
-            <value>15</value>
-        </qualifier>
-        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-    </variable>
-    <variable label="Rule 17 Fwd" CV="16.0.287" default="0" item="ESU FnOut A2-1 Check 2" mask="XXXXXVXX">
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>gt</relation>
-            <value>0</value>
-        </qualifier>
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>le</relation>
-            <value>15</value>
-        </qualifier>
-        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-        <label xml:lang="de">Rule 17 vorwärts</label>
-    </variable>
-    <variable label="Rule 17 Rev" CV="16.0.287" default="0" item="ESU FnOut A2-1 Check 3" mask="XXXXVXXX">
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>gt</relation>
-            <value>0</value>
-        </qualifier>
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>le</relation>
-            <value>15</value>
-        </qualifier>
-        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-        <label xml:lang="de">Rule 17 rückwärts</label>
-    </variable>
-    <variable label="Dimmer" CV="16.0.287" default="0" item="ESU FnOut A2-1 Check 4" mask="XXXVXXXX">
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>gt</relation>
-            <value>0</value>
-        </qualifier>
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>le</relation>
-            <value>15</value>
-        </qualifier>
-        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-        <label xml:lang="de">Abdimmen</label>
-    </variable>
-    <variable label="LED Mode" CV="16.0.287" default="0" item="ESU FnOut A2-1 Check 5" mask="VXXXXXXX">
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>gt</relation>
-            <value>0</value>
-        </qualifier>
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>le</relation>
-            <value>15</value>
-        </qualifier>
-        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-        <label xml:lang="de">LED Modus</label>
-    </variable>
-    <variable item="Special Function CV288" label="Special Function CV 2" CV="16.0.288" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
-        <decVal/>
-    </variable>
-    <variable label="Fan Decceleration rate" CV="16.0.288" default="0" item="ESU FnOut A2-1 Slider 13" mask="XXXVVVVV">
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>eq</relation>
-            <value>23</value>
-        </qualifier>
-        <decVal max="31"/>
-        <label xml:lang="de">Bremszeit</label>
-    </variable>
-    <variable label="Maximum driving heat" CV="16.0.288" default="0" item="ESU FnOut A2-1 Slider 16" mask="XXXVVVVV">
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>eq</relation>
-            <value>24</value>
-        </qualifier>
-        <decVal max="31"/>
-        <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
-    </variable>
-    <variable label="Timeout" CV="16.0.288" default="0" item="ESU FnOut A2-1 Slider 10" tooltip="Units = 0.25 sec">
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>eq</relation>
-            <value>25</value>
-        </qualifier>
-        <decVal/>
-    </variable>
-    <variable label="Startup Time" CV="16.0.288" default="0" item="ESU FnOut A2-1 Slider 6">
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>ge</relation>
-            <value>16</value>
-        </qualifier>
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>le</relation>
-            <value>17</value>
-        </qualifier>
-        <decVal/>
-        <label xml:lang="de">Startzeit</label>
-    </variable>
-    <variable label="Level" CV="16.0.288" default="0" item="ESU FnOut A2-1 Slider 20" mask="XVVVVVVV">
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>eq</relation>
-            <value>19</value>
-        </qualifier>
-        <decVal max="127"/>
-    </variable>
-    <!-- exclude AUX3 to AUX18 -->
-    <variables exclude="Essential Sound Unit">
-        <!-- AUX3 Mode -->
-        <variable label="AUX3 Mode" CV="16.0.291" default="1" item="ESU FnOut A3 Mode">
+    <!-- exclude AUX2 [1] to AUX 18 -->
+    <variables exclude="LokSound 5 micro DCC Direct Atlas S2">
+        <!-- AUX2 [1] Mode -->
+        <variable label="AUX2 [1] Mode" CV="16.0.283" default="1" item="ESU FnOut A2-1 Mode">
             <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
         </variable>
-        <variable label="Function Switch On Delay" CV="16.0.292" default="0" item="ESU FnOut A3 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
+        <variable label="Function Switch On Delay" CV="16.0.284" default="0" item="ESU FnOut A2-1 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
             <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>gt</relation>
                 <value>0</value>
             </qualifier>
             <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>ne</relation>
                 <value>27</value>
             </qualifier>
             <decVal max="15"/>
             <label xml:lang="de">Verzögerung beim Einschalten</label>
         </variable>
-        <variable label="Function Switch Off Delay" CV="16.0.292" default="0" mask="VVVVXXXX" item="ESU FnOut A3 Slider 2" tooltip="Units = 0.4 sec">
+        <variable label="Function Switch Off Delay" CV="16.0.284" default="0" mask="VVVVXXXX" item="ESU FnOut A2-1 Slider 2" tooltip="Units = 0.4 sec">
             <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>gt</relation>
                 <value>0</value>
             </qualifier>
             <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>ne</relation>
                 <value>27</value>
             </qualifier>
             <decVal max="15"/>
             <label xml:lang="de">Verzögerung beim Ausschalten</label>
         </variable>
-        <variable label="Function Auto Switch Off" CV="16.0.293" default="0" item="ESU FnOut A3 Slider 3" tooltip="Units = 0.4 sec">
+        <variable label="Function Auto Switch Off" CV="16.0.285" default="0" item="ESU FnOut A2-1 Slider 3" tooltip="Units = 0.4 sec">
             <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>gt</relation>
                 <value>0</value>
             </qualifier>
             <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>ne</relation>
                 <value>27</value>
             </qualifier>
             <decVal/>
             <label xml:lang="de">Ausgang automatisch Ausschalten</label>
         </variable>
-        <variable item="Brightness CV294" label="Brightness CV" CV="16.0.294" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
+        <variable item="Brightness CV286" label="Brightness CV" CV="16.0.286" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
             <decVal/>
         </variable>
-        <variable label="Brightness" CV="16.0.294" default="31" item="ESU FnOut A3 Slider 5" mask="XXXVVVVV">
+        <variable label="Brightness" CV="16.0.286" default="31" item="ESU FnOut A2-1 Slider 5" mask="XXXVVVVV">
             <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>gt</relation>
                 <value>0</value>
             </qualifier>
             <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>le</relation>
                 <value>18</value>
             </qualifier>
             <decVal max="31"/>
             <label xml:lang="de">Helligkeit</label>
         </variable>
-        <variable label="Mode" CV="16.0.294" default="0" item="ESU FnOut A3 Option 1" mask="XXXXXXXV">
+        <variable label="Mode" CV="16.0.286" default="0" item="ESU FnOut A2-1 Option 1" mask="XXXXXXXV">
             <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>eq</relation>
                 <value>22</value>
             </qualifier>
@@ -1312,605 +1006,299 @@
             </enumVal>
             <label xml:lang="de">Modus</label>
         </variable>
-        <variable label="Coupler Force" CV="16.0.294" default="31" item="ESU FnOut A3 Slider 7" mask="XXXVVVVV">
+        <variable label="Coupler Force" CV="16.0.286" default="31" item="ESU FnOut A2-1 Slider 7" mask="XXXVVVVV">
             <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>ge</relation>
                 <value>28</value>
             </qualifier>
             <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>ne</relation>
                 <value>29</value>
             </qualifier>
             <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>ne</relation>
                 <value>30</value>
             </qualifier>
             <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>ne</relation>
                 <value>31</value>
             </qualifier>
             <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>ne</relation>
                 <value>32</value>
             </qualifier>
             <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>le</relation>
                 <value>33</value>
             </qualifier>
             <decVal max="31"/>
             <label xml:lang="de">Stärke des Kupplers</label>
         </variable>
-        <variable label="Fan Speed" CV="16.0.294" default="31" item="ESU FnOut A3 Slider 11" mask="XXXVVVVV">
+        <variable label="Fan Speed" CV="16.0.286" default="31" item="ESU FnOut A2-1 Slider 11" mask="XXXVVVVV">
             <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>eq</relation>
                 <value>23</value>
             </qualifier>
             <decVal max="31"/>
             <label xml:lang="de">Geschwindigkeit</label>
         </variable>
-        <variable label="Standing heat" CV="16.0.294" default="31" item="ESU FnOut A3 Slider 14" mask="XXXVVVVV">
+        <variable label="Standing heat" CV="16.0.286" default="31" item="ESU FnOut A2-1 Slider 14" mask="XXXVVVVV">
             <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>eq</relation>
                 <value>24</value>
             </qualifier>
             <decVal max="31"/>
             <label xml:lang="de">Heizstufe im Stand</label>
         </variable>
-        <variable label="Chuff power" CV="16.0.294" default="31" item="ESU FnOut A3 Slider 8" mask="XXXVVVVV">
+        <variable label="Chuff power" CV="16.0.286" default="31" item="ESU FnOut A2-1 Slider 8" mask="XXXVVVVV">
             <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>eq</relation>
                 <value>25</value>
             </qualifier>
             <decVal max="31"/>
             <label xml:lang="de">Dampfstoßstärke</label>
         </variable>
-        <variable item="Special Function CV295" label="Special Function CV 1" CV="16.0.295" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+        <variable item="Special Function CV287" label="Special Function CV 1" CV="16.0.287" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
             <decVal/>
         </variable>
-        <variable label="Fan Acceleration rate" CV="16.0.295" default="0" item="ESU FnOut A3 Slider 12" mask="XXXVVVVV">
+        <variable label="Fan Acceleration rate" CV="16.0.287" default="0" item="ESU FnOut A2-1 Slider 12" mask="XXXVVVVV">
             <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>eq</relation>
                 <value>23</value>
             </qualifier>
             <decVal max="31"/>
             <label xml:lang="de">Beschleunigungszeit</label>
         </variable>
-        <variable label="Minimum driving heat" CV="16.0.295" default="0" item="ESU FnOut A3 Slider 15" mask="XXXVVVVV">
+        <variable label="Minimum driving heat" CV="16.0.287" default="0" item="ESU FnOut A2-1 Slider 15" mask="XXXVVVVV">
             <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>eq</relation>
                 <value>24</value>
             </qualifier>
             <decVal max="31"/>
             <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
         </variable>
-        <variable label="Fan power" CV="16.0.295" default="0" item="ESU FnOut A3 Slider 9" mask="XXXVVVVV">
+        <variable label="Fan power" CV="16.0.287" default="0" item="ESU FnOut A2-1 Slider 9" mask="XXXVVVVV">
             <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>eq</relation>
                 <value>25</value>
             </qualifier>
             <decVal max="31"/>
             <label xml:lang="de">Stäke des Bläsers</label>
         </variable>
-        <variable label="Phase Reverse" CV="16.0.295" default="0" item="ESU FnOut A3 Check 6" mask="XXXXXXXV">
+        <variable label="Phase Reverse" CV="16.0.287" default="0" item="ESU FnOut A2-1 Check 6" mask="XXXXXXXV">
             <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>gt</relation>
                 <value>0</value>
             </qualifier>
             <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>le</relation>
                 <value>15</value>
             </qualifier>
             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
             <label xml:lang="de">Phase tauschen</label>
         </variable>
-        <variable label="Grade Crossing" CV="16.0.295" default="0" item="ESU FnOut A3 Check 1" mask="XXXXXXVX">
+        <variable label="Grade Crossing" CV="16.0.287" default="0" item="ESU FnOut A2-1 Check 1" mask="XXXXXXVX">
             <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>gt</relation>
                 <value>0</value>
             </qualifier>
             <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>le</relation>
                 <value>15</value>
             </qualifier>
             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
         </variable>
-        <variable label="Rule 17 Fwd" CV="16.0.295" default="0" item="ESU FnOut A3 Check 2" mask="XXXXXVXX">
+        <variable label="Rule 17 Fwd" CV="16.0.287" default="0" item="ESU FnOut A2-1 Check 2" mask="XXXXXVXX">
             <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>gt</relation>
                 <value>0</value>
             </qualifier>
             <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
-                <relation>le</relation>
-                <value>15</value>
-            </qualifier>
-            <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-            <label xml:lang="de">Rule 17 vorwärts</label>
-        </variable>
-        <variable label="Rule 17 Rev" CV="16.0.295" default="0" item="ESU FnOut A3 Check 3" mask="XXXXVXXX">
-            <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
-                <relation>gt</relation>
-                <value>0</value>
-            </qualifier>
-            <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
-                <relation>le</relation>
-                <value>15</value>
-            </qualifier>
-            <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-            <label xml:lang="de">Rule 17 rückwärts</label>
-        </variable>
-        <variable label="Dimmer" CV="16.0.295" default="0" item="ESU FnOut A3 Check 4" mask="XXXVXXXX">
-            <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
-                <relation>gt</relation>
-                <value>0</value>
-            </qualifier>
-            <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
-                <relation>le</relation>
-                <value>15</value>
-            </qualifier>
-            <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-            <label xml:lang="de">Abdimmen</label>
-        </variable>
-        <variable label="LED Mode" CV="16.0.295" default="0" item="ESU FnOut A3 Check 5" mask="VXXXXXXX">
-            <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
-                <relation>gt</relation>
-                <value>0</value>
-            </qualifier>
-            <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
-                <relation>le</relation>
-                <value>15</value>
-            </qualifier>
-            <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-            <label xml:lang="de">LED Modus</label>
-        </variable>
-        <variable item="Special Function CV296" label="Special Function CV 2" CV="16.0.296" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
-            <decVal/>
-        </variable>
-        <variable label="Fan Decceleration rate" CV="16.0.296" default="0" item="ESU FnOut A3 Slider 13" mask="XXXVVVVV">
-            <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
-                <relation>eq</relation>
-                <value>23</value>
-            </qualifier>
-            <decVal max="31"/>
-            <label xml:lang="de">Bremszeit</label>
-        </variable>
-        <variable label="Maximum driving heat" CV="16.0.296" default="0" item="ESU FnOut A3 Slider 16" mask="XXXVVVVV">
-            <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
-                <relation>eq</relation>
-                <value>24</value>
-            </qualifier>
-            <decVal max="31"/>
-            <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
-        </variable>
-        <variable label="Timeout" CV="16.0.296" default="0" item="ESU FnOut A3 Slider 10" tooltip="Units = 0.25 sec">
-            <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
-                <relation>eq</relation>
-                <value>25</value>
-            </qualifier>
-            <decVal/>
-        </variable>
-        <variable label="Startup Time" CV="16.0.296" default="0" item="ESU FnOut A3 Slider 6">
-            <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
-                <relation>ge</relation>
-                <value>16</value>
-            </qualifier>
-            <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
-                <relation>le</relation>
-                <value>17</value>
-            </qualifier>
-            <decVal/>
-            <label xml:lang="de">Startzeit</label>
-        </variable>
-        <variable label="Level" CV="16.0.296" default="0" item="ESU FnOut A3 Slider 20" mask="XVVVVVVV">
-            <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
-                <relation>eq</relation>
-                <value>19</value>
-            </qualifier>
-            <decVal max="127"/>
-        </variable>
-        <!-- AUX4 Mode -->
-        <variable label="AUX4 Mode" CV="16.0.299" default="1" item="ESU FnOut A4 Mode">
-            <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
-        </variable>
-        <variable label="Function Switch On Delay" CV="16.0.300" default="0" item="ESU FnOut A4 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
-            <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
-                <relation>gt</relation>
-                <value>0</value>
-            </qualifier>
-            <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
-                <relation>ne</relation>
-                <value>27</value>
-            </qualifier>
-            <decVal max="15"/>
-            <label xml:lang="de">Verzögerung beim Einschalten</label>
-        </variable>
-        <variable label="Function Switch Off Delay" CV="16.0.300" default="0" mask="VVVVXXXX" item="ESU FnOut A4 Slider 2" tooltip="Units = 0.4 sec">
-            <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
-                <relation>gt</relation>
-                <value>0</value>
-            </qualifier>
-            <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
-                <relation>ne</relation>
-                <value>27</value>
-            </qualifier>
-            <decVal max="15"/>
-            <label xml:lang="de">Verzögerung beim Ausschalten</label>
-        </variable>
-        <variable label="Function Auto Switch Off" CV="16.0.301" default="0" item="ESU FnOut A4 Slider 3" tooltip="Units = 0.4 sec">
-            <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
-                <relation>gt</relation>
-                <value>0</value>
-            </qualifier>
-            <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
-                <relation>ne</relation>
-                <value>27</value>
-            </qualifier>
-            <decVal/>
-            <label xml:lang="de">Ausgang automatisch Ausschalten</label>
-        </variable>
-        <variable item="Brightness CV302" label="Brightness CV" CV="16.0.302" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
-            <decVal/>
-        </variable>
-        <variable label="Brightness" CV="16.0.302" default="31" item="ESU FnOut A4 Slider 5" mask="XXXVVVVV">
-            <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
-                <relation>gt</relation>
-                <value>0</value>
-            </qualifier>
-            <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
-                <relation>le</relation>
-                <value>18</value>
-            </qualifier>
-            <decVal max="31"/>
-            <label xml:lang="de">Helligkeit</label>
-        </variable>
-        <variable label="Mode" CV="16.0.302" default="0" item="ESU FnOut A4 Option 1" mask="XXXXXXXV">
-            <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
-                <relation>eq</relation>
-                <value>22</value>
-            </qualifier>
-            <enumVal>
-                <enumChoice choice="Heating control">
-                    <choice>Heating control</choice>
-                    <choice xml:lang="de">Heizungssteuerung</choice>
-                </enumChoice>
-                <enumChoice choice="Fan control">
-                    <choice>Fan control</choice>
-                    <choice xml:lang="de">Lüftersteuerung</choice>
-                </enumChoice>
-            </enumVal>
-            <label xml:lang="de">Modus</label>
-        </variable>
-        <variable label="Coupler Force" CV="16.0.302" default="31" item="ESU FnOut A4 Slider 7" mask="XXXVVVVV">
-            <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
-                <relation>ge</relation>
-                <value>28</value>
-            </qualifier>
-            <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
-                <relation>ne</relation>
-                <value>29</value>
-            </qualifier>
-            <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
-                <relation>ne</relation>
-                <value>30</value>
-            </qualifier>
-            <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
-                <relation>ne</relation>
-                <value>31</value>
-            </qualifier>
-            <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
-                <relation>ne</relation>
-                <value>32</value>
-            </qualifier>
-            <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
-                <relation>le</relation>
-                <value>33</value>
-            </qualifier>
-            <decVal max="31"/>
-            <label xml:lang="de">Stärke des Kupplers</label>
-        </variable>
-        <variable label="Fan Speed" CV="16.0.302" default="31" item="ESU FnOut A4 Slider 11" mask="XXXVVVVV">
-            <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
-                <relation>eq</relation>
-                <value>23</value>
-            </qualifier>
-            <decVal max="31"/>
-            <label xml:lang="de">Geschwindigkeit</label>
-        </variable>
-        <variable label="Standing heat" CV="16.0.302" default="31" item="ESU FnOut A4 Slider 14" mask="XXXVVVVV">
-            <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
-                <relation>eq</relation>
-                <value>24</value>
-            </qualifier>
-            <decVal max="31"/>
-            <label xml:lang="de">Heizstufe im Stand</label>
-        </variable>
-        <variable label="Chuff power" CV="16.0.302" default="31" item="ESU FnOut A4 Slider 8" mask="XXXVVVVV">
-            <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
-                <relation>eq</relation>
-                <value>25</value>
-            </qualifier>
-            <decVal max="31"/>
-            <label xml:lang="de">Dampfstoßstärke</label>
-        </variable>
-        <variable item="Special Function CV303" label="Special Function CV 1" CV="16.0.303" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
-            <decVal/>
-        </variable>
-        <variable label="Fan Acceleration rate" CV="16.0.303" default="0" item="ESU FnOut A4 Slider 12" mask="XXXVVVVV">
-            <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
-                <relation>eq</relation>
-                <value>23</value>
-            </qualifier>
-            <decVal max="31"/>
-            <label xml:lang="de">Beschleunigungszeit</label>
-        </variable>
-        <variable label="Minimum driving heat" CV="16.0.303" default="0" item="ESU FnOut A4 Slider 15" mask="XXXVVVVV">
-            <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
-                <relation>eq</relation>
-                <value>24</value>
-            </qualifier>
-            <decVal max="31"/>
-            <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
-        </variable>
-        <variable label="Fan power" CV="16.0.303" default="0" item="ESU FnOut A4 Slider 9" mask="XXXVVVVV">
-            <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
-                <relation>eq</relation>
-                <value>25</value>
-            </qualifier>
-            <decVal max="31"/>
-            <label xml:lang="de">Stäke des Bläsers</label>
-        </variable>
-        <variable label="Phase Reverse" CV="16.0.303" default="0" item="ESU FnOut A4 Check 6" mask="XXXXXXXV">
-            <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
-                <relation>gt</relation>
-                <value>0</value>
-            </qualifier>
-            <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
-                <relation>le</relation>
-                <value>15</value>
-            </qualifier>
-            <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-            <label xml:lang="de">Phase tauschen</label>
-        </variable>
-        <variable label="Grade Crossing" CV="16.0.303" default="0" item="ESU FnOut A4 Check 1" mask="XXXXXXVX">
-            <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
-                <relation>gt</relation>
-                <value>0</value>
-            </qualifier>
-            <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
-                <relation>le</relation>
-                <value>15</value>
-            </qualifier>
-            <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-        </variable>
-        <variable label="Rule 17 Fwd" CV="16.0.303" default="0" item="ESU FnOut A4 Check 2" mask="XXXXXVXX">
-            <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
-                <relation>gt</relation>
-                <value>0</value>
-            </qualifier>
-            <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>le</relation>
                 <value>15</value>
             </qualifier>
             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
             <label xml:lang="de">Rule 17 vorwärts</label>
         </variable>
-        <variable label="Rule 17 Rev" CV="16.0.303" default="0" item="ESU FnOut A4 Check 3" mask="XXXXVXXX">
+        <variable label="Rule 17 Rev" CV="16.0.287" default="0" item="ESU FnOut A2-1 Check 3" mask="XXXXVXXX">
             <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>gt</relation>
                 <value>0</value>
             </qualifier>
             <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>le</relation>
                 <value>15</value>
             </qualifier>
             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
             <label xml:lang="de">Rule 17 rückwärts</label>
         </variable>
-        <variable label="Dimmer" CV="16.0.303" default="0" item="ESU FnOut A4 Check 4" mask="XXXVXXXX">
+        <variable label="Dimmer" CV="16.0.287" default="0" item="ESU FnOut A2-1 Check 4" mask="XXXVXXXX">
             <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>gt</relation>
                 <value>0</value>
             </qualifier>
             <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>le</relation>
                 <value>15</value>
             </qualifier>
             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
             <label xml:lang="de">Abdimmen</label>
         </variable>
-        <variable label="LED Mode" CV="16.0.303" default="0" item="ESU FnOut A4 Check 5" mask="VXXXXXXX">
+        <variable label="LED Mode" CV="16.0.287" default="0" item="ESU FnOut A2-1 Check 5" mask="VXXXXXXX">
             <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>gt</relation>
                 <value>0</value>
             </qualifier>
             <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>le</relation>
                 <value>15</value>
             </qualifier>
             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
             <label xml:lang="de">LED Modus</label>
         </variable>
-        <variable item="Special Function CV304" label="Special Function CV 2" CV="16.0.304" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+        <variable item="Special Function CV288" label="Special Function CV 2" CV="16.0.288" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
             <decVal/>
         </variable>
-        <variable label="Fan Decceleration rate" CV="16.0.304" default="0" item="ESU FnOut A4 Slider 13" mask="XXXVVVVV">
+        <variable label="Fan Decceleration rate" CV="16.0.288" default="0" item="ESU FnOut A2-1 Slider 13" mask="XXXVVVVV">
             <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>eq</relation>
                 <value>23</value>
             </qualifier>
             <decVal max="31"/>
             <label xml:lang="de">Bremszeit</label>
         </variable>
-        <variable label="Maximum driving heat" CV="16.0.304" default="0" item="ESU FnOut A4 Slider 16" mask="XXXVVVVV">
+        <variable label="Maximum driving heat" CV="16.0.288" default="0" item="ESU FnOut A2-1 Slider 16" mask="XXXVVVVV">
             <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>eq</relation>
                 <value>24</value>
             </qualifier>
             <decVal max="31"/>
             <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
         </variable>
-        <variable label="Timeout" CV="16.0.304" default="0" item="ESU FnOut A4 Slider 10" tooltip="Units = 0.25 sec">
+        <variable label="Timeout" CV="16.0.288" default="0" item="ESU FnOut A2-1 Slider 10" tooltip="Units = 0.25 sec">
             <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>eq</relation>
                 <value>25</value>
             </qualifier>
             <decVal/>
         </variable>
-        <variable label="Startup Time" CV="16.0.304" default="0" item="ESU FnOut A4 Slider 6">
+        <variable label="Startup Time" CV="16.0.288" default="0" item="ESU FnOut A2-1 Slider 6">
             <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>ge</relation>
                 <value>16</value>
             </qualifier>
             <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>le</relation>
                 <value>17</value>
             </qualifier>
             <decVal/>
             <label xml:lang="de">Startzeit</label>
         </variable>
-        <variable label="Level" CV="16.0.304" default="0" item="ESU FnOut A4 Slider 20" mask="XVVVVVVV">
+        <variable label="Level" CV="16.0.288" default="0" item="ESU FnOut A2-1 Slider 20" mask="XVVVVVVV">
             <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>eq</relation>
                 <value>19</value>
             </qualifier>
             <decVal max="127"/>
         </variable>
-        <!-- exclude AUX5 to AUX18 -->
-        <variables exclude="LokPilot 5 micro,LokPilot 5 micro DCC,LokSound 5 micro DCC Direct Atlas Legacy">
-            <!-- AUX5 Mode -->
-            <variable label="AUX5 Mode" CV="16.0.307" default="1" item="ESU FnOut A5 Mode">
+        <!-- exclude AUX3 to AUX18 -->
+        <variables exclude="Essential Sound Unit">
+            <!-- AUX3 Mode -->
+            <variable label="AUX3 Mode" CV="16.0.291" default="1" item="ESU FnOut A3 Mode">
                 <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
             </variable>
-            <variable label="Function Switch On Delay" CV="16.0.308" default="0" item="ESU FnOut A5 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
+            <variable label="Function Switch On Delay" CV="16.0.292" default="0" item="ESU FnOut A3 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>gt</relation>
                     <value>0</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>ne</relation>
                     <value>27</value>
                 </qualifier>
                 <decVal max="15"/>
                 <label xml:lang="de">Verzögerung beim Einschalten</label>
             </variable>
-            <variable label="Function Switch Off Delay" CV="16.0.308" default="0" mask="VVVVXXXX" item="ESU FnOut A5 Slider 2" tooltip="Units = 0.4 sec">
+            <variable label="Function Switch Off Delay" CV="16.0.292" default="0" mask="VVVVXXXX" item="ESU FnOut A3 Slider 2" tooltip="Units = 0.4 sec">
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>gt</relation>
                     <value>0</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>ne</relation>
                     <value>27</value>
                 </qualifier>
                 <decVal max="15"/>
                 <label xml:lang="de">Verzögerung beim Ausschalten</label>
             </variable>
-            <variable label="Function Auto Switch Off" CV="16.0.309" default="0" item="ESU FnOut A5 Slider 3" tooltip="Units = 0.4 sec">
+            <variable label="Function Auto Switch Off" CV="16.0.293" default="0" item="ESU FnOut A3 Slider 3" tooltip="Units = 0.4 sec">
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>gt</relation>
                     <value>0</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>ne</relation>
                     <value>27</value>
                 </qualifier>
                 <decVal/>
                 <label xml:lang="de">Ausgang automatisch Ausschalten</label>
             </variable>
-            <variable item="Brightness CV310" label="Brightness CV" CV="16.0.310" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
+            <variable item="Brightness CV294" label="Brightness CV" CV="16.0.294" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
                 <decVal/>
             </variable>
-            <variable label="Brightness" CV="16.0.310" default="31" item="ESU FnOut A5 Slider 5" mask="XXXVVVVV">
+            <variable label="Brightness" CV="16.0.294" default="31" item="ESU FnOut A3 Slider 5" mask="XXXVVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>gt</relation>
                     <value>0</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>le</relation>
                     <value>18</value>
                 </qualifier>
                 <decVal max="31"/>
                 <label xml:lang="de">Helligkeit</label>
             </variable>
-            <variable label="Mode" CV="16.0.310" default="0" item="ESU FnOut A5 Option 1" mask="XXXXXXXV">
+            <variable label="Mode" CV="16.0.294" default="0" item="ESU FnOut A3 Option 1" mask="XXXXXXXV">
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>eq</relation>
                     <value>22</value>
                 </qualifier>
@@ -1926,297 +1314,297 @@
                 </enumVal>
                 <label xml:lang="de">Modus</label>
             </variable>
-            <variable label="Coupler Force" CV="16.0.310" default="31" item="ESU FnOut A5 Slider 7" mask="XXXVVVVV">
+            <variable label="Coupler Force" CV="16.0.294" default="31" item="ESU FnOut A3 Slider 7" mask="XXXVVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>ge</relation>
                     <value>28</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>ne</relation>
                     <value>29</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>ne</relation>
                     <value>30</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>ne</relation>
                     <value>31</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>ne</relation>
                     <value>32</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>le</relation>
                     <value>33</value>
                 </qualifier>
                 <decVal max="31"/>
                 <label xml:lang="de">Stärke des Kupplers</label>
             </variable>
-            <variable label="Fan Speed" CV="16.0.310" default="31" item="ESU FnOut A5 Slider 11" mask="XXXVVVVV">
+            <variable label="Fan Speed" CV="16.0.294" default="31" item="ESU FnOut A3 Slider 11" mask="XXXVVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>eq</relation>
                     <value>23</value>
                 </qualifier>
                 <decVal max="31"/>
                 <label xml:lang="de">Geschwindigkeit</label>
             </variable>
-            <variable label="Standing heat" CV="16.0.310" default="31" item="ESU FnOut A5 Slider 14" mask="XXXVVVVV">
+            <variable label="Standing heat" CV="16.0.294" default="31" item="ESU FnOut A3 Slider 14" mask="XXXVVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>eq</relation>
                     <value>24</value>
                 </qualifier>
                 <decVal max="31"/>
                 <label xml:lang="de">Heizstufe im Stand</label>
             </variable>
-            <variable label="Chuff power" CV="16.0.310" default="31" item="ESU FnOut A5 Slider 8" mask="XXXVVVVV">
+            <variable label="Chuff power" CV="16.0.294" default="31" item="ESU FnOut A3 Slider 8" mask="XXXVVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>eq</relation>
                     <value>25</value>
                 </qualifier>
                 <decVal max="31"/>
                 <label xml:lang="de">Dampfstoßstärke</label>
             </variable>
-            <variable item="Special Function CV311" label="Special Function CV 1" CV="16.0.311" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+            <variable item="Special Function CV295" label="Special Function CV 1" CV="16.0.295" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
                 <decVal/>
             </variable>
-            <variable label="Fan Acceleration rate" CV="16.0.311" default="0" item="ESU FnOut A5 Slider 12" mask="XXXVVVVV">
+            <variable label="Fan Acceleration rate" CV="16.0.295" default="0" item="ESU FnOut A3 Slider 12" mask="XXXVVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>eq</relation>
                     <value>23</value>
                 </qualifier>
                 <decVal max="31"/>
                 <label xml:lang="de">Beschleunigungszeit</label>
             </variable>
-            <variable label="Minimum driving heat" CV="16.0.311" default="0" item="ESU FnOut A5 Slider 15" mask="XXXVVVVV">
+            <variable label="Minimum driving heat" CV="16.0.295" default="0" item="ESU FnOut A3 Slider 15" mask="XXXVVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>eq</relation>
                     <value>24</value>
                 </qualifier>
                 <decVal max="31"/>
                 <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
             </variable>
-            <variable label="Fan power" CV="16.0.311" default="0" item="ESU FnOut A5 Slider 9" mask="XXXVVVVV">
+            <variable label="Fan power" CV="16.0.295" default="0" item="ESU FnOut A3 Slider 9" mask="XXXVVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>eq</relation>
                     <value>25</value>
                 </qualifier>
                 <decVal max="31"/>
                 <label xml:lang="de">Stäke des Bläsers</label>
             </variable>
-            <variable label="Phase Reverse" CV="16.0.311" default="0" item="ESU FnOut A5 Check 6" mask="XXXXXXXV">
+            <variable label="Phase Reverse" CV="16.0.295" default="0" item="ESU FnOut A3 Check 6" mask="XXXXXXXV">
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>gt</relation>
                     <value>0</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>le</relation>
                     <value>15</value>
                 </qualifier>
                 <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                 <label xml:lang="de">Phase tauschen</label>
             </variable>
-            <variable label="Grade Crossing" CV="16.0.311" default="0" item="ESU FnOut A5 Check 1" mask="XXXXXXVX">
+            <variable label="Grade Crossing" CV="16.0.295" default="0" item="ESU FnOut A3 Check 1" mask="XXXXXXVX">
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>gt</relation>
                     <value>0</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>le</relation>
                     <value>15</value>
                 </qualifier>
                 <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
             </variable>
-            <variable label="Rule 17 Fwd" CV="16.0.311" default="0" item="ESU FnOut A5 Check 2" mask="XXXXXVXX">
+            <variable label="Rule 17 Fwd" CV="16.0.295" default="0" item="ESU FnOut A3 Check 2" mask="XXXXXVXX">
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>gt</relation>
                     <value>0</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>le</relation>
                     <value>15</value>
                 </qualifier>
                 <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                 <label xml:lang="de">Rule 17 vorwärts</label>
             </variable>
-            <variable label="Rule 17 Rev" CV="16.0.311" default="0" item="ESU FnOut A5 Check 3" mask="XXXXVXXX">
+            <variable label="Rule 17 Rev" CV="16.0.295" default="0" item="ESU FnOut A3 Check 3" mask="XXXXVXXX">
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>gt</relation>
                     <value>0</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>le</relation>
                     <value>15</value>
                 </qualifier>
                 <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                 <label xml:lang="de">Rule 17 rückwärts</label>
             </variable>
-            <variable label="Dimmer" CV="16.0.311" default="0" item="ESU FnOut A5 Check 4" mask="XXXVXXXX">
+            <variable label="Dimmer" CV="16.0.295" default="0" item="ESU FnOut A3 Check 4" mask="XXXVXXXX">
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>gt</relation>
                     <value>0</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>le</relation>
                     <value>15</value>
                 </qualifier>
                 <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                 <label xml:lang="de">Abdimmen</label>
             </variable>
-            <variable label="LED Mode" CV="16.0.311" default="0" item="ESU FnOut A5 Check 5" mask="VXXXXXXX">
+            <variable label="LED Mode" CV="16.0.295" default="0" item="ESU FnOut A3 Check 5" mask="VXXXXXXX">
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>gt</relation>
                     <value>0</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>le</relation>
                     <value>15</value>
                 </qualifier>
                 <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                 <label xml:lang="de">LED Modus</label>
             </variable>
-            <variable item="Special Function CV312" label="Special Function CV 2" CV="16.0.312" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+            <variable item="Special Function CV296" label="Special Function CV 2" CV="16.0.296" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
                 <decVal/>
             </variable>
-            <variable label="Fan Decceleration rate" CV="16.0.312" default="0" item="ESU FnOut A5 Slider 13" mask="XXXVVVVV">
+            <variable label="Fan Decceleration rate" CV="16.0.296" default="0" item="ESU FnOut A3 Slider 13" mask="XXXVVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>eq</relation>
                     <value>23</value>
                 </qualifier>
                 <decVal max="31"/>
                 <label xml:lang="de">Bremszeit</label>
             </variable>
-            <variable label="Maximum driving heat" CV="16.0.312" default="0" item="ESU FnOut A5 Slider 16" mask="XXXVVVVV">
+            <variable label="Maximum driving heat" CV="16.0.296" default="0" item="ESU FnOut A3 Slider 16" mask="XXXVVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>eq</relation>
                     <value>24</value>
                 </qualifier>
                 <decVal max="31"/>
                 <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
             </variable>
-            <variable label="Timeout" CV="16.0.312" default="0" item="ESU FnOut A5 Slider 10" tooltip="Units = 0.25 sec">
+            <variable label="Timeout" CV="16.0.296" default="0" item="ESU FnOut A3 Slider 10" tooltip="Units = 0.25 sec">
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>eq</relation>
                     <value>25</value>
                 </qualifier>
                 <decVal/>
             </variable>
-            <variable label="Startup Time" CV="16.0.312" default="0" item="ESU FnOut A5 Slider 6">
+            <variable label="Startup Time" CV="16.0.296" default="0" item="ESU FnOut A3 Slider 6">
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>ge</relation>
                     <value>16</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>le</relation>
                     <value>17</value>
                 </qualifier>
                 <decVal/>
                 <label xml:lang="de">Startzeit</label>
             </variable>
-            <variable label="Level" CV="16.0.312" default="0" item="ESU FnOut A5 Slider 20" mask="XVVVVVVV">
+            <variable label="Level" CV="16.0.296" default="0" item="ESU FnOut A3 Slider 20" mask="XVVVVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>eq</relation>
                     <value>19</value>
                 </qualifier>
                 <decVal max="127"/>
             </variable>
-            <!-- AUX6 Mode -->
-            <variable label="AUX6 Mode" CV="16.0.315" default="1" item="ESU FnOut A6 Mode">
+            <!-- AUX4 Mode -->
+            <variable label="AUX4 Mode" CV="16.0.299" default="1" item="ESU FnOut A4 Mode">
                 <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
             </variable>
-            <variable label="Function Switch On Delay" CV="16.0.316" default="0" item="ESU FnOut A6 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
+            <variable label="Function Switch On Delay" CV="16.0.300" default="0" item="ESU FnOut A4 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>gt</relation>
                     <value>0</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>ne</relation>
                     <value>27</value>
                 </qualifier>
                 <decVal max="15"/>
                 <label xml:lang="de">Verzögerung beim Einschalten</label>
             </variable>
-            <variable label="Function Switch Off Delay" CV="16.0.316" default="0" mask="VVVVXXXX" item="ESU FnOut A6 Slider 2" tooltip="Units = 0.4 sec">
+            <variable label="Function Switch Off Delay" CV="16.0.300" default="0" mask="VVVVXXXX" item="ESU FnOut A4 Slider 2" tooltip="Units = 0.4 sec">
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>gt</relation>
                     <value>0</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>ne</relation>
                     <value>27</value>
                 </qualifier>
                 <decVal max="15"/>
                 <label xml:lang="de">Verzögerung beim Ausschalten</label>
             </variable>
-            <variable label="Function Auto Switch Off" CV="16.0.317" default="0" item="ESU FnOut A6 Slider 3" tooltip="Units = 0.4 sec">
+            <variable label="Function Auto Switch Off" CV="16.0.301" default="0" item="ESU FnOut A4 Slider 3" tooltip="Units = 0.4 sec">
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>gt</relation>
                     <value>0</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>ne</relation>
                     <value>27</value>
                 </qualifier>
                 <decVal/>
                 <label xml:lang="de">Ausgang automatisch Ausschalten</label>
             </variable>
-            <variable item="Brightness CV318" label="Brightness CV" CV="16.0.318" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
+            <variable item="Brightness CV302" label="Brightness CV" CV="16.0.302" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
                 <decVal/>
             </variable>
-            <variable label="Brightness" CV="16.0.318" default="31" item="ESU FnOut A6 Slider 5" mask="XXXVVVVV">
+            <variable label="Brightness" CV="16.0.302" default="31" item="ESU FnOut A4 Slider 5" mask="XXXVVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>gt</relation>
                     <value>0</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>le</relation>
                     <value>18</value>
                 </qualifier>
                 <decVal max="31"/>
                 <label xml:lang="de">Helligkeit</label>
             </variable>
-            <variable label="Mode" CV="16.0.318" default="0" item="ESU FnOut A6 Option 1" mask="XXXXXXXV">
+            <variable label="Mode" CV="16.0.302" default="0" item="ESU FnOut A4 Option 1" mask="XXXXXXXV">
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>eq</relation>
                     <value>22</value>
                 </qualifier>
@@ -2232,299 +1620,299 @@
                 </enumVal>
                 <label xml:lang="de">Modus</label>
             </variable>
-            <variable label="Coupler Force" CV="16.0.318" default="31" item="ESU FnOut A6 Slider 7" mask="XXXVVVVV">
+            <variable label="Coupler Force" CV="16.0.302" default="31" item="ESU FnOut A4 Slider 7" mask="XXXVVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>ge</relation>
                     <value>28</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>ne</relation>
                     <value>29</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>ne</relation>
                     <value>30</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>ne</relation>
                     <value>31</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>ne</relation>
                     <value>32</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>le</relation>
                     <value>33</value>
                 </qualifier>
                 <decVal max="31"/>
                 <label xml:lang="de">Stärke des Kupplers</label>
             </variable>
-            <variable label="Fan Speed" CV="16.0.318" default="31" item="ESU FnOut A6 Slider 11" mask="XXXVVVVV">
+            <variable label="Fan Speed" CV="16.0.302" default="31" item="ESU FnOut A4 Slider 11" mask="XXXVVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>eq</relation>
                     <value>23</value>
                 </qualifier>
                 <decVal max="31"/>
                 <label xml:lang="de">Geschwindigkeit</label>
             </variable>
-            <variable label="Standing heat" CV="16.0.318" default="31" item="ESU FnOut A6 Slider 14" mask="XXXVVVVV">
+            <variable label="Standing heat" CV="16.0.302" default="31" item="ESU FnOut A4 Slider 14" mask="XXXVVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>eq</relation>
                     <value>24</value>
                 </qualifier>
                 <decVal max="31"/>
                 <label xml:lang="de">Heizstufe im Stand</label>
             </variable>
-            <variable label="Chuff power" CV="16.0.318" default="31" item="ESU FnOut A6 Slider 8" mask="XXXVVVVV">
+            <variable label="Chuff power" CV="16.0.302" default="31" item="ESU FnOut A4 Slider 8" mask="XXXVVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>eq</relation>
                     <value>25</value>
                 </qualifier>
                 <decVal max="31"/>
                 <label xml:lang="de">Dampfstoßstärke</label>
             </variable>
-            <variable item="Special Function CV319" label="Special Function CV 1" CV="16.0.319" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+            <variable item="Special Function CV303" label="Special Function CV 1" CV="16.0.303" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
                 <decVal/>
             </variable>
-            <variable label="Fan Acceleration rate" CV="16.0.319" default="0" item="ESU FnOut A6 Slider 12" mask="XXXVVVVV">
+            <variable label="Fan Acceleration rate" CV="16.0.303" default="0" item="ESU FnOut A4 Slider 12" mask="XXXVVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>eq</relation>
                     <value>23</value>
                 </qualifier>
                 <decVal max="31"/>
                 <label xml:lang="de">Beschleunigungszeit</label>
             </variable>
-            <variable label="Minimum driving heat" CV="16.0.319" default="0" item="ESU FnOut A6 Slider 15" mask="XXXVVVVV">
+            <variable label="Minimum driving heat" CV="16.0.303" default="0" item="ESU FnOut A4 Slider 15" mask="XXXVVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>eq</relation>
                     <value>24</value>
                 </qualifier>
                 <decVal max="31"/>
                 <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
             </variable>
-            <variable label="Fan power" CV="16.0.319" default="0" item="ESU FnOut A6 Slider 9" mask="XXXVVVVV">
+            <variable label="Fan power" CV="16.0.303" default="0" item="ESU FnOut A4 Slider 9" mask="XXXVVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>eq</relation>
                     <value>25</value>
                 </qualifier>
                 <decVal max="31"/>
                 <label xml:lang="de">Stäke des Bläsers</label>
             </variable>
-            <variable label="Phase Reverse" CV="16.0.319" default="0" item="ESU FnOut A6 Check 6" mask="XXXXXXXV">
+            <variable label="Phase Reverse" CV="16.0.303" default="0" item="ESU FnOut A4 Check 6" mask="XXXXXXXV">
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>gt</relation>
                     <value>0</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>le</relation>
                     <value>15</value>
                 </qualifier>
                 <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                 <label xml:lang="de">Phase tauschen</label>
             </variable>
-            <variable label="Grade Crossing" CV="16.0.319" default="0" item="ESU FnOut A6 Check 1" mask="XXXXXXVX">
+            <variable label="Grade Crossing" CV="16.0.303" default="0" item="ESU FnOut A4 Check 1" mask="XXXXXXVX">
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>gt</relation>
                     <value>0</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>le</relation>
                     <value>15</value>
                 </qualifier>
                 <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
             </variable>
-            <variable label="Rule 17 Fwd" CV="16.0.319" default="0" item="ESU FnOut A6 Check 2" mask="XXXXXVXX">
+            <variable label="Rule 17 Fwd" CV="16.0.303" default="0" item="ESU FnOut A4 Check 2" mask="XXXXXVXX">
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>gt</relation>
                     <value>0</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>le</relation>
                     <value>15</value>
                 </qualifier>
                 <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                 <label xml:lang="de">Rule 17 vorwärts</label>
             </variable>
-            <variable label="Rule 17 Rev" CV="16.0.319" default="0" item="ESU FnOut A6 Check 3" mask="XXXXVXXX">
+            <variable label="Rule 17 Rev" CV="16.0.303" default="0" item="ESU FnOut A4 Check 3" mask="XXXXVXXX">
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>gt</relation>
                     <value>0</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>le</relation>
                     <value>15</value>
                 </qualifier>
                 <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                 <label xml:lang="de">Rule 17 rückwärts</label>
             </variable>
-            <variable label="Dimmer" CV="16.0.319" default="0" item="ESU FnOut A6 Check 4" mask="XXXVXXXX">
+            <variable label="Dimmer" CV="16.0.303" default="0" item="ESU FnOut A4 Check 4" mask="XXXVXXXX">
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>gt</relation>
                     <value>0</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>le</relation>
                     <value>15</value>
                 </qualifier>
                 <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                 <label xml:lang="de">Abdimmen</label>
             </variable>
-            <variable label="LED Mode" CV="16.0.319" default="0" item="ESU FnOut A6 Check 5" mask="VXXXXXXX">
+            <variable label="LED Mode" CV="16.0.303" default="0" item="ESU FnOut A4 Check 5" mask="VXXXXXXX">
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>gt</relation>
                     <value>0</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>le</relation>
                     <value>15</value>
                 </qualifier>
                 <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                 <label xml:lang="de">LED Modus</label>
             </variable>
-            <variable item="Special Function CV320" label="Special Function CV 2" CV="16.0.320" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+            <variable item="Special Function CV304" label="Special Function CV 2" CV="16.0.304" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
                 <decVal/>
             </variable>
-            <variable label="Fan Decceleration rate" CV="16.0.320" default="0" item="ESU FnOut A6 Slider 13" mask="XXXVVVVV">
+            <variable label="Fan Decceleration rate" CV="16.0.304" default="0" item="ESU FnOut A4 Slider 13" mask="XXXVVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>eq</relation>
                     <value>23</value>
                 </qualifier>
                 <decVal max="31"/>
                 <label xml:lang="de">Bremszeit</label>
             </variable>
-            <variable label="Maximum driving heat" CV="16.0.320" default="0" item="ESU FnOut A6 Slider 16" mask="XXXVVVVV">
+            <variable label="Maximum driving heat" CV="16.0.304" default="0" item="ESU FnOut A4 Slider 16" mask="XXXVVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>eq</relation>
                     <value>24</value>
                 </qualifier>
                 <decVal max="31"/>
                 <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
             </variable>
-            <variable label="Timeout" CV="16.0.320" default="0" item="ESU FnOut A6 Slider 10" tooltip="Units = 0.25 sec">
+            <variable label="Timeout" CV="16.0.304" default="0" item="ESU FnOut A4 Slider 10" tooltip="Units = 0.25 sec">
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>eq</relation>
                     <value>25</value>
                 </qualifier>
                 <decVal/>
             </variable>
-            <variable label="Startup Time" CV="16.0.320" default="0" item="ESU FnOut A6 Slider 6">
+            <variable label="Startup Time" CV="16.0.304" default="0" item="ESU FnOut A4 Slider 6">
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>ge</relation>
                     <value>16</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>le</relation>
                     <value>17</value>
                 </qualifier>
                 <decVal/>
                 <label xml:lang="de">Startzeit</label>
             </variable>
-            <variable label="Level" CV="16.0.320" default="0" item="ESU FnOut A6 Slider 20" mask="XVVVVVVV">
+            <variable label="Level" CV="16.0.304" default="0" item="ESU FnOut A4 Slider 20" mask="XVVVVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>eq</relation>
                     <value>19</value>
                 </qualifier>
                 <decVal max="127"/>
             </variable>
-            <!-- exclude AUX7 to AUX18 -->
-            <variables exclude="LokPilot 5 Fx micro,LokPilot 5 Fx micro DCC">
-                <!-- AUX7 Mode -->
-                <variable label="AUX7 Mode" CV="16.0.323" default="1" item="ESU FnOut A7 Mode">
+            <!-- exclude AUX5 to AUX18 -->
+            <variables exclude="LokPilot 5 micro,LokPilot 5 micro DCC,LokSound 5 micro DCC Direct Atlas Legacy">
+                <!-- AUX5 Mode -->
+                <variable label="AUX5 Mode" CV="16.0.307" default="1" item="ESU FnOut A5 Mode">
                     <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
                 </variable>
-                <variable label="Function Switch On Delay" CV="16.0.324" default="0" item="ESU FnOut A7 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
+                <variable label="Function Switch On Delay" CV="16.0.308" default="0" item="ESU FnOut A5 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>gt</relation>
                         <value>0</value>
                     </qualifier>
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>ne</relation>
                         <value>27</value>
                     </qualifier>
                     <decVal max="15"/>
                     <label xml:lang="de">Verzögerung beim Einschalten</label>
                 </variable>
-                <variable label="Function Switch Off Delay" CV="16.0.324" default="0" mask="VVVVXXXX" item="ESU FnOut A7 Slider 2" tooltip="Units = 0.4 sec">
+                <variable label="Function Switch Off Delay" CV="16.0.308" default="0" mask="VVVVXXXX" item="ESU FnOut A5 Slider 2" tooltip="Units = 0.4 sec">
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>gt</relation>
                         <value>0</value>
                     </qualifier>
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>ne</relation>
                         <value>27</value>
                     </qualifier>
                     <decVal max="15"/>
                     <label xml:lang="de">Verzögerung beim Ausschalten</label>
                 </variable>
-                <variable label="Function Auto Switch Off" CV="16.0.325" default="0" item="ESU FnOut A7 Slider 3" tooltip="Units = 0.4 sec">
+                <variable label="Function Auto Switch Off" CV="16.0.309" default="0" item="ESU FnOut A5 Slider 3" tooltip="Units = 0.4 sec">
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>gt</relation>
                         <value>0</value>
                     </qualifier>
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>ne</relation>
                         <value>27</value>
                     </qualifier>
                     <decVal/>
                     <label xml:lang="de">Ausgang automatisch Ausschalten</label>
                 </variable>
-                <variable item="Brightness CV326" label="Brightness CV" CV="16.0.326" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
+                <variable item="Brightness CV310" label="Brightness CV" CV="16.0.310" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
                     <decVal/>
                 </variable>
-                <variable label="Brightness" CV="16.0.326" default="31" item="ESU FnOut A7 Slider 5" mask="XXXVVVVV">
+                <variable label="Brightness" CV="16.0.310" default="31" item="ESU FnOut A5 Slider 5" mask="XXXVVVVV">
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>gt</relation>
                         <value>0</value>
                     </qualifier>
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>le</relation>
                         <value>18</value>
                     </qualifier>
                     <decVal max="31"/>
                     <label xml:lang="de">Helligkeit</label>
                 </variable>
-                <variable label="Mode" CV="16.0.326" default="0" item="ESU FnOut A7 Option 1" mask="XXXXXXXV">
+                <variable label="Mode" CV="16.0.310" default="0" item="ESU FnOut A5 Option 1" mask="XXXXXXXV">
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>eq</relation>
                         <value>22</value>
                     </qualifier>
@@ -2540,299 +1928,605 @@
                     </enumVal>
                     <label xml:lang="de">Modus</label>
                 </variable>
-                <variable label="Coupler Force" CV="16.0.326" default="31" item="ESU FnOut A7 Slider 7" mask="XXXVVVVV">
+                <variable label="Coupler Force" CV="16.0.310" default="31" item="ESU FnOut A5 Slider 7" mask="XXXVVVVV">
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>ge</relation>
                         <value>28</value>
                     </qualifier>
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>ne</relation>
                         <value>29</value>
                     </qualifier>
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>ne</relation>
                         <value>30</value>
                     </qualifier>
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>ne</relation>
                         <value>31</value>
                     </qualifier>
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>ne</relation>
                         <value>32</value>
                     </qualifier>
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>le</relation>
                         <value>33</value>
                     </qualifier>
                     <decVal max="31"/>
                     <label xml:lang="de">Stärke des Kupplers</label>
                 </variable>
-                <variable label="Fan Speed" CV="16.0.326" default="31" item="ESU FnOut A7 Slider 11" mask="XXXVVVVV">
+                <variable label="Fan Speed" CV="16.0.310" default="31" item="ESU FnOut A5 Slider 11" mask="XXXVVVVV">
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>eq</relation>
                         <value>23</value>
                     </qualifier>
                     <decVal max="31"/>
                     <label xml:lang="de">Geschwindigkeit</label>
                 </variable>
-                <variable label="Standing heat" CV="16.0.326" default="31" item="ESU FnOut A7 Slider 14" mask="XXXVVVVV">
+                <variable label="Standing heat" CV="16.0.310" default="31" item="ESU FnOut A5 Slider 14" mask="XXXVVVVV">
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>eq</relation>
                         <value>24</value>
                     </qualifier>
                     <decVal max="31"/>
                     <label xml:lang="de">Heizstufe im Stand</label>
                 </variable>
-                <variable label="Chuff power" CV="16.0.326" default="31" item="ESU FnOut A7 Slider 8" mask="XXXVVVVV">
+                <variable label="Chuff power" CV="16.0.310" default="31" item="ESU FnOut A5 Slider 8" mask="XXXVVVVV">
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>eq</relation>
                         <value>25</value>
                     </qualifier>
                     <decVal max="31"/>
                     <label xml:lang="de">Dampfstoßstärke</label>
                 </variable>
-                <variable item="Special Function CV327" label="Special Function CV 1" CV="16.0.327" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                <variable item="Special Function CV311" label="Special Function CV 1" CV="16.0.311" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
                     <decVal/>
                 </variable>
-                <variable label="Fan Acceleration rate" CV="16.0.327" default="0" item="ESU FnOut A7 Slider 12" mask="XXXVVVVV">
+                <variable label="Fan Acceleration rate" CV="16.0.311" default="0" item="ESU FnOut A5 Slider 12" mask="XXXVVVVV">
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>eq</relation>
                         <value>23</value>
                     </qualifier>
                     <decVal max="31"/>
                     <label xml:lang="de">Beschleunigungszeit</label>
                 </variable>
-                <variable label="Minimum driving heat" CV="16.0.327" default="0" item="ESU FnOut A7 Slider 15" mask="XXXVVVVV">
+                <variable label="Minimum driving heat" CV="16.0.311" default="0" item="ESU FnOut A5 Slider 15" mask="XXXVVVVV">
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>eq</relation>
                         <value>24</value>
                     </qualifier>
                     <decVal max="31"/>
                     <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
                 </variable>
-                <variable label="Fan power" CV="16.0.327" default="0" item="ESU FnOut A7 Slider 9" mask="XXXVVVVV">
+                <variable label="Fan power" CV="16.0.311" default="0" item="ESU FnOut A5 Slider 9" mask="XXXVVVVV">
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>eq</relation>
                         <value>25</value>
                     </qualifier>
                     <decVal max="31"/>
                     <label xml:lang="de">Stäke des Bläsers</label>
                 </variable>
-                <variable label="Phase Reverse" CV="16.0.327" default="0" item="ESU FnOut A7 Check 6" mask="XXXXXXXV">
+                <variable label="Phase Reverse" CV="16.0.311" default="0" item="ESU FnOut A5 Check 6" mask="XXXXXXXV">
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>gt</relation>
                         <value>0</value>
                     </qualifier>
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>le</relation>
                         <value>15</value>
                     </qualifier>
                     <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                     <label xml:lang="de">Phase tauschen</label>
                 </variable>
-                <variable label="Grade Crossing" CV="16.0.327" default="0" item="ESU FnOut A7 Check 1" mask="XXXXXXVX">
+                <variable label="Grade Crossing" CV="16.0.311" default="0" item="ESU FnOut A5 Check 1" mask="XXXXXXVX">
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>gt</relation>
                         <value>0</value>
                     </qualifier>
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>le</relation>
                         <value>15</value>
                     </qualifier>
                     <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                 </variable>
-                <variable label="Rule 17 Fwd" CV="16.0.327" default="0" item="ESU FnOut A7 Check 2" mask="XXXXXVXX">
+                <variable label="Rule 17 Fwd" CV="16.0.311" default="0" item="ESU FnOut A5 Check 2" mask="XXXXXVXX">
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>gt</relation>
                         <value>0</value>
                     </qualifier>
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>le</relation>
                         <value>15</value>
                     </qualifier>
                     <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                     <label xml:lang="de">Rule 17 vorwärts</label>
                 </variable>
-                <variable label="Rule 17 Rev" CV="16.0.327" default="0" item="ESU FnOut A7 Check 3" mask="XXXXVXXX">
+                <variable label="Rule 17 Rev" CV="16.0.311" default="0" item="ESU FnOut A5 Check 3" mask="XXXXVXXX">
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>gt</relation>
                         <value>0</value>
                     </qualifier>
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>le</relation>
                         <value>15</value>
                     </qualifier>
                     <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                     <label xml:lang="de">Rule 17 rückwärts</label>
                 </variable>
-                <variable label="Dimmer" CV="16.0.327" default="0" item="ESU FnOut A7 Check 4" mask="XXXVXXXX">
+                <variable label="Dimmer" CV="16.0.311" default="0" item="ESU FnOut A5 Check 4" mask="XXXVXXXX">
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>gt</relation>
                         <value>0</value>
                     </qualifier>
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>le</relation>
                         <value>15</value>
                     </qualifier>
                     <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                     <label xml:lang="de">Abdimmen</label>
                 </variable>
-                <variable label="LED Mode" CV="16.0.327" default="0" item="ESU FnOut A7 Check 5" mask="VXXXXXXX">
+                <variable label="LED Mode" CV="16.0.311" default="0" item="ESU FnOut A5 Check 5" mask="VXXXXXXX">
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>gt</relation>
                         <value>0</value>
                     </qualifier>
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>le</relation>
                         <value>15</value>
                     </qualifier>
                     <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                     <label xml:lang="de">LED Modus</label>
                 </variable>
-                <variable item="Special Function CV328" label="Special Function CV 2" CV="16.0.328" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                <variable item="Special Function CV312" label="Special Function CV 2" CV="16.0.312" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
                     <decVal/>
                 </variable>
-                <variable label="Fan Decceleration rate" CV="16.0.328" default="0" item="ESU FnOut A7 Slider 13" mask="XXXVVVVV">
+                <variable label="Fan Decceleration rate" CV="16.0.312" default="0" item="ESU FnOut A5 Slider 13" mask="XXXVVVVV">
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>eq</relation>
                         <value>23</value>
                     </qualifier>
                     <decVal max="31"/>
                     <label xml:lang="de">Bremszeit</label>
                 </variable>
-                <variable label="Maximum driving heat" CV="16.0.328" default="0" item="ESU FnOut A7 Slider 16" mask="XXXVVVVV">
+                <variable label="Maximum driving heat" CV="16.0.312" default="0" item="ESU FnOut A5 Slider 16" mask="XXXVVVVV">
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>eq</relation>
                         <value>24</value>
                     </qualifier>
                     <decVal max="31"/>
                     <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
                 </variable>
-                <variable label="Timeout" CV="16.0.328" default="0" item="ESU FnOut A7 Slider 10" tooltip="Units = 0.25 sec">
+                <variable label="Timeout" CV="16.0.312" default="0" item="ESU FnOut A5 Slider 10" tooltip="Units = 0.25 sec">
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>eq</relation>
                         <value>25</value>
                     </qualifier>
                     <decVal/>
                 </variable>
-                <variable label="Startup Time" CV="16.0.328" default="0" item="ESU FnOut A7 Slider 6">
+                <variable label="Startup Time" CV="16.0.312" default="0" item="ESU FnOut A5 Slider 6">
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>ge</relation>
                         <value>16</value>
                     </qualifier>
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>le</relation>
                         <value>17</value>
                     </qualifier>
                     <decVal/>
                     <label xml:lang="de">Startzeit</label>
                 </variable>
-                <variable label="Level" CV="16.0.328" default="0" item="ESU FnOut A7 Slider 20" mask="XVVVVVVV">
+                <variable label="Level" CV="16.0.312" default="0" item="ESU FnOut A5 Slider 20" mask="XVVVVVVV">
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>eq</relation>
                         <value>19</value>
                     </qualifier>
                     <decVal max="127"/>
                 </variable>
-                <!-- exclude AUX8 only -->
-                <variables exclude="LokSound 5 Fx,LokSound 5 Fx DCC">
-                    <!-- AUX8 Mode -->
-                    <variable label="AUX8 Mode" CV="16.0.331" default="1" item="ESU FnOut A8 Mode">
+                <!-- AUX6 Mode -->
+                <variable label="AUX6 Mode" CV="16.0.315" default="1" item="ESU FnOut A6 Mode">
+                    <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
+                </variable>
+                <variable label="Function Switch On Delay" CV="16.0.316" default="0" item="ESU FnOut A6 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>gt</relation>
+                        <value>0</value>
+                    </qualifier>
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>ne</relation>
+                        <value>27</value>
+                    </qualifier>
+                    <decVal max="15"/>
+                    <label xml:lang="de">Verzögerung beim Einschalten</label>
+                </variable>
+                <variable label="Function Switch Off Delay" CV="16.0.316" default="0" mask="VVVVXXXX" item="ESU FnOut A6 Slider 2" tooltip="Units = 0.4 sec">
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>gt</relation>
+                        <value>0</value>
+                    </qualifier>
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>ne</relation>
+                        <value>27</value>
+                    </qualifier>
+                    <decVal max="15"/>
+                    <label xml:lang="de">Verzögerung beim Ausschalten</label>
+                </variable>
+                <variable label="Function Auto Switch Off" CV="16.0.317" default="0" item="ESU FnOut A6 Slider 3" tooltip="Units = 0.4 sec">
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>gt</relation>
+                        <value>0</value>
+                    </qualifier>
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>ne</relation>
+                        <value>27</value>
+                    </qualifier>
+                    <decVal/>
+                    <label xml:lang="de">Ausgang automatisch Ausschalten</label>
+                </variable>
+                <variable item="Brightness CV318" label="Brightness CV" CV="16.0.318" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
+                    <decVal/>
+                </variable>
+                <variable label="Brightness" CV="16.0.318" default="31" item="ESU FnOut A6 Slider 5" mask="XXXVVVVV">
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>gt</relation>
+                        <value>0</value>
+                    </qualifier>
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>le</relation>
+                        <value>18</value>
+                    </qualifier>
+                    <decVal max="31"/>
+                    <label xml:lang="de">Helligkeit</label>
+                </variable>
+                <variable label="Mode" CV="16.0.318" default="0" item="ESU FnOut A6 Option 1" mask="XXXXXXXV">
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>eq</relation>
+                        <value>22</value>
+                    </qualifier>
+                    <enumVal>
+                        <enumChoice choice="Heating control">
+                            <choice>Heating control</choice>
+                            <choice xml:lang="de">Heizungssteuerung</choice>
+                        </enumChoice>
+                        <enumChoice choice="Fan control">
+                            <choice>Fan control</choice>
+                            <choice xml:lang="de">Lüftersteuerung</choice>
+                        </enumChoice>
+                    </enumVal>
+                    <label xml:lang="de">Modus</label>
+                </variable>
+                <variable label="Coupler Force" CV="16.0.318" default="31" item="ESU FnOut A6 Slider 7" mask="XXXVVVVV">
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>ge</relation>
+                        <value>28</value>
+                    </qualifier>
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>ne</relation>
+                        <value>29</value>
+                    </qualifier>
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>ne</relation>
+                        <value>30</value>
+                    </qualifier>
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>ne</relation>
+                        <value>31</value>
+                    </qualifier>
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>ne</relation>
+                        <value>32</value>
+                    </qualifier>
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>le</relation>
+                        <value>33</value>
+                    </qualifier>
+                    <decVal max="31"/>
+                    <label xml:lang="de">Stärke des Kupplers</label>
+                </variable>
+                <variable label="Fan Speed" CV="16.0.318" default="31" item="ESU FnOut A6 Slider 11" mask="XXXVVVVV">
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>eq</relation>
+                        <value>23</value>
+                    </qualifier>
+                    <decVal max="31"/>
+                    <label xml:lang="de">Geschwindigkeit</label>
+                </variable>
+                <variable label="Standing heat" CV="16.0.318" default="31" item="ESU FnOut A6 Slider 14" mask="XXXVVVVV">
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>eq</relation>
+                        <value>24</value>
+                    </qualifier>
+                    <decVal max="31"/>
+                    <label xml:lang="de">Heizstufe im Stand</label>
+                </variable>
+                <variable label="Chuff power" CV="16.0.318" default="31" item="ESU FnOut A6 Slider 8" mask="XXXVVVVV">
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>eq</relation>
+                        <value>25</value>
+                    </qualifier>
+                    <decVal max="31"/>
+                    <label xml:lang="de">Dampfstoßstärke</label>
+                </variable>
+                <variable item="Special Function CV319" label="Special Function CV 1" CV="16.0.319" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                    <decVal/>
+                </variable>
+                <variable label="Fan Acceleration rate" CV="16.0.319" default="0" item="ESU FnOut A6 Slider 12" mask="XXXVVVVV">
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>eq</relation>
+                        <value>23</value>
+                    </qualifier>
+                    <decVal max="31"/>
+                    <label xml:lang="de">Beschleunigungszeit</label>
+                </variable>
+                <variable label="Minimum driving heat" CV="16.0.319" default="0" item="ESU FnOut A6 Slider 15" mask="XXXVVVVV">
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>eq</relation>
+                        <value>24</value>
+                    </qualifier>
+                    <decVal max="31"/>
+                    <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
+                </variable>
+                <variable label="Fan power" CV="16.0.319" default="0" item="ESU FnOut A6 Slider 9" mask="XXXVVVVV">
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>eq</relation>
+                        <value>25</value>
+                    </qualifier>
+                    <decVal max="31"/>
+                    <label xml:lang="de">Stäke des Bläsers</label>
+                </variable>
+                <variable label="Phase Reverse" CV="16.0.319" default="0" item="ESU FnOut A6 Check 6" mask="XXXXXXXV">
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>gt</relation>
+                        <value>0</value>
+                    </qualifier>
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>le</relation>
+                        <value>15</value>
+                    </qualifier>
+                    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                    <label xml:lang="de">Phase tauschen</label>
+                </variable>
+                <variable label="Grade Crossing" CV="16.0.319" default="0" item="ESU FnOut A6 Check 1" mask="XXXXXXVX">
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>gt</relation>
+                        <value>0</value>
+                    </qualifier>
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>le</relation>
+                        <value>15</value>
+                    </qualifier>
+                    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                </variable>
+                <variable label="Rule 17 Fwd" CV="16.0.319" default="0" item="ESU FnOut A6 Check 2" mask="XXXXXVXX">
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>gt</relation>
+                        <value>0</value>
+                    </qualifier>
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>le</relation>
+                        <value>15</value>
+                    </qualifier>
+                    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                    <label xml:lang="de">Rule 17 vorwärts</label>
+                </variable>
+                <variable label="Rule 17 Rev" CV="16.0.319" default="0" item="ESU FnOut A6 Check 3" mask="XXXXVXXX">
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>gt</relation>
+                        <value>0</value>
+                    </qualifier>
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>le</relation>
+                        <value>15</value>
+                    </qualifier>
+                    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                    <label xml:lang="de">Rule 17 rückwärts</label>
+                </variable>
+                <variable label="Dimmer" CV="16.0.319" default="0" item="ESU FnOut A6 Check 4" mask="XXXVXXXX">
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>gt</relation>
+                        <value>0</value>
+                    </qualifier>
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>le</relation>
+                        <value>15</value>
+                    </qualifier>
+                    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                    <label xml:lang="de">Abdimmen</label>
+                </variable>
+                <variable label="LED Mode" CV="16.0.319" default="0" item="ESU FnOut A6 Check 5" mask="VXXXXXXX">
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>gt</relation>
+                        <value>0</value>
+                    </qualifier>
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>le</relation>
+                        <value>15</value>
+                    </qualifier>
+                    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                    <label xml:lang="de">LED Modus</label>
+                </variable>
+                <variable item="Special Function CV320" label="Special Function CV 2" CV="16.0.320" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                    <decVal/>
+                </variable>
+                <variable label="Fan Decceleration rate" CV="16.0.320" default="0" item="ESU FnOut A6 Slider 13" mask="XXXVVVVV">
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>eq</relation>
+                        <value>23</value>
+                    </qualifier>
+                    <decVal max="31"/>
+                    <label xml:lang="de">Bremszeit</label>
+                </variable>
+                <variable label="Maximum driving heat" CV="16.0.320" default="0" item="ESU FnOut A6 Slider 16" mask="XXXVVVVV">
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>eq</relation>
+                        <value>24</value>
+                    </qualifier>
+                    <decVal max="31"/>
+                    <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
+                </variable>
+                <variable label="Timeout" CV="16.0.320" default="0" item="ESU FnOut A6 Slider 10" tooltip="Units = 0.25 sec">
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>eq</relation>
+                        <value>25</value>
+                    </qualifier>
+                    <decVal/>
+                </variable>
+                <variable label="Startup Time" CV="16.0.320" default="0" item="ESU FnOut A6 Slider 6">
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>ge</relation>
+                        <value>16</value>
+                    </qualifier>
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>le</relation>
+                        <value>17</value>
+                    </qualifier>
+                    <decVal/>
+                    <label xml:lang="de">Startzeit</label>
+                </variable>
+                <variable label="Level" CV="16.0.320" default="0" item="ESU FnOut A6 Slider 20" mask="XVVVVVVV">
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>eq</relation>
+                        <value>19</value>
+                    </qualifier>
+                    <decVal max="127"/>
+                </variable>
+                <!-- exclude AUX7 to AUX18 -->
+                <variables exclude="LokPilot 5 Fx micro,LokPilot 5 Fx micro DCC">
+                    <!-- AUX7 Mode -->
+                    <variable label="AUX7 Mode" CV="16.0.323" default="1" item="ESU FnOut A7 Mode">
                         <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
                     </variable>
-                    <variable label="Function Switch On Delay" CV="16.0.332" default="0" item="ESU FnOut A8 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
+                    <variable label="Function Switch On Delay" CV="16.0.324" default="0" item="ESU FnOut A7 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
                         <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>gt</relation>
                             <value>0</value>
                         </qualifier>
                         <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>ne</relation>
                             <value>27</value>
                         </qualifier>
                         <decVal max="15"/>
                         <label xml:lang="de">Verzögerung beim Einschalten</label>
                     </variable>
-                    <variable label="Function Switch Off Delay" CV="16.0.332" default="0" mask="VVVVXXXX" item="ESU FnOut A8 Slider 2" tooltip="Units = 0.4 sec">
+                    <variable label="Function Switch Off Delay" CV="16.0.324" default="0" mask="VVVVXXXX" item="ESU FnOut A7 Slider 2" tooltip="Units = 0.4 sec">
                         <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>gt</relation>
                             <value>0</value>
                         </qualifier>
                         <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>ne</relation>
                             <value>27</value>
                         </qualifier>
                         <decVal max="15"/>
                         <label xml:lang="de">Verzögerung beim Ausschalten</label>
                     </variable>
-                    <variable label="Function Auto Switch Off" CV="16.0.333" default="0" item="ESU FnOut A8 Slider 3" tooltip="Units = 0.4 sec">
+                    <variable label="Function Auto Switch Off" CV="16.0.325" default="0" item="ESU FnOut A7 Slider 3" tooltip="Units = 0.4 sec">
                         <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>gt</relation>
                             <value>0</value>
                         </qualifier>
                         <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>ne</relation>
                             <value>27</value>
                         </qualifier>
                         <decVal/>
                         <label xml:lang="de">Ausgang automatisch Ausschalten</label>
                     </variable>
-                    <variable item="Brightness CV334" label="Brightness CV" CV="16.0.334" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
+                    <variable item="Brightness CV326" label="Brightness CV" CV="16.0.326" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
                         <decVal/>
                     </variable>
-                    <variable label="Brightness" CV="16.0.334" default="31" item="ESU FnOut A8 Slider 5" mask="XXXVVVVV">
+                    <variable label="Brightness" CV="16.0.326" default="31" item="ESU FnOut A7 Slider 5" mask="XXXVVVVV">
                         <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>gt</relation>
                             <value>0</value>
                         </qualifier>
                         <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>le</relation>
                             <value>18</value>
                         </qualifier>
                         <decVal max="31"/>
                         <label xml:lang="de">Helligkeit</label>
                     </variable>
-                    <variable label="Mode" CV="16.0.334" default="0" item="ESU FnOut A8 Option 1" mask="XXXXXXXV">
+                    <variable label="Mode" CV="16.0.326" default="0" item="ESU FnOut A7 Option 1" mask="XXXXXXXV">
                         <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>eq</relation>
                             <value>22</value>
                         </qualifier>
@@ -2848,1564 +2542,286 @@
                         </enumVal>
                         <label xml:lang="de">Modus</label>
                     </variable>
-                    <variable label="Coupler Force" CV="16.0.334" default="31" item="ESU FnOut A8 Slider 7" mask="XXXVVVVV">
+                    <variable label="Coupler Force" CV="16.0.326" default="31" item="ESU FnOut A7 Slider 7" mask="XXXVVVVV">
                         <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>ge</relation>
                             <value>28</value>
                         </qualifier>
                         <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>ne</relation>
                             <value>29</value>
                         </qualifier>
                         <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>ne</relation>
                             <value>30</value>
                         </qualifier>
                         <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>ne</relation>
                             <value>31</value>
                         </qualifier>
                         <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>ne</relation>
                             <value>32</value>
                         </qualifier>
                         <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>le</relation>
                             <value>33</value>
                         </qualifier>
                         <decVal max="31"/>
                         <label xml:lang="de">Stärke des Kupplers</label>
                     </variable>
-                    <variable label="Fan Speed" CV="16.0.334" default="31" item="ESU FnOut A8 Slider 11" mask="XXXVVVVV">
+                    <variable label="Fan Speed" CV="16.0.326" default="31" item="ESU FnOut A7 Slider 11" mask="XXXVVVVV">
                         <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>eq</relation>
                             <value>23</value>
                         </qualifier>
                         <decVal max="31"/>
                         <label xml:lang="de">Geschwindigkeit</label>
                     </variable>
-                    <variable label="Standing heat" CV="16.0.334" default="31" item="ESU FnOut A8 Slider 14" mask="XXXVVVVV">
+                    <variable label="Standing heat" CV="16.0.326" default="31" item="ESU FnOut A7 Slider 14" mask="XXXVVVVV">
                         <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>eq</relation>
                             <value>24</value>
                         </qualifier>
                         <decVal max="31"/>
                         <label xml:lang="de">Heizstufe im Stand</label>
                     </variable>
-                    <variable label="Chuff power" CV="16.0.334" default="31" item="ESU FnOut A8 Slider 8" mask="XXXVVVVV">
+                    <variable label="Chuff power" CV="16.0.326" default="31" item="ESU FnOut A7 Slider 8" mask="XXXVVVVV">
                         <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>eq</relation>
                             <value>25</value>
                         </qualifier>
                         <decVal max="31"/>
                         <label xml:lang="de">Dampfstoßstärke</label>
                     </variable>
-                    <variable item="Special Function CV335" label="Special Function CV 1" CV="16.0.335" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                    <variable item="Special Function CV327" label="Special Function CV 1" CV="16.0.327" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
                         <decVal/>
                     </variable>
-                    <variable label="Fan Acceleration rate" CV="16.0.335" default="0" item="ESU FnOut A8 Slider 12" mask="XXXVVVVV">
+                    <variable label="Fan Acceleration rate" CV="16.0.327" default="0" item="ESU FnOut A7 Slider 12" mask="XXXVVVVV">
                         <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>eq</relation>
                             <value>23</value>
                         </qualifier>
                         <decVal max="31"/>
                         <label xml:lang="de">Beschleunigungszeit</label>
                     </variable>
-                    <variable label="Minimum driving heat" CV="16.0.335" default="0" item="ESU FnOut A8 Slider 15" mask="XXXVVVVV">
+                    <variable label="Minimum driving heat" CV="16.0.327" default="0" item="ESU FnOut A7 Slider 15" mask="XXXVVVVV">
                         <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>eq</relation>
                             <value>24</value>
                         </qualifier>
                         <decVal max="31"/>
                         <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
                     </variable>
-                    <variable label="Fan power" CV="16.0.335" default="0" item="ESU FnOut A8 Slider 9" mask="XXXVVVVV">
+                    <variable label="Fan power" CV="16.0.327" default="0" item="ESU FnOut A7 Slider 9" mask="XXXVVVVV">
                         <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>eq</relation>
                             <value>25</value>
                         </qualifier>
                         <decVal max="31"/>
                         <label xml:lang="de">Stäke des Bläsers</label>
                     </variable>
-                    <variable label="Phase Reverse" CV="16.0.335" default="0" item="ESU FnOut A8 Check 6" mask="XXXXXXXV">
+
+                    <variable label="Grade Crossing" CV="16.0.327" default="0" item="ESU FnOut A7 Check 1" mask="XXXXXXVX">
                         <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>gt</relation>
                             <value>0</value>
                         </qualifier>
                         <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
-                            <relation>le</relation>
-                            <value>15</value>
-                        </qualifier>
-                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                        <label xml:lang="de">Phase tauschen</label>
-                    </variable>
-                    <variable label="Grade Crossing" CV="16.0.335" default="0" item="ESU FnOut A8 Check 1" mask="XXXXXXVX">
-                        <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>le</relation>
                             <value>15</value>
                         </qualifier>
                         <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                     </variable>
-                    <variable label="Rule 17 Fwd" CV="16.0.335" default="0" item="ESU FnOut A8 Check 2" mask="XXXXXVXX">
+                    <variable label="Rule 17 Fwd" CV="16.0.327" default="0" item="ESU FnOut A7 Check 2" mask="XXXXXVXX">
                         <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>gt</relation>
                             <value>0</value>
                         </qualifier>
                         <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>le</relation>
                             <value>15</value>
                         </qualifier>
                         <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                         <label xml:lang="de">Rule 17 vorwärts</label>
                     </variable>
-                    <variable label="Rule 17 Rev" CV="16.0.335" default="0" item="ESU FnOut A8 Check 3" mask="XXXXVXXX">
+                    <variable label="Rule 17 Rev" CV="16.0.327" default="0" item="ESU FnOut A7 Check 3" mask="XXXXVXXX">
                         <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>gt</relation>
                             <value>0</value>
                         </qualifier>
                         <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>le</relation>
                             <value>15</value>
                         </qualifier>
                         <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                         <label xml:lang="de">Rule 17 rückwärts</label>
                     </variable>
-                    <variable label="Dimmer" CV="16.0.335" default="0" item="ESU FnOut A8 Check 4" mask="XXXVXXXX">
+                    <variable label="Dimmer" CV="16.0.327" default="0" item="ESU FnOut A7 Check 4" mask="XXXVXXXX">
                         <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>gt</relation>
                             <value>0</value>
                         </qualifier>
                         <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>le</relation>
                             <value>15</value>
                         </qualifier>
                         <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                         <label xml:lang="de">Abdimmen</label>
                     </variable>
-                    <variable label="LED Mode" CV="16.0.335" default="0" item="ESU FnOut A8 Check 5" mask="VXXXXXXX">
+                    <variable label="LED Mode" CV="16.0.327" default="0" item="ESU FnOut A7 Check 5" mask="VXXXXXXX">
                         <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>gt</relation>
                             <value>0</value>
                         </qualifier>
                         <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>le</relation>
                             <value>15</value>
                         </qualifier>
                         <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                         <label xml:lang="de">LED Modus</label>
                     </variable>
-                    <variable item="Special Function CV336" label="Special Function CV 2" CV="16.0.336" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                    <variable item="Special Function CV328" label="Special Function CV 2" CV="16.0.328" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
                         <decVal/>
                     </variable>
-                    <variable label="Fan Decceleration rate" CV="16.0.336" default="0" item="ESU FnOut A8 Slider 13" mask="XXXVVVVV">
+                    <variable label="Fan Decceleration rate" CV="16.0.328" default="0" item="ESU FnOut A7 Slider 13" mask="XXXVVVVV">
                         <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>eq</relation>
                             <value>23</value>
                         </qualifier>
                         <decVal max="31"/>
                         <label xml:lang="de">Bremszeit</label>
                     </variable>
-                    <variable label="Maximum driving heat" CV="16.0.336" default="0" item="ESU FnOut A8 Slider 16" mask="XXXVVVVV">
+                    <variable label="Maximum driving heat" CV="16.0.328" default="0" item="ESU FnOut A7 Slider 16" mask="XXXVVVVV">
                         <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>eq</relation>
                             <value>24</value>
                         </qualifier>
                         <decVal max="31"/>
                         <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
                     </variable>
-                    <variable label="Timeout" CV="16.0.336" default="0" item="ESU FnOut A8 Slider 10" tooltip="Units = 0.25 sec">
+                    <variable label="Timeout" CV="16.0.328" default="0" item="ESU FnOut A7 Slider 10" tooltip="Units = 0.25 sec">
                         <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>eq</relation>
                             <value>25</value>
                         </qualifier>
                         <decVal/>
                     </variable>
-                    <variable label="Startup Time" CV="16.0.336" default="0" item="ESU FnOut A8 Slider 6">
+                    <variable label="Startup Time" CV="16.0.328" default="0" item="ESU FnOut A7 Slider 6">
                         <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>ge</relation>
                             <value>16</value>
                         </qualifier>
                         <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>le</relation>
                             <value>17</value>
                         </qualifier>
                         <decVal/>
                         <label xml:lang="de">Startzeit</label>
                     </variable>
-                    <variable label="Level" CV="16.0.336" default="0" item="ESU FnOut A8 Slider 20" mask="XVVVVVVV">
+                    <variable label="Level" CV="16.0.328" default="0" item="ESU FnOut A7 Slider 20" mask="XVVVVVVV">
                         <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>eq</relation>
                             <value>19</value>
                         </qualifier>
                         <decVal max="127"/>
                     </variable>
-                </variables>
-                <!-- exclude AUX9 to AUX18 -->
-                <variables exclude="LokSound 5 micro DCC Direct">
-                    <!-- AUX9 Mode -->
-                    <variable label="AUX9 Mode" CV="16.0.339" default="1" item="ESU FnOut A9 Mode">
-                        <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
-                    </variable>
-                    <variable label="Function Switch On Delay" CV="16.0.340" default="0" item="ESU FnOut A9 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
-                            <relation>ne</relation>
-                            <value>27</value>
-                        </qualifier>
-                        <decVal max="15"/>
-                        <label xml:lang="de">Verzögerung beim Einschalten</label>
-                    </variable>
-                    <variable label="Function Switch Off Delay" CV="16.0.340" default="0" mask="VVVVXXXX" item="ESU FnOut A9 Slider 2" tooltip="Units = 0.4 sec">
-                        <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
-                            <relation>ne</relation>
-                            <value>27</value>
-                        </qualifier>
-                        <decVal max="15"/>
-                        <label xml:lang="de">Verzögerung beim Ausschalten</label>
-                    </variable>
-                    <variable label="Function Auto Switch Off" CV="16.0.341" default="0" item="ESU FnOut A9 Slider 3" tooltip="Units = 0.4 sec">
-                        <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
-                            <relation>ne</relation>
-                            <value>27</value>
-                        </qualifier>
-                        <decVal/>
-                        <label xml:lang="de">Ausgang automatisch Ausschalten</label>
-                    </variable>
-                    <variable item="Brightness CV342" label="Brightness CV" CV="16.0.342" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
-                        <decVal/>
-                    </variable>
-                    <variable label="Brightness" CV="16.0.342" default="31" item="ESU FnOut A9 Slider 5" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
-                            <relation>le</relation>
-                            <value>18</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Helligkeit</label>
-                    </variable>
-                    <variable label="Mode" CV="16.0.342" default="0" item="ESU FnOut A9 Option 1" mask="XXXXXXXV">
-                        <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>22</value>
-                        </qualifier>
-                        <enumVal>
-                            <enumChoice choice="Heating control">
-                                <choice>Heating control</choice>
-                                <choice xml:lang="de">Heizungssteuerung</choice>
-                            </enumChoice>
-                            <enumChoice choice="Fan control">
-                                <choice>Fan control</choice>
-                                <choice xml:lang="de">Lüftersteuerung</choice>
-                            </enumChoice>
-                        </enumVal>
-                        <label xml:lang="de">Modus</label>
-                    </variable>
-                    <variable label="Coupler Force" CV="16.0.342" default="31" item="ESU FnOut A9 Slider 7" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
-                            <relation>ge</relation>
-                            <value>28</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
-                            <relation>ne</relation>
-                            <value>29</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
-                            <relation>ne</relation>
-                            <value>30</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
-                            <relation>ne</relation>
-                            <value>31</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
-                            <relation>ne</relation>
-                            <value>32</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
-                            <relation>le</relation>
-                            <value>33</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Stärke des Kupplers</label>
-                    </variable>
-                    <variable label="Fan Speed" CV="16.0.342" default="31" item="ESU FnOut A9 Slider 11" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>23</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Geschwindigkeit</label>
-                    </variable>
-                    <variable label="Standing heat" CV="16.0.342" default="31" item="ESU FnOut A9 Slider 14" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>24</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Heizstufe im Stand</label>
-                    </variable>
-                    <variable label="Chuff power" CV="16.0.342" default="31" item="ESU FnOut A9 Slider 8" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>25</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Dampfstoßstärke</label>
-                    </variable>
-                    <variable item="Special Function CV343" label="Special Function CV 1" CV="16.0.343" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
-                        <decVal/>
-                    </variable>
-                    <variable label="Fan Acceleration rate" CV="16.0.343" default="0" item="ESU FnOut A9 Slider 12" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>23</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Beschleunigungszeit</label>
-                    </variable>
-                    <variable label="Minimum driving heat" CV="16.0.343" default="0" item="ESU FnOut A9 Slider 15" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>24</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
-                    </variable>
-                    <variable label="Fan power" CV="16.0.343" default="0" item="ESU FnOut A9 Slider 9" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>25</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Stäke des Bläsers</label>
-                    </variable>
-                    <variable label="Phase Reverse" CV="16.0.343" default="0" item="ESU FnOut A9 Check 6" mask="XXXXXXXV">
-                        <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
-                            <relation>le</relation>
-                            <value>15</value>
-                        </qualifier>
-                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                        <label xml:lang="de">Phase tauschen</label>
-                    </variable>
-                    <variable label="Grade Crossing" CV="16.0.343" default="0" item="ESU FnOut A9 Check 1" mask="XXXXXXVX">
-                        <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
-                            <relation>le</relation>
-                            <value>15</value>
-                        </qualifier>
-                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                    </variable>
-                    <variable label="Rule 17 Fwd" CV="16.0.343" default="0" item="ESU FnOut A9 Check 2" mask="XXXXXVXX">
-                        <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
-                            <relation>le</relation>
-                            <value>15</value>
-                        </qualifier>
-                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                        <label xml:lang="de">Rule 17 vorwärts</label>
-                    </variable>
-                    <variable label="Rule 17 Rev" CV="16.0.343" default="0" item="ESU FnOut A9 Check 3" mask="XXXXVXXX">
-                        <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
-                            <relation>le</relation>
-                            <value>15</value>
-                        </qualifier>
-                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                        <label xml:lang="de">Rule 17 rückwärts</label>
-                    </variable>
-                    <variable label="Dimmer" CV="16.0.343" default="0" item="ESU FnOut A9 Check 4" mask="XXXVXXXX">
-                        <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
-                            <relation>le</relation>
-                            <value>15</value>
-                        </qualifier>
-                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                        <label xml:lang="de">Abdimmen</label>
-                    </variable>
-                    <variable label="LED Mode" CV="16.0.343" default="0" item="ESU FnOut A9 Check 5" mask="VXXXXXXX">
-                        <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
-                            <relation>le</relation>
-                            <value>15</value>
-                        </qualifier>
-                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                        <label xml:lang="de">LED Modus</label>
-                    </variable>
-                    <variable item="Special Function CV344" label="Special Function CV 2" CV="16.0.344" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
-                        <decVal/>
-                    </variable>
-                    <variable label="Fan Decceleration rate" CV="16.0.344" default="0" item="ESU FnOut A9 Slider 13" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>23</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Bremszeit</label>
-                    </variable>
-                    <variable label="Maximum driving heat" CV="16.0.344" default="0" item="ESU FnOut A9 Slider 16" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>24</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
-                    </variable>
-                    <variable label="Timeout" CV="16.0.344" default="0" item="ESU FnOut A9 Slider 10" tooltip="Units = 0.25 sec">
-                        <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>25</value>
-                        </qualifier>
-                        <decVal/>
-                    </variable>
-                    <variable label="Startup Time" CV="16.0.344" default="0" item="ESU FnOut A9 Slider 6">
-                        <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
-                            <relation>ge</relation>
-                            <value>16</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
-                            <relation>le</relation>
-                            <value>17</value>
-                        </qualifier>
-                        <decVal/>
-                        <label xml:lang="de">Startzeit</label>
-                    </variable>
-                    <variable label="Level" CV="16.0.344" default="0" item="ESU FnOut A9 Slider 20" mask="XVVVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>19</value>
-                        </qualifier>
-                        <decVal max="127"/>
-                    </variable>
-                    <!-- AUX10 Mode -->
-                    <variable label="AUX10 Mode" CV="16.0.347" default="1" item="ESU FnOut A10 Mode">
-                        <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
-                    </variable>
-                    <variable label="Function Switch On Delay" CV="16.0.348" default="0" item="ESU FnOut A10 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>ne</relation>
-                            <value>27</value>
-                        </qualifier>
-                        <decVal max="15"/>
-                        <label xml:lang="de">Verzögerung beim Einschalten</label>
-                    </variable>
-                    <variable label="Function Switch Off Delay" CV="16.0.348" default="0" mask="VVVVXXXX" item="ESU FnOut A10 Slider 2" tooltip="Units = 0.4 sec">
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>ne</relation>
-                            <value>27</value>
-                        </qualifier>
-                        <decVal max="15"/>
-                        <label xml:lang="de">Verzögerung beim Ausschalten</label>
-                    </variable>
-                    <variable label="Function Auto Switch Off" CV="16.0.349" default="0" item="ESU FnOut A10 Slider 3" tooltip="Units = 0.4 sec">
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>ne</relation>
-                            <value>27</value>
-                        </qualifier>
-                        <decVal/>
-                        <label xml:lang="de">Ausgang automatisch Ausschalten</label>
-                    </variable>
-                    <variable item="Brightness CV350" label="Brightness CV" CV="16.0.350" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
-                        <decVal/>
-                    </variable>
-                    <variable label="Brightness" CV="16.0.350" default="31" item="ESU FnOut A10 Slider 5" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>le</relation>
-                            <value>18</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Helligkeit</label>
-                    </variable>
-                    <variable label="Mode" CV="16.0.350" default="0" item="ESU FnOut A10 Option 1" mask="XXXXXXXV">
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>22</value>
-                        </qualifier>
-                        <enumVal>
-                            <enumChoice choice="Heating control">
-                                <choice>Heating control</choice>
-                                <choice xml:lang="de">Heizungssteuerung</choice>
-                            </enumChoice>
-                            <enumChoice choice="Fan control">
-                                <choice>Fan control</choice>
-                                <choice xml:lang="de">Lüftersteuerung</choice>
-                            </enumChoice>
-                        </enumVal>
-                        <label xml:lang="de">Modus</label>
-                    </variable>
-                    <variable label="Coupler Force" CV="16.0.350" default="31" item="ESU FnOut A10 Slider 7" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>ge</relation>
-                            <value>28</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>ne</relation>
-                            <value>29</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>ne</relation>
-                            <value>30</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>ne</relation>
-                            <value>31</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>ne</relation>
-                            <value>32</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>le</relation>
-                            <value>33</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Stärke des Kupplers</label>
-                    </variable>
-                    <variable label="Fan Speed" CV="16.0.350" default="31" item="ESU FnOut A10 Slider 11" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>23</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Geschwindigkeit</label>
-                    </variable>
-                    <variable label="Standing heat" CV="16.0.350" default="31" item="ESU FnOut A10 Slider 14" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>24</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Heizstufe im Stand</label>
-                    </variable>
-                    <variable label="Chuff power" CV="16.0.350" default="31" item="ESU FnOut A10 Slider 8" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>25</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Dampfstoßstärke</label>
-                    </variable>
-                    <variable item="Special Function CV351" label="Special Function CV 1" CV="16.0.351" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
-                        <decVal/>
-                    </variable>
-                    <variable label="Fan Acceleration rate" CV="16.0.351" default="0" item="ESU FnOut A10 Slider 12" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>23</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Beschleunigungszeit</label>
-                    </variable>
-                    <variable label="Minimum driving heat" CV="16.0.351" default="0" item="ESU FnOut A10 Slider 15" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>24</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
-                    </variable>
-                    <variable label="Fan power" CV="16.0.351" default="0" item="ESU FnOut A10 Slider 9" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>25</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Stäke des Bläsers</label>
-                    </variable>
-                    <variable label="Phase Reverse" CV="16.0.351" default="0" item="ESU FnOut A10 Check 6" mask="XXXXXXXV">
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>le</relation>
-                            <value>15</value>
-                        </qualifier>
-                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                        <label xml:lang="de">Phase tauschen</label>
-                    </variable>
-                    <variable label="Grade Crossing" CV="16.0.351" default="0" item="ESU FnOut A10 Check 1" mask="XXXXXXVX">
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>le</relation>
-                            <value>15</value>
-                        </qualifier>
-                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                    </variable>
-                    <variable label="Rule 17 Fwd" CV="16.0.351" default="0" item="ESU FnOut A10 Check 2" mask="XXXXXVXX">
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>le</relation>
-                            <value>15</value>
-                        </qualifier>
-                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                        <label xml:lang="de">Rule 17 vorwärts</label>
-                    </variable>
-                    <variable label="Rule 17 Rev" CV="16.0.351" default="0" item="ESU FnOut A10 Check 3" mask="XXXXVXXX">
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>le</relation>
-                            <value>15</value>
-                        </qualifier>
-                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                        <label xml:lang="de">Rule 17 rückwärts</label>
-                    </variable>
-                    <variable label="Dimmer" CV="16.0.351" default="0" item="ESU FnOut A10 Check 4" mask="XXXVXXXX">
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>le</relation>
-                            <value>15</value>
-                        </qualifier>
-                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                        <label xml:lang="de">Abdimmen</label>
-                    </variable>
-                    <variable label="LED Mode" CV="16.0.351" default="0" item="ESU FnOut A10 Check 5" mask="VXXXXXXX">
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>le</relation>
-                            <value>15</value>
-                        </qualifier>
-                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                        <label xml:lang="de">LED Modus</label>
-                    </variable>
-                    <variable item="Special Function CV352" label="Special Function CV 2" CV="16.0.352" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
-                        <decVal/>
-                    </variable>
-                    <variable label="Fan Decceleration rate" CV="16.0.352" default="0" item="ESU FnOut A10 Slider 13" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>23</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Bremszeit</label>
-                    </variable>
-                    <variable label="Maximum driving heat" CV="16.0.352" default="0" item="ESU FnOut A10 Slider 16" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>24</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
-                    </variable>
-                    <variable label="Timeout" CV="16.0.352" default="0" item="ESU FnOut A10 Slider 10" tooltip="Units = 0.25 sec">
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>25</value>
-                        </qualifier>
-                        <decVal/>
-                    </variable>
-                    <variable label="Startup Time" CV="16.0.352" default="0" item="ESU FnOut A10 Slider 6">
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>ge</relation>
-                            <value>16</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>le</relation>
-                            <value>17</value>
-                        </qualifier>
-                        <decVal/>
-                        <label xml:lang="de">Startzeit</label>
-                    </variable>
-                    <variable label="Level" CV="16.0.352" default="0" item="ESU FnOut A10 Slider 20" mask="XVVVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>19</value>
-                        </qualifier>
-                        <decVal max="127"/>
-                    </variable>
-                    <!-- AUX11 Mode -->
-                    <variable label="AUX11 Mode" CV="16.0.355" default="1" item="ESU FnOut A11 Mode">
-                        <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
-                        <!--label xml:lang="de">Licht vorn - 2</label-->
-                    </variable>
-                    <variable label="Function Switch On Delay" CV="16.0.356" default="0" item="ESU FnOut A11 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <decVal max="15"/>
-                        <label xml:lang="de">Verzögerung beim Einschalten</label>
-                    </variable>
-                    <variable label="Function Switch Off Delay" CV="16.0.356" default="0" mask="VVVVXXXX" item="ESU FnOut A11 Slider 2" tooltip="Units = 0.4 sec">
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <decVal max="15"/>
-                        <label xml:lang="de">Verzögerung beim Ausschalten</label>
-                    </variable>
-                    <variable label="Function Auto Switch Off" CV="16.0.357" default="0" item="ESU FnOut A11 Slider 3" tooltip="Units = 0.4 sec">
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <decVal/>
-                        <label xml:lang="de">Ausgang automatisch Ausschalten</label>
-                    </variable>
-                    <variable item="Brightness CV358" label="Brightness CV" CV="16.0.358" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
-                        <decVal/>
-                    </variable>
-                    <variable label="Brightness" CV="16.0.358" default="31" item="ESU FnOut A11 Slider 5" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>le</relation>
-                            <value>18</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Helligkeit</label>
-                    </variable>
-                    <variable label="Mode" CV="16.0.358" default="0" item="ESU FnOut A11 Option 1" mask="XXXXXXXV">
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>22</value>
-                        </qualifier>
-                        <enumVal>
-                            <enumChoice choice="Heating control">
-                                <choice>Heating control</choice>
-                                <choice xml:lang="de">Heizungssteuerung</choice>
-                            </enumChoice>
-                            <enumChoice choice="Fan control">
-                                <choice>Fan control</choice>
-                                <choice xml:lang="de">Lüftersteuerung</choice>
-                            </enumChoice>
-                        </enumVal>
-                        <label xml:lang="de">Modus</label>
-                    </variable>
-                    <variable label="Coupler Force" CV="16.0.358" default="31" item="ESU FnOut A11 Slider 7" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>ge</relation>
-                            <value>28</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>ne</relation>
-                            <value>29</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>ne</relation>
-                            <value>30</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>ne</relation>
-                            <value>31</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>ne</relation>
-                            <value>32</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>le</relation>
-                            <value>33</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Stärke des Kupplers</label>
-                    </variable>
-                    <variable label="Fan Speed" CV="16.0.358" default="31" item="ESU FnOut A11 Slider 11" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>23</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Geschwindigkeit</label>
-                    </variable>
-                    <variable label="Standing heat" CV="16.0.358" default="31" item="ESU FnOut A11 Slider 14" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>24</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Heizstufe im Stand</label>
-                    </variable>
-                    <variable label="Chuff power" CV="16.0.358" default="31" item="ESU FnOut A11 Slider 8" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>25</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Dampfstoßstärke</label>
-                    </variable>
-                    <variable label="Duration (speed) A" CV="16.0.354" default="31" item="ESU FnOut A11 Slider 4" mask="XXVVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>27</value>
-                        </qualifier>
-                        <decVal max="63"/>
-                        <label xml:lang="de">Dauer (Geschwindigkeit)</label>
-                    </variable>
-                    <variable label="Duration (speed) B" CV="16.0.358" default="31" item="ESU FnOut A11 Slider 17" mask="XXVVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>27</value>
-                        </qualifier>
-                        <decVal max="63"/>
-                        <label xml:lang="de">Dauer (Geschwindigkeit)</label>
-                    </variable>
-                    <variable item="Special Function CV359" label="Special Function CV 1" CV="16.0.359" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
-                        <decVal/>
-                    </variable>
-                    <variable label="Fan Acceleration rate" CV="16.0.359" default="0" item="ESU FnOut A11 Slider 12" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>23</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Beschleunigungszeit</label>
-                    </variable>
-                    <variable label="Minimum driving heat" CV="16.0.359" default="0" item="ESU FnOut A11 Slider 15" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>24</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
-                    </variable>
-                    <variable label="Position A" CV="16.0.359" default="0" item="ESU FnOut A11 Slider 18" mask="XXVVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>27</value>
-                        </qualifier>
-                        <decVal max="63"/>
-                    </variable>
-                    <variable label="Fan power" CV="16.0.359" default="0" item="ESU FnOut A11 Slider 9" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>25</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Stäke des Bläsers</label>
-                    </variable>
-                    <variable label="Phase Reverse" CV="16.0.359" default="0" item="ESU FnOut A11 Check 6" mask="XXXXXXXV">
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>le</relation>
-                            <value>15</value>
-                        </qualifier>
-                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                        <label xml:lang="de">Phase tauschen</label>
-                    </variable>
-                    <variable label="Grade Crossing" CV="16.0.359" default="0" item="ESU FnOut A11 Check 1" mask="XXXXXXVX">
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>le</relation>
-                            <value>15</value>
-                        </qualifier>
-                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                    </variable>
-                    <variable label="Rule 17 Fwd" CV="16.0.359" default="0" item="ESU FnOut A11 Check 2" mask="XXXXXVXX">
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>le</relation>
-                            <value>15</value>
-                        </qualifier>
-                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                        <label xml:lang="de">Rule 17 vorwärts</label>
-                    </variable>
-                    <variable label="Rule 17 Rev" CV="16.0.359" default="0" item="ESU FnOut A11 Check 3" mask="XXXXVXXX">
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>le</relation>
-                            <value>15</value>
-                        </qualifier>
-                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                        <label xml:lang="de">Rule 17 rückwärts</label>
-                    </variable>
-                    <variable label="Dimmer" CV="16.0.359" default="0" item="ESU FnOut A11 Check 4" mask="XXXVXXXX">
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>le</relation>
-                            <value>15</value>
-                        </qualifier>
-                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                        <label xml:lang="de">Abdimmen</label>
-                    </variable>
-                    <variable label="LED Mode" CV="16.0.359" default="0" item="ESU FnOut A11 Check 5" mask="VXXXXXXX">
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>le</relation>
-                            <value>15</value>
-                        </qualifier>
-                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                        <label xml:lang="de">LED Modus</label>
-                    </variable>
-                    <variable item="Special Function CV360" label="Special Function CV 2" CV="16.0.360" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
-                        <decVal/>
-                    </variable>
-                    <variable label="Fan Decceleration rate" CV="16.0.360" default="0" item="ESU FnOut A11 Slider 13" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>23</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Bremszeit</label>
-                    </variable>
-                    <variable label="Maximum driving heat" CV="16.0.360" default="0" item="ESU FnOut A11 Slider 16" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>24</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
-                    </variable>
-                    <variable label="Timeout" CV="16.0.360" default="0" item="ESU FnOut A11 Slider 10" tooltip="Units = 0.25 sec">
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>25</value>
-                        </qualifier>
-                        <decVal/>
-                    </variable>
-                    <variable label="Startup Time" CV="16.0.360" default="0" item="ESU FnOut A11 Slider 6">
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>ge</relation>
-                            <value>16</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>le</relation>
-                            <value>17</value>
-                        </qualifier>
-                        <decVal/>
-                        <label xml:lang="de">Startzeit</label>
-                    </variable>
-                    <variable label="Level" CV="16.0.360" default="0" item="ESU FnOut A11 Slider 20" mask="XVVVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>19</value>
-                        </qualifier>
-                        <decVal max="127"/>
-                    </variable>
-                    <variable label="Position B" CV="16.0.360" default="0" item="ESU FnOut A11 Slider 19" mask="XXVVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>27</value>
-                        </qualifier>
-                        <decVal max="63"/>
-                    </variable>
-                    <!-- AUX12 Mode -->
-                    <variable label="AUX12 Mode" CV="16.0.363" default="1" item="ESU FnOut A12 Mode">
-                        <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
-                    </variable>
-                    <variable label="Function Switch On Delay" CV="16.0.364" default="0" item="ESU FnOut A12 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <decVal max="15"/>
-                        <label xml:lang="de">Verzögerung beim Einschalten</label>
-                    </variable>
-                    <variable label="Function Switch Off Delay" CV="16.0.364" default="0" mask="VVVVXXXX" item="ESU FnOut A12 Slider 2" tooltip="Units = 0.4 sec">
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <decVal max="15"/>
-                        <label xml:lang="de">Verzögerung beim Ausschalten</label>
-                    </variable>
-                    <variable label="Function Auto Switch Off" CV="16.0.365" default="0" item="ESU FnOut A12 Slider 3" tooltip="Units = 0.4 sec">
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <decVal/>
-                        <label xml:lang="de">Ausgang automatisch Ausschalten</label>
-                    </variable>
-                    <variable item="Brightness CV366" label="Brightness CV" CV="16.0.366" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
-                        <decVal/>
-                    </variable>
-                    <variable label="Brightness" CV="16.0.366" default="31" item="ESU FnOut A12 Slider 5" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>le</relation>
-                            <value>18</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Helligkeit</label>
-                    </variable>
-                    <variable label="Mode" CV="16.0.366" default="0" item="ESU FnOut A12 Option 1" mask="XXXXXXXV">
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>22</value>
-                        </qualifier>
-                        <enumVal>
-                            <enumChoice choice="Heating control">
-                                <choice>Heating control</choice>
-                                <choice xml:lang="de">Heizungssteuerung</choice>
-                            </enumChoice>
-                            <enumChoice choice="Fan control">
-                                <choice>Fan control</choice>
-                                <choice xml:lang="de">Lüftersteuerung</choice>
-                            </enumChoice>
-                        </enumVal>
-                        <label xml:lang="de">Modus</label>
-                    </variable>
-                    <variable label="Coupler Force" CV="16.0.366" default="31" item="ESU FnOut A12 Slider 7" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>ge</relation>
-                            <value>28</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>ne</relation>
-                            <value>29</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>ne</relation>
-                            <value>30</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>ne</relation>
-                            <value>31</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>ne</relation>
-                            <value>32</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>le</relation>
-                            <value>33</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Stärke des Kupplers</label>
-                    </variable>
-                    <variable label="Fan Speed" CV="16.0.366" default="31" item="ESU FnOut A12 Slider 11" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>23</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Geschwindigkeit</label>
-                    </variable>
-                    <variable label="Standing heat" CV="16.0.366" default="31" item="ESU FnOut A12 Slider 14" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>24</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Heizstufe im Stand</label>
-                    </variable>
-                    <variable label="Chuff power" CV="16.0.366" default="31" item="ESU FnOut A12 Slider 8" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>25</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Dampfstoßstärke</label>
-                    </variable>
-                    <variable label="Duration (speed) A" CV="16.0.362" default="31" item="ESU FnOut A12 Slider 4" mask="XXVVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>27</value>
-                        </qualifier>
-                        <decVal max="63"/>
-                        <label xml:lang="de">Dauer (Geschwindigkeit)</label>
-                    </variable>
-                    <variable label="Duration (speed) B" CV="16.0.366" default="31" item="ESU FnOut A12 Slider 17" mask="XXVVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>27</value>
-                        </qualifier>
-                        <decVal max="63"/>
-                        <label xml:lang="de">Dauer (Geschwindigkeit)</label>
-                    </variable>
-                    <variable item="Special Function CV367" label="Special Function CV 1" CV="16.0.367" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
-                        <decVal/>
-                    </variable>
-                    <variable label="Fan Acceleration rate" CV="16.0.367" default="0" item="ESU FnOut A12 Slider 12" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>23</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Beschleunigungszeit</label>
-                    </variable>
-                    <variable label="Minimum driving heat" CV="16.0.367" default="0" item="ESU FnOut A12 Slider 15" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>24</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
-                    </variable>
-                    <variable label="Position A" CV="16.0.367" default="0" item="ESU FnOut A12 Slider 18" mask="XXVVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>27</value>
-                        </qualifier>
-                        <decVal max="63"/>
-                    </variable>
-                    <variable label="Fan power" CV="16.0.367" default="0" item="ESU FnOut A12 Slider 9" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>25</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Stäke des Bläsers</label>
-                    </variable>
-                    <variable label="Phase Reverse" CV="16.0.367" default="0" item="ESU FnOut A12 Check 6" mask="XXXXXXXV">
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>le</relation>
-                            <value>15</value>
-                        </qualifier>
-                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                        <label xml:lang="de">Phase tauschen</label>
-                    </variable>
-                    <variable label="Grade Crossing" CV="16.0.367" default="0" item="ESU FnOut A12 Check 1" mask="XXXXXXVX">
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>le</relation>
-                            <value>15</value>
-                        </qualifier>
-                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                    </variable>
-                    <variable label="Rule 17 Fwd" CV="16.0.367" default="0" item="ESU FnOut A12 Check 2" mask="XXXXXVXX">
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>le</relation>
-                            <value>15</value>
-                        </qualifier>
-                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                        <label xml:lang="de">Rule 17 vorwärts</label>
-                    </variable>
-                    <variable label="Rule 17 Rev" CV="16.0.367" default="0" item="ESU FnOut A12 Check 3" mask="XXXXVXXX">
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>le</relation>
-                            <value>15</value>
-                        </qualifier>
-                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                        <label xml:lang="de">Rule 17 rückwärts</label>
-                    </variable>
-                    <variable label="Dimmer" CV="16.0.367" default="0" item="ESU FnOut A12 Check 4" mask="XXXVXXXX">
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>le</relation>
-                            <value>15</value>
-                        </qualifier>
-                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                        <label xml:lang="de">Abdimmen</label>
-                    </variable>
-                    <variable label="LED Mode" CV="16.0.367" default="0" item="ESU FnOut A12 Check 5" mask="VXXXXXXX">
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>le</relation>
-                            <value>15</value>
-                        </qualifier>
-                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                        <label xml:lang="de">LED Modus</label>
-                    </variable>
-                    <variable item="Special Function CV368" label="Special Function CV 2" CV="16.0.368" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
-                        <decVal/>
-                    </variable>
-                    <variable label="Fan Decceleration rate" CV="16.0.368" default="0" item="ESU FnOut A12 Slider 13" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>23</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Bremszeit</label>
-                    </variable>
-                    <variable label="Maximum driving heat" CV="16.0.368" default="0" item="ESU FnOut A12 Slider 16" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>24</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
-                    </variable>
-                    <variable label="Timeout" CV="16.0.368" default="0" item="ESU FnOut A12 Slider 10" tooltip="Units = 0.25 sec">
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>25</value>
-                        </qualifier>
-                        <decVal/>
-                    </variable>
-                    <variable label="Startup Time" CV="16.0.368" default="0" item="ESU FnOut A12 Slider 6">
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>ge</relation>
-                            <value>16</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>le</relation>
-                            <value>17</value>
-                        </qualifier>
-                        <decVal/>
-                        <label xml:lang="de">Startzeit</label>
-                    </variable>
-                    <variable label="Level" CV="16.0.368" default="0" item="ESU FnOut A12 Slider 20" mask="XVVVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>19</value>
-                        </qualifier>
-                        <decVal max="127"/>
-                    </variable>
-                    <variable label="Position B" CV="16.0.368" default="0" item="ESU FnOut A12 Slider 19" mask="XXVVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>27</value>
-                        </qualifier>
-                        <decVal max="63"/>
-                    </variable>
-                    <!-- exclude AUX13 to AUX18 -->
-                    <variables exclude="LokSound 5 Fx,LokSound 5 Fx DCC,LokPilot 5 Fx,LokPilot 5 Fx DCC">                <!-- AUX13 Mode -->
-                        <variable label="AUX13 Mode" CV="16.0.371" default="1" item="ESU FnOut A13 Mode">
+                    <!-- exclude AUX8 only -->
+                    <variables exclude="LokSound 5 Fx,LokSound 5 Fx DCC">
+                        <!-- AUX8 Mode -->
+                        <variable label="AUX8 Mode" CV="16.0.331" default="1" item="ESU FnOut A8 Mode">
                             <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
                         </variable>
-                        <variable label="Function Switch On Delay" CV="16.0.372" default="0" item="ESU FnOut A13 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
+                        <variable label="Function Switch On Delay" CV="16.0.332" default="0" item="ESU FnOut A8 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>27</value>
                             </qualifier>
                             <decVal max="15"/>
                             <label xml:lang="de">Verzögerung beim Einschalten</label>
                         </variable>
-                        <variable label="Function Switch Off Delay" CV="16.0.372" default="0" mask="VVVVXXXX" item="ESU FnOut A13 Slider 2" tooltip="Units = 0.4 sec">
+                        <variable label="Function Switch Off Delay" CV="16.0.332" default="0" mask="VVVVXXXX" item="ESU FnOut A8 Slider 2" tooltip="Units = 0.4 sec">
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>27</value>
                             </qualifier>
                             <decVal max="15"/>
                             <label xml:lang="de">Verzögerung beim Ausschalten</label>
                         </variable>
-                        <variable label="Function Auto Switch Off" CV="16.0.373" default="0" item="ESU FnOut A13 Slider 3" tooltip="Units = 0.4 sec">
+                        <variable label="Function Auto Switch Off" CV="16.0.333" default="0" item="ESU FnOut A8 Slider 3" tooltip="Units = 0.4 sec">
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>27</value>
                             </qualifier>
                             <decVal/>
                             <label xml:lang="de">Ausgang automatisch Ausschalten</label>
                         </variable>
-                        <variable item="Brightness CV374" label="Brightness CV" CV="16.0.374" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
+                        <variable item="Brightness CV334" label="Brightness CV" CV="16.0.334" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
                             <decVal/>
                         </variable>
-                        <variable label="Brightness" CV="16.0.374" default="31" item="ESU FnOut A13 Slider 5" mask="XXXVVVVV">
+                        <variable label="Brightness" CV="16.0.334" default="31" item="ESU FnOut A8 Slider 5" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>le</relation>
                                 <value>18</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Helligkeit</label>
                         </variable>
-                        <variable label="Mode" CV="16.0.374" default="0" item="ESU FnOut A13 Option 1" mask="XXXXXXXV">
+                        <variable label="Mode" CV="16.0.334" default="0" item="ESU FnOut A8 Option 1" mask="XXXXXXXV">
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>22</value>
                             </qualifier>
@@ -4421,297 +2837,300 @@
                             </enumVal>
                             <label xml:lang="de">Modus</label>
                         </variable>
-                        <variable label="Coupler Force" CV="16.0.374" default="31" item="ESU FnOut A13 Slider 7" mask="XXXVVVVV">
+                        <variable label="Coupler Force" CV="16.0.334" default="31" item="ESU FnOut A8 Slider 7" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>ge</relation>
                                 <value>28</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>29</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>30</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>31</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>32</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>le</relation>
                                 <value>33</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Stärke des Kupplers</label>
                         </variable>
-                        <variable label="Fan Speed" CV="16.0.374" default="31" item="ESU FnOut A13 Slider 11" mask="XXXVVVVV">
+                        <variable label="Fan Speed" CV="16.0.334" default="31" item="ESU FnOut A8 Slider 11" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>23</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Geschwindigkeit</label>
                         </variable>
-                        <variable label="Standing heat" CV="16.0.374" default="31" item="ESU FnOut A13 Slider 14" mask="XXXVVVVV">
+                        <variable label="Standing heat" CV="16.0.334" default="31" item="ESU FnOut A8 Slider 14" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>24</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Heizstufe im Stand</label>
                         </variable>
-                        <variable label="Chuff power" CV="16.0.374" default="31" item="ESU FnOut A13 Slider 8" mask="XXXVVVVV">
+                        <variable label="Chuff power" CV="16.0.334" default="31" item="ESU FnOut A8 Slider 8" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>25</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Dampfstoßstärke</label>
                         </variable>
-                        <variable item="Special Function CV375" label="Special Function CV 1" CV="16.0.375" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                        <variable item="Special Function CV335" label="Special Function CV 1" CV="16.0.335" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
                             <decVal/>
                         </variable>
-                        <variable label="Fan Acceleration rate" CV="16.0.375" default="0" item="ESU FnOut A13 Slider 12" mask="XXXVVVVV">
+                        <variable label="Fan Acceleration rate" CV="16.0.335" default="0" item="ESU FnOut A8 Slider 12" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>23</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Beschleunigungszeit</label>
                         </variable>
-                        <variable label="Minimum driving heat" CV="16.0.375" default="0" item="ESU FnOut A13 Slider 15" mask="XXXVVVVV">
+                        <variable label="Minimum driving heat" CV="16.0.335" default="0" item="ESU FnOut A8 Slider 15" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>24</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
                         </variable>
-                        <variable label="Fan power" CV="16.0.375" default="0" item="ESU FnOut A13 Slider 9" mask="XXXVVVVV">
+                        <variable label="Fan power" CV="16.0.335" default="0" item="ESU FnOut A8 Slider 9" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>25</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Stäke des Bläsers</label>
                         </variable>
-                        <variable label="Phase Reverse" CV="16.0.375" default="0" item="ESU FnOut A13 Check 6" mask="XXXXXXXV">
+                        <variable label="Phase Reverse" CV="16.0.335" default="0" item="ESU FnOut A8 Check 6" mask="XXXXXXXV">
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                             <label xml:lang="de">Phase tauschen</label>
                         </variable>
-                        <variable label="Grade Crossing" CV="16.0.375" default="0" item="ESU FnOut A13 Check 1" mask="XXXXXXVX">
+                        <variable label="Grade Crossing" CV="16.0.335" default="0" item="ESU FnOut A8 Check 1" mask="XXXXXXVX">
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                         </variable>
-                        <variable label="Rule 17 Fwd" CV="16.0.375" default="0" item="ESU FnOut A13 Check 2" mask="XXXXXVXX">
+                        <variable label="Rule 17 Fwd" CV="16.0.335" default="0" item="ESU FnOut A8 Check 2" mask="XXXXXVXX">
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                             <label xml:lang="de">Rule 17 vorwärts</label>
                         </variable>
-                        <variable label="Rule 17 Rev" CV="16.0.375" default="0" item="ESU FnOut A13 Check 3" mask="XXXXVXXX">
+                        <variable label="Rule 17 Rev" CV="16.0.335" default="0" item="ESU FnOut A8 Check 3" mask="XXXXVXXX">
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                             <label xml:lang="de">Rule 17 rückwärts</label>
                         </variable>
-                        <variable label="Dimmer" CV="16.0.375" default="0" item="ESU FnOut A13 Check 4" mask="XXXVXXXX">
+                        <variable label="Dimmer" CV="16.0.335" default="0" item="ESU FnOut A8 Check 4" mask="XXXVXXXX">
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                             <label xml:lang="de">Abdimmen</label>
                         </variable>
-                        <variable label="LED Mode" CV="16.0.375" default="0" item="ESU FnOut A13 Check 5" mask="VXXXXXXX">
+                        <variable label="LED Mode" CV="16.0.335" default="0" item="ESU FnOut A8 Check 5" mask="VXXXXXXX">
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                             <label xml:lang="de">LED Modus</label>
                         </variable>
-                        <variable item="Special Function CV376" label="Special Function CV 2" CV="16.0.376" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                        <variable item="Special Function CV336" label="Special Function CV 2" CV="16.0.336" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
                             <decVal/>
                         </variable>
-                        <variable label="Fan Decceleration rate" CV="16.0.376" default="0" item="ESU FnOut A13 Slider 13" mask="XXXVVVVV">
+                        <variable label="Fan Decceleration rate" CV="16.0.336" default="0" item="ESU FnOut A8 Slider 13" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>23</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Bremszeit</label>
                         </variable>
-                        <variable label="Maximum driving heat" CV="16.0.376" default="0" item="ESU FnOut A13 Slider 16" mask="XXXVVVVV">
+                        <variable label="Maximum driving heat" CV="16.0.336" default="0" item="ESU FnOut A8 Slider 16" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>24</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
                         </variable>
-                        <variable label="Timeout" CV="16.0.376" default="0" item="ESU FnOut A13 Slider 10" tooltip="Units = 0.25 sec">
+                        <variable label="Timeout" CV="16.0.336" default="0" item="ESU FnOut A8 Slider 10" tooltip="Units = 0.25 sec">
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>25</value>
                             </qualifier>
                             <decVal/>
                         </variable>
-                        <variable label="Startup Time" CV="16.0.376" default="0" item="ESU FnOut A13 Slider 6">
+                        <variable label="Startup Time" CV="16.0.336" default="0" item="ESU FnOut A8 Slider 6">
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>ge</relation>
                                 <value>16</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>le</relation>
                                 <value>17</value>
                             </qualifier>
                             <decVal/>
                             <label xml:lang="de">Startzeit</label>
                         </variable>
-                        <variable label="Level" CV="16.0.376" default="0" item="ESU FnOut A13 Slider 20" mask="XVVVVVVV">
+                        <variable label="Level" CV="16.0.336" default="0" item="ESU FnOut A8 Slider 20" mask="XVVVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>19</value>
                             </qualifier>
                             <decVal max="127"/>
                         </variable>
-                        <!-- AUX14 Mode -->
-                        <variable label="AUX14 Mode" CV="16.0.379" default="1" item="ESU FnOut A14 Mode">
+                    </variables>
+                    <!-- exclude AUX9 to AUX18 -->
+                    <variables exclude="LokPilot 5 micro DCC Direct,LokSound 5 micro DCC Direct">
+                        <!-- AUX9 Mode -->
+                        <variable label="AUX9 Mode" CV="16.0.339" default="1" item="ESU FnOut A9 Mode">
                             <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
                         </variable>
-                        <variable label="Function Switch On Delay" CV="16.0.380" default="0" item="ESU FnOut A14 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
+                        <variable label="Function Switch On Delay" CV="16.0.340" default="0" item="ESU FnOut A9 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>27</value>
                             </qualifier>
                             <decVal max="15"/>
                             <label xml:lang="de">Verzögerung beim Einschalten</label>
                         </variable>
-                        <variable label="Function Switch Off Delay" CV="16.0.380" default="0" mask="VVVVXXXX" item="ESU FnOut A14 Slider 2" tooltip="Units = 0.4 sec">
+                        <variable label="Function Switch Off Delay" CV="16.0.340" default="0" mask="VVVVXXXX" item="ESU FnOut A9 Slider 2" tooltip="Units = 0.4 sec">
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>27</value>
                             </qualifier>
                             <decVal max="15"/>
                             <label xml:lang="de">Verzögerung beim Ausschalten</label>
                         </variable>
-                        <variable label="Function Auto Switch Off" CV="16.0.381" default="0" item="ESU FnOut A14 Slider 3" tooltip="Units = 0.4 sec">
+                        <variable label="Function Auto Switch Off" CV="16.0.341" default="0" item="ESU FnOut A9 Slider 3" tooltip="Units = 0.4 sec">
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>27</value>
                             </qualifier>
                             <decVal/>
                             <label xml:lang="de">Ausgang automatisch Ausschalten</label>
                         </variable>
-                        <variable item="Brightness CV382" label="Brightness CV" CV="16.0.382" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
+                        <variable item="Brightness CV342" label="Brightness CV" CV="16.0.342" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
                             <decVal/>
                         </variable>
-                        <variable label="Brightness" CV="16.0.382" default="31" item="ESU FnOut A14 Slider 5" mask="XXXVVVVV">
+                        <variable label="Brightness" CV="16.0.342" default="31" item="ESU FnOut A9 Slider 5" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>le</relation>
                                 <value>18</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Helligkeit</label>
                         </variable>
-                        <variable label="Mode" CV="16.0.382" default="0" item="ESU FnOut A14 Option 1" mask="XXXXXXXV">
+                        <variable label="Mode" CV="16.0.342" default="0" item="ESU FnOut A9 Option 1" mask="XXXXXXXV">
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>22</value>
                             </qualifier>
@@ -4727,282 +3146,297 @@
                             </enumVal>
                             <label xml:lang="de">Modus</label>
                         </variable>
-                        <variable label="Coupler Force" CV="16.0.382" default="31" item="ESU FnOut A14 Slider 7" mask="XXXVVVVV">
+                        <variable label="Coupler Force" CV="16.0.342" default="31" item="ESU FnOut A9 Slider 7" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>ge</relation>
                                 <value>28</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>29</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>30</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>31</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>32</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>le</relation>
                                 <value>33</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Stärke des Kupplers</label>
                         </variable>
-                        <variable label="Fan Speed" CV="16.0.382" default="31" item="ESU FnOut A14 Slider 11" mask="XXXVVVVV">
+                        <variable label="Fan Speed" CV="16.0.342" default="31" item="ESU FnOut A9 Slider 11" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>23</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Geschwindigkeit</label>
                         </variable>
-                        <variable label="Standing heat" CV="16.0.382" default="31" item="ESU FnOut A14 Slider 14" mask="XXXVVVVV">
+                        <variable label="Standing heat" CV="16.0.342" default="31" item="ESU FnOut A9 Slider 14" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>24</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Heizstufe im Stand</label>
                         </variable>
-                        <variable label="Chuff power" CV="16.0.382" default="31" item="ESU FnOut A14 Slider 8" mask="XXXVVVVV">
+                        <variable label="Chuff power" CV="16.0.342" default="31" item="ESU FnOut A9 Slider 8" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>25</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Dampfstoßstärke</label>
                         </variable>
-                        <variable item="Special Function CV383" label="Special Function CV 1" CV="16.0.383" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                        <variable item="Special Function CV343" label="Special Function CV 1" CV="16.0.343" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
                             <decVal/>
                         </variable>
-                        <variable label="Fan Acceleration rate" CV="16.0.383" default="0" item="ESU FnOut A14 Slider 12" mask="XXXVVVVV">
+                        <variable label="Fan Acceleration rate" CV="16.0.343" default="0" item="ESU FnOut A9 Slider 12" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>23</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Beschleunigungszeit</label>
                         </variable>
-                        <variable label="Minimum driving heat" CV="16.0.383" default="0" item="ESU FnOut A14 Slider 15" mask="XXXVVVVV">
+                        <variable label="Minimum driving heat" CV="16.0.343" default="0" item="ESU FnOut A9 Slider 15" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>24</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
                         </variable>
-                        <variable label="Fan power" CV="16.0.383" default="0" item="ESU FnOut A14 Slider 9" mask="XXXVVVVV">
+                        <variable label="Fan power" CV="16.0.343" default="0" item="ESU FnOut A9 Slider 9" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>25</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Stäke des Bläsers</label>
                         </variable>
-                        <variable label="Phase Reverse" CV="16.0.383" default="0" item="ESU FnOut A14 Check 6" mask="XXXXXXXV">
+                        <variable label="Phase Reverse" CV="16.0.343" default="0" item="ESU FnOut A9 Check 6" mask="XXXXXXXV">
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                             <label xml:lang="de">Phase tauschen</label>
                         </variable>
-                        <variable label="Grade Crossing" CV="16.0.383" default="0" item="ESU FnOut A14 Check 1" mask="XXXXXXVX">
+                        <variable label="Grade Crossing" CV="16.0.343" default="0" item="ESU FnOut A9 Check 1" mask="XXXXXXVX">
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                         </variable>
-                        <variable label="Rule 17 Fwd" CV="16.0.383" default="0" item="ESU FnOut A14 Check 2" mask="XXXXXVXX">
+                        <variable label="Rule 17 Fwd" CV="16.0.343" default="0" item="ESU FnOut A9 Check 2" mask="XXXXXVXX">
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                             <label xml:lang="de">Rule 17 vorwärts</label>
                         </variable>
-                        <variable label="Rule 17 Rev" CV="16.0.383" default="0" item="ESU FnOut A14 Check 3" mask="XXXXVXXX">
+                        <variable label="Rule 17 Rev" CV="16.0.343" default="0" item="ESU FnOut A9 Check 3" mask="XXXXVXXX">
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                             <label xml:lang="de">Rule 17 rückwärts</label>
                         </variable>
-                        <variable label="Dimmer" CV="16.0.383" default="0" item="ESU FnOut A14 Check 4" mask="XXXVXXXX">
+                        <variable label="Dimmer" CV="16.0.343" default="0" item="ESU FnOut A9 Check 4" mask="XXXVXXXX">
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                             <label xml:lang="de">Abdimmen</label>
                         </variable>
-                        <variable label="LED Mode" CV="16.0.383" default="0" item="ESU FnOut A14 Check 5" mask="VXXXXXXX">
+                        <variable label="LED Mode" CV="16.0.343" default="0" item="ESU FnOut A9 Check 5" mask="VXXXXXXX">
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                             <label xml:lang="de">LED Modus</label>
                         </variable>
-                        <variable item="Special Function CV384" label="Special Function CV 2" CV="16.0.384" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                        <variable item="Special Function CV344" label="Special Function CV 2" CV="16.0.344" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
                             <decVal/>
                         </variable>
-                        <variable label="Fan Decceleration rate" CV="16.0.384" default="0" item="ESU FnOut A14 Slider 13" mask="XXXVVVVV">
+                        <variable label="Fan Decceleration rate" CV="16.0.344" default="0" item="ESU FnOut A9 Slider 13" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>23</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Bremszeit</label>
                         </variable>
-                        <variable label="Maximum driving heat" CV="16.0.384" default="0" item="ESU FnOut A14 Slider 16" mask="XXXVVVVV">
+                        <variable label="Maximum driving heat" CV="16.0.344" default="0" item="ESU FnOut A9 Slider 16" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>24</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
                         </variable>
-                        <variable label="Timeout" CV="16.0.384" default="0" item="ESU FnOut A14 Slider 10" tooltip="Units = 0.25 sec">
+                        <variable label="Timeout" CV="16.0.344" default="0" item="ESU FnOut A9 Slider 10" tooltip="Units = 0.25 sec">
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>25</value>
                             </qualifier>
                             <decVal/>
                         </variable>
-                        <variable label="Startup Time" CV="16.0.384" default="0" item="ESU FnOut A14 Slider 6">
+                        <variable label="Startup Time" CV="16.0.344" default="0" item="ESU FnOut A9 Slider 6">
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>ge</relation>
                                 <value>16</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>le</relation>
                                 <value>17</value>
                             </qualifier>
                             <decVal/>
                             <label xml:lang="de">Startzeit</label>
                         </variable>
-                        <variable label="Level" CV="16.0.384" default="0" item="ESU FnOut A14 Slider 20" mask="XVVVVVVV">
+                        <variable label="Level" CV="16.0.344" default="0" item="ESU FnOut A9 Slider 20" mask="XVVVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>19</value>
                             </qualifier>
                             <decVal max="127"/>
                         </variable>
-                        <!-- AUX15 Mode -->
-                        <variable label="AUX15 Mode" CV="16.0.387" default="1" item="ESU FnOut A15 Mode">
+                        <!-- AUX10 Mode -->
+                        <variable label="AUX10 Mode" CV="16.0.347" default="1" item="ESU FnOut A10 Mode">
                             <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
                         </variable>
-                        <variable label="Function Switch On Delay" CV="16.0.388" default="0" item="ESU FnOut A15 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
+                        <variable label="Function Switch On Delay" CV="16.0.348" default="0" item="ESU FnOut A10 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
+                            </qualifier>
+                            <qualifier>
+                                <variableref>ESU FnOut A10 Mode</variableref>
+                                <relation>ne</relation>
+                                <value>27</value>
                             </qualifier>
                             <decVal max="15"/>
                             <label xml:lang="de">Verzögerung beim Einschalten</label>
                         </variable>
-                        <variable label="Function Switch Off Delay" CV="16.0.388" default="0" mask="VVVVXXXX" item="ESU FnOut A15 Slider 2" tooltip="Units = 0.4 sec">
+                        <variable label="Function Switch Off Delay" CV="16.0.348" default="0" mask="VVVVXXXX" item="ESU FnOut A10 Slider 2" tooltip="Units = 0.4 sec">
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
+                            </qualifier>
+                            <qualifier>
+                                <variableref>ESU FnOut A10 Mode</variableref>
+                                <relation>ne</relation>
+                                <value>27</value>
                             </qualifier>
                             <decVal max="15"/>
                             <label xml:lang="de">Verzögerung beim Ausschalten</label>
                         </variable>
-                        <variable label="Function Auto Switch Off" CV="16.0.389" default="0" item="ESU FnOut A15 Slider 3" tooltip="Units = 0.4 sec">
+                        <variable label="Function Auto Switch Off" CV="16.0.349" default="0" item="ESU FnOut A10 Slider 3" tooltip="Units = 0.4 sec">
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
+                            </qualifier>
+                            <qualifier>
+                                <variableref>ESU FnOut A10 Mode</variableref>
+                                <relation>ne</relation>
+                                <value>27</value>
                             </qualifier>
                             <decVal/>
                             <label xml:lang="de">Ausgang automatisch Ausschalten</label>
                         </variable>
-                        <variable item="Brightness CV390" label="Brightness CV" CV="16.0.390" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
+                        <variable item="Brightness CV350" label="Brightness CV" CV="16.0.350" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
                             <decVal/>
                         </variable>
-                        <variable label="Brightness" CV="16.0.390" default="31" item="ESU FnOut A15 Slider 5" mask="XXXVVVVV">
+                        <variable label="Brightness" CV="16.0.350" default="31" item="ESU FnOut A10 Slider 5" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>le</relation>
                                 <value>18</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Helligkeit</label>
                         </variable>
-                        <variable label="Mode" CV="16.0.390" default="0" item="ESU FnOut A15 Option 1" mask="XXXXXXXV">
+                        <variable label="Mode" CV="16.0.350" default="0" item="ESU FnOut A10 Option 1" mask="XXXXXXXV">
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>22</value>
                             </qualifier>
@@ -5018,316 +3452,283 @@
                             </enumVal>
                             <label xml:lang="de">Modus</label>
                         </variable>
-                        <variable label="Coupler Force" CV="16.0.390" default="31" item="ESU FnOut A15 Slider 7" mask="XXXVVVVV">
+                        <variable label="Coupler Force" CV="16.0.350" default="31" item="ESU FnOut A10 Slider 7" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>ge</relation>
                                 <value>28</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>29</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>30</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>31</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>32</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>le</relation>
                                 <value>33</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Stärke des Kupplers</label>
                         </variable>
-                        <variable label="Fan Speed" CV="16.0.390" default="31" item="ESU FnOut A15 Slider 11" mask="XXXVVVVV">
+                        <variable label="Fan Speed" CV="16.0.350" default="31" item="ESU FnOut A10 Slider 11" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>23</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Geschwindigkeit</label>
                         </variable>
-                        <variable label="Standing heat" CV="16.0.390" default="31" item="ESU FnOut A15 Slider 14" mask="XXXVVVVV">
+                        <variable label="Standing heat" CV="16.0.350" default="31" item="ESU FnOut A10 Slider 14" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>24</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Heizstufe im Stand</label>
                         </variable>
-                        <variable label="Chuff power" CV="16.0.390" default="31" item="ESU FnOut A15 Slider 8" mask="XXXVVVVV">
+                        <variable label="Chuff power" CV="16.0.350" default="31" item="ESU FnOut A10 Slider 8" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>25</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Dampfstoßstärke</label>
                         </variable>
-                        <variable label="Duration (speed) A" CV="16.0.386" default="31" item="ESU FnOut A15 Slider 4" mask="XXVVVVVV">
-                            <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
-                                <relation>eq</relation>
-                                <value>27</value>
-                            </qualifier>
-                            <decVal max="63"/>
-                            <label xml:lang="de">Dauer (Geschwindigkeit)</label>
-                        </variable>
-                        <variable label="Duration (speed) B" CV="16.0.390" default="31" item="ESU FnOut A15 Slider 17" mask="XXVVVVVV">
-                            <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
-                                <relation>eq</relation>
-                                <value>27</value>
-                            </qualifier>
-                            <decVal max="63"/>
-                            <label xml:lang="de">Dauer (Geschwindigkeit)</label>
-                        </variable>
-                        <variable item="Special Function CV391" label="Special Function CV 1" CV="16.0.391" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                        <variable item="Special Function CV351" label="Special Function CV 1" CV="16.0.351" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
                             <decVal/>
                         </variable>
-                        <variable label="Fan Acceleration rate" CV="16.0.391" default="0" item="ESU FnOut A15 Slider 12" mask="XXXVVVVV">
+                        <variable label="Fan Acceleration rate" CV="16.0.351" default="0" item="ESU FnOut A10 Slider 12" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>23</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Beschleunigungszeit</label>
                         </variable>
-                        <variable label="Minimum driving heat" CV="16.0.391" default="0" item="ESU FnOut A15 Slider 15" mask="XXXVVVVV">
+                        <variable label="Minimum driving heat" CV="16.0.351" default="0" item="ESU FnOut A10 Slider 15" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>24</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
                         </variable>
-                        <variable label="Position A" CV="16.0.391" default="0" item="ESU FnOut A15 Slider 18" mask="XXVVVVVV">
+                        <variable label="Fan power" CV="16.0.351" default="0" item="ESU FnOut A10 Slider 9" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
-                                <relation>eq</relation>
-                                <value>27</value>
-                            </qualifier>
-                            <decVal max="63"/>
-                        </variable>
-                        <variable label="Fan power" CV="16.0.391" default="0" item="ESU FnOut A15 Slider 9" mask="XXXVVVVV">
-                            <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>25</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Stäke des Bläsers</label>
                         </variable>
-                        <variable label="Phase Reverse" CV="16.0.391" default="0" item="ESU FnOut A15 Check 6" mask="XXXXXXXV">
+                        <variable label="Phase Reverse" CV="16.0.351" default="0" item="ESU FnOut A10 Check 6" mask="XXXXXXXV">
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                             <label xml:lang="de">Phase tauschen</label>
                         </variable>
-                        <variable label="Grade Crossing" CV="16.0.391" default="0" item="ESU FnOut A15 Check 1" mask="XXXXXXVX">
+                        <variable label="Grade Crossing" CV="16.0.351" default="0" item="ESU FnOut A10 Check 1" mask="XXXXXXVX">
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                         </variable>
-                        <variable label="Rule 17 Fwd" CV="16.0.391" default="0" item="ESU FnOut A15 Check 2" mask="XXXXXVXX">
+                        <variable label="Rule 17 Fwd" CV="16.0.351" default="0" item="ESU FnOut A10 Check 2" mask="XXXXXVXX">
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                             <label xml:lang="de">Rule 17 vorwärts</label>
                         </variable>
-                        <variable label="Rule 17 Rev" CV="16.0.391" default="0" item="ESU FnOut A15 Check 3" mask="XXXXVXXX">
+                        <variable label="Rule 17 Rev" CV="16.0.351" default="0" item="ESU FnOut A10 Check 3" mask="XXXXVXXX">
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                             <label xml:lang="de">Rule 17 rückwärts</label>
                         </variable>
-                        <variable label="Dimmer" CV="16.0.391" default="0" item="ESU FnOut A15 Check 4" mask="XXXVXXXX">
+                        <variable label="Dimmer" CV="16.0.351" default="0" item="ESU FnOut A10 Check 4" mask="XXXVXXXX">
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                             <label xml:lang="de">Abdimmen</label>
                         </variable>
-                        <variable label="LED Mode" CV="16.0.391" default="0" item="ESU FnOut A15 Check 5" mask="VXXXXXXX">
+                        <variable label="LED Mode" CV="16.0.351" default="0" item="ESU FnOut A10 Check 5" mask="VXXXXXXX">
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                             <label xml:lang="de">LED Modus</label>
                         </variable>
-                        <variable item="Special Function CV392" label="Special Function CV 2" CV="16.0.392" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                        <variable item="Special Function CV352" label="Special Function CV 2" CV="16.0.352" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
                             <decVal/>
                         </variable>
-                        <variable label="Fan Decceleration rate" CV="16.0.392" default="0" item="ESU FnOut A15 Slider 13" mask="XXXVVVVV">
+                        <variable label="Fan Decceleration rate" CV="16.0.352" default="0" item="ESU FnOut A10 Slider 13" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>23</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Bremszeit</label>
                         </variable>
-                        <variable label="Maximum driving heat" CV="16.0.392" default="0" item="ESU FnOut A15 Slider 16" mask="XXXVVVVV">
+                        <variable label="Maximum driving heat" CV="16.0.352" default="0" item="ESU FnOut A10 Slider 16" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>24</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
                         </variable>
-                        <variable label="Timeout" CV="16.0.392" default="0" item="ESU FnOut A15 Slider 10" tooltip="Units = 0.25 sec">
+                        <variable label="Timeout" CV="16.0.352" default="0" item="ESU FnOut A10 Slider 10" tooltip="Units = 0.25 sec">
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>25</value>
                             </qualifier>
                             <decVal/>
                         </variable>
-                        <variable label="Startup Time" CV="16.0.392" default="0" item="ESU FnOut A15 Slider 6">
+                        <variable label="Startup Time" CV="16.0.352" default="0" item="ESU FnOut A10 Slider 6">
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>ge</relation>
                                 <value>16</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>le</relation>
                                 <value>17</value>
                             </qualifier>
                             <decVal/>
                             <label xml:lang="de">Startzeit</label>
                         </variable>
-                        <variable label="Level" CV="16.0.392" default="0" item="ESU FnOut A15 Slider 20" mask="XVVVVVVV">
+                        <variable label="Level" CV="16.0.352" default="0" item="ESU FnOut A10 Slider 20" mask="XVVVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>19</value>
                             </qualifier>
                             <decVal max="127"/>
                         </variable>
-                        <variable label="Position B" CV="16.0.392" default="0" item="ESU FnOut A15 Slider 19" mask="XXVVVVVV">
-                            <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
-                                <relation>eq</relation>
-                                <value>27</value>
-                            </qualifier>
-                            <decVal max="63"/>
-                        </variable>
-                        <!-- AUX16 Mode -->
-                        <variable label="AUX16 Mode" CV="16.0.395" default="1" item="ESU FnOut A16 Mode">
+                        <!-- AUX11 Mode -->
+                        <variable label="AUX11 Mode" CV="16.0.355" default="1" item="ESU FnOut A11 Mode">
                             <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
+                            <!--label xml:lang="de">Licht vorn - 2</label-->
                         </variable>
-                        <variable label="Function Switch On Delay" CV="16.0.396" default="0" item="ESU FnOut A16 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
+                        <variable label="Function Switch On Delay" CV="16.0.356" default="0" item="ESU FnOut A11 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <decVal max="15"/>
                             <label xml:lang="de">Verzögerung beim Einschalten</label>
                         </variable>
-                        <variable label="Function Switch Off Delay" CV="16.0.396" default="0" mask="VVVVXXXX" item="ESU FnOut A16 Slider 2" tooltip="Units = 0.4 sec">
+                        <variable label="Function Switch Off Delay" CV="16.0.356" default="0" mask="VVVVXXXX" item="ESU FnOut A11 Slider 2" tooltip="Units = 0.4 sec">
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <decVal max="15"/>
                             <label xml:lang="de">Verzögerung beim Ausschalten</label>
                         </variable>
-                        <variable label="Function Auto Switch Off" CV="16.0.397" default="0" item="ESU FnOut A16 Slider 3" tooltip="Units = 0.4 sec">
+                        <variable label="Function Auto Switch Off" CV="16.0.357" default="0" item="ESU FnOut A11 Slider 3" tooltip="Units = 0.4 sec">
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <decVal/>
                             <label xml:lang="de">Ausgang automatisch Ausschalten</label>
                         </variable>
-                        <variable item="Brightness CV398" label="Brightness CV" CV="16.0.398" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
+                        <variable item="Brightness CV358" label="Brightness CV" CV="16.0.358" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
                             <decVal/>
                         </variable>
-                        <variable label="Brightness" CV="16.0.398" default="31" item="ESU FnOut A16 Slider 5" mask="XXXVVVVV">
+                        <variable label="Brightness" CV="16.0.358" default="31" item="ESU FnOut A11 Slider 5" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>le</relation>
                                 <value>18</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Helligkeit</label>
                         </variable>
-                        <variable label="Mode" CV="16.0.398" default="0" item="ESU FnOut A16 Option 1" mask="XXXXXXXV">
+                        <variable label="Mode" CV="16.0.358" default="0" item="ESU FnOut A11 Option 1" mask="XXXXXXXV">
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>22</value>
                             </qualifier>
@@ -5343,316 +3744,316 @@
                             </enumVal>
                             <label xml:lang="de">Modus</label>
                         </variable>
-                        <variable label="Coupler Force" CV="16.0.398" default="31" item="ESU FnOut A16 Slider 7" mask="XXXVVVVV">
+                        <variable label="Coupler Force" CV="16.0.358" default="31" item="ESU FnOut A11 Slider 7" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>ge</relation>
                                 <value>28</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>29</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>30</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>31</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>32</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>le</relation>
                                 <value>33</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Stärke des Kupplers</label>
                         </variable>
-                        <variable label="Fan Speed" CV="16.0.398" default="31" item="ESU FnOut A16 Slider 11" mask="XXXVVVVV">
+                        <variable label="Fan Speed" CV="16.0.358" default="31" item="ESU FnOut A11 Slider 11" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>23</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Geschwindigkeit</label>
                         </variable>
-                        <variable label="Standing heat" CV="16.0.398" default="31" item="ESU FnOut A16 Slider 14" mask="XXXVVVVV">
+                        <variable label="Standing heat" CV="16.0.358" default="31" item="ESU FnOut A11 Slider 14" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>24</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Heizstufe im Stand</label>
                         </variable>
-                        <variable label="Chuff power" CV="16.0.398" default="31" item="ESU FnOut A16 Slider 8" mask="XXXVVVVV">
+                        <variable label="Chuff power" CV="16.0.358" default="31" item="ESU FnOut A11 Slider 8" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>25</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Dampfstoßstärke</label>
                         </variable>
-                        <variable label="Duration (speed) A" CV="16.0.394" default="31" item="ESU FnOut A16 Slider 4" mask="XXVVVVVV">
+                        <variable label="Duration (speed) A" CV="16.0.354" default="31" item="ESU FnOut A11 Slider 4" mask="XXVVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>27</value>
                             </qualifier>
                             <decVal max="63"/>
                             <label xml:lang="de">Dauer (Geschwindigkeit)</label>
                         </variable>
-                        <variable label="Duration (speed) B" CV="16.0.398" default="31" item="ESU FnOut A16 Slider 17" mask="XXVVVVVV">
+                        <variable label="Duration (speed) B" CV="16.0.358" default="31" item="ESU FnOut A11 Slider 17" mask="XXVVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>27</value>
                             </qualifier>
                             <decVal max="63"/>
                             <label xml:lang="de">Dauer (Geschwindigkeit)</label>
                         </variable>
-                        <variable item="Special Function CV399" label="Special Function CV 1" CV="16.0.399" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                        <variable item="Special Function CV359" label="Special Function CV 1" CV="16.0.359" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
                             <decVal/>
                         </variable>
-                        <variable label="Fan Acceleration rate" CV="16.0.399" default="0" item="ESU FnOut A16 Slider 12" mask="XXXVVVVV">
+                        <variable label="Fan Acceleration rate" CV="16.0.359" default="0" item="ESU FnOut A11 Slider 12" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>23</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Beschleunigungszeit</label>
                         </variable>
-                        <variable label="Minimum driving heat" CV="16.0.399" default="0" item="ESU FnOut A16 Slider 15" mask="XXXVVVVV">
+                        <variable label="Minimum driving heat" CV="16.0.359" default="0" item="ESU FnOut A11 Slider 15" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>24</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
                         </variable>
-                        <variable label="Position A" CV="16.0.399" default="0" item="ESU FnOut A16 Slider 18" mask="XXVVVVVV">
+                        <variable label="Position A" CV="16.0.359" default="0" item="ESU FnOut A11 Slider 18" mask="XXVVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>27</value>
                             </qualifier>
                             <decVal max="63"/>
                         </variable>
-                        <variable label="Fan power" CV="16.0.399" default="0" item="ESU FnOut A16 Slider 9" mask="XXXVVVVV">
+                        <variable label="Fan power" CV="16.0.359" default="0" item="ESU FnOut A11 Slider 9" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>25</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Stäke des Bläsers</label>
                         </variable>
-                        <variable label="Phase Reverse" CV="16.0.399" default="0" item="ESU FnOut A16 Check 6" mask="XXXXXXXV">
+                        <variable label="Phase Reverse" CV="16.0.359" default="0" item="ESU FnOut A11 Check 6" mask="XXXXXXXV">
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                             <label xml:lang="de">Phase tauschen</label>
                         </variable>
-                        <variable label="Grade Crossing" CV="16.0.399" default="0" item="ESU FnOut A16 Check 1" mask="XXXXXXVX">
+                        <variable label="Grade Crossing" CV="16.0.359" default="0" item="ESU FnOut A11 Check 1" mask="XXXXXXVX">
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                         </variable>
-                        <variable label="Rule 17 Fwd" CV="16.0.399" default="0" item="ESU FnOut A16 Check 2" mask="XXXXXVXX">
+                        <variable label="Rule 17 Fwd" CV="16.0.359" default="0" item="ESU FnOut A11 Check 2" mask="XXXXXVXX">
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                             <label xml:lang="de">Rule 17 vorwärts</label>
                         </variable>
-                        <variable label="Rule 17 Rev" CV="16.0.399" default="0" item="ESU FnOut A16 Check 3" mask="XXXXVXXX">
+                        <variable label="Rule 17 Rev" CV="16.0.359" default="0" item="ESU FnOut A11 Check 3" mask="XXXXVXXX">
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                             <label xml:lang="de">Rule 17 rückwärts</label>
                         </variable>
-                        <variable label="Dimmer" CV="16.0.399" default="0" item="ESU FnOut A16 Check 4" mask="XXXVXXXX">
+                        <variable label="Dimmer" CV="16.0.359" default="0" item="ESU FnOut A11 Check 4" mask="XXXVXXXX">
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                             <label xml:lang="de">Abdimmen</label>
                         </variable>
-                        <variable label="LED Mode" CV="16.0.399" default="0" item="ESU FnOut A16 Check 5" mask="VXXXXXXX">
+                        <variable label="LED Mode" CV="16.0.359" default="0" item="ESU FnOut A11 Check 5" mask="VXXXXXXX">
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                             <label xml:lang="de">LED Modus</label>
                         </variable>
-                        <variable item="Special Function CV400" label="Special Function CV 2" CV="16.0.400" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                        <variable item="Special Function CV360" label="Special Function CV 2" CV="16.0.360" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
                             <decVal/>
                         </variable>
-                        <variable label="Fan Decceleration rate" CV="16.0.400" default="0" item="ESU FnOut A16 Slider 13" mask="XXXVVVVV">
+                        <variable label="Fan Decceleration rate" CV="16.0.360" default="0" item="ESU FnOut A11 Slider 13" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>23</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Bremszeit</label>
                         </variable>
-                        <variable label="Maximum driving heat" CV="16.0.400" default="0" item="ESU FnOut A16 Slider 16" mask="XXXVVVVV">
+                        <variable label="Maximum driving heat" CV="16.0.360" default="0" item="ESU FnOut A11 Slider 16" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>24</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
                         </variable>
-                        <variable label="Timeout" CV="16.0.400" default="0" item="ESU FnOut A16 Slider 10" tooltip="Units = 0.25 sec">
+                        <variable label="Timeout" CV="16.0.360" default="0" item="ESU FnOut A11 Slider 10" tooltip="Units = 0.25 sec">
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>25</value>
                             </qualifier>
                             <decVal/>
                         </variable>
-                        <variable label="Startup Time" CV="16.0.400" default="0" item="ESU FnOut A16 Slider 6">
+                        <variable label="Startup Time" CV="16.0.360" default="0" item="ESU FnOut A11 Slider 6">
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>ge</relation>
                                 <value>16</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>le</relation>
                                 <value>17</value>
                             </qualifier>
                             <decVal/>
                             <label xml:lang="de">Startzeit</label>
                         </variable>
-                        <variable label="Level" CV="16.0.400" default="0" item="ESU FnOut A16 Slider 20" mask="XVVVVVVV">
+                        <variable label="Level" CV="16.0.360" default="0" item="ESU FnOut A11 Slider 20" mask="XVVVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>19</value>
                             </qualifier>
                             <decVal max="127"/>
                         </variable>
-                        <variable label="Position B" CV="16.0.400" default="0" item="ESU FnOut A16 Slider 19" mask="XXVVVVVV">
+                        <variable label="Position B" CV="16.0.360" default="0" item="ESU FnOut A11 Slider 19" mask="XXVVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>27</value>
                             </qualifier>
                             <decVal max="63"/>
                         </variable>
-                        <!-- AUX17 Mode -->
-                        <variable label="AUX17 Mode" CV="16.0.403" default="1" item="ESU FnOut A17 Mode">
+                        <!-- AUX12 Mode -->
+                        <variable label="AUX12 Mode" CV="16.0.363" default="1" item="ESU FnOut A12 Mode">
                             <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
                         </variable>
-                        <variable label="Function Switch On Delay" CV="16.0.404" default="0" item="ESU FnOut A17 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
+                        <variable label="Function Switch On Delay" CV="16.0.364" default="0" item="ESU FnOut A12 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <decVal max="15"/>
                             <label xml:lang="de">Verzögerung beim Einschalten</label>
                         </variable>
-                        <variable label="Function Switch Off Delay" CV="16.0.404" default="0" mask="VVVVXXXX" item="ESU FnOut A17 Slider 2" tooltip="Units = 0.4 sec">
+                        <variable label="Function Switch Off Delay" CV="16.0.364" default="0" mask="VVVVXXXX" item="ESU FnOut A12 Slider 2" tooltip="Units = 0.4 sec">
                             <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <decVal max="15"/>
                             <label xml:lang="de">Verzögerung beim Ausschalten</label>
                         </variable>
-                        <variable label="Function Auto Switch Off" CV="16.0.405" default="0" item="ESU FnOut A17 Slider 3" tooltip="Units = 0.4 sec">
+                        <variable label="Function Auto Switch Off" CV="16.0.365" default="0" item="ESU FnOut A12 Slider 3" tooltip="Units = 0.4 sec">
                             <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <decVal/>
                             <label xml:lang="de">Ausgang automatisch Ausschalten</label>
                         </variable>
-                        <variable item="Brightness CV406" label="Brightness CV" CV="16.0.406" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
+                        <variable item="Brightness CV366" label="Brightness CV" CV="16.0.366" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
                             <decVal/>
                         </variable>
-                        <variable label="Brightness" CV="16.0.406" default="31" item="ESU FnOut A17 Slider 5" mask="XXXVVVVV">
+                        <variable label="Brightness" CV="16.0.366" default="31" item="ESU FnOut A12 Slider 5" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>le</relation>
                                 <value>18</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Helligkeit</label>
                         </variable>
-                        <variable label="Mode" CV="16.0.406" default="0" item="ESU FnOut A17 Option 1" mask="XXXXXXXV">
+                        <variable label="Mode" CV="16.0.366" default="0" item="ESU FnOut A12 Option 1" mask="XXXXXXXV">
                             <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>22</value>
                             </qualifier>
@@ -5668,590 +4069,2179 @@
                             </enumVal>
                             <label xml:lang="de">Modus</label>
                         </variable>
-                        <variable label="Coupler Force" CV="16.0.406" default="31" item="ESU FnOut A17 Slider 7" mask="XXXVVVVV">
+                        <variable label="Coupler Force" CV="16.0.366" default="31" item="ESU FnOut A12 Slider 7" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>ge</relation>
                                 <value>28</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>29</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>30</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>31</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>32</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>le</relation>
                                 <value>33</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Stärke des Kupplers</label>
                         </variable>
-                        <variable label="Fan Speed" CV="16.0.406" default="31" item="ESU FnOut A17 Slider 11" mask="XXXVVVVV">
+                        <variable label="Fan Speed" CV="16.0.366" default="31" item="ESU FnOut A12 Slider 11" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>23</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Geschwindigkeit</label>
                         </variable>
-                        <variable label="Standing heat" CV="16.0.406" default="31" item="ESU FnOut A17 Slider 14" mask="XXXVVVVV">
+                        <variable label="Standing heat" CV="16.0.366" default="31" item="ESU FnOut A12 Slider 14" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>24</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Heizstufe im Stand</label>
                         </variable>
-                        <variable label="Chuff power" CV="16.0.406" default="31" item="ESU FnOut A17 Slider 8" mask="XXXVVVVV">
+                        <variable label="Chuff power" CV="16.0.366" default="31" item="ESU FnOut A12 Slider 8" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>25</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Dampfstoßstärke</label>
                         </variable>
-                        <variable label="Duration (speed) A" CV="16.0.402" default="31" item="ESU FnOut A17 Slider 4" mask="XXVVVVVV">
+                        <variable label="Duration (speed) A" CV="16.0.362" default="31" item="ESU FnOut A12 Slider 4" mask="XXVVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>27</value>
                             </qualifier>
                             <decVal max="63"/>
                             <label xml:lang="de">Dauer (Geschwindigkeit)</label>
                         </variable>
-                        <variable label="Duration (speed) B" CV="16.0.406" default="31" item="ESU FnOut A17 Slider 17" mask="XXVVVVVV">
+                        <variable label="Duration (speed) B" CV="16.0.366" default="31" item="ESU FnOut A12 Slider 17" mask="XXVVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>27</value>
                             </qualifier>
                             <decVal max="63"/>
                             <label xml:lang="de">Dauer (Geschwindigkeit)</label>
                         </variable>
-                        <variable item="Special Function CV407" label="Special Function CV 1" CV="16.0.407" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                        <variable item="Special Function CV367" label="Special Function CV 1" CV="16.0.367" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
                             <decVal/>
                         </variable>
-                        <variable label="Fan Acceleration rate" CV="16.0.407" default="0" item="ESU FnOut A17 Slider 12" mask="XXXVVVVV">
+                        <variable label="Fan Acceleration rate" CV="16.0.367" default="0" item="ESU FnOut A12 Slider 12" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>23</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Beschleunigungszeit</label>
                         </variable>
-                        <variable label="Minimum driving heat" CV="16.0.407" default="0" item="ESU FnOut A17 Slider 15" mask="XXXVVVVV">
+                        <variable label="Minimum driving heat" CV="16.0.367" default="0" item="ESU FnOut A12 Slider 15" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>24</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
                         </variable>
-                        <variable label="Position A" CV="16.0.407" default="0" item="ESU FnOut A17 Slider 18" mask="XXVVVVVV">
+                        <variable label="Position A" CV="16.0.367" default="0" item="ESU FnOut A12 Slider 18" mask="XXVVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>27</value>
                             </qualifier>
                             <decVal max="63"/>
                         </variable>
-                        <variable label="Fan power" CV="16.0.407" default="0" item="ESU FnOut A17 Slider 9" mask="XXXVVVVV">
+                        <variable label="Fan power" CV="16.0.367" default="0" item="ESU FnOut A12 Slider 9" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>25</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Stäke des Bläsers</label>
                         </variable>
-                        <variable label="Phase Reverse" CV="16.0.407" default="0" item="ESU FnOut A17 Check 6" mask="XXXXXXXV">
+                        <variable label="Phase Reverse" CV="16.0.367" default="0" item="ESU FnOut A12 Check 6" mask="XXXXXXXV">
                             <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                             <label xml:lang="de">Phase tauschen</label>
                         </variable>
-                        <variable label="Grade Crossing" CV="16.0.407" default="0" item="ESU FnOut A17 Check 1" mask="XXXXXXVX">
+                        <variable label="Grade Crossing" CV="16.0.367" default="0" item="ESU FnOut A12 Check 1" mask="XXXXXXVX">
                             <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                         </variable>
-                        <variable label="Rule 17 Fwd" CV="16.0.407" default="0" item="ESU FnOut A17 Check 2" mask="XXXXXVXX">
+                        <variable label="Rule 17 Fwd" CV="16.0.367" default="0" item="ESU FnOut A12 Check 2" mask="XXXXXVXX">
                             <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
-                                <relation>le</relation>
-                                <value>15</value>
-                            </qualifier>
-                            <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                            <label xml:lang="de">Rule 17 vorwärts</label>
-                        </variable>
-                        <variable label="Rule 17 Rev" CV="16.0.407" default="0" item="ESU FnOut A17 Check 3" mask="XXXXVXXX">
-                            <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
-                                <relation>gt</relation>
-                                <value>0</value>
-                            </qualifier>
-                            <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
-                                <relation>le</relation>
-                                <value>15</value>
-                            </qualifier>
-                            <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                            <label xml:lang="de">Rule 17 rückwärts</label>
-                        </variable>
-                        <variable label="Dimmer" CV="16.0.407" default="0" item="ESU FnOut A17 Check 4" mask="XXXVXXXX">
-                            <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
-                                <relation>gt</relation>
-                                <value>0</value>
-                            </qualifier>
-                            <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
-                                <relation>le</relation>
-                                <value>15</value>
-                            </qualifier>
-                            <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                            <label xml:lang="de">Abdimmen</label>
-                        </variable>
-                        <variable label="LED Mode" CV="16.0.407" default="0" item="ESU FnOut A17 Check 5" mask="VXXXXXXX">
-                            <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
-                                <relation>gt</relation>
-                                <value>0</value>
-                            </qualifier>
-                            <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
-                                <relation>le</relation>
-                                <value>15</value>
-                            </qualifier>
-                            <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                            <label xml:lang="de">LED Modus</label>
-                        </variable>
-                        <variable item="Special Function CV408" label="Special Function CV 2" CV="16.0.408" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
-                            <decVal/>
-                        </variable>
-                        <variable label="Fan Decceleration rate" CV="16.0.408" default="0" item="ESU FnOut A17 Slider 13" mask="XXXVVVVV">
-                            <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
-                                <relation>eq</relation>
-                                <value>23</value>
-                            </qualifier>
-                            <decVal max="31"/>
-                            <label xml:lang="de">Bremszeit</label>
-                        </variable>
-                        <variable label="Maximum driving heat" CV="16.0.408" default="0" item="ESU FnOut A17 Slider 16" mask="XXXVVVVV">
-                            <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
-                                <relation>eq</relation>
-                                <value>24</value>
-                            </qualifier>
-                            <decVal max="31"/>
-                            <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
-                        </variable>
-                        <variable label="Timeout" CV="16.0.408" default="0" item="ESU FnOut A17 Slider 10" tooltip="Units = 0.25 sec">
-                            <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
-                                <relation>eq</relation>
-                                <value>25</value>
-                            </qualifier>
-                            <decVal/>
-                        </variable>
-                        <variable label="Startup Time" CV="16.0.408" default="0" item="ESU FnOut A17 Slider 6">
-                            <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
-                                <relation>ge</relation>
-                                <value>16</value>
-                            </qualifier>
-                            <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
-                                <relation>le</relation>
-                                <value>17</value>
-                            </qualifier>
-                            <decVal/>
-                            <label xml:lang="de">Startzeit</label>
-                        </variable>
-                        <variable label="Level" CV="16.0.408" default="0" item="ESU FnOut A17 Slider 20" mask="XVVVVVVV">
-                            <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
-                                <relation>eq</relation>
-                                <value>19</value>
-                            </qualifier>
-                            <decVal max="127"/>
-                        </variable>
-                        <variable label="Position B" CV="16.0.408" default="0" item="ESU FnOut A17 Slider 19" mask="XXVVVVVV">
-                            <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
-                                <relation>eq</relation>
-                                <value>27</value>
-                            </qualifier>
-                            <decVal max="63"/>
-                        </variable>
-                        <!-- AUX18 Mode -->
-                        <variable label="AUX18 Mode" CV="16.0.411" default="1" item="ESU FnOut A18 Mode">
-                            <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
-                        </variable>
-                        <variable label="Function Switch On Delay" CV="16.0.412" default="0" item="ESU FnOut A18 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
-                            <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
-                                <relation>gt</relation>
-                                <value>0</value>
-                            </qualifier>
-                            <decVal max="15"/>
-                            <label xml:lang="de">Verzögerung beim Einschalten</label>
-                        </variable>
-                        <variable label="Function Switch Off Delay" CV="16.0.412" default="0" mask="VVVVXXXX" item="ESU FnOut A18 Slider 2" tooltip="Units = 0.4 sec">
-                            <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
-                                <relation>gt</relation>
-                                <value>0</value>
-                            </qualifier>
-                            <decVal max="15"/>
-                            <label xml:lang="de">Verzögerung beim Ausschalten</label>
-                        </variable>
-                        <variable label="Function Auto Switch Off" CV="16.0.413" default="0" item="ESU FnOut A18 Slider 3" tooltip="Units = 0.4 sec">
-                            <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
-                                <relation>gt</relation>
-                                <value>0</value>
-                            </qualifier>
-                            <decVal/>
-                            <label xml:lang="de">Ausgang automatisch Ausschalten</label>
-                        </variable>
-                        <variable item="Brightness CV414" label="Brightness CV" CV="16.0.414" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
-                            <decVal/>
-                        </variable>
-                        <variable label="Brightness" CV="16.0.414" default="31" item="ESU FnOut A18 Slider 5" mask="XXXVVVVV">
-                            <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
-                                <relation>gt</relation>
-                                <value>0</value>
-                            </qualifier>
-                            <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
-                                <relation>le</relation>
-                                <value>18</value>
-                            </qualifier>
-                            <decVal max="31"/>
-                            <label xml:lang="de">Helligkeit</label>
-                        </variable>
-                        <variable label="Mode" CV="16.0.414" default="0" item="ESU FnOut A18 Option 1" mask="XXXXXXXV">
-                            <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
-                                <relation>eq</relation>
-                                <value>22</value>
-                            </qualifier>
-                            <enumVal>
-                                <enumChoice choice="Heating control">
-                                    <choice>Heating control</choice>
-                                    <choice xml:lang="de">Heizungssteuerung</choice>
-                                </enumChoice>
-                                <enumChoice choice="Fan control">
-                                    <choice>Fan control</choice>
-                                    <choice xml:lang="de">Lüftersteuerung</choice>
-                                </enumChoice>
-                            </enumVal>
-                            <label xml:lang="de">Modus</label>
-                        </variable>
-                        <variable label="Coupler Force" CV="16.0.414" default="31" item="ESU FnOut A18 Slider 7" mask="XXXVVVVV">
-                            <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
-                                <relation>ge</relation>
-                                <value>28</value>
-                            </qualifier>
-                            <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
-                                <relation>ne</relation>
-                                <value>29</value>
-                            </qualifier>
-                            <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
-                                <relation>ne</relation>
-                                <value>30</value>
-                            </qualifier>
-                            <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
-                                <relation>ne</relation>
-                                <value>31</value>
-                            </qualifier>
-                            <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
-                                <relation>ne</relation>
-                                <value>32</value>
-                            </qualifier>
-                            <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
-                                <relation>le</relation>
-                                <value>33</value>
-                            </qualifier>
-                            <decVal max="31"/>
-                            <label xml:lang="de">Stärke des Kupplers</label>
-                        </variable>
-                        <variable label="Fan Speed" CV="16.0.414" default="31" item="ESU FnOut A18 Slider 11" mask="XXXVVVVV">
-                            <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
-                                <relation>eq</relation>
-                                <value>23</value>
-                            </qualifier>
-                            <decVal max="31"/>
-                            <label xml:lang="de">Geschwindigkeit</label>
-                        </variable>
-                        <variable label="Standing heat" CV="16.0.414" default="31" item="ESU FnOut A18 Slider 14" mask="XXXVVVVV">
-                            <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
-                                <relation>eq</relation>
-                                <value>24</value>
-                            </qualifier>
-                            <decVal max="31"/>
-                            <label xml:lang="de">Heizstufe im Stand</label>
-                        </variable>
-                        <variable label="Chuff power" CV="16.0.414" default="31" item="ESU FnOut A18 Slider 8" mask="XXXVVVVV">
-                            <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
-                                <relation>eq</relation>
-                                <value>25</value>
-                            </qualifier>
-                            <decVal max="31"/>
-                            <label xml:lang="de">Dampfstoßstärke</label>
-                        </variable>
-                        <variable label="Duration (speed) A" CV="16.0.410" default="31" item="ESU FnOut A18 Slider 4" mask="XXVVVVVV">
-                            <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
-                                <relation>eq</relation>
-                                <value>27</value>
-                            </qualifier>
-                            <decVal max="63"/>
-                            <label xml:lang="de">Dauer (Geschwindigkeit)</label>
-                        </variable>
-                        <variable label="Duration (speed) B" CV="16.0.414" default="31" item="ESU FnOut A18 Slider 17" mask="XXVVVVVV">
-                            <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
-                                <relation>eq</relation>
-                                <value>27</value>
-                            </qualifier>
-                            <decVal max="63"/>
-                            <label xml:lang="de">Dauer (Geschwindigkeit)</label>
-                        </variable>
-                        <variable item="Special Function CV415" label="Special Function CV 1" CV="16.0.415" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
-                            <decVal/>
-                        </variable>
-                        <variable label="Fan Acceleration rate" CV="16.0.415" default="0" item="ESU FnOut A18 Slider 12" mask="XXXVVVVV">
-                            <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
-                                <relation>eq</relation>
-                                <value>23</value>
-                            </qualifier>
-                            <decVal max="31"/>
-                            <label xml:lang="de">Beschleunigungszeit</label>
-                        </variable>
-                        <variable label="Minimum driving heat" CV="16.0.415" default="0" item="ESU FnOut A18 Slider 15" mask="XXXVVVVV">
-                            <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
-                                <relation>eq</relation>
-                                <value>24</value>
-                            </qualifier>
-                            <decVal max="31"/>
-                            <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
-                        </variable>
-                        <variable label="Position A" CV="16.0.415" default="0" item="ESU FnOut A18 Slider 18" mask="XXVVVVVV">
-                            <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
-                                <relation>eq</relation>
-                                <value>27</value>
-                            </qualifier>
-                            <decVal max="63"/>
-                        </variable>
-                        <variable label="Fan power" CV="16.0.415" default="0" item="ESU FnOut A18 Slider 9" mask="XXXVVVVV">
-                            <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
-                                <relation>eq</relation>
-                                <value>25</value>
-                            </qualifier>
-                            <decVal max="31"/>
-                            <label xml:lang="de">Stäke des Bläsers</label>
-                        </variable>
-                        <variable label="Phase Reverse" CV="16.0.415" default="0" item="ESU FnOut A18 Check 6" mask="XXXXXXXV">
-                            <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
-                                <relation>gt</relation>
-                                <value>0</value>
-                            </qualifier>
-                            <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
-                                <relation>le</relation>
-                                <value>15</value>
-                            </qualifier>
-                            <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                            <label xml:lang="de">Phase tauschen</label>
-                        </variable>
-                        <variable label="Grade Crossing" CV="16.0.415" default="0" item="ESU FnOut A18 Check 1" mask="XXXXXXVX">
-                            <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
-                                <relation>gt</relation>
-                                <value>0</value>
-                            </qualifier>
-                            <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
-                                <relation>le</relation>
-                                <value>15</value>
-                            </qualifier>
-                            <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                        </variable>
-                        <variable label="Rule 17 Fwd" CV="16.0.415" default="0" item="ESU FnOut A18 Check 2" mask="XXXXXVXX">
-                            <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
-                                <relation>gt</relation>
-                                <value>0</value>
-                            </qualifier>
-                            <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                             <label xml:lang="de">Rule 17 vorwärts</label>
                         </variable>
-                        <variable label="Rule 17 Rev" CV="16.0.415" default="0" item="ESU FnOut A18 Check 3" mask="XXXXVXXX">
+                        <variable label="Rule 17 Rev" CV="16.0.367" default="0" item="ESU FnOut A12 Check 3" mask="XXXXVXXX">
                             <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                             <label xml:lang="de">Rule 17 rückwärts</label>
                         </variable>
-                        <variable label="Dimmer" CV="16.0.415" default="0" item="ESU FnOut A18 Check 4" mask="XXXVXXXX">
+                        <variable label="Dimmer" CV="16.0.367" default="0" item="ESU FnOut A12 Check 4" mask="XXXVXXXX">
                             <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                             <label xml:lang="de">Abdimmen</label>
                         </variable>
-                        <variable label="LED Mode" CV="16.0.415" default="0" item="ESU FnOut A18 Check 5" mask="VXXXXXXX">
+                        <variable label="LED Mode" CV="16.0.367" default="0" item="ESU FnOut A12 Check 5" mask="VXXXXXXX">
                             <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                             <label xml:lang="de">LED Modus</label>
                         </variable>
-                        <variable item="Special Function CV416" label="Special Function CV 2" CV="16.0.416" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                        <variable item="Special Function CV368" label="Special Function CV 2" CV="16.0.368" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
                             <decVal/>
                         </variable>
-                        <variable label="Fan Decceleration rate" CV="16.0.416" default="0" item="ESU FnOut A18 Slider 13" mask="XXXVVVVV">
+                        <variable label="Fan Decceleration rate" CV="16.0.368" default="0" item="ESU FnOut A12 Slider 13" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>23</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Bremszeit</label>
                         </variable>
-                        <variable label="Maximum driving heat" CV="16.0.416" default="0" item="ESU FnOut A18 Slider 16" mask="XXXVVVVV">
+                        <variable label="Maximum driving heat" CV="16.0.368" default="0" item="ESU FnOut A12 Slider 16" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>24</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
                         </variable>
-                        <variable label="Timeout" CV="16.0.416" default="0" item="ESU FnOut A18 Slider 10" tooltip="Units = 0.25 sec">
+                        <variable label="Timeout" CV="16.0.368" default="0" item="ESU FnOut A12 Slider 10" tooltip="Units = 0.25 sec">
                             <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>25</value>
                             </qualifier>
                             <decVal/>
                         </variable>
-                        <variable label="Startup Time" CV="16.0.416" default="0" item="ESU FnOut A18 Slider 6">
+                        <variable label="Startup Time" CV="16.0.368" default="0" item="ESU FnOut A12 Slider 6">
                             <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>ge</relation>
                                 <value>16</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>le</relation>
                                 <value>17</value>
                             </qualifier>
                             <decVal/>
                             <label xml:lang="de">Startzeit</label>
                         </variable>
-                        <variable label="Level" CV="16.0.416" default="0" item="ESU FnOut A18 Slider 20" mask="XVVVVVVV">
+                        <variable label="Level" CV="16.0.368" default="0" item="ESU FnOut A12 Slider 20" mask="XVVVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>19</value>
                             </qualifier>
                             <decVal max="127"/>
                         </variable>
-                        <variable label="Position B" CV="16.0.416" default="0" item="ESU FnOut A18 Slider 19" mask="XXVVVVVV">
+                        <variable label="Position B" CV="16.0.368" default="0" item="ESU FnOut A12 Slider 19" mask="XXVVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>27</value>
                             </qualifier>
                             <decVal max="63"/>
                         </variable>
+                        <!-- exclude AUX13 to AUX18 -->
+                        <variables exclude="LokSound 5 Fx,LokSound 5 Fx DCC,LokPilot 5 Fx,LokPilot 5 Fx DCC">                <!-- AUX13 Mode -->
+                            <variable label="AUX13 Mode" CV="16.0.371" default="1" item="ESU FnOut A13 Mode">
+                                <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
+                            </variable>
+                            <variable label="Function Switch On Delay" CV="16.0.372" default="0" item="ESU FnOut A13 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>ne</relation>
+                                    <value>27</value>
+                                </qualifier>
+                                <decVal max="15"/>
+                                <label xml:lang="de">Verzögerung beim Einschalten</label>
+                            </variable>
+                            <variable label="Function Switch Off Delay" CV="16.0.372" default="0" mask="VVVVXXXX" item="ESU FnOut A13 Slider 2" tooltip="Units = 0.4 sec">
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>ne</relation>
+                                    <value>27</value>
+                                </qualifier>
+                                <decVal max="15"/>
+                                <label xml:lang="de">Verzögerung beim Ausschalten</label>
+                            </variable>
+                            <variable label="Function Auto Switch Off" CV="16.0.373" default="0" item="ESU FnOut A13 Slider 3" tooltip="Units = 0.4 sec">
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>ne</relation>
+                                    <value>27</value>
+                                </qualifier>
+                                <decVal/>
+                                <label xml:lang="de">Ausgang automatisch Ausschalten</label>
+                            </variable>
+                            <variable item="Brightness CV374" label="Brightness CV" CV="16.0.374" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
+                                <decVal/>
+                            </variable>
+                            <variable label="Brightness" CV="16.0.374" default="31" item="ESU FnOut A13 Slider 5" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>18</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Helligkeit</label>
+                            </variable>
+                            <variable label="Mode" CV="16.0.374" default="0" item="ESU FnOut A13 Option 1" mask="XXXXXXXV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>22</value>
+                                </qualifier>
+                                <enumVal>
+                                    <enumChoice choice="Heating control">
+                                        <choice>Heating control</choice>
+                                        <choice xml:lang="de">Heizungssteuerung</choice>
+                                    </enumChoice>
+                                    <enumChoice choice="Fan control">
+                                        <choice>Fan control</choice>
+                                        <choice xml:lang="de">Lüftersteuerung</choice>
+                                    </enumChoice>
+                                </enumVal>
+                                <label xml:lang="de">Modus</label>
+                            </variable>
+                            <variable label="Coupler Force" CV="16.0.374" default="31" item="ESU FnOut A13 Slider 7" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>ge</relation>
+                                    <value>28</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>ne</relation>
+                                    <value>29</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>ne</relation>
+                                    <value>30</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>ne</relation>
+                                    <value>31</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>ne</relation>
+                                    <value>32</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>33</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Stärke des Kupplers</label>
+                            </variable>
+                            <variable label="Fan Speed" CV="16.0.374" default="31" item="ESU FnOut A13 Slider 11" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>23</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Geschwindigkeit</label>
+                            </variable>
+                            <variable label="Standing heat" CV="16.0.374" default="31" item="ESU FnOut A13 Slider 14" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>24</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Heizstufe im Stand</label>
+                            </variable>
+                            <variable label="Chuff power" CV="16.0.374" default="31" item="ESU FnOut A13 Slider 8" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>25</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Dampfstoßstärke</label>
+                            </variable>
+                            <variable item="Special Function CV375" label="Special Function CV 1" CV="16.0.375" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                                <decVal/>
+                            </variable>
+                            <variable label="Fan Acceleration rate" CV="16.0.375" default="0" item="ESU FnOut A13 Slider 12" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>23</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Beschleunigungszeit</label>
+                            </variable>
+                            <variable label="Minimum driving heat" CV="16.0.375" default="0" item="ESU FnOut A13 Slider 15" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>24</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
+                            </variable>
+                            <variable label="Fan power" CV="16.0.375" default="0" item="ESU FnOut A13 Slider 9" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>25</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Stäke des Bläsers</label>
+                            </variable>
+                            <variable label="Phase Reverse" CV="16.0.375" default="0" item="ESU FnOut A13 Check 6" mask="XXXXXXXV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                                <label xml:lang="de">Phase tauschen</label>
+                            </variable>
+                            <variable label="Grade Crossing" CV="16.0.375" default="0" item="ESU FnOut A13 Check 1" mask="XXXXXXVX">
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                            </variable>
+                            <variable label="Rule 17 Fwd" CV="16.0.375" default="0" item="ESU FnOut A13 Check 2" mask="XXXXXVXX">
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                                <label xml:lang="de">Rule 17 vorwärts</label>
+                            </variable>
+                            <variable label="Rule 17 Rev" CV="16.0.375" default="0" item="ESU FnOut A13 Check 3" mask="XXXXVXXX">
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                                <label xml:lang="de">Rule 17 rückwärts</label>
+                            </variable>
+                            <variable label="Dimmer" CV="16.0.375" default="0" item="ESU FnOut A13 Check 4" mask="XXXVXXXX">
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                                <label xml:lang="de">Abdimmen</label>
+                            </variable>
+                            <variable label="LED Mode" CV="16.0.375" default="0" item="ESU FnOut A13 Check 5" mask="VXXXXXXX">
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                                <label xml:lang="de">LED Modus</label>
+                            </variable>
+                            <variable item="Special Function CV376" label="Special Function CV 2" CV="16.0.376" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                                <decVal/>
+                            </variable>
+                            <variable label="Fan Decceleration rate" CV="16.0.376" default="0" item="ESU FnOut A13 Slider 13" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>23</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Bremszeit</label>
+                            </variable>
+                            <variable label="Maximum driving heat" CV="16.0.376" default="0" item="ESU FnOut A13 Slider 16" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>24</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
+                            </variable>
+                            <variable label="Timeout" CV="16.0.376" default="0" item="ESU FnOut A13 Slider 10" tooltip="Units = 0.25 sec">
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>25</value>
+                                </qualifier>
+                                <decVal/>
+                            </variable>
+                            <variable label="Startup Time" CV="16.0.376" default="0" item="ESU FnOut A13 Slider 6">
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>ge</relation>
+                                    <value>16</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>17</value>
+                                </qualifier>
+                                <decVal/>
+                                <label xml:lang="de">Startzeit</label>
+                            </variable>
+                            <variable label="Level" CV="16.0.376" default="0" item="ESU FnOut A13 Slider 20" mask="XVVVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>19</value>
+                                </qualifier>
+                                <decVal max="127"/>
+                            </variable>
+                            <!-- AUX14 Mode -->
+                            <variable label="AUX14 Mode" CV="16.0.379" default="1" item="ESU FnOut A14 Mode">
+                                <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
+                            </variable>
+                            <variable label="Function Switch On Delay" CV="16.0.380" default="0" item="ESU FnOut A14 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>ne</relation>
+                                    <value>27</value>
+                                </qualifier>
+                                <decVal max="15"/>
+                                <label xml:lang="de">Verzögerung beim Einschalten</label>
+                            </variable>
+                            <variable label="Function Switch Off Delay" CV="16.0.380" default="0" mask="VVVVXXXX" item="ESU FnOut A14 Slider 2" tooltip="Units = 0.4 sec">
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>ne</relation>
+                                    <value>27</value>
+                                </qualifier>
+                                <decVal max="15"/>
+                                <label xml:lang="de">Verzögerung beim Ausschalten</label>
+                            </variable>
+                            <variable label="Function Auto Switch Off" CV="16.0.381" default="0" item="ESU FnOut A14 Slider 3" tooltip="Units = 0.4 sec">
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>ne</relation>
+                                    <value>27</value>
+                                </qualifier>
+                                <decVal/>
+                                <label xml:lang="de">Ausgang automatisch Ausschalten</label>
+                            </variable>
+                            <variable item="Brightness CV382" label="Brightness CV" CV="16.0.382" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
+                                <decVal/>
+                            </variable>
+                            <variable label="Brightness" CV="16.0.382" default="31" item="ESU FnOut A14 Slider 5" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>18</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Helligkeit</label>
+                            </variable>
+                            <variable label="Mode" CV="16.0.382" default="0" item="ESU FnOut A14 Option 1" mask="XXXXXXXV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>22</value>
+                                </qualifier>
+                                <enumVal>
+                                    <enumChoice choice="Heating control">
+                                        <choice>Heating control</choice>
+                                        <choice xml:lang="de">Heizungssteuerung</choice>
+                                    </enumChoice>
+                                    <enumChoice choice="Fan control">
+                                        <choice>Fan control</choice>
+                                        <choice xml:lang="de">Lüftersteuerung</choice>
+                                    </enumChoice>
+                                </enumVal>
+                                <label xml:lang="de">Modus</label>
+                            </variable>
+                            <variable label="Coupler Force" CV="16.0.382" default="31" item="ESU FnOut A14 Slider 7" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>ge</relation>
+                                    <value>28</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>ne</relation>
+                                    <value>29</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>ne</relation>
+                                    <value>30</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>ne</relation>
+                                    <value>31</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>ne</relation>
+                                    <value>32</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>33</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Stärke des Kupplers</label>
+                            </variable>
+                            <variable label="Fan Speed" CV="16.0.382" default="31" item="ESU FnOut A14 Slider 11" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>23</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Geschwindigkeit</label>
+                            </variable>
+                            <variable label="Standing heat" CV="16.0.382" default="31" item="ESU FnOut A14 Slider 14" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>24</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Heizstufe im Stand</label>
+                            </variable>
+                            <variable label="Chuff power" CV="16.0.382" default="31" item="ESU FnOut A14 Slider 8" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>25</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Dampfstoßstärke</label>
+                            </variable>
+                            <variable item="Special Function CV383" label="Special Function CV 1" CV="16.0.383" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                                <decVal/>
+                            </variable>
+                            <variable label="Fan Acceleration rate" CV="16.0.383" default="0" item="ESU FnOut A14 Slider 12" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>23</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Beschleunigungszeit</label>
+                            </variable>
+                            <variable label="Minimum driving heat" CV="16.0.383" default="0" item="ESU FnOut A14 Slider 15" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>24</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
+                            </variable>
+                            <variable label="Fan power" CV="16.0.383" default="0" item="ESU FnOut A14 Slider 9" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>25</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Stäke des Bläsers</label>
+                            </variable>
+                            <variable label="Phase Reverse" CV="16.0.383" default="0" item="ESU FnOut A14 Check 6" mask="XXXXXXXV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                                <label xml:lang="de">Phase tauschen</label>
+                            </variable>
+                            <variable label="Grade Crossing" CV="16.0.383" default="0" item="ESU FnOut A14 Check 1" mask="XXXXXXVX">
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                            </variable>
+                            <variable label="Rule 17 Fwd" CV="16.0.383" default="0" item="ESU FnOut A14 Check 2" mask="XXXXXVXX">
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                                <label xml:lang="de">Rule 17 vorwärts</label>
+                            </variable>
+                            <variable label="Rule 17 Rev" CV="16.0.383" default="0" item="ESU FnOut A14 Check 3" mask="XXXXVXXX">
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                                <label xml:lang="de">Rule 17 rückwärts</label>
+                            </variable>
+                            <variable label="Dimmer" CV="16.0.383" default="0" item="ESU FnOut A14 Check 4" mask="XXXVXXXX">
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                                <label xml:lang="de">Abdimmen</label>
+                            </variable>
+                            <variable label="LED Mode" CV="16.0.383" default="0" item="ESU FnOut A14 Check 5" mask="VXXXXXXX">
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                                <label xml:lang="de">LED Modus</label>
+                            </variable>
+                            <variable item="Special Function CV384" label="Special Function CV 2" CV="16.0.384" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                                <decVal/>
+                            </variable>
+                            <variable label="Fan Decceleration rate" CV="16.0.384" default="0" item="ESU FnOut A14 Slider 13" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>23</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Bremszeit</label>
+                            </variable>
+                            <variable label="Maximum driving heat" CV="16.0.384" default="0" item="ESU FnOut A14 Slider 16" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>24</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
+                            </variable>
+                            <variable label="Timeout" CV="16.0.384" default="0" item="ESU FnOut A14 Slider 10" tooltip="Units = 0.25 sec">
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>25</value>
+                                </qualifier>
+                                <decVal/>
+                            </variable>
+                            <variable label="Startup Time" CV="16.0.384" default="0" item="ESU FnOut A14 Slider 6">
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>ge</relation>
+                                    <value>16</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>17</value>
+                                </qualifier>
+                                <decVal/>
+                                <label xml:lang="de">Startzeit</label>
+                            </variable>
+                            <variable label="Level" CV="16.0.384" default="0" item="ESU FnOut A14 Slider 20" mask="XVVVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>19</value>
+                                </qualifier>
+                                <decVal max="127"/>
+                            </variable>
+                            <!-- AUX15 Mode -->
+                            <variable label="AUX15 Mode" CV="16.0.387" default="1" item="ESU FnOut A15 Mode">
+                                <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
+                            </variable>
+                            <variable label="Function Switch On Delay" CV="16.0.388" default="0" item="ESU FnOut A15 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <decVal max="15"/>
+                                <label xml:lang="de">Verzögerung beim Einschalten</label>
+                            </variable>
+                            <variable label="Function Switch Off Delay" CV="16.0.388" default="0" mask="VVVVXXXX" item="ESU FnOut A15 Slider 2" tooltip="Units = 0.4 sec">
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <decVal max="15"/>
+                                <label xml:lang="de">Verzögerung beim Ausschalten</label>
+                            </variable>
+                            <variable label="Function Auto Switch Off" CV="16.0.389" default="0" item="ESU FnOut A15 Slider 3" tooltip="Units = 0.4 sec">
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <decVal/>
+                                <label xml:lang="de">Ausgang automatisch Ausschalten</label>
+                            </variable>
+                            <variable item="Brightness CV390" label="Brightness CV" CV="16.0.390" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
+                                <decVal/>
+                            </variable>
+                            <variable label="Brightness" CV="16.0.390" default="31" item="ESU FnOut A15 Slider 5" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>18</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Helligkeit</label>
+                            </variable>
+                            <variable label="Mode" CV="16.0.390" default="0" item="ESU FnOut A15 Option 1" mask="XXXXXXXV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>22</value>
+                                </qualifier>
+                                <enumVal>
+                                    <enumChoice choice="Heating control">
+                                        <choice>Heating control</choice>
+                                        <choice xml:lang="de">Heizungssteuerung</choice>
+                                    </enumChoice>
+                                    <enumChoice choice="Fan control">
+                                        <choice>Fan control</choice>
+                                        <choice xml:lang="de">Lüftersteuerung</choice>
+                                    </enumChoice>
+                                </enumVal>
+                                <label xml:lang="de">Modus</label>
+                            </variable>
+                            <variable label="Coupler Force" CV="16.0.390" default="31" item="ESU FnOut A15 Slider 7" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>ge</relation>
+                                    <value>28</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>ne</relation>
+                                    <value>29</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>ne</relation>
+                                    <value>30</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>ne</relation>
+                                    <value>31</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>ne</relation>
+                                    <value>32</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>33</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Stärke des Kupplers</label>
+                            </variable>
+                            <variable label="Fan Speed" CV="16.0.390" default="31" item="ESU FnOut A15 Slider 11" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>23</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Geschwindigkeit</label>
+                            </variable>
+                            <variable label="Standing heat" CV="16.0.390" default="31" item="ESU FnOut A15 Slider 14" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>24</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Heizstufe im Stand</label>
+                            </variable>
+                            <variable label="Chuff power" CV="16.0.390" default="31" item="ESU FnOut A15 Slider 8" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>25</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Dampfstoßstärke</label>
+                            </variable>
+                            <variable label="Duration (speed) A" CV="16.0.386" default="31" item="ESU FnOut A15 Slider 4" mask="XXVVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>27</value>
+                                </qualifier>
+                                <decVal max="63"/>
+                                <label xml:lang="de">Dauer (Geschwindigkeit)</label>
+                            </variable>
+                            <variable label="Duration (speed) B" CV="16.0.390" default="31" item="ESU FnOut A15 Slider 17" mask="XXVVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>27</value>
+                                </qualifier>
+                                <decVal max="63"/>
+                                <label xml:lang="de">Dauer (Geschwindigkeit)</label>
+                            </variable>
+                            <variable item="Special Function CV391" label="Special Function CV 1" CV="16.0.391" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                                <decVal/>
+                            </variable>
+                            <variable label="Fan Acceleration rate" CV="16.0.391" default="0" item="ESU FnOut A15 Slider 12" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>23</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Beschleunigungszeit</label>
+                            </variable>
+                            <variable label="Minimum driving heat" CV="16.0.391" default="0" item="ESU FnOut A15 Slider 15" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>24</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
+                            </variable>
+                            <variable label="Position A" CV="16.0.391" default="0" item="ESU FnOut A15 Slider 18" mask="XXVVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>27</value>
+                                </qualifier>
+                                <decVal max="63"/>
+                            </variable>
+                            <variable label="Fan power" CV="16.0.391" default="0" item="ESU FnOut A15 Slider 9" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>25</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Stäke des Bläsers</label>
+                            </variable>
+                            <variable label="Phase Reverse" CV="16.0.391" default="0" item="ESU FnOut A15 Check 6" mask="XXXXXXXV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                                <label xml:lang="de">Phase tauschen</label>
+                            </variable>
+                            <variable label="Grade Crossing" CV="16.0.391" default="0" item="ESU FnOut A15 Check 1" mask="XXXXXXVX">
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                            </variable>
+                            <variable label="Rule 17 Fwd" CV="16.0.391" default="0" item="ESU FnOut A15 Check 2" mask="XXXXXVXX">
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                                <label xml:lang="de">Rule 17 vorwärts</label>
+                            </variable>
+                            <variable label="Rule 17 Rev" CV="16.0.391" default="0" item="ESU FnOut A15 Check 3" mask="XXXXVXXX">
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                                <label xml:lang="de">Rule 17 rückwärts</label>
+                            </variable>
+                            <variable label="Dimmer" CV="16.0.391" default="0" item="ESU FnOut A15 Check 4" mask="XXXVXXXX">
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                                <label xml:lang="de">Abdimmen</label>
+                            </variable>
+                            <variable label="LED Mode" CV="16.0.391" default="0" item="ESU FnOut A15 Check 5" mask="VXXXXXXX">
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                                <label xml:lang="de">LED Modus</label>
+                            </variable>
+                            <variable item="Special Function CV392" label="Special Function CV 2" CV="16.0.392" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                                <decVal/>
+                            </variable>
+                            <variable label="Fan Decceleration rate" CV="16.0.392" default="0" item="ESU FnOut A15 Slider 13" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>23</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Bremszeit</label>
+                            </variable>
+                            <variable label="Maximum driving heat" CV="16.0.392" default="0" item="ESU FnOut A15 Slider 16" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>24</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
+                            </variable>
+                            <variable label="Timeout" CV="16.0.392" default="0" item="ESU FnOut A15 Slider 10" tooltip="Units = 0.25 sec">
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>25</value>
+                                </qualifier>
+                                <decVal/>
+                            </variable>
+                            <variable label="Startup Time" CV="16.0.392" default="0" item="ESU FnOut A15 Slider 6">
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>ge</relation>
+                                    <value>16</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>17</value>
+                                </qualifier>
+                                <decVal/>
+                                <label xml:lang="de">Startzeit</label>
+                            </variable>
+                            <variable label="Level" CV="16.0.392" default="0" item="ESU FnOut A15 Slider 20" mask="XVVVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>19</value>
+                                </qualifier>
+                                <decVal max="127"/>
+                            </variable>
+                            <variable label="Position B" CV="16.0.392" default="0" item="ESU FnOut A15 Slider 19" mask="XXVVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>27</value>
+                                </qualifier>
+                                <decVal max="63"/>
+                            </variable>
+                            <!-- AUX16 Mode -->
+                            <variable label="AUX16 Mode" CV="16.0.395" default="1" item="ESU FnOut A16 Mode">
+                                <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
+                            </variable>
+                            <variable label="Function Switch On Delay" CV="16.0.396" default="0" item="ESU FnOut A16 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <decVal max="15"/>
+                                <label xml:lang="de">Verzögerung beim Einschalten</label>
+                            </variable>
+                            <variable label="Function Switch Off Delay" CV="16.0.396" default="0" mask="VVVVXXXX" item="ESU FnOut A16 Slider 2" tooltip="Units = 0.4 sec">
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <decVal max="15"/>
+                                <label xml:lang="de">Verzögerung beim Ausschalten</label>
+                            </variable>
+                            <variable label="Function Auto Switch Off" CV="16.0.397" default="0" item="ESU FnOut A16 Slider 3" tooltip="Units = 0.4 sec">
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <decVal/>
+                                <label xml:lang="de">Ausgang automatisch Ausschalten</label>
+                            </variable>
+                            <variable item="Brightness CV398" label="Brightness CV" CV="16.0.398" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
+                                <decVal/>
+                            </variable>
+                            <variable label="Brightness" CV="16.0.398" default="31" item="ESU FnOut A16 Slider 5" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>18</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Helligkeit</label>
+                            </variable>
+                            <variable label="Mode" CV="16.0.398" default="0" item="ESU FnOut A16 Option 1" mask="XXXXXXXV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>22</value>
+                                </qualifier>
+                                <enumVal>
+                                    <enumChoice choice="Heating control">
+                                        <choice>Heating control</choice>
+                                        <choice xml:lang="de">Heizungssteuerung</choice>
+                                    </enumChoice>
+                                    <enumChoice choice="Fan control">
+                                        <choice>Fan control</choice>
+                                        <choice xml:lang="de">Lüftersteuerung</choice>
+                                    </enumChoice>
+                                </enumVal>
+                                <label xml:lang="de">Modus</label>
+                            </variable>
+                            <variable label="Coupler Force" CV="16.0.398" default="31" item="ESU FnOut A16 Slider 7" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>ge</relation>
+                                    <value>28</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>ne</relation>
+                                    <value>29</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>ne</relation>
+                                    <value>30</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>ne</relation>
+                                    <value>31</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>ne</relation>
+                                    <value>32</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>33</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Stärke des Kupplers</label>
+                            </variable>
+                            <variable label="Fan Speed" CV="16.0.398" default="31" item="ESU FnOut A16 Slider 11" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>23</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Geschwindigkeit</label>
+                            </variable>
+                            <variable label="Standing heat" CV="16.0.398" default="31" item="ESU FnOut A16 Slider 14" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>24</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Heizstufe im Stand</label>
+                            </variable>
+                            <variable label="Chuff power" CV="16.0.398" default="31" item="ESU FnOut A16 Slider 8" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>25</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Dampfstoßstärke</label>
+                            </variable>
+                            <variable label="Duration (speed) A" CV="16.0.394" default="31" item="ESU FnOut A16 Slider 4" mask="XXVVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>27</value>
+                                </qualifier>
+                                <decVal max="63"/>
+                                <label xml:lang="de">Dauer (Geschwindigkeit)</label>
+                            </variable>
+                            <variable label="Duration (speed) B" CV="16.0.398" default="31" item="ESU FnOut A16 Slider 17" mask="XXVVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>27</value>
+                                </qualifier>
+                                <decVal max="63"/>
+                                <label xml:lang="de">Dauer (Geschwindigkeit)</label>
+                            </variable>
+                            <variable item="Special Function CV399" label="Special Function CV 1" CV="16.0.399" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                                <decVal/>
+                            </variable>
+                            <variable label="Fan Acceleration rate" CV="16.0.399" default="0" item="ESU FnOut A16 Slider 12" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>23</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Beschleunigungszeit</label>
+                            </variable>
+                            <variable label="Minimum driving heat" CV="16.0.399" default="0" item="ESU FnOut A16 Slider 15" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>24</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
+                            </variable>
+                            <variable label="Position A" CV="16.0.399" default="0" item="ESU FnOut A16 Slider 18" mask="XXVVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>27</value>
+                                </qualifier>
+                                <decVal max="63"/>
+                            </variable>
+                            <variable label="Fan power" CV="16.0.399" default="0" item="ESU FnOut A16 Slider 9" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>25</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Stäke des Bläsers</label>
+                            </variable>
+                            <variable label="Phase Reverse" CV="16.0.399" default="0" item="ESU FnOut A16 Check 6" mask="XXXXXXXV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                                <label xml:lang="de">Phase tauschen</label>
+                            </variable>
+                            <variable label="Grade Crossing" CV="16.0.399" default="0" item="ESU FnOut A16 Check 1" mask="XXXXXXVX">
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                            </variable>
+                            <variable label="Rule 17 Fwd" CV="16.0.399" default="0" item="ESU FnOut A16 Check 2" mask="XXXXXVXX">
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                                <label xml:lang="de">Rule 17 vorwärts</label>
+                            </variable>
+                            <variable label="Rule 17 Rev" CV="16.0.399" default="0" item="ESU FnOut A16 Check 3" mask="XXXXVXXX">
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                                <label xml:lang="de">Rule 17 rückwärts</label>
+                            </variable>
+                            <variable label="Dimmer" CV="16.0.399" default="0" item="ESU FnOut A16 Check 4" mask="XXXVXXXX">
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                                <label xml:lang="de">Abdimmen</label>
+                            </variable>
+                            <variable label="LED Mode" CV="16.0.399" default="0" item="ESU FnOut A16 Check 5" mask="VXXXXXXX">
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                                <label xml:lang="de">LED Modus</label>
+                            </variable>
+                            <variable item="Special Function CV400" label="Special Function CV 2" CV="16.0.400" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                                <decVal/>
+                            </variable>
+                            <variable label="Fan Decceleration rate" CV="16.0.400" default="0" item="ESU FnOut A16 Slider 13" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>23</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Bremszeit</label>
+                            </variable>
+                            <variable label="Maximum driving heat" CV="16.0.400" default="0" item="ESU FnOut A16 Slider 16" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>24</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
+                            </variable>
+                            <variable label="Timeout" CV="16.0.400" default="0" item="ESU FnOut A16 Slider 10" tooltip="Units = 0.25 sec">
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>25</value>
+                                </qualifier>
+                                <decVal/>
+                            </variable>
+                            <variable label="Startup Time" CV="16.0.400" default="0" item="ESU FnOut A16 Slider 6">
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>ge</relation>
+                                    <value>16</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>17</value>
+                                </qualifier>
+                                <decVal/>
+                                <label xml:lang="de">Startzeit</label>
+                            </variable>
+                            <variable label="Level" CV="16.0.400" default="0" item="ESU FnOut A16 Slider 20" mask="XVVVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>19</value>
+                                </qualifier>
+                                <decVal max="127"/>
+                            </variable>
+                            <variable label="Position B" CV="16.0.400" default="0" item="ESU FnOut A16 Slider 19" mask="XXVVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>27</value>
+                                </qualifier>
+                                <decVal max="63"/>
+                            </variable>
+                            <!-- AUX17 Mode -->
+                            <variable label="AUX17 Mode" CV="16.0.403" default="1" item="ESU FnOut A17 Mode">
+                                <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
+                            </variable>
+                            <variable label="Function Switch On Delay" CV="16.0.404" default="0" item="ESU FnOut A17 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <decVal max="15"/>
+                                <label xml:lang="de">Verzögerung beim Einschalten</label>
+                            </variable>
+                            <variable label="Function Switch Off Delay" CV="16.0.404" default="0" mask="VVVVXXXX" item="ESU FnOut A17 Slider 2" tooltip="Units = 0.4 sec">
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <decVal max="15"/>
+                                <label xml:lang="de">Verzögerung beim Ausschalten</label>
+                            </variable>
+                            <variable label="Function Auto Switch Off" CV="16.0.405" default="0" item="ESU FnOut A17 Slider 3" tooltip="Units = 0.4 sec">
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <decVal/>
+                                <label xml:lang="de">Ausgang automatisch Ausschalten</label>
+                            </variable>
+                            <variable item="Brightness CV406" label="Brightness CV" CV="16.0.406" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
+                                <decVal/>
+                            </variable>
+                            <variable label="Brightness" CV="16.0.406" default="31" item="ESU FnOut A17 Slider 5" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>18</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Helligkeit</label>
+                            </variable>
+                            <variable label="Mode" CV="16.0.406" default="0" item="ESU FnOut A17 Option 1" mask="XXXXXXXV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>22</value>
+                                </qualifier>
+                                <enumVal>
+                                    <enumChoice choice="Heating control">
+                                        <choice>Heating control</choice>
+                                        <choice xml:lang="de">Heizungssteuerung</choice>
+                                    </enumChoice>
+                                    <enumChoice choice="Fan control">
+                                        <choice>Fan control</choice>
+                                        <choice xml:lang="de">Lüftersteuerung</choice>
+                                    </enumChoice>
+                                </enumVal>
+                                <label xml:lang="de">Modus</label>
+                            </variable>
+                            <variable label="Coupler Force" CV="16.0.406" default="31" item="ESU FnOut A17 Slider 7" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>ge</relation>
+                                    <value>28</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>ne</relation>
+                                    <value>29</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>ne</relation>
+                                    <value>30</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>ne</relation>
+                                    <value>31</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>ne</relation>
+                                    <value>32</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>33</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Stärke des Kupplers</label>
+                            </variable>
+                            <variable label="Fan Speed" CV="16.0.406" default="31" item="ESU FnOut A17 Slider 11" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>23</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Geschwindigkeit</label>
+                            </variable>
+                            <variable label="Standing heat" CV="16.0.406" default="31" item="ESU FnOut A17 Slider 14" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>24</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Heizstufe im Stand</label>
+                            </variable>
+                            <variable label="Chuff power" CV="16.0.406" default="31" item="ESU FnOut A17 Slider 8" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>25</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Dampfstoßstärke</label>
+                            </variable>
+                            <variable label="Duration (speed) A" CV="16.0.402" default="31" item="ESU FnOut A17 Slider 4" mask="XXVVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>27</value>
+                                </qualifier>
+                                <decVal max="63"/>
+                                <label xml:lang="de">Dauer (Geschwindigkeit)</label>
+                            </variable>
+                            <variable label="Duration (speed) B" CV="16.0.406" default="31" item="ESU FnOut A17 Slider 17" mask="XXVVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>27</value>
+                                </qualifier>
+                                <decVal max="63"/>
+                                <label xml:lang="de">Dauer (Geschwindigkeit)</label>
+                            </variable>
+                            <variable item="Special Function CV407" label="Special Function CV 1" CV="16.0.407" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                                <decVal/>
+                            </variable>
+                            <variable label="Fan Acceleration rate" CV="16.0.407" default="0" item="ESU FnOut A17 Slider 12" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>23</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Beschleunigungszeit</label>
+                            </variable>
+                            <variable label="Minimum driving heat" CV="16.0.407" default="0" item="ESU FnOut A17 Slider 15" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>24</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
+                            </variable>
+                            <variable label="Position A" CV="16.0.407" default="0" item="ESU FnOut A17 Slider 18" mask="XXVVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>27</value>
+                                </qualifier>
+                                <decVal max="63"/>
+                            </variable>
+                            <variable label="Fan power" CV="16.0.407" default="0" item="ESU FnOut A17 Slider 9" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>25</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Stäke des Bläsers</label>
+                            </variable>
+                            <variable label="Phase Reverse" CV="16.0.407" default="0" item="ESU FnOut A17 Check 6" mask="XXXXXXXV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                                <label xml:lang="de">Phase tauschen</label>
+                            </variable>
+                            <variable label="Grade Crossing" CV="16.0.407" default="0" item="ESU FnOut A17 Check 1" mask="XXXXXXVX">
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                            </variable>
+                            <variable label="Rule 17 Fwd" CV="16.0.407" default="0" item="ESU FnOut A17 Check 2" mask="XXXXXVXX">
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                                <label xml:lang="de">Rule 17 vorwärts</label>
+                            </variable>
+                            <variable label="Rule 17 Rev" CV="16.0.407" default="0" item="ESU FnOut A17 Check 3" mask="XXXXVXXX">
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                                <label xml:lang="de">Rule 17 rückwärts</label>
+                            </variable>
+                            <variable label="Dimmer" CV="16.0.407" default="0" item="ESU FnOut A17 Check 4" mask="XXXVXXXX">
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                                <label xml:lang="de">Abdimmen</label>
+                            </variable>
+                            <variable label="LED Mode" CV="16.0.407" default="0" item="ESU FnOut A17 Check 5" mask="VXXXXXXX">
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                                <label xml:lang="de">LED Modus</label>
+                            </variable>
+                            <variable item="Special Function CV408" label="Special Function CV 2" CV="16.0.408" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                                <decVal/>
+                            </variable>
+                            <variable label="Fan Decceleration rate" CV="16.0.408" default="0" item="ESU FnOut A17 Slider 13" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>23</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Bremszeit</label>
+                            </variable>
+                            <variable label="Maximum driving heat" CV="16.0.408" default="0" item="ESU FnOut A17 Slider 16" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>24</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
+                            </variable>
+                            <variable label="Timeout" CV="16.0.408" default="0" item="ESU FnOut A17 Slider 10" tooltip="Units = 0.25 sec">
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>25</value>
+                                </qualifier>
+                                <decVal/>
+                            </variable>
+                            <variable label="Startup Time" CV="16.0.408" default="0" item="ESU FnOut A17 Slider 6">
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>ge</relation>
+                                    <value>16</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>17</value>
+                                </qualifier>
+                                <decVal/>
+                                <label xml:lang="de">Startzeit</label>
+                            </variable>
+                            <variable label="Level" CV="16.0.408" default="0" item="ESU FnOut A17 Slider 20" mask="XVVVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>19</value>
+                                </qualifier>
+                                <decVal max="127"/>
+                            </variable>
+                            <variable label="Position B" CV="16.0.408" default="0" item="ESU FnOut A17 Slider 19" mask="XXVVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>27</value>
+                                </qualifier>
+                                <decVal max="63"/>
+                            </variable>
+                            <!-- AUX18 Mode -->
+                            <variable label="AUX18 Mode" CV="16.0.411" default="1" item="ESU FnOut A18 Mode">
+                                <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
+                            </variable>
+                            <variable label="Function Switch On Delay" CV="16.0.412" default="0" item="ESU FnOut A18 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <decVal max="15"/>
+                                <label xml:lang="de">Verzögerung beim Einschalten</label>
+                            </variable>
+                            <variable label="Function Switch Off Delay" CV="16.0.412" default="0" mask="VVVVXXXX" item="ESU FnOut A18 Slider 2" tooltip="Units = 0.4 sec">
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <decVal max="15"/>
+                                <label xml:lang="de">Verzögerung beim Ausschalten</label>
+                            </variable>
+                            <variable label="Function Auto Switch Off" CV="16.0.413" default="0" item="ESU FnOut A18 Slider 3" tooltip="Units = 0.4 sec">
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <decVal/>
+                                <label xml:lang="de">Ausgang automatisch Ausschalten</label>
+                            </variable>
+                            <variable item="Brightness CV414" label="Brightness CV" CV="16.0.414" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
+                                <decVal/>
+                            </variable>
+                            <variable label="Brightness" CV="16.0.414" default="31" item="ESU FnOut A18 Slider 5" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>18</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Helligkeit</label>
+                            </variable>
+                            <variable label="Mode" CV="16.0.414" default="0" item="ESU FnOut A18 Option 1" mask="XXXXXXXV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>22</value>
+                                </qualifier>
+                                <enumVal>
+                                    <enumChoice choice="Heating control">
+                                        <choice>Heating control</choice>
+                                        <choice xml:lang="de">Heizungssteuerung</choice>
+                                    </enumChoice>
+                                    <enumChoice choice="Fan control">
+                                        <choice>Fan control</choice>
+                                        <choice xml:lang="de">Lüftersteuerung</choice>
+                                    </enumChoice>
+                                </enumVal>
+                                <label xml:lang="de">Modus</label>
+                            </variable>
+                            <variable label="Coupler Force" CV="16.0.414" default="31" item="ESU FnOut A18 Slider 7" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>ge</relation>
+                                    <value>28</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>ne</relation>
+                                    <value>29</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>ne</relation>
+                                    <value>30</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>ne</relation>
+                                    <value>31</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>ne</relation>
+                                    <value>32</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>33</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Stärke des Kupplers</label>
+                            </variable>
+                            <variable label="Fan Speed" CV="16.0.414" default="31" item="ESU FnOut A18 Slider 11" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>23</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Geschwindigkeit</label>
+                            </variable>
+                            <variable label="Standing heat" CV="16.0.414" default="31" item="ESU FnOut A18 Slider 14" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>24</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Heizstufe im Stand</label>
+                            </variable>
+                            <variable label="Chuff power" CV="16.0.414" default="31" item="ESU FnOut A18 Slider 8" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>25</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Dampfstoßstärke</label>
+                            </variable>
+                            <variable label="Duration (speed) A" CV="16.0.410" default="31" item="ESU FnOut A18 Slider 4" mask="XXVVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>27</value>
+                                </qualifier>
+                                <decVal max="63"/>
+                                <label xml:lang="de">Dauer (Geschwindigkeit)</label>
+                            </variable>
+                            <variable label="Duration (speed) B" CV="16.0.414" default="31" item="ESU FnOut A18 Slider 17" mask="XXVVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>27</value>
+                                </qualifier>
+                                <decVal max="63"/>
+                                <label xml:lang="de">Dauer (Geschwindigkeit)</label>
+                            </variable>
+                            <variable item="Special Function CV415" label="Special Function CV 1" CV="16.0.415" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                                <decVal/>
+                            </variable>
+                            <variable label="Fan Acceleration rate" CV="16.0.415" default="0" item="ESU FnOut A18 Slider 12" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>23</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Beschleunigungszeit</label>
+                            </variable>
+                            <variable label="Minimum driving heat" CV="16.0.415" default="0" item="ESU FnOut A18 Slider 15" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>24</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
+                            </variable>
+                            <variable label="Position A" CV="16.0.415" default="0" item="ESU FnOut A18 Slider 18" mask="XXVVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>27</value>
+                                </qualifier>
+                                <decVal max="63"/>
+                            </variable>
+                            <variable label="Fan power" CV="16.0.415" default="0" item="ESU FnOut A18 Slider 9" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>25</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Stäke des Bläsers</label>
+                            </variable>
+                            <variable label="Phase Reverse" CV="16.0.415" default="0" item="ESU FnOut A18 Check 6" mask="XXXXXXXV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                                <label xml:lang="de">Phase tauschen</label>
+                            </variable>
+                            <variable label="Grade Crossing" CV="16.0.415" default="0" item="ESU FnOut A18 Check 1" mask="XXXXXXVX">
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                            </variable>
+                            <variable label="Rule 17 Fwd" CV="16.0.415" default="0" item="ESU FnOut A18 Check 2" mask="XXXXXVXX">
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                                <label xml:lang="de">Rule 17 vorwärts</label>
+                            </variable>
+                            <variable label="Rule 17 Rev" CV="16.0.415" default="0" item="ESU FnOut A18 Check 3" mask="XXXXVXXX">
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                                <label xml:lang="de">Rule 17 rückwärts</label>
+                            </variable>
+                            <variable label="Dimmer" CV="16.0.415" default="0" item="ESU FnOut A18 Check 4" mask="XXXVXXXX">
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                                <label xml:lang="de">Abdimmen</label>
+                            </variable>
+                            <variable label="LED Mode" CV="16.0.415" default="0" item="ESU FnOut A18 Check 5" mask="VXXXXXXX">
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                                <label xml:lang="de">LED Modus</label>
+                            </variable>
+                            <variable item="Special Function CV416" label="Special Function CV 2" CV="16.0.416" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                                <decVal/>
+                            </variable>
+                            <variable label="Fan Decceleration rate" CV="16.0.416" default="0" item="ESU FnOut A18 Slider 13" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>23</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Bremszeit</label>
+                            </variable>
+                            <variable label="Maximum driving heat" CV="16.0.416" default="0" item="ESU FnOut A18 Slider 16" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>24</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
+                            </variable>
+                            <variable label="Timeout" CV="16.0.416" default="0" item="ESU FnOut A18 Slider 10" tooltip="Units = 0.25 sec">
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>25</value>
+                                </qualifier>
+                                <decVal/>
+                            </variable>
+                            <variable label="Startup Time" CV="16.0.416" default="0" item="ESU FnOut A18 Slider 6">
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>ge</relation>
+                                    <value>16</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>17</value>
+                                </qualifier>
+                                <decVal/>
+                                <label xml:lang="de">Startzeit</label>
+                            </variable>
+                            <variable label="Level" CV="16.0.416" default="0" item="ESU FnOut A18 Slider 20" mask="XVVVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>19</value>
+                                </qualifier>
+                                <decVal max="127"/>
+                            </variable>
+                            <variable label="Position B" CV="16.0.416" default="0" item="ESU FnOut A18 Slider 19" mask="XXVVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>27</value>
+                                </qualifier>
+                                <decVal max="63"/>
+                            </variable>
+                        </variables>
                     </variables>
                 </variables>
             </variables>
@@ -7180,311 +7170,314 @@
 	    </qualifier>
 	    <decVal max="127"/>
 	</variable>
-	<!-- AUX2 [2] Mode -->
-	<variable label="AUX2 [2] Mode" CV="16.0.443" default="1" item="ESU FnOut A2-2 Mode">
-	    <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
-	</variable>
-	<variable label="Function Switch On Delay" CV="16.0.444" default="0" item="ESU FnOut A2-2 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>gt</relation>
-		<value>0</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>ne</relation>
-		<value>27</value>
-	    </qualifier>
-	    <decVal max="15"/>
-	    <label xml:lang="de">Verzögerung beim Einschalten</label>
-	</variable>
-	<variable label="Function Switch Off Delay" CV="16.0.444" default="0" mask="VVVVXXXX" item="ESU FnOut A2-2 Slider 2" tooltip="Units = 0.4 sec">
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>gt</relation>
-		<value>0</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>ne</relation>
-		<value>27</value>
-	    </qualifier>
-	    <decVal max="15"/>
-	    <label xml:lang="de">Verzögerung beim Ausschalten</label>
-	</variable>
-	<variable label="Function Auto Switch Off" CV="16.0.445" default="0" item="ESU FnOut A2-2 Slider 3" tooltip="Units = 0.4 sec">
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>gt</relation>
-		<value>0</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>ne</relation>
-		<value>27</value>
-	    </qualifier>
-	    <decVal/>
-	    <label xml:lang="de">Ausgang automatisch Ausschalten</label>
-	</variable>
-	<variable item="Brightness CV446" label="Brightness CV" CV="16.0.446" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
-	    <decVal/>
-	</variable>
-	<variable label="Brightness" CV="16.0.446" default="31" item="ESU FnOut A2-2 Slider 5" mask="XXXVVVVV">
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>gt</relation>
-		<value>0</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>le</relation>
-		<value>18</value>
-	    </qualifier>
-	    <decVal max="31"/>
-	    <label xml:lang="de">Helligkeit</label>
-	</variable>
-	<variable label="Mode" CV="16.0.446" default="0" item="ESU FnOut A2-2 Option 1" mask="XXXXXXXV">
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>eq</relation>
-		<value>22</value>
-	    </qualifier>
-	    <enumVal>
-		<enumChoice choice="Heating control">
-		    <choice>Heating control</choice>
-		    <choice xml:lang="de">Heizungssteuerung</choice>
-		</enumChoice>
-		<enumChoice choice="Fan control">
-		    <choice>Fan control</choice>
-		    <choice xml:lang="de">Lüftersteuerung</choice>
-		</enumChoice>
-	    </enumVal>
-	    <label xml:lang="de">Modus</label>
-	</variable>
-	<variable label="Coupler Force" CV="16.0.446" default="31" item="ESU FnOut A2-2 Slider 7" mask="XXXVVVVV">
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>ge</relation>
-		<value>28</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>ne</relation>
-		<value>29</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>ne</relation>
-		<value>30</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>ne</relation>
-		<value>31</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>ne</relation>
-		<value>32</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>le</relation>
-		<value>33</value>
-	    </qualifier>
-	    <decVal max="31"/>
-	    <label xml:lang="de">Stärke des Kupplers</label>
-	</variable>
-	<variable label="Fan Speed" CV="16.0.446" default="31" item="ESU FnOut A2-2 Slider 11" mask="XXXVVVVV">
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>eq</relation>
-		<value>23</value>
-	    </qualifier>
-	    <decVal max="31"/>
-	    <label xml:lang="de">Geschwindigkeit</label>
-	</variable>
-	<variable label="Standing heat" CV="16.0.446" default="31" item="ESU FnOut A2-2 Slider 14" mask="XXXVVVVV">
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>eq</relation>
-		<value>24</value>
-	    </qualifier>
-	    <decVal max="31"/>
-	    <label xml:lang="de">Heizstufe im Stand</label>
-	</variable>
-	<variable label="Chuff power" CV="16.0.446" default="31" item="ESU FnOut A2-2 Slider 8" mask="XXXVVVVV">
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>eq</relation>
-		<value>25</value>
-	    </qualifier>
-	    <decVal max="31"/>
-	    <label xml:lang="de">Dampfstoßstärke</label>
-	</variable>
-	<variable item="Special Function CV447" label="Special Function CV 1" CV="16.0.447" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
-	    <decVal/>
-	</variable>
-	<variable label="Fan Acceleration rate" CV="16.0.447" default="0" item="ESU FnOut A2-2 Slider 12" mask="XXXVVVVV">
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>eq</relation>
-		<value>23</value>
-	    </qualifier>
-	    <decVal max="31"/>
-	    <label xml:lang="de">Beschleunigungszeit</label>
-	</variable>
-	<variable label="Minimum driving heat" CV="16.0.447" default="0" item="ESU FnOut A2-2 Slider 15" mask="XXXVVVVV">
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>eq</relation>
-		<value>24</value>
-	    </qualifier>
-	    <decVal max="31"/>
-	    <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
-	</variable>
-	<variable label="Fan power" CV="16.0.447" default="0" item="ESU FnOut A2-2 Slider 9" mask="XXXVVVVV">
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>eq</relation>
-		<value>25</value>
-	    </qualifier>
-	    <decVal max="31"/>
-	    <label xml:lang="de">Stäke des Bläsers</label>
-	</variable>
-	<variable label="Phase Reverse" CV="16.0.447" default="0" item="ESU FnOut A2-2 Check 6" mask="XXXXXXXV">
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>gt</relation>
-		<value>0</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>le</relation>
-		<value>15</value>
-	    </qualifier>
-	    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-	    <label xml:lang="de">Phase tauschen</label>
-	</variable>
-	<variable label="Grade Crossing" CV="16.0.447" default="0" item="ESU FnOut A2-2 Check 1" mask="XXXXXXVX">
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>gt</relation>
-		<value>0</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>le</relation>
-		<value>15</value>
-	    </qualifier>
-	    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-	</variable>
-	<variable label="Rule 17 Fwd" CV="16.0.447" default="0" item="ESU FnOut A2-2 Check 2" mask="XXXXXVXX">
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>gt</relation>
-		<value>0</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>le</relation>
-		<value>15</value>
-	    </qualifier>
-	    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-	    <label xml:lang="de">Rule 17 vorwärts</label>
-	</variable>
-	<variable label="Rule 17 Rev" CV="16.0.447" default="0" item="ESU FnOut A2-2 Check 3" mask="XXXXVXXX">
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>gt</relation>
-		<value>0</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>le</relation>
-		<value>15</value>
-	    </qualifier>
-	    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-	    <label xml:lang="de">Rule 17 rückwärts</label>
-	</variable>
-	<variable label="Dimmer" CV="16.0.447" default="0" item="ESU FnOut A2-2 Check 4" mask="XXXVXXXX">
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>gt</relation>
-		<value>0</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>le</relation>
-		<value>15</value>
-	    </qualifier>
-	    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-	    <label xml:lang="de">Abdimmen</label>
-	</variable>
-	<variable label="LED Mode" CV="16.0.447" default="0" item="ESU FnOut A2-2 Check 5" mask="VXXXXXXX">
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>gt</relation>
-		<value>0</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>le</relation>
-		<value>15</value>
-	    </qualifier>
-	    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-	    <label xml:lang="de">LED Modus</label>
-	</variable>
-	<variable item="Special Function CV448" label="Special Function CV 2" CV="16.0.448" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
-	    <decVal/>
-	</variable>
-	<variable label="Fan Decceleration rate" CV="16.0.448" default="0" item="ESU FnOut A2-2 Slider 13" mask="XXXVVVVV">
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>eq</relation>
-		<value>23</value>
-	    </qualifier>
-	    <decVal max="31"/>
-	    <label xml:lang="de">Bremszeit</label>
-	</variable>
-	<variable label="Maximum driving heat" CV="16.0.448" default="0" item="ESU FnOut A2-2 Slider 16" mask="XXXVVVVV">
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>eq</relation>
-		<value>24</value>
-	    </qualifier>
-	    <decVal max="31"/>
-	    <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
-	</variable>
-	<variable label="Timeout" CV="16.0.448" default="0" item="ESU FnOut A2-2 Slider 10" tooltip="Units = 0.25 sec">
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>eq</relation>
-		<value>25</value>
-	    </qualifier>
-	    <decVal/>
-	</variable>
-	<variable label="Startup Time" CV="16.0.448" default="0" item="ESU FnOut A2-2 Slider 6">
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>ge</relation>
-		<value>16</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>le</relation>
-		<value>17</value>
-	    </qualifier>
-	    <decVal/>
-	    <label xml:lang="de">Startzeit</label>
-	</variable>
-	<variable label="Level" CV="16.0.448" default="0" item="ESU FnOut A2-2 Slider 20" mask="XVVVVVVV">
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>eq</relation>
-		<value>19</value>
-	    </qualifier>
-	    <decVal max="127"/>
-	</variable>
+        <!-- exclude AUX2 [2] -->
+	<variables exclude="LokSound 5 DCC Direct Atlas S2">
+            <!-- AUX2 [2] Mode -->
+            <variable label="AUX2 [2] Mode" CV="16.0.443" default="1" item="ESU FnOut A2-2 Mode">
+	        <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
+	    </variable>
+	    <variable label="Function Switch On Delay" CV="16.0.444" default="0" item="ESU FnOut A2-2 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
+	        <qualifier>
+		    <variableref>ESU FnOut A2-2 Mode</variableref>
+		    <relation>gt</relation>
+		    <value>0</value>
+	        </qualifier>
+	        <qualifier>
+		    <variableref>ESU FnOut A2-2 Mode</variableref>
+		    <relation>ne</relation>
+		    <value>27</value>
+	        </qualifier>
+	        <decVal max="15"/>
+	        <label xml:lang="de">Verzögerung beim Einschalten</label>
+	    </variable>
+	    <variable label="Function Switch Off Delay" CV="16.0.444" default="0" mask="VVVVXXXX" item="ESU FnOut A2-2 Slider 2" tooltip="Units = 0.4 sec">
+	        <qualifier>
+		    <variableref>ESU FnOut A2-2 Mode</variableref>
+		    <relation>gt</relation>
+		    <value>0</value>
+	        </qualifier>
+	        <qualifier>
+		    <variableref>ESU FnOut A2-2 Mode</variableref>
+		    <relation>ne</relation>
+		    <value>27</value>
+	        </qualifier>
+	        <decVal max="15"/>
+	        <label xml:lang="de">Verzögerung beim Ausschalten</label>
+	    </variable>
+	    <variable label="Function Auto Switch Off" CV="16.0.445" default="0" item="ESU FnOut A2-2 Slider 3" tooltip="Units = 0.4 sec">
+	        <qualifier>
+		    <variableref>ESU FnOut A2-2 Mode</variableref>
+		    <relation>gt</relation>
+		    <value>0</value>
+	        </qualifier>
+	        <qualifier>
+		    <variableref>ESU FnOut A2-2 Mode</variableref>
+		    <relation>ne</relation>
+		    <value>27</value>
+	        </qualifier>
+	        <decVal/>
+	        <label xml:lang="de">Ausgang automatisch Ausschalten</label>
+	    </variable>
+	    <variable item="Brightness CV446" label="Brightness CV" CV="16.0.446" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
+	        <decVal/>
+	    </variable>
+	    <variable label="Brightness" CV="16.0.446" default="31" item="ESU FnOut A2-2 Slider 5" mask="XXXVVVVV">
+	        <qualifier>
+		    <variableref>ESU FnOut A2-2 Mode</variableref>
+		    <relation>gt</relation>
+		    <value>0</value>
+	        </qualifier>
+	        <qualifier>
+		    <variableref>ESU FnOut A2-2 Mode</variableref>
+		    <relation>le</relation>
+		    <value>18</value>
+	        </qualifier>
+	        <decVal max="31"/>
+	        <label xml:lang="de">Helligkeit</label>
+	    </variable>
+	    <variable label="Mode" CV="16.0.446" default="0" item="ESU FnOut A2-2 Option 1" mask="XXXXXXXV">
+	        <qualifier>
+		    <variableref>ESU FnOut A2-2 Mode</variableref>
+		    <relation>eq</relation>
+		    <value>22</value>
+	        </qualifier>
+	        <enumVal>
+		    <enumChoice choice="Heating control">
+		        <choice>Heating control</choice>
+		        <choice xml:lang="de">Heizungssteuerung</choice>
+		    </enumChoice>
+		    <enumChoice choice="Fan control">
+		        <choice>Fan control</choice>
+		        <choice xml:lang="de">Lüftersteuerung</choice>
+		    </enumChoice>
+	        </enumVal>
+	        <label xml:lang="de">Modus</label>
+	    </variable>
+	    <variable label="Coupler Force" CV="16.0.446" default="31" item="ESU FnOut A2-2 Slider 7" mask="XXXVVVVV">
+	        <qualifier>
+		    <variableref>ESU FnOut A2-2 Mode</variableref>
+		    <relation>ge</relation>
+		    <value>28</value>
+	        </qualifier>
+	        <qualifier>
+		    <variableref>ESU FnOut A2-2 Mode</variableref>
+		    <relation>ne</relation>
+		    <value>29</value>
+	        </qualifier>
+	        <qualifier>
+		    <variableref>ESU FnOut A2-2 Mode</variableref>
+		    <relation>ne</relation>
+		    <value>30</value>
+	        </qualifier>
+	        <qualifier>
+		    <variableref>ESU FnOut A2-2 Mode</variableref>
+		    <relation>ne</relation>
+		    <value>31</value>
+	        </qualifier>
+	        <qualifier>
+		    <variableref>ESU FnOut A2-2 Mode</variableref>
+		    <relation>ne</relation>
+		    <value>32</value>
+	        </qualifier>
+	        <qualifier>
+		    <variableref>ESU FnOut A2-2 Mode</variableref>
+		    <relation>le</relation>
+		    <value>33</value>
+	        </qualifier>
+	        <decVal max="31"/>
+	        <label xml:lang="de">Stärke des Kupplers</label>
+	    </variable>
+	    <variable label="Fan Speed" CV="16.0.446" default="31" item="ESU FnOut A2-2 Slider 11" mask="XXXVVVVV">
+	        <qualifier>
+		    <variableref>ESU FnOut A2-2 Mode</variableref>
+		    <relation>eq</relation>
+		    <value>23</value>
+	        </qualifier>
+	        <decVal max="31"/>
+	        <label xml:lang="de">Geschwindigkeit</label>
+	    </variable>
+	    <variable label="Standing heat" CV="16.0.446" default="31" item="ESU FnOut A2-2 Slider 14" mask="XXXVVVVV">
+	        <qualifier>
+		    <variableref>ESU FnOut A2-2 Mode</variableref>
+		    <relation>eq</relation>
+		    <value>24</value>
+	        </qualifier>
+	        <decVal max="31"/>
+	        <label xml:lang="de">Heizstufe im Stand</label>
+	    </variable>
+	    <variable label="Chuff power" CV="16.0.446" default="31" item="ESU FnOut A2-2 Slider 8" mask="XXXVVVVV">
+	        <qualifier>
+		    <variableref>ESU FnOut A2-2 Mode</variableref>
+		    <relation>eq</relation>
+		    <value>25</value>
+	        </qualifier>
+	        <decVal max="31"/>
+	        <label xml:lang="de">Dampfstoßstärke</label>
+	    </variable>
+	    <variable item="Special Function CV447" label="Special Function CV 1" CV="16.0.447" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+	        <decVal/>
+	    </variable>
+	    <variable label="Fan Acceleration rate" CV="16.0.447" default="0" item="ESU FnOut A2-2 Slider 12" mask="XXXVVVVV">
+	        <qualifier>
+		    <variableref>ESU FnOut A2-2 Mode</variableref>
+		    <relation>eq</relation>
+		    <value>23</value>
+	        </qualifier>
+	        <decVal max="31"/>
+	        <label xml:lang="de">Beschleunigungszeit</label>
+	    </variable>
+	    <variable label="Minimum driving heat" CV="16.0.447" default="0" item="ESU FnOut A2-2 Slider 15" mask="XXXVVVVV">
+	        <qualifier>
+		    <variableref>ESU FnOut A2-2 Mode</variableref>
+		    <relation>eq</relation>
+		    <value>24</value>
+	        </qualifier>
+	        <decVal max="31"/>
+	        <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
+	    </variable>
+	    <variable label="Fan power" CV="16.0.447" default="0" item="ESU FnOut A2-2 Slider 9" mask="XXXVVVVV">
+	        <qualifier>
+		    <variableref>ESU FnOut A2-2 Mode</variableref>
+		    <relation>eq</relation>
+		    <value>25</value>
+	        </qualifier>
+	        <decVal max="31"/>
+	        <label xml:lang="de">Stäke des Bläsers</label>
+	    </variable>
+	    <variable label="Phase Reverse" CV="16.0.447" default="0" item="ESU FnOut A2-2 Check 6" mask="XXXXXXXV">
+	        <qualifier>
+		    <variableref>ESU FnOut A2-2 Mode</variableref>
+		    <relation>gt</relation>
+		    <value>0</value>
+	        </qualifier>
+	        <qualifier>
+		    <variableref>ESU FnOut A2-2 Mode</variableref>
+		    <relation>le</relation>
+		    <value>15</value>
+	        </qualifier>
+	        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+	        <label xml:lang="de">Phase tauschen</label>
+	    </variable>
+	    <variable label="Grade Crossing" CV="16.0.447" default="0" item="ESU FnOut A2-2 Check 1" mask="XXXXXXVX">
+	        <qualifier>
+		    <variableref>ESU FnOut A2-2 Mode</variableref>
+		    <relation>gt</relation>
+		    <value>0</value>
+	        </qualifier>
+	        <qualifier>
+		    <variableref>ESU FnOut A2-2 Mode</variableref>
+		    <relation>le</relation>
+		    <value>15</value>
+	        </qualifier>
+	        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+	    </variable>
+	    <variable label="Rule 17 Fwd" CV="16.0.447" default="0" item="ESU FnOut A2-2 Check 2" mask="XXXXXVXX">
+	        <qualifier>
+		    <variableref>ESU FnOut A2-2 Mode</variableref>
+		    <relation>gt</relation>
+		    <value>0</value>
+	        </qualifier>
+	        <qualifier>
+		    <variableref>ESU FnOut A2-2 Mode</variableref>
+		    <relation>le</relation>
+		    <value>15</value>
+	        </qualifier>
+	        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+	        <label xml:lang="de">Rule 17 vorwärts</label>
+	    </variable>
+	    <variable label="Rule 17 Rev" CV="16.0.447" default="0" item="ESU FnOut A2-2 Check 3" mask="XXXXVXXX">
+	        <qualifier>
+		    <variableref>ESU FnOut A2-2 Mode</variableref>
+		    <relation>gt</relation>
+		    <value>0</value>
+	        </qualifier>
+	        <qualifier>
+		    <variableref>ESU FnOut A2-2 Mode</variableref>
+		    <relation>le</relation>
+		    <value>15</value>
+	        </qualifier>
+	        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+	        <label xml:lang="de">Rule 17 rückwärts</label>
+	    </variable>
+	    <variable label="Dimmer" CV="16.0.447" default="0" item="ESU FnOut A2-2 Check 4" mask="XXXVXXXX">
+	        <qualifier>
+		    <variableref>ESU FnOut A2-2 Mode</variableref>
+		    <relation>gt</relation>
+		    <value>0</value>
+	        </qualifier>
+	        <qualifier>
+		    <variableref>ESU FnOut A2-2 Mode</variableref>
+		    <relation>le</relation>
+		    <value>15</value>
+	        </qualifier>
+	        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+	        <label xml:lang="de">Abdimmen</label>
+	    </variable>
+	    <variable label="LED Mode" CV="16.0.447" default="0" item="ESU FnOut A2-2 Check 5" mask="VXXXXXXX">
+	        <qualifier>
+		    <variableref>ESU FnOut A2-2 Mode</variableref>
+		    <relation>gt</relation>
+		    <value>0</value>
+	        </qualifier>
+	        <qualifier>
+		    <variableref>ESU FnOut A2-2 Mode</variableref>
+		    <relation>le</relation>
+		    <value>15</value>
+	        </qualifier>
+	        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+	        <label xml:lang="de">LED Modus</label>
+	    </variable>
+	    <variable item="Special Function CV448" label="Special Function CV 2" CV="16.0.448" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+	        <decVal/>
+	    </variable>
+	    <variable label="Fan Decceleration rate" CV="16.0.448" default="0" item="ESU FnOut A2-2 Slider 13" mask="XXXVVVVV">
+	        <qualifier>
+		    <variableref>ESU FnOut A2-2 Mode</variableref>
+		    <relation>eq</relation>
+		    <value>23</value>
+	        </qualifier>
+	        <decVal max="31"/>
+	        <label xml:lang="de">Bremszeit</label>
+	    </variable>
+	    <variable label="Maximum driving heat" CV="16.0.448" default="0" item="ESU FnOut A2-2 Slider 16" mask="XXXVVVVV">
+	        <qualifier>
+		    <variableref>ESU FnOut A2-2 Mode</variableref>
+		    <relation>eq</relation>
+		    <value>24</value>
+	        </qualifier>
+	        <decVal max="31"/>
+	        <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
+	    </variable>
+	    <variable label="Timeout" CV="16.0.448" default="0" item="ESU FnOut A2-2 Slider 10" tooltip="Units = 0.25 sec">
+	        <qualifier>
+		    <variableref>ESU FnOut A2-2 Mode</variableref>
+		    <relation>eq</relation>
+		    <value>25</value>
+	        </qualifier>
+	        <decVal/>
+	    </variable>
+	    <variable label="Startup Time" CV="16.0.448" default="0" item="ESU FnOut A2-2 Slider 6">
+	        <qualifier>
+		    <variableref>ESU FnOut A2-2 Mode</variableref>
+		    <relation>ge</relation>
+		    <value>16</value>
+	        </qualifier>
+	        <qualifier>
+		    <variableref>ESU FnOut A2-2 Mode</variableref>
+		    <relation>le</relation>
+		    <value>17</value>
+	        </qualifier>
+	        <decVal/>
+	        <label xml:lang="de">Startzeit</label>
+	    </variable>
+	    <variable label="Level" CV="16.0.448" default="0" item="ESU FnOut A2-2 Slider 20" mask="XVVVVVVV">
+	        <qualifier>
+		    <variableref>ESU FnOut A2-2 Mode</variableref>
+		    <relation>eq</relation>
+		    <value>19</value>
+	        </qualifier>
+	        <decVal max="127"/>
+	    </variable>
+        </variables>
     </variables>
 </variables>

--- a/xml/decoders/esu/v5fnOutCVs.xml
+++ b/xml/decoders/esu/v5fnOutCVs.xml
@@ -2,15 +2,15 @@
 <!-- Copyright (C) JMRI 2019 All rights reserved -->
 
 <variables xmlns:xi="http://www.w3.org/2001/XInclude"
-           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-           xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
     <!-- Headlight [1] Mode -->
     <variable label="Headlight [1] Mode" CV="16.0.259" default="1" item="ESU FnOut HL-1 Mode">
-        <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
-        <!--label xml:lang="de">Licht vorn - 1</label-->
+	<xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
+	<!--label xml:lang="de">Licht vorn - 1</label-->
     </variable>
     <variable label="Function Switch On Delay" CV="16.0.260" default="0" item="ESU FnOut HL-1 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
-        <qualifier>
+	<qualifier>
             <variableref>ESU FnOut HL-1 Mode</variableref>
             <relation>gt</relation>
             <value>0</value>
@@ -925,380 +925,72 @@
     </variable>
     <!-- exclude AUX2 [1] to AUX18 -->
     <variables exclude="LokSound 5 micro DCC Direct Atlas S2">
-    <!-- AUX2 [1] Mode -->
-    <variable label="AUX2 [1] Mode" CV="16.0.283" default="1" item="ESU FnOut A2-1 Mode">
-        <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
-    </variable>
-    <variable label="Function Switch On Delay" CV="16.0.284" default="0" item="ESU FnOut A2-1 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>gt</relation>
-            <value>0</value>
-        </qualifier>
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>ne</relation>
-            <value>27</value>
-        </qualifier>
-        <decVal max="15"/>
-        <label xml:lang="de">Verzögerung beim Einschalten</label>
-    </variable>
-    <variable label="Function Switch Off Delay" CV="16.0.284" default="0" mask="VVVVXXXX" item="ESU FnOut A2-1 Slider 2" tooltip="Units = 0.4 sec">
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>gt</relation>
-            <value>0</value>
-        </qualifier>
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>ne</relation>
-            <value>27</value>
-        </qualifier>
-        <decVal max="15"/>
-        <label xml:lang="de">Verzögerung beim Ausschalten</label>
-    </variable>
-    <variable label="Function Auto Switch Off" CV="16.0.285" default="0" item="ESU FnOut A2-1 Slider 3" tooltip="Units = 0.4 sec">
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>gt</relation>
-            <value>0</value>
-        </qualifier>
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>ne</relation>
-            <value>27</value>
-        </qualifier>
-        <decVal/>
-        <label xml:lang="de">Ausgang automatisch Ausschalten</label>
-    </variable>
-    <variable item="Brightness CV286" label="Brightness CV" CV="16.0.286" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
-        <decVal/>
-    </variable>
-    <variable label="Brightness" CV="16.0.286" default="31" item="ESU FnOut A2-1 Slider 5" mask="XXXVVVVV">
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>gt</relation>
-            <value>0</value>
-        </qualifier>
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>le</relation>
-            <value>18</value>
-        </qualifier>
-        <decVal max="31"/>
-        <label xml:lang="de">Helligkeit</label>
-    </variable>
-    <variable label="Mode" CV="16.0.286" default="0" item="ESU FnOut A2-1 Option 1" mask="XXXXXXXV">
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>eq</relation>
-            <value>22</value>
-        </qualifier>
-        <enumVal>
-            <enumChoice choice="Heating control">
-                <choice>Heating control</choice>
-                <choice xml:lang="de">Heizungssteuerung</choice>
-            </enumChoice>
-            <enumChoice choice="Fan control">
-                <choice>Fan control</choice>
-                <choice xml:lang="de">Lüftersteuerung</choice>
-            </enumChoice>
-        </enumVal>
-        <label xml:lang="de">Modus</label>
-    </variable>
-    <variable label="Coupler Force" CV="16.0.286" default="31" item="ESU FnOut A2-1 Slider 7" mask="XXXVVVVV">
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>ge</relation>
-            <value>28</value>
-        </qualifier>
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>ne</relation>
-            <value>29</value>
-        </qualifier>
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>ne</relation>
-            <value>30</value>
-        </qualifier>
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>ne</relation>
-            <value>31</value>
-        </qualifier>
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>ne</relation>
-            <value>32</value>
-        </qualifier>
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>le</relation>
-            <value>33</value>
-        </qualifier>
-        <decVal max="31"/>
-        <label xml:lang="de">Stärke des Kupplers</label>
-    </variable>
-    <variable label="Fan Speed" CV="16.0.286" default="31" item="ESU FnOut A2-1 Slider 11" mask="XXXVVVVV">
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>eq</relation>
-            <value>23</value>
-        </qualifier>
-        <decVal max="31"/>
-        <label xml:lang="de">Geschwindigkeit</label>
-    </variable>
-    <variable label="Standing heat" CV="16.0.286" default="31" item="ESU FnOut A2-1 Slider 14" mask="XXXVVVVV">
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>eq</relation>
-            <value>24</value>
-        </qualifier>
-        <decVal max="31"/>
-        <label xml:lang="de">Heizstufe im Stand</label>
-    </variable>
-    <variable label="Chuff power" CV="16.0.286" default="31" item="ESU FnOut A2-1 Slider 8" mask="XXXVVVVV">
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>eq</relation>
-            <value>25</value>
-        </qualifier>
-        <decVal max="31"/>
-        <label xml:lang="de">Dampfstoßstärke</label>
-    </variable>
-    <variable item="Special Function CV287" label="Special Function CV 1" CV="16.0.287" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
-        <decVal/>
-    </variable>
-    <variable label="Fan Acceleration rate" CV="16.0.287" default="0" item="ESU FnOut A2-1 Slider 12" mask="XXXVVVVV">
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>eq</relation>
-            <value>23</value>
-        </qualifier>
-        <decVal max="31"/>
-        <label xml:lang="de">Beschleunigungszeit</label>
-    </variable>
-    <variable label="Minimum driving heat" CV="16.0.287" default="0" item="ESU FnOut A2-1 Slider 15" mask="XXXVVVVV">
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>eq</relation>
-            <value>24</value>
-        </qualifier>
-        <decVal max="31"/>
-        <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
-    </variable>
-    <variable label="Fan power" CV="16.0.287" default="0" item="ESU FnOut A2-1 Slider 9" mask="XXXVVVVV">
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>eq</relation>
-            <value>25</value>
-        </qualifier>
-        <decVal max="31"/>
-        <label xml:lang="de">Stäke des Bläsers</label>
-    </variable>
-    <variable label="Phase Reverse" CV="16.0.287" default="0" item="ESU FnOut A2-1 Check 6" mask="XXXXXXXV">
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>gt</relation>
-            <value>0</value>
-        </qualifier>
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>le</relation>
-            <value>15</value>
-        </qualifier>
-        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-        <label xml:lang="de">Phase tauschen</label>
-    </variable>
-    <variable label="Grade Crossing" CV="16.0.287" default="0" item="ESU FnOut A2-1 Check 1" mask="XXXXXXVX">
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>gt</relation>
-            <value>0</value>
-        </qualifier>
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>le</relation>
-            <value>15</value>
-        </qualifier>
-        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-    </variable>
-    <variable label="Rule 17 Fwd" CV="16.0.287" default="0" item="ESU FnOut A2-1 Check 2" mask="XXXXXVXX">
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>gt</relation>
-            <value>0</value>
-        </qualifier>
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>le</relation>
-            <value>15</value>
-        </qualifier>
-        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-        <label xml:lang="de">Rule 17 vorwärts</label>
-    </variable>
-    <variable label="Rule 17 Rev" CV="16.0.287" default="0" item="ESU FnOut A2-1 Check 3" mask="XXXXVXXX">
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>gt</relation>
-            <value>0</value>
-        </qualifier>
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>le</relation>
-            <value>15</value>
-        </qualifier>
-        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-        <label xml:lang="de">Rule 17 rückwärts</label>
-    </variable>
-    <variable label="Dimmer" CV="16.0.287" default="0" item="ESU FnOut A2-1 Check 4" mask="XXXVXXXX">
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>gt</relation>
-            <value>0</value>
-        </qualifier>
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>le</relation>
-            <value>15</value>
-        </qualifier>
-        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-        <label xml:lang="de">Abdimmen</label>
-    </variable>
-    <variable label="LED Mode" CV="16.0.287" default="0" item="ESU FnOut A2-1 Check 5" mask="VXXXXXXX">
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>gt</relation>
-            <value>0</value>
-        </qualifier>
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>le</relation>
-            <value>15</value>
-        </qualifier>
-        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-        <label xml:lang="de">LED Modus</label>
-    </variable>
-    <variable item="Special Function CV288" label="Special Function CV 2" CV="16.0.288" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
-        <decVal/>
-    </variable>
-    <variable label="Fan Decceleration rate" CV="16.0.288" default="0" item="ESU FnOut A2-1 Slider 13" mask="XXXVVVVV">
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>eq</relation>
-            <value>23</value>
-        </qualifier>
-        <decVal max="31"/>
-        <label xml:lang="de">Bremszeit</label>
-    </variable>
-    <variable label="Maximum driving heat" CV="16.0.288" default="0" item="ESU FnOut A2-1 Slider 16" mask="XXXVVVVV">
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>eq</relation>
-            <value>24</value>
-        </qualifier>
-        <decVal max="31"/>
-        <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
-    </variable>
-    <variable label="Timeout" CV="16.0.288" default="0" item="ESU FnOut A2-1 Slider 10" tooltip="Units = 0.25 sec">
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>eq</relation>
-            <value>25</value>
-        </qualifier>
-        <decVal/>
-    </variable>
-    <variable label="Startup Time" CV="16.0.288" default="0" item="ESU FnOut A2-1 Slider 6">
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>ge</relation>
-            <value>16</value>
-        </qualifier>
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>le</relation>
-            <value>17</value>
-        </qualifier>
-        <decVal/>
-        <label xml:lang="de">Startzeit</label>
-    </variable>
-    <variable label="Level" CV="16.0.288" default="0" item="ESU FnOut A2-1 Slider 20" mask="XVVVVVVV">
-        <qualifier>
-            <variableref>ESU FnOut A2-1 Mode</variableref>
-            <relation>eq</relation>
-            <value>19</value>
-        </qualifier>
-        <decVal max="127"/>
-    </variable>
-    <!-- exclude AUX3 to AUX18 -->
-    <variables exclude="Essential Sound Unit">
-        <!-- AUX3 Mode -->
-        <variable label="AUX3 Mode" CV="16.0.291" default="1" item="ESU FnOut A3 Mode">
+        <!-- AUX2 [1] Mode -->
+        <variable label="AUX2 [1] Mode" CV="16.0.283" default="1" item="ESU FnOut A2-1 Mode">
             <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
         </variable>
-        <variable label="Function Switch On Delay" CV="16.0.292" default="0" item="ESU FnOut A3 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
+        <variable label="Function Switch On Delay" CV="16.0.284" default="0" item="ESU FnOut A2-1 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
             <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>gt</relation>
                 <value>0</value>
             </qualifier>
             <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>ne</relation>
                 <value>27</value>
             </qualifier>
             <decVal max="15"/>
             <label xml:lang="de">Verzögerung beim Einschalten</label>
         </variable>
-        <variable label="Function Switch Off Delay" CV="16.0.292" default="0" mask="VVVVXXXX" item="ESU FnOut A3 Slider 2" tooltip="Units = 0.4 sec">
+        <variable label="Function Switch Off Delay" CV="16.0.284" default="0" mask="VVVVXXXX" item="ESU FnOut A2-1 Slider 2" tooltip="Units = 0.4 sec">
             <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>gt</relation>
                 <value>0</value>
             </qualifier>
             <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>ne</relation>
                 <value>27</value>
             </qualifier>
             <decVal max="15"/>
             <label xml:lang="de">Verzögerung beim Ausschalten</label>
         </variable>
-        <variable label="Function Auto Switch Off" CV="16.0.293" default="0" item="ESU FnOut A3 Slider 3" tooltip="Units = 0.4 sec">
+        <variable label="Function Auto Switch Off" CV="16.0.285" default="0" item="ESU FnOut A2-1 Slider 3" tooltip="Units = 0.4 sec">
             <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>gt</relation>
                 <value>0</value>
             </qualifier>
             <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>ne</relation>
                 <value>27</value>
             </qualifier>
             <decVal/>
             <label xml:lang="de">Ausgang automatisch Ausschalten</label>
         </variable>
-        <variable item="Brightness CV294" label="Brightness CV" CV="16.0.294" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
+        <variable item="Brightness CV286" label="Brightness CV" CV="16.0.286" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
             <decVal/>
         </variable>
-        <variable label="Brightness" CV="16.0.294" default="31" item="ESU FnOut A3 Slider 5" mask="XXXVVVVV">
+        <variable label="Brightness" CV="16.0.286" default="31" item="ESU FnOut A2-1 Slider 5" mask="XXXVVVVV">
             <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>gt</relation>
                 <value>0</value>
             </qualifier>
             <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>le</relation>
                 <value>18</value>
             </qualifier>
             <decVal max="31"/>
             <label xml:lang="de">Helligkeit</label>
         </variable>
-        <variable label="Mode" CV="16.0.294" default="0" item="ESU FnOut A3 Option 1" mask="XXXXXXXV">
+        <variable label="Mode" CV="16.0.286" default="0" item="ESU FnOut A2-1 Option 1" mask="XXXXXXXV">
             <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>eq</relation>
                 <value>22</value>
             </qualifier>
@@ -1314,605 +1006,299 @@
             </enumVal>
             <label xml:lang="de">Modus</label>
         </variable>
-        <variable label="Coupler Force" CV="16.0.294" default="31" item="ESU FnOut A3 Slider 7" mask="XXXVVVVV">
+        <variable label="Coupler Force" CV="16.0.286" default="31" item="ESU FnOut A2-1 Slider 7" mask="XXXVVVVV">
             <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>ge</relation>
                 <value>28</value>
             </qualifier>
             <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>ne</relation>
                 <value>29</value>
             </qualifier>
             <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>ne</relation>
                 <value>30</value>
             </qualifier>
             <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>ne</relation>
                 <value>31</value>
             </qualifier>
             <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>ne</relation>
                 <value>32</value>
             </qualifier>
             <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>le</relation>
                 <value>33</value>
             </qualifier>
             <decVal max="31"/>
             <label xml:lang="de">Stärke des Kupplers</label>
         </variable>
-        <variable label="Fan Speed" CV="16.0.294" default="31" item="ESU FnOut A3 Slider 11" mask="XXXVVVVV">
+        <variable label="Fan Speed" CV="16.0.286" default="31" item="ESU FnOut A2-1 Slider 11" mask="XXXVVVVV">
             <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>eq</relation>
                 <value>23</value>
             </qualifier>
             <decVal max="31"/>
             <label xml:lang="de">Geschwindigkeit</label>
         </variable>
-        <variable label="Standing heat" CV="16.0.294" default="31" item="ESU FnOut A3 Slider 14" mask="XXXVVVVV">
+        <variable label="Standing heat" CV="16.0.286" default="31" item="ESU FnOut A2-1 Slider 14" mask="XXXVVVVV">
             <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>eq</relation>
                 <value>24</value>
             </qualifier>
             <decVal max="31"/>
             <label xml:lang="de">Heizstufe im Stand</label>
         </variable>
-        <variable label="Chuff power" CV="16.0.294" default="31" item="ESU FnOut A3 Slider 8" mask="XXXVVVVV">
+        <variable label="Chuff power" CV="16.0.286" default="31" item="ESU FnOut A2-1 Slider 8" mask="XXXVVVVV">
             <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>eq</relation>
                 <value>25</value>
             </qualifier>
             <decVal max="31"/>
             <label xml:lang="de">Dampfstoßstärke</label>
         </variable>
-        <variable item="Special Function CV295" label="Special Function CV 1" CV="16.0.295" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+        <variable item="Special Function CV287" label="Special Function CV 1" CV="16.0.287" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
             <decVal/>
         </variable>
-        <variable label="Fan Acceleration rate" CV="16.0.295" default="0" item="ESU FnOut A3 Slider 12" mask="XXXVVVVV">
+        <variable label="Fan Acceleration rate" CV="16.0.287" default="0" item="ESU FnOut A2-1 Slider 12" mask="XXXVVVVV">
             <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>eq</relation>
                 <value>23</value>
             </qualifier>
             <decVal max="31"/>
             <label xml:lang="de">Beschleunigungszeit</label>
         </variable>
-        <variable label="Minimum driving heat" CV="16.0.295" default="0" item="ESU FnOut A3 Slider 15" mask="XXXVVVVV">
+        <variable label="Minimum driving heat" CV="16.0.287" default="0" item="ESU FnOut A2-1 Slider 15" mask="XXXVVVVV">
             <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>eq</relation>
                 <value>24</value>
             </qualifier>
             <decVal max="31"/>
             <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
         </variable>
-        <variable label="Fan power" CV="16.0.295" default="0" item="ESU FnOut A3 Slider 9" mask="XXXVVVVV">
+        <variable label="Fan power" CV="16.0.287" default="0" item="ESU FnOut A2-1 Slider 9" mask="XXXVVVVV">
             <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>eq</relation>
                 <value>25</value>
             </qualifier>
             <decVal max="31"/>
             <label xml:lang="de">Stäke des Bläsers</label>
         </variable>
-        <variable label="Phase Reverse" CV="16.0.295" default="0" item="ESU FnOut A3 Check 6" mask="XXXXXXXV">
+        <variable label="Phase Reverse" CV="16.0.287" default="0" item="ESU FnOut A2-1 Check 6" mask="XXXXXXXV">
             <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>gt</relation>
                 <value>0</value>
             </qualifier>
             <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>le</relation>
                 <value>15</value>
             </qualifier>
             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
             <label xml:lang="de">Phase tauschen</label>
         </variable>
-        <variable label="Grade Crossing" CV="16.0.295" default="0" item="ESU FnOut A3 Check 1" mask="XXXXXXVX">
+        <variable label="Grade Crossing" CV="16.0.287" default="0" item="ESU FnOut A2-1 Check 1" mask="XXXXXXVX">
             <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>gt</relation>
                 <value>0</value>
             </qualifier>
             <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>le</relation>
                 <value>15</value>
             </qualifier>
             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
         </variable>
-        <variable label="Rule 17 Fwd" CV="16.0.295" default="0" item="ESU FnOut A3 Check 2" mask="XXXXXVXX">
+        <variable label="Rule 17 Fwd" CV="16.0.287" default="0" item="ESU FnOut A2-1 Check 2" mask="XXXXXVXX">
             <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>gt</relation>
                 <value>0</value>
             </qualifier>
             <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
-                <relation>le</relation>
-                <value>15</value>
-            </qualifier>
-            <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-            <label xml:lang="de">Rule 17 vorwärts</label>
-        </variable>
-        <variable label="Rule 17 Rev" CV="16.0.295" default="0" item="ESU FnOut A3 Check 3" mask="XXXXVXXX">
-            <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
-                <relation>gt</relation>
-                <value>0</value>
-            </qualifier>
-            <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
-                <relation>le</relation>
-                <value>15</value>
-            </qualifier>
-            <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-            <label xml:lang="de">Rule 17 rückwärts</label>
-        </variable>
-        <variable label="Dimmer" CV="16.0.295" default="0" item="ESU FnOut A3 Check 4" mask="XXXVXXXX">
-            <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
-                <relation>gt</relation>
-                <value>0</value>
-            </qualifier>
-            <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
-                <relation>le</relation>
-                <value>15</value>
-            </qualifier>
-            <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-            <label xml:lang="de">Abdimmen</label>
-        </variable>
-        <variable label="LED Mode" CV="16.0.295" default="0" item="ESU FnOut A3 Check 5" mask="VXXXXXXX">
-            <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
-                <relation>gt</relation>
-                <value>0</value>
-            </qualifier>
-            <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
-                <relation>le</relation>
-                <value>15</value>
-            </qualifier>
-            <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-            <label xml:lang="de">LED Modus</label>
-        </variable>
-        <variable item="Special Function CV296" label="Special Function CV 2" CV="16.0.296" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
-            <decVal/>
-        </variable>
-        <variable label="Fan Decceleration rate" CV="16.0.296" default="0" item="ESU FnOut A3 Slider 13" mask="XXXVVVVV">
-            <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
-                <relation>eq</relation>
-                <value>23</value>
-            </qualifier>
-            <decVal max="31"/>
-            <label xml:lang="de">Bremszeit</label>
-        </variable>
-        <variable label="Maximum driving heat" CV="16.0.296" default="0" item="ESU FnOut A3 Slider 16" mask="XXXVVVVV">
-            <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
-                <relation>eq</relation>
-                <value>24</value>
-            </qualifier>
-            <decVal max="31"/>
-            <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
-        </variable>
-        <variable label="Timeout" CV="16.0.296" default="0" item="ESU FnOut A3 Slider 10" tooltip="Units = 0.25 sec">
-            <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
-                <relation>eq</relation>
-                <value>25</value>
-            </qualifier>
-            <decVal/>
-        </variable>
-        <variable label="Startup Time" CV="16.0.296" default="0" item="ESU FnOut A3 Slider 6">
-            <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
-                <relation>ge</relation>
-                <value>16</value>
-            </qualifier>
-            <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
-                <relation>le</relation>
-                <value>17</value>
-            </qualifier>
-            <decVal/>
-            <label xml:lang="de">Startzeit</label>
-        </variable>
-        <variable label="Level" CV="16.0.296" default="0" item="ESU FnOut A3 Slider 20" mask="XVVVVVVV">
-            <qualifier>
-                <variableref>ESU FnOut A3 Mode</variableref>
-                <relation>eq</relation>
-                <value>19</value>
-            </qualifier>
-            <decVal max="127"/>
-        </variable>
-        <!-- AUX4 Mode -->
-        <variable label="AUX4 Mode" CV="16.0.299" default="1" item="ESU FnOut A4 Mode">
-            <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
-        </variable>
-        <variable label="Function Switch On Delay" CV="16.0.300" default="0" item="ESU FnOut A4 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
-            <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
-                <relation>gt</relation>
-                <value>0</value>
-            </qualifier>
-            <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
-                <relation>ne</relation>
-                <value>27</value>
-            </qualifier>
-            <decVal max="15"/>
-            <label xml:lang="de">Verzögerung beim Einschalten</label>
-        </variable>
-        <variable label="Function Switch Off Delay" CV="16.0.300" default="0" mask="VVVVXXXX" item="ESU FnOut A4 Slider 2" tooltip="Units = 0.4 sec">
-            <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
-                <relation>gt</relation>
-                <value>0</value>
-            </qualifier>
-            <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
-                <relation>ne</relation>
-                <value>27</value>
-            </qualifier>
-            <decVal max="15"/>
-            <label xml:lang="de">Verzögerung beim Ausschalten</label>
-        </variable>
-        <variable label="Function Auto Switch Off" CV="16.0.301" default="0" item="ESU FnOut A4 Slider 3" tooltip="Units = 0.4 sec">
-            <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
-                <relation>gt</relation>
-                <value>0</value>
-            </qualifier>
-            <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
-                <relation>ne</relation>
-                <value>27</value>
-            </qualifier>
-            <decVal/>
-            <label xml:lang="de">Ausgang automatisch Ausschalten</label>
-        </variable>
-        <variable item="Brightness CV302" label="Brightness CV" CV="16.0.302" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
-            <decVal/>
-        </variable>
-        <variable label="Brightness" CV="16.0.302" default="31" item="ESU FnOut A4 Slider 5" mask="XXXVVVVV">
-            <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
-                <relation>gt</relation>
-                <value>0</value>
-            </qualifier>
-            <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
-                <relation>le</relation>
-                <value>18</value>
-            </qualifier>
-            <decVal max="31"/>
-            <label xml:lang="de">Helligkeit</label>
-        </variable>
-        <variable label="Mode" CV="16.0.302" default="0" item="ESU FnOut A4 Option 1" mask="XXXXXXXV">
-            <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
-                <relation>eq</relation>
-                <value>22</value>
-            </qualifier>
-            <enumVal>
-                <enumChoice choice="Heating control">
-                    <choice>Heating control</choice>
-                    <choice xml:lang="de">Heizungssteuerung</choice>
-                </enumChoice>
-                <enumChoice choice="Fan control">
-                    <choice>Fan control</choice>
-                    <choice xml:lang="de">Lüftersteuerung</choice>
-                </enumChoice>
-            </enumVal>
-            <label xml:lang="de">Modus</label>
-        </variable>
-        <variable label="Coupler Force" CV="16.0.302" default="31" item="ESU FnOut A4 Slider 7" mask="XXXVVVVV">
-            <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
-                <relation>ge</relation>
-                <value>28</value>
-            </qualifier>
-            <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
-                <relation>ne</relation>
-                <value>29</value>
-            </qualifier>
-            <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
-                <relation>ne</relation>
-                <value>30</value>
-            </qualifier>
-            <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
-                <relation>ne</relation>
-                <value>31</value>
-            </qualifier>
-            <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
-                <relation>ne</relation>
-                <value>32</value>
-            </qualifier>
-            <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
-                <relation>le</relation>
-                <value>33</value>
-            </qualifier>
-            <decVal max="31"/>
-            <label xml:lang="de">Stärke des Kupplers</label>
-        </variable>
-        <variable label="Fan Speed" CV="16.0.302" default="31" item="ESU FnOut A4 Slider 11" mask="XXXVVVVV">
-            <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
-                <relation>eq</relation>
-                <value>23</value>
-            </qualifier>
-            <decVal max="31"/>
-            <label xml:lang="de">Geschwindigkeit</label>
-        </variable>
-        <variable label="Standing heat" CV="16.0.302" default="31" item="ESU FnOut A4 Slider 14" mask="XXXVVVVV">
-            <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
-                <relation>eq</relation>
-                <value>24</value>
-            </qualifier>
-            <decVal max="31"/>
-            <label xml:lang="de">Heizstufe im Stand</label>
-        </variable>
-        <variable label="Chuff power" CV="16.0.302" default="31" item="ESU FnOut A4 Slider 8" mask="XXXVVVVV">
-            <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
-                <relation>eq</relation>
-                <value>25</value>
-            </qualifier>
-            <decVal max="31"/>
-            <label xml:lang="de">Dampfstoßstärke</label>
-        </variable>
-        <variable item="Special Function CV303" label="Special Function CV 1" CV="16.0.303" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
-            <decVal/>
-        </variable>
-        <variable label="Fan Acceleration rate" CV="16.0.303" default="0" item="ESU FnOut A4 Slider 12" mask="XXXVVVVV">
-            <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
-                <relation>eq</relation>
-                <value>23</value>
-            </qualifier>
-            <decVal max="31"/>
-            <label xml:lang="de">Beschleunigungszeit</label>
-        </variable>
-        <variable label="Minimum driving heat" CV="16.0.303" default="0" item="ESU FnOut A4 Slider 15" mask="XXXVVVVV">
-            <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
-                <relation>eq</relation>
-                <value>24</value>
-            </qualifier>
-            <decVal max="31"/>
-            <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
-        </variable>
-        <variable label="Fan power" CV="16.0.303" default="0" item="ESU FnOut A4 Slider 9" mask="XXXVVVVV">
-            <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
-                <relation>eq</relation>
-                <value>25</value>
-            </qualifier>
-            <decVal max="31"/>
-            <label xml:lang="de">Stäke des Bläsers</label>
-        </variable>
-        <variable label="Phase Reverse" CV="16.0.303" default="0" item="ESU FnOut A4 Check 6" mask="XXXXXXXV">
-            <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
-                <relation>gt</relation>
-                <value>0</value>
-            </qualifier>
-            <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
-                <relation>le</relation>
-                <value>15</value>
-            </qualifier>
-            <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-            <label xml:lang="de">Phase tauschen</label>
-        </variable>
-        <variable label="Grade Crossing" CV="16.0.303" default="0" item="ESU FnOut A4 Check 1" mask="XXXXXXVX">
-            <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
-                <relation>gt</relation>
-                <value>0</value>
-            </qualifier>
-            <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
-                <relation>le</relation>
-                <value>15</value>
-            </qualifier>
-            <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-        </variable>
-        <variable label="Rule 17 Fwd" CV="16.0.303" default="0" item="ESU FnOut A4 Check 2" mask="XXXXXVXX">
-            <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
-                <relation>gt</relation>
-                <value>0</value>
-            </qualifier>
-            <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>le</relation>
                 <value>15</value>
             </qualifier>
             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
             <label xml:lang="de">Rule 17 vorwärts</label>
         </variable>
-        <variable label="Rule 17 Rev" CV="16.0.303" default="0" item="ESU FnOut A4 Check 3" mask="XXXXVXXX">
+        <variable label="Rule 17 Rev" CV="16.0.287" default="0" item="ESU FnOut A2-1 Check 3" mask="XXXXVXXX">
             <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>gt</relation>
                 <value>0</value>
             </qualifier>
             <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>le</relation>
                 <value>15</value>
             </qualifier>
             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
             <label xml:lang="de">Rule 17 rückwärts</label>
         </variable>
-        <variable label="Dimmer" CV="16.0.303" default="0" item="ESU FnOut A4 Check 4" mask="XXXVXXXX">
+        <variable label="Dimmer" CV="16.0.287" default="0" item="ESU FnOut A2-1 Check 4" mask="XXXVXXXX">
             <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>gt</relation>
                 <value>0</value>
             </qualifier>
             <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>le</relation>
                 <value>15</value>
             </qualifier>
             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
             <label xml:lang="de">Abdimmen</label>
         </variable>
-        <variable label="LED Mode" CV="16.0.303" default="0" item="ESU FnOut A4 Check 5" mask="VXXXXXXX">
+        <variable label="LED Mode" CV="16.0.287" default="0" item="ESU FnOut A2-1 Check 5" mask="VXXXXXXX">
             <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>gt</relation>
                 <value>0</value>
             </qualifier>
             <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>le</relation>
                 <value>15</value>
             </qualifier>
             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
             <label xml:lang="de">LED Modus</label>
         </variable>
-        <variable item="Special Function CV304" label="Special Function CV 2" CV="16.0.304" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+        <variable item="Special Function CV288" label="Special Function CV 2" CV="16.0.288" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
             <decVal/>
         </variable>
-        <variable label="Fan Decceleration rate" CV="16.0.304" default="0" item="ESU FnOut A4 Slider 13" mask="XXXVVVVV">
+        <variable label="Fan Decceleration rate" CV="16.0.288" default="0" item="ESU FnOut A2-1 Slider 13" mask="XXXVVVVV">
             <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>eq</relation>
                 <value>23</value>
             </qualifier>
             <decVal max="31"/>
             <label xml:lang="de">Bremszeit</label>
         </variable>
-        <variable label="Maximum driving heat" CV="16.0.304" default="0" item="ESU FnOut A4 Slider 16" mask="XXXVVVVV">
+        <variable label="Maximum driving heat" CV="16.0.288" default="0" item="ESU FnOut A2-1 Slider 16" mask="XXXVVVVV">
             <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>eq</relation>
                 <value>24</value>
             </qualifier>
             <decVal max="31"/>
             <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
         </variable>
-        <variable label="Timeout" CV="16.0.304" default="0" item="ESU FnOut A4 Slider 10" tooltip="Units = 0.25 sec">
+        <variable label="Timeout" CV="16.0.288" default="0" item="ESU FnOut A2-1 Slider 10" tooltip="Units = 0.25 sec">
             <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>eq</relation>
                 <value>25</value>
             </qualifier>
             <decVal/>
         </variable>
-        <variable label="Startup Time" CV="16.0.304" default="0" item="ESU FnOut A4 Slider 6">
+        <variable label="Startup Time" CV="16.0.288" default="0" item="ESU FnOut A2-1 Slider 6">
             <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>ge</relation>
                 <value>16</value>
             </qualifier>
             <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>le</relation>
                 <value>17</value>
             </qualifier>
             <decVal/>
             <label xml:lang="de">Startzeit</label>
         </variable>
-        <variable label="Level" CV="16.0.304" default="0" item="ESU FnOut A4 Slider 20" mask="XVVVVVVV">
+        <variable label="Level" CV="16.0.288" default="0" item="ESU FnOut A2-1 Slider 20" mask="XVVVVVVV">
             <qualifier>
-                <variableref>ESU FnOut A4 Mode</variableref>
+                <variableref>ESU FnOut A2-1 Mode</variableref>
                 <relation>eq</relation>
                 <value>19</value>
             </qualifier>
             <decVal max="127"/>
         </variable>
-        <!-- exclude AUX5 to AUX18 -->
-        <variables exclude="LokPilot 5 micro,LokPilot 5 micro DCC,LokSound 5 micro DCC Direct Atlas Legacy">
-            <!-- AUX5 Mode -->
-            <variable label="AUX5 Mode" CV="16.0.307" default="1" item="ESU FnOut A5 Mode">
+        <!-- exclude AUX3 to AUX18 -->
+        <variables exclude="Essential Sound Unit">
+            <!-- AUX3 Mode -->
+            <variable label="AUX3 Mode" CV="16.0.291" default="1" item="ESU FnOut A3 Mode">
                 <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
             </variable>
-            <variable label="Function Switch On Delay" CV="16.0.308" default="0" item="ESU FnOut A5 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
+            <variable label="Function Switch On Delay" CV="16.0.292" default="0" item="ESU FnOut A3 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>gt</relation>
                     <value>0</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>ne</relation>
                     <value>27</value>
                 </qualifier>
                 <decVal max="15"/>
                 <label xml:lang="de">Verzögerung beim Einschalten</label>
             </variable>
-            <variable label="Function Switch Off Delay" CV="16.0.308" default="0" mask="VVVVXXXX" item="ESU FnOut A5 Slider 2" tooltip="Units = 0.4 sec">
+            <variable label="Function Switch Off Delay" CV="16.0.292" default="0" mask="VVVVXXXX" item="ESU FnOut A3 Slider 2" tooltip="Units = 0.4 sec">
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>gt</relation>
                     <value>0</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>ne</relation>
                     <value>27</value>
                 </qualifier>
                 <decVal max="15"/>
                 <label xml:lang="de">Verzögerung beim Ausschalten</label>
             </variable>
-            <variable label="Function Auto Switch Off" CV="16.0.309" default="0" item="ESU FnOut A5 Slider 3" tooltip="Units = 0.4 sec">
+            <variable label="Function Auto Switch Off" CV="16.0.293" default="0" item="ESU FnOut A3 Slider 3" tooltip="Units = 0.4 sec">
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>gt</relation>
                     <value>0</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>ne</relation>
                     <value>27</value>
                 </qualifier>
                 <decVal/>
                 <label xml:lang="de">Ausgang automatisch Ausschalten</label>
             </variable>
-            <variable item="Brightness CV310" label="Brightness CV" CV="16.0.310" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
+            <variable item="Brightness CV294" label="Brightness CV" CV="16.0.294" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
                 <decVal/>
             </variable>
-            <variable label="Brightness" CV="16.0.310" default="31" item="ESU FnOut A5 Slider 5" mask="XXXVVVVV">
+            <variable label="Brightness" CV="16.0.294" default="31" item="ESU FnOut A3 Slider 5" mask="XXXVVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>gt</relation>
                     <value>0</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>le</relation>
                     <value>18</value>
                 </qualifier>
                 <decVal max="31"/>
                 <label xml:lang="de">Helligkeit</label>
             </variable>
-            <variable label="Mode" CV="16.0.310" default="0" item="ESU FnOut A5 Option 1" mask="XXXXXXXV">
+            <variable label="Mode" CV="16.0.294" default="0" item="ESU FnOut A3 Option 1" mask="XXXXXXXV">
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>eq</relation>
                     <value>22</value>
                 </qualifier>
@@ -1928,297 +1314,297 @@
                 </enumVal>
                 <label xml:lang="de">Modus</label>
             </variable>
-            <variable label="Coupler Force" CV="16.0.310" default="31" item="ESU FnOut A5 Slider 7" mask="XXXVVVVV">
+            <variable label="Coupler Force" CV="16.0.294" default="31" item="ESU FnOut A3 Slider 7" mask="XXXVVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>ge</relation>
                     <value>28</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>ne</relation>
                     <value>29</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>ne</relation>
                     <value>30</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>ne</relation>
                     <value>31</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>ne</relation>
                     <value>32</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>le</relation>
                     <value>33</value>
                 </qualifier>
                 <decVal max="31"/>
                 <label xml:lang="de">Stärke des Kupplers</label>
             </variable>
-            <variable label="Fan Speed" CV="16.0.310" default="31" item="ESU FnOut A5 Slider 11" mask="XXXVVVVV">
+            <variable label="Fan Speed" CV="16.0.294" default="31" item="ESU FnOut A3 Slider 11" mask="XXXVVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>eq</relation>
                     <value>23</value>
                 </qualifier>
                 <decVal max="31"/>
                 <label xml:lang="de">Geschwindigkeit</label>
             </variable>
-            <variable label="Standing heat" CV="16.0.310" default="31" item="ESU FnOut A5 Slider 14" mask="XXXVVVVV">
+            <variable label="Standing heat" CV="16.0.294" default="31" item="ESU FnOut A3 Slider 14" mask="XXXVVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>eq</relation>
                     <value>24</value>
                 </qualifier>
                 <decVal max="31"/>
                 <label xml:lang="de">Heizstufe im Stand</label>
             </variable>
-            <variable label="Chuff power" CV="16.0.310" default="31" item="ESU FnOut A5 Slider 8" mask="XXXVVVVV">
+            <variable label="Chuff power" CV="16.0.294" default="31" item="ESU FnOut A3 Slider 8" mask="XXXVVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>eq</relation>
                     <value>25</value>
                 </qualifier>
                 <decVal max="31"/>
                 <label xml:lang="de">Dampfstoßstärke</label>
             </variable>
-            <variable item="Special Function CV311" label="Special Function CV 1" CV="16.0.311" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+            <variable item="Special Function CV295" label="Special Function CV 1" CV="16.0.295" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
                 <decVal/>
             </variable>
-            <variable label="Fan Acceleration rate" CV="16.0.311" default="0" item="ESU FnOut A5 Slider 12" mask="XXXVVVVV">
+            <variable label="Fan Acceleration rate" CV="16.0.295" default="0" item="ESU FnOut A3 Slider 12" mask="XXXVVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>eq</relation>
                     <value>23</value>
                 </qualifier>
                 <decVal max="31"/>
                 <label xml:lang="de">Beschleunigungszeit</label>
             </variable>
-            <variable label="Minimum driving heat" CV="16.0.311" default="0" item="ESU FnOut A5 Slider 15" mask="XXXVVVVV">
+            <variable label="Minimum driving heat" CV="16.0.295" default="0" item="ESU FnOut A3 Slider 15" mask="XXXVVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>eq</relation>
                     <value>24</value>
                 </qualifier>
                 <decVal max="31"/>
                 <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
             </variable>
-            <variable label="Fan power" CV="16.0.311" default="0" item="ESU FnOut A5 Slider 9" mask="XXXVVVVV">
+            <variable label="Fan power" CV="16.0.295" default="0" item="ESU FnOut A3 Slider 9" mask="XXXVVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>eq</relation>
                     <value>25</value>
                 </qualifier>
                 <decVal max="31"/>
                 <label xml:lang="de">Stäke des Bläsers</label>
             </variable>
-            <variable label="Phase Reverse" CV="16.0.311" default="0" item="ESU FnOut A5 Check 6" mask="XXXXXXXV">
+            <variable label="Phase Reverse" CV="16.0.295" default="0" item="ESU FnOut A3 Check 6" mask="XXXXXXXV">
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>gt</relation>
                     <value>0</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>le</relation>
                     <value>15</value>
                 </qualifier>
                 <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                 <label xml:lang="de">Phase tauschen</label>
             </variable>
-            <variable label="Grade Crossing" CV="16.0.311" default="0" item="ESU FnOut A5 Check 1" mask="XXXXXXVX">
+            <variable label="Grade Crossing" CV="16.0.295" default="0" item="ESU FnOut A3 Check 1" mask="XXXXXXVX">
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>gt</relation>
                     <value>0</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>le</relation>
                     <value>15</value>
                 </qualifier>
                 <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
             </variable>
-            <variable label="Rule 17 Fwd" CV="16.0.311" default="0" item="ESU FnOut A5 Check 2" mask="XXXXXVXX">
+            <variable label="Rule 17 Fwd" CV="16.0.295" default="0" item="ESU FnOut A3 Check 2" mask="XXXXXVXX">
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>gt</relation>
                     <value>0</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>le</relation>
                     <value>15</value>
                 </qualifier>
                 <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                 <label xml:lang="de">Rule 17 vorwärts</label>
             </variable>
-            <variable label="Rule 17 Rev" CV="16.0.311" default="0" item="ESU FnOut A5 Check 3" mask="XXXXVXXX">
+            <variable label="Rule 17 Rev" CV="16.0.295" default="0" item="ESU FnOut A3 Check 3" mask="XXXXVXXX">
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>gt</relation>
                     <value>0</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>le</relation>
                     <value>15</value>
                 </qualifier>
                 <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                 <label xml:lang="de">Rule 17 rückwärts</label>
             </variable>
-            <variable label="Dimmer" CV="16.0.311" default="0" item="ESU FnOut A5 Check 4" mask="XXXVXXXX">
+            <variable label="Dimmer" CV="16.0.295" default="0" item="ESU FnOut A3 Check 4" mask="XXXVXXXX">
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>gt</relation>
                     <value>0</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>le</relation>
                     <value>15</value>
                 </qualifier>
                 <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                 <label xml:lang="de">Abdimmen</label>
             </variable>
-            <variable label="LED Mode" CV="16.0.311" default="0" item="ESU FnOut A5 Check 5" mask="VXXXXXXX">
+            <variable label="LED Mode" CV="16.0.295" default="0" item="ESU FnOut A3 Check 5" mask="VXXXXXXX">
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>gt</relation>
                     <value>0</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>le</relation>
                     <value>15</value>
                 </qualifier>
                 <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                 <label xml:lang="de">LED Modus</label>
             </variable>
-            <variable item="Special Function CV312" label="Special Function CV 2" CV="16.0.312" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+            <variable item="Special Function CV296" label="Special Function CV 2" CV="16.0.296" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
                 <decVal/>
             </variable>
-            <variable label="Fan Decceleration rate" CV="16.0.312" default="0" item="ESU FnOut A5 Slider 13" mask="XXXVVVVV">
+            <variable label="Fan Decceleration rate" CV="16.0.296" default="0" item="ESU FnOut A3 Slider 13" mask="XXXVVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>eq</relation>
                     <value>23</value>
                 </qualifier>
                 <decVal max="31"/>
                 <label xml:lang="de">Bremszeit</label>
             </variable>
-            <variable label="Maximum driving heat" CV="16.0.312" default="0" item="ESU FnOut A5 Slider 16" mask="XXXVVVVV">
+            <variable label="Maximum driving heat" CV="16.0.296" default="0" item="ESU FnOut A3 Slider 16" mask="XXXVVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>eq</relation>
                     <value>24</value>
                 </qualifier>
                 <decVal max="31"/>
                 <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
             </variable>
-            <variable label="Timeout" CV="16.0.312" default="0" item="ESU FnOut A5 Slider 10" tooltip="Units = 0.25 sec">
+            <variable label="Timeout" CV="16.0.296" default="0" item="ESU FnOut A3 Slider 10" tooltip="Units = 0.25 sec">
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>eq</relation>
                     <value>25</value>
                 </qualifier>
                 <decVal/>
             </variable>
-            <variable label="Startup Time" CV="16.0.312" default="0" item="ESU FnOut A5 Slider 6">
+            <variable label="Startup Time" CV="16.0.296" default="0" item="ESU FnOut A3 Slider 6">
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>ge</relation>
                     <value>16</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>le</relation>
                     <value>17</value>
                 </qualifier>
                 <decVal/>
                 <label xml:lang="de">Startzeit</label>
             </variable>
-            <variable label="Level" CV="16.0.312" default="0" item="ESU FnOut A5 Slider 20" mask="XVVVVVVV">
+            <variable label="Level" CV="16.0.296" default="0" item="ESU FnOut A3 Slider 20" mask="XVVVVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A5 Mode</variableref>
+                    <variableref>ESU FnOut A3 Mode</variableref>
                     <relation>eq</relation>
                     <value>19</value>
                 </qualifier>
                 <decVal max="127"/>
             </variable>
-            <!-- AUX6 Mode -->
-            <variable label="AUX6 Mode" CV="16.0.315" default="1" item="ESU FnOut A6 Mode">
+            <!-- AUX4 Mode -->
+            <variable label="AUX4 Mode" CV="16.0.299" default="1" item="ESU FnOut A4 Mode">
                 <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
             </variable>
-            <variable label="Function Switch On Delay" CV="16.0.316" default="0" item="ESU FnOut A6 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
+            <variable label="Function Switch On Delay" CV="16.0.300" default="0" item="ESU FnOut A4 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>gt</relation>
                     <value>0</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>ne</relation>
                     <value>27</value>
                 </qualifier>
                 <decVal max="15"/>
                 <label xml:lang="de">Verzögerung beim Einschalten</label>
             </variable>
-            <variable label="Function Switch Off Delay" CV="16.0.316" default="0" mask="VVVVXXXX" item="ESU FnOut A6 Slider 2" tooltip="Units = 0.4 sec">
+            <variable label="Function Switch Off Delay" CV="16.0.300" default="0" mask="VVVVXXXX" item="ESU FnOut A4 Slider 2" tooltip="Units = 0.4 sec">
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>gt</relation>
                     <value>0</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>ne</relation>
                     <value>27</value>
                 </qualifier>
                 <decVal max="15"/>
                 <label xml:lang="de">Verzögerung beim Ausschalten</label>
             </variable>
-            <variable label="Function Auto Switch Off" CV="16.0.317" default="0" item="ESU FnOut A6 Slider 3" tooltip="Units = 0.4 sec">
+            <variable label="Function Auto Switch Off" CV="16.0.301" default="0" item="ESU FnOut A4 Slider 3" tooltip="Units = 0.4 sec">
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>gt</relation>
                     <value>0</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>ne</relation>
                     <value>27</value>
                 </qualifier>
                 <decVal/>
                 <label xml:lang="de">Ausgang automatisch Ausschalten</label>
             </variable>
-            <variable item="Brightness CV318" label="Brightness CV" CV="16.0.318" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
+            <variable item="Brightness CV302" label="Brightness CV" CV="16.0.302" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
                 <decVal/>
             </variable>
-            <variable label="Brightness" CV="16.0.318" default="31" item="ESU FnOut A6 Slider 5" mask="XXXVVVVV">
+            <variable label="Brightness" CV="16.0.302" default="31" item="ESU FnOut A4 Slider 5" mask="XXXVVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>gt</relation>
                     <value>0</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>le</relation>
                     <value>18</value>
                 </qualifier>
                 <decVal max="31"/>
                 <label xml:lang="de">Helligkeit</label>
             </variable>
-            <variable label="Mode" CV="16.0.318" default="0" item="ESU FnOut A6 Option 1" mask="XXXXXXXV">
+            <variable label="Mode" CV="16.0.302" default="0" item="ESU FnOut A4 Option 1" mask="XXXXXXXV">
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>eq</relation>
                     <value>22</value>
                 </qualifier>
@@ -2234,299 +1620,299 @@
                 </enumVal>
                 <label xml:lang="de">Modus</label>
             </variable>
-            <variable label="Coupler Force" CV="16.0.318" default="31" item="ESU FnOut A6 Slider 7" mask="XXXVVVVV">
+            <variable label="Coupler Force" CV="16.0.302" default="31" item="ESU FnOut A4 Slider 7" mask="XXXVVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>ge</relation>
                     <value>28</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>ne</relation>
                     <value>29</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>ne</relation>
                     <value>30</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>ne</relation>
                     <value>31</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>ne</relation>
                     <value>32</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>le</relation>
                     <value>33</value>
                 </qualifier>
                 <decVal max="31"/>
                 <label xml:lang="de">Stärke des Kupplers</label>
             </variable>
-            <variable label="Fan Speed" CV="16.0.318" default="31" item="ESU FnOut A6 Slider 11" mask="XXXVVVVV">
+            <variable label="Fan Speed" CV="16.0.302" default="31" item="ESU FnOut A4 Slider 11" mask="XXXVVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>eq</relation>
                     <value>23</value>
                 </qualifier>
                 <decVal max="31"/>
                 <label xml:lang="de">Geschwindigkeit</label>
             </variable>
-            <variable label="Standing heat" CV="16.0.318" default="31" item="ESU FnOut A6 Slider 14" mask="XXXVVVVV">
+            <variable label="Standing heat" CV="16.0.302" default="31" item="ESU FnOut A4 Slider 14" mask="XXXVVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>eq</relation>
                     <value>24</value>
                 </qualifier>
                 <decVal max="31"/>
                 <label xml:lang="de">Heizstufe im Stand</label>
             </variable>
-            <variable label="Chuff power" CV="16.0.318" default="31" item="ESU FnOut A6 Slider 8" mask="XXXVVVVV">
+            <variable label="Chuff power" CV="16.0.302" default="31" item="ESU FnOut A4 Slider 8" mask="XXXVVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>eq</relation>
                     <value>25</value>
                 </qualifier>
                 <decVal max="31"/>
                 <label xml:lang="de">Dampfstoßstärke</label>
             </variable>
-            <variable item="Special Function CV319" label="Special Function CV 1" CV="16.0.319" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+            <variable item="Special Function CV303" label="Special Function CV 1" CV="16.0.303" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
                 <decVal/>
             </variable>
-            <variable label="Fan Acceleration rate" CV="16.0.319" default="0" item="ESU FnOut A6 Slider 12" mask="XXXVVVVV">
+            <variable label="Fan Acceleration rate" CV="16.0.303" default="0" item="ESU FnOut A4 Slider 12" mask="XXXVVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>eq</relation>
                     <value>23</value>
                 </qualifier>
                 <decVal max="31"/>
                 <label xml:lang="de">Beschleunigungszeit</label>
             </variable>
-            <variable label="Minimum driving heat" CV="16.0.319" default="0" item="ESU FnOut A6 Slider 15" mask="XXXVVVVV">
+            <variable label="Minimum driving heat" CV="16.0.303" default="0" item="ESU FnOut A4 Slider 15" mask="XXXVVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>eq</relation>
                     <value>24</value>
                 </qualifier>
                 <decVal max="31"/>
                 <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
             </variable>
-            <variable label="Fan power" CV="16.0.319" default="0" item="ESU FnOut A6 Slider 9" mask="XXXVVVVV">
+            <variable label="Fan power" CV="16.0.303" default="0" item="ESU FnOut A4 Slider 9" mask="XXXVVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>eq</relation>
                     <value>25</value>
                 </qualifier>
                 <decVal max="31"/>
                 <label xml:lang="de">Stäke des Bläsers</label>
             </variable>
-            <variable label="Phase Reverse" CV="16.0.319" default="0" item="ESU FnOut A6 Check 6" mask="XXXXXXXV">
+            <variable label="Phase Reverse" CV="16.0.303" default="0" item="ESU FnOut A4 Check 6" mask="XXXXXXXV">
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>gt</relation>
                     <value>0</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>le</relation>
                     <value>15</value>
                 </qualifier>
                 <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                 <label xml:lang="de">Phase tauschen</label>
             </variable>
-            <variable label="Grade Crossing" CV="16.0.319" default="0" item="ESU FnOut A6 Check 1" mask="XXXXXXVX">
+            <variable label="Grade Crossing" CV="16.0.303" default="0" item="ESU FnOut A4 Check 1" mask="XXXXXXVX">
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>gt</relation>
                     <value>0</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>le</relation>
                     <value>15</value>
                 </qualifier>
                 <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
             </variable>
-            <variable label="Rule 17 Fwd" CV="16.0.319" default="0" item="ESU FnOut A6 Check 2" mask="XXXXXVXX">
+            <variable label="Rule 17 Fwd" CV="16.0.303" default="0" item="ESU FnOut A4 Check 2" mask="XXXXXVXX">
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>gt</relation>
                     <value>0</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>le</relation>
                     <value>15</value>
                 </qualifier>
                 <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                 <label xml:lang="de">Rule 17 vorwärts</label>
             </variable>
-            <variable label="Rule 17 Rev" CV="16.0.319" default="0" item="ESU FnOut A6 Check 3" mask="XXXXVXXX">
+            <variable label="Rule 17 Rev" CV="16.0.303" default="0" item="ESU FnOut A4 Check 3" mask="XXXXVXXX">
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>gt</relation>
                     <value>0</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>le</relation>
                     <value>15</value>
                 </qualifier>
                 <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                 <label xml:lang="de">Rule 17 rückwärts</label>
             </variable>
-            <variable label="Dimmer" CV="16.0.319" default="0" item="ESU FnOut A6 Check 4" mask="XXXVXXXX">
+            <variable label="Dimmer" CV="16.0.303" default="0" item="ESU FnOut A4 Check 4" mask="XXXVXXXX">
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>gt</relation>
                     <value>0</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>le</relation>
                     <value>15</value>
                 </qualifier>
                 <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                 <label xml:lang="de">Abdimmen</label>
             </variable>
-            <variable label="LED Mode" CV="16.0.319" default="0" item="ESU FnOut A6 Check 5" mask="VXXXXXXX">
+            <variable label="LED Mode" CV="16.0.303" default="0" item="ESU FnOut A4 Check 5" mask="VXXXXXXX">
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>gt</relation>
                     <value>0</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>le</relation>
                     <value>15</value>
                 </qualifier>
                 <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                 <label xml:lang="de">LED Modus</label>
             </variable>
-            <variable item="Special Function CV320" label="Special Function CV 2" CV="16.0.320" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+            <variable item="Special Function CV304" label="Special Function CV 2" CV="16.0.304" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
                 <decVal/>
             </variable>
-            <variable label="Fan Decceleration rate" CV="16.0.320" default="0" item="ESU FnOut A6 Slider 13" mask="XXXVVVVV">
+            <variable label="Fan Decceleration rate" CV="16.0.304" default="0" item="ESU FnOut A4 Slider 13" mask="XXXVVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>eq</relation>
                     <value>23</value>
                 </qualifier>
                 <decVal max="31"/>
                 <label xml:lang="de">Bremszeit</label>
             </variable>
-            <variable label="Maximum driving heat" CV="16.0.320" default="0" item="ESU FnOut A6 Slider 16" mask="XXXVVVVV">
+            <variable label="Maximum driving heat" CV="16.0.304" default="0" item="ESU FnOut A4 Slider 16" mask="XXXVVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>eq</relation>
                     <value>24</value>
                 </qualifier>
                 <decVal max="31"/>
                 <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
             </variable>
-            <variable label="Timeout" CV="16.0.320" default="0" item="ESU FnOut A6 Slider 10" tooltip="Units = 0.25 sec">
+            <variable label="Timeout" CV="16.0.304" default="0" item="ESU FnOut A4 Slider 10" tooltip="Units = 0.25 sec">
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>eq</relation>
                     <value>25</value>
                 </qualifier>
                 <decVal/>
             </variable>
-            <variable label="Startup Time" CV="16.0.320" default="0" item="ESU FnOut A6 Slider 6">
+            <variable label="Startup Time" CV="16.0.304" default="0" item="ESU FnOut A4 Slider 6">
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>ge</relation>
                     <value>16</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>le</relation>
                     <value>17</value>
                 </qualifier>
                 <decVal/>
                 <label xml:lang="de">Startzeit</label>
             </variable>
-            <variable label="Level" CV="16.0.320" default="0" item="ESU FnOut A6 Slider 20" mask="XVVVVVVV">
+            <variable label="Level" CV="16.0.304" default="0" item="ESU FnOut A4 Slider 20" mask="XVVVVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A6 Mode</variableref>
+                    <variableref>ESU FnOut A4 Mode</variableref>
                     <relation>eq</relation>
                     <value>19</value>
                 </qualifier>
                 <decVal max="127"/>
             </variable>
-            <!-- exclude AUX7 to AUX18 -->
-            <variables exclude="LokPilot 5 Fx micro,LokPilot 5 Fx micro DCC">
-                <!-- AUX7 Mode -->
-                <variable label="AUX7 Mode" CV="16.0.323" default="1" item="ESU FnOut A7 Mode">
+            <!-- exclude AUX5 to AUX18 -->
+            <variables exclude="LokPilot 5 micro,LokPilot 5 micro DCC,LokSound 5 micro DCC Direct Atlas Legacy">
+                <!-- AUX5 Mode -->
+                <variable label="AUX5 Mode" CV="16.0.307" default="1" item="ESU FnOut A5 Mode">
                     <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
                 </variable>
-                <variable label="Function Switch On Delay" CV="16.0.324" default="0" item="ESU FnOut A7 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
+                <variable label="Function Switch On Delay" CV="16.0.308" default="0" item="ESU FnOut A5 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>gt</relation>
                         <value>0</value>
                     </qualifier>
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>ne</relation>
                         <value>27</value>
                     </qualifier>
                     <decVal max="15"/>
                     <label xml:lang="de">Verzögerung beim Einschalten</label>
                 </variable>
-                <variable label="Function Switch Off Delay" CV="16.0.324" default="0" mask="VVVVXXXX" item="ESU FnOut A7 Slider 2" tooltip="Units = 0.4 sec">
+                <variable label="Function Switch Off Delay" CV="16.0.308" default="0" mask="VVVVXXXX" item="ESU FnOut A5 Slider 2" tooltip="Units = 0.4 sec">
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>gt</relation>
                         <value>0</value>
                     </qualifier>
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>ne</relation>
                         <value>27</value>
                     </qualifier>
                     <decVal max="15"/>
                     <label xml:lang="de">Verzögerung beim Ausschalten</label>
                 </variable>
-                <variable label="Function Auto Switch Off" CV="16.0.325" default="0" item="ESU FnOut A7 Slider 3" tooltip="Units = 0.4 sec">
+                <variable label="Function Auto Switch Off" CV="16.0.309" default="0" item="ESU FnOut A5 Slider 3" tooltip="Units = 0.4 sec">
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>gt</relation>
                         <value>0</value>
                     </qualifier>
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>ne</relation>
                         <value>27</value>
                     </qualifier>
                     <decVal/>
                     <label xml:lang="de">Ausgang automatisch Ausschalten</label>
                 </variable>
-                <variable item="Brightness CV326" label="Brightness CV" CV="16.0.326" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
+                <variable item="Brightness CV310" label="Brightness CV" CV="16.0.310" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
                     <decVal/>
                 </variable>
-                <variable label="Brightness" CV="16.0.326" default="31" item="ESU FnOut A7 Slider 5" mask="XXXVVVVV">
+                <variable label="Brightness" CV="16.0.310" default="31" item="ESU FnOut A5 Slider 5" mask="XXXVVVVV">
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>gt</relation>
                         <value>0</value>
                     </qualifier>
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>le</relation>
                         <value>18</value>
                     </qualifier>
                     <decVal max="31"/>
                     <label xml:lang="de">Helligkeit</label>
                 </variable>
-                <variable label="Mode" CV="16.0.326" default="0" item="ESU FnOut A7 Option 1" mask="XXXXXXXV">
+                <variable label="Mode" CV="16.0.310" default="0" item="ESU FnOut A5 Option 1" mask="XXXXXXXV">
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>eq</relation>
                         <value>22</value>
                     </qualifier>
@@ -2542,299 +1928,605 @@
                     </enumVal>
                     <label xml:lang="de">Modus</label>
                 </variable>
-                <variable label="Coupler Force" CV="16.0.326" default="31" item="ESU FnOut A7 Slider 7" mask="XXXVVVVV">
+                <variable label="Coupler Force" CV="16.0.310" default="31" item="ESU FnOut A5 Slider 7" mask="XXXVVVVV">
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>ge</relation>
                         <value>28</value>
                     </qualifier>
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>ne</relation>
                         <value>29</value>
                     </qualifier>
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>ne</relation>
                         <value>30</value>
                     </qualifier>
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>ne</relation>
                         <value>31</value>
                     </qualifier>
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>ne</relation>
                         <value>32</value>
                     </qualifier>
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>le</relation>
                         <value>33</value>
                     </qualifier>
                     <decVal max="31"/>
                     <label xml:lang="de">Stärke des Kupplers</label>
                 </variable>
-                <variable label="Fan Speed" CV="16.0.326" default="31" item="ESU FnOut A7 Slider 11" mask="XXXVVVVV">
+                <variable label="Fan Speed" CV="16.0.310" default="31" item="ESU FnOut A5 Slider 11" mask="XXXVVVVV">
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>eq</relation>
                         <value>23</value>
                     </qualifier>
                     <decVal max="31"/>
                     <label xml:lang="de">Geschwindigkeit</label>
                 </variable>
-                <variable label="Standing heat" CV="16.0.326" default="31" item="ESU FnOut A7 Slider 14" mask="XXXVVVVV">
+                <variable label="Standing heat" CV="16.0.310" default="31" item="ESU FnOut A5 Slider 14" mask="XXXVVVVV">
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>eq</relation>
                         <value>24</value>
                     </qualifier>
                     <decVal max="31"/>
                     <label xml:lang="de">Heizstufe im Stand</label>
                 </variable>
-                <variable label="Chuff power" CV="16.0.326" default="31" item="ESU FnOut A7 Slider 8" mask="XXXVVVVV">
+                <variable label="Chuff power" CV="16.0.310" default="31" item="ESU FnOut A5 Slider 8" mask="XXXVVVVV">
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>eq</relation>
                         <value>25</value>
                     </qualifier>
                     <decVal max="31"/>
                     <label xml:lang="de">Dampfstoßstärke</label>
                 </variable>
-                <variable item="Special Function CV327" label="Special Function CV 1" CV="16.0.327" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                <variable item="Special Function CV311" label="Special Function CV 1" CV="16.0.311" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
                     <decVal/>
                 </variable>
-                <variable label="Fan Acceleration rate" CV="16.0.327" default="0" item="ESU FnOut A7 Slider 12" mask="XXXVVVVV">
+                <variable label="Fan Acceleration rate" CV="16.0.311" default="0" item="ESU FnOut A5 Slider 12" mask="XXXVVVVV">
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>eq</relation>
                         <value>23</value>
                     </qualifier>
                     <decVal max="31"/>
                     <label xml:lang="de">Beschleunigungszeit</label>
                 </variable>
-                <variable label="Minimum driving heat" CV="16.0.327" default="0" item="ESU FnOut A7 Slider 15" mask="XXXVVVVV">
+                <variable label="Minimum driving heat" CV="16.0.311" default="0" item="ESU FnOut A5 Slider 15" mask="XXXVVVVV">
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>eq</relation>
                         <value>24</value>
                     </qualifier>
                     <decVal max="31"/>
                     <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
                 </variable>
-                <variable label="Fan power" CV="16.0.327" default="0" item="ESU FnOut A7 Slider 9" mask="XXXVVVVV">
+                <variable label="Fan power" CV="16.0.311" default="0" item="ESU FnOut A5 Slider 9" mask="XXXVVVVV">
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>eq</relation>
                         <value>25</value>
                     </qualifier>
                     <decVal max="31"/>
                     <label xml:lang="de">Stäke des Bläsers</label>
                 </variable>
-                <variable label="Phase Reverse" CV="16.0.327" default="0" item="ESU FnOut A7 Check 6" mask="XXXXXXXV">
+                <variable label="Phase Reverse" CV="16.0.311" default="0" item="ESU FnOut A5 Check 6" mask="XXXXXXXV">
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>gt</relation>
                         <value>0</value>
                     </qualifier>
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>le</relation>
                         <value>15</value>
                     </qualifier>
                     <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                     <label xml:lang="de">Phase tauschen</label>
                 </variable>
-                <variable label="Grade Crossing" CV="16.0.327" default="0" item="ESU FnOut A7 Check 1" mask="XXXXXXVX">
+                <variable label="Grade Crossing" CV="16.0.311" default="0" item="ESU FnOut A5 Check 1" mask="XXXXXXVX">
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>gt</relation>
                         <value>0</value>
                     </qualifier>
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>le</relation>
                         <value>15</value>
                     </qualifier>
                     <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                 </variable>
-                <variable label="Rule 17 Fwd" CV="16.0.327" default="0" item="ESU FnOut A7 Check 2" mask="XXXXXVXX">
+                <variable label="Rule 17 Fwd" CV="16.0.311" default="0" item="ESU FnOut A5 Check 2" mask="XXXXXVXX">
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>gt</relation>
                         <value>0</value>
                     </qualifier>
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>le</relation>
                         <value>15</value>
                     </qualifier>
                     <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                     <label xml:lang="de">Rule 17 vorwärts</label>
                 </variable>
-                <variable label="Rule 17 Rev" CV="16.0.327" default="0" item="ESU FnOut A7 Check 3" mask="XXXXVXXX">
+                <variable label="Rule 17 Rev" CV="16.0.311" default="0" item="ESU FnOut A5 Check 3" mask="XXXXVXXX">
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>gt</relation>
                         <value>0</value>
                     </qualifier>
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>le</relation>
                         <value>15</value>
                     </qualifier>
                     <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                     <label xml:lang="de">Rule 17 rückwärts</label>
                 </variable>
-                <variable label="Dimmer" CV="16.0.327" default="0" item="ESU FnOut A7 Check 4" mask="XXXVXXXX">
+                <variable label="Dimmer" CV="16.0.311" default="0" item="ESU FnOut A5 Check 4" mask="XXXVXXXX">
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>gt</relation>
                         <value>0</value>
                     </qualifier>
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>le</relation>
                         <value>15</value>
                     </qualifier>
                     <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                     <label xml:lang="de">Abdimmen</label>
                 </variable>
-                <variable label="LED Mode" CV="16.0.327" default="0" item="ESU FnOut A7 Check 5" mask="VXXXXXXX">
+                <variable label="LED Mode" CV="16.0.311" default="0" item="ESU FnOut A5 Check 5" mask="VXXXXXXX">
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>gt</relation>
                         <value>0</value>
                     </qualifier>
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>le</relation>
                         <value>15</value>
                     </qualifier>
                     <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                     <label xml:lang="de">LED Modus</label>
                 </variable>
-                <variable item="Special Function CV328" label="Special Function CV 2" CV="16.0.328" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                <variable item="Special Function CV312" label="Special Function CV 2" CV="16.0.312" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
                     <decVal/>
                 </variable>
-                <variable label="Fan Decceleration rate" CV="16.0.328" default="0" item="ESU FnOut A7 Slider 13" mask="XXXVVVVV">
+                <variable label="Fan Decceleration rate" CV="16.0.312" default="0" item="ESU FnOut A5 Slider 13" mask="XXXVVVVV">
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>eq</relation>
                         <value>23</value>
                     </qualifier>
                     <decVal max="31"/>
                     <label xml:lang="de">Bremszeit</label>
                 </variable>
-                <variable label="Maximum driving heat" CV="16.0.328" default="0" item="ESU FnOut A7 Slider 16" mask="XXXVVVVV">
+                <variable label="Maximum driving heat" CV="16.0.312" default="0" item="ESU FnOut A5 Slider 16" mask="XXXVVVVV">
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>eq</relation>
                         <value>24</value>
                     </qualifier>
                     <decVal max="31"/>
                     <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
                 </variable>
-                <variable label="Timeout" CV="16.0.328" default="0" item="ESU FnOut A7 Slider 10" tooltip="Units = 0.25 sec">
+                <variable label="Timeout" CV="16.0.312" default="0" item="ESU FnOut A5 Slider 10" tooltip="Units = 0.25 sec">
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>eq</relation>
                         <value>25</value>
                     </qualifier>
                     <decVal/>
                 </variable>
-                <variable label="Startup Time" CV="16.0.328" default="0" item="ESU FnOut A7 Slider 6">
+                <variable label="Startup Time" CV="16.0.312" default="0" item="ESU FnOut A5 Slider 6">
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>ge</relation>
                         <value>16</value>
                     </qualifier>
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>le</relation>
                         <value>17</value>
                     </qualifier>
                     <decVal/>
                     <label xml:lang="de">Startzeit</label>
                 </variable>
-                <variable label="Level" CV="16.0.328" default="0" item="ESU FnOut A7 Slider 20" mask="XVVVVVVV">
+                <variable label="Level" CV="16.0.312" default="0" item="ESU FnOut A5 Slider 20" mask="XVVVVVVV">
                     <qualifier>
-                        <variableref>ESU FnOut A7 Mode</variableref>
+                        <variableref>ESU FnOut A5 Mode</variableref>
                         <relation>eq</relation>
                         <value>19</value>
                     </qualifier>
                     <decVal max="127"/>
                 </variable>
-                <!-- exclude AUX8 only -->
-                <variables exclude="LokSound 5 Fx,LokSound 5 Fx DCC">
-                    <!-- AUX8 Mode -->
-                    <variable label="AUX8 Mode" CV="16.0.331" default="1" item="ESU FnOut A8 Mode">
+                <!-- AUX6 Mode -->
+                <variable label="AUX6 Mode" CV="16.0.315" default="1" item="ESU FnOut A6 Mode">
+                    <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
+                </variable>
+                <variable label="Function Switch On Delay" CV="16.0.316" default="0" item="ESU FnOut A6 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>gt</relation>
+                        <value>0</value>
+                    </qualifier>
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>ne</relation>
+                        <value>27</value>
+                    </qualifier>
+                    <decVal max="15"/>
+                    <label xml:lang="de">Verzögerung beim Einschalten</label>
+                </variable>
+                <variable label="Function Switch Off Delay" CV="16.0.316" default="0" mask="VVVVXXXX" item="ESU FnOut A6 Slider 2" tooltip="Units = 0.4 sec">
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>gt</relation>
+                        <value>0</value>
+                    </qualifier>
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>ne</relation>
+                        <value>27</value>
+                    </qualifier>
+                    <decVal max="15"/>
+                    <label xml:lang="de">Verzögerung beim Ausschalten</label>
+                </variable>
+                <variable label="Function Auto Switch Off" CV="16.0.317" default="0" item="ESU FnOut A6 Slider 3" tooltip="Units = 0.4 sec">
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>gt</relation>
+                        <value>0</value>
+                    </qualifier>
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>ne</relation>
+                        <value>27</value>
+                    </qualifier>
+                    <decVal/>
+                    <label xml:lang="de">Ausgang automatisch Ausschalten</label>
+                </variable>
+                <variable item="Brightness CV318" label="Brightness CV" CV="16.0.318" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
+                    <decVal/>
+                </variable>
+                <variable label="Brightness" CV="16.0.318" default="31" item="ESU FnOut A6 Slider 5" mask="XXXVVVVV">
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>gt</relation>
+                        <value>0</value>
+                    </qualifier>
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>le</relation>
+                        <value>18</value>
+                    </qualifier>
+                    <decVal max="31"/>
+                    <label xml:lang="de">Helligkeit</label>
+                </variable>
+                <variable label="Mode" CV="16.0.318" default="0" item="ESU FnOut A6 Option 1" mask="XXXXXXXV">
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>eq</relation>
+                        <value>22</value>
+                    </qualifier>
+                    <enumVal>
+                        <enumChoice choice="Heating control">
+                            <choice>Heating control</choice>
+                            <choice xml:lang="de">Heizungssteuerung</choice>
+                        </enumChoice>
+                        <enumChoice choice="Fan control">
+                            <choice>Fan control</choice>
+                            <choice xml:lang="de">Lüftersteuerung</choice>
+                        </enumChoice>
+                    </enumVal>
+                    <label xml:lang="de">Modus</label>
+                </variable>
+                <variable label="Coupler Force" CV="16.0.318" default="31" item="ESU FnOut A6 Slider 7" mask="XXXVVVVV">
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>ge</relation>
+                        <value>28</value>
+                    </qualifier>
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>ne</relation>
+                        <value>29</value>
+                    </qualifier>
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>ne</relation>
+                        <value>30</value>
+                    </qualifier>
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>ne</relation>
+                        <value>31</value>
+                    </qualifier>
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>ne</relation>
+                        <value>32</value>
+                    </qualifier>
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>le</relation>
+                        <value>33</value>
+                    </qualifier>
+                    <decVal max="31"/>
+                    <label xml:lang="de">Stärke des Kupplers</label>
+                </variable>
+                <variable label="Fan Speed" CV="16.0.318" default="31" item="ESU FnOut A6 Slider 11" mask="XXXVVVVV">
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>eq</relation>
+                        <value>23</value>
+                    </qualifier>
+                    <decVal max="31"/>
+                    <label xml:lang="de">Geschwindigkeit</label>
+                </variable>
+                <variable label="Standing heat" CV="16.0.318" default="31" item="ESU FnOut A6 Slider 14" mask="XXXVVVVV">
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>eq</relation>
+                        <value>24</value>
+                    </qualifier>
+                    <decVal max="31"/>
+                    <label xml:lang="de">Heizstufe im Stand</label>
+                </variable>
+                <variable label="Chuff power" CV="16.0.318" default="31" item="ESU FnOut A6 Slider 8" mask="XXXVVVVV">
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>eq</relation>
+                        <value>25</value>
+                    </qualifier>
+                    <decVal max="31"/>
+                    <label xml:lang="de">Dampfstoßstärke</label>
+                </variable>
+                <variable item="Special Function CV319" label="Special Function CV 1" CV="16.0.319" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                    <decVal/>
+                </variable>
+                <variable label="Fan Acceleration rate" CV="16.0.319" default="0" item="ESU FnOut A6 Slider 12" mask="XXXVVVVV">
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>eq</relation>
+                        <value>23</value>
+                    </qualifier>
+                    <decVal max="31"/>
+                    <label xml:lang="de">Beschleunigungszeit</label>
+                </variable>
+                <variable label="Minimum driving heat" CV="16.0.319" default="0" item="ESU FnOut A6 Slider 15" mask="XXXVVVVV">
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>eq</relation>
+                        <value>24</value>
+                    </qualifier>
+                    <decVal max="31"/>
+                    <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
+                </variable>
+                <variable label="Fan power" CV="16.0.319" default="0" item="ESU FnOut A6 Slider 9" mask="XXXVVVVV">
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>eq</relation>
+                        <value>25</value>
+                    </qualifier>
+                    <decVal max="31"/>
+                    <label xml:lang="de">Stäke des Bläsers</label>
+                </variable>
+                <variable label="Phase Reverse" CV="16.0.319" default="0" item="ESU FnOut A6 Check 6" mask="XXXXXXXV">
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>gt</relation>
+                        <value>0</value>
+                    </qualifier>
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>le</relation>
+                        <value>15</value>
+                    </qualifier>
+                    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                    <label xml:lang="de">Phase tauschen</label>
+                </variable>
+                <variable label="Grade Crossing" CV="16.0.319" default="0" item="ESU FnOut A6 Check 1" mask="XXXXXXVX">
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>gt</relation>
+                        <value>0</value>
+                    </qualifier>
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>le</relation>
+                        <value>15</value>
+                    </qualifier>
+                    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                </variable>
+                <variable label="Rule 17 Fwd" CV="16.0.319" default="0" item="ESU FnOut A6 Check 2" mask="XXXXXVXX">
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>gt</relation>
+                        <value>0</value>
+                    </qualifier>
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>le</relation>
+                        <value>15</value>
+                    </qualifier>
+                    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                    <label xml:lang="de">Rule 17 vorwärts</label>
+                </variable>
+                <variable label="Rule 17 Rev" CV="16.0.319" default="0" item="ESU FnOut A6 Check 3" mask="XXXXVXXX">
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>gt</relation>
+                        <value>0</value>
+                    </qualifier>
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>le</relation>
+                        <value>15</value>
+                    </qualifier>
+                    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                    <label xml:lang="de">Rule 17 rückwärts</label>
+                </variable>
+                <variable label="Dimmer" CV="16.0.319" default="0" item="ESU FnOut A6 Check 4" mask="XXXVXXXX">
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>gt</relation>
+                        <value>0</value>
+                    </qualifier>
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>le</relation>
+                        <value>15</value>
+                    </qualifier>
+                    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                    <label xml:lang="de">Abdimmen</label>
+                </variable>
+                <variable label="LED Mode" CV="16.0.319" default="0" item="ESU FnOut A6 Check 5" mask="VXXXXXXX">
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>gt</relation>
+                        <value>0</value>
+                    </qualifier>
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>le</relation>
+                        <value>15</value>
+                    </qualifier>
+                    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                    <label xml:lang="de">LED Modus</label>
+                </variable>
+                <variable item="Special Function CV320" label="Special Function CV 2" CV="16.0.320" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                    <decVal/>
+                </variable>
+                <variable label="Fan Decceleration rate" CV="16.0.320" default="0" item="ESU FnOut A6 Slider 13" mask="XXXVVVVV">
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>eq</relation>
+                        <value>23</value>
+                    </qualifier>
+                    <decVal max="31"/>
+                    <label xml:lang="de">Bremszeit</label>
+                </variable>
+                <variable label="Maximum driving heat" CV="16.0.320" default="0" item="ESU FnOut A6 Slider 16" mask="XXXVVVVV">
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>eq</relation>
+                        <value>24</value>
+                    </qualifier>
+                    <decVal max="31"/>
+                    <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
+                </variable>
+                <variable label="Timeout" CV="16.0.320" default="0" item="ESU FnOut A6 Slider 10" tooltip="Units = 0.25 sec">
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>eq</relation>
+                        <value>25</value>
+                    </qualifier>
+                    <decVal/>
+                </variable>
+                <variable label="Startup Time" CV="16.0.320" default="0" item="ESU FnOut A6 Slider 6">
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>ge</relation>
+                        <value>16</value>
+                    </qualifier>
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>le</relation>
+                        <value>17</value>
+                    </qualifier>
+                    <decVal/>
+                    <label xml:lang="de">Startzeit</label>
+                </variable>
+                <variable label="Level" CV="16.0.320" default="0" item="ESU FnOut A6 Slider 20" mask="XVVVVVVV">
+                    <qualifier>
+                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <relation>eq</relation>
+                        <value>19</value>
+                    </qualifier>
+                    <decVal max="127"/>
+                </variable>
+                <!-- exclude AUX7 to AUX18 -->
+                <variables exclude="LokPilot 5 Fx micro,LokPilot 5 Fx micro DCC">
+                    <!-- AUX7 Mode -->
+                    <variable label="AUX7 Mode" CV="16.0.323" default="1" item="ESU FnOut A7 Mode">
                         <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
                     </variable>
-                    <variable label="Function Switch On Delay" CV="16.0.332" default="0" item="ESU FnOut A8 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
+                    <variable label="Function Switch On Delay" CV="16.0.324" default="0" item="ESU FnOut A7 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
                         <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>gt</relation>
                             <value>0</value>
                         </qualifier>
                         <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>ne</relation>
                             <value>27</value>
                         </qualifier>
                         <decVal max="15"/>
                         <label xml:lang="de">Verzögerung beim Einschalten</label>
                     </variable>
-                    <variable label="Function Switch Off Delay" CV="16.0.332" default="0" mask="VVVVXXXX" item="ESU FnOut A8 Slider 2" tooltip="Units = 0.4 sec">
+                    <variable label="Function Switch Off Delay" CV="16.0.324" default="0" mask="VVVVXXXX" item="ESU FnOut A7 Slider 2" tooltip="Units = 0.4 sec">
                         <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>gt</relation>
                             <value>0</value>
                         </qualifier>
                         <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>ne</relation>
                             <value>27</value>
                         </qualifier>
                         <decVal max="15"/>
                         <label xml:lang="de">Verzögerung beim Ausschalten</label>
                     </variable>
-                    <variable label="Function Auto Switch Off" CV="16.0.333" default="0" item="ESU FnOut A8 Slider 3" tooltip="Units = 0.4 sec">
+                    <variable label="Function Auto Switch Off" CV="16.0.325" default="0" item="ESU FnOut A7 Slider 3" tooltip="Units = 0.4 sec">
                         <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>gt</relation>
                             <value>0</value>
                         </qualifier>
                         <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>ne</relation>
                             <value>27</value>
                         </qualifier>
                         <decVal/>
                         <label xml:lang="de">Ausgang automatisch Ausschalten</label>
                     </variable>
-                    <variable item="Brightness CV334" label="Brightness CV" CV="16.0.334" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
+                    <variable item="Brightness CV326" label="Brightness CV" CV="16.0.326" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
                         <decVal/>
                     </variable>
-                    <variable label="Brightness" CV="16.0.334" default="31" item="ESU FnOut A8 Slider 5" mask="XXXVVVVV">
+                    <variable label="Brightness" CV="16.0.326" default="31" item="ESU FnOut A7 Slider 5" mask="XXXVVVVV">
                         <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>gt</relation>
                             <value>0</value>
                         </qualifier>
                         <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>le</relation>
                             <value>18</value>
                         </qualifier>
                         <decVal max="31"/>
                         <label xml:lang="de">Helligkeit</label>
                     </variable>
-                    <variable label="Mode" CV="16.0.334" default="0" item="ESU FnOut A8 Option 1" mask="XXXXXXXV">
+                    <variable label="Mode" CV="16.0.326" default="0" item="ESU FnOut A7 Option 1" mask="XXXXXXXV">
                         <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>eq</relation>
                             <value>22</value>
                         </qualifier>
@@ -2850,1564 +2542,299 @@
                         </enumVal>
                         <label xml:lang="de">Modus</label>
                     </variable>
-                    <variable label="Coupler Force" CV="16.0.334" default="31" item="ESU FnOut A8 Slider 7" mask="XXXVVVVV">
+                    <variable label="Coupler Force" CV="16.0.326" default="31" item="ESU FnOut A7 Slider 7" mask="XXXVVVVV">
                         <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>ge</relation>
                             <value>28</value>
                         </qualifier>
                         <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>ne</relation>
                             <value>29</value>
                         </qualifier>
                         <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>ne</relation>
                             <value>30</value>
                         </qualifier>
                         <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>ne</relation>
                             <value>31</value>
                         </qualifier>
                         <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>ne</relation>
                             <value>32</value>
                         </qualifier>
                         <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>le</relation>
                             <value>33</value>
                         </qualifier>
                         <decVal max="31"/>
                         <label xml:lang="de">Stärke des Kupplers</label>
                     </variable>
-                    <variable label="Fan Speed" CV="16.0.334" default="31" item="ESU FnOut A8 Slider 11" mask="XXXVVVVV">
+                    <variable label="Fan Speed" CV="16.0.326" default="31" item="ESU FnOut A7 Slider 11" mask="XXXVVVVV">
                         <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>eq</relation>
                             <value>23</value>
                         </qualifier>
                         <decVal max="31"/>
                         <label xml:lang="de">Geschwindigkeit</label>
                     </variable>
-                    <variable label="Standing heat" CV="16.0.334" default="31" item="ESU FnOut A8 Slider 14" mask="XXXVVVVV">
+                    <variable label="Standing heat" CV="16.0.326" default="31" item="ESU FnOut A7 Slider 14" mask="XXXVVVVV">
                         <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>eq</relation>
                             <value>24</value>
                         </qualifier>
                         <decVal max="31"/>
                         <label xml:lang="de">Heizstufe im Stand</label>
                     </variable>
-                    <variable label="Chuff power" CV="16.0.334" default="31" item="ESU FnOut A8 Slider 8" mask="XXXVVVVV">
+                    <variable label="Chuff power" CV="16.0.326" default="31" item="ESU FnOut A7 Slider 8" mask="XXXVVVVV">
                         <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>eq</relation>
                             <value>25</value>
                         </qualifier>
                         <decVal max="31"/>
                         <label xml:lang="de">Dampfstoßstärke</label>
                     </variable>
-                    <variable item="Special Function CV335" label="Special Function CV 1" CV="16.0.335" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                    <variable item="Special Function CV327" label="Special Function CV 1" CV="16.0.327" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
                         <decVal/>
                     </variable>
-                    <variable label="Fan Acceleration rate" CV="16.0.335" default="0" item="ESU FnOut A8 Slider 12" mask="XXXVVVVV">
+                    <variable label="Fan Acceleration rate" CV="16.0.327" default="0" item="ESU FnOut A7 Slider 12" mask="XXXVVVVV">
                         <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>eq</relation>
                             <value>23</value>
                         </qualifier>
                         <decVal max="31"/>
                         <label xml:lang="de">Beschleunigungszeit</label>
                     </variable>
-                    <variable label="Minimum driving heat" CV="16.0.335" default="0" item="ESU FnOut A8 Slider 15" mask="XXXVVVVV">
+                    <variable label="Minimum driving heat" CV="16.0.327" default="0" item="ESU FnOut A7 Slider 15" mask="XXXVVVVV">
                         <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>eq</relation>
                             <value>24</value>
                         </qualifier>
                         <decVal max="31"/>
                         <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
                     </variable>
-                    <variable label="Fan power" CV="16.0.335" default="0" item="ESU FnOut A8 Slider 9" mask="XXXVVVVV">
+                    <variable label="Fan power" CV="16.0.327" default="0" item="ESU FnOut A7 Slider 9" mask="XXXVVVVV">
                         <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>eq</relation>
                             <value>25</value>
                         </qualifier>
                         <decVal max="31"/>
                         <label xml:lang="de">Stäke des Bläsers</label>
                     </variable>
-                    <variable label="Phase Reverse" CV="16.0.335" default="0" item="ESU FnOut A8 Check 6" mask="XXXXXXXV">
+                    <variable label="Phase Reverse" CV="16.0.327" default="0" item="ESU FnOut A7 Check 6" mask="XXXXXXXV">
                         <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>gt</relation>
                             <value>0</value>
                         </qualifier>
                         <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>le</relation>
                             <value>15</value>
                         </qualifier>
                         <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                         <label xml:lang="de">Phase tauschen</label>
                     </variable>
-                    <variable label="Grade Crossing" CV="16.0.335" default="0" item="ESU FnOut A8 Check 1" mask="XXXXXXVX">
+                    <variable label="Grade Crossing" CV="16.0.327" default="0" item="ESU FnOut A7 Check 1" mask="XXXXXXVX">
                         <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>gt</relation>
                             <value>0</value>
                         </qualifier>
                         <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>le</relation>
                             <value>15</value>
                         </qualifier>
                         <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                     </variable>
-                    <variable label="Rule 17 Fwd" CV="16.0.335" default="0" item="ESU FnOut A8 Check 2" mask="XXXXXVXX">
+                    <variable label="Rule 17 Fwd" CV="16.0.327" default="0" item="ESU FnOut A7 Check 2" mask="XXXXXVXX">
                         <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>gt</relation>
                             <value>0</value>
                         </qualifier>
                         <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
-                            <relation>le</relation>
-                            <value>15</value>
-                        </qualifier>
-                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                        <label xml:lang="de">Rule 17 vorwärts</label>
-                    </variable>
-                    <variable label="Rule 17 Rev" CV="16.0.335" default="0" item="ESU FnOut A8 Check 3" mask="XXXXVXXX">
-                        <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
-                            <relation>le</relation>
-                            <value>15</value>
-                        </qualifier>
-                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                        <label xml:lang="de">Rule 17 rückwärts</label>
-                    </variable>
-                    <variable label="Dimmer" CV="16.0.335" default="0" item="ESU FnOut A8 Check 4" mask="XXXVXXXX">
-                        <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
-                            <relation>le</relation>
-                            <value>15</value>
-                        </qualifier>
-                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                        <label xml:lang="de">Abdimmen</label>
-                    </variable>
-                    <variable label="LED Mode" CV="16.0.335" default="0" item="ESU FnOut A8 Check 5" mask="VXXXXXXX">
-                        <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
-                            <relation>le</relation>
-                            <value>15</value>
-                        </qualifier>
-                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                        <label xml:lang="de">LED Modus</label>
-                    </variable>
-                    <variable item="Special Function CV336" label="Special Function CV 2" CV="16.0.336" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
-                        <decVal/>
-                    </variable>
-                    <variable label="Fan Decceleration rate" CV="16.0.336" default="0" item="ESU FnOut A8 Slider 13" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>23</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Bremszeit</label>
-                    </variable>
-                    <variable label="Maximum driving heat" CV="16.0.336" default="0" item="ESU FnOut A8 Slider 16" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>24</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
-                    </variable>
-                    <variable label="Timeout" CV="16.0.336" default="0" item="ESU FnOut A8 Slider 10" tooltip="Units = 0.25 sec">
-                        <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>25</value>
-                        </qualifier>
-                        <decVal/>
-                    </variable>
-                    <variable label="Startup Time" CV="16.0.336" default="0" item="ESU FnOut A8 Slider 6">
-                        <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
-                            <relation>ge</relation>
-                            <value>16</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
-                            <relation>le</relation>
-                            <value>17</value>
-                        </qualifier>
-                        <decVal/>
-                        <label xml:lang="de">Startzeit</label>
-                    </variable>
-                    <variable label="Level" CV="16.0.336" default="0" item="ESU FnOut A8 Slider 20" mask="XVVVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A8 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>19</value>
-                        </qualifier>
-                        <decVal max="127"/>
-                    </variable>
-                </variables>
-                <!-- exclude AUX9 to AUX18 -->
-                <variables exclude="LokPilot 5 micro DCC Direct,LokSound 5 micro DCC Direct">
-                    <!-- AUX9 Mode -->
-                    <variable label="AUX9 Mode" CV="16.0.339" default="1" item="ESU FnOut A9 Mode">
-                        <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
-                    </variable>
-                    <variable label="Function Switch On Delay" CV="16.0.340" default="0" item="ESU FnOut A9 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
-                            <relation>ne</relation>
-                            <value>27</value>
-                        </qualifier>
-                        <decVal max="15"/>
-                        <label xml:lang="de">Verzögerung beim Einschalten</label>
-                    </variable>
-                    <variable label="Function Switch Off Delay" CV="16.0.340" default="0" mask="VVVVXXXX" item="ESU FnOut A9 Slider 2" tooltip="Units = 0.4 sec">
-                        <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
-                            <relation>ne</relation>
-                            <value>27</value>
-                        </qualifier>
-                        <decVal max="15"/>
-                        <label xml:lang="de">Verzögerung beim Ausschalten</label>
-                    </variable>
-                    <variable label="Function Auto Switch Off" CV="16.0.341" default="0" item="ESU FnOut A9 Slider 3" tooltip="Units = 0.4 sec">
-                        <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
-                            <relation>ne</relation>
-                            <value>27</value>
-                        </qualifier>
-                        <decVal/>
-                        <label xml:lang="de">Ausgang automatisch Ausschalten</label>
-                    </variable>
-                    <variable item="Brightness CV342" label="Brightness CV" CV="16.0.342" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
-                        <decVal/>
-                    </variable>
-                    <variable label="Brightness" CV="16.0.342" default="31" item="ESU FnOut A9 Slider 5" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
-                            <relation>le</relation>
-                            <value>18</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Helligkeit</label>
-                    </variable>
-                    <variable label="Mode" CV="16.0.342" default="0" item="ESU FnOut A9 Option 1" mask="XXXXXXXV">
-                        <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>22</value>
-                        </qualifier>
-                        <enumVal>
-                            <enumChoice choice="Heating control">
-                                <choice>Heating control</choice>
-                                <choice xml:lang="de">Heizungssteuerung</choice>
-                            </enumChoice>
-                            <enumChoice choice="Fan control">
-                                <choice>Fan control</choice>
-                                <choice xml:lang="de">Lüftersteuerung</choice>
-                            </enumChoice>
-                        </enumVal>
-                        <label xml:lang="de">Modus</label>
-                    </variable>
-                    <variable label="Coupler Force" CV="16.0.342" default="31" item="ESU FnOut A9 Slider 7" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
-                            <relation>ge</relation>
-                            <value>28</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
-                            <relation>ne</relation>
-                            <value>29</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
-                            <relation>ne</relation>
-                            <value>30</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
-                            <relation>ne</relation>
-                            <value>31</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
-                            <relation>ne</relation>
-                            <value>32</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
-                            <relation>le</relation>
-                            <value>33</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Stärke des Kupplers</label>
-                    </variable>
-                    <variable label="Fan Speed" CV="16.0.342" default="31" item="ESU FnOut A9 Slider 11" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>23</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Geschwindigkeit</label>
-                    </variable>
-                    <variable label="Standing heat" CV="16.0.342" default="31" item="ESU FnOut A9 Slider 14" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>24</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Heizstufe im Stand</label>
-                    </variable>
-                    <variable label="Chuff power" CV="16.0.342" default="31" item="ESU FnOut A9 Slider 8" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>25</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Dampfstoßstärke</label>
-                    </variable>
-                    <variable item="Special Function CV343" label="Special Function CV 1" CV="16.0.343" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
-                        <decVal/>
-                    </variable>
-                    <variable label="Fan Acceleration rate" CV="16.0.343" default="0" item="ESU FnOut A9 Slider 12" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>23</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Beschleunigungszeit</label>
-                    </variable>
-                    <variable label="Minimum driving heat" CV="16.0.343" default="0" item="ESU FnOut A9 Slider 15" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>24</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
-                    </variable>
-                    <variable label="Fan power" CV="16.0.343" default="0" item="ESU FnOut A9 Slider 9" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>25</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Stäke des Bläsers</label>
-                    </variable>
-                    <variable label="Phase Reverse" CV="16.0.343" default="0" item="ESU FnOut A9 Check 6" mask="XXXXXXXV">
-                        <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
-                            <relation>le</relation>
-                            <value>15</value>
-                        </qualifier>
-                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                        <label xml:lang="de">Phase tauschen</label>
-                    </variable>
-                    <variable label="Grade Crossing" CV="16.0.343" default="0" item="ESU FnOut A9 Check 1" mask="XXXXXXVX">
-                        <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
-                            <relation>le</relation>
-                            <value>15</value>
-                        </qualifier>
-                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                    </variable>
-                    <variable label="Rule 17 Fwd" CV="16.0.343" default="0" item="ESU FnOut A9 Check 2" mask="XXXXXVXX">
-                        <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>le</relation>
                             <value>15</value>
                         </qualifier>
                         <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                         <label xml:lang="de">Rule 17 vorwärts</label>
                     </variable>
-                    <variable label="Rule 17 Rev" CV="16.0.343" default="0" item="ESU FnOut A9 Check 3" mask="XXXXVXXX">
+                    <variable label="Rule 17 Rev" CV="16.0.327" default="0" item="ESU FnOut A7 Check 3" mask="XXXXVXXX">
                         <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>gt</relation>
                             <value>0</value>
                         </qualifier>
                         <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>le</relation>
                             <value>15</value>
                         </qualifier>
                         <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                         <label xml:lang="de">Rule 17 rückwärts</label>
                     </variable>
-                    <variable label="Dimmer" CV="16.0.343" default="0" item="ESU FnOut A9 Check 4" mask="XXXVXXXX">
+                    <variable label="Dimmer" CV="16.0.327" default="0" item="ESU FnOut A7 Check 4" mask="XXXVXXXX">
                         <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>gt</relation>
                             <value>0</value>
                         </qualifier>
                         <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>le</relation>
                             <value>15</value>
                         </qualifier>
                         <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                         <label xml:lang="de">Abdimmen</label>
                     </variable>
-                    <variable label="LED Mode" CV="16.0.343" default="0" item="ESU FnOut A9 Check 5" mask="VXXXXXXX">
+                    <variable label="LED Mode" CV="16.0.327" default="0" item="ESU FnOut A7 Check 5" mask="VXXXXXXX">
                         <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>gt</relation>
                             <value>0</value>
                         </qualifier>
                         <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>le</relation>
                             <value>15</value>
                         </qualifier>
                         <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                         <label xml:lang="de">LED Modus</label>
                     </variable>
-                    <variable item="Special Function CV344" label="Special Function CV 2" CV="16.0.344" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                    <variable item="Special Function CV328" label="Special Function CV 2" CV="16.0.328" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
                         <decVal/>
                     </variable>
-                    <variable label="Fan Decceleration rate" CV="16.0.344" default="0" item="ESU FnOut A9 Slider 13" mask="XXXVVVVV">
+                    <variable label="Fan Decceleration rate" CV="16.0.328" default="0" item="ESU FnOut A7 Slider 13" mask="XXXVVVVV">
                         <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>eq</relation>
                             <value>23</value>
                         </qualifier>
                         <decVal max="31"/>
                         <label xml:lang="de">Bremszeit</label>
                     </variable>
-                    <variable label="Maximum driving heat" CV="16.0.344" default="0" item="ESU FnOut A9 Slider 16" mask="XXXVVVVV">
+                    <variable label="Maximum driving heat" CV="16.0.328" default="0" item="ESU FnOut A7 Slider 16" mask="XXXVVVVV">
                         <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>eq</relation>
                             <value>24</value>
                         </qualifier>
                         <decVal max="31"/>
                         <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
                     </variable>
-                    <variable label="Timeout" CV="16.0.344" default="0" item="ESU FnOut A9 Slider 10" tooltip="Units = 0.25 sec">
+                    <variable label="Timeout" CV="16.0.328" default="0" item="ESU FnOut A7 Slider 10" tooltip="Units = 0.25 sec">
                         <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>eq</relation>
                             <value>25</value>
                         </qualifier>
                         <decVal/>
                     </variable>
-                    <variable label="Startup Time" CV="16.0.344" default="0" item="ESU FnOut A9 Slider 6">
+                    <variable label="Startup Time" CV="16.0.328" default="0" item="ESU FnOut A7 Slider 6">
                         <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>ge</relation>
                             <value>16</value>
                         </qualifier>
                         <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>le</relation>
                             <value>17</value>
                         </qualifier>
                         <decVal/>
                         <label xml:lang="de">Startzeit</label>
                     </variable>
-                    <variable label="Level" CV="16.0.344" default="0" item="ESU FnOut A9 Slider 20" mask="XVVVVVVV">
+                    <variable label="Level" CV="16.0.328" default="0" item="ESU FnOut A7 Slider 20" mask="XVVVVVVV">
                         <qualifier>
-                            <variableref>ESU FnOut A9 Mode</variableref>
+                            <variableref>ESU FnOut A7 Mode</variableref>
                             <relation>eq</relation>
                             <value>19</value>
                         </qualifier>
                         <decVal max="127"/>
                     </variable>
-                    <!-- AUX10 Mode -->
-                    <variable label="AUX10 Mode" CV="16.0.347" default="1" item="ESU FnOut A10 Mode">
-                        <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
-                    </variable>
-                    <variable label="Function Switch On Delay" CV="16.0.348" default="0" item="ESU FnOut A10 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>ne</relation>
-                            <value>27</value>
-                        </qualifier>
-                        <decVal max="15"/>
-                        <label xml:lang="de">Verzögerung beim Einschalten</label>
-                    </variable>
-                    <variable label="Function Switch Off Delay" CV="16.0.348" default="0" mask="VVVVXXXX" item="ESU FnOut A10 Slider 2" tooltip="Units = 0.4 sec">
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>ne</relation>
-                            <value>27</value>
-                        </qualifier>
-                        <decVal max="15"/>
-                        <label xml:lang="de">Verzögerung beim Ausschalten</label>
-                    </variable>
-                    <variable label="Function Auto Switch Off" CV="16.0.349" default="0" item="ESU FnOut A10 Slider 3" tooltip="Units = 0.4 sec">
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>ne</relation>
-                            <value>27</value>
-                        </qualifier>
-                        <decVal/>
-                        <label xml:lang="de">Ausgang automatisch Ausschalten</label>
-                    </variable>
-                    <variable item="Brightness CV350" label="Brightness CV" CV="16.0.350" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
-                        <decVal/>
-                    </variable>
-                    <variable label="Brightness" CV="16.0.350" default="31" item="ESU FnOut A10 Slider 5" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>le</relation>
-                            <value>18</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Helligkeit</label>
-                    </variable>
-                    <variable label="Mode" CV="16.0.350" default="0" item="ESU FnOut A10 Option 1" mask="XXXXXXXV">
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>22</value>
-                        </qualifier>
-                        <enumVal>
-                            <enumChoice choice="Heating control">
-                                <choice>Heating control</choice>
-                                <choice xml:lang="de">Heizungssteuerung</choice>
-                            </enumChoice>
-                            <enumChoice choice="Fan control">
-                                <choice>Fan control</choice>
-                                <choice xml:lang="de">Lüftersteuerung</choice>
-                            </enumChoice>
-                        </enumVal>
-                        <label xml:lang="de">Modus</label>
-                    </variable>
-                    <variable label="Coupler Force" CV="16.0.350" default="31" item="ESU FnOut A10 Slider 7" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>ge</relation>
-                            <value>28</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>ne</relation>
-                            <value>29</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>ne</relation>
-                            <value>30</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>ne</relation>
-                            <value>31</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>ne</relation>
-                            <value>32</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>le</relation>
-                            <value>33</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Stärke des Kupplers</label>
-                    </variable>
-                    <variable label="Fan Speed" CV="16.0.350" default="31" item="ESU FnOut A10 Slider 11" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>23</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Geschwindigkeit</label>
-                    </variable>
-                    <variable label="Standing heat" CV="16.0.350" default="31" item="ESU FnOut A10 Slider 14" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>24</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Heizstufe im Stand</label>
-                    </variable>
-                    <variable label="Chuff power" CV="16.0.350" default="31" item="ESU FnOut A10 Slider 8" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>25</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Dampfstoßstärke</label>
-                    </variable>
-                    <variable item="Special Function CV351" label="Special Function CV 1" CV="16.0.351" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
-                        <decVal/>
-                    </variable>
-                    <variable label="Fan Acceleration rate" CV="16.0.351" default="0" item="ESU FnOut A10 Slider 12" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>23</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Beschleunigungszeit</label>
-                    </variable>
-                    <variable label="Minimum driving heat" CV="16.0.351" default="0" item="ESU FnOut A10 Slider 15" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>24</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
-                    </variable>
-                    <variable label="Fan power" CV="16.0.351" default="0" item="ESU FnOut A10 Slider 9" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>25</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Stäke des Bläsers</label>
-                    </variable>
-                    <variable label="Phase Reverse" CV="16.0.351" default="0" item="ESU FnOut A10 Check 6" mask="XXXXXXXV">
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>le</relation>
-                            <value>15</value>
-                        </qualifier>
-                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                        <label xml:lang="de">Phase tauschen</label>
-                    </variable>
-                    <variable label="Grade Crossing" CV="16.0.351" default="0" item="ESU FnOut A10 Check 1" mask="XXXXXXVX">
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>le</relation>
-                            <value>15</value>
-                        </qualifier>
-                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                    </variable>
-                    <variable label="Rule 17 Fwd" CV="16.0.351" default="0" item="ESU FnOut A10 Check 2" mask="XXXXXVXX">
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>le</relation>
-                            <value>15</value>
-                        </qualifier>
-                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                        <label xml:lang="de">Rule 17 vorwärts</label>
-                    </variable>
-                    <variable label="Rule 17 Rev" CV="16.0.351" default="0" item="ESU FnOut A10 Check 3" mask="XXXXVXXX">
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>le</relation>
-                            <value>15</value>
-                        </qualifier>
-                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                        <label xml:lang="de">Rule 17 rückwärts</label>
-                    </variable>
-                    <variable label="Dimmer" CV="16.0.351" default="0" item="ESU FnOut A10 Check 4" mask="XXXVXXXX">
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>le</relation>
-                            <value>15</value>
-                        </qualifier>
-                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                        <label xml:lang="de">Abdimmen</label>
-                    </variable>
-                    <variable label="LED Mode" CV="16.0.351" default="0" item="ESU FnOut A10 Check 5" mask="VXXXXXXX">
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>le</relation>
-                            <value>15</value>
-                        </qualifier>
-                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                        <label xml:lang="de">LED Modus</label>
-                    </variable>
-                    <variable item="Special Function CV352" label="Special Function CV 2" CV="16.0.352" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
-                        <decVal/>
-                    </variable>
-                    <variable label="Fan Decceleration rate" CV="16.0.352" default="0" item="ESU FnOut A10 Slider 13" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>23</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Bremszeit</label>
-                    </variable>
-                    <variable label="Maximum driving heat" CV="16.0.352" default="0" item="ESU FnOut A10 Slider 16" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>24</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
-                    </variable>
-                    <variable label="Timeout" CV="16.0.352" default="0" item="ESU FnOut A10 Slider 10" tooltip="Units = 0.25 sec">
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>25</value>
-                        </qualifier>
-                        <decVal/>
-                    </variable>
-                    <variable label="Startup Time" CV="16.0.352" default="0" item="ESU FnOut A10 Slider 6">
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>ge</relation>
-                            <value>16</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>le</relation>
-                            <value>17</value>
-                        </qualifier>
-                        <decVal/>
-                        <label xml:lang="de">Startzeit</label>
-                    </variable>
-                    <variable label="Level" CV="16.0.352" default="0" item="ESU FnOut A10 Slider 20" mask="XVVVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A10 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>19</value>
-                        </qualifier>
-                        <decVal max="127"/>
-                    </variable>
-                    <!-- AUX11 Mode -->
-                    <variable label="AUX11 Mode" CV="16.0.355" default="1" item="ESU FnOut A11 Mode">
-                        <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
-                        <!--label xml:lang="de">Licht vorn - 2</label-->
-                    </variable>
-                    <variable label="Function Switch On Delay" CV="16.0.356" default="0" item="ESU FnOut A11 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <decVal max="15"/>
-                        <label xml:lang="de">Verzögerung beim Einschalten</label>
-                    </variable>
-                    <variable label="Function Switch Off Delay" CV="16.0.356" default="0" mask="VVVVXXXX" item="ESU FnOut A11 Slider 2" tooltip="Units = 0.4 sec">
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <decVal max="15"/>
-                        <label xml:lang="de">Verzögerung beim Ausschalten</label>
-                    </variable>
-                    <variable label="Function Auto Switch Off" CV="16.0.357" default="0" item="ESU FnOut A11 Slider 3" tooltip="Units = 0.4 sec">
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <decVal/>
-                        <label xml:lang="de">Ausgang automatisch Ausschalten</label>
-                    </variable>
-                    <variable item="Brightness CV358" label="Brightness CV" CV="16.0.358" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
-                        <decVal/>
-                    </variable>
-                    <variable label="Brightness" CV="16.0.358" default="31" item="ESU FnOut A11 Slider 5" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>le</relation>
-                            <value>18</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Helligkeit</label>
-                    </variable>
-                    <variable label="Mode" CV="16.0.358" default="0" item="ESU FnOut A11 Option 1" mask="XXXXXXXV">
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>22</value>
-                        </qualifier>
-                        <enumVal>
-                            <enumChoice choice="Heating control">
-                                <choice>Heating control</choice>
-                                <choice xml:lang="de">Heizungssteuerung</choice>
-                            </enumChoice>
-                            <enumChoice choice="Fan control">
-                                <choice>Fan control</choice>
-                                <choice xml:lang="de">Lüftersteuerung</choice>
-                            </enumChoice>
-                        </enumVal>
-                        <label xml:lang="de">Modus</label>
-                    </variable>
-                    <variable label="Coupler Force" CV="16.0.358" default="31" item="ESU FnOut A11 Slider 7" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>ge</relation>
-                            <value>28</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>ne</relation>
-                            <value>29</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>ne</relation>
-                            <value>30</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>ne</relation>
-                            <value>31</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>ne</relation>
-                            <value>32</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>le</relation>
-                            <value>33</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Stärke des Kupplers</label>
-                    </variable>
-                    <variable label="Fan Speed" CV="16.0.358" default="31" item="ESU FnOut A11 Slider 11" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>23</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Geschwindigkeit</label>
-                    </variable>
-                    <variable label="Standing heat" CV="16.0.358" default="31" item="ESU FnOut A11 Slider 14" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>24</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Heizstufe im Stand</label>
-                    </variable>
-                    <variable label="Chuff power" CV="16.0.358" default="31" item="ESU FnOut A11 Slider 8" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>25</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Dampfstoßstärke</label>
-                    </variable>
-                    <variable label="Duration (speed) A" CV="16.0.354" default="31" item="ESU FnOut A11 Slider 4" mask="XXVVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>27</value>
-                        </qualifier>
-                        <decVal max="63"/>
-                        <label xml:lang="de">Dauer (Geschwindigkeit)</label>
-                    </variable>
-                    <variable label="Duration (speed) B" CV="16.0.358" default="31" item="ESU FnOut A11 Slider 17" mask="XXVVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>27</value>
-                        </qualifier>
-                        <decVal max="63"/>
-                        <label xml:lang="de">Dauer (Geschwindigkeit)</label>
-                    </variable>
-                    <variable item="Special Function CV359" label="Special Function CV 1" CV="16.0.359" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
-                        <decVal/>
-                    </variable>
-                    <variable label="Fan Acceleration rate" CV="16.0.359" default="0" item="ESU FnOut A11 Slider 12" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>23</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Beschleunigungszeit</label>
-                    </variable>
-                    <variable label="Minimum driving heat" CV="16.0.359" default="0" item="ESU FnOut A11 Slider 15" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>24</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
-                    </variable>
-                    <variable label="Position A" CV="16.0.359" default="0" item="ESU FnOut A11 Slider 18" mask="XXVVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>27</value>
-                        </qualifier>
-                        <decVal max="63"/>
-                    </variable>
-                    <variable label="Fan power" CV="16.0.359" default="0" item="ESU FnOut A11 Slider 9" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>25</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Stäke des Bläsers</label>
-                    </variable>
-                    <variable label="Phase Reverse" CV="16.0.359" default="0" item="ESU FnOut A11 Check 6" mask="XXXXXXXV">
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>le</relation>
-                            <value>15</value>
-                        </qualifier>
-                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                        <label xml:lang="de">Phase tauschen</label>
-                    </variable>
-                    <variable label="Grade Crossing" CV="16.0.359" default="0" item="ESU FnOut A11 Check 1" mask="XXXXXXVX">
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>le</relation>
-                            <value>15</value>
-                        </qualifier>
-                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                    </variable>
-                    <variable label="Rule 17 Fwd" CV="16.0.359" default="0" item="ESU FnOut A11 Check 2" mask="XXXXXVXX">
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>le</relation>
-                            <value>15</value>
-                        </qualifier>
-                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                        <label xml:lang="de">Rule 17 vorwärts</label>
-                    </variable>
-                    <variable label="Rule 17 Rev" CV="16.0.359" default="0" item="ESU FnOut A11 Check 3" mask="XXXXVXXX">
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>le</relation>
-                            <value>15</value>
-                        </qualifier>
-                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                        <label xml:lang="de">Rule 17 rückwärts</label>
-                    </variable>
-                    <variable label="Dimmer" CV="16.0.359" default="0" item="ESU FnOut A11 Check 4" mask="XXXVXXXX">
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>le</relation>
-                            <value>15</value>
-                        </qualifier>
-                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                        <label xml:lang="de">Abdimmen</label>
-                    </variable>
-                    <variable label="LED Mode" CV="16.0.359" default="0" item="ESU FnOut A11 Check 5" mask="VXXXXXXX">
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>le</relation>
-                            <value>15</value>
-                        </qualifier>
-                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                        <label xml:lang="de">LED Modus</label>
-                    </variable>
-                    <variable item="Special Function CV360" label="Special Function CV 2" CV="16.0.360" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
-                        <decVal/>
-                    </variable>
-                    <variable label="Fan Decceleration rate" CV="16.0.360" default="0" item="ESU FnOut A11 Slider 13" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>23</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Bremszeit</label>
-                    </variable>
-                    <variable label="Maximum driving heat" CV="16.0.360" default="0" item="ESU FnOut A11 Slider 16" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>24</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
-                    </variable>
-                    <variable label="Timeout" CV="16.0.360" default="0" item="ESU FnOut A11 Slider 10" tooltip="Units = 0.25 sec">
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>25</value>
-                        </qualifier>
-                        <decVal/>
-                    </variable>
-                    <variable label="Startup Time" CV="16.0.360" default="0" item="ESU FnOut A11 Slider 6">
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>ge</relation>
-                            <value>16</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>le</relation>
-                            <value>17</value>
-                        </qualifier>
-                        <decVal/>
-                        <label xml:lang="de">Startzeit</label>
-                    </variable>
-                    <variable label="Level" CV="16.0.360" default="0" item="ESU FnOut A11 Slider 20" mask="XVVVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>19</value>
-                        </qualifier>
-                        <decVal max="127"/>
-                    </variable>
-                    <variable label="Position B" CV="16.0.360" default="0" item="ESU FnOut A11 Slider 19" mask="XXVVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A11 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>27</value>
-                        </qualifier>
-                        <decVal max="63"/>
-                    </variable>
-                    <!-- AUX12 Mode -->
-                    <variable label="AUX12 Mode" CV="16.0.363" default="1" item="ESU FnOut A12 Mode">
-                        <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
-                    </variable>
-                    <variable label="Function Switch On Delay" CV="16.0.364" default="0" item="ESU FnOut A12 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <decVal max="15"/>
-                        <label xml:lang="de">Verzögerung beim Einschalten</label>
-                    </variable>
-                    <variable label="Function Switch Off Delay" CV="16.0.364" default="0" mask="VVVVXXXX" item="ESU FnOut A12 Slider 2" tooltip="Units = 0.4 sec">
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <decVal max="15"/>
-                        <label xml:lang="de">Verzögerung beim Ausschalten</label>
-                    </variable>
-                    <variable label="Function Auto Switch Off" CV="16.0.365" default="0" item="ESU FnOut A12 Slider 3" tooltip="Units = 0.4 sec">
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <decVal/>
-                        <label xml:lang="de">Ausgang automatisch Ausschalten</label>
-                    </variable>
-                    <variable item="Brightness CV366" label="Brightness CV" CV="16.0.366" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
-                        <decVal/>
-                    </variable>
-                    <variable label="Brightness" CV="16.0.366" default="31" item="ESU FnOut A12 Slider 5" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>le</relation>
-                            <value>18</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Helligkeit</label>
-                    </variable>
-                    <variable label="Mode" CV="16.0.366" default="0" item="ESU FnOut A12 Option 1" mask="XXXXXXXV">
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>22</value>
-                        </qualifier>
-                        <enumVal>
-                            <enumChoice choice="Heating control">
-                                <choice>Heating control</choice>
-                                <choice xml:lang="de">Heizungssteuerung</choice>
-                            </enumChoice>
-                            <enumChoice choice="Fan control">
-                                <choice>Fan control</choice>
-                                <choice xml:lang="de">Lüftersteuerung</choice>
-                            </enumChoice>
-                        </enumVal>
-                        <label xml:lang="de">Modus</label>
-                    </variable>
-                    <variable label="Coupler Force" CV="16.0.366" default="31" item="ESU FnOut A12 Slider 7" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>ge</relation>
-                            <value>28</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>ne</relation>
-                            <value>29</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>ne</relation>
-                            <value>30</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>ne</relation>
-                            <value>31</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>ne</relation>
-                            <value>32</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>le</relation>
-                            <value>33</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Stärke des Kupplers</label>
-                    </variable>
-                    <variable label="Fan Speed" CV="16.0.366" default="31" item="ESU FnOut A12 Slider 11" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>23</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Geschwindigkeit</label>
-                    </variable>
-                    <variable label="Standing heat" CV="16.0.366" default="31" item="ESU FnOut A12 Slider 14" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>24</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Heizstufe im Stand</label>
-                    </variable>
-                    <variable label="Chuff power" CV="16.0.366" default="31" item="ESU FnOut A12 Slider 8" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>25</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Dampfstoßstärke</label>
-                    </variable>
-                    <variable label="Duration (speed) A" CV="16.0.362" default="31" item="ESU FnOut A12 Slider 4" mask="XXVVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>27</value>
-                        </qualifier>
-                        <decVal max="63"/>
-                        <label xml:lang="de">Dauer (Geschwindigkeit)</label>
-                    </variable>
-                    <variable label="Duration (speed) B" CV="16.0.366" default="31" item="ESU FnOut A12 Slider 17" mask="XXVVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>27</value>
-                        </qualifier>
-                        <decVal max="63"/>
-                        <label xml:lang="de">Dauer (Geschwindigkeit)</label>
-                    </variable>
-                    <variable item="Special Function CV367" label="Special Function CV 1" CV="16.0.367" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
-                        <decVal/>
-                    </variable>
-                    <variable label="Fan Acceleration rate" CV="16.0.367" default="0" item="ESU FnOut A12 Slider 12" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>23</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Beschleunigungszeit</label>
-                    </variable>
-                    <variable label="Minimum driving heat" CV="16.0.367" default="0" item="ESU FnOut A12 Slider 15" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>24</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
-                    </variable>
-                    <variable label="Position A" CV="16.0.367" default="0" item="ESU FnOut A12 Slider 18" mask="XXVVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>27</value>
-                        </qualifier>
-                        <decVal max="63"/>
-                    </variable>
-                    <variable label="Fan power" CV="16.0.367" default="0" item="ESU FnOut A12 Slider 9" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>25</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Stäke des Bläsers</label>
-                    </variable>
-                    <variable label="Phase Reverse" CV="16.0.367" default="0" item="ESU FnOut A12 Check 6" mask="XXXXXXXV">
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>le</relation>
-                            <value>15</value>
-                        </qualifier>
-                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                        <label xml:lang="de">Phase tauschen</label>
-                    </variable>
-                    <variable label="Grade Crossing" CV="16.0.367" default="0" item="ESU FnOut A12 Check 1" mask="XXXXXXVX">
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>le</relation>
-                            <value>15</value>
-                        </qualifier>
-                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                    </variable>
-                    <variable label="Rule 17 Fwd" CV="16.0.367" default="0" item="ESU FnOut A12 Check 2" mask="XXXXXVXX">
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>le</relation>
-                            <value>15</value>
-                        </qualifier>
-                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                        <label xml:lang="de">Rule 17 vorwärts</label>
-                    </variable>
-                    <variable label="Rule 17 Rev" CV="16.0.367" default="0" item="ESU FnOut A12 Check 3" mask="XXXXVXXX">
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>le</relation>
-                            <value>15</value>
-                        </qualifier>
-                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                        <label xml:lang="de">Rule 17 rückwärts</label>
-                    </variable>
-                    <variable label="Dimmer" CV="16.0.367" default="0" item="ESU FnOut A12 Check 4" mask="XXXVXXXX">
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>le</relation>
-                            <value>15</value>
-                        </qualifier>
-                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                        <label xml:lang="de">Abdimmen</label>
-                    </variable>
-                    <variable label="LED Mode" CV="16.0.367" default="0" item="ESU FnOut A12 Check 5" mask="VXXXXXXX">
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>gt</relation>
-                            <value>0</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>le</relation>
-                            <value>15</value>
-                        </qualifier>
-                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                        <label xml:lang="de">LED Modus</label>
-                    </variable>
-                    <variable item="Special Function CV368" label="Special Function CV 2" CV="16.0.368" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
-                        <decVal/>
-                    </variable>
-                    <variable label="Fan Decceleration rate" CV="16.0.368" default="0" item="ESU FnOut A12 Slider 13" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>23</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Bremszeit</label>
-                    </variable>
-                    <variable label="Maximum driving heat" CV="16.0.368" default="0" item="ESU FnOut A12 Slider 16" mask="XXXVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>24</value>
-                        </qualifier>
-                        <decVal max="31"/>
-                        <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
-                    </variable>
-                    <variable label="Timeout" CV="16.0.368" default="0" item="ESU FnOut A12 Slider 10" tooltip="Units = 0.25 sec">
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>25</value>
-                        </qualifier>
-                        <decVal/>
-                    </variable>
-                    <variable label="Startup Time" CV="16.0.368" default="0" item="ESU FnOut A12 Slider 6">
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>ge</relation>
-                            <value>16</value>
-                        </qualifier>
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>le</relation>
-                            <value>17</value>
-                        </qualifier>
-                        <decVal/>
-                        <label xml:lang="de">Startzeit</label>
-                    </variable>
-                    <variable label="Level" CV="16.0.368" default="0" item="ESU FnOut A12 Slider 20" mask="XVVVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>19</value>
-                        </qualifier>
-                        <decVal max="127"/>
-                    </variable>
-                    <variable label="Position B" CV="16.0.368" default="0" item="ESU FnOut A12 Slider 19" mask="XXVVVVVV">
-                        <qualifier>
-                            <variableref>ESU FnOut A12 Mode</variableref>
-                            <relation>eq</relation>
-                            <value>27</value>
-                        </qualifier>
-                        <decVal max="63"/>
-                    </variable>
-                    <!-- exclude AUX13 to AUX18 -->
-                    <variables exclude="LokSound 5 Fx,LokSound 5 Fx DCC,LokPilot 5 Fx,LokPilot 5 Fx DCC">                <!-- AUX13 Mode -->
-                        <variable label="AUX13 Mode" CV="16.0.371" default="1" item="ESU FnOut A13 Mode">
+                    <!-- exclude AUX8 only -->
+                    <variables exclude="LokSound 5 Fx,LokSound 5 Fx DCC">
+                        <!-- AUX8 Mode -->
+                        <variable label="AUX8 Mode" CV="16.0.331" default="1" item="ESU FnOut A8 Mode">
                             <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
                         </variable>
-                        <variable label="Function Switch On Delay" CV="16.0.372" default="0" item="ESU FnOut A13 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
+                        <variable label="Function Switch On Delay" CV="16.0.332" default="0" item="ESU FnOut A8 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>27</value>
                             </qualifier>
                             <decVal max="15"/>
                             <label xml:lang="de">Verzögerung beim Einschalten</label>
                         </variable>
-                        <variable label="Function Switch Off Delay" CV="16.0.372" default="0" mask="VVVVXXXX" item="ESU FnOut A13 Slider 2" tooltip="Units = 0.4 sec">
+                        <variable label="Function Switch Off Delay" CV="16.0.332" default="0" mask="VVVVXXXX" item="ESU FnOut A8 Slider 2" tooltip="Units = 0.4 sec">
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>27</value>
                             </qualifier>
                             <decVal max="15"/>
                             <label xml:lang="de">Verzögerung beim Ausschalten</label>
                         </variable>
-                        <variable label="Function Auto Switch Off" CV="16.0.373" default="0" item="ESU FnOut A13 Slider 3" tooltip="Units = 0.4 sec">
+                        <variable label="Function Auto Switch Off" CV="16.0.333" default="0" item="ESU FnOut A8 Slider 3" tooltip="Units = 0.4 sec">
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>27</value>
                             </qualifier>
                             <decVal/>
                             <label xml:lang="de">Ausgang automatisch Ausschalten</label>
                         </variable>
-                        <variable item="Brightness CV374" label="Brightness CV" CV="16.0.374" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
+                        <variable item="Brightness CV334" label="Brightness CV" CV="16.0.334" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
                             <decVal/>
                         </variable>
-                        <variable label="Brightness" CV="16.0.374" default="31" item="ESU FnOut A13 Slider 5" mask="XXXVVVVV">
+                        <variable label="Brightness" CV="16.0.334" default="31" item="ESU FnOut A8 Slider 5" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>le</relation>
                                 <value>18</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Helligkeit</label>
                         </variable>
-                        <variable label="Mode" CV="16.0.374" default="0" item="ESU FnOut A13 Option 1" mask="XXXXXXXV">
+                        <variable label="Mode" CV="16.0.334" default="0" item="ESU FnOut A8 Option 1" mask="XXXXXXXV">
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>22</value>
                             </qualifier>
@@ -4423,297 +2850,300 @@
                             </enumVal>
                             <label xml:lang="de">Modus</label>
                         </variable>
-                        <variable label="Coupler Force" CV="16.0.374" default="31" item="ESU FnOut A13 Slider 7" mask="XXXVVVVV">
+                        <variable label="Coupler Force" CV="16.0.334" default="31" item="ESU FnOut A8 Slider 7" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>ge</relation>
                                 <value>28</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>29</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>30</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>31</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>32</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>le</relation>
                                 <value>33</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Stärke des Kupplers</label>
                         </variable>
-                        <variable label="Fan Speed" CV="16.0.374" default="31" item="ESU FnOut A13 Slider 11" mask="XXXVVVVV">
+                        <variable label="Fan Speed" CV="16.0.334" default="31" item="ESU FnOut A8 Slider 11" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>23</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Geschwindigkeit</label>
                         </variable>
-                        <variable label="Standing heat" CV="16.0.374" default="31" item="ESU FnOut A13 Slider 14" mask="XXXVVVVV">
+                        <variable label="Standing heat" CV="16.0.334" default="31" item="ESU FnOut A8 Slider 14" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>24</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Heizstufe im Stand</label>
                         </variable>
-                        <variable label="Chuff power" CV="16.0.374" default="31" item="ESU FnOut A13 Slider 8" mask="XXXVVVVV">
+                        <variable label="Chuff power" CV="16.0.334" default="31" item="ESU FnOut A8 Slider 8" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>25</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Dampfstoßstärke</label>
                         </variable>
-                        <variable item="Special Function CV375" label="Special Function CV 1" CV="16.0.375" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                        <variable item="Special Function CV335" label="Special Function CV 1" CV="16.0.335" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
                             <decVal/>
                         </variable>
-                        <variable label="Fan Acceleration rate" CV="16.0.375" default="0" item="ESU FnOut A13 Slider 12" mask="XXXVVVVV">
+                        <variable label="Fan Acceleration rate" CV="16.0.335" default="0" item="ESU FnOut A8 Slider 12" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>23</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Beschleunigungszeit</label>
                         </variable>
-                        <variable label="Minimum driving heat" CV="16.0.375" default="0" item="ESU FnOut A13 Slider 15" mask="XXXVVVVV">
+                        <variable label="Minimum driving heat" CV="16.0.335" default="0" item="ESU FnOut A8 Slider 15" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>24</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
                         </variable>
-                        <variable label="Fan power" CV="16.0.375" default="0" item="ESU FnOut A13 Slider 9" mask="XXXVVVVV">
+                        <variable label="Fan power" CV="16.0.335" default="0" item="ESU FnOut A8 Slider 9" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>25</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Stäke des Bläsers</label>
                         </variable>
-                        <variable label="Phase Reverse" CV="16.0.375" default="0" item="ESU FnOut A13 Check 6" mask="XXXXXXXV">
+                        <variable label="Phase Reverse" CV="16.0.335" default="0" item="ESU FnOut A8 Check 6" mask="XXXXXXXV">
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                             <label xml:lang="de">Phase tauschen</label>
                         </variable>
-                        <variable label="Grade Crossing" CV="16.0.375" default="0" item="ESU FnOut A13 Check 1" mask="XXXXXXVX">
+                        <variable label="Grade Crossing" CV="16.0.335" default="0" item="ESU FnOut A8 Check 1" mask="XXXXXXVX">
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                         </variable>
-                        <variable label="Rule 17 Fwd" CV="16.0.375" default="0" item="ESU FnOut A13 Check 2" mask="XXXXXVXX">
+                        <variable label="Rule 17 Fwd" CV="16.0.335" default="0" item="ESU FnOut A8 Check 2" mask="XXXXXVXX">
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                             <label xml:lang="de">Rule 17 vorwärts</label>
                         </variable>
-                        <variable label="Rule 17 Rev" CV="16.0.375" default="0" item="ESU FnOut A13 Check 3" mask="XXXXVXXX">
+                        <variable label="Rule 17 Rev" CV="16.0.335" default="0" item="ESU FnOut A8 Check 3" mask="XXXXVXXX">
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                             <label xml:lang="de">Rule 17 rückwärts</label>
                         </variable>
-                        <variable label="Dimmer" CV="16.0.375" default="0" item="ESU FnOut A13 Check 4" mask="XXXVXXXX">
+                        <variable label="Dimmer" CV="16.0.335" default="0" item="ESU FnOut A8 Check 4" mask="XXXVXXXX">
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                             <label xml:lang="de">Abdimmen</label>
                         </variable>
-                        <variable label="LED Mode" CV="16.0.375" default="0" item="ESU FnOut A13 Check 5" mask="VXXXXXXX">
+                        <variable label="LED Mode" CV="16.0.335" default="0" item="ESU FnOut A8 Check 5" mask="VXXXXXXX">
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                             <label xml:lang="de">LED Modus</label>
                         </variable>
-                        <variable item="Special Function CV376" label="Special Function CV 2" CV="16.0.376" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                        <variable item="Special Function CV336" label="Special Function CV 2" CV="16.0.336" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
                             <decVal/>
                         </variable>
-                        <variable label="Fan Decceleration rate" CV="16.0.376" default="0" item="ESU FnOut A13 Slider 13" mask="XXXVVVVV">
+                        <variable label="Fan Decceleration rate" CV="16.0.336" default="0" item="ESU FnOut A8 Slider 13" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>23</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Bremszeit</label>
                         </variable>
-                        <variable label="Maximum driving heat" CV="16.0.376" default="0" item="ESU FnOut A13 Slider 16" mask="XXXVVVVV">
+                        <variable label="Maximum driving heat" CV="16.0.336" default="0" item="ESU FnOut A8 Slider 16" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>24</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
                         </variable>
-                        <variable label="Timeout" CV="16.0.376" default="0" item="ESU FnOut A13 Slider 10" tooltip="Units = 0.25 sec">
+                        <variable label="Timeout" CV="16.0.336" default="0" item="ESU FnOut A8 Slider 10" tooltip="Units = 0.25 sec">
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>25</value>
                             </qualifier>
                             <decVal/>
                         </variable>
-                        <variable label="Startup Time" CV="16.0.376" default="0" item="ESU FnOut A13 Slider 6">
+                        <variable label="Startup Time" CV="16.0.336" default="0" item="ESU FnOut A8 Slider 6">
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>ge</relation>
                                 <value>16</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>le</relation>
                                 <value>17</value>
                             </qualifier>
                             <decVal/>
                             <label xml:lang="de">Startzeit</label>
                         </variable>
-                        <variable label="Level" CV="16.0.376" default="0" item="ESU FnOut A13 Slider 20" mask="XVVVVVVV">
+                        <variable label="Level" CV="16.0.336" default="0" item="ESU FnOut A8 Slider 20" mask="XVVVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A13 Mode</variableref>
+                                <variableref>ESU FnOut A8 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>19</value>
                             </qualifier>
                             <decVal max="127"/>
                         </variable>
-                        <!-- AUX14 Mode -->
-                        <variable label="AUX14 Mode" CV="16.0.379" default="1" item="ESU FnOut A14 Mode">
+                    </variables>
+                    <!-- exclude AUX9 to AUX18 -->
+                    <variables exclude="LokPilot 5 micro DCC Direct,LokSound 5 micro DCC Direct">
+                        <!-- AUX9 Mode -->
+                        <variable label="AUX9 Mode" CV="16.0.339" default="1" item="ESU FnOut A9 Mode">
                             <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
                         </variable>
-                        <variable label="Function Switch On Delay" CV="16.0.380" default="0" item="ESU FnOut A14 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
+                        <variable label="Function Switch On Delay" CV="16.0.340" default="0" item="ESU FnOut A9 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>27</value>
                             </qualifier>
                             <decVal max="15"/>
                             <label xml:lang="de">Verzögerung beim Einschalten</label>
                         </variable>
-                        <variable label="Function Switch Off Delay" CV="16.0.380" default="0" mask="VVVVXXXX" item="ESU FnOut A14 Slider 2" tooltip="Units = 0.4 sec">
+                        <variable label="Function Switch Off Delay" CV="16.0.340" default="0" mask="VVVVXXXX" item="ESU FnOut A9 Slider 2" tooltip="Units = 0.4 sec">
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>27</value>
                             </qualifier>
                             <decVal max="15"/>
                             <label xml:lang="de">Verzögerung beim Ausschalten</label>
                         </variable>
-                        <variable label="Function Auto Switch Off" CV="16.0.381" default="0" item="ESU FnOut A14 Slider 3" tooltip="Units = 0.4 sec">
+                        <variable label="Function Auto Switch Off" CV="16.0.341" default="0" item="ESU FnOut A9 Slider 3" tooltip="Units = 0.4 sec">
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>27</value>
                             </qualifier>
                             <decVal/>
                             <label xml:lang="de">Ausgang automatisch Ausschalten</label>
                         </variable>
-                        <variable item="Brightness CV382" label="Brightness CV" CV="16.0.382" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
+                        <variable item="Brightness CV342" label="Brightness CV" CV="16.0.342" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
                             <decVal/>
                         </variable>
-                        <variable label="Brightness" CV="16.0.382" default="31" item="ESU FnOut A14 Slider 5" mask="XXXVVVVV">
+                        <variable label="Brightness" CV="16.0.342" default="31" item="ESU FnOut A9 Slider 5" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>le</relation>
                                 <value>18</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Helligkeit</label>
                         </variable>
-                        <variable label="Mode" CV="16.0.382" default="0" item="ESU FnOut A14 Option 1" mask="XXXXXXXV">
+                        <variable label="Mode" CV="16.0.342" default="0" item="ESU FnOut A9 Option 1" mask="XXXXXXXV">
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>22</value>
                             </qualifier>
@@ -4729,282 +3159,297 @@
                             </enumVal>
                             <label xml:lang="de">Modus</label>
                         </variable>
-                        <variable label="Coupler Force" CV="16.0.382" default="31" item="ESU FnOut A14 Slider 7" mask="XXXVVVVV">
+                        <variable label="Coupler Force" CV="16.0.342" default="31" item="ESU FnOut A9 Slider 7" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>ge</relation>
                                 <value>28</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>29</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>30</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>31</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>32</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>le</relation>
                                 <value>33</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Stärke des Kupplers</label>
                         </variable>
-                        <variable label="Fan Speed" CV="16.0.382" default="31" item="ESU FnOut A14 Slider 11" mask="XXXVVVVV">
+                        <variable label="Fan Speed" CV="16.0.342" default="31" item="ESU FnOut A9 Slider 11" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>23</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Geschwindigkeit</label>
                         </variable>
-                        <variable label="Standing heat" CV="16.0.382" default="31" item="ESU FnOut A14 Slider 14" mask="XXXVVVVV">
+                        <variable label="Standing heat" CV="16.0.342" default="31" item="ESU FnOut A9 Slider 14" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>24</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Heizstufe im Stand</label>
                         </variable>
-                        <variable label="Chuff power" CV="16.0.382" default="31" item="ESU FnOut A14 Slider 8" mask="XXXVVVVV">
+                        <variable label="Chuff power" CV="16.0.342" default="31" item="ESU FnOut A9 Slider 8" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>25</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Dampfstoßstärke</label>
                         </variable>
-                        <variable item="Special Function CV383" label="Special Function CV 1" CV="16.0.383" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                        <variable item="Special Function CV343" label="Special Function CV 1" CV="16.0.343" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
                             <decVal/>
                         </variable>
-                        <variable label="Fan Acceleration rate" CV="16.0.383" default="0" item="ESU FnOut A14 Slider 12" mask="XXXVVVVV">
+                        <variable label="Fan Acceleration rate" CV="16.0.343" default="0" item="ESU FnOut A9 Slider 12" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>23</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Beschleunigungszeit</label>
                         </variable>
-                        <variable label="Minimum driving heat" CV="16.0.383" default="0" item="ESU FnOut A14 Slider 15" mask="XXXVVVVV">
+                        <variable label="Minimum driving heat" CV="16.0.343" default="0" item="ESU FnOut A9 Slider 15" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>24</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
                         </variable>
-                        <variable label="Fan power" CV="16.0.383" default="0" item="ESU FnOut A14 Slider 9" mask="XXXVVVVV">
+                        <variable label="Fan power" CV="16.0.343" default="0" item="ESU FnOut A9 Slider 9" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>25</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Stäke des Bläsers</label>
                         </variable>
-                        <variable label="Phase Reverse" CV="16.0.383" default="0" item="ESU FnOut A14 Check 6" mask="XXXXXXXV">
+                        <variable label="Phase Reverse" CV="16.0.343" default="0" item="ESU FnOut A9 Check 6" mask="XXXXXXXV">
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                             <label xml:lang="de">Phase tauschen</label>
                         </variable>
-                        <variable label="Grade Crossing" CV="16.0.383" default="0" item="ESU FnOut A14 Check 1" mask="XXXXXXVX">
+                        <variable label="Grade Crossing" CV="16.0.343" default="0" item="ESU FnOut A9 Check 1" mask="XXXXXXVX">
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                         </variable>
-                        <variable label="Rule 17 Fwd" CV="16.0.383" default="0" item="ESU FnOut A14 Check 2" mask="XXXXXVXX">
+                        <variable label="Rule 17 Fwd" CV="16.0.343" default="0" item="ESU FnOut A9 Check 2" mask="XXXXXVXX">
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                             <label xml:lang="de">Rule 17 vorwärts</label>
                         </variable>
-                        <variable label="Rule 17 Rev" CV="16.0.383" default="0" item="ESU FnOut A14 Check 3" mask="XXXXVXXX">
+                        <variable label="Rule 17 Rev" CV="16.0.343" default="0" item="ESU FnOut A9 Check 3" mask="XXXXVXXX">
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                             <label xml:lang="de">Rule 17 rückwärts</label>
                         </variable>
-                        <variable label="Dimmer" CV="16.0.383" default="0" item="ESU FnOut A14 Check 4" mask="XXXVXXXX">
+                        <variable label="Dimmer" CV="16.0.343" default="0" item="ESU FnOut A9 Check 4" mask="XXXVXXXX">
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                             <label xml:lang="de">Abdimmen</label>
                         </variable>
-                        <variable label="LED Mode" CV="16.0.383" default="0" item="ESU FnOut A14 Check 5" mask="VXXXXXXX">
+                        <variable label="LED Mode" CV="16.0.343" default="0" item="ESU FnOut A9 Check 5" mask="VXXXXXXX">
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                             <label xml:lang="de">LED Modus</label>
                         </variable>
-                        <variable item="Special Function CV384" label="Special Function CV 2" CV="16.0.384" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                        <variable item="Special Function CV344" label="Special Function CV 2" CV="16.0.344" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
                             <decVal/>
                         </variable>
-                        <variable label="Fan Decceleration rate" CV="16.0.384" default="0" item="ESU FnOut A14 Slider 13" mask="XXXVVVVV">
+                        <variable label="Fan Decceleration rate" CV="16.0.344" default="0" item="ESU FnOut A9 Slider 13" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>23</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Bremszeit</label>
                         </variable>
-                        <variable label="Maximum driving heat" CV="16.0.384" default="0" item="ESU FnOut A14 Slider 16" mask="XXXVVVVV">
+                        <variable label="Maximum driving heat" CV="16.0.344" default="0" item="ESU FnOut A9 Slider 16" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>24</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
                         </variable>
-                        <variable label="Timeout" CV="16.0.384" default="0" item="ESU FnOut A14 Slider 10" tooltip="Units = 0.25 sec">
+                        <variable label="Timeout" CV="16.0.344" default="0" item="ESU FnOut A9 Slider 10" tooltip="Units = 0.25 sec">
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>25</value>
                             </qualifier>
                             <decVal/>
                         </variable>
-                        <variable label="Startup Time" CV="16.0.384" default="0" item="ESU FnOut A14 Slider 6">
+                        <variable label="Startup Time" CV="16.0.344" default="0" item="ESU FnOut A9 Slider 6">
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>ge</relation>
                                 <value>16</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>le</relation>
                                 <value>17</value>
                             </qualifier>
                             <decVal/>
                             <label xml:lang="de">Startzeit</label>
                         </variable>
-                        <variable label="Level" CV="16.0.384" default="0" item="ESU FnOut A14 Slider 20" mask="XVVVVVVV">
+                        <variable label="Level" CV="16.0.344" default="0" item="ESU FnOut A9 Slider 20" mask="XVVVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A14 Mode</variableref>
+                                <variableref>ESU FnOut A9 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>19</value>
                             </qualifier>
                             <decVal max="127"/>
                         </variable>
-                        <!-- AUX15 Mode -->
-                        <variable label="AUX15 Mode" CV="16.0.387" default="1" item="ESU FnOut A15 Mode">
+                        <!-- AUX10 Mode -->
+                        <variable label="AUX10 Mode" CV="16.0.347" default="1" item="ESU FnOut A10 Mode">
                             <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
                         </variable>
-                        <variable label="Function Switch On Delay" CV="16.0.388" default="0" item="ESU FnOut A15 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
+                        <variable label="Function Switch On Delay" CV="16.0.348" default="0" item="ESU FnOut A10 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
+                            </qualifier>
+                            <qualifier>
+                                <variableref>ESU FnOut A10 Mode</variableref>
+                                <relation>ne</relation>
+                                <value>27</value>
                             </qualifier>
                             <decVal max="15"/>
                             <label xml:lang="de">Verzögerung beim Einschalten</label>
                         </variable>
-                        <variable label="Function Switch Off Delay" CV="16.0.388" default="0" mask="VVVVXXXX" item="ESU FnOut A15 Slider 2" tooltip="Units = 0.4 sec">
+                        <variable label="Function Switch Off Delay" CV="16.0.348" default="0" mask="VVVVXXXX" item="ESU FnOut A10 Slider 2" tooltip="Units = 0.4 sec">
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
+                            </qualifier>
+                            <qualifier>
+                                <variableref>ESU FnOut A10 Mode</variableref>
+                                <relation>ne</relation>
+                                <value>27</value>
                             </qualifier>
                             <decVal max="15"/>
                             <label xml:lang="de">Verzögerung beim Ausschalten</label>
                         </variable>
-                        <variable label="Function Auto Switch Off" CV="16.0.389" default="0" item="ESU FnOut A15 Slider 3" tooltip="Units = 0.4 sec">
+                        <variable label="Function Auto Switch Off" CV="16.0.349" default="0" item="ESU FnOut A10 Slider 3" tooltip="Units = 0.4 sec">
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
+                            </qualifier>
+                            <qualifier>
+                                <variableref>ESU FnOut A10 Mode</variableref>
+                                <relation>ne</relation>
+                                <value>27</value>
                             </qualifier>
                             <decVal/>
                             <label xml:lang="de">Ausgang automatisch Ausschalten</label>
                         </variable>
-                        <variable item="Brightness CV390" label="Brightness CV" CV="16.0.390" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
+                        <variable item="Brightness CV350" label="Brightness CV" CV="16.0.350" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
                             <decVal/>
                         </variable>
-                        <variable label="Brightness" CV="16.0.390" default="31" item="ESU FnOut A15 Slider 5" mask="XXXVVVVV">
+                        <variable label="Brightness" CV="16.0.350" default="31" item="ESU FnOut A10 Slider 5" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>le</relation>
                                 <value>18</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Helligkeit</label>
                         </variable>
-                        <variable label="Mode" CV="16.0.390" default="0" item="ESU FnOut A15 Option 1" mask="XXXXXXXV">
+                        <variable label="Mode" CV="16.0.350" default="0" item="ESU FnOut A10 Option 1" mask="XXXXXXXV">
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>22</value>
                             </qualifier>
@@ -5020,316 +3465,283 @@
                             </enumVal>
                             <label xml:lang="de">Modus</label>
                         </variable>
-                        <variable label="Coupler Force" CV="16.0.390" default="31" item="ESU FnOut A15 Slider 7" mask="XXXVVVVV">
+                        <variable label="Coupler Force" CV="16.0.350" default="31" item="ESU FnOut A10 Slider 7" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>ge</relation>
                                 <value>28</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>29</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>30</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>31</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>32</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>le</relation>
                                 <value>33</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Stärke des Kupplers</label>
                         </variable>
-                        <variable label="Fan Speed" CV="16.0.390" default="31" item="ESU FnOut A15 Slider 11" mask="XXXVVVVV">
+                        <variable label="Fan Speed" CV="16.0.350" default="31" item="ESU FnOut A10 Slider 11" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>23</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Geschwindigkeit</label>
                         </variable>
-                        <variable label="Standing heat" CV="16.0.390" default="31" item="ESU FnOut A15 Slider 14" mask="XXXVVVVV">
+                        <variable label="Standing heat" CV="16.0.350" default="31" item="ESU FnOut A10 Slider 14" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>24</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Heizstufe im Stand</label>
                         </variable>
-                        <variable label="Chuff power" CV="16.0.390" default="31" item="ESU FnOut A15 Slider 8" mask="XXXVVVVV">
+                        <variable label="Chuff power" CV="16.0.350" default="31" item="ESU FnOut A10 Slider 8" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>25</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Dampfstoßstärke</label>
                         </variable>
-                        <variable label="Duration (speed) A" CV="16.0.386" default="31" item="ESU FnOut A15 Slider 4" mask="XXVVVVVV">
-                            <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
-                                <relation>eq</relation>
-                                <value>27</value>
-                            </qualifier>
-                            <decVal max="63"/>
-                            <label xml:lang="de">Dauer (Geschwindigkeit)</label>
-                        </variable>
-                        <variable label="Duration (speed) B" CV="16.0.390" default="31" item="ESU FnOut A15 Slider 17" mask="XXVVVVVV">
-                            <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
-                                <relation>eq</relation>
-                                <value>27</value>
-                            </qualifier>
-                            <decVal max="63"/>
-                            <label xml:lang="de">Dauer (Geschwindigkeit)</label>
-                        </variable>
-                        <variable item="Special Function CV391" label="Special Function CV 1" CV="16.0.391" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                        <variable item="Special Function CV351" label="Special Function CV 1" CV="16.0.351" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
                             <decVal/>
                         </variable>
-                        <variable label="Fan Acceleration rate" CV="16.0.391" default="0" item="ESU FnOut A15 Slider 12" mask="XXXVVVVV">
+                        <variable label="Fan Acceleration rate" CV="16.0.351" default="0" item="ESU FnOut A10 Slider 12" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>23</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Beschleunigungszeit</label>
                         </variable>
-                        <variable label="Minimum driving heat" CV="16.0.391" default="0" item="ESU FnOut A15 Slider 15" mask="XXXVVVVV">
+                        <variable label="Minimum driving heat" CV="16.0.351" default="0" item="ESU FnOut A10 Slider 15" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>24</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
                         </variable>
-                        <variable label="Position A" CV="16.0.391" default="0" item="ESU FnOut A15 Slider 18" mask="XXVVVVVV">
+                        <variable label="Fan power" CV="16.0.351" default="0" item="ESU FnOut A10 Slider 9" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
-                                <relation>eq</relation>
-                                <value>27</value>
-                            </qualifier>
-                            <decVal max="63"/>
-                        </variable>
-                        <variable label="Fan power" CV="16.0.391" default="0" item="ESU FnOut A15 Slider 9" mask="XXXVVVVV">
-                            <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>25</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Stäke des Bläsers</label>
                         </variable>
-                        <variable label="Phase Reverse" CV="16.0.391" default="0" item="ESU FnOut A15 Check 6" mask="XXXXXXXV">
+                        <variable label="Phase Reverse" CV="16.0.351" default="0" item="ESU FnOut A10 Check 6" mask="XXXXXXXV">
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                             <label xml:lang="de">Phase tauschen</label>
                         </variable>
-                        <variable label="Grade Crossing" CV="16.0.391" default="0" item="ESU FnOut A15 Check 1" mask="XXXXXXVX">
+                        <variable label="Grade Crossing" CV="16.0.351" default="0" item="ESU FnOut A10 Check 1" mask="XXXXXXVX">
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                         </variable>
-                        <variable label="Rule 17 Fwd" CV="16.0.391" default="0" item="ESU FnOut A15 Check 2" mask="XXXXXVXX">
+                        <variable label="Rule 17 Fwd" CV="16.0.351" default="0" item="ESU FnOut A10 Check 2" mask="XXXXXVXX">
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                             <label xml:lang="de">Rule 17 vorwärts</label>
                         </variable>
-                        <variable label="Rule 17 Rev" CV="16.0.391" default="0" item="ESU FnOut A15 Check 3" mask="XXXXVXXX">
+                        <variable label="Rule 17 Rev" CV="16.0.351" default="0" item="ESU FnOut A10 Check 3" mask="XXXXVXXX">
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                             <label xml:lang="de">Rule 17 rückwärts</label>
                         </variable>
-                        <variable label="Dimmer" CV="16.0.391" default="0" item="ESU FnOut A15 Check 4" mask="XXXVXXXX">
+                        <variable label="Dimmer" CV="16.0.351" default="0" item="ESU FnOut A10 Check 4" mask="XXXVXXXX">
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                             <label xml:lang="de">Abdimmen</label>
                         </variable>
-                        <variable label="LED Mode" CV="16.0.391" default="0" item="ESU FnOut A15 Check 5" mask="VXXXXXXX">
+                        <variable label="LED Mode" CV="16.0.351" default="0" item="ESU FnOut A10 Check 5" mask="VXXXXXXX">
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                             <label xml:lang="de">LED Modus</label>
                         </variable>
-                        <variable item="Special Function CV392" label="Special Function CV 2" CV="16.0.392" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                        <variable item="Special Function CV352" label="Special Function CV 2" CV="16.0.352" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
                             <decVal/>
                         </variable>
-                        <variable label="Fan Decceleration rate" CV="16.0.392" default="0" item="ESU FnOut A15 Slider 13" mask="XXXVVVVV">
+                        <variable label="Fan Decceleration rate" CV="16.0.352" default="0" item="ESU FnOut A10 Slider 13" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>23</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Bremszeit</label>
                         </variable>
-                        <variable label="Maximum driving heat" CV="16.0.392" default="0" item="ESU FnOut A15 Slider 16" mask="XXXVVVVV">
+                        <variable label="Maximum driving heat" CV="16.0.352" default="0" item="ESU FnOut A10 Slider 16" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>24</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
                         </variable>
-                        <variable label="Timeout" CV="16.0.392" default="0" item="ESU FnOut A15 Slider 10" tooltip="Units = 0.25 sec">
+                        <variable label="Timeout" CV="16.0.352" default="0" item="ESU FnOut A10 Slider 10" tooltip="Units = 0.25 sec">
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>25</value>
                             </qualifier>
                             <decVal/>
                         </variable>
-                        <variable label="Startup Time" CV="16.0.392" default="0" item="ESU FnOut A15 Slider 6">
+                        <variable label="Startup Time" CV="16.0.352" default="0" item="ESU FnOut A10 Slider 6">
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>ge</relation>
                                 <value>16</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>le</relation>
                                 <value>17</value>
                             </qualifier>
                             <decVal/>
                             <label xml:lang="de">Startzeit</label>
                         </variable>
-                        <variable label="Level" CV="16.0.392" default="0" item="ESU FnOut A15 Slider 20" mask="XVVVVVVV">
+                        <variable label="Level" CV="16.0.352" default="0" item="ESU FnOut A10 Slider 20" mask="XVVVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
+                                <variableref>ESU FnOut A10 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>19</value>
                             </qualifier>
                             <decVal max="127"/>
                         </variable>
-                        <variable label="Position B" CV="16.0.392" default="0" item="ESU FnOut A15 Slider 19" mask="XXVVVVVV">
-                            <qualifier>
-                                <variableref>ESU FnOut A15 Mode</variableref>
-                                <relation>eq</relation>
-                                <value>27</value>
-                            </qualifier>
-                            <decVal max="63"/>
-                        </variable>
-                        <!-- AUX16 Mode -->
-                        <variable label="AUX16 Mode" CV="16.0.395" default="1" item="ESU FnOut A16 Mode">
+                        <!-- AUX11 Mode -->
+                        <variable label="AUX11 Mode" CV="16.0.355" default="1" item="ESU FnOut A11 Mode">
                             <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
+                            <!--label xml:lang="de">Licht vorn - 2</label-->
                         </variable>
-                        <variable label="Function Switch On Delay" CV="16.0.396" default="0" item="ESU FnOut A16 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
+                        <variable label="Function Switch On Delay" CV="16.0.356" default="0" item="ESU FnOut A11 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <decVal max="15"/>
                             <label xml:lang="de">Verzögerung beim Einschalten</label>
                         </variable>
-                        <variable label="Function Switch Off Delay" CV="16.0.396" default="0" mask="VVVVXXXX" item="ESU FnOut A16 Slider 2" tooltip="Units = 0.4 sec">
+                        <variable label="Function Switch Off Delay" CV="16.0.356" default="0" mask="VVVVXXXX" item="ESU FnOut A11 Slider 2" tooltip="Units = 0.4 sec">
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <decVal max="15"/>
                             <label xml:lang="de">Verzögerung beim Ausschalten</label>
                         </variable>
-                        <variable label="Function Auto Switch Off" CV="16.0.397" default="0" item="ESU FnOut A16 Slider 3" tooltip="Units = 0.4 sec">
+                        <variable label="Function Auto Switch Off" CV="16.0.357" default="0" item="ESU FnOut A11 Slider 3" tooltip="Units = 0.4 sec">
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <decVal/>
                             <label xml:lang="de">Ausgang automatisch Ausschalten</label>
                         </variable>
-                        <variable item="Brightness CV398" label="Brightness CV" CV="16.0.398" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
+                        <variable item="Brightness CV358" label="Brightness CV" CV="16.0.358" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
                             <decVal/>
                         </variable>
-                        <variable label="Brightness" CV="16.0.398" default="31" item="ESU FnOut A16 Slider 5" mask="XXXVVVVV">
+                        <variable label="Brightness" CV="16.0.358" default="31" item="ESU FnOut A11 Slider 5" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>le</relation>
                                 <value>18</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Helligkeit</label>
                         </variable>
-                        <variable label="Mode" CV="16.0.398" default="0" item="ESU FnOut A16 Option 1" mask="XXXXXXXV">
+                        <variable label="Mode" CV="16.0.358" default="0" item="ESU FnOut A11 Option 1" mask="XXXXXXXV">
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>22</value>
                             </qualifier>
@@ -5345,316 +3757,316 @@
                             </enumVal>
                             <label xml:lang="de">Modus</label>
                         </variable>
-                        <variable label="Coupler Force" CV="16.0.398" default="31" item="ESU FnOut A16 Slider 7" mask="XXXVVVVV">
+                        <variable label="Coupler Force" CV="16.0.358" default="31" item="ESU FnOut A11 Slider 7" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>ge</relation>
                                 <value>28</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>29</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>30</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>31</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>32</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>le</relation>
                                 <value>33</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Stärke des Kupplers</label>
                         </variable>
-                        <variable label="Fan Speed" CV="16.0.398" default="31" item="ESU FnOut A16 Slider 11" mask="XXXVVVVV">
+                        <variable label="Fan Speed" CV="16.0.358" default="31" item="ESU FnOut A11 Slider 11" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>23</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Geschwindigkeit</label>
                         </variable>
-                        <variable label="Standing heat" CV="16.0.398" default="31" item="ESU FnOut A16 Slider 14" mask="XXXVVVVV">
+                        <variable label="Standing heat" CV="16.0.358" default="31" item="ESU FnOut A11 Slider 14" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>24</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Heizstufe im Stand</label>
                         </variable>
-                        <variable label="Chuff power" CV="16.0.398" default="31" item="ESU FnOut A16 Slider 8" mask="XXXVVVVV">
+                        <variable label="Chuff power" CV="16.0.358" default="31" item="ESU FnOut A11 Slider 8" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>25</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Dampfstoßstärke</label>
                         </variable>
-                        <variable label="Duration (speed) A" CV="16.0.394" default="31" item="ESU FnOut A16 Slider 4" mask="XXVVVVVV">
+                        <variable label="Duration (speed) A" CV="16.0.354" default="31" item="ESU FnOut A11 Slider 4" mask="XXVVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>27</value>
                             </qualifier>
                             <decVal max="63"/>
                             <label xml:lang="de">Dauer (Geschwindigkeit)</label>
                         </variable>
-                        <variable label="Duration (speed) B" CV="16.0.398" default="31" item="ESU FnOut A16 Slider 17" mask="XXVVVVVV">
+                        <variable label="Duration (speed) B" CV="16.0.358" default="31" item="ESU FnOut A11 Slider 17" mask="XXVVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>27</value>
                             </qualifier>
                             <decVal max="63"/>
                             <label xml:lang="de">Dauer (Geschwindigkeit)</label>
                         </variable>
-                        <variable item="Special Function CV399" label="Special Function CV 1" CV="16.0.399" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                        <variable item="Special Function CV359" label="Special Function CV 1" CV="16.0.359" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
                             <decVal/>
                         </variable>
-                        <variable label="Fan Acceleration rate" CV="16.0.399" default="0" item="ESU FnOut A16 Slider 12" mask="XXXVVVVV">
+                        <variable label="Fan Acceleration rate" CV="16.0.359" default="0" item="ESU FnOut A11 Slider 12" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>23</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Beschleunigungszeit</label>
                         </variable>
-                        <variable label="Minimum driving heat" CV="16.0.399" default="0" item="ESU FnOut A16 Slider 15" mask="XXXVVVVV">
+                        <variable label="Minimum driving heat" CV="16.0.359" default="0" item="ESU FnOut A11 Slider 15" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>24</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
                         </variable>
-                        <variable label="Position A" CV="16.0.399" default="0" item="ESU FnOut A16 Slider 18" mask="XXVVVVVV">
+                        <variable label="Position A" CV="16.0.359" default="0" item="ESU FnOut A11 Slider 18" mask="XXVVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>27</value>
                             </qualifier>
                             <decVal max="63"/>
                         </variable>
-                        <variable label="Fan power" CV="16.0.399" default="0" item="ESU FnOut A16 Slider 9" mask="XXXVVVVV">
+                        <variable label="Fan power" CV="16.0.359" default="0" item="ESU FnOut A11 Slider 9" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>25</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Stäke des Bläsers</label>
                         </variable>
-                        <variable label="Phase Reverse" CV="16.0.399" default="0" item="ESU FnOut A16 Check 6" mask="XXXXXXXV">
+                        <variable label="Phase Reverse" CV="16.0.359" default="0" item="ESU FnOut A11 Check 6" mask="XXXXXXXV">
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                             <label xml:lang="de">Phase tauschen</label>
                         </variable>
-                        <variable label="Grade Crossing" CV="16.0.399" default="0" item="ESU FnOut A16 Check 1" mask="XXXXXXVX">
+                        <variable label="Grade Crossing" CV="16.0.359" default="0" item="ESU FnOut A11 Check 1" mask="XXXXXXVX">
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                         </variable>
-                        <variable label="Rule 17 Fwd" CV="16.0.399" default="0" item="ESU FnOut A16 Check 2" mask="XXXXXVXX">
+                        <variable label="Rule 17 Fwd" CV="16.0.359" default="0" item="ESU FnOut A11 Check 2" mask="XXXXXVXX">
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                             <label xml:lang="de">Rule 17 vorwärts</label>
                         </variable>
-                        <variable label="Rule 17 Rev" CV="16.0.399" default="0" item="ESU FnOut A16 Check 3" mask="XXXXVXXX">
+                        <variable label="Rule 17 Rev" CV="16.0.359" default="0" item="ESU FnOut A11 Check 3" mask="XXXXVXXX">
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                             <label xml:lang="de">Rule 17 rückwärts</label>
                         </variable>
-                        <variable label="Dimmer" CV="16.0.399" default="0" item="ESU FnOut A16 Check 4" mask="XXXVXXXX">
+                        <variable label="Dimmer" CV="16.0.359" default="0" item="ESU FnOut A11 Check 4" mask="XXXVXXXX">
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                             <label xml:lang="de">Abdimmen</label>
                         </variable>
-                        <variable label="LED Mode" CV="16.0.399" default="0" item="ESU FnOut A16 Check 5" mask="VXXXXXXX">
+                        <variable label="LED Mode" CV="16.0.359" default="0" item="ESU FnOut A11 Check 5" mask="VXXXXXXX">
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                             <label xml:lang="de">LED Modus</label>
                         </variable>
-                        <variable item="Special Function CV400" label="Special Function CV 2" CV="16.0.400" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                        <variable item="Special Function CV360" label="Special Function CV 2" CV="16.0.360" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
                             <decVal/>
                         </variable>
-                        <variable label="Fan Decceleration rate" CV="16.0.400" default="0" item="ESU FnOut A16 Slider 13" mask="XXXVVVVV">
+                        <variable label="Fan Decceleration rate" CV="16.0.360" default="0" item="ESU FnOut A11 Slider 13" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>23</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Bremszeit</label>
                         </variable>
-                        <variable label="Maximum driving heat" CV="16.0.400" default="0" item="ESU FnOut A16 Slider 16" mask="XXXVVVVV">
+                        <variable label="Maximum driving heat" CV="16.0.360" default="0" item="ESU FnOut A11 Slider 16" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>24</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
                         </variable>
-                        <variable label="Timeout" CV="16.0.400" default="0" item="ESU FnOut A16 Slider 10" tooltip="Units = 0.25 sec">
+                        <variable label="Timeout" CV="16.0.360" default="0" item="ESU FnOut A11 Slider 10" tooltip="Units = 0.25 sec">
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>25</value>
                             </qualifier>
                             <decVal/>
                         </variable>
-                        <variable label="Startup Time" CV="16.0.400" default="0" item="ESU FnOut A16 Slider 6">
+                        <variable label="Startup Time" CV="16.0.360" default="0" item="ESU FnOut A11 Slider 6">
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>ge</relation>
                                 <value>16</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>le</relation>
                                 <value>17</value>
                             </qualifier>
                             <decVal/>
                             <label xml:lang="de">Startzeit</label>
                         </variable>
-                        <variable label="Level" CV="16.0.400" default="0" item="ESU FnOut A16 Slider 20" mask="XVVVVVVV">
+                        <variable label="Level" CV="16.0.360" default="0" item="ESU FnOut A11 Slider 20" mask="XVVVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>19</value>
                             </qualifier>
                             <decVal max="127"/>
                         </variable>
-                        <variable label="Position B" CV="16.0.400" default="0" item="ESU FnOut A16 Slider 19" mask="XXVVVVVV">
+                        <variable label="Position B" CV="16.0.360" default="0" item="ESU FnOut A11 Slider 19" mask="XXVVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A16 Mode</variableref>
+                                <variableref>ESU FnOut A11 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>27</value>
                             </qualifier>
                             <decVal max="63"/>
                         </variable>
-                        <!-- AUX17 Mode -->
-                        <variable label="AUX17 Mode" CV="16.0.403" default="1" item="ESU FnOut A17 Mode">
+                        <!-- AUX12 Mode -->
+                        <variable label="AUX12 Mode" CV="16.0.363" default="1" item="ESU FnOut A12 Mode">
                             <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
                         </variable>
-                        <variable label="Function Switch On Delay" CV="16.0.404" default="0" item="ESU FnOut A17 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
+                        <variable label="Function Switch On Delay" CV="16.0.364" default="0" item="ESU FnOut A12 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <decVal max="15"/>
                             <label xml:lang="de">Verzögerung beim Einschalten</label>
                         </variable>
-                        <variable label="Function Switch Off Delay" CV="16.0.404" default="0" mask="VVVVXXXX" item="ESU FnOut A17 Slider 2" tooltip="Units = 0.4 sec">
+                        <variable label="Function Switch Off Delay" CV="16.0.364" default="0" mask="VVVVXXXX" item="ESU FnOut A12 Slider 2" tooltip="Units = 0.4 sec">
                             <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <decVal max="15"/>
                             <label xml:lang="de">Verzögerung beim Ausschalten</label>
                         </variable>
-                        <variable label="Function Auto Switch Off" CV="16.0.405" default="0" item="ESU FnOut A17 Slider 3" tooltip="Units = 0.4 sec">
+                        <variable label="Function Auto Switch Off" CV="16.0.365" default="0" item="ESU FnOut A12 Slider 3" tooltip="Units = 0.4 sec">
                             <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <decVal/>
                             <label xml:lang="de">Ausgang automatisch Ausschalten</label>
                         </variable>
-                        <variable item="Brightness CV406" label="Brightness CV" CV="16.0.406" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
+                        <variable item="Brightness CV366" label="Brightness CV" CV="16.0.366" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
                             <decVal/>
                         </variable>
-                        <variable label="Brightness" CV="16.0.406" default="31" item="ESU FnOut A17 Slider 5" mask="XXXVVVVV">
+                        <variable label="Brightness" CV="16.0.366" default="31" item="ESU FnOut A12 Slider 5" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>le</relation>
                                 <value>18</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Helligkeit</label>
                         </variable>
-                        <variable label="Mode" CV="16.0.406" default="0" item="ESU FnOut A17 Option 1" mask="XXXXXXXV">
+                        <variable label="Mode" CV="16.0.366" default="0" item="ESU FnOut A12 Option 1" mask="XXXXXXXV">
                             <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>22</value>
                             </qualifier>
@@ -5670,602 +4082,2190 @@
                             </enumVal>
                             <label xml:lang="de">Modus</label>
                         </variable>
-                        <variable label="Coupler Force" CV="16.0.406" default="31" item="ESU FnOut A17 Slider 7" mask="XXXVVVVV">
+                        <variable label="Coupler Force" CV="16.0.366" default="31" item="ESU FnOut A12 Slider 7" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>ge</relation>
                                 <value>28</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>29</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>30</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>31</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>32</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>le</relation>
                                 <value>33</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Stärke des Kupplers</label>
                         </variable>
-                        <variable label="Fan Speed" CV="16.0.406" default="31" item="ESU FnOut A17 Slider 11" mask="XXXVVVVV">
+                        <variable label="Fan Speed" CV="16.0.366" default="31" item="ESU FnOut A12 Slider 11" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>23</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Geschwindigkeit</label>
                         </variable>
-                        <variable label="Standing heat" CV="16.0.406" default="31" item="ESU FnOut A17 Slider 14" mask="XXXVVVVV">
+                        <variable label="Standing heat" CV="16.0.366" default="31" item="ESU FnOut A12 Slider 14" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>24</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Heizstufe im Stand</label>
                         </variable>
-                        <variable label="Chuff power" CV="16.0.406" default="31" item="ESU FnOut A17 Slider 8" mask="XXXVVVVV">
+                        <variable label="Chuff power" CV="16.0.366" default="31" item="ESU FnOut A12 Slider 8" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>25</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Dampfstoßstärke</label>
                         </variable>
-                        <variable label="Duration (speed) A" CV="16.0.402" default="31" item="ESU FnOut A17 Slider 4" mask="XXVVVVVV">
+                        <variable label="Duration (speed) A" CV="16.0.362" default="31" item="ESU FnOut A12 Slider 4" mask="XXVVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>27</value>
                             </qualifier>
                             <decVal max="63"/>
                             <label xml:lang="de">Dauer (Geschwindigkeit)</label>
                         </variable>
-                        <variable label="Duration (speed) B" CV="16.0.406" default="31" item="ESU FnOut A17 Slider 17" mask="XXVVVVVV">
+                        <variable label="Duration (speed) B" CV="16.0.366" default="31" item="ESU FnOut A12 Slider 17" mask="XXVVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>27</value>
                             </qualifier>
                             <decVal max="63"/>
                             <label xml:lang="de">Dauer (Geschwindigkeit)</label>
                         </variable>
-                        <variable item="Special Function CV407" label="Special Function CV 1" CV="16.0.407" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                        <variable item="Special Function CV367" label="Special Function CV 1" CV="16.0.367" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
                             <decVal/>
                         </variable>
-                        <variable label="Fan Acceleration rate" CV="16.0.407" default="0" item="ESU FnOut A17 Slider 12" mask="XXXVVVVV">
+                        <variable label="Fan Acceleration rate" CV="16.0.367" default="0" item="ESU FnOut A12 Slider 12" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>23</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Beschleunigungszeit</label>
                         </variable>
-                        <variable label="Minimum driving heat" CV="16.0.407" default="0" item="ESU FnOut A17 Slider 15" mask="XXXVVVVV">
+                        <variable label="Minimum driving heat" CV="16.0.367" default="0" item="ESU FnOut A12 Slider 15" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>24</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
                         </variable>
-                        <variable label="Position A" CV="16.0.407" default="0" item="ESU FnOut A17 Slider 18" mask="XXVVVVVV">
+                        <variable label="Position A" CV="16.0.367" default="0" item="ESU FnOut A12 Slider 18" mask="XXVVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>27</value>
                             </qualifier>
                             <decVal max="63"/>
                         </variable>
-                        <variable label="Fan power" CV="16.0.407" default="0" item="ESU FnOut A17 Slider 9" mask="XXXVVVVV">
+                        <variable label="Fan power" CV="16.0.367" default="0" item="ESU FnOut A12 Slider 9" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>25</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Stäke des Bläsers</label>
                         </variable>
-                        <variable label="Phase Reverse" CV="16.0.407" default="0" item="ESU FnOut A17 Check 6" mask="XXXXXXXV">
+                        <variable label="Phase Reverse" CV="16.0.367" default="0" item="ESU FnOut A12 Check 6" mask="XXXXXXXV">
                             <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                             <label xml:lang="de">Phase tauschen</label>
                         </variable>
-                        <variable label="Grade Crossing" CV="16.0.407" default="0" item="ESU FnOut A17 Check 1" mask="XXXXXXVX">
+                        <variable label="Grade Crossing" CV="16.0.367" default="0" item="ESU FnOut A12 Check 1" mask="XXXXXXVX">
                             <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                         </variable>
-                        <variable label="Rule 17 Fwd" CV="16.0.407" default="0" item="ESU FnOut A17 Check 2" mask="XXXXXVXX">
+                        <variable label="Rule 17 Fwd" CV="16.0.367" default="0" item="ESU FnOut A12 Check 2" mask="XXXXXVXX">
                             <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
-                                <relation>le</relation>
-                                <value>15</value>
-                            </qualifier>
-                            <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                            <label xml:lang="de">Rule 17 vorwärts</label>
-                        </variable>
-                        <variable label="Rule 17 Rev" CV="16.0.407" default="0" item="ESU FnOut A17 Check 3" mask="XXXXVXXX">
-                            <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
-                                <relation>gt</relation>
-                                <value>0</value>
-                            </qualifier>
-                            <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
-                                <relation>le</relation>
-                                <value>15</value>
-                            </qualifier>
-                            <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                            <label xml:lang="de">Rule 17 rückwärts</label>
-                        </variable>
-                        <variable label="Dimmer" CV="16.0.407" default="0" item="ESU FnOut A17 Check 4" mask="XXXVXXXX">
-                            <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
-                                <relation>gt</relation>
-                                <value>0</value>
-                            </qualifier>
-                            <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
-                                <relation>le</relation>
-                                <value>15</value>
-                            </qualifier>
-                            <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                            <label xml:lang="de">Abdimmen</label>
-                        </variable>
-                        <variable label="LED Mode" CV="16.0.407" default="0" item="ESU FnOut A17 Check 5" mask="VXXXXXXX">
-                            <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
-                                <relation>gt</relation>
-                                <value>0</value>
-                            </qualifier>
-                            <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
-                                <relation>le</relation>
-                                <value>15</value>
-                            </qualifier>
-                            <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                            <label xml:lang="de">LED Modus</label>
-                        </variable>
-                        <variable item="Special Function CV408" label="Special Function CV 2" CV="16.0.408" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
-                            <decVal/>
-                        </variable>
-                        <variable label="Fan Decceleration rate" CV="16.0.408" default="0" item="ESU FnOut A17 Slider 13" mask="XXXVVVVV">
-                            <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
-                                <relation>eq</relation>
-                                <value>23</value>
-                            </qualifier>
-                            <decVal max="31"/>
-                            <label xml:lang="de">Bremszeit</label>
-                        </variable>
-                        <variable label="Maximum driving heat" CV="16.0.408" default="0" item="ESU FnOut A17 Slider 16" mask="XXXVVVVV">
-                            <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
-                                <relation>eq</relation>
-                                <value>24</value>
-                            </qualifier>
-                            <decVal max="31"/>
-                            <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
-                        </variable>
-                        <variable label="Timeout" CV="16.0.408" default="0" item="ESU FnOut A17 Slider 10" tooltip="Units = 0.25 sec">
-                            <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
-                                <relation>eq</relation>
-                                <value>25</value>
-                            </qualifier>
-                            <decVal/>
-                        </variable>
-                        <variable label="Startup Time" CV="16.0.408" default="0" item="ESU FnOut A17 Slider 6">
-                            <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
-                                <relation>ge</relation>
-                                <value>16</value>
-                            </qualifier>
-                            <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
-                                <relation>le</relation>
-                                <value>17</value>
-                            </qualifier>
-                            <decVal/>
-                            <label xml:lang="de">Startzeit</label>
-                        </variable>
-                        <variable label="Level" CV="16.0.408" default="0" item="ESU FnOut A17 Slider 20" mask="XVVVVVVV">
-                            <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
-                                <relation>eq</relation>
-                                <value>19</value>
-                            </qualifier>
-                            <decVal max="127"/>
-                        </variable>
-                        <variable label="Position B" CV="16.0.408" default="0" item="ESU FnOut A17 Slider 19" mask="XXVVVVVV">
-                            <qualifier>
-                                <variableref>ESU FnOut A17 Mode</variableref>
-                                <relation>eq</relation>
-                                <value>27</value>
-                            </qualifier>
-                            <decVal max="63"/>
-                        </variable>
-                        <!-- AUX18 Mode -->
-                        <variable label="AUX18 Mode" CV="16.0.411" default="1" item="ESU FnOut A18 Mode">
-                            <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
-                        </variable>
-                        <variable label="Function Switch On Delay" CV="16.0.412" default="0" item="ESU FnOut A18 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
-                            <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
-                                <relation>gt</relation>
-                                <value>0</value>
-                            </qualifier>
-                            <decVal max="15"/>
-                            <label xml:lang="de">Verzögerung beim Einschalten</label>
-                        </variable>
-                        <variable label="Function Switch Off Delay" CV="16.0.412" default="0" mask="VVVVXXXX" item="ESU FnOut A18 Slider 2" tooltip="Units = 0.4 sec">
-                            <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
-                                <relation>gt</relation>
-                                <value>0</value>
-                            </qualifier>
-                            <decVal max="15"/>
-                            <label xml:lang="de">Verzögerung beim Ausschalten</label>
-                        </variable>
-                        <variable label="Function Auto Switch Off" CV="16.0.413" default="0" item="ESU FnOut A18 Slider 3" tooltip="Units = 0.4 sec">
-                            <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
-                                <relation>gt</relation>
-                                <value>0</value>
-                            </qualifier>
-                            <decVal/>
-                            <label xml:lang="de">Ausgang automatisch Ausschalten</label>
-                        </variable>
-                        <variable item="Brightness CV414" label="Brightness CV" CV="16.0.414" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
-                            <decVal/>
-                        </variable>
-                        <variable label="Brightness" CV="16.0.414" default="31" item="ESU FnOut A18 Slider 5" mask="XXXVVVVV">
-                            <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
-                                <relation>gt</relation>
-                                <value>0</value>
-                            </qualifier>
-                            <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
-                                <relation>le</relation>
-                                <value>18</value>
-                            </qualifier>
-                            <decVal max="31"/>
-                            <label xml:lang="de">Helligkeit</label>
-                        </variable>
-                        <variable label="Mode" CV="16.0.414" default="0" item="ESU FnOut A18 Option 1" mask="XXXXXXXV">
-                            <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
-                                <relation>eq</relation>
-                                <value>22</value>
-                            </qualifier>
-                            <enumVal>
-                                <enumChoice choice="Heating control">
-                                    <choice>Heating control</choice>
-                                    <choice xml:lang="de">Heizungssteuerung</choice>
-                                </enumChoice>
-                                <enumChoice choice="Fan control">
-                                    <choice>Fan control</choice>
-                                    <choice xml:lang="de">Lüftersteuerung</choice>
-                                </enumChoice>
-                            </enumVal>
-                            <label xml:lang="de">Modus</label>
-                        </variable>
-                        <variable label="Coupler Force" CV="16.0.414" default="31" item="ESU FnOut A18 Slider 7" mask="XXXVVVVV">
-                            <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
-                                <relation>ge</relation>
-                                <value>28</value>
-                            </qualifier>
-                            <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
-                                <relation>ne</relation>
-                                <value>29</value>
-                            </qualifier>
-                            <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
-                                <relation>ne</relation>
-                                <value>30</value>
-                            </qualifier>
-                            <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
-                                <relation>ne</relation>
-                                <value>31</value>
-                            </qualifier>
-                            <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
-                                <relation>ne</relation>
-                                <value>32</value>
-                            </qualifier>
-                            <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
-                                <relation>le</relation>
-                                <value>33</value>
-                            </qualifier>
-                            <decVal max="31"/>
-                            <label xml:lang="de">Stärke des Kupplers</label>
-                        </variable>
-                        <variable label="Fan Speed" CV="16.0.414" default="31" item="ESU FnOut A18 Slider 11" mask="XXXVVVVV">
-                            <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
-                                <relation>eq</relation>
-                                <value>23</value>
-                            </qualifier>
-                            <decVal max="31"/>
-                            <label xml:lang="de">Geschwindigkeit</label>
-                        </variable>
-                        <variable label="Standing heat" CV="16.0.414" default="31" item="ESU FnOut A18 Slider 14" mask="XXXVVVVV">
-                            <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
-                                <relation>eq</relation>
-                                <value>24</value>
-                            </qualifier>
-                            <decVal max="31"/>
-                            <label xml:lang="de">Heizstufe im Stand</label>
-                        </variable>
-                        <variable label="Chuff power" CV="16.0.414" default="31" item="ESU FnOut A18 Slider 8" mask="XXXVVVVV">
-                            <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
-                                <relation>eq</relation>
-                                <value>25</value>
-                            </qualifier>
-                            <decVal max="31"/>
-                            <label xml:lang="de">Dampfstoßstärke</label>
-                        </variable>
-                        <variable label="Duration (speed) A" CV="16.0.410" default="31" item="ESU FnOut A18 Slider 4" mask="XXVVVVVV">
-                            <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
-                                <relation>eq</relation>
-                                <value>27</value>
-                            </qualifier>
-                            <decVal max="63"/>
-                            <label xml:lang="de">Dauer (Geschwindigkeit)</label>
-                        </variable>
-                        <variable label="Duration (speed) B" CV="16.0.414" default="31" item="ESU FnOut A18 Slider 17" mask="XXVVVVVV">
-                            <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
-                                <relation>eq</relation>
-                                <value>27</value>
-                            </qualifier>
-                            <decVal max="63"/>
-                            <label xml:lang="de">Dauer (Geschwindigkeit)</label>
-                        </variable>
-                        <variable item="Special Function CV415" label="Special Function CV 1" CV="16.0.415" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
-                            <decVal/>
-                        </variable>
-                        <variable label="Fan Acceleration rate" CV="16.0.415" default="0" item="ESU FnOut A18 Slider 12" mask="XXXVVVVV">
-                            <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
-                                <relation>eq</relation>
-                                <value>23</value>
-                            </qualifier>
-                            <decVal max="31"/>
-                            <label xml:lang="de">Beschleunigungszeit</label>
-                        </variable>
-                        <variable label="Minimum driving heat" CV="16.0.415" default="0" item="ESU FnOut A18 Slider 15" mask="XXXVVVVV">
-                            <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
-                                <relation>eq</relation>
-                                <value>24</value>
-                            </qualifier>
-                            <decVal max="31"/>
-                            <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
-                        </variable>
-                        <variable label="Position A" CV="16.0.415" default="0" item="ESU FnOut A18 Slider 18" mask="XXVVVVVV">
-                            <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
-                                <relation>eq</relation>
-                                <value>27</value>
-                            </qualifier>
-                            <decVal max="63"/>
-                        </variable>
-                        <variable label="Fan power" CV="16.0.415" default="0" item="ESU FnOut A18 Slider 9" mask="XXXVVVVV">
-                            <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
-                                <relation>eq</relation>
-                                <value>25</value>
-                            </qualifier>
-                            <decVal max="31"/>
-                            <label xml:lang="de">Stäke des Bläsers</label>
-                        </variable>
-                        <variable label="Phase Reverse" CV="16.0.415" default="0" item="ESU FnOut A18 Check 6" mask="XXXXXXXV">
-                            <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
-                                <relation>gt</relation>
-                                <value>0</value>
-                            </qualifier>
-                            <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
-                                <relation>le</relation>
-                                <value>15</value>
-                            </qualifier>
-                            <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                            <label xml:lang="de">Phase tauschen</label>
-                        </variable>
-                        <variable label="Grade Crossing" CV="16.0.415" default="0" item="ESU FnOut A18 Check 1" mask="XXXXXXVX">
-                            <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
-                                <relation>gt</relation>
-                                <value>0</value>
-                            </qualifier>
-                            <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
-                                <relation>le</relation>
-                                <value>15</value>
-                            </qualifier>
-                            <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                        </variable>
-                        <variable label="Rule 17 Fwd" CV="16.0.415" default="0" item="ESU FnOut A18 Check 2" mask="XXXXXVXX">
-                            <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
-                                <relation>gt</relation>
-                                <value>0</value>
-                            </qualifier>
-                            <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                             <label xml:lang="de">Rule 17 vorwärts</label>
                         </variable>
-                        <variable label="Rule 17 Rev" CV="16.0.415" default="0" item="ESU FnOut A18 Check 3" mask="XXXXVXXX">
+                        <variable label="Rule 17 Rev" CV="16.0.367" default="0" item="ESU FnOut A12 Check 3" mask="XXXXVXXX">
                             <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                             <label xml:lang="de">Rule 17 rückwärts</label>
                         </variable>
-                        <variable label="Dimmer" CV="16.0.415" default="0" item="ESU FnOut A18 Check 4" mask="XXXVXXXX">
+                        <variable label="Dimmer" CV="16.0.367" default="0" item="ESU FnOut A12 Check 4" mask="XXXVXXXX">
                             <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                             <label xml:lang="de">Abdimmen</label>
                         </variable>
-                        <variable label="LED Mode" CV="16.0.415" default="0" item="ESU FnOut A18 Check 5" mask="VXXXXXXX">
+                        <variable label="LED Mode" CV="16.0.367" default="0" item="ESU FnOut A12 Check 5" mask="VXXXXXXX">
                             <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                             <label xml:lang="de">LED Modus</label>
                         </variable>
-                        <variable item="Special Function CV416" label="Special Function CV 2" CV="16.0.416" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                        <variable item="Special Function CV368" label="Special Function CV 2" CV="16.0.368" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
                             <decVal/>
                         </variable>
-                        <variable label="Fan Decceleration rate" CV="16.0.416" default="0" item="ESU FnOut A18 Slider 13" mask="XXXVVVVV">
+                        <variable label="Fan Decceleration rate" CV="16.0.368" default="0" item="ESU FnOut A12 Slider 13" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>23</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Bremszeit</label>
                         </variable>
-                        <variable label="Maximum driving heat" CV="16.0.416" default="0" item="ESU FnOut A18 Slider 16" mask="XXXVVVVV">
+                        <variable label="Maximum driving heat" CV="16.0.368" default="0" item="ESU FnOut A12 Slider 16" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>24</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
                         </variable>
-                        <variable label="Timeout" CV="16.0.416" default="0" item="ESU FnOut A18 Slider 10" tooltip="Units = 0.25 sec">
+                        <variable label="Timeout" CV="16.0.368" default="0" item="ESU FnOut A12 Slider 10" tooltip="Units = 0.25 sec">
                             <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>25</value>
                             </qualifier>
                             <decVal/>
                         </variable>
-                        <variable label="Startup Time" CV="16.0.416" default="0" item="ESU FnOut A18 Slider 6">
+                        <variable label="Startup Time" CV="16.0.368" default="0" item="ESU FnOut A12 Slider 6">
                             <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>ge</relation>
                                 <value>16</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>le</relation>
                                 <value>17</value>
                             </qualifier>
                             <decVal/>
                             <label xml:lang="de">Startzeit</label>
                         </variable>
-                        <variable label="Level" CV="16.0.416" default="0" item="ESU FnOut A18 Slider 20" mask="XVVVVVVV">
+                        <variable label="Level" CV="16.0.368" default="0" item="ESU FnOut A12 Slider 20" mask="XVVVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>19</value>
                             </qualifier>
                             <decVal max="127"/>
                         </variable>
-                        <variable label="Position B" CV="16.0.416" default="0" item="ESU FnOut A18 Slider 19" mask="XXVVVVVV">
+                        <variable label="Position B" CV="16.0.368" default="0" item="ESU FnOut A12 Slider 19" mask="XXVVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A18 Mode</variableref>
+                                <variableref>ESU FnOut A12 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>27</value>
                             </qualifier>
                             <decVal max="63"/>
                         </variable>
+                        <!-- exclude AUX13 to AUX18 -->
+                        <variables exclude="LokSound 5 Fx,LokSound 5 Fx DCC,LokPilot 5 Fx,LokPilot 5 Fx DCC">                <!-- AUX13 Mode -->
+                            <variable label="AUX13 Mode" CV="16.0.371" default="1" item="ESU FnOut A13 Mode">
+                                <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
+                            </variable>
+                            <variable label="Function Switch On Delay" CV="16.0.372" default="0" item="ESU FnOut A13 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>ne</relation>
+                                    <value>27</value>
+                                </qualifier>
+                                <decVal max="15"/>
+                                <label xml:lang="de">Verzögerung beim Einschalten</label>
+                            </variable>
+                            <variable label="Function Switch Off Delay" CV="16.0.372" default="0" mask="VVVVXXXX" item="ESU FnOut A13 Slider 2" tooltip="Units = 0.4 sec">
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>ne</relation>
+                                    <value>27</value>
+                                </qualifier>
+                                <decVal max="15"/>
+                                <label xml:lang="de">Verzögerung beim Ausschalten</label>
+                            </variable>
+                            <variable label="Function Auto Switch Off" CV="16.0.373" default="0" item="ESU FnOut A13 Slider 3" tooltip="Units = 0.4 sec">
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>ne</relation>
+                                    <value>27</value>
+                                </qualifier>
+                                <decVal/>
+                                <label xml:lang="de">Ausgang automatisch Ausschalten</label>
+                            </variable>
+                            <variable item="Brightness CV374" label="Brightness CV" CV="16.0.374" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
+                                <decVal/>
+                            </variable>
+                            <variable label="Brightness" CV="16.0.374" default="31" item="ESU FnOut A13 Slider 5" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>18</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Helligkeit</label>
+                            </variable>
+                            <variable label="Mode" CV="16.0.374" default="0" item="ESU FnOut A13 Option 1" mask="XXXXXXXV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>22</value>
+                                </qualifier>
+                                <enumVal>
+                                    <enumChoice choice="Heating control">
+                                        <choice>Heating control</choice>
+                                        <choice xml:lang="de">Heizungssteuerung</choice>
+                                    </enumChoice>
+                                    <enumChoice choice="Fan control">
+                                        <choice>Fan control</choice>
+                                        <choice xml:lang="de">Lüftersteuerung</choice>
+                                    </enumChoice>
+                                </enumVal>
+                                <label xml:lang="de">Modus</label>
+                            </variable>
+                            <variable label="Coupler Force" CV="16.0.374" default="31" item="ESU FnOut A13 Slider 7" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>ge</relation>
+                                    <value>28</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>ne</relation>
+                                    <value>29</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>ne</relation>
+                                    <value>30</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>ne</relation>
+                                    <value>31</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>ne</relation>
+                                    <value>32</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>33</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Stärke des Kupplers</label>
+                            </variable>
+                            <variable label="Fan Speed" CV="16.0.374" default="31" item="ESU FnOut A13 Slider 11" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>23</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Geschwindigkeit</label>
+                            </variable>
+                            <variable label="Standing heat" CV="16.0.374" default="31" item="ESU FnOut A13 Slider 14" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>24</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Heizstufe im Stand</label>
+                            </variable>
+                            <variable label="Chuff power" CV="16.0.374" default="31" item="ESU FnOut A13 Slider 8" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>25</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Dampfstoßstärke</label>
+                            </variable>
+                            <variable item="Special Function CV375" label="Special Function CV 1" CV="16.0.375" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                                <decVal/>
+                            </variable>
+                            <variable label="Fan Acceleration rate" CV="16.0.375" default="0" item="ESU FnOut A13 Slider 12" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>23</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Beschleunigungszeit</label>
+                            </variable>
+                            <variable label="Minimum driving heat" CV="16.0.375" default="0" item="ESU FnOut A13 Slider 15" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>24</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
+                            </variable>
+                            <variable label="Fan power" CV="16.0.375" default="0" item="ESU FnOut A13 Slider 9" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>25</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Stäke des Bläsers</label>
+                            </variable>
+                            <variable label="Phase Reverse" CV="16.0.375" default="0" item="ESU FnOut A13 Check 6" mask="XXXXXXXV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                                <label xml:lang="de">Phase tauschen</label>
+                            </variable>
+                            <variable label="Grade Crossing" CV="16.0.375" default="0" item="ESU FnOut A13 Check 1" mask="XXXXXXVX">
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                            </variable>
+                            <variable label="Rule 17 Fwd" CV="16.0.375" default="0" item="ESU FnOut A13 Check 2" mask="XXXXXVXX">
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                                <label xml:lang="de">Rule 17 vorwärts</label>
+                            </variable>
+                            <variable label="Rule 17 Rev" CV="16.0.375" default="0" item="ESU FnOut A13 Check 3" mask="XXXXVXXX">
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                                <label xml:lang="de">Rule 17 rückwärts</label>
+                            </variable>
+                            <variable label="Dimmer" CV="16.0.375" default="0" item="ESU FnOut A13 Check 4" mask="XXXVXXXX">
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                                <label xml:lang="de">Abdimmen</label>
+                            </variable>
+                            <variable label="LED Mode" CV="16.0.375" default="0" item="ESU FnOut A13 Check 5" mask="VXXXXXXX">
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                                <label xml:lang="de">LED Modus</label>
+                            </variable>
+                            <variable item="Special Function CV376" label="Special Function CV 2" CV="16.0.376" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                                <decVal/>
+                            </variable>
+                            <variable label="Fan Decceleration rate" CV="16.0.376" default="0" item="ESU FnOut A13 Slider 13" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>23</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Bremszeit</label>
+                            </variable>
+                            <variable label="Maximum driving heat" CV="16.0.376" default="0" item="ESU FnOut A13 Slider 16" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>24</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
+                            </variable>
+                            <variable label="Timeout" CV="16.0.376" default="0" item="ESU FnOut A13 Slider 10" tooltip="Units = 0.25 sec">
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>25</value>
+                                </qualifier>
+                                <decVal/>
+                            </variable>
+                            <variable label="Startup Time" CV="16.0.376" default="0" item="ESU FnOut A13 Slider 6">
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>ge</relation>
+                                    <value>16</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>17</value>
+                                </qualifier>
+                                <decVal/>
+                                <label xml:lang="de">Startzeit</label>
+                            </variable>
+                            <variable label="Level" CV="16.0.376" default="0" item="ESU FnOut A13 Slider 20" mask="XVVVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A13 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>19</value>
+                                </qualifier>
+                                <decVal max="127"/>
+                            </variable>
+                            <!-- AUX14 Mode -->
+                            <variable label="AUX14 Mode" CV="16.0.379" default="1" item="ESU FnOut A14 Mode">
+                                <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
+                            </variable>
+                            <variable label="Function Switch On Delay" CV="16.0.380" default="0" item="ESU FnOut A14 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>ne</relation>
+                                    <value>27</value>
+                                </qualifier>
+                                <decVal max="15"/>
+                                <label xml:lang="de">Verzögerung beim Einschalten</label>
+                            </variable>
+                            <variable label="Function Switch Off Delay" CV="16.0.380" default="0" mask="VVVVXXXX" item="ESU FnOut A14 Slider 2" tooltip="Units = 0.4 sec">
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>ne</relation>
+                                    <value>27</value>
+                                </qualifier>
+                                <decVal max="15"/>
+                                <label xml:lang="de">Verzögerung beim Ausschalten</label>
+                            </variable>
+                            <variable label="Function Auto Switch Off" CV="16.0.381" default="0" item="ESU FnOut A14 Slider 3" tooltip="Units = 0.4 sec">
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>ne</relation>
+                                    <value>27</value>
+                                </qualifier>
+                                <decVal/>
+                                <label xml:lang="de">Ausgang automatisch Ausschalten</label>
+                            </variable>
+                            <variable item="Brightness CV382" label="Brightness CV" CV="16.0.382" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
+                                <decVal/>
+                            </variable>
+                            <variable label="Brightness" CV="16.0.382" default="31" item="ESU FnOut A14 Slider 5" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>18</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Helligkeit</label>
+                            </variable>
+                            <variable label="Mode" CV="16.0.382" default="0" item="ESU FnOut A14 Option 1" mask="XXXXXXXV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>22</value>
+                                </qualifier>
+                                <enumVal>
+                                    <enumChoice choice="Heating control">
+                                        <choice>Heating control</choice>
+                                        <choice xml:lang="de">Heizungssteuerung</choice>
+                                    </enumChoice>
+                                    <enumChoice choice="Fan control">
+                                        <choice>Fan control</choice>
+                                        <choice xml:lang="de">Lüftersteuerung</choice>
+                                    </enumChoice>
+                                </enumVal>
+                                <label xml:lang="de">Modus</label>
+                            </variable>
+                            <variable label="Coupler Force" CV="16.0.382" default="31" item="ESU FnOut A14 Slider 7" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>ge</relation>
+                                    <value>28</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>ne</relation>
+                                    <value>29</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>ne</relation>
+                                    <value>30</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>ne</relation>
+                                    <value>31</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>ne</relation>
+                                    <value>32</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>33</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Stärke des Kupplers</label>
+                            </variable>
+                            <variable label="Fan Speed" CV="16.0.382" default="31" item="ESU FnOut A14 Slider 11" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>23</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Geschwindigkeit</label>
+                            </variable>
+                            <variable label="Standing heat" CV="16.0.382" default="31" item="ESU FnOut A14 Slider 14" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>24</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Heizstufe im Stand</label>
+                            </variable>
+                            <variable label="Chuff power" CV="16.0.382" default="31" item="ESU FnOut A14 Slider 8" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>25</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Dampfstoßstärke</label>
+                            </variable>
+                            <variable item="Special Function CV383" label="Special Function CV 1" CV="16.0.383" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                                <decVal/>
+                            </variable>
+                            <variable label="Fan Acceleration rate" CV="16.0.383" default="0" item="ESU FnOut A14 Slider 12" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>23</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Beschleunigungszeit</label>
+                            </variable>
+                            <variable label="Minimum driving heat" CV="16.0.383" default="0" item="ESU FnOut A14 Slider 15" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>24</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
+                            </variable>
+                            <variable label="Fan power" CV="16.0.383" default="0" item="ESU FnOut A14 Slider 9" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>25</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Stäke des Bläsers</label>
+                            </variable>
+                            <variable label="Phase Reverse" CV="16.0.383" default="0" item="ESU FnOut A14 Check 6" mask="XXXXXXXV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                                <label xml:lang="de">Phase tauschen</label>
+                            </variable>
+                            <variable label="Grade Crossing" CV="16.0.383" default="0" item="ESU FnOut A14 Check 1" mask="XXXXXXVX">
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                            </variable>
+                            <variable label="Rule 17 Fwd" CV="16.0.383" default="0" item="ESU FnOut A14 Check 2" mask="XXXXXVXX">
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                                <label xml:lang="de">Rule 17 vorwärts</label>
+                            </variable>
+                            <variable label="Rule 17 Rev" CV="16.0.383" default="0" item="ESU FnOut A14 Check 3" mask="XXXXVXXX">
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                                <label xml:lang="de">Rule 17 rückwärts</label>
+                            </variable>
+                            <variable label="Dimmer" CV="16.0.383" default="0" item="ESU FnOut A14 Check 4" mask="XXXVXXXX">
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                                <label xml:lang="de">Abdimmen</label>
+                            </variable>
+                            <variable label="LED Mode" CV="16.0.383" default="0" item="ESU FnOut A14 Check 5" mask="VXXXXXXX">
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                                <label xml:lang="de">LED Modus</label>
+                            </variable>
+                            <variable item="Special Function CV384" label="Special Function CV 2" CV="16.0.384" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                                <decVal/>
+                            </variable>
+                            <variable label="Fan Decceleration rate" CV="16.0.384" default="0" item="ESU FnOut A14 Slider 13" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>23</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Bremszeit</label>
+                            </variable>
+                            <variable label="Maximum driving heat" CV="16.0.384" default="0" item="ESU FnOut A14 Slider 16" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>24</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
+                            </variable>
+                            <variable label="Timeout" CV="16.0.384" default="0" item="ESU FnOut A14 Slider 10" tooltip="Units = 0.25 sec">
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>25</value>
+                                </qualifier>
+                                <decVal/>
+                            </variable>
+                            <variable label="Startup Time" CV="16.0.384" default="0" item="ESU FnOut A14 Slider 6">
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>ge</relation>
+                                    <value>16</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>17</value>
+                                </qualifier>
+                                <decVal/>
+                                <label xml:lang="de">Startzeit</label>
+                            </variable>
+                            <variable label="Level" CV="16.0.384" default="0" item="ESU FnOut A14 Slider 20" mask="XVVVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A14 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>19</value>
+                                </qualifier>
+                                <decVal max="127"/>
+                            </variable>
+                            <!-- AUX15 Mode -->
+                            <variable label="AUX15 Mode" CV="16.0.387" default="1" item="ESU FnOut A15 Mode">
+                                <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
+                            </variable>
+                            <variable label="Function Switch On Delay" CV="16.0.388" default="0" item="ESU FnOut A15 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <decVal max="15"/>
+                                <label xml:lang="de">Verzögerung beim Einschalten</label>
+                            </variable>
+                            <variable label="Function Switch Off Delay" CV="16.0.388" default="0" mask="VVVVXXXX" item="ESU FnOut A15 Slider 2" tooltip="Units = 0.4 sec">
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <decVal max="15"/>
+                                <label xml:lang="de">Verzögerung beim Ausschalten</label>
+                            </variable>
+                            <variable label="Function Auto Switch Off" CV="16.0.389" default="0" item="ESU FnOut A15 Slider 3" tooltip="Units = 0.4 sec">
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <decVal/>
+                                <label xml:lang="de">Ausgang automatisch Ausschalten</label>
+                            </variable>
+                            <variable item="Brightness CV390" label="Brightness CV" CV="16.0.390" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
+                                <decVal/>
+                            </variable>
+                            <variable label="Brightness" CV="16.0.390" default="31" item="ESU FnOut A15 Slider 5" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>18</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Helligkeit</label>
+                            </variable>
+                            <variable label="Mode" CV="16.0.390" default="0" item="ESU FnOut A15 Option 1" mask="XXXXXXXV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>22</value>
+                                </qualifier>
+                                <enumVal>
+                                    <enumChoice choice="Heating control">
+                                        <choice>Heating control</choice>
+                                        <choice xml:lang="de">Heizungssteuerung</choice>
+                                    </enumChoice>
+                                    <enumChoice choice="Fan control">
+                                        <choice>Fan control</choice>
+                                        <choice xml:lang="de">Lüftersteuerung</choice>
+                                    </enumChoice>
+                                </enumVal>
+                                <label xml:lang="de">Modus</label>
+                            </variable>
+                            <variable label="Coupler Force" CV="16.0.390" default="31" item="ESU FnOut A15 Slider 7" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>ge</relation>
+                                    <value>28</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>ne</relation>
+                                    <value>29</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>ne</relation>
+                                    <value>30</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>ne</relation>
+                                    <value>31</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>ne</relation>
+                                    <value>32</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>33</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Stärke des Kupplers</label>
+                            </variable>
+                            <variable label="Fan Speed" CV="16.0.390" default="31" item="ESU FnOut A15 Slider 11" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>23</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Geschwindigkeit</label>
+                            </variable>
+                            <variable label="Standing heat" CV="16.0.390" default="31" item="ESU FnOut A15 Slider 14" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>24</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Heizstufe im Stand</label>
+                            </variable>
+                            <variable label="Chuff power" CV="16.0.390" default="31" item="ESU FnOut A15 Slider 8" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>25</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Dampfstoßstärke</label>
+                            </variable>
+                            <variable label="Duration (speed) A" CV="16.0.386" default="31" item="ESU FnOut A15 Slider 4" mask="XXVVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>27</value>
+                                </qualifier>
+                                <decVal max="63"/>
+                                <label xml:lang="de">Dauer (Geschwindigkeit)</label>
+                            </variable>
+                            <variable label="Duration (speed) B" CV="16.0.390" default="31" item="ESU FnOut A15 Slider 17" mask="XXVVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>27</value>
+                                </qualifier>
+                                <decVal max="63"/>
+                                <label xml:lang="de">Dauer (Geschwindigkeit)</label>
+                            </variable>
+                            <variable item="Special Function CV391" label="Special Function CV 1" CV="16.0.391" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                                <decVal/>
+                            </variable>
+                            <variable label="Fan Acceleration rate" CV="16.0.391" default="0" item="ESU FnOut A15 Slider 12" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>23</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Beschleunigungszeit</label>
+                            </variable>
+                            <variable label="Minimum driving heat" CV="16.0.391" default="0" item="ESU FnOut A15 Slider 15" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>24</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
+                            </variable>
+                            <variable label="Position A" CV="16.0.391" default="0" item="ESU FnOut A15 Slider 18" mask="XXVVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>27</value>
+                                </qualifier>
+                                <decVal max="63"/>
+                            </variable>
+                            <variable label="Fan power" CV="16.0.391" default="0" item="ESU FnOut A15 Slider 9" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>25</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Stäke des Bläsers</label>
+                            </variable>
+                            <variable label="Phase Reverse" CV="16.0.391" default="0" item="ESU FnOut A15 Check 6" mask="XXXXXXXV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                                <label xml:lang="de">Phase tauschen</label>
+                            </variable>
+                            <variable label="Grade Crossing" CV="16.0.391" default="0" item="ESU FnOut A15 Check 1" mask="XXXXXXVX">
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                            </variable>
+                            <variable label="Rule 17 Fwd" CV="16.0.391" default="0" item="ESU FnOut A15 Check 2" mask="XXXXXVXX">
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                                <label xml:lang="de">Rule 17 vorwärts</label>
+                            </variable>
+                            <variable label="Rule 17 Rev" CV="16.0.391" default="0" item="ESU FnOut A15 Check 3" mask="XXXXVXXX">
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                                <label xml:lang="de">Rule 17 rückwärts</label>
+                            </variable>
+                            <variable label="Dimmer" CV="16.0.391" default="0" item="ESU FnOut A15 Check 4" mask="XXXVXXXX">
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                                <label xml:lang="de">Abdimmen</label>
+                            </variable>
+                            <variable label="LED Mode" CV="16.0.391" default="0" item="ESU FnOut A15 Check 5" mask="VXXXXXXX">
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                                <label xml:lang="de">LED Modus</label>
+                            </variable>
+                            <variable item="Special Function CV392" label="Special Function CV 2" CV="16.0.392" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                                <decVal/>
+                            </variable>
+                            <variable label="Fan Decceleration rate" CV="16.0.392" default="0" item="ESU FnOut A15 Slider 13" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>23</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Bremszeit</label>
+                            </variable>
+                            <variable label="Maximum driving heat" CV="16.0.392" default="0" item="ESU FnOut A15 Slider 16" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>24</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
+                            </variable>
+                            <variable label="Timeout" CV="16.0.392" default="0" item="ESU FnOut A15 Slider 10" tooltip="Units = 0.25 sec">
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>25</value>
+                                </qualifier>
+                                <decVal/>
+                            </variable>
+                            <variable label="Startup Time" CV="16.0.392" default="0" item="ESU FnOut A15 Slider 6">
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>ge</relation>
+                                    <value>16</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>17</value>
+                                </qualifier>
+                                <decVal/>
+                                <label xml:lang="de">Startzeit</label>
+                            </variable>
+                            <variable label="Level" CV="16.0.392" default="0" item="ESU FnOut A15 Slider 20" mask="XVVVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>19</value>
+                                </qualifier>
+                                <decVal max="127"/>
+                            </variable>
+                            <variable label="Position B" CV="16.0.392" default="0" item="ESU FnOut A15 Slider 19" mask="XXVVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A15 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>27</value>
+                                </qualifier>
+                                <decVal max="63"/>
+                            </variable>
+                            <!-- AUX16 Mode -->
+                            <variable label="AUX16 Mode" CV="16.0.395" default="1" item="ESU FnOut A16 Mode">
+                                <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
+                            </variable>
+                            <variable label="Function Switch On Delay" CV="16.0.396" default="0" item="ESU FnOut A16 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <decVal max="15"/>
+                                <label xml:lang="de">Verzögerung beim Einschalten</label>
+                            </variable>
+                            <variable label="Function Switch Off Delay" CV="16.0.396" default="0" mask="VVVVXXXX" item="ESU FnOut A16 Slider 2" tooltip="Units = 0.4 sec">
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <decVal max="15"/>
+                                <label xml:lang="de">Verzögerung beim Ausschalten</label>
+                            </variable>
+                            <variable label="Function Auto Switch Off" CV="16.0.397" default="0" item="ESU FnOut A16 Slider 3" tooltip="Units = 0.4 sec">
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <decVal/>
+                                <label xml:lang="de">Ausgang automatisch Ausschalten</label>
+                            </variable>
+                            <variable item="Brightness CV398" label="Brightness CV" CV="16.0.398" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
+                                <decVal/>
+                            </variable>
+                            <variable label="Brightness" CV="16.0.398" default="31" item="ESU FnOut A16 Slider 5" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>18</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Helligkeit</label>
+                            </variable>
+                            <variable label="Mode" CV="16.0.398" default="0" item="ESU FnOut A16 Option 1" mask="XXXXXXXV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>22</value>
+                                </qualifier>
+                                <enumVal>
+                                    <enumChoice choice="Heating control">
+                                        <choice>Heating control</choice>
+                                        <choice xml:lang="de">Heizungssteuerung</choice>
+                                    </enumChoice>
+                                    <enumChoice choice="Fan control">
+                                        <choice>Fan control</choice>
+                                        <choice xml:lang="de">Lüftersteuerung</choice>
+                                    </enumChoice>
+                                </enumVal>
+                                <label xml:lang="de">Modus</label>
+                            </variable>
+                            <variable label="Coupler Force" CV="16.0.398" default="31" item="ESU FnOut A16 Slider 7" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>ge</relation>
+                                    <value>28</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>ne</relation>
+                                    <value>29</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>ne</relation>
+                                    <value>30</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>ne</relation>
+                                    <value>31</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>ne</relation>
+                                    <value>32</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>33</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Stärke des Kupplers</label>
+                            </variable>
+                            <variable label="Fan Speed" CV="16.0.398" default="31" item="ESU FnOut A16 Slider 11" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>23</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Geschwindigkeit</label>
+                            </variable>
+                            <variable label="Standing heat" CV="16.0.398" default="31" item="ESU FnOut A16 Slider 14" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>24</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Heizstufe im Stand</label>
+                            </variable>
+                            <variable label="Chuff power" CV="16.0.398" default="31" item="ESU FnOut A16 Slider 8" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>25</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Dampfstoßstärke</label>
+                            </variable>
+                            <variable label="Duration (speed) A" CV="16.0.394" default="31" item="ESU FnOut A16 Slider 4" mask="XXVVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>27</value>
+                                </qualifier>
+                                <decVal max="63"/>
+                                <label xml:lang="de">Dauer (Geschwindigkeit)</label>
+                            </variable>
+                            <variable label="Duration (speed) B" CV="16.0.398" default="31" item="ESU FnOut A16 Slider 17" mask="XXVVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>27</value>
+                                </qualifier>
+                                <decVal max="63"/>
+                                <label xml:lang="de">Dauer (Geschwindigkeit)</label>
+                            </variable>
+                            <variable item="Special Function CV399" label="Special Function CV 1" CV="16.0.399" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                                <decVal/>
+                            </variable>
+                            <variable label="Fan Acceleration rate" CV="16.0.399" default="0" item="ESU FnOut A16 Slider 12" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>23</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Beschleunigungszeit</label>
+                            </variable>
+                            <variable label="Minimum driving heat" CV="16.0.399" default="0" item="ESU FnOut A16 Slider 15" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>24</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
+                            </variable>
+                            <variable label="Position A" CV="16.0.399" default="0" item="ESU FnOut A16 Slider 18" mask="XXVVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>27</value>
+                                </qualifier>
+                                <decVal max="63"/>
+                            </variable>
+                            <variable label="Fan power" CV="16.0.399" default="0" item="ESU FnOut A16 Slider 9" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>25</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Stäke des Bläsers</label>
+                            </variable>
+                            <variable label="Phase Reverse" CV="16.0.399" default="0" item="ESU FnOut A16 Check 6" mask="XXXXXXXV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                                <label xml:lang="de">Phase tauschen</label>
+                            </variable>
+                            <variable label="Grade Crossing" CV="16.0.399" default="0" item="ESU FnOut A16 Check 1" mask="XXXXXXVX">
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                            </variable>
+                            <variable label="Rule 17 Fwd" CV="16.0.399" default="0" item="ESU FnOut A16 Check 2" mask="XXXXXVXX">
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                                <label xml:lang="de">Rule 17 vorwärts</label>
+                            </variable>
+                            <variable label="Rule 17 Rev" CV="16.0.399" default="0" item="ESU FnOut A16 Check 3" mask="XXXXVXXX">
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                                <label xml:lang="de">Rule 17 rückwärts</label>
+                            </variable>
+                            <variable label="Dimmer" CV="16.0.399" default="0" item="ESU FnOut A16 Check 4" mask="XXXVXXXX">
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                                <label xml:lang="de">Abdimmen</label>
+                            </variable>
+                            <variable label="LED Mode" CV="16.0.399" default="0" item="ESU FnOut A16 Check 5" mask="VXXXXXXX">
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                                <label xml:lang="de">LED Modus</label>
+                            </variable>
+                            <variable item="Special Function CV400" label="Special Function CV 2" CV="16.0.400" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                                <decVal/>
+                            </variable>
+                            <variable label="Fan Decceleration rate" CV="16.0.400" default="0" item="ESU FnOut A16 Slider 13" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>23</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Bremszeit</label>
+                            </variable>
+                            <variable label="Maximum driving heat" CV="16.0.400" default="0" item="ESU FnOut A16 Slider 16" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>24</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
+                            </variable>
+                            <variable label="Timeout" CV="16.0.400" default="0" item="ESU FnOut A16 Slider 10" tooltip="Units = 0.25 sec">
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>25</value>
+                                </qualifier>
+                                <decVal/>
+                            </variable>
+                            <variable label="Startup Time" CV="16.0.400" default="0" item="ESU FnOut A16 Slider 6">
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>ge</relation>
+                                    <value>16</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>17</value>
+                                </qualifier>
+                                <decVal/>
+                                <label xml:lang="de">Startzeit</label>
+                            </variable>
+                            <variable label="Level" CV="16.0.400" default="0" item="ESU FnOut A16 Slider 20" mask="XVVVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>19</value>
+                                </qualifier>
+                                <decVal max="127"/>
+                            </variable>
+                            <variable label="Position B" CV="16.0.400" default="0" item="ESU FnOut A16 Slider 19" mask="XXVVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A16 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>27</value>
+                                </qualifier>
+                                <decVal max="63"/>
+                            </variable>
+                            <!-- AUX17 Mode -->
+                            <variable label="AUX17 Mode" CV="16.0.403" default="1" item="ESU FnOut A17 Mode">
+                                <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
+                            </variable>
+                            <variable label="Function Switch On Delay" CV="16.0.404" default="0" item="ESU FnOut A17 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <decVal max="15"/>
+                                <label xml:lang="de">Verzögerung beim Einschalten</label>
+                            </variable>
+                            <variable label="Function Switch Off Delay" CV="16.0.404" default="0" mask="VVVVXXXX" item="ESU FnOut A17 Slider 2" tooltip="Units = 0.4 sec">
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <decVal max="15"/>
+                                <label xml:lang="de">Verzögerung beim Ausschalten</label>
+                            </variable>
+                            <variable label="Function Auto Switch Off" CV="16.0.405" default="0" item="ESU FnOut A17 Slider 3" tooltip="Units = 0.4 sec">
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <decVal/>
+                                <label xml:lang="de">Ausgang automatisch Ausschalten</label>
+                            </variable>
+                            <variable item="Brightness CV406" label="Brightness CV" CV="16.0.406" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
+                                <decVal/>
+                            </variable>
+                            <variable label="Brightness" CV="16.0.406" default="31" item="ESU FnOut A17 Slider 5" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>18</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Helligkeit</label>
+                            </variable>
+                            <variable label="Mode" CV="16.0.406" default="0" item="ESU FnOut A17 Option 1" mask="XXXXXXXV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>22</value>
+                                </qualifier>
+                                <enumVal>
+                                    <enumChoice choice="Heating control">
+                                        <choice>Heating control</choice>
+                                        <choice xml:lang="de">Heizungssteuerung</choice>
+                                    </enumChoice>
+                                    <enumChoice choice="Fan control">
+                                        <choice>Fan control</choice>
+                                        <choice xml:lang="de">Lüftersteuerung</choice>
+                                    </enumChoice>
+                                </enumVal>
+                                <label xml:lang="de">Modus</label>
+                            </variable>
+                            <variable label="Coupler Force" CV="16.0.406" default="31" item="ESU FnOut A17 Slider 7" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>ge</relation>
+                                    <value>28</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>ne</relation>
+                                    <value>29</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>ne</relation>
+                                    <value>30</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>ne</relation>
+                                    <value>31</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>ne</relation>
+                                    <value>32</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>33</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Stärke des Kupplers</label>
+                            </variable>
+                            <variable label="Fan Speed" CV="16.0.406" default="31" item="ESU FnOut A17 Slider 11" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>23</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Geschwindigkeit</label>
+                            </variable>
+                            <variable label="Standing heat" CV="16.0.406" default="31" item="ESU FnOut A17 Slider 14" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>24</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Heizstufe im Stand</label>
+                            </variable>
+                            <variable label="Chuff power" CV="16.0.406" default="31" item="ESU FnOut A17 Slider 8" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>25</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Dampfstoßstärke</label>
+                            </variable>
+                            <variable label="Duration (speed) A" CV="16.0.402" default="31" item="ESU FnOut A17 Slider 4" mask="XXVVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>27</value>
+                                </qualifier>
+                                <decVal max="63"/>
+                                <label xml:lang="de">Dauer (Geschwindigkeit)</label>
+                            </variable>
+                            <variable label="Duration (speed) B" CV="16.0.406" default="31" item="ESU FnOut A17 Slider 17" mask="XXVVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>27</value>
+                                </qualifier>
+                                <decVal max="63"/>
+                                <label xml:lang="de">Dauer (Geschwindigkeit)</label>
+                            </variable>
+                            <variable item="Special Function CV407" label="Special Function CV 1" CV="16.0.407" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                                <decVal/>
+                            </variable>
+                            <variable label="Fan Acceleration rate" CV="16.0.407" default="0" item="ESU FnOut A17 Slider 12" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>23</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Beschleunigungszeit</label>
+                            </variable>
+                            <variable label="Minimum driving heat" CV="16.0.407" default="0" item="ESU FnOut A17 Slider 15" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>24</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
+                            </variable>
+                            <variable label="Position A" CV="16.0.407" default="0" item="ESU FnOut A17 Slider 18" mask="XXVVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>27</value>
+                                </qualifier>
+                                <decVal max="63"/>
+                            </variable>
+                            <variable label="Fan power" CV="16.0.407" default="0" item="ESU FnOut A17 Slider 9" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>25</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Stäke des Bläsers</label>
+                            </variable>
+                            <variable label="Phase Reverse" CV="16.0.407" default="0" item="ESU FnOut A17 Check 6" mask="XXXXXXXV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                                <label xml:lang="de">Phase tauschen</label>
+                            </variable>
+                            <variable label="Grade Crossing" CV="16.0.407" default="0" item="ESU FnOut A17 Check 1" mask="XXXXXXVX">
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                            </variable>
+                            <variable label="Rule 17 Fwd" CV="16.0.407" default="0" item="ESU FnOut A17 Check 2" mask="XXXXXVXX">
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                                <label xml:lang="de">Rule 17 vorwärts</label>
+                            </variable>
+                            <variable label="Rule 17 Rev" CV="16.0.407" default="0" item="ESU FnOut A17 Check 3" mask="XXXXVXXX">
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                                <label xml:lang="de">Rule 17 rückwärts</label>
+                            </variable>
+                            <variable label="Dimmer" CV="16.0.407" default="0" item="ESU FnOut A17 Check 4" mask="XXXVXXXX">
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                                <label xml:lang="de">Abdimmen</label>
+                            </variable>
+                            <variable label="LED Mode" CV="16.0.407" default="0" item="ESU FnOut A17 Check 5" mask="VXXXXXXX">
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                                <label xml:lang="de">LED Modus</label>
+                            </variable>
+                            <variable item="Special Function CV408" label="Special Function CV 2" CV="16.0.408" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                                <decVal/>
+                            </variable>
+                            <variable label="Fan Decceleration rate" CV="16.0.408" default="0" item="ESU FnOut A17 Slider 13" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>23</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Bremszeit</label>
+                            </variable>
+                            <variable label="Maximum driving heat" CV="16.0.408" default="0" item="ESU FnOut A17 Slider 16" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>24</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
+                            </variable>
+                            <variable label="Timeout" CV="16.0.408" default="0" item="ESU FnOut A17 Slider 10" tooltip="Units = 0.25 sec">
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>25</value>
+                                </qualifier>
+                                <decVal/>
+                            </variable>
+                            <variable label="Startup Time" CV="16.0.408" default="0" item="ESU FnOut A17 Slider 6">
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>ge</relation>
+                                    <value>16</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>17</value>
+                                </qualifier>
+                                <decVal/>
+                                <label xml:lang="de">Startzeit</label>
+                            </variable>
+                            <variable label="Level" CV="16.0.408" default="0" item="ESU FnOut A17 Slider 20" mask="XVVVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>19</value>
+                                </qualifier>
+                                <decVal max="127"/>
+                            </variable>
+                            <variable label="Position B" CV="16.0.408" default="0" item="ESU FnOut A17 Slider 19" mask="XXVVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A17 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>27</value>
+                                </qualifier>
+                                <decVal max="63"/>
+                            </variable>
+                            <!-- AUX18 Mode -->
+                            <variable label="AUX18 Mode" CV="16.0.411" default="1" item="ESU FnOut A18 Mode">
+                                <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
+                            </variable>
+                            <variable label="Function Switch On Delay" CV="16.0.412" default="0" item="ESU FnOut A18 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <decVal max="15"/>
+                                <label xml:lang="de">Verzögerung beim Einschalten</label>
+                            </variable>
+                            <variable label="Function Switch Off Delay" CV="16.0.412" default="0" mask="VVVVXXXX" item="ESU FnOut A18 Slider 2" tooltip="Units = 0.4 sec">
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <decVal max="15"/>
+                                <label xml:lang="de">Verzögerung beim Ausschalten</label>
+                            </variable>
+                            <variable label="Function Auto Switch Off" CV="16.0.413" default="0" item="ESU FnOut A18 Slider 3" tooltip="Units = 0.4 sec">
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <decVal/>
+                                <label xml:lang="de">Ausgang automatisch Ausschalten</label>
+                            </variable>
+                            <variable item="Brightness CV414" label="Brightness CV" CV="16.0.414" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
+                                <decVal/>
+                            </variable>
+                            <variable label="Brightness" CV="16.0.414" default="31" item="ESU FnOut A18 Slider 5" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>18</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Helligkeit</label>
+                            </variable>
+                            <variable label="Mode" CV="16.0.414" default="0" item="ESU FnOut A18 Option 1" mask="XXXXXXXV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>22</value>
+                                </qualifier>
+                                <enumVal>
+                                    <enumChoice choice="Heating control">
+                                        <choice>Heating control</choice>
+                                        <choice xml:lang="de">Heizungssteuerung</choice>
+                                    </enumChoice>
+                                    <enumChoice choice="Fan control">
+                                        <choice>Fan control</choice>
+                                        <choice xml:lang="de">Lüftersteuerung</choice>
+                                    </enumChoice>
+                                </enumVal>
+                                <label xml:lang="de">Modus</label>
+                            </variable>
+                            <variable label="Coupler Force" CV="16.0.414" default="31" item="ESU FnOut A18 Slider 7" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>ge</relation>
+                                    <value>28</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>ne</relation>
+                                    <value>29</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>ne</relation>
+                                    <value>30</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>ne</relation>
+                                    <value>31</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>ne</relation>
+                                    <value>32</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>33</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Stärke des Kupplers</label>
+                            </variable>
+                            <variable label="Fan Speed" CV="16.0.414" default="31" item="ESU FnOut A18 Slider 11" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>23</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Geschwindigkeit</label>
+                            </variable>
+                            <variable label="Standing heat" CV="16.0.414" default="31" item="ESU FnOut A18 Slider 14" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>24</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Heizstufe im Stand</label>
+                            </variable>
+                            <variable label="Chuff power" CV="16.0.414" default="31" item="ESU FnOut A18 Slider 8" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>25</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Dampfstoßstärke</label>
+                            </variable>
+                            <variable label="Duration (speed) A" CV="16.0.410" default="31" item="ESU FnOut A18 Slider 4" mask="XXVVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>27</value>
+                                </qualifier>
+                                <decVal max="63"/>
+                                <label xml:lang="de">Dauer (Geschwindigkeit)</label>
+                            </variable>
+                            <variable label="Duration (speed) B" CV="16.0.414" default="31" item="ESU FnOut A18 Slider 17" mask="XXVVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>27</value>
+                                </qualifier>
+                                <decVal max="63"/>
+                                <label xml:lang="de">Dauer (Geschwindigkeit)</label>
+                            </variable>
+                            <variable item="Special Function CV415" label="Special Function CV 1" CV="16.0.415" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                                <decVal/>
+                            </variable>
+                            <variable label="Fan Acceleration rate" CV="16.0.415" default="0" item="ESU FnOut A18 Slider 12" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>23</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Beschleunigungszeit</label>
+                            </variable>
+                            <variable label="Minimum driving heat" CV="16.0.415" default="0" item="ESU FnOut A18 Slider 15" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>24</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
+                            </variable>
+                            <variable label="Position A" CV="16.0.415" default="0" item="ESU FnOut A18 Slider 18" mask="XXVVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>27</value>
+                                </qualifier>
+                                <decVal max="63"/>
+                            </variable>
+                            <variable label="Fan power" CV="16.0.415" default="0" item="ESU FnOut A18 Slider 9" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>25</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Stäke des Bläsers</label>
+                            </variable>
+                            <variable label="Phase Reverse" CV="16.0.415" default="0" item="ESU FnOut A18 Check 6" mask="XXXXXXXV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                                <label xml:lang="de">Phase tauschen</label>
+                            </variable>
+                            <variable label="Grade Crossing" CV="16.0.415" default="0" item="ESU FnOut A18 Check 1" mask="XXXXXXVX">
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                            </variable>
+                            <variable label="Rule 17 Fwd" CV="16.0.415" default="0" item="ESU FnOut A18 Check 2" mask="XXXXXVXX">
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                                <label xml:lang="de">Rule 17 vorwärts</label>
+                            </variable>
+                            <variable label="Rule 17 Rev" CV="16.0.415" default="0" item="ESU FnOut A18 Check 3" mask="XXXXVXXX">
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                                <label xml:lang="de">Rule 17 rückwärts</label>
+                            </variable>
+                            <variable label="Dimmer" CV="16.0.415" default="0" item="ESU FnOut A18 Check 4" mask="XXXVXXXX">
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                                <label xml:lang="de">Abdimmen</label>
+                            </variable>
+                            <variable label="LED Mode" CV="16.0.415" default="0" item="ESU FnOut A18 Check 5" mask="VXXXXXXX">
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>gt</relation>
+                                    <value>0</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>15</value>
+                                </qualifier>
+                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                                <label xml:lang="de">LED Modus</label>
+                            </variable>
+                            <variable item="Special Function CV416" label="Special Function CV 2" CV="16.0.416" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                                <decVal/>
+                            </variable>
+                            <variable label="Fan Decceleration rate" CV="16.0.416" default="0" item="ESU FnOut A18 Slider 13" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>23</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Bremszeit</label>
+                            </variable>
+                            <variable label="Maximum driving heat" CV="16.0.416" default="0" item="ESU FnOut A18 Slider 16" mask="XXXVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>24</value>
+                                </qualifier>
+                                <decVal max="31"/>
+                                <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
+                            </variable>
+                            <variable label="Timeout" CV="16.0.416" default="0" item="ESU FnOut A18 Slider 10" tooltip="Units = 0.25 sec">
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>25</value>
+                                </qualifier>
+                                <decVal/>
+                            </variable>
+                            <variable label="Startup Time" CV="16.0.416" default="0" item="ESU FnOut A18 Slider 6">
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>ge</relation>
+                                    <value>16</value>
+                                </qualifier>
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>le</relation>
+                                    <value>17</value>
+                                </qualifier>
+                                <decVal/>
+                                <label xml:lang="de">Startzeit</label>
+                            </variable>
+                            <variable label="Level" CV="16.0.416" default="0" item="ESU FnOut A18 Slider 20" mask="XVVVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>19</value>
+                                </qualifier>
+                                <decVal max="127"/>
+                            </variable>
+                            <variable label="Position B" CV="16.0.416" default="0" item="ESU FnOut A18 Slider 19" mask="XXVVVVVV">
+                                <qualifier>
+                                    <variableref>ESU FnOut A18 Mode</variableref>
+                                    <relation>eq</relation>
+                                    <value>27</value>
+                                </qualifier>
+                                <decVal max="63"/>
+                            </variable>
+                        </variables>
                     </variables>
                 </variables>
             </variables>
         </variables>
     </variables>
-    </variables>
     <!-- Exclude [2] outputs to avoid tripping over a firmware bug -->
     <!-- At least up to 5.8.156 (current as of writing this) these functions are not -->
     <!-- accessible through standard CV programming on ESU 58751 -->
     <variables exclude="LokSound 5 micro DCC Direct Atlas Legacy">
-	<!-- Headlight [2] Mode -->
-	<variable label="Headlight [2] Mode" CV="16.0.419" default="1" item="ESU FnOut HL-2 Mode">
+        <!-- Headlight [2] Mode -->
+        <variable label="Headlight [2] Mode" CV="16.0.419" default="1" item="ESU FnOut HL-2 Mode">
             <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
             <!--label xml:lang="de">Licht vorn - 2</label-->
         </variable>
@@ -6297,1200 +6297,1200 @@
             <decVal max="15"/>
             <label xml:lang="de">Verzögerung beim Ausschalten</label>
         </variable>
-	<variable label="Function Auto Switch Off" CV="16.0.421" default="0" item="ESU FnOut HL-2 Slider 3" tooltip="Units = 0.4 sec">
-	    <qualifier>
-		<variableref>ESU FnOut HL-2 Mode</variableref>
-		<relation>gt</relation>
-		<value>0</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut HL-2 Mode</variableref>
-		<relation>ne</relation>
-		<value>27</value>
-	    </qualifier>
-	    <decVal/>
-	    <label xml:lang="de">Ausgang automatisch Ausschalten</label>
-	</variable>
-	<variable item="Brightness CV422" label="Brightness CV" CV="16.0.422" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
-	    <decVal/>
-	</variable>
-	<variable label="Brightness" CV="16.0.422" default="31" item="ESU FnOut HL-2 Slider 5" mask="XXXVVVVV">
-	    <qualifier>
-		<variableref>ESU FnOut HL-2 Mode</variableref>
-		<relation>gt</relation>
-		<value>0</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut HL-2 Mode</variableref>
-		<relation>le</relation>
-		<value>18</value>
-	    </qualifier>
-	    <decVal max="31"/>
-	    <label xml:lang="de">Helligkeit</label>
-	</variable>
-	<variable label="Mode" CV="16.0.422" default="0" item="ESU FnOut HL-2 Option 1" mask="XXXXXXXV">
-	    <qualifier>
-		<variableref>ESU FnOut HL-2 Mode</variableref>
-		<relation>eq</relation>
-		<value>22</value>
-	    </qualifier>
-	    <enumVal>
-		<enumChoice choice="Heating control">
-		    <choice>Heating control</choice>
-		    <choice xml:lang="de">Heizungssteuerung</choice>
-		</enumChoice>
-		<enumChoice choice="Fan control">
-		    <choice>Fan control</choice>
-		    <choice xml:lang="de">Lüftersteuerung</choice>
-		</enumChoice>
-	    </enumVal>
-	    <label xml:lang="de">Modus</label>
-	</variable>
-	<variable label="Coupler Force" CV="16.0.422" default="31" item="ESU FnOut HL-2 Slider 7" mask="XXXVVVVV">
-	    <qualifier>
-		<variableref>ESU FnOut HL-2 Mode</variableref>
-		<relation>ge</relation>
-		<value>28</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut HL-2 Mode</variableref>
-		<relation>ne</relation>
-		<value>29</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut HL-2 Mode</variableref>
-		<relation>ne</relation>
-		<value>30</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut HL-2 Mode</variableref>
-		<relation>ne</relation>
-		<value>31</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut HL-2 Mode</variableref>
-		<relation>ne</relation>
-		<value>32</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut HL-2 Mode</variableref>
-		<relation>le</relation>
-		<value>33</value>
-	    </qualifier>
-	    <decVal max="31"/>
-	    <label xml:lang="de">Stärke des Kupplers</label>
-	</variable>
-	<variable label="Fan Speed" CV="16.0.422" default="31" item="ESU FnOut HL-2 Slider 11" mask="XXXVVVVV">
-	    <qualifier>
-		<variableref>ESU FnOut HL-2 Mode</variableref>
-		<relation>eq</relation>
-		<value>23</value>
-	    </qualifier>
-	    <decVal max="31"/>
-	    <label xml:lang="de">Geschwindigkeit</label>
-	</variable>
-	<variable label="Standing heat" CV="16.0.422" default="31" item="ESU FnOut HL-2 Slider 14" mask="XXXVVVVV">
-	    <qualifier>
-		<variableref>ESU FnOut HL-2 Mode</variableref>
-		<relation>eq</relation>
-		<value>24</value>
-	    </qualifier>
-	    <decVal max="31"/>
-	    <label xml:lang="de">Heizstufe im Stand</label>
-	</variable>
-	<variable label="Chuff power" CV="16.0.422" default="31" item="ESU FnOut HL-2 Slider 8" mask="XXXVVVVV">
-	    <qualifier>
-		<variableref>ESU FnOut HL-2 Mode</variableref>
-		<relation>eq</relation>
-		<value>25</value>
-	    </qualifier>
-	    <decVal max="31"/>
-	    <label xml:lang="de">Dampfstoßstärke</label>
-	</variable>
-	<variable item="Special Function CV423" label="Special Function CV 1" CV="16.0.423" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
-	    <decVal/>
-	</variable>
-	<variable label="Fan Acceleration rate" CV="16.0.423" default="0" item="ESU FnOut HL-2 Slider 12" mask="XXXVVVVV">
-	    <qualifier>
-		<variableref>ESU FnOut HL-2 Mode</variableref>
-		<relation>eq</relation>
-		<value>23</value>
-	    </qualifier>
-	    <decVal max="31"/>
-	    <label xml:lang="de">Beschleunigungszeit</label>
-	</variable>
-	<variable label="Minimum driving heat" CV="16.0.423" default="0" item="ESU FnOut HL-2 Slider 15" mask="XXXVVVVV">
-	    <qualifier>
-		<variableref>ESU FnOut HL-2 Mode</variableref>
-		<relation>eq</relation>
-		<value>24</value>
-	    </qualifier>
-	    <decVal max="31"/>
-	    <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
-	</variable>
-	<variable label="Fan power" CV="16.0.423" default="0" item="ESU FnOut HL-2 Slider 9" mask="XXXVVVVV">
-	    <qualifier>
-		<variableref>ESU FnOut HL-2 Mode</variableref>
-		<relation>eq</relation>
-		<value>25</value>
-	    </qualifier>
-	    <decVal max="31"/>
-	    <label xml:lang="de">Stäke des Bläsers</label>
-	</variable>
-	<variable label="Phase Reverse" CV="16.0.423" default="0" item="ESU FnOut HL-2 Check 6" mask="XXXXXXXV">
-	    <qualifier>
-		<variableref>ESU FnOut HL-2 Mode</variableref>
-		<relation>gt</relation>
-		<value>0</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut HL-2 Mode</variableref>
-		<relation>le</relation>
-		<value>15</value>
-	    </qualifier>
-	    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-	    <label xml:lang="de">Phase tauschen</label>
-	</variable>
-	<variable label="Grade Crossing" CV="16.0.423" default="0" item="ESU FnOut HL-2 Check 1" mask="XXXXXXVX">
-	    <qualifier>
-		<variableref>ESU FnOut HL-2 Mode</variableref>
-		<relation>gt</relation>
-		<value>0</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut HL-2 Mode</variableref>
-		<relation>le</relation>
-		<value>15</value>
-	    </qualifier>
-	    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-	</variable>
-	<variable label="Rule 17 Fwd" CV="16.0.423" default="0" item="ESU FnOut HL-2 Check 2" mask="XXXXXVXX">
-	    <qualifier>
-		<variableref>ESU FnOut HL-2 Mode</variableref>
-		<relation>gt</relation>
-		<value>0</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut HL-2 Mode</variableref>
-		<relation>le</relation>
-		<value>15</value>
-	    </qualifier>
-	    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-	    <label xml:lang="de">Rule 17 vorwärts</label>
-	</variable>
-	<variable label="Rule 17 Rev" CV="16.0.423" default="0" item="ESU FnOut HL-2 Check 3" mask="XXXXVXXX">
-	    <qualifier>
-		<variableref>ESU FnOut HL-2 Mode</variableref>
-		<relation>gt</relation>
-		<value>0</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut HL-2 Mode</variableref>
-		<relation>le</relation>
-		<value>15</value>
-	    </qualifier>
-	    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-	    <label xml:lang="de">Rule 17 rückwärts</label>
-	</variable>
-	<variable label="Dimmer" CV="16.0.423" default="0" item="ESU FnOut HL-2 Check 4" mask="XXXVXXXX">
-	    <qualifier>
-		<variableref>ESU FnOut HL-2 Mode</variableref>
-		<relation>gt</relation>
-		<value>0</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut HL-2 Mode</variableref>
-		<relation>le</relation>
-		<value>15</value>
-	    </qualifier>
-	    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-	    <label xml:lang="de">Abdimmen</label>
-	</variable>
-	<variable label="LED Mode" CV="16.0.423" default="0" item="ESU FnOut HL-2 Check 5" mask="VXXXXXXX">
-	    <qualifier>
-		<variableref>ESU FnOut HL-2 Mode</variableref>
-		<relation>gt</relation>
-		<value>0</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut HL-2 Mode</variableref>
-		<relation>le</relation>
-		<value>15</value>
-	    </qualifier>
-	    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-	    <label xml:lang="de">LED Modus</label>
-	</variable>
-	<variable item="Special Function CV424" label="Special Function CV 2" CV="16.0.424" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
-	    <decVal/>
-	</variable>
-	<variable label="Fan Decceleration rate" CV="16.0.424" default="0" item="ESU FnOut HL-2 Slider 13" mask="XXXVVVVV">
-	    <qualifier>
-		<variableref>ESU FnOut HL-2 Mode</variableref>
-		<relation>eq</relation>
-		<value>23</value>
-	    </qualifier>
-	    <decVal max="31"/>
-	    <label xml:lang="de">Bremszeit</label>
-	</variable>
-	<variable label="Maximum driving heat" CV="16.0.424" default="0" item="ESU FnOut HL-2 Slider 16" mask="XXXVVVVV">
-	    <qualifier>
-		<variableref>ESU FnOut HL-2 Mode</variableref>
-		<relation>eq</relation>
-		<value>24</value>
-	    </qualifier>
-	    <decVal max="31"/>
-	    <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
-	</variable>
-	<variable label="Timeout" CV="16.0.424" default="0" item="ESU FnOut HL-2 Slider 10" tooltip="Units = 0.25 sec">
-	    <qualifier>
-		<variableref>ESU FnOut HL-2 Mode</variableref>
-		<relation>eq</relation>
-		<value>25</value>
-	    </qualifier>
-	    <decVal/>
-	</variable>
-	<variable label="Startup Time" CV="16.0.424" default="0" item="ESU FnOut HL-2 Slider 6">
-	    <qualifier>
-		<variableref>ESU FnOut HL-2 Mode</variableref>
-		<relation>ge</relation>
-		<value>16</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut HL-2 Mode</variableref>
-		<relation>le</relation>
-		<value>17</value>
-	    </qualifier>
-	    <decVal/>
-	    <label xml:lang="de">Startzeit</label>
-	</variable>
-	<variable label="Level" CV="16.0.424" default="0" item="ESU FnOut HL-2 Slider 20" mask="XVVVVVVV">
-	    <qualifier>
-		<variableref>ESU FnOut HL-2 Mode</variableref>
-		<relation>eq</relation>
-		<value>19</value>
-	    </qualifier>
-	    <decVal max="127"/>
-	</variable>
-	<!-- Rearlight [2] Mode -->
-	<variable label="Rearlight [2] Mode" CV="16.0.427" default="1" item="ESU FnOut RL-2 Mode">
-	    <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
-	</variable>
-	<variable label="Function Switch On Delay" CV="16.0.428" default="0" item="ESU FnOut RL-2 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
-	    <qualifier>
-		<variableref>ESU FnOut RL-2 Mode</variableref>
-		<relation>gt</relation>
-		<value>0</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut RL-2 Mode</variableref>
-		<relation>ne</relation>
-		<value>27</value>
-	    </qualifier>
-	    <decVal max="15"/>
-	    <label xml:lang="de">Verzögerung beim Einschalten</label>
-	</variable>
-	<variable label="Function Switch Off Delay" CV="16.0.428" default="0" mask="VVVVXXXX" item="ESU FnOut RL-2 Slider 2" tooltip="Units = 0.4 sec">
-	    <qualifier>
-		<variableref>ESU FnOut RL-2 Mode</variableref>
-		<relation>gt</relation>
-		<value>0</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut RL-2 Mode</variableref>
-		<relation>ne</relation>
-		<value>27</value>
-	    </qualifier>
-	    <decVal max="15"/>
-	    <label xml:lang="de">Verzögerung beim Ausschalten</label>
-	</variable>
-	<variable label="Function Auto Switch Off" CV="16.0.429" default="0" item="ESU FnOut RL-2 Slider 3" tooltip="Units = 0.4 sec">
-	    <qualifier>
-		<variableref>ESU FnOut RL-2 Mode</variableref>
-		<relation>gt</relation>
-		<value>0</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut RL-2 Mode</variableref>
-		<relation>ne</relation>
-		<value>27</value>
-	    </qualifier>
-	    <decVal/>
-	    <label xml:lang="de">Ausgang automatisch Ausschalten</label>
-	</variable>
-	<variable item="Brightness CV430" label="Brightness CV" CV="16.0.430" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
-	    <decVal/>
-	</variable>
-	<variable label="Brightness" CV="16.0.430" default="31" item="ESU FnOut RL-2 Slider 5" mask="XXXVVVVV">
-	    <qualifier>
-		<variableref>ESU FnOut RL-2 Mode</variableref>
-		<relation>gt</relation>
-		<value>0</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut RL-2 Mode</variableref>
-		<relation>le</relation>
-		<value>18</value>
-	    </qualifier>
-	    <decVal max="31"/>
-	    <label xml:lang="de">Helligkeit</label>
-	</variable>
-	<variable label="Mode" CV="16.0.430" default="0" item="ESU FnOut RL-2 Option 1" mask="XXXXXXXV">
-	    <qualifier>
-		<variableref>ESU FnOut RL-2 Mode</variableref>
-		<relation>eq</relation>
-		<value>22</value>
-	    </qualifier>
-	    <enumVal>
-		<enumChoice choice="Heating control">
-		    <choice>Heating control</choice>
-		    <choice xml:lang="de">Heizungssteuerung</choice>
-		</enumChoice>
-		<enumChoice choice="Fan control">
-		    <choice>Fan control</choice>
-		    <choice xml:lang="de">Lüftersteuerung</choice>
-		</enumChoice>
-	    </enumVal>
-	    <label xml:lang="de">Modus</label>
-	</variable>
-	<variable label="Coupler Force" CV="16.0.430" default="31" item="ESU FnOut RL-2 Slider 7" mask="XXXVVVVV">
-	    <qualifier>
-		<variableref>ESU FnOut RL-2 Mode</variableref>
-		<relation>ge</relation>
-		<value>28</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut RL-2 Mode</variableref>
-		<relation>ne</relation>
-		<value>29</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut RL-2 Mode</variableref>
-		<relation>ne</relation>
-		<value>30</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut RL-2 Mode</variableref>
-		<relation>ne</relation>
-		<value>31</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut RL-2 Mode</variableref>
-		<relation>ne</relation>
-		<value>32</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut RL-2 Mode</variableref>
-		<relation>le</relation>
-		<value>33</value>
-	    </qualifier>
-	    <decVal max="31"/>
-	    <label xml:lang="de">Stärke des Kupplers</label>
-	</variable>
-	<variable label="Fan Speed" CV="16.0.430" default="31" item="ESU FnOut RL-2 Slider 11" mask="XXXVVVVV">
-	    <qualifier>
-		<variableref>ESU FnOut RL-2 Mode</variableref>
-		<relation>eq</relation>
-		<value>23</value>
-	    </qualifier>
-	    <decVal max="31"/>
-	    <label xml:lang="de">Geschwindigkeit</label>
-	</variable>
-	<variable label="Standing heat" CV="16.0.430" default="31" item="ESU FnOut RL-2 Slider 14" mask="XXXVVVVV">
-	    <qualifier>
-		<variableref>ESU FnOut RL-2 Mode</variableref>
-		<relation>eq</relation>
-		<value>24</value>
-	    </qualifier>
-	    <decVal max="31"/>
-	    <label xml:lang="de">Heizstufe im Stand</label>
-	</variable>
-	<variable label="Chuff power" CV="16.0.430" default="31" item="ESU FnOut RL-2 Slider 8" mask="XXXVVVVV">
-	    <qualifier>
-		<variableref>ESU FnOut RL-2 Mode</variableref>
-		<relation>eq</relation>
-		<value>25</value>
-	    </qualifier>
-	    <decVal max="31"/>
-	    <label xml:lang="de">Dampfstoßstärke</label>
-	</variable>
-	<variable item="Special Function CV431" label="Special Function CV 1" CV="16.0.431" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
-	    <decVal/>
-	</variable>
-	<variable label="Fan Acceleration rate" CV="16.0.431" default="0" item="ESU FnOut RL-2 Slider 12" mask="XXXVVVVV">
-	    <qualifier>
-		<variableref>ESU FnOut RL-2 Mode</variableref>
-		<relation>eq</relation>
-		<value>23</value>
-	    </qualifier>
-	    <decVal max="31"/>
-	    <label xml:lang="de">Beschleunigungszeit</label>
-	</variable>
-	<variable label="Minimum driving heat" CV="16.0.431" default="0" item="ESU FnOut RL-2 Slider 15" mask="XXXVVVVV">
-	    <qualifier>
-		<variableref>ESU FnOut RL-2 Mode</variableref>
-		<relation>eq</relation>
-		<value>24</value>
-	    </qualifier>
-	    <decVal max="31"/>
-	    <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
-	</variable>
-	<variable label="Fan power" CV="16.0.431" default="0" item="ESU FnOut RL-2 Slider 9" mask="XXXVVVVV">
-	    <qualifier>
-		<variableref>ESU FnOut RL-2 Mode</variableref>
-		<relation>eq</relation>
-		<value>25</value>
-	    </qualifier>
-	    <decVal max="31"/>
-	    <label xml:lang="de">Stäke des Bläsers</label>
-	</variable>
-	<variable label="Phase Reverse" CV="16.0.431" default="0" item="ESU FnOut RL-2 Check 6" mask="XXXXXXXV">
-	    <qualifier>
-		<variableref>ESU FnOut RL-2 Mode</variableref>
-		<relation>gt</relation>
-		<value>0</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut RL-2 Mode</variableref>
-		<relation>le</relation>
-		<value>15</value>
-	    </qualifier>
-	    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-	    <label xml:lang="de">Phase tauschen</label>
-	</variable>
-	<variable label="Grade Crossing" CV="16.0.431" default="0" item="ESU FnOut RL-2 Check 1" mask="XXXXXXVX">
-	    <qualifier>
-		<variableref>ESU FnOut RL-2 Mode</variableref>
-		<relation>gt</relation>
-		<value>0</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut RL-2 Mode</variableref>
-		<relation>le</relation>
-		<value>15</value>
-	    </qualifier>
-	    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-	</variable>
-	<variable label="Rule 17 Fwd" CV="16.0.431" default="0" item="ESU FnOut RL-2 Check 2" mask="XXXXXVXX">
-	    <qualifier>
-		<variableref>ESU FnOut RL-2 Mode</variableref>
-		<relation>gt</relation>
-		<value>0</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut RL-2 Mode</variableref>
-		<relation>le</relation>
-		<value>15</value>
-	    </qualifier>
-	    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-	    <label xml:lang="de">Rule 17 vorwärts</label>
-	</variable>
-	<variable label="Rule 17 Rev" CV="16.0.431" default="0" item="ESU FnOut RL-2 Check 3" mask="XXXXVXXX">
-	    <qualifier>
-		<variableref>ESU FnOut RL-2 Mode</variableref>
-		<relation>gt</relation>
-		<value>0</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut RL-2 Mode</variableref>
-		<relation>le</relation>
-		<value>15</value>
-	    </qualifier>
-	    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-	    <label xml:lang="de">Rule 17 rückwärts</label>
-	</variable>
-	<variable label="Dimmer" CV="16.0.431" default="0" item="ESU FnOut RL-2 Check 4" mask="XXXVXXXX">
-	    <qualifier>
-		<variableref>ESU FnOut RL-2 Mode</variableref>
-		<relation>gt</relation>
-		<value>0</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut RL-2 Mode</variableref>
-		<relation>le</relation>
-		<value>15</value>
-	    </qualifier>
-	    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-	    <label xml:lang="de">Abdimmen</label>
-	</variable>
-	<variable label="LED Mode" CV="16.0.431" default="0" item="ESU FnOut RL-2 Check 5" mask="VXXXXXXX">
-	    <qualifier>
-		<variableref>ESU FnOut RL-2 Mode</variableref>
-		<relation>gt</relation>
-		<value>0</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut RL-2 Mode</variableref>
-		<relation>le</relation>
-		<value>15</value>
-	    </qualifier>
-	    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-	    <label xml:lang="de">LED Modus</label>
-	</variable>
-	<variable item="Special Function CV432" label="Special Function CV 2" CV="16.0.432" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
-	    <decVal/>
-	</variable>
-	<variable label="Fan Decceleration rate" CV="16.0.432" default="0" item="ESU FnOut RL-2 Slider 13" mask="XXXVVVVV">
-	    <qualifier>
-		<variableref>ESU FnOut RL-2 Mode</variableref>
-		<relation>eq</relation>
-		<value>23</value>
-	    </qualifier>
-	    <decVal max="31"/>
-	    <label xml:lang="de">Bremszeit</label>
-	</variable>
-	<variable label="Maximum driving heat" CV="16.0.432" default="0" item="ESU FnOut RL-2 Slider 16" mask="XXXVVVVV">
-	    <qualifier>
-		<variableref>ESU FnOut RL-2 Mode</variableref>
-		<relation>eq</relation>
-		<value>24</value>
-	    </qualifier>
-	    <decVal max="31"/>
-	    <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
-	</variable>
-	<variable label="Timeout" CV="16.0.432" default="0" item="ESU FnOut RL-2 Slider 10" tooltip="Units = 0.25 sec">
-	    <qualifier>
-		<variableref>ESU FnOut RL-2 Mode</variableref>
-		<relation>eq</relation>
-		<value>25</value>
-	    </qualifier>
-	    <decVal/>
-	</variable>
-	<variable label="Startup Time" CV="16.0.432" default="0" item="ESU FnOut RL-2 Slider 6">
-	    <qualifier>
-		<variableref>ESU FnOut RL-2 Mode</variableref>
-		<relation>ge</relation>
-		<value>16</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut RL-2 Mode</variableref>
-		<relation>le</relation>
-		<value>17</value>
-	    </qualifier>
-	    <decVal/>
-	    <label xml:lang="de">Startzeit</label>
-	</variable>
-	<variable label="Level" CV="16.0.432" default="0" item="ESU FnOut RL-2 Slider 20" mask="XVVVVVVV">
-	    <qualifier>
-		<variableref>ESU FnOut RL-2 Mode</variableref>
-		<relation>eq</relation>
-		<value>19</value>
-	    </qualifier>
-	    <decVal max="127"/>
-	</variable>
-	<!-- AUX1 [2] Mode -->
-	<variable label="AUX1 [2] Mode" CV="16.0.435" default="1" item="ESU FnOut A1-2 Mode">
-	    <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
-	</variable>
-	<variable label="Function Switch On Delay" CV="16.0.436" default="0" item="ESU FnOut A1-2 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
-	    <qualifier>
-		<variableref>ESU FnOut A1-2 Mode</variableref>
-		<relation>gt</relation>
-		<value>0</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut A1-2 Mode</variableref>
-		<relation>ne</relation>
-		<value>27</value>
-	    </qualifier>
-	    <decVal max="15"/>
-	    <label xml:lang="de">Verzögerung beim Einschalten</label>
-	</variable>
-	<variable label="Function Switch Off Delay" CV="16.0.436" default="0" mask="VVVVXXXX" item="ESU FnOut A1-2 Slider 2" tooltip="Units = 0.4 sec">
-	    <qualifier>
-		<variableref>ESU FnOut A1-2 Mode</variableref>
-		<relation>gt</relation>
-		<value>0</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut A1-2 Mode</variableref>
-		<relation>ne</relation>
-		<value>27</value>
-	    </qualifier>
-	    <decVal max="15"/>
-	    <label xml:lang="de">Verzögerung beim Ausschalten</label>
-	</variable>
-	<variable label="Function Auto Switch Off" CV="16.0.437" default="0" item="ESU FnOut A1-2 Slider 3" tooltip="Units = 0.4 sec">
-	    <qualifier>
-		<variableref>ESU FnOut A1-2 Mode</variableref>
-		<relation>gt</relation>
-		<value>0</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut A1-2 Mode</variableref>
-		<relation>ne</relation>
-		<value>27</value>
-	    </qualifier>
-	    <decVal/>
-	    <label xml:lang="de">Ausgang automatisch Ausschalten</label>
-	</variable>
-	<variable item="Brightness CV438" label="Brightness CV" CV="16.0.438" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
-	    <decVal/>
-	</variable>
-	<variable label="Brightness" CV="16.0.438" default="31" item="ESU FnOut A1-2 Slider 5" mask="XXXVVVVV">
-	    <qualifier>
-		<variableref>ESU FnOut A1-2 Mode</variableref>
-		<relation>gt</relation>
-		<value>0</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut A1-2 Mode</variableref>
-		<relation>le</relation>
-		<value>18</value>
-	    </qualifier>
-	    <decVal max="31"/>
-	    <label xml:lang="de">Helligkeit</label>
-	</variable>
-	<variable label="Mode" CV="16.0.438" default="0" item="ESU FnOut A1-2 Option 1" mask="XXXXXXXV">
-	    <qualifier>
-		<variableref>ESU FnOut A1-2 Mode</variableref>
-		<relation>eq</relation>
-		<value>22</value>
-	    </qualifier>
-	    <enumVal>
-		<enumChoice choice="Heating control">
-		    <choice>Heating control</choice>
-		    <choice xml:lang="de">Heizungssteuerung</choice>
-		</enumChoice>
-		<enumChoice choice="Fan control">
-		    <choice>Fan control</choice>
-		    <choice xml:lang="de">Lüftersteuerung</choice>
-		</enumChoice>
-	    </enumVal>
-	    <label xml:lang="de">Modus</label>
-	</variable>
-	<variable label="Coupler Force" CV="16.0.438" default="31" item="ESU FnOut A1-2 Slider 7" mask="XXXVVVVV">
-	    <qualifier>
-		<variableref>ESU FnOut A1-2 Mode</variableref>
-		<relation>ge</relation>
-		<value>28</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut A1-2 Mode</variableref>
-		<relation>ne</relation>
-		<value>29</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut A1-2 Mode</variableref>
-		<relation>ne</relation>
-		<value>30</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut A1-2 Mode</variableref>
-		<relation>ne</relation>
-		<value>31</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut A1-2 Mode</variableref>
-		<relation>ne</relation>
-		<value>32</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut A1-2 Mode</variableref>
-		<relation>le</relation>
-		<value>33</value>
-	    </qualifier>
-	    <decVal max="31"/>
-	    <label xml:lang="de">Stärke des Kupplers</label>
-	</variable>
-	<variable label="Fan Speed" CV="16.0.438" default="31" item="ESU FnOut A1-2 Slider 11" mask="XXXVVVVV">
-	    <qualifier>
-		<variableref>ESU FnOut A1-2 Mode</variableref>
-		<relation>eq</relation>
-		<value>23</value>
-	    </qualifier>
-	    <decVal max="31"/>
-	    <label xml:lang="de">Geschwindigkeit</label>
-	</variable>
-	<variable label="Standing heat" CV="16.0.438" default="31" item="ESU FnOut A1-2 Slider 14" mask="XXXVVVVV">
-	    <qualifier>
-		<variableref>ESU FnOut A1-2 Mode</variableref>
-		<relation>eq</relation>
-		<value>24</value>
-	    </qualifier>
-	    <decVal max="31"/>
-	    <label xml:lang="de">Heizstufe im Stand</label>
-	</variable>
-	<variable label="Chuff power" CV="16.0.438" default="31" item="ESU FnOut A1-2 Slider 8" mask="XXXVVVVV">
-	    <qualifier>
-		<variableref>ESU FnOut A1-2 Mode</variableref>
-		<relation>eq</relation>
-		<value>25</value>
-	    </qualifier>
-	    <decVal max="31"/>
-	    <label xml:lang="de">Dampfstoßstärke</label>
-	</variable>
-	<variable item="Special Function CV439" label="Special Function CV 1" CV="16.0.439" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
-	    <decVal/>
-	</variable>
-	<variable label="Fan Acceleration rate" CV="16.0.439" default="0" item="ESU FnOut A1-2 Slider 12" mask="XXXVVVVV">
-	    <qualifier>
-		<variableref>ESU FnOut A1-2 Mode</variableref>
-		<relation>eq</relation>
-		<value>23</value>
-	    </qualifier>
-	    <decVal max="31"/>
-	    <label xml:lang="de">Beschleunigungszeit</label>
-	</variable>
-	<variable label="Minimum driving heat" CV="16.0.439" default="0" item="ESU FnOut A1-2 Slider 15" mask="XXXVVVVV">
-	    <qualifier>
-		<variableref>ESU FnOut A1-2 Mode</variableref>
-		<relation>eq</relation>
-		<value>24</value>
-	    </qualifier>
-	    <decVal max="31"/>
-	    <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
-	</variable>
-	<variable label="Fan power" CV="16.0.439" default="0" item="ESU FnOut A1-2 Slider 9" mask="XXXVVVVV">
-	    <qualifier>
-		<variableref>ESU FnOut A1-2 Mode</variableref>
-		<relation>eq</relation>
-		<value>25</value>
-	    </qualifier>
-	    <decVal max="31"/>
-	    <label xml:lang="de">Stäke des Bläsers</label>
-	</variable>
-	<variable label="Phase Reverse" CV="16.0.439" default="0" item="ESU FnOut A1-2 Check 6" mask="XXXXXXXV">
-	    <qualifier>
-		<variableref>ESU FnOut A1-2 Mode</variableref>
-		<relation>gt</relation>
-		<value>0</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut A1-2 Mode</variableref>
-		<relation>le</relation>
-		<value>15</value>
-	    </qualifier>
-	    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-	    <label xml:lang="de">Phase tauschen</label>
-	</variable>
-	<variable label="Grade Crossing" CV="16.0.439" default="0" item="ESU FnOut A1-2 Check 1" mask="XXXXXXVX">
-	    <qualifier>
-		<variableref>ESU FnOut A1-2 Mode</variableref>
-		<relation>gt</relation>
-		<value>0</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut A1-2 Mode</variableref>
-		<relation>le</relation>
-		<value>15</value>
-	    </qualifier>
-	    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-	</variable>
-	<variable label="Rule 17 Fwd" CV="16.0.439" default="0" item="ESU FnOut A1-2 Check 2" mask="XXXXXVXX">
-	    <qualifier>
-		<variableref>ESU FnOut A1-2 Mode</variableref>
-		<relation>gt</relation>
-		<value>0</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut A1-2 Mode</variableref>
-		<relation>le</relation>
-		<value>15</value>
-	    </qualifier>
-	    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-	    <label xml:lang="de">Rule 17 vorwärts</label>
-	</variable>
-	<variable label="Rule 17 Rev" CV="16.0.439" default="0" item="ESU FnOut A1-2 Check 3" mask="XXXXVXXX">
-	    <qualifier>
-		<variableref>ESU FnOut A1-2 Mode</variableref>
-		<relation>gt</relation>
-		<value>0</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut A1-2 Mode</variableref>
-		<relation>le</relation>
-		<value>15</value>
-	    </qualifier>
-	    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-	    <label xml:lang="de">Rule 17 rückwärts</label>
-	</variable>
-	<variable label="Dimmer" CV="16.0.439" default="0" item="ESU FnOut A1-2 Check 4" mask="XXXVXXXX">
-	    <qualifier>
-		<variableref>ESU FnOut A1-2 Mode</variableref>
-		<relation>gt</relation>
-		<value>0</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut A1-2 Mode</variableref>
-		<relation>le</relation>
-		<value>15</value>
-	    </qualifier>
-	    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-	    <label xml:lang="de">Abdimmen</label>
-	</variable>
-	<variable label="LED Mode" CV="16.0.439" default="0" item="ESU FnOut A1-2 Check 5" mask="VXXXXXXX">
-	    <qualifier>
-		<variableref>ESU FnOut A1-2 Mode</variableref>
-		<relation>gt</relation>
-		<value>0</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut A1-2 Mode</variableref>
-		<relation>le</relation>
-		<value>15</value>
-	    </qualifier>
-	    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-	    <label xml:lang="de">LED Modus</label>
-	</variable>
-	<variable item="Special Function CV440" label="Special Function CV 2" CV="16.0.440" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
-	    <decVal/>
-	</variable>
-	<variable label="Fan Decceleration rate" CV="16.0.440" default="0" item="ESU FnOut A1-2 Slider 13" mask="XXXVVVVV">
-	    <qualifier>
-		<variableref>ESU FnOut A1-2 Mode</variableref>
-		<relation>eq</relation>
-		<value>23</value>
-	    </qualifier>
-	    <decVal max="31"/>
-	    <label xml:lang="de">Bremszeit</label>
-	</variable>
-	<variable label="Maximum driving heat" CV="16.0.440" default="0" item="ESU FnOut A1-2 Slider 16" mask="XXXVVVVV">
-	    <qualifier>
-		<variableref>ESU FnOut A1-2 Mode</variableref>
-		<relation>eq</relation>
-		<value>24</value>
-	    </qualifier>
-	    <decVal max="31"/>
-	    <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
-	</variable>
-	<variable label="Timeout" CV="16.0.440" default="0" item="ESU FnOut A1-2 Slider 10" tooltip="Units = 0.25 sec">
-	    <qualifier>
-		<variableref>ESU FnOut A1-2 Mode</variableref>
-		<relation>eq</relation>
-		<value>25</value>
-	    </qualifier>
-	    <decVal/>
-	</variable>
-	<variable label="Startup Time" CV="16.0.440" default="0" item="ESU FnOut A1-2 Slider 6">
-	    <qualifier>
-		<variableref>ESU FnOut A1-2 Mode</variableref>
-		<relation>ge</relation>
-		<value>16</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut A1-2 Mode</variableref>
-		<relation>le</relation>
-		<value>17</value>
-	    </qualifier>
-	    <decVal/>
-	    <label xml:lang="de">Startzeit</label>
-	</variable>
-	<variable label="Level" CV="16.0.440" default="0" item="ESU FnOut A1-2 Slider 20" mask="XVVVVVVV">
-	    <qualifier>
-		<variableref>ESU FnOut A1-2 Mode</variableref>
-		<relation>eq</relation>
-		<value>19</value>
-	    </qualifier>
-	    <decVal max="127"/>
-	</variable>
+        <variable label="Function Auto Switch Off" CV="16.0.421" default="0" item="ESU FnOut HL-2 Slider 3" tooltip="Units = 0.4 sec">
+            <qualifier>
+                <variableref>ESU FnOut HL-2 Mode</variableref>
+                <relation>gt</relation>
+                <value>0</value>
+            </qualifier>
+            <qualifier>
+                <variableref>ESU FnOut HL-2 Mode</variableref>
+                <relation>ne</relation>
+                <value>27</value>
+            </qualifier>
+            <decVal/>
+            <label xml:lang="de">Ausgang automatisch Ausschalten</label>
+        </variable>
+        <variable item="Brightness CV422" label="Brightness CV" CV="16.0.422" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
+            <decVal/>
+        </variable>
+        <variable label="Brightness" CV="16.0.422" default="31" item="ESU FnOut HL-2 Slider 5" mask="XXXVVVVV">
+            <qualifier>
+                <variableref>ESU FnOut HL-2 Mode</variableref>
+                <relation>gt</relation>
+                <value>0</value>
+            </qualifier>
+            <qualifier>
+                <variableref>ESU FnOut HL-2 Mode</variableref>
+                <relation>le</relation>
+                <value>18</value>
+            </qualifier>
+            <decVal max="31"/>
+            <label xml:lang="de">Helligkeit</label>
+        </variable>
+        <variable label="Mode" CV="16.0.422" default="0" item="ESU FnOut HL-2 Option 1" mask="XXXXXXXV">
+            <qualifier>
+                <variableref>ESU FnOut HL-2 Mode</variableref>
+                <relation>eq</relation>
+                <value>22</value>
+            </qualifier>
+            <enumVal>
+                <enumChoice choice="Heating control">
+                    <choice>Heating control</choice>
+                    <choice xml:lang="de">Heizungssteuerung</choice>
+                </enumChoice>
+                <enumChoice choice="Fan control">
+                    <choice>Fan control</choice>
+                    <choice xml:lang="de">Lüftersteuerung</choice>
+                </enumChoice>
+            </enumVal>
+            <label xml:lang="de">Modus</label>
+        </variable>
+        <variable label="Coupler Force" CV="16.0.422" default="31" item="ESU FnOut HL-2 Slider 7" mask="XXXVVVVV">
+            <qualifier>
+                <variableref>ESU FnOut HL-2 Mode</variableref>
+                <relation>ge</relation>
+                <value>28</value>
+            </qualifier>
+            <qualifier>
+                <variableref>ESU FnOut HL-2 Mode</variableref>
+                <relation>ne</relation>
+                <value>29</value>
+            </qualifier>
+            <qualifier>
+                <variableref>ESU FnOut HL-2 Mode</variableref>
+                <relation>ne</relation>
+                <value>30</value>
+            </qualifier>
+            <qualifier>
+                <variableref>ESU FnOut HL-2 Mode</variableref>
+                <relation>ne</relation>
+                <value>31</value>
+            </qualifier>
+            <qualifier>
+                <variableref>ESU FnOut HL-2 Mode</variableref>
+                <relation>ne</relation>
+                <value>32</value>
+            </qualifier>
+            <qualifier>
+                <variableref>ESU FnOut HL-2 Mode</variableref>
+                <relation>le</relation>
+                <value>33</value>
+            </qualifier>
+            <decVal max="31"/>
+            <label xml:lang="de">Stärke des Kupplers</label>
+        </variable>
+        <variable label="Fan Speed" CV="16.0.422" default="31" item="ESU FnOut HL-2 Slider 11" mask="XXXVVVVV">
+            <qualifier>
+                <variableref>ESU FnOut HL-2 Mode</variableref>
+                <relation>eq</relation>
+                <value>23</value>
+            </qualifier>
+            <decVal max="31"/>
+            <label xml:lang="de">Geschwindigkeit</label>
+        </variable>
+        <variable label="Standing heat" CV="16.0.422" default="31" item="ESU FnOut HL-2 Slider 14" mask="XXXVVVVV">
+            <qualifier>
+                <variableref>ESU FnOut HL-2 Mode</variableref>
+                <relation>eq</relation>
+                <value>24</value>
+            </qualifier>
+            <decVal max="31"/>
+            <label xml:lang="de">Heizstufe im Stand</label>
+        </variable>
+        <variable label="Chuff power" CV="16.0.422" default="31" item="ESU FnOut HL-2 Slider 8" mask="XXXVVVVV">
+            <qualifier>
+                <variableref>ESU FnOut HL-2 Mode</variableref>
+                <relation>eq</relation>
+                <value>25</value>
+            </qualifier>
+            <decVal max="31"/>
+            <label xml:lang="de">Dampfstoßstärke</label>
+        </variable>
+        <variable item="Special Function CV423" label="Special Function CV 1" CV="16.0.423" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+            <decVal/>
+        </variable>
+        <variable label="Fan Acceleration rate" CV="16.0.423" default="0" item="ESU FnOut HL-2 Slider 12" mask="XXXVVVVV">
+            <qualifier>
+                <variableref>ESU FnOut HL-2 Mode</variableref>
+                <relation>eq</relation>
+                <value>23</value>
+            </qualifier>
+            <decVal max="31"/>
+            <label xml:lang="de">Beschleunigungszeit</label>
+        </variable>
+        <variable label="Minimum driving heat" CV="16.0.423" default="0" item="ESU FnOut HL-2 Slider 15" mask="XXXVVVVV">
+            <qualifier>
+                <variableref>ESU FnOut HL-2 Mode</variableref>
+                <relation>eq</relation>
+                <value>24</value>
+            </qualifier>
+            <decVal max="31"/>
+            <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
+        </variable>
+        <variable label="Fan power" CV="16.0.423" default="0" item="ESU FnOut HL-2 Slider 9" mask="XXXVVVVV">
+            <qualifier>
+                <variableref>ESU FnOut HL-2 Mode</variableref>
+                <relation>eq</relation>
+                <value>25</value>
+            </qualifier>
+            <decVal max="31"/>
+            <label xml:lang="de">Stäke des Bläsers</label>
+        </variable>
+        <variable label="Phase Reverse" CV="16.0.423" default="0" item="ESU FnOut HL-2 Check 6" mask="XXXXXXXV">
+            <qualifier>
+                <variableref>ESU FnOut HL-2 Mode</variableref>
+                <relation>gt</relation>
+                <value>0</value>
+            </qualifier>
+            <qualifier>
+                <variableref>ESU FnOut HL-2 Mode</variableref>
+                <relation>le</relation>
+                <value>15</value>
+            </qualifier>
+            <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+            <label xml:lang="de">Phase tauschen</label>
+        </variable>
+        <variable label="Grade Crossing" CV="16.0.423" default="0" item="ESU FnOut HL-2 Check 1" mask="XXXXXXVX">
+            <qualifier>
+                <variableref>ESU FnOut HL-2 Mode</variableref>
+                <relation>gt</relation>
+                <value>0</value>
+            </qualifier>
+            <qualifier>
+                <variableref>ESU FnOut HL-2 Mode</variableref>
+                <relation>le</relation>
+                <value>15</value>
+            </qualifier>
+            <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+        </variable>
+        <variable label="Rule 17 Fwd" CV="16.0.423" default="0" item="ESU FnOut HL-2 Check 2" mask="XXXXXVXX">
+            <qualifier>
+                <variableref>ESU FnOut HL-2 Mode</variableref>
+                <relation>gt</relation>
+                <value>0</value>
+            </qualifier>
+            <qualifier>
+                <variableref>ESU FnOut HL-2 Mode</variableref>
+                <relation>le</relation>
+                <value>15</value>
+            </qualifier>
+            <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+            <label xml:lang="de">Rule 17 vorwärts</label>
+        </variable>
+        <variable label="Rule 17 Rev" CV="16.0.423" default="0" item="ESU FnOut HL-2 Check 3" mask="XXXXVXXX">
+            <qualifier>
+                <variableref>ESU FnOut HL-2 Mode</variableref>
+                <relation>gt</relation>
+                <value>0</value>
+            </qualifier>
+            <qualifier>
+                <variableref>ESU FnOut HL-2 Mode</variableref>
+                <relation>le</relation>
+                <value>15</value>
+            </qualifier>
+            <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+            <label xml:lang="de">Rule 17 rückwärts</label>
+        </variable>
+        <variable label="Dimmer" CV="16.0.423" default="0" item="ESU FnOut HL-2 Check 4" mask="XXXVXXXX">
+            <qualifier>
+                <variableref>ESU FnOut HL-2 Mode</variableref>
+                <relation>gt</relation>
+                <value>0</value>
+            </qualifier>
+            <qualifier>
+                <variableref>ESU FnOut HL-2 Mode</variableref>
+                <relation>le</relation>
+                <value>15</value>
+            </qualifier>
+            <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+            <label xml:lang="de">Abdimmen</label>
+        </variable>
+        <variable label="LED Mode" CV="16.0.423" default="0" item="ESU FnOut HL-2 Check 5" mask="VXXXXXXX">
+            <qualifier>
+                <variableref>ESU FnOut HL-2 Mode</variableref>
+                <relation>gt</relation>
+                <value>0</value>
+            </qualifier>
+            <qualifier>
+                <variableref>ESU FnOut HL-2 Mode</variableref>
+                <relation>le</relation>
+                <value>15</value>
+            </qualifier>
+            <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+            <label xml:lang="de">LED Modus</label>
+        </variable>
+        <variable item="Special Function CV424" label="Special Function CV 2" CV="16.0.424" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+            <decVal/>
+        </variable>
+        <variable label="Fan Decceleration rate" CV="16.0.424" default="0" item="ESU FnOut HL-2 Slider 13" mask="XXXVVVVV">
+            <qualifier>
+                <variableref>ESU FnOut HL-2 Mode</variableref>
+                <relation>eq</relation>
+                <value>23</value>
+            </qualifier>
+            <decVal max="31"/>
+            <label xml:lang="de">Bremszeit</label>
+        </variable>
+        <variable label="Maximum driving heat" CV="16.0.424" default="0" item="ESU FnOut HL-2 Slider 16" mask="XXXVVVVV">
+            <qualifier>
+                <variableref>ESU FnOut HL-2 Mode</variableref>
+                <relation>eq</relation>
+                <value>24</value>
+            </qualifier>
+            <decVal max="31"/>
+            <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
+        </variable>
+        <variable label="Timeout" CV="16.0.424" default="0" item="ESU FnOut HL-2 Slider 10" tooltip="Units = 0.25 sec">
+            <qualifier>
+                <variableref>ESU FnOut HL-2 Mode</variableref>
+                <relation>eq</relation>
+                <value>25</value>
+            </qualifier>
+            <decVal/>
+        </variable>
+        <variable label="Startup Time" CV="16.0.424" default="0" item="ESU FnOut HL-2 Slider 6">
+            <qualifier>
+                <variableref>ESU FnOut HL-2 Mode</variableref>
+                <relation>ge</relation>
+                <value>16</value>
+            </qualifier>
+            <qualifier>
+                <variableref>ESU FnOut HL-2 Mode</variableref>
+                <relation>le</relation>
+                <value>17</value>
+            </qualifier>
+            <decVal/>
+            <label xml:lang="de">Startzeit</label>
+        </variable>
+        <variable label="Level" CV="16.0.424" default="0" item="ESU FnOut HL-2 Slider 20" mask="XVVVVVVV">
+            <qualifier>
+                <variableref>ESU FnOut HL-2 Mode</variableref>
+                <relation>eq</relation>
+                <value>19</value>
+            </qualifier>
+            <decVal max="127"/>
+        </variable>
+        <!-- Rearlight [2] Mode -->
+        <variable label="Rearlight [2] Mode" CV="16.0.427" default="1" item="ESU FnOut RL-2 Mode">
+            <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
+        </variable>
+        <variable label="Function Switch On Delay" CV="16.0.428" default="0" item="ESU FnOut RL-2 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
+            <qualifier>
+                <variableref>ESU FnOut RL-2 Mode</variableref>
+                <relation>gt</relation>
+                <value>0</value>
+            </qualifier>
+            <qualifier>
+                <variableref>ESU FnOut RL-2 Mode</variableref>
+                <relation>ne</relation>
+                <value>27</value>
+            </qualifier>
+            <decVal max="15"/>
+            <label xml:lang="de">Verzögerung beim Einschalten</label>
+        </variable>
+        <variable label="Function Switch Off Delay" CV="16.0.428" default="0" mask="VVVVXXXX" item="ESU FnOut RL-2 Slider 2" tooltip="Units = 0.4 sec">
+            <qualifier>
+                <variableref>ESU FnOut RL-2 Mode</variableref>
+                <relation>gt</relation>
+                <value>0</value>
+            </qualifier>
+            <qualifier>
+                <variableref>ESU FnOut RL-2 Mode</variableref>
+                <relation>ne</relation>
+                <value>27</value>
+            </qualifier>
+            <decVal max="15"/>
+            <label xml:lang="de">Verzögerung beim Ausschalten</label>
+        </variable>
+        <variable label="Function Auto Switch Off" CV="16.0.429" default="0" item="ESU FnOut RL-2 Slider 3" tooltip="Units = 0.4 sec">
+            <qualifier>
+                <variableref>ESU FnOut RL-2 Mode</variableref>
+                <relation>gt</relation>
+                <value>0</value>
+            </qualifier>
+            <qualifier>
+                <variableref>ESU FnOut RL-2 Mode</variableref>
+                <relation>ne</relation>
+                <value>27</value>
+            </qualifier>
+            <decVal/>
+            <label xml:lang="de">Ausgang automatisch Ausschalten</label>
+        </variable>
+        <variable item="Brightness CV430" label="Brightness CV" CV="16.0.430" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
+            <decVal/>
+        </variable>
+        <variable label="Brightness" CV="16.0.430" default="31" item="ESU FnOut RL-2 Slider 5" mask="XXXVVVVV">
+            <qualifier>
+                <variableref>ESU FnOut RL-2 Mode</variableref>
+                <relation>gt</relation>
+                <value>0</value>
+            </qualifier>
+            <qualifier>
+                <variableref>ESU FnOut RL-2 Mode</variableref>
+                <relation>le</relation>
+                <value>18</value>
+            </qualifier>
+            <decVal max="31"/>
+            <label xml:lang="de">Helligkeit</label>
+        </variable>
+        <variable label="Mode" CV="16.0.430" default="0" item="ESU FnOut RL-2 Option 1" mask="XXXXXXXV">
+            <qualifier>
+                <variableref>ESU FnOut RL-2 Mode</variableref>
+                <relation>eq</relation>
+                <value>22</value>
+            </qualifier>
+            <enumVal>
+                <enumChoice choice="Heating control">
+                    <choice>Heating control</choice>
+                    <choice xml:lang="de">Heizungssteuerung</choice>
+                </enumChoice>
+                <enumChoice choice="Fan control">
+                    <choice>Fan control</choice>
+                    <choice xml:lang="de">Lüftersteuerung</choice>
+                </enumChoice>
+            </enumVal>
+            <label xml:lang="de">Modus</label>
+        </variable>
+        <variable label="Coupler Force" CV="16.0.430" default="31" item="ESU FnOut RL-2 Slider 7" mask="XXXVVVVV">
+            <qualifier>
+                <variableref>ESU FnOut RL-2 Mode</variableref>
+                <relation>ge</relation>
+                <value>28</value>
+            </qualifier>
+            <qualifier>
+                <variableref>ESU FnOut RL-2 Mode</variableref>
+                <relation>ne</relation>
+                <value>29</value>
+            </qualifier>
+            <qualifier>
+                <variableref>ESU FnOut RL-2 Mode</variableref>
+                <relation>ne</relation>
+                <value>30</value>
+            </qualifier>
+            <qualifier>
+                <variableref>ESU FnOut RL-2 Mode</variableref>
+                <relation>ne</relation>
+                <value>31</value>
+            </qualifier>
+            <qualifier>
+                <variableref>ESU FnOut RL-2 Mode</variableref>
+                <relation>ne</relation>
+                <value>32</value>
+            </qualifier>
+            <qualifier>
+                <variableref>ESU FnOut RL-2 Mode</variableref>
+                <relation>le</relation>
+                <value>33</value>
+            </qualifier>
+            <decVal max="31"/>
+            <label xml:lang="de">Stärke des Kupplers</label>
+        </variable>
+        <variable label="Fan Speed" CV="16.0.430" default="31" item="ESU FnOut RL-2 Slider 11" mask="XXXVVVVV">
+            <qualifier>
+                <variableref>ESU FnOut RL-2 Mode</variableref>
+                <relation>eq</relation>
+                <value>23</value>
+            </qualifier>
+            <decVal max="31"/>
+            <label xml:lang="de">Geschwindigkeit</label>
+        </variable>
+        <variable label="Standing heat" CV="16.0.430" default="31" item="ESU FnOut RL-2 Slider 14" mask="XXXVVVVV">
+            <qualifier>
+                <variableref>ESU FnOut RL-2 Mode</variableref>
+                <relation>eq</relation>
+                <value>24</value>
+            </qualifier>
+            <decVal max="31"/>
+            <label xml:lang="de">Heizstufe im Stand</label>
+        </variable>
+        <variable label="Chuff power" CV="16.0.430" default="31" item="ESU FnOut RL-2 Slider 8" mask="XXXVVVVV">
+            <qualifier>
+                <variableref>ESU FnOut RL-2 Mode</variableref>
+                <relation>eq</relation>
+                <value>25</value>
+            </qualifier>
+            <decVal max="31"/>
+            <label xml:lang="de">Dampfstoßstärke</label>
+        </variable>
+        <variable item="Special Function CV431" label="Special Function CV 1" CV="16.0.431" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+            <decVal/>
+        </variable>
+        <variable label="Fan Acceleration rate" CV="16.0.431" default="0" item="ESU FnOut RL-2 Slider 12" mask="XXXVVVVV">
+            <qualifier>
+                <variableref>ESU FnOut RL-2 Mode</variableref>
+                <relation>eq</relation>
+                <value>23</value>
+            </qualifier>
+            <decVal max="31"/>
+            <label xml:lang="de">Beschleunigungszeit</label>
+        </variable>
+        <variable label="Minimum driving heat" CV="16.0.431" default="0" item="ESU FnOut RL-2 Slider 15" mask="XXXVVVVV">
+            <qualifier>
+                <variableref>ESU FnOut RL-2 Mode</variableref>
+                <relation>eq</relation>
+                <value>24</value>
+            </qualifier>
+            <decVal max="31"/>
+            <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
+        </variable>
+        <variable label="Fan power" CV="16.0.431" default="0" item="ESU FnOut RL-2 Slider 9" mask="XXXVVVVV">
+            <qualifier>
+                <variableref>ESU FnOut RL-2 Mode</variableref>
+                <relation>eq</relation>
+                <value>25</value>
+            </qualifier>
+            <decVal max="31"/>
+            <label xml:lang="de">Stäke des Bläsers</label>
+        </variable>
+        <variable label="Phase Reverse" CV="16.0.431" default="0" item="ESU FnOut RL-2 Check 6" mask="XXXXXXXV">
+            <qualifier>
+                <variableref>ESU FnOut RL-2 Mode</variableref>
+                <relation>gt</relation>
+                <value>0</value>
+            </qualifier>
+            <qualifier>
+                <variableref>ESU FnOut RL-2 Mode</variableref>
+                <relation>le</relation>
+                <value>15</value>
+            </qualifier>
+            <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+            <label xml:lang="de">Phase tauschen</label>
+        </variable>
+        <variable label="Grade Crossing" CV="16.0.431" default="0" item="ESU FnOut RL-2 Check 1" mask="XXXXXXVX">
+            <qualifier>
+                <variableref>ESU FnOut RL-2 Mode</variableref>
+                <relation>gt</relation>
+                <value>0</value>
+            </qualifier>
+            <qualifier>
+                <variableref>ESU FnOut RL-2 Mode</variableref>
+                <relation>le</relation>
+                <value>15</value>
+            </qualifier>
+            <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+        </variable>
+        <variable label="Rule 17 Fwd" CV="16.0.431" default="0" item="ESU FnOut RL-2 Check 2" mask="XXXXXVXX">
+            <qualifier>
+                <variableref>ESU FnOut RL-2 Mode</variableref>
+                <relation>gt</relation>
+                <value>0</value>
+            </qualifier>
+            <qualifier>
+                <variableref>ESU FnOut RL-2 Mode</variableref>
+                <relation>le</relation>
+                <value>15</value>
+            </qualifier>
+            <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+            <label xml:lang="de">Rule 17 vorwärts</label>
+        </variable>
+        <variable label="Rule 17 Rev" CV="16.0.431" default="0" item="ESU FnOut RL-2 Check 3" mask="XXXXVXXX">
+            <qualifier>
+                <variableref>ESU FnOut RL-2 Mode</variableref>
+                <relation>gt</relation>
+                <value>0</value>
+            </qualifier>
+            <qualifier>
+                <variableref>ESU FnOut RL-2 Mode</variableref>
+                <relation>le</relation>
+                <value>15</value>
+            </qualifier>
+            <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+            <label xml:lang="de">Rule 17 rückwärts</label>
+        </variable>
+        <variable label="Dimmer" CV="16.0.431" default="0" item="ESU FnOut RL-2 Check 4" mask="XXXVXXXX">
+            <qualifier>
+                <variableref>ESU FnOut RL-2 Mode</variableref>
+                <relation>gt</relation>
+                <value>0</value>
+            </qualifier>
+            <qualifier>
+                <variableref>ESU FnOut RL-2 Mode</variableref>
+                <relation>le</relation>
+                <value>15</value>
+            </qualifier>
+            <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+            <label xml:lang="de">Abdimmen</label>
+        </variable>
+        <variable label="LED Mode" CV="16.0.431" default="0" item="ESU FnOut RL-2 Check 5" mask="VXXXXXXX">
+            <qualifier>
+                <variableref>ESU FnOut RL-2 Mode</variableref>
+                <relation>gt</relation>
+                <value>0</value>
+            </qualifier>
+            <qualifier>
+                <variableref>ESU FnOut RL-2 Mode</variableref>
+                <relation>le</relation>
+                <value>15</value>
+            </qualifier>
+            <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+            <label xml:lang="de">LED Modus</label>
+        </variable>
+        <variable item="Special Function CV432" label="Special Function CV 2" CV="16.0.432" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+            <decVal/>
+        </variable>
+        <variable label="Fan Decceleration rate" CV="16.0.432" default="0" item="ESU FnOut RL-2 Slider 13" mask="XXXVVVVV">
+            <qualifier>
+                <variableref>ESU FnOut RL-2 Mode</variableref>
+                <relation>eq</relation>
+                <value>23</value>
+            </qualifier>
+            <decVal max="31"/>
+            <label xml:lang="de">Bremszeit</label>
+        </variable>
+        <variable label="Maximum driving heat" CV="16.0.432" default="0" item="ESU FnOut RL-2 Slider 16" mask="XXXVVVVV">
+            <qualifier>
+                <variableref>ESU FnOut RL-2 Mode</variableref>
+                <relation>eq</relation>
+                <value>24</value>
+            </qualifier>
+            <decVal max="31"/>
+            <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
+        </variable>
+        <variable label="Timeout" CV="16.0.432" default="0" item="ESU FnOut RL-2 Slider 10" tooltip="Units = 0.25 sec">
+            <qualifier>
+                <variableref>ESU FnOut RL-2 Mode</variableref>
+                <relation>eq</relation>
+                <value>25</value>
+            </qualifier>
+            <decVal/>
+        </variable>
+        <variable label="Startup Time" CV="16.0.432" default="0" item="ESU FnOut RL-2 Slider 6">
+            <qualifier>
+                <variableref>ESU FnOut RL-2 Mode</variableref>
+                <relation>ge</relation>
+                <value>16</value>
+            </qualifier>
+            <qualifier>
+                <variableref>ESU FnOut RL-2 Mode</variableref>
+                <relation>le</relation>
+                <value>17</value>
+            </qualifier>
+            <decVal/>
+            <label xml:lang="de">Startzeit</label>
+        </variable>
+        <variable label="Level" CV="16.0.432" default="0" item="ESU FnOut RL-2 Slider 20" mask="XVVVVVVV">
+            <qualifier>
+                <variableref>ESU FnOut RL-2 Mode</variableref>
+                <relation>eq</relation>
+                <value>19</value>
+            </qualifier>
+            <decVal max="127"/>
+        </variable>
+        <!-- AUX1 [2] Mode -->
+        <variable label="AUX1 [2] Mode" CV="16.0.435" default="1" item="ESU FnOut A1-2 Mode">
+            <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
+        </variable>
+        <variable label="Function Switch On Delay" CV="16.0.436" default="0" item="ESU FnOut A1-2 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
+            <qualifier>
+                <variableref>ESU FnOut A1-2 Mode</variableref>
+                <relation>gt</relation>
+                <value>0</value>
+            </qualifier>
+            <qualifier>
+                <variableref>ESU FnOut A1-2 Mode</variableref>
+                <relation>ne</relation>
+                <value>27</value>
+            </qualifier>
+            <decVal max="15"/>
+            <label xml:lang="de">Verzögerung beim Einschalten</label>
+        </variable>
+        <variable label="Function Switch Off Delay" CV="16.0.436" default="0" mask="VVVVXXXX" item="ESU FnOut A1-2 Slider 2" tooltip="Units = 0.4 sec">
+            <qualifier>
+                <variableref>ESU FnOut A1-2 Mode</variableref>
+                <relation>gt</relation>
+                <value>0</value>
+            </qualifier>
+            <qualifier>
+                <variableref>ESU FnOut A1-2 Mode</variableref>
+                <relation>ne</relation>
+                <value>27</value>
+            </qualifier>
+            <decVal max="15"/>
+            <label xml:lang="de">Verzögerung beim Ausschalten</label>
+        </variable>
+        <variable label="Function Auto Switch Off" CV="16.0.437" default="0" item="ESU FnOut A1-2 Slider 3" tooltip="Units = 0.4 sec">
+            <qualifier>
+                <variableref>ESU FnOut A1-2 Mode</variableref>
+                <relation>gt</relation>
+                <value>0</value>
+            </qualifier>
+            <qualifier>
+                <variableref>ESU FnOut A1-2 Mode</variableref>
+                <relation>ne</relation>
+                <value>27</value>
+            </qualifier>
+            <decVal/>
+            <label xml:lang="de">Ausgang automatisch Ausschalten</label>
+        </variable>
+        <variable item="Brightness CV438" label="Brightness CV" CV="16.0.438" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
+            <decVal/>
+        </variable>
+        <variable label="Brightness" CV="16.0.438" default="31" item="ESU FnOut A1-2 Slider 5" mask="XXXVVVVV">
+            <qualifier>
+                <variableref>ESU FnOut A1-2 Mode</variableref>
+                <relation>gt</relation>
+                <value>0</value>
+            </qualifier>
+            <qualifier>
+                <variableref>ESU FnOut A1-2 Mode</variableref>
+                <relation>le</relation>
+                <value>18</value>
+            </qualifier>
+            <decVal max="31"/>
+            <label xml:lang="de">Helligkeit</label>
+        </variable>
+        <variable label="Mode" CV="16.0.438" default="0" item="ESU FnOut A1-2 Option 1" mask="XXXXXXXV">
+            <qualifier>
+                <variableref>ESU FnOut A1-2 Mode</variableref>
+                <relation>eq</relation>
+                <value>22</value>
+            </qualifier>
+            <enumVal>
+                <enumChoice choice="Heating control">
+                    <choice>Heating control</choice>
+                    <choice xml:lang="de">Heizungssteuerung</choice>
+                </enumChoice>
+                <enumChoice choice="Fan control">
+                    <choice>Fan control</choice>
+                    <choice xml:lang="de">Lüftersteuerung</choice>
+                </enumChoice>
+            </enumVal>
+            <label xml:lang="de">Modus</label>
+        </variable>
+        <variable label="Coupler Force" CV="16.0.438" default="31" item="ESU FnOut A1-2 Slider 7" mask="XXXVVVVV">
+            <qualifier>
+                <variableref>ESU FnOut A1-2 Mode</variableref>
+                <relation>ge</relation>
+                <value>28</value>
+            </qualifier>
+            <qualifier>
+                <variableref>ESU FnOut A1-2 Mode</variableref>
+                <relation>ne</relation>
+                <value>29</value>
+            </qualifier>
+            <qualifier>
+                <variableref>ESU FnOut A1-2 Mode</variableref>
+                <relation>ne</relation>
+                <value>30</value>
+            </qualifier>
+            <qualifier>
+                <variableref>ESU FnOut A1-2 Mode</variableref>
+                <relation>ne</relation>
+                <value>31</value>
+            </qualifier>
+            <qualifier>
+                <variableref>ESU FnOut A1-2 Mode</variableref>
+                <relation>ne</relation>
+                <value>32</value>
+            </qualifier>
+            <qualifier>
+                <variableref>ESU FnOut A1-2 Mode</variableref>
+                <relation>le</relation>
+                <value>33</value>
+            </qualifier>
+            <decVal max="31"/>
+            <label xml:lang="de">Stärke des Kupplers</label>
+        </variable>
+        <variable label="Fan Speed" CV="16.0.438" default="31" item="ESU FnOut A1-2 Slider 11" mask="XXXVVVVV">
+            <qualifier>
+                <variableref>ESU FnOut A1-2 Mode</variableref>
+                <relation>eq</relation>
+                <value>23</value>
+            </qualifier>
+            <decVal max="31"/>
+            <label xml:lang="de">Geschwindigkeit</label>
+        </variable>
+        <variable label="Standing heat" CV="16.0.438" default="31" item="ESU FnOut A1-2 Slider 14" mask="XXXVVVVV">
+            <qualifier>
+                <variableref>ESU FnOut A1-2 Mode</variableref>
+                <relation>eq</relation>
+                <value>24</value>
+            </qualifier>
+            <decVal max="31"/>
+            <label xml:lang="de">Heizstufe im Stand</label>
+        </variable>
+        <variable label="Chuff power" CV="16.0.438" default="31" item="ESU FnOut A1-2 Slider 8" mask="XXXVVVVV">
+            <qualifier>
+                <variableref>ESU FnOut A1-2 Mode</variableref>
+                <relation>eq</relation>
+                <value>25</value>
+            </qualifier>
+            <decVal max="31"/>
+            <label xml:lang="de">Dampfstoßstärke</label>
+        </variable>
+        <variable item="Special Function CV439" label="Special Function CV 1" CV="16.0.439" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+            <decVal/>
+        </variable>
+        <variable label="Fan Acceleration rate" CV="16.0.439" default="0" item="ESU FnOut A1-2 Slider 12" mask="XXXVVVVV">
+            <qualifier>
+                <variableref>ESU FnOut A1-2 Mode</variableref>
+                <relation>eq</relation>
+                <value>23</value>
+            </qualifier>
+            <decVal max="31"/>
+            <label xml:lang="de">Beschleunigungszeit</label>
+        </variable>
+        <variable label="Minimum driving heat" CV="16.0.439" default="0" item="ESU FnOut A1-2 Slider 15" mask="XXXVVVVV">
+            <qualifier>
+                <variableref>ESU FnOut A1-2 Mode</variableref>
+                <relation>eq</relation>
+                <value>24</value>
+            </qualifier>
+            <decVal max="31"/>
+            <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
+        </variable>
+        <variable label="Fan power" CV="16.0.439" default="0" item="ESU FnOut A1-2 Slider 9" mask="XXXVVVVV">
+            <qualifier>
+                <variableref>ESU FnOut A1-2 Mode</variableref>
+                <relation>eq</relation>
+                <value>25</value>
+            </qualifier>
+            <decVal max="31"/>
+            <label xml:lang="de">Stäke des Bläsers</label>
+        </variable>
+        <variable label="Phase Reverse" CV="16.0.439" default="0" item="ESU FnOut A1-2 Check 6" mask="XXXXXXXV">
+            <qualifier>
+                <variableref>ESU FnOut A1-2 Mode</variableref>
+                <relation>gt</relation>
+                <value>0</value>
+            </qualifier>
+            <qualifier>
+                <variableref>ESU FnOut A1-2 Mode</variableref>
+                <relation>le</relation>
+                <value>15</value>
+            </qualifier>
+            <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+            <label xml:lang="de">Phase tauschen</label>
+        </variable>
+        <variable label="Grade Crossing" CV="16.0.439" default="0" item="ESU FnOut A1-2 Check 1" mask="XXXXXXVX">
+            <qualifier>
+                <variableref>ESU FnOut A1-2 Mode</variableref>
+                <relation>gt</relation>
+                <value>0</value>
+            </qualifier>
+            <qualifier>
+                <variableref>ESU FnOut A1-2 Mode</variableref>
+                <relation>le</relation>
+                <value>15</value>
+            </qualifier>
+            <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+        </variable>
+        <variable label="Rule 17 Fwd" CV="16.0.439" default="0" item="ESU FnOut A1-2 Check 2" mask="XXXXXVXX">
+            <qualifier>
+                <variableref>ESU FnOut A1-2 Mode</variableref>
+                <relation>gt</relation>
+                <value>0</value>
+            </qualifier>
+            <qualifier>
+                <variableref>ESU FnOut A1-2 Mode</variableref>
+                <relation>le</relation>
+                <value>15</value>
+            </qualifier>
+            <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+            <label xml:lang="de">Rule 17 vorwärts</label>
+        </variable>
+        <variable label="Rule 17 Rev" CV="16.0.439" default="0" item="ESU FnOut A1-2 Check 3" mask="XXXXVXXX">
+            <qualifier>
+                <variableref>ESU FnOut A1-2 Mode</variableref>
+                <relation>gt</relation>
+                <value>0</value>
+            </qualifier>
+            <qualifier>
+                <variableref>ESU FnOut A1-2 Mode</variableref>
+                <relation>le</relation>
+                <value>15</value>
+            </qualifier>
+            <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+            <label xml:lang="de">Rule 17 rückwärts</label>
+        </variable>
+        <variable label="Dimmer" CV="16.0.439" default="0" item="ESU FnOut A1-2 Check 4" mask="XXXVXXXX">
+            <qualifier>
+                <variableref>ESU FnOut A1-2 Mode</variableref>
+                <relation>gt</relation>
+                <value>0</value>
+            </qualifier>
+            <qualifier>
+                <variableref>ESU FnOut A1-2 Mode</variableref>
+                <relation>le</relation>
+                <value>15</value>
+            </qualifier>
+            <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+            <label xml:lang="de">Abdimmen</label>
+        </variable>
+        <variable label="LED Mode" CV="16.0.439" default="0" item="ESU FnOut A1-2 Check 5" mask="VXXXXXXX">
+            <qualifier>
+                <variableref>ESU FnOut A1-2 Mode</variableref>
+                <relation>gt</relation>
+                <value>0</value>
+            </qualifier>
+            <qualifier>
+                <variableref>ESU FnOut A1-2 Mode</variableref>
+                <relation>le</relation>
+                <value>15</value>
+            </qualifier>
+            <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+            <label xml:lang="de">LED Modus</label>
+        </variable>
+        <variable item="Special Function CV440" label="Special Function CV 2" CV="16.0.440" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+            <decVal/>
+        </variable>
+        <variable label="Fan Decceleration rate" CV="16.0.440" default="0" item="ESU FnOut A1-2 Slider 13" mask="XXXVVVVV">
+            <qualifier>
+                <variableref>ESU FnOut A1-2 Mode</variableref>
+                <relation>eq</relation>
+                <value>23</value>
+            </qualifier>
+            <decVal max="31"/>
+            <label xml:lang="de">Bremszeit</label>
+        </variable>
+        <variable label="Maximum driving heat" CV="16.0.440" default="0" item="ESU FnOut A1-2 Slider 16" mask="XXXVVVVV">
+            <qualifier>
+                <variableref>ESU FnOut A1-2 Mode</variableref>
+                <relation>eq</relation>
+                <value>24</value>
+            </qualifier>
+            <decVal max="31"/>
+            <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
+        </variable>
+        <variable label="Timeout" CV="16.0.440" default="0" item="ESU FnOut A1-2 Slider 10" tooltip="Units = 0.25 sec">
+            <qualifier>
+                <variableref>ESU FnOut A1-2 Mode</variableref>
+                <relation>eq</relation>
+                <value>25</value>
+            </qualifier>
+            <decVal/>
+        </variable>
+        <variable label="Startup Time" CV="16.0.440" default="0" item="ESU FnOut A1-2 Slider 6">
+            <qualifier>
+                <variableref>ESU FnOut A1-2 Mode</variableref>
+                <relation>ge</relation>
+                <value>16</value>
+            </qualifier>
+            <qualifier>
+                <variableref>ESU FnOut A1-2 Mode</variableref>
+                <relation>le</relation>
+                <value>17</value>
+            </qualifier>
+            <decVal/>
+            <label xml:lang="de">Startzeit</label>
+        </variable>
+        <variable label="Level" CV="16.0.440" default="0" item="ESU FnOut A1-2 Slider 20" mask="XVVVVVVV">
+            <qualifier>
+                <variableref>ESU FnOut A1-2 Mode</variableref>
+                <relation>eq</relation>
+                <value>19</value>
+            </qualifier>
+            <decVal max="127"/>
+        </variable>
         <!-- exclude AUX2 [2] -->
         <variables exclude="LokSound 5 micro DCC Direct Atlas S2">
-	<!-- AUX2 [2] Mode -->
-	<variable label="AUX2 [2] Mode" CV="16.0.443" default="1" item="ESU FnOut A2-2 Mode">
-	    <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
-	</variable>
-	<variable label="Function Switch On Delay" CV="16.0.444" default="0" item="ESU FnOut A2-2 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>gt</relation>
-		<value>0</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>ne</relation>
-		<value>27</value>
-	    </qualifier>
-	    <decVal max="15"/>
-	    <label xml:lang="de">Verzögerung beim Einschalten</label>
-	</variable>
-	<variable label="Function Switch Off Delay" CV="16.0.444" default="0" mask="VVVVXXXX" item="ESU FnOut A2-2 Slider 2" tooltip="Units = 0.4 sec">
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>gt</relation>
-		<value>0</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>ne</relation>
-		<value>27</value>
-	    </qualifier>
-	    <decVal max="15"/>
-	    <label xml:lang="de">Verzögerung beim Ausschalten</label>
-	</variable>
-	<variable label="Function Auto Switch Off" CV="16.0.445" default="0" item="ESU FnOut A2-2 Slider 3" tooltip="Units = 0.4 sec">
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>gt</relation>
-		<value>0</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>ne</relation>
-		<value>27</value>
-	    </qualifier>
-	    <decVal/>
-	    <label xml:lang="de">Ausgang automatisch Ausschalten</label>
-	</variable>
-	<variable item="Brightness CV446" label="Brightness CV" CV="16.0.446" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
-	    <decVal/>
-	</variable>
-	<variable label="Brightness" CV="16.0.446" default="31" item="ESU FnOut A2-2 Slider 5" mask="XXXVVVVV">
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>gt</relation>
-		<value>0</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>le</relation>
-		<value>18</value>
-	    </qualifier>
-	    <decVal max="31"/>
-	    <label xml:lang="de">Helligkeit</label>
-	</variable>
-	<variable label="Mode" CV="16.0.446" default="0" item="ESU FnOut A2-2 Option 1" mask="XXXXXXXV">
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>eq</relation>
-		<value>22</value>
-	    </qualifier>
-	    <enumVal>
-		<enumChoice choice="Heating control">
-		    <choice>Heating control</choice>
-		    <choice xml:lang="de">Heizungssteuerung</choice>
-		</enumChoice>
-		<enumChoice choice="Fan control">
-		    <choice>Fan control</choice>
-		    <choice xml:lang="de">Lüftersteuerung</choice>
-		</enumChoice>
-	    </enumVal>
-	    <label xml:lang="de">Modus</label>
-	</variable>
-	<variable label="Coupler Force" CV="16.0.446" default="31" item="ESU FnOut A2-2 Slider 7" mask="XXXVVVVV">
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>ge</relation>
-		<value>28</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>ne</relation>
-		<value>29</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>ne</relation>
-		<value>30</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>ne</relation>
-		<value>31</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>ne</relation>
-		<value>32</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>le</relation>
-		<value>33</value>
-	    </qualifier>
-	    <decVal max="31"/>
-	    <label xml:lang="de">Stärke des Kupplers</label>
-	</variable>
-	<variable label="Fan Speed" CV="16.0.446" default="31" item="ESU FnOut A2-2 Slider 11" mask="XXXVVVVV">
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>eq</relation>
-		<value>23</value>
-	    </qualifier>
-	    <decVal max="31"/>
-	    <label xml:lang="de">Geschwindigkeit</label>
-	</variable>
-	<variable label="Standing heat" CV="16.0.446" default="31" item="ESU FnOut A2-2 Slider 14" mask="XXXVVVVV">
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>eq</relation>
-		<value>24</value>
-	    </qualifier>
-	    <decVal max="31"/>
-	    <label xml:lang="de">Heizstufe im Stand</label>
-	</variable>
-	<variable label="Chuff power" CV="16.0.446" default="31" item="ESU FnOut A2-2 Slider 8" mask="XXXVVVVV">
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>eq</relation>
-		<value>25</value>
-	    </qualifier>
-	    <decVal max="31"/>
-	    <label xml:lang="de">Dampfstoßstärke</label>
-	</variable>
-	<variable item="Special Function CV447" label="Special Function CV 1" CV="16.0.447" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
-	    <decVal/>
-	</variable>
-	<variable label="Fan Acceleration rate" CV="16.0.447" default="0" item="ESU FnOut A2-2 Slider 12" mask="XXXVVVVV">
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>eq</relation>
-		<value>23</value>
-	    </qualifier>
-	    <decVal max="31"/>
-	    <label xml:lang="de">Beschleunigungszeit</label>
-	</variable>
-	<variable label="Minimum driving heat" CV="16.0.447" default="0" item="ESU FnOut A2-2 Slider 15" mask="XXXVVVVV">
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>eq</relation>
-		<value>24</value>
-	    </qualifier>
-	    <decVal max="31"/>
-	    <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
-	</variable>
-	<variable label="Fan power" CV="16.0.447" default="0" item="ESU FnOut A2-2 Slider 9" mask="XXXVVVVV">
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>eq</relation>
-		<value>25</value>
-	    </qualifier>
-	    <decVal max="31"/>
-	    <label xml:lang="de">Stäke des Bläsers</label>
-	</variable>
-	<variable label="Phase Reverse" CV="16.0.447" default="0" item="ESU FnOut A2-2 Check 6" mask="XXXXXXXV">
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>gt</relation>
-		<value>0</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>le</relation>
-		<value>15</value>
-	    </qualifier>
-	    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-	    <label xml:lang="de">Phase tauschen</label>
-	</variable>
-	<variable label="Grade Crossing" CV="16.0.447" default="0" item="ESU FnOut A2-2 Check 1" mask="XXXXXXVX">
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>gt</relation>
-		<value>0</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>le</relation>
-		<value>15</value>
-	    </qualifier>
-	    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-	</variable>
-	<variable label="Rule 17 Fwd" CV="16.0.447" default="0" item="ESU FnOut A2-2 Check 2" mask="XXXXXVXX">
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>gt</relation>
-		<value>0</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>le</relation>
-		<value>15</value>
-	    </qualifier>
-	    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-	    <label xml:lang="de">Rule 17 vorwärts</label>
-	</variable>
-	<variable label="Rule 17 Rev" CV="16.0.447" default="0" item="ESU FnOut A2-2 Check 3" mask="XXXXVXXX">
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>gt</relation>
-		<value>0</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>le</relation>
-		<value>15</value>
-	    </qualifier>
-	    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-	    <label xml:lang="de">Rule 17 rückwärts</label>
-	</variable>
-	<variable label="Dimmer" CV="16.0.447" default="0" item="ESU FnOut A2-2 Check 4" mask="XXXVXXXX">
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>gt</relation>
-		<value>0</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>le</relation>
-		<value>15</value>
-	    </qualifier>
-	    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-	    <label xml:lang="de">Abdimmen</label>
-	</variable>
-	<variable label="LED Mode" CV="16.0.447" default="0" item="ESU FnOut A2-2 Check 5" mask="VXXXXXXX">
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>gt</relation>
-		<value>0</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>le</relation>
-		<value>15</value>
-	    </qualifier>
-	    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-	    <label xml:lang="de">LED Modus</label>
-	</variable>
-	<variable item="Special Function CV448" label="Special Function CV 2" CV="16.0.448" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
-	    <decVal/>
-	</variable>
-	<variable label="Fan Decceleration rate" CV="16.0.448" default="0" item="ESU FnOut A2-2 Slider 13" mask="XXXVVVVV">
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>eq</relation>
-		<value>23</value>
-	    </qualifier>
-	    <decVal max="31"/>
-	    <label xml:lang="de">Bremszeit</label>
-	</variable>
-	<variable label="Maximum driving heat" CV="16.0.448" default="0" item="ESU FnOut A2-2 Slider 16" mask="XXXVVVVV">
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>eq</relation>
-		<value>24</value>
-	    </qualifier>
-	    <decVal max="31"/>
-	    <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
-	</variable>
-	<variable label="Timeout" CV="16.0.448" default="0" item="ESU FnOut A2-2 Slider 10" tooltip="Units = 0.25 sec">
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>eq</relation>
-		<value>25</value>
-	    </qualifier>
-	    <decVal/>
-	</variable>
-	<variable label="Startup Time" CV="16.0.448" default="0" item="ESU FnOut A2-2 Slider 6">
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>ge</relation>
-		<value>16</value>
-	    </qualifier>
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>le</relation>
-		<value>17</value>
-	    </qualifier>
-	    <decVal/>
-	    <label xml:lang="de">Startzeit</label>
-	</variable>
-	<variable label="Level" CV="16.0.448" default="0" item="ESU FnOut A2-2 Slider 20" mask="XVVVVVVV">
-	    <qualifier>
-		<variableref>ESU FnOut A2-2 Mode</variableref>
-		<relation>eq</relation>
-		<value>19</value>
-	    </qualifier>
-	    <decVal max="127"/>
-	</variable>
+            <!-- AUX2 [2] Mode -->
+            <variable label="AUX2 [2] Mode" CV="16.0.443" default="1" item="ESU FnOut A2-2 Mode">
+                <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
+            </variable>
+            <variable label="Function Switch On Delay" CV="16.0.444" default="0" item="ESU FnOut A2-2 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
+                <qualifier>
+                    <variableref>ESU FnOut A2-2 Mode</variableref>
+                    <relation>gt</relation>
+                    <value>0</value>
+                </qualifier>
+                <qualifier>
+                    <variableref>ESU FnOut A2-2 Mode</variableref>
+                    <relation>ne</relation>
+                    <value>27</value>
+                </qualifier>
+                <decVal max="15"/>
+                <label xml:lang="de">Verzögerung beim Einschalten</label>
+            </variable>
+            <variable label="Function Switch Off Delay" CV="16.0.444" default="0" mask="VVVVXXXX" item="ESU FnOut A2-2 Slider 2" tooltip="Units = 0.4 sec">
+                <qualifier>
+                    <variableref>ESU FnOut A2-2 Mode</variableref>
+                    <relation>gt</relation>
+                    <value>0</value>
+                </qualifier>
+                <qualifier>
+                    <variableref>ESU FnOut A2-2 Mode</variableref>
+                    <relation>ne</relation>
+                    <value>27</value>
+                </qualifier>
+                <decVal max="15"/>
+                <label xml:lang="de">Verzögerung beim Ausschalten</label>
+            </variable>
+            <variable label="Function Auto Switch Off" CV="16.0.445" default="0" item="ESU FnOut A2-2 Slider 3" tooltip="Units = 0.4 sec">
+                <qualifier>
+                    <variableref>ESU FnOut A2-2 Mode</variableref>
+                    <relation>gt</relation>
+                    <value>0</value>
+                </qualifier>
+                <qualifier>
+                    <variableref>ESU FnOut A2-2 Mode</variableref>
+                    <relation>ne</relation>
+                    <value>27</value>
+                </qualifier>
+                <decVal/>
+                <label xml:lang="de">Ausgang automatisch Ausschalten</label>
+            </variable>
+            <variable item="Brightness CV446" label="Brightness CV" CV="16.0.446" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
+                <decVal/>
+            </variable>
+            <variable label="Brightness" CV="16.0.446" default="31" item="ESU FnOut A2-2 Slider 5" mask="XXXVVVVV">
+                <qualifier>
+                    <variableref>ESU FnOut A2-2 Mode</variableref>
+                    <relation>gt</relation>
+                    <value>0</value>
+                </qualifier>
+                <qualifier>
+                    <variableref>ESU FnOut A2-2 Mode</variableref>
+                    <relation>le</relation>
+                    <value>18</value>
+                </qualifier>
+                <decVal max="31"/>
+                <label xml:lang="de">Helligkeit</label>
+            </variable>
+            <variable label="Mode" CV="16.0.446" default="0" item="ESU FnOut A2-2 Option 1" mask="XXXXXXXV">
+                <qualifier>
+                    <variableref>ESU FnOut A2-2 Mode</variableref>
+                    <relation>eq</relation>
+                    <value>22</value>
+                </qualifier>
+                <enumVal>
+                    <enumChoice choice="Heating control">
+                        <choice>Heating control</choice>
+                        <choice xml:lang="de">Heizungssteuerung</choice>
+                    </enumChoice>
+                    <enumChoice choice="Fan control">
+                        <choice>Fan control</choice>
+                        <choice xml:lang="de">Lüftersteuerung</choice>
+                    </enumChoice>
+                </enumVal>
+                <label xml:lang="de">Modus</label>
+            </variable>
+            <variable label="Coupler Force" CV="16.0.446" default="31" item="ESU FnOut A2-2 Slider 7" mask="XXXVVVVV">
+                <qualifier>
+                    <variableref>ESU FnOut A2-2 Mode</variableref>
+                    <relation>ge</relation>
+                    <value>28</value>
+                </qualifier>
+                <qualifier>
+                    <variableref>ESU FnOut A2-2 Mode</variableref>
+                    <relation>ne</relation>
+                    <value>29</value>
+                </qualifier>
+                <qualifier>
+                    <variableref>ESU FnOut A2-2 Mode</variableref>
+                    <relation>ne</relation>
+                    <value>30</value>
+                </qualifier>
+                <qualifier>
+                    <variableref>ESU FnOut A2-2 Mode</variableref>
+                    <relation>ne</relation>
+                    <value>31</value>
+                </qualifier>
+                <qualifier>
+                    <variableref>ESU FnOut A2-2 Mode</variableref>
+                    <relation>ne</relation>
+                    <value>32</value>
+                </qualifier>
+                <qualifier>
+                    <variableref>ESU FnOut A2-2 Mode</variableref>
+                    <relation>le</relation>
+                    <value>33</value>
+                </qualifier>
+                <decVal max="31"/>
+                <label xml:lang="de">Stärke des Kupplers</label>
+            </variable>
+            <variable label="Fan Speed" CV="16.0.446" default="31" item="ESU FnOut A2-2 Slider 11" mask="XXXVVVVV">
+                <qualifier>
+                    <variableref>ESU FnOut A2-2 Mode</variableref>
+                    <relation>eq</relation>
+                    <value>23</value>
+                </qualifier>
+                <decVal max="31"/>
+                <label xml:lang="de">Geschwindigkeit</label>
+            </variable>
+            <variable label="Standing heat" CV="16.0.446" default="31" item="ESU FnOut A2-2 Slider 14" mask="XXXVVVVV">
+                <qualifier>
+                    <variableref>ESU FnOut A2-2 Mode</variableref>
+                    <relation>eq</relation>
+                    <value>24</value>
+                </qualifier>
+                <decVal max="31"/>
+                <label xml:lang="de">Heizstufe im Stand</label>
+            </variable>
+            <variable label="Chuff power" CV="16.0.446" default="31" item="ESU FnOut A2-2 Slider 8" mask="XXXVVVVV">
+                <qualifier>
+                    <variableref>ESU FnOut A2-2 Mode</variableref>
+                    <relation>eq</relation>
+                    <value>25</value>
+                </qualifier>
+                <decVal max="31"/>
+                <label xml:lang="de">Dampfstoßstärke</label>
+            </variable>
+            <variable item="Special Function CV447" label="Special Function CV 1" CV="16.0.447" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                <decVal/>
+            </variable>
+            <variable label="Fan Acceleration rate" CV="16.0.447" default="0" item="ESU FnOut A2-2 Slider 12" mask="XXXVVVVV">
+                <qualifier>
+                    <variableref>ESU FnOut A2-2 Mode</variableref>
+                    <relation>eq</relation>
+                    <value>23</value>
+                </qualifier>
+                <decVal max="31"/>
+                <label xml:lang="de">Beschleunigungszeit</label>
+            </variable>
+            <variable label="Minimum driving heat" CV="16.0.447" default="0" item="ESU FnOut A2-2 Slider 15" mask="XXXVVVVV">
+                <qualifier>
+                    <variableref>ESU FnOut A2-2 Mode</variableref>
+                    <relation>eq</relation>
+                    <value>24</value>
+                </qualifier>
+                <decVal max="31"/>
+                <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
+            </variable>
+            <variable label="Fan power" CV="16.0.447" default="0" item="ESU FnOut A2-2 Slider 9" mask="XXXVVVVV">
+                <qualifier>
+                    <variableref>ESU FnOut A2-2 Mode</variableref>
+                    <relation>eq</relation>
+                    <value>25</value>
+                </qualifier>
+                <decVal max="31"/>
+                <label xml:lang="de">Stäke des Bläsers</label>
+            </variable>
+            <variable label="Phase Reverse" CV="16.0.447" default="0" item="ESU FnOut A2-2 Check 6" mask="XXXXXXXV">
+                <qualifier>
+                    <variableref>ESU FnOut A2-2 Mode</variableref>
+                    <relation>gt</relation>
+                    <value>0</value>
+                </qualifier>
+                <qualifier>
+                    <variableref>ESU FnOut A2-2 Mode</variableref>
+                    <relation>le</relation>
+                    <value>15</value>
+                </qualifier>
+                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                <label xml:lang="de">Phase tauschen</label>
+            </variable>
+            <variable label="Grade Crossing" CV="16.0.447" default="0" item="ESU FnOut A2-2 Check 1" mask="XXXXXXVX">
+                <qualifier>
+                    <variableref>ESU FnOut A2-2 Mode</variableref>
+                    <relation>gt</relation>
+                    <value>0</value>
+                </qualifier>
+                <qualifier>
+                    <variableref>ESU FnOut A2-2 Mode</variableref>
+                    <relation>le</relation>
+                    <value>15</value>
+                </qualifier>
+                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+            </variable>
+            <variable label="Rule 17 Fwd" CV="16.0.447" default="0" item="ESU FnOut A2-2 Check 2" mask="XXXXXVXX">
+                <qualifier>
+                    <variableref>ESU FnOut A2-2 Mode</variableref>
+                    <relation>gt</relation>
+                    <value>0</value>
+                </qualifier>
+                <qualifier>
+                    <variableref>ESU FnOut A2-2 Mode</variableref>
+                    <relation>le</relation>
+                    <value>15</value>
+                </qualifier>
+                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                <label xml:lang="de">Rule 17 vorwärts</label>
+            </variable>
+            <variable label="Rule 17 Rev" CV="16.0.447" default="0" item="ESU FnOut A2-2 Check 3" mask="XXXXVXXX">
+                <qualifier>
+                    <variableref>ESU FnOut A2-2 Mode</variableref>
+                    <relation>gt</relation>
+                    <value>0</value>
+                </qualifier>
+                <qualifier>
+                    <variableref>ESU FnOut A2-2 Mode</variableref>
+                    <relation>le</relation>
+                    <value>15</value>
+                </qualifier>
+                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                <label xml:lang="de">Rule 17 rückwärts</label>
+            </variable>
+            <variable label="Dimmer" CV="16.0.447" default="0" item="ESU FnOut A2-2 Check 4" mask="XXXVXXXX">
+                <qualifier>
+                    <variableref>ESU FnOut A2-2 Mode</variableref>
+                    <relation>gt</relation>
+                    <value>0</value>
+                </qualifier>
+                <qualifier>
+                    <variableref>ESU FnOut A2-2 Mode</variableref>
+                    <relation>le</relation>
+                    <value>15</value>
+                </qualifier>
+                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                <label xml:lang="de">Abdimmen</label>
+            </variable>
+            <variable label="LED Mode" CV="16.0.447" default="0" item="ESU FnOut A2-2 Check 5" mask="VXXXXXXX">
+                <qualifier>
+                    <variableref>ESU FnOut A2-2 Mode</variableref>
+                    <relation>gt</relation>
+                    <value>0</value>
+                </qualifier>
+                <qualifier>
+                    <variableref>ESU FnOut A2-2 Mode</variableref>
+                    <relation>le</relation>
+                    <value>15</value>
+                </qualifier>
+                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                <label xml:lang="de">LED Modus</label>
+            </variable>
+            <variable item="Special Function CV448" label="Special Function CV 2" CV="16.0.448" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                <decVal/>
+            </variable>
+            <variable label="Fan Decceleration rate" CV="16.0.448" default="0" item="ESU FnOut A2-2 Slider 13" mask="XXXVVVVV">
+                <qualifier>
+                    <variableref>ESU FnOut A2-2 Mode</variableref>
+                    <relation>eq</relation>
+                    <value>23</value>
+                </qualifier>
+                <decVal max="31"/>
+                <label xml:lang="de">Bremszeit</label>
+            </variable>
+            <variable label="Maximum driving heat" CV="16.0.448" default="0" item="ESU FnOut A2-2 Slider 16" mask="XXXVVVVV">
+                <qualifier>
+                    <variableref>ESU FnOut A2-2 Mode</variableref>
+                    <relation>eq</relation>
+                    <value>24</value>
+                </qualifier>
+                <decVal max="31"/>
+                <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
+            </variable>
+            <variable label="Timeout" CV="16.0.448" default="0" item="ESU FnOut A2-2 Slider 10" tooltip="Units = 0.25 sec">
+                <qualifier>
+                    <variableref>ESU FnOut A2-2 Mode</variableref>
+                    <relation>eq</relation>
+                    <value>25</value>
+                </qualifier>
+                <decVal/>
+            </variable>
+            <variable label="Startup Time" CV="16.0.448" default="0" item="ESU FnOut A2-2 Slider 6">
+                <qualifier>
+                    <variableref>ESU FnOut A2-2 Mode</variableref>
+                    <relation>ge</relation>
+                    <value>16</value>
+                </qualifier>
+                <qualifier>
+                    <variableref>ESU FnOut A2-2 Mode</variableref>
+                    <relation>le</relation>
+                    <value>17</value>
+                </qualifier>
+                <decVal/>
+                <label xml:lang="de">Startzeit</label>
+            </variable>
+            <variable label="Level" CV="16.0.448" default="0" item="ESU FnOut A2-2 Slider 20" mask="XVVVVVVV">
+                <qualifier>
+                    <variableref>ESU FnOut A2-2 Mode</variableref>
+                    <relation>eq</relation>
+                    <value>19</value>
+                </qualifier>
+                <decVal max="127"/>
+            </variable>
+        </variables>
     </variables>
-</variables>
 </variables>

--- a/xml/decoders/esu/v5fnOutCVs.xml
+++ b/xml/decoders/esu/v5fnOutCVs.xml
@@ -923,74 +923,380 @@
         </qualifier>
         <decVal max="127"/>
     </variable>
-    <!-- exclude AUX2 [1] to AUX 18 -->
-    <variables exclude="LokSound 5 micro DCC Direct Atlas S2">
-        <!-- AUX2 [1] Mode -->
-        <variable label="AUX2 [1] Mode" CV="16.0.283" default="1" item="ESU FnOut A2-1 Mode">
+    <!-- AUX2 [1] Mode -->
+    <variable label="AUX2 [1] Mode" CV="16.0.283" default="1" item="ESU FnOut A2-1 Mode">
+        <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
+    </variable>
+    <variable label="Function Switch On Delay" CV="16.0.284" default="0" item="ESU FnOut A2-1 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
+        <qualifier>
+            <variableref>ESU FnOut A2-1 Mode</variableref>
+            <relation>gt</relation>
+            <value>0</value>
+        </qualifier>
+        <qualifier>
+            <variableref>ESU FnOut A2-1 Mode</variableref>
+            <relation>ne</relation>
+            <value>27</value>
+        </qualifier>
+        <decVal max="15"/>
+        <label xml:lang="de">Verzögerung beim Einschalten</label>
+    </variable>
+    <variable label="Function Switch Off Delay" CV="16.0.284" default="0" mask="VVVVXXXX" item="ESU FnOut A2-1 Slider 2" tooltip="Units = 0.4 sec">
+        <qualifier>
+            <variableref>ESU FnOut A2-1 Mode</variableref>
+            <relation>gt</relation>
+            <value>0</value>
+        </qualifier>
+        <qualifier>
+            <variableref>ESU FnOut A2-1 Mode</variableref>
+            <relation>ne</relation>
+            <value>27</value>
+        </qualifier>
+        <decVal max="15"/>
+        <label xml:lang="de">Verzögerung beim Ausschalten</label>
+    </variable>
+    <variable label="Function Auto Switch Off" CV="16.0.285" default="0" item="ESU FnOut A2-1 Slider 3" tooltip="Units = 0.4 sec">
+        <qualifier>
+            <variableref>ESU FnOut A2-1 Mode</variableref>
+            <relation>gt</relation>
+            <value>0</value>
+        </qualifier>
+        <qualifier>
+            <variableref>ESU FnOut A2-1 Mode</variableref>
+            <relation>ne</relation>
+            <value>27</value>
+        </qualifier>
+        <decVal/>
+        <label xml:lang="de">Ausgang automatisch Ausschalten</label>
+    </variable>
+    <variable item="Brightness CV286" label="Brightness CV" CV="16.0.286" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
+        <decVal/>
+    </variable>
+    <variable label="Brightness" CV="16.0.286" default="31" item="ESU FnOut A2-1 Slider 5" mask="XXXVVVVV">
+        <qualifier>
+            <variableref>ESU FnOut A2-1 Mode</variableref>
+            <relation>gt</relation>
+            <value>0</value>
+        </qualifier>
+        <qualifier>
+            <variableref>ESU FnOut A2-1 Mode</variableref>
+            <relation>le</relation>
+            <value>18</value>
+        </qualifier>
+        <decVal max="31"/>
+        <label xml:lang="de">Helligkeit</label>
+    </variable>
+    <variable label="Mode" CV="16.0.286" default="0" item="ESU FnOut A2-1 Option 1" mask="XXXXXXXV">
+        <qualifier>
+            <variableref>ESU FnOut A2-1 Mode</variableref>
+            <relation>eq</relation>
+            <value>22</value>
+        </qualifier>
+        <enumVal>
+            <enumChoice choice="Heating control">
+                <choice>Heating control</choice>
+                <choice xml:lang="de">Heizungssteuerung</choice>
+            </enumChoice>
+            <enumChoice choice="Fan control">
+                <choice>Fan control</choice>
+                <choice xml:lang="de">Lüftersteuerung</choice>
+            </enumChoice>
+        </enumVal>
+        <label xml:lang="de">Modus</label>
+    </variable>
+    <variable label="Coupler Force" CV="16.0.286" default="31" item="ESU FnOut A2-1 Slider 7" mask="XXXVVVVV">
+        <qualifier>
+            <variableref>ESU FnOut A2-1 Mode</variableref>
+            <relation>ge</relation>
+            <value>28</value>
+        </qualifier>
+        <qualifier>
+            <variableref>ESU FnOut A2-1 Mode</variableref>
+            <relation>ne</relation>
+            <value>29</value>
+        </qualifier>
+        <qualifier>
+            <variableref>ESU FnOut A2-1 Mode</variableref>
+            <relation>ne</relation>
+            <value>30</value>
+        </qualifier>
+        <qualifier>
+            <variableref>ESU FnOut A2-1 Mode</variableref>
+            <relation>ne</relation>
+            <value>31</value>
+        </qualifier>
+        <qualifier>
+            <variableref>ESU FnOut A2-1 Mode</variableref>
+            <relation>ne</relation>
+            <value>32</value>
+        </qualifier>
+        <qualifier>
+            <variableref>ESU FnOut A2-1 Mode</variableref>
+            <relation>le</relation>
+            <value>33</value>
+        </qualifier>
+        <decVal max="31"/>
+        <label xml:lang="de">Stärke des Kupplers</label>
+    </variable>
+    <variable label="Fan Speed" CV="16.0.286" default="31" item="ESU FnOut A2-1 Slider 11" mask="XXXVVVVV">
+        <qualifier>
+            <variableref>ESU FnOut A2-1 Mode</variableref>
+            <relation>eq</relation>
+            <value>23</value>
+        </qualifier>
+        <decVal max="31"/>
+        <label xml:lang="de">Geschwindigkeit</label>
+    </variable>
+    <variable label="Standing heat" CV="16.0.286" default="31" item="ESU FnOut A2-1 Slider 14" mask="XXXVVVVV">
+        <qualifier>
+            <variableref>ESU FnOut A2-1 Mode</variableref>
+            <relation>eq</relation>
+            <value>24</value>
+        </qualifier>
+        <decVal max="31"/>
+        <label xml:lang="de">Heizstufe im Stand</label>
+    </variable>
+    <variable label="Chuff power" CV="16.0.286" default="31" item="ESU FnOut A2-1 Slider 8" mask="XXXVVVVV">
+        <qualifier>
+            <variableref>ESU FnOut A2-1 Mode</variableref>
+            <relation>eq</relation>
+            <value>25</value>
+        </qualifier>
+        <decVal max="31"/>
+        <label xml:lang="de">Dampfstoßstärke</label>
+    </variable>
+    <variable item="Special Function CV287" label="Special Function CV 1" CV="16.0.287" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+        <decVal/>
+    </variable>
+    <variable label="Fan Acceleration rate" CV="16.0.287" default="0" item="ESU FnOut A2-1 Slider 12" mask="XXXVVVVV">
+        <qualifier>
+            <variableref>ESU FnOut A2-1 Mode</variableref>
+            <relation>eq</relation>
+            <value>23</value>
+        </qualifier>
+        <decVal max="31"/>
+        <label xml:lang="de">Beschleunigungszeit</label>
+    </variable>
+    <variable label="Minimum driving heat" CV="16.0.287" default="0" item="ESU FnOut A2-1 Slider 15" mask="XXXVVVVV">
+        <qualifier>
+            <variableref>ESU FnOut A2-1 Mode</variableref>
+            <relation>eq</relation>
+            <value>24</value>
+        </qualifier>
+        <decVal max="31"/>
+        <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
+    </variable>
+    <variable label="Fan power" CV="16.0.287" default="0" item="ESU FnOut A2-1 Slider 9" mask="XXXVVVVV">
+        <qualifier>
+            <variableref>ESU FnOut A2-1 Mode</variableref>
+            <relation>eq</relation>
+            <value>25</value>
+        </qualifier>
+        <decVal max="31"/>
+        <label xml:lang="de">Stäke des Bläsers</label>
+    </variable>
+    <variable label="Phase Reverse" CV="16.0.287" default="0" item="ESU FnOut A2-1 Check 6" mask="XXXXXXXV">
+        <qualifier>
+            <variableref>ESU FnOut A2-1 Mode</variableref>
+            <relation>gt</relation>
+            <value>0</value>
+        </qualifier>
+        <qualifier>
+            <variableref>ESU FnOut A2-1 Mode</variableref>
+            <relation>le</relation>
+            <value>15</value>
+        </qualifier>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+        <label xml:lang="de">Phase tauschen</label>
+    </variable>
+    <variable label="Grade Crossing" CV="16.0.287" default="0" item="ESU FnOut A2-1 Check 1" mask="XXXXXXVX">
+        <qualifier>
+            <variableref>ESU FnOut A2-1 Mode</variableref>
+            <relation>gt</relation>
+            <value>0</value>
+        </qualifier>
+        <qualifier>
+            <variableref>ESU FnOut A2-1 Mode</variableref>
+            <relation>le</relation>
+            <value>15</value>
+        </qualifier>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+    </variable>
+    <variable label="Rule 17 Fwd" CV="16.0.287" default="0" item="ESU FnOut A2-1 Check 2" mask="XXXXXVXX">
+        <qualifier>
+            <variableref>ESU FnOut A2-1 Mode</variableref>
+            <relation>gt</relation>
+            <value>0</value>
+        </qualifier>
+        <qualifier>
+            <variableref>ESU FnOut A2-1 Mode</variableref>
+            <relation>le</relation>
+            <value>15</value>
+        </qualifier>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+        <label xml:lang="de">Rule 17 vorwärts</label>
+    </variable>
+    <variable label="Rule 17 Rev" CV="16.0.287" default="0" item="ESU FnOut A2-1 Check 3" mask="XXXXVXXX">
+        <qualifier>
+            <variableref>ESU FnOut A2-1 Mode</variableref>
+            <relation>gt</relation>
+            <value>0</value>
+        </qualifier>
+        <qualifier>
+            <variableref>ESU FnOut A2-1 Mode</variableref>
+            <relation>le</relation>
+            <value>15</value>
+        </qualifier>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+        <label xml:lang="de">Rule 17 rückwärts</label>
+    </variable>
+    <variable label="Dimmer" CV="16.0.287" default="0" item="ESU FnOut A2-1 Check 4" mask="XXXVXXXX">
+        <qualifier>
+            <variableref>ESU FnOut A2-1 Mode</variableref>
+            <relation>gt</relation>
+            <value>0</value>
+        </qualifier>
+        <qualifier>
+            <variableref>ESU FnOut A2-1 Mode</variableref>
+            <relation>le</relation>
+            <value>15</value>
+        </qualifier>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+        <label xml:lang="de">Abdimmen</label>
+    </variable>
+    <variable label="LED Mode" CV="16.0.287" default="0" item="ESU FnOut A2-1 Check 5" mask="VXXXXXXX">
+        <qualifier>
+            <variableref>ESU FnOut A2-1 Mode</variableref>
+            <relation>gt</relation>
+            <value>0</value>
+        </qualifier>
+        <qualifier>
+            <variableref>ESU FnOut A2-1 Mode</variableref>
+            <relation>le</relation>
+            <value>15</value>
+        </qualifier>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+        <label xml:lang="de">LED Modus</label>
+    </variable>
+    <variable item="Special Function CV288" label="Special Function CV 2" CV="16.0.288" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+        <decVal/>
+    </variable>
+    <variable label="Fan Decceleration rate" CV="16.0.288" default="0" item="ESU FnOut A2-1 Slider 13" mask="XXXVVVVV">
+        <qualifier>
+            <variableref>ESU FnOut A2-1 Mode</variableref>
+            <relation>eq</relation>
+            <value>23</value>
+        </qualifier>
+        <decVal max="31"/>
+        <label xml:lang="de">Bremszeit</label>
+    </variable>
+    <variable label="Maximum driving heat" CV="16.0.288" default="0" item="ESU FnOut A2-1 Slider 16" mask="XXXVVVVV">
+        <qualifier>
+            <variableref>ESU FnOut A2-1 Mode</variableref>
+            <relation>eq</relation>
+            <value>24</value>
+        </qualifier>
+        <decVal max="31"/>
+        <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
+    </variable>
+    <variable label="Timeout" CV="16.0.288" default="0" item="ESU FnOut A2-1 Slider 10" tooltip="Units = 0.25 sec">
+        <qualifier>
+            <variableref>ESU FnOut A2-1 Mode</variableref>
+            <relation>eq</relation>
+            <value>25</value>
+        </qualifier>
+        <decVal/>
+    </variable>
+    <variable label="Startup Time" CV="16.0.288" default="0" item="ESU FnOut A2-1 Slider 6">
+        <qualifier>
+            <variableref>ESU FnOut A2-1 Mode</variableref>
+            <relation>ge</relation>
+            <value>16</value>
+        </qualifier>
+        <qualifier>
+            <variableref>ESU FnOut A2-1 Mode</variableref>
+            <relation>le</relation>
+            <value>17</value>
+        </qualifier>
+        <decVal/>
+        <label xml:lang="de">Startzeit</label>
+    </variable>
+    <variable label="Level" CV="16.0.288" default="0" item="ESU FnOut A2-1 Slider 20" mask="XVVVVVVV">
+        <qualifier>
+            <variableref>ESU FnOut A2-1 Mode</variableref>
+            <relation>eq</relation>
+            <value>19</value>
+        </qualifier>
+        <decVal max="127"/>
+    </variable>
+    <!-- exclude AUX3 to AUX18 -->
+    <variables exclude="Essential Sound Unit">
+        <!-- AUX3 Mode -->
+        <variable label="AUX3 Mode" CV="16.0.291" default="1" item="ESU FnOut A3 Mode">
             <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
         </variable>
-        <variable label="Function Switch On Delay" CV="16.0.284" default="0" item="ESU FnOut A2-1 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
+        <variable label="Function Switch On Delay" CV="16.0.292" default="0" item="ESU FnOut A3 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
             <qualifier>
-                <variableref>ESU FnOut A2-1 Mode</variableref>
+                <variableref>ESU FnOut A3 Mode</variableref>
                 <relation>gt</relation>
                 <value>0</value>
             </qualifier>
             <qualifier>
-                <variableref>ESU FnOut A2-1 Mode</variableref>
+                <variableref>ESU FnOut A3 Mode</variableref>
                 <relation>ne</relation>
                 <value>27</value>
             </qualifier>
             <decVal max="15"/>
             <label xml:lang="de">Verzögerung beim Einschalten</label>
         </variable>
-        <variable label="Function Switch Off Delay" CV="16.0.284" default="0" mask="VVVVXXXX" item="ESU FnOut A2-1 Slider 2" tooltip="Units = 0.4 sec">
+        <variable label="Function Switch Off Delay" CV="16.0.292" default="0" mask="VVVVXXXX" item="ESU FnOut A3 Slider 2" tooltip="Units = 0.4 sec">
             <qualifier>
-                <variableref>ESU FnOut A2-1 Mode</variableref>
+                <variableref>ESU FnOut A3 Mode</variableref>
                 <relation>gt</relation>
                 <value>0</value>
             </qualifier>
             <qualifier>
-                <variableref>ESU FnOut A2-1 Mode</variableref>
+                <variableref>ESU FnOut A3 Mode</variableref>
                 <relation>ne</relation>
                 <value>27</value>
             </qualifier>
             <decVal max="15"/>
             <label xml:lang="de">Verzögerung beim Ausschalten</label>
         </variable>
-        <variable label="Function Auto Switch Off" CV="16.0.285" default="0" item="ESU FnOut A2-1 Slider 3" tooltip="Units = 0.4 sec">
+        <variable label="Function Auto Switch Off" CV="16.0.293" default="0" item="ESU FnOut A3 Slider 3" tooltip="Units = 0.4 sec">
             <qualifier>
-                <variableref>ESU FnOut A2-1 Mode</variableref>
+                <variableref>ESU FnOut A3 Mode</variableref>
                 <relation>gt</relation>
                 <value>0</value>
             </qualifier>
             <qualifier>
-                <variableref>ESU FnOut A2-1 Mode</variableref>
+                <variableref>ESU FnOut A3 Mode</variableref>
                 <relation>ne</relation>
                 <value>27</value>
             </qualifier>
             <decVal/>
             <label xml:lang="de">Ausgang automatisch Ausschalten</label>
         </variable>
-        <variable item="Brightness CV286" label="Brightness CV" CV="16.0.286" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
+        <variable item="Brightness CV294" label="Brightness CV" CV="16.0.294" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
             <decVal/>
         </variable>
-        <variable label="Brightness" CV="16.0.286" default="31" item="ESU FnOut A2-1 Slider 5" mask="XXXVVVVV">
+        <variable label="Brightness" CV="16.0.294" default="31" item="ESU FnOut A3 Slider 5" mask="XXXVVVVV">
             <qualifier>
-                <variableref>ESU FnOut A2-1 Mode</variableref>
+                <variableref>ESU FnOut A3 Mode</variableref>
                 <relation>gt</relation>
                 <value>0</value>
             </qualifier>
             <qualifier>
-                <variableref>ESU FnOut A2-1 Mode</variableref>
+                <variableref>ESU FnOut A3 Mode</variableref>
                 <relation>le</relation>
                 <value>18</value>
             </qualifier>
             <decVal max="31"/>
             <label xml:lang="de">Helligkeit</label>
         </variable>
-        <variable label="Mode" CV="16.0.286" default="0" item="ESU FnOut A2-1 Option 1" mask="XXXXXXXV">
+        <variable label="Mode" CV="16.0.294" default="0" item="ESU FnOut A3 Option 1" mask="XXXXXXXV">
             <qualifier>
-                <variableref>ESU FnOut A2-1 Mode</variableref>
+                <variableref>ESU FnOut A3 Mode</variableref>
                 <relation>eq</relation>
                 <value>22</value>
             </qualifier>
@@ -1006,299 +1312,605 @@
             </enumVal>
             <label xml:lang="de">Modus</label>
         </variable>
-        <variable label="Coupler Force" CV="16.0.286" default="31" item="ESU FnOut A2-1 Slider 7" mask="XXXVVVVV">
+        <variable label="Coupler Force" CV="16.0.294" default="31" item="ESU FnOut A3 Slider 7" mask="XXXVVVVV">
             <qualifier>
-                <variableref>ESU FnOut A2-1 Mode</variableref>
+                <variableref>ESU FnOut A3 Mode</variableref>
                 <relation>ge</relation>
                 <value>28</value>
             </qualifier>
             <qualifier>
-                <variableref>ESU FnOut A2-1 Mode</variableref>
+                <variableref>ESU FnOut A3 Mode</variableref>
                 <relation>ne</relation>
                 <value>29</value>
             </qualifier>
             <qualifier>
-                <variableref>ESU FnOut A2-1 Mode</variableref>
+                <variableref>ESU FnOut A3 Mode</variableref>
                 <relation>ne</relation>
                 <value>30</value>
             </qualifier>
             <qualifier>
-                <variableref>ESU FnOut A2-1 Mode</variableref>
+                <variableref>ESU FnOut A3 Mode</variableref>
                 <relation>ne</relation>
                 <value>31</value>
             </qualifier>
             <qualifier>
-                <variableref>ESU FnOut A2-1 Mode</variableref>
+                <variableref>ESU FnOut A3 Mode</variableref>
                 <relation>ne</relation>
                 <value>32</value>
             </qualifier>
             <qualifier>
-                <variableref>ESU FnOut A2-1 Mode</variableref>
+                <variableref>ESU FnOut A3 Mode</variableref>
                 <relation>le</relation>
                 <value>33</value>
             </qualifier>
             <decVal max="31"/>
             <label xml:lang="de">Stärke des Kupplers</label>
         </variable>
-        <variable label="Fan Speed" CV="16.0.286" default="31" item="ESU FnOut A2-1 Slider 11" mask="XXXVVVVV">
+        <variable label="Fan Speed" CV="16.0.294" default="31" item="ESU FnOut A3 Slider 11" mask="XXXVVVVV">
             <qualifier>
-                <variableref>ESU FnOut A2-1 Mode</variableref>
+                <variableref>ESU FnOut A3 Mode</variableref>
                 <relation>eq</relation>
                 <value>23</value>
             </qualifier>
             <decVal max="31"/>
             <label xml:lang="de">Geschwindigkeit</label>
         </variable>
-        <variable label="Standing heat" CV="16.0.286" default="31" item="ESU FnOut A2-1 Slider 14" mask="XXXVVVVV">
+        <variable label="Standing heat" CV="16.0.294" default="31" item="ESU FnOut A3 Slider 14" mask="XXXVVVVV">
             <qualifier>
-                <variableref>ESU FnOut A2-1 Mode</variableref>
+                <variableref>ESU FnOut A3 Mode</variableref>
                 <relation>eq</relation>
                 <value>24</value>
             </qualifier>
             <decVal max="31"/>
             <label xml:lang="de">Heizstufe im Stand</label>
         </variable>
-        <variable label="Chuff power" CV="16.0.286" default="31" item="ESU FnOut A2-1 Slider 8" mask="XXXVVVVV">
+        <variable label="Chuff power" CV="16.0.294" default="31" item="ESU FnOut A3 Slider 8" mask="XXXVVVVV">
             <qualifier>
-                <variableref>ESU FnOut A2-1 Mode</variableref>
+                <variableref>ESU FnOut A3 Mode</variableref>
                 <relation>eq</relation>
                 <value>25</value>
             </qualifier>
             <decVal max="31"/>
             <label xml:lang="de">Dampfstoßstärke</label>
         </variable>
-        <variable item="Special Function CV287" label="Special Function CV 1" CV="16.0.287" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+        <variable item="Special Function CV295" label="Special Function CV 1" CV="16.0.295" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
             <decVal/>
         </variable>
-        <variable label="Fan Acceleration rate" CV="16.0.287" default="0" item="ESU FnOut A2-1 Slider 12" mask="XXXVVVVV">
+        <variable label="Fan Acceleration rate" CV="16.0.295" default="0" item="ESU FnOut A3 Slider 12" mask="XXXVVVVV">
             <qualifier>
-                <variableref>ESU FnOut A2-1 Mode</variableref>
+                <variableref>ESU FnOut A3 Mode</variableref>
                 <relation>eq</relation>
                 <value>23</value>
             </qualifier>
             <decVal max="31"/>
             <label xml:lang="de">Beschleunigungszeit</label>
         </variable>
-        <variable label="Minimum driving heat" CV="16.0.287" default="0" item="ESU FnOut A2-1 Slider 15" mask="XXXVVVVV">
+        <variable label="Minimum driving heat" CV="16.0.295" default="0" item="ESU FnOut A3 Slider 15" mask="XXXVVVVV">
             <qualifier>
-                <variableref>ESU FnOut A2-1 Mode</variableref>
+                <variableref>ESU FnOut A3 Mode</variableref>
                 <relation>eq</relation>
                 <value>24</value>
             </qualifier>
             <decVal max="31"/>
             <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
         </variable>
-        <variable label="Fan power" CV="16.0.287" default="0" item="ESU FnOut A2-1 Slider 9" mask="XXXVVVVV">
+        <variable label="Fan power" CV="16.0.295" default="0" item="ESU FnOut A3 Slider 9" mask="XXXVVVVV">
             <qualifier>
-                <variableref>ESU FnOut A2-1 Mode</variableref>
+                <variableref>ESU FnOut A3 Mode</variableref>
                 <relation>eq</relation>
                 <value>25</value>
             </qualifier>
             <decVal max="31"/>
             <label xml:lang="de">Stäke des Bläsers</label>
         </variable>
-        <variable label="Phase Reverse" CV="16.0.287" default="0" item="ESU FnOut A2-1 Check 6" mask="XXXXXXXV">
+        <variable label="Phase Reverse" CV="16.0.295" default="0" item="ESU FnOut A3 Check 6" mask="XXXXXXXV">
             <qualifier>
-                <variableref>ESU FnOut A2-1 Mode</variableref>
+                <variableref>ESU FnOut A3 Mode</variableref>
                 <relation>gt</relation>
                 <value>0</value>
             </qualifier>
             <qualifier>
-                <variableref>ESU FnOut A2-1 Mode</variableref>
+                <variableref>ESU FnOut A3 Mode</variableref>
                 <relation>le</relation>
                 <value>15</value>
             </qualifier>
             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
             <label xml:lang="de">Phase tauschen</label>
         </variable>
-        <variable label="Grade Crossing" CV="16.0.287" default="0" item="ESU FnOut A2-1 Check 1" mask="XXXXXXVX">
+        <variable label="Grade Crossing" CV="16.0.295" default="0" item="ESU FnOut A3 Check 1" mask="XXXXXXVX">
             <qualifier>
-                <variableref>ESU FnOut A2-1 Mode</variableref>
+                <variableref>ESU FnOut A3 Mode</variableref>
                 <relation>gt</relation>
                 <value>0</value>
             </qualifier>
             <qualifier>
-                <variableref>ESU FnOut A2-1 Mode</variableref>
+                <variableref>ESU FnOut A3 Mode</variableref>
                 <relation>le</relation>
                 <value>15</value>
             </qualifier>
             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
         </variable>
-        <variable label="Rule 17 Fwd" CV="16.0.287" default="0" item="ESU FnOut A2-1 Check 2" mask="XXXXXVXX">
+        <variable label="Rule 17 Fwd" CV="16.0.295" default="0" item="ESU FnOut A3 Check 2" mask="XXXXXVXX">
             <qualifier>
-                <variableref>ESU FnOut A2-1 Mode</variableref>
+                <variableref>ESU FnOut A3 Mode</variableref>
                 <relation>gt</relation>
                 <value>0</value>
             </qualifier>
             <qualifier>
-                <variableref>ESU FnOut A2-1 Mode</variableref>
+                <variableref>ESU FnOut A3 Mode</variableref>
                 <relation>le</relation>
                 <value>15</value>
             </qualifier>
             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
             <label xml:lang="de">Rule 17 vorwärts</label>
         </variable>
-        <variable label="Rule 17 Rev" CV="16.0.287" default="0" item="ESU FnOut A2-1 Check 3" mask="XXXXVXXX">
+        <variable label="Rule 17 Rev" CV="16.0.295" default="0" item="ESU FnOut A3 Check 3" mask="XXXXVXXX">
             <qualifier>
-                <variableref>ESU FnOut A2-1 Mode</variableref>
+                <variableref>ESU FnOut A3 Mode</variableref>
                 <relation>gt</relation>
                 <value>0</value>
             </qualifier>
             <qualifier>
-                <variableref>ESU FnOut A2-1 Mode</variableref>
+                <variableref>ESU FnOut A3 Mode</variableref>
                 <relation>le</relation>
                 <value>15</value>
             </qualifier>
             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
             <label xml:lang="de">Rule 17 rückwärts</label>
         </variable>
-        <variable label="Dimmer" CV="16.0.287" default="0" item="ESU FnOut A2-1 Check 4" mask="XXXVXXXX">
+        <variable label="Dimmer" CV="16.0.295" default="0" item="ESU FnOut A3 Check 4" mask="XXXVXXXX">
             <qualifier>
-                <variableref>ESU FnOut A2-1 Mode</variableref>
+                <variableref>ESU FnOut A3 Mode</variableref>
                 <relation>gt</relation>
                 <value>0</value>
             </qualifier>
             <qualifier>
-                <variableref>ESU FnOut A2-1 Mode</variableref>
+                <variableref>ESU FnOut A3 Mode</variableref>
                 <relation>le</relation>
                 <value>15</value>
             </qualifier>
             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
             <label xml:lang="de">Abdimmen</label>
         </variable>
-        <variable label="LED Mode" CV="16.0.287" default="0" item="ESU FnOut A2-1 Check 5" mask="VXXXXXXX">
+        <variable label="LED Mode" CV="16.0.295" default="0" item="ESU FnOut A3 Check 5" mask="VXXXXXXX">
             <qualifier>
-                <variableref>ESU FnOut A2-1 Mode</variableref>
+                <variableref>ESU FnOut A3 Mode</variableref>
                 <relation>gt</relation>
                 <value>0</value>
             </qualifier>
             <qualifier>
-                <variableref>ESU FnOut A2-1 Mode</variableref>
+                <variableref>ESU FnOut A3 Mode</variableref>
                 <relation>le</relation>
                 <value>15</value>
             </qualifier>
             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
             <label xml:lang="de">LED Modus</label>
         </variable>
-        <variable item="Special Function CV288" label="Special Function CV 2" CV="16.0.288" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+        <variable item="Special Function CV296" label="Special Function CV 2" CV="16.0.296" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
             <decVal/>
         </variable>
-        <variable label="Fan Decceleration rate" CV="16.0.288" default="0" item="ESU FnOut A2-1 Slider 13" mask="XXXVVVVV">
+        <variable label="Fan Decceleration rate" CV="16.0.296" default="0" item="ESU FnOut A3 Slider 13" mask="XXXVVVVV">
             <qualifier>
-                <variableref>ESU FnOut A2-1 Mode</variableref>
+                <variableref>ESU FnOut A3 Mode</variableref>
                 <relation>eq</relation>
                 <value>23</value>
             </qualifier>
             <decVal max="31"/>
             <label xml:lang="de">Bremszeit</label>
         </variable>
-        <variable label="Maximum driving heat" CV="16.0.288" default="0" item="ESU FnOut A2-1 Slider 16" mask="XXXVVVVV">
+        <variable label="Maximum driving heat" CV="16.0.296" default="0" item="ESU FnOut A3 Slider 16" mask="XXXVVVVV">
             <qualifier>
-                <variableref>ESU FnOut A2-1 Mode</variableref>
+                <variableref>ESU FnOut A3 Mode</variableref>
                 <relation>eq</relation>
                 <value>24</value>
             </qualifier>
             <decVal max="31"/>
             <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
         </variable>
-        <variable label="Timeout" CV="16.0.288" default="0" item="ESU FnOut A2-1 Slider 10" tooltip="Units = 0.25 sec">
+        <variable label="Timeout" CV="16.0.296" default="0" item="ESU FnOut A3 Slider 10" tooltip="Units = 0.25 sec">
             <qualifier>
-                <variableref>ESU FnOut A2-1 Mode</variableref>
+                <variableref>ESU FnOut A3 Mode</variableref>
                 <relation>eq</relation>
                 <value>25</value>
             </qualifier>
             <decVal/>
         </variable>
-        <variable label="Startup Time" CV="16.0.288" default="0" item="ESU FnOut A2-1 Slider 6">
+        <variable label="Startup Time" CV="16.0.296" default="0" item="ESU FnOut A3 Slider 6">
             <qualifier>
-                <variableref>ESU FnOut A2-1 Mode</variableref>
+                <variableref>ESU FnOut A3 Mode</variableref>
                 <relation>ge</relation>
                 <value>16</value>
             </qualifier>
             <qualifier>
-                <variableref>ESU FnOut A2-1 Mode</variableref>
+                <variableref>ESU FnOut A3 Mode</variableref>
                 <relation>le</relation>
                 <value>17</value>
             </qualifier>
             <decVal/>
             <label xml:lang="de">Startzeit</label>
         </variable>
-        <variable label="Level" CV="16.0.288" default="0" item="ESU FnOut A2-1 Slider 20" mask="XVVVVVVV">
+        <variable label="Level" CV="16.0.296" default="0" item="ESU FnOut A3 Slider 20" mask="XVVVVVVV">
             <qualifier>
-                <variableref>ESU FnOut A2-1 Mode</variableref>
+                <variableref>ESU FnOut A3 Mode</variableref>
                 <relation>eq</relation>
                 <value>19</value>
             </qualifier>
             <decVal max="127"/>
         </variable>
-        <!-- exclude AUX3 to AUX18 -->
-        <variables exclude="Essential Sound Unit">
-            <!-- AUX3 Mode -->
-            <variable label="AUX3 Mode" CV="16.0.291" default="1" item="ESU FnOut A3 Mode">
+        <!-- AUX4 Mode -->
+        <variable label="AUX4 Mode" CV="16.0.299" default="1" item="ESU FnOut A4 Mode">
+            <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
+        </variable>
+        <variable label="Function Switch On Delay" CV="16.0.300" default="0" item="ESU FnOut A4 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
+            <qualifier>
+                <variableref>ESU FnOut A4 Mode</variableref>
+                <relation>gt</relation>
+                <value>0</value>
+            </qualifier>
+            <qualifier>
+                <variableref>ESU FnOut A4 Mode</variableref>
+                <relation>ne</relation>
+                <value>27</value>
+            </qualifier>
+            <decVal max="15"/>
+            <label xml:lang="de">Verzögerung beim Einschalten</label>
+        </variable>
+        <variable label="Function Switch Off Delay" CV="16.0.300" default="0" mask="VVVVXXXX" item="ESU FnOut A4 Slider 2" tooltip="Units = 0.4 sec">
+            <qualifier>
+                <variableref>ESU FnOut A4 Mode</variableref>
+                <relation>gt</relation>
+                <value>0</value>
+            </qualifier>
+            <qualifier>
+                <variableref>ESU FnOut A4 Mode</variableref>
+                <relation>ne</relation>
+                <value>27</value>
+            </qualifier>
+            <decVal max="15"/>
+            <label xml:lang="de">Verzögerung beim Ausschalten</label>
+        </variable>
+        <variable label="Function Auto Switch Off" CV="16.0.301" default="0" item="ESU FnOut A4 Slider 3" tooltip="Units = 0.4 sec">
+            <qualifier>
+                <variableref>ESU FnOut A4 Mode</variableref>
+                <relation>gt</relation>
+                <value>0</value>
+            </qualifier>
+            <qualifier>
+                <variableref>ESU FnOut A4 Mode</variableref>
+                <relation>ne</relation>
+                <value>27</value>
+            </qualifier>
+            <decVal/>
+            <label xml:lang="de">Ausgang automatisch Ausschalten</label>
+        </variable>
+        <variable item="Brightness CV302" label="Brightness CV" CV="16.0.302" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
+            <decVal/>
+        </variable>
+        <variable label="Brightness" CV="16.0.302" default="31" item="ESU FnOut A4 Slider 5" mask="XXXVVVVV">
+            <qualifier>
+                <variableref>ESU FnOut A4 Mode</variableref>
+                <relation>gt</relation>
+                <value>0</value>
+            </qualifier>
+            <qualifier>
+                <variableref>ESU FnOut A4 Mode</variableref>
+                <relation>le</relation>
+                <value>18</value>
+            </qualifier>
+            <decVal max="31"/>
+            <label xml:lang="de">Helligkeit</label>
+        </variable>
+        <variable label="Mode" CV="16.0.302" default="0" item="ESU FnOut A4 Option 1" mask="XXXXXXXV">
+            <qualifier>
+                <variableref>ESU FnOut A4 Mode</variableref>
+                <relation>eq</relation>
+                <value>22</value>
+            </qualifier>
+            <enumVal>
+                <enumChoice choice="Heating control">
+                    <choice>Heating control</choice>
+                    <choice xml:lang="de">Heizungssteuerung</choice>
+                </enumChoice>
+                <enumChoice choice="Fan control">
+                    <choice>Fan control</choice>
+                    <choice xml:lang="de">Lüftersteuerung</choice>
+                </enumChoice>
+            </enumVal>
+            <label xml:lang="de">Modus</label>
+        </variable>
+        <variable label="Coupler Force" CV="16.0.302" default="31" item="ESU FnOut A4 Slider 7" mask="XXXVVVVV">
+            <qualifier>
+                <variableref>ESU FnOut A4 Mode</variableref>
+                <relation>ge</relation>
+                <value>28</value>
+            </qualifier>
+            <qualifier>
+                <variableref>ESU FnOut A4 Mode</variableref>
+                <relation>ne</relation>
+                <value>29</value>
+            </qualifier>
+            <qualifier>
+                <variableref>ESU FnOut A4 Mode</variableref>
+                <relation>ne</relation>
+                <value>30</value>
+            </qualifier>
+            <qualifier>
+                <variableref>ESU FnOut A4 Mode</variableref>
+                <relation>ne</relation>
+                <value>31</value>
+            </qualifier>
+            <qualifier>
+                <variableref>ESU FnOut A4 Mode</variableref>
+                <relation>ne</relation>
+                <value>32</value>
+            </qualifier>
+            <qualifier>
+                <variableref>ESU FnOut A4 Mode</variableref>
+                <relation>le</relation>
+                <value>33</value>
+            </qualifier>
+            <decVal max="31"/>
+            <label xml:lang="de">Stärke des Kupplers</label>
+        </variable>
+        <variable label="Fan Speed" CV="16.0.302" default="31" item="ESU FnOut A4 Slider 11" mask="XXXVVVVV">
+            <qualifier>
+                <variableref>ESU FnOut A4 Mode</variableref>
+                <relation>eq</relation>
+                <value>23</value>
+            </qualifier>
+            <decVal max="31"/>
+            <label xml:lang="de">Geschwindigkeit</label>
+        </variable>
+        <variable label="Standing heat" CV="16.0.302" default="31" item="ESU FnOut A4 Slider 14" mask="XXXVVVVV">
+            <qualifier>
+                <variableref>ESU FnOut A4 Mode</variableref>
+                <relation>eq</relation>
+                <value>24</value>
+            </qualifier>
+            <decVal max="31"/>
+            <label xml:lang="de">Heizstufe im Stand</label>
+        </variable>
+        <variable label="Chuff power" CV="16.0.302" default="31" item="ESU FnOut A4 Slider 8" mask="XXXVVVVV">
+            <qualifier>
+                <variableref>ESU FnOut A4 Mode</variableref>
+                <relation>eq</relation>
+                <value>25</value>
+            </qualifier>
+            <decVal max="31"/>
+            <label xml:lang="de">Dampfstoßstärke</label>
+        </variable>
+        <variable item="Special Function CV303" label="Special Function CV 1" CV="16.0.303" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+            <decVal/>
+        </variable>
+        <variable label="Fan Acceleration rate" CV="16.0.303" default="0" item="ESU FnOut A4 Slider 12" mask="XXXVVVVV">
+            <qualifier>
+                <variableref>ESU FnOut A4 Mode</variableref>
+                <relation>eq</relation>
+                <value>23</value>
+            </qualifier>
+            <decVal max="31"/>
+            <label xml:lang="de">Beschleunigungszeit</label>
+        </variable>
+        <variable label="Minimum driving heat" CV="16.0.303" default="0" item="ESU FnOut A4 Slider 15" mask="XXXVVVVV">
+            <qualifier>
+                <variableref>ESU FnOut A4 Mode</variableref>
+                <relation>eq</relation>
+                <value>24</value>
+            </qualifier>
+            <decVal max="31"/>
+            <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
+        </variable>
+        <variable label="Fan power" CV="16.0.303" default="0" item="ESU FnOut A4 Slider 9" mask="XXXVVVVV">
+            <qualifier>
+                <variableref>ESU FnOut A4 Mode</variableref>
+                <relation>eq</relation>
+                <value>25</value>
+            </qualifier>
+            <decVal max="31"/>
+            <label xml:lang="de">Stäke des Bläsers</label>
+        </variable>
+        <variable label="Phase Reverse" CV="16.0.303" default="0" item="ESU FnOut A4 Check 6" mask="XXXXXXXV">
+            <qualifier>
+                <variableref>ESU FnOut A4 Mode</variableref>
+                <relation>gt</relation>
+                <value>0</value>
+            </qualifier>
+            <qualifier>
+                <variableref>ESU FnOut A4 Mode</variableref>
+                <relation>le</relation>
+                <value>15</value>
+            </qualifier>
+            <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+            <label xml:lang="de">Phase tauschen</label>
+        </variable>
+        <variable label="Grade Crossing" CV="16.0.303" default="0" item="ESU FnOut A4 Check 1" mask="XXXXXXVX">
+            <qualifier>
+                <variableref>ESU FnOut A4 Mode</variableref>
+                <relation>gt</relation>
+                <value>0</value>
+            </qualifier>
+            <qualifier>
+                <variableref>ESU FnOut A4 Mode</variableref>
+                <relation>le</relation>
+                <value>15</value>
+            </qualifier>
+            <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+        </variable>
+        <variable label="Rule 17 Fwd" CV="16.0.303" default="0" item="ESU FnOut A4 Check 2" mask="XXXXXVXX">
+            <qualifier>
+                <variableref>ESU FnOut A4 Mode</variableref>
+                <relation>gt</relation>
+                <value>0</value>
+            </qualifier>
+            <qualifier>
+                <variableref>ESU FnOut A4 Mode</variableref>
+                <relation>le</relation>
+                <value>15</value>
+            </qualifier>
+            <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+            <label xml:lang="de">Rule 17 vorwärts</label>
+        </variable>
+        <variable label="Rule 17 Rev" CV="16.0.303" default="0" item="ESU FnOut A4 Check 3" mask="XXXXVXXX">
+            <qualifier>
+                <variableref>ESU FnOut A4 Mode</variableref>
+                <relation>gt</relation>
+                <value>0</value>
+            </qualifier>
+            <qualifier>
+                <variableref>ESU FnOut A4 Mode</variableref>
+                <relation>le</relation>
+                <value>15</value>
+            </qualifier>
+            <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+            <label xml:lang="de">Rule 17 rückwärts</label>
+        </variable>
+        <variable label="Dimmer" CV="16.0.303" default="0" item="ESU FnOut A4 Check 4" mask="XXXVXXXX">
+            <qualifier>
+                <variableref>ESU FnOut A4 Mode</variableref>
+                <relation>gt</relation>
+                <value>0</value>
+            </qualifier>
+            <qualifier>
+                <variableref>ESU FnOut A4 Mode</variableref>
+                <relation>le</relation>
+                <value>15</value>
+            </qualifier>
+            <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+            <label xml:lang="de">Abdimmen</label>
+        </variable>
+        <variable label="LED Mode" CV="16.0.303" default="0" item="ESU FnOut A4 Check 5" mask="VXXXXXXX">
+            <qualifier>
+                <variableref>ESU FnOut A4 Mode</variableref>
+                <relation>gt</relation>
+                <value>0</value>
+            </qualifier>
+            <qualifier>
+                <variableref>ESU FnOut A4 Mode</variableref>
+                <relation>le</relation>
+                <value>15</value>
+            </qualifier>
+            <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+            <label xml:lang="de">LED Modus</label>
+        </variable>
+        <variable item="Special Function CV304" label="Special Function CV 2" CV="16.0.304" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+            <decVal/>
+        </variable>
+        <variable label="Fan Decceleration rate" CV="16.0.304" default="0" item="ESU FnOut A4 Slider 13" mask="XXXVVVVV">
+            <qualifier>
+                <variableref>ESU FnOut A4 Mode</variableref>
+                <relation>eq</relation>
+                <value>23</value>
+            </qualifier>
+            <decVal max="31"/>
+            <label xml:lang="de">Bremszeit</label>
+        </variable>
+        <variable label="Maximum driving heat" CV="16.0.304" default="0" item="ESU FnOut A4 Slider 16" mask="XXXVVVVV">
+            <qualifier>
+                <variableref>ESU FnOut A4 Mode</variableref>
+                <relation>eq</relation>
+                <value>24</value>
+            </qualifier>
+            <decVal max="31"/>
+            <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
+        </variable>
+        <variable label="Timeout" CV="16.0.304" default="0" item="ESU FnOut A4 Slider 10" tooltip="Units = 0.25 sec">
+            <qualifier>
+                <variableref>ESU FnOut A4 Mode</variableref>
+                <relation>eq</relation>
+                <value>25</value>
+            </qualifier>
+            <decVal/>
+        </variable>
+        <variable label="Startup Time" CV="16.0.304" default="0" item="ESU FnOut A4 Slider 6">
+            <qualifier>
+                <variableref>ESU FnOut A4 Mode</variableref>
+                <relation>ge</relation>
+                <value>16</value>
+            </qualifier>
+            <qualifier>
+                <variableref>ESU FnOut A4 Mode</variableref>
+                <relation>le</relation>
+                <value>17</value>
+            </qualifier>
+            <decVal/>
+            <label xml:lang="de">Startzeit</label>
+        </variable>
+        <variable label="Level" CV="16.0.304" default="0" item="ESU FnOut A4 Slider 20" mask="XVVVVVVV">
+            <qualifier>
+                <variableref>ESU FnOut A4 Mode</variableref>
+                <relation>eq</relation>
+                <value>19</value>
+            </qualifier>
+            <decVal max="127"/>
+        </variable>
+        <!-- exclude AUX5 to AUX18 -->
+        <variables exclude="LokPilot 5 micro,LokPilot 5 micro DCC,LokSound 5 micro DCC Direct Atlas Legacy">
+            <!-- AUX5 Mode -->
+            <variable label="AUX5 Mode" CV="16.0.307" default="1" item="ESU FnOut A5 Mode">
                 <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
             </variable>
-            <variable label="Function Switch On Delay" CV="16.0.292" default="0" item="ESU FnOut A3 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
+            <variable label="Function Switch On Delay" CV="16.0.308" default="0" item="ESU FnOut A5 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A3 Mode</variableref>
+                    <variableref>ESU FnOut A5 Mode</variableref>
                     <relation>gt</relation>
                     <value>0</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A3 Mode</variableref>
+                    <variableref>ESU FnOut A5 Mode</variableref>
                     <relation>ne</relation>
                     <value>27</value>
                 </qualifier>
                 <decVal max="15"/>
                 <label xml:lang="de">Verzögerung beim Einschalten</label>
             </variable>
-            <variable label="Function Switch Off Delay" CV="16.0.292" default="0" mask="VVVVXXXX" item="ESU FnOut A3 Slider 2" tooltip="Units = 0.4 sec">
+            <variable label="Function Switch Off Delay" CV="16.0.308" default="0" mask="VVVVXXXX" item="ESU FnOut A5 Slider 2" tooltip="Units = 0.4 sec">
                 <qualifier>
-                    <variableref>ESU FnOut A3 Mode</variableref>
+                    <variableref>ESU FnOut A5 Mode</variableref>
                     <relation>gt</relation>
                     <value>0</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A3 Mode</variableref>
+                    <variableref>ESU FnOut A5 Mode</variableref>
                     <relation>ne</relation>
                     <value>27</value>
                 </qualifier>
                 <decVal max="15"/>
                 <label xml:lang="de">Verzögerung beim Ausschalten</label>
             </variable>
-            <variable label="Function Auto Switch Off" CV="16.0.293" default="0" item="ESU FnOut A3 Slider 3" tooltip="Units = 0.4 sec">
+            <variable label="Function Auto Switch Off" CV="16.0.309" default="0" item="ESU FnOut A5 Slider 3" tooltip="Units = 0.4 sec">
                 <qualifier>
-                    <variableref>ESU FnOut A3 Mode</variableref>
+                    <variableref>ESU FnOut A5 Mode</variableref>
                     <relation>gt</relation>
                     <value>0</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A3 Mode</variableref>
+                    <variableref>ESU FnOut A5 Mode</variableref>
                     <relation>ne</relation>
                     <value>27</value>
                 </qualifier>
                 <decVal/>
                 <label xml:lang="de">Ausgang automatisch Ausschalten</label>
             </variable>
-            <variable item="Brightness CV294" label="Brightness CV" CV="16.0.294" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
+            <variable item="Brightness CV310" label="Brightness CV" CV="16.0.310" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
                 <decVal/>
             </variable>
-            <variable label="Brightness" CV="16.0.294" default="31" item="ESU FnOut A3 Slider 5" mask="XXXVVVVV">
+            <variable label="Brightness" CV="16.0.310" default="31" item="ESU FnOut A5 Slider 5" mask="XXXVVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A3 Mode</variableref>
+                    <variableref>ESU FnOut A5 Mode</variableref>
                     <relation>gt</relation>
                     <value>0</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A3 Mode</variableref>
+                    <variableref>ESU FnOut A5 Mode</variableref>
                     <relation>le</relation>
                     <value>18</value>
                 </qualifier>
                 <decVal max="31"/>
                 <label xml:lang="de">Helligkeit</label>
             </variable>
-            <variable label="Mode" CV="16.0.294" default="0" item="ESU FnOut A3 Option 1" mask="XXXXXXXV">
+            <variable label="Mode" CV="16.0.310" default="0" item="ESU FnOut A5 Option 1" mask="XXXXXXXV">
                 <qualifier>
-                    <variableref>ESU FnOut A3 Mode</variableref>
+                    <variableref>ESU FnOut A5 Mode</variableref>
                     <relation>eq</relation>
                     <value>22</value>
                 </qualifier>
@@ -1314,297 +1926,297 @@
                 </enumVal>
                 <label xml:lang="de">Modus</label>
             </variable>
-            <variable label="Coupler Force" CV="16.0.294" default="31" item="ESU FnOut A3 Slider 7" mask="XXXVVVVV">
+            <variable label="Coupler Force" CV="16.0.310" default="31" item="ESU FnOut A5 Slider 7" mask="XXXVVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A3 Mode</variableref>
+                    <variableref>ESU FnOut A5 Mode</variableref>
                     <relation>ge</relation>
                     <value>28</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A3 Mode</variableref>
+                    <variableref>ESU FnOut A5 Mode</variableref>
                     <relation>ne</relation>
                     <value>29</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A3 Mode</variableref>
+                    <variableref>ESU FnOut A5 Mode</variableref>
                     <relation>ne</relation>
                     <value>30</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A3 Mode</variableref>
+                    <variableref>ESU FnOut A5 Mode</variableref>
                     <relation>ne</relation>
                     <value>31</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A3 Mode</variableref>
+                    <variableref>ESU FnOut A5 Mode</variableref>
                     <relation>ne</relation>
                     <value>32</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A3 Mode</variableref>
+                    <variableref>ESU FnOut A5 Mode</variableref>
                     <relation>le</relation>
                     <value>33</value>
                 </qualifier>
                 <decVal max="31"/>
                 <label xml:lang="de">Stärke des Kupplers</label>
             </variable>
-            <variable label="Fan Speed" CV="16.0.294" default="31" item="ESU FnOut A3 Slider 11" mask="XXXVVVVV">
+            <variable label="Fan Speed" CV="16.0.310" default="31" item="ESU FnOut A5 Slider 11" mask="XXXVVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A3 Mode</variableref>
+                    <variableref>ESU FnOut A5 Mode</variableref>
                     <relation>eq</relation>
                     <value>23</value>
                 </qualifier>
                 <decVal max="31"/>
                 <label xml:lang="de">Geschwindigkeit</label>
             </variable>
-            <variable label="Standing heat" CV="16.0.294" default="31" item="ESU FnOut A3 Slider 14" mask="XXXVVVVV">
+            <variable label="Standing heat" CV="16.0.310" default="31" item="ESU FnOut A5 Slider 14" mask="XXXVVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A3 Mode</variableref>
+                    <variableref>ESU FnOut A5 Mode</variableref>
                     <relation>eq</relation>
                     <value>24</value>
                 </qualifier>
                 <decVal max="31"/>
                 <label xml:lang="de">Heizstufe im Stand</label>
             </variable>
-            <variable label="Chuff power" CV="16.0.294" default="31" item="ESU FnOut A3 Slider 8" mask="XXXVVVVV">
+            <variable label="Chuff power" CV="16.0.310" default="31" item="ESU FnOut A5 Slider 8" mask="XXXVVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A3 Mode</variableref>
+                    <variableref>ESU FnOut A5 Mode</variableref>
                     <relation>eq</relation>
                     <value>25</value>
                 </qualifier>
                 <decVal max="31"/>
                 <label xml:lang="de">Dampfstoßstärke</label>
             </variable>
-            <variable item="Special Function CV295" label="Special Function CV 1" CV="16.0.295" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+            <variable item="Special Function CV311" label="Special Function CV 1" CV="16.0.311" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
                 <decVal/>
             </variable>
-            <variable label="Fan Acceleration rate" CV="16.0.295" default="0" item="ESU FnOut A3 Slider 12" mask="XXXVVVVV">
+            <variable label="Fan Acceleration rate" CV="16.0.311" default="0" item="ESU FnOut A5 Slider 12" mask="XXXVVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A3 Mode</variableref>
+                    <variableref>ESU FnOut A5 Mode</variableref>
                     <relation>eq</relation>
                     <value>23</value>
                 </qualifier>
                 <decVal max="31"/>
                 <label xml:lang="de">Beschleunigungszeit</label>
             </variable>
-            <variable label="Minimum driving heat" CV="16.0.295" default="0" item="ESU FnOut A3 Slider 15" mask="XXXVVVVV">
+            <variable label="Minimum driving heat" CV="16.0.311" default="0" item="ESU FnOut A5 Slider 15" mask="XXXVVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A3 Mode</variableref>
+                    <variableref>ESU FnOut A5 Mode</variableref>
                     <relation>eq</relation>
                     <value>24</value>
                 </qualifier>
                 <decVal max="31"/>
                 <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
             </variable>
-            <variable label="Fan power" CV="16.0.295" default="0" item="ESU FnOut A3 Slider 9" mask="XXXVVVVV">
+            <variable label="Fan power" CV="16.0.311" default="0" item="ESU FnOut A5 Slider 9" mask="XXXVVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A3 Mode</variableref>
+                    <variableref>ESU FnOut A5 Mode</variableref>
                     <relation>eq</relation>
                     <value>25</value>
                 </qualifier>
                 <decVal max="31"/>
                 <label xml:lang="de">Stäke des Bläsers</label>
             </variable>
-            <variable label="Phase Reverse" CV="16.0.295" default="0" item="ESU FnOut A3 Check 6" mask="XXXXXXXV">
+            <variable label="Phase Reverse" CV="16.0.311" default="0" item="ESU FnOut A5 Check 6" mask="XXXXXXXV">
                 <qualifier>
-                    <variableref>ESU FnOut A3 Mode</variableref>
+                    <variableref>ESU FnOut A5 Mode</variableref>
                     <relation>gt</relation>
                     <value>0</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A3 Mode</variableref>
+                    <variableref>ESU FnOut A5 Mode</variableref>
                     <relation>le</relation>
                     <value>15</value>
                 </qualifier>
                 <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                 <label xml:lang="de">Phase tauschen</label>
             </variable>
-            <variable label="Grade Crossing" CV="16.0.295" default="0" item="ESU FnOut A3 Check 1" mask="XXXXXXVX">
+            <variable label="Grade Crossing" CV="16.0.311" default="0" item="ESU FnOut A5 Check 1" mask="XXXXXXVX">
                 <qualifier>
-                    <variableref>ESU FnOut A3 Mode</variableref>
+                    <variableref>ESU FnOut A5 Mode</variableref>
                     <relation>gt</relation>
                     <value>0</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A3 Mode</variableref>
+                    <variableref>ESU FnOut A5 Mode</variableref>
                     <relation>le</relation>
                     <value>15</value>
                 </qualifier>
                 <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
             </variable>
-            <variable label="Rule 17 Fwd" CV="16.0.295" default="0" item="ESU FnOut A3 Check 2" mask="XXXXXVXX">
+            <variable label="Rule 17 Fwd" CV="16.0.311" default="0" item="ESU FnOut A5 Check 2" mask="XXXXXVXX">
                 <qualifier>
-                    <variableref>ESU FnOut A3 Mode</variableref>
+                    <variableref>ESU FnOut A5 Mode</variableref>
                     <relation>gt</relation>
                     <value>0</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A3 Mode</variableref>
+                    <variableref>ESU FnOut A5 Mode</variableref>
                     <relation>le</relation>
                     <value>15</value>
                 </qualifier>
                 <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                 <label xml:lang="de">Rule 17 vorwärts</label>
             </variable>
-            <variable label="Rule 17 Rev" CV="16.0.295" default="0" item="ESU FnOut A3 Check 3" mask="XXXXVXXX">
+            <variable label="Rule 17 Rev" CV="16.0.311" default="0" item="ESU FnOut A5 Check 3" mask="XXXXVXXX">
                 <qualifier>
-                    <variableref>ESU FnOut A3 Mode</variableref>
+                    <variableref>ESU FnOut A5 Mode</variableref>
                     <relation>gt</relation>
                     <value>0</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A3 Mode</variableref>
+                    <variableref>ESU FnOut A5 Mode</variableref>
                     <relation>le</relation>
                     <value>15</value>
                 </qualifier>
                 <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                 <label xml:lang="de">Rule 17 rückwärts</label>
             </variable>
-            <variable label="Dimmer" CV="16.0.295" default="0" item="ESU FnOut A3 Check 4" mask="XXXVXXXX">
+            <variable label="Dimmer" CV="16.0.311" default="0" item="ESU FnOut A5 Check 4" mask="XXXVXXXX">
                 <qualifier>
-                    <variableref>ESU FnOut A3 Mode</variableref>
+                    <variableref>ESU FnOut A5 Mode</variableref>
                     <relation>gt</relation>
                     <value>0</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A3 Mode</variableref>
+                    <variableref>ESU FnOut A5 Mode</variableref>
                     <relation>le</relation>
                     <value>15</value>
                 </qualifier>
                 <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                 <label xml:lang="de">Abdimmen</label>
             </variable>
-            <variable label="LED Mode" CV="16.0.295" default="0" item="ESU FnOut A3 Check 5" mask="VXXXXXXX">
+            <variable label="LED Mode" CV="16.0.311" default="0" item="ESU FnOut A5 Check 5" mask="VXXXXXXX">
                 <qualifier>
-                    <variableref>ESU FnOut A3 Mode</variableref>
+                    <variableref>ESU FnOut A5 Mode</variableref>
                     <relation>gt</relation>
                     <value>0</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A3 Mode</variableref>
+                    <variableref>ESU FnOut A5 Mode</variableref>
                     <relation>le</relation>
                     <value>15</value>
                 </qualifier>
                 <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                 <label xml:lang="de">LED Modus</label>
             </variable>
-            <variable item="Special Function CV296" label="Special Function CV 2" CV="16.0.296" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+            <variable item="Special Function CV312" label="Special Function CV 2" CV="16.0.312" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
                 <decVal/>
             </variable>
-            <variable label="Fan Decceleration rate" CV="16.0.296" default="0" item="ESU FnOut A3 Slider 13" mask="XXXVVVVV">
+            <variable label="Fan Decceleration rate" CV="16.0.312" default="0" item="ESU FnOut A5 Slider 13" mask="XXXVVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A3 Mode</variableref>
+                    <variableref>ESU FnOut A5 Mode</variableref>
                     <relation>eq</relation>
                     <value>23</value>
                 </qualifier>
                 <decVal max="31"/>
                 <label xml:lang="de">Bremszeit</label>
             </variable>
-            <variable label="Maximum driving heat" CV="16.0.296" default="0" item="ESU FnOut A3 Slider 16" mask="XXXVVVVV">
+            <variable label="Maximum driving heat" CV="16.0.312" default="0" item="ESU FnOut A5 Slider 16" mask="XXXVVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A3 Mode</variableref>
+                    <variableref>ESU FnOut A5 Mode</variableref>
                     <relation>eq</relation>
                     <value>24</value>
                 </qualifier>
                 <decVal max="31"/>
                 <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
             </variable>
-            <variable label="Timeout" CV="16.0.296" default="0" item="ESU FnOut A3 Slider 10" tooltip="Units = 0.25 sec">
+            <variable label="Timeout" CV="16.0.312" default="0" item="ESU FnOut A5 Slider 10" tooltip="Units = 0.25 sec">
                 <qualifier>
-                    <variableref>ESU FnOut A3 Mode</variableref>
+                    <variableref>ESU FnOut A5 Mode</variableref>
                     <relation>eq</relation>
                     <value>25</value>
                 </qualifier>
                 <decVal/>
             </variable>
-            <variable label="Startup Time" CV="16.0.296" default="0" item="ESU FnOut A3 Slider 6">
+            <variable label="Startup Time" CV="16.0.312" default="0" item="ESU FnOut A5 Slider 6">
                 <qualifier>
-                    <variableref>ESU FnOut A3 Mode</variableref>
+                    <variableref>ESU FnOut A5 Mode</variableref>
                     <relation>ge</relation>
                     <value>16</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A3 Mode</variableref>
+                    <variableref>ESU FnOut A5 Mode</variableref>
                     <relation>le</relation>
                     <value>17</value>
                 </qualifier>
                 <decVal/>
                 <label xml:lang="de">Startzeit</label>
             </variable>
-            <variable label="Level" CV="16.0.296" default="0" item="ESU FnOut A3 Slider 20" mask="XVVVVVVV">
+            <variable label="Level" CV="16.0.312" default="0" item="ESU FnOut A5 Slider 20" mask="XVVVVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A3 Mode</variableref>
+                    <variableref>ESU FnOut A5 Mode</variableref>
                     <relation>eq</relation>
                     <value>19</value>
                 </qualifier>
                 <decVal max="127"/>
             </variable>
-            <!-- AUX4 Mode -->
-            <variable label="AUX4 Mode" CV="16.0.299" default="1" item="ESU FnOut A4 Mode">
+            <!-- AUX6 Mode -->
+            <variable label="AUX6 Mode" CV="16.0.315" default="1" item="ESU FnOut A6 Mode">
                 <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
             </variable>
-            <variable label="Function Switch On Delay" CV="16.0.300" default="0" item="ESU FnOut A4 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
+            <variable label="Function Switch On Delay" CV="16.0.316" default="0" item="ESU FnOut A6 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A4 Mode</variableref>
+                    <variableref>ESU FnOut A6 Mode</variableref>
                     <relation>gt</relation>
                     <value>0</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A4 Mode</variableref>
+                    <variableref>ESU FnOut A6 Mode</variableref>
                     <relation>ne</relation>
                     <value>27</value>
                 </qualifier>
                 <decVal max="15"/>
                 <label xml:lang="de">Verzögerung beim Einschalten</label>
             </variable>
-            <variable label="Function Switch Off Delay" CV="16.0.300" default="0" mask="VVVVXXXX" item="ESU FnOut A4 Slider 2" tooltip="Units = 0.4 sec">
+            <variable label="Function Switch Off Delay" CV="16.0.316" default="0" mask="VVVVXXXX" item="ESU FnOut A6 Slider 2" tooltip="Units = 0.4 sec">
                 <qualifier>
-                    <variableref>ESU FnOut A4 Mode</variableref>
+                    <variableref>ESU FnOut A6 Mode</variableref>
                     <relation>gt</relation>
                     <value>0</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A4 Mode</variableref>
+                    <variableref>ESU FnOut A6 Mode</variableref>
                     <relation>ne</relation>
                     <value>27</value>
                 </qualifier>
                 <decVal max="15"/>
                 <label xml:lang="de">Verzögerung beim Ausschalten</label>
             </variable>
-            <variable label="Function Auto Switch Off" CV="16.0.301" default="0" item="ESU FnOut A4 Slider 3" tooltip="Units = 0.4 sec">
+            <variable label="Function Auto Switch Off" CV="16.0.317" default="0" item="ESU FnOut A6 Slider 3" tooltip="Units = 0.4 sec">
                 <qualifier>
-                    <variableref>ESU FnOut A4 Mode</variableref>
+                    <variableref>ESU FnOut A6 Mode</variableref>
                     <relation>gt</relation>
                     <value>0</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A4 Mode</variableref>
+                    <variableref>ESU FnOut A6 Mode</variableref>
                     <relation>ne</relation>
                     <value>27</value>
                 </qualifier>
                 <decVal/>
                 <label xml:lang="de">Ausgang automatisch Ausschalten</label>
             </variable>
-            <variable item="Brightness CV302" label="Brightness CV" CV="16.0.302" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
+            <variable item="Brightness CV318" label="Brightness CV" CV="16.0.318" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
                 <decVal/>
             </variable>
-            <variable label="Brightness" CV="16.0.302" default="31" item="ESU FnOut A4 Slider 5" mask="XXXVVVVV">
+            <variable label="Brightness" CV="16.0.318" default="31" item="ESU FnOut A6 Slider 5" mask="XXXVVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A4 Mode</variableref>
+                    <variableref>ESU FnOut A6 Mode</variableref>
                     <relation>gt</relation>
                     <value>0</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A4 Mode</variableref>
+                    <variableref>ESU FnOut A6 Mode</variableref>
                     <relation>le</relation>
                     <value>18</value>
                 </qualifier>
                 <decVal max="31"/>
                 <label xml:lang="de">Helligkeit</label>
             </variable>
-            <variable label="Mode" CV="16.0.302" default="0" item="ESU FnOut A4 Option 1" mask="XXXXXXXV">
+            <variable label="Mode" CV="16.0.318" default="0" item="ESU FnOut A6 Option 1" mask="XXXXXXXV">
                 <qualifier>
-                    <variableref>ESU FnOut A4 Mode</variableref>
+                    <variableref>ESU FnOut A6 Mode</variableref>
                     <relation>eq</relation>
                     <value>22</value>
                 </qualifier>
@@ -1620,299 +2232,299 @@
                 </enumVal>
                 <label xml:lang="de">Modus</label>
             </variable>
-            <variable label="Coupler Force" CV="16.0.302" default="31" item="ESU FnOut A4 Slider 7" mask="XXXVVVVV">
+            <variable label="Coupler Force" CV="16.0.318" default="31" item="ESU FnOut A6 Slider 7" mask="XXXVVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A4 Mode</variableref>
+                    <variableref>ESU FnOut A6 Mode</variableref>
                     <relation>ge</relation>
                     <value>28</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A4 Mode</variableref>
+                    <variableref>ESU FnOut A6 Mode</variableref>
                     <relation>ne</relation>
                     <value>29</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A4 Mode</variableref>
+                    <variableref>ESU FnOut A6 Mode</variableref>
                     <relation>ne</relation>
                     <value>30</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A4 Mode</variableref>
+                    <variableref>ESU FnOut A6 Mode</variableref>
                     <relation>ne</relation>
                     <value>31</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A4 Mode</variableref>
+                    <variableref>ESU FnOut A6 Mode</variableref>
                     <relation>ne</relation>
                     <value>32</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A4 Mode</variableref>
+                    <variableref>ESU FnOut A6 Mode</variableref>
                     <relation>le</relation>
                     <value>33</value>
                 </qualifier>
                 <decVal max="31"/>
                 <label xml:lang="de">Stärke des Kupplers</label>
             </variable>
-            <variable label="Fan Speed" CV="16.0.302" default="31" item="ESU FnOut A4 Slider 11" mask="XXXVVVVV">
+            <variable label="Fan Speed" CV="16.0.318" default="31" item="ESU FnOut A6 Slider 11" mask="XXXVVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A4 Mode</variableref>
+                    <variableref>ESU FnOut A6 Mode</variableref>
                     <relation>eq</relation>
                     <value>23</value>
                 </qualifier>
                 <decVal max="31"/>
                 <label xml:lang="de">Geschwindigkeit</label>
             </variable>
-            <variable label="Standing heat" CV="16.0.302" default="31" item="ESU FnOut A4 Slider 14" mask="XXXVVVVV">
+            <variable label="Standing heat" CV="16.0.318" default="31" item="ESU FnOut A6 Slider 14" mask="XXXVVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A4 Mode</variableref>
+                    <variableref>ESU FnOut A6 Mode</variableref>
                     <relation>eq</relation>
                     <value>24</value>
                 </qualifier>
                 <decVal max="31"/>
                 <label xml:lang="de">Heizstufe im Stand</label>
             </variable>
-            <variable label="Chuff power" CV="16.0.302" default="31" item="ESU FnOut A4 Slider 8" mask="XXXVVVVV">
+            <variable label="Chuff power" CV="16.0.318" default="31" item="ESU FnOut A6 Slider 8" mask="XXXVVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A4 Mode</variableref>
+                    <variableref>ESU FnOut A6 Mode</variableref>
                     <relation>eq</relation>
                     <value>25</value>
                 </qualifier>
                 <decVal max="31"/>
                 <label xml:lang="de">Dampfstoßstärke</label>
             </variable>
-            <variable item="Special Function CV303" label="Special Function CV 1" CV="16.0.303" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+            <variable item="Special Function CV319" label="Special Function CV 1" CV="16.0.319" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
                 <decVal/>
             </variable>
-            <variable label="Fan Acceleration rate" CV="16.0.303" default="0" item="ESU FnOut A4 Slider 12" mask="XXXVVVVV">
+            <variable label="Fan Acceleration rate" CV="16.0.319" default="0" item="ESU FnOut A6 Slider 12" mask="XXXVVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A4 Mode</variableref>
+                    <variableref>ESU FnOut A6 Mode</variableref>
                     <relation>eq</relation>
                     <value>23</value>
                 </qualifier>
                 <decVal max="31"/>
                 <label xml:lang="de">Beschleunigungszeit</label>
             </variable>
-            <variable label="Minimum driving heat" CV="16.0.303" default="0" item="ESU FnOut A4 Slider 15" mask="XXXVVVVV">
+            <variable label="Minimum driving heat" CV="16.0.319" default="0" item="ESU FnOut A6 Slider 15" mask="XXXVVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A4 Mode</variableref>
+                    <variableref>ESU FnOut A6 Mode</variableref>
                     <relation>eq</relation>
                     <value>24</value>
                 </qualifier>
                 <decVal max="31"/>
                 <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
             </variable>
-            <variable label="Fan power" CV="16.0.303" default="0" item="ESU FnOut A4 Slider 9" mask="XXXVVVVV">
+            <variable label="Fan power" CV="16.0.319" default="0" item="ESU FnOut A6 Slider 9" mask="XXXVVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A4 Mode</variableref>
+                    <variableref>ESU FnOut A6 Mode</variableref>
                     <relation>eq</relation>
                     <value>25</value>
                 </qualifier>
                 <decVal max="31"/>
                 <label xml:lang="de">Stäke des Bläsers</label>
             </variable>
-            <variable label="Phase Reverse" CV="16.0.303" default="0" item="ESU FnOut A4 Check 6" mask="XXXXXXXV">
+            <variable label="Phase Reverse" CV="16.0.319" default="0" item="ESU FnOut A6 Check 6" mask="XXXXXXXV">
                 <qualifier>
-                    <variableref>ESU FnOut A4 Mode</variableref>
+                    <variableref>ESU FnOut A6 Mode</variableref>
                     <relation>gt</relation>
                     <value>0</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A4 Mode</variableref>
+                    <variableref>ESU FnOut A6 Mode</variableref>
                     <relation>le</relation>
                     <value>15</value>
                 </qualifier>
                 <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                 <label xml:lang="de">Phase tauschen</label>
             </variable>
-            <variable label="Grade Crossing" CV="16.0.303" default="0" item="ESU FnOut A4 Check 1" mask="XXXXXXVX">
+            <variable label="Grade Crossing" CV="16.0.319" default="0" item="ESU FnOut A6 Check 1" mask="XXXXXXVX">
                 <qualifier>
-                    <variableref>ESU FnOut A4 Mode</variableref>
+                    <variableref>ESU FnOut A6 Mode</variableref>
                     <relation>gt</relation>
                     <value>0</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A4 Mode</variableref>
+                    <variableref>ESU FnOut A6 Mode</variableref>
                     <relation>le</relation>
                     <value>15</value>
                 </qualifier>
                 <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
             </variable>
-            <variable label="Rule 17 Fwd" CV="16.0.303" default="0" item="ESU FnOut A4 Check 2" mask="XXXXXVXX">
+            <variable label="Rule 17 Fwd" CV="16.0.319" default="0" item="ESU FnOut A6 Check 2" mask="XXXXXVXX">
                 <qualifier>
-                    <variableref>ESU FnOut A4 Mode</variableref>
+                    <variableref>ESU FnOut A6 Mode</variableref>
                     <relation>gt</relation>
                     <value>0</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A4 Mode</variableref>
+                    <variableref>ESU FnOut A6 Mode</variableref>
                     <relation>le</relation>
                     <value>15</value>
                 </qualifier>
                 <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                 <label xml:lang="de">Rule 17 vorwärts</label>
             </variable>
-            <variable label="Rule 17 Rev" CV="16.0.303" default="0" item="ESU FnOut A4 Check 3" mask="XXXXVXXX">
+            <variable label="Rule 17 Rev" CV="16.0.319" default="0" item="ESU FnOut A6 Check 3" mask="XXXXVXXX">
                 <qualifier>
-                    <variableref>ESU FnOut A4 Mode</variableref>
+                    <variableref>ESU FnOut A6 Mode</variableref>
                     <relation>gt</relation>
                     <value>0</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A4 Mode</variableref>
+                    <variableref>ESU FnOut A6 Mode</variableref>
                     <relation>le</relation>
                     <value>15</value>
                 </qualifier>
                 <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                 <label xml:lang="de">Rule 17 rückwärts</label>
             </variable>
-            <variable label="Dimmer" CV="16.0.303" default="0" item="ESU FnOut A4 Check 4" mask="XXXVXXXX">
+            <variable label="Dimmer" CV="16.0.319" default="0" item="ESU FnOut A6 Check 4" mask="XXXVXXXX">
                 <qualifier>
-                    <variableref>ESU FnOut A4 Mode</variableref>
+                    <variableref>ESU FnOut A6 Mode</variableref>
                     <relation>gt</relation>
                     <value>0</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A4 Mode</variableref>
+                    <variableref>ESU FnOut A6 Mode</variableref>
                     <relation>le</relation>
                     <value>15</value>
                 </qualifier>
                 <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                 <label xml:lang="de">Abdimmen</label>
             </variable>
-            <variable label="LED Mode" CV="16.0.303" default="0" item="ESU FnOut A4 Check 5" mask="VXXXXXXX">
+            <variable label="LED Mode" CV="16.0.319" default="0" item="ESU FnOut A6 Check 5" mask="VXXXXXXX">
                 <qualifier>
-                    <variableref>ESU FnOut A4 Mode</variableref>
+                    <variableref>ESU FnOut A6 Mode</variableref>
                     <relation>gt</relation>
                     <value>0</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A4 Mode</variableref>
+                    <variableref>ESU FnOut A6 Mode</variableref>
                     <relation>le</relation>
                     <value>15</value>
                 </qualifier>
                 <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                 <label xml:lang="de">LED Modus</label>
             </variable>
-            <variable item="Special Function CV304" label="Special Function CV 2" CV="16.0.304" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+            <variable item="Special Function CV320" label="Special Function CV 2" CV="16.0.320" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
                 <decVal/>
             </variable>
-            <variable label="Fan Decceleration rate" CV="16.0.304" default="0" item="ESU FnOut A4 Slider 13" mask="XXXVVVVV">
+            <variable label="Fan Decceleration rate" CV="16.0.320" default="0" item="ESU FnOut A6 Slider 13" mask="XXXVVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A4 Mode</variableref>
+                    <variableref>ESU FnOut A6 Mode</variableref>
                     <relation>eq</relation>
                     <value>23</value>
                 </qualifier>
                 <decVal max="31"/>
                 <label xml:lang="de">Bremszeit</label>
             </variable>
-            <variable label="Maximum driving heat" CV="16.0.304" default="0" item="ESU FnOut A4 Slider 16" mask="XXXVVVVV">
+            <variable label="Maximum driving heat" CV="16.0.320" default="0" item="ESU FnOut A6 Slider 16" mask="XXXVVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A4 Mode</variableref>
+                    <variableref>ESU FnOut A6 Mode</variableref>
                     <relation>eq</relation>
                     <value>24</value>
                 </qualifier>
                 <decVal max="31"/>
                 <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
             </variable>
-            <variable label="Timeout" CV="16.0.304" default="0" item="ESU FnOut A4 Slider 10" tooltip="Units = 0.25 sec">
+            <variable label="Timeout" CV="16.0.320" default="0" item="ESU FnOut A6 Slider 10" tooltip="Units = 0.25 sec">
                 <qualifier>
-                    <variableref>ESU FnOut A4 Mode</variableref>
+                    <variableref>ESU FnOut A6 Mode</variableref>
                     <relation>eq</relation>
                     <value>25</value>
                 </qualifier>
                 <decVal/>
             </variable>
-            <variable label="Startup Time" CV="16.0.304" default="0" item="ESU FnOut A4 Slider 6">
+            <variable label="Startup Time" CV="16.0.320" default="0" item="ESU FnOut A6 Slider 6">
                 <qualifier>
-                    <variableref>ESU FnOut A4 Mode</variableref>
+                    <variableref>ESU FnOut A6 Mode</variableref>
                     <relation>ge</relation>
                     <value>16</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>ESU FnOut A4 Mode</variableref>
+                    <variableref>ESU FnOut A6 Mode</variableref>
                     <relation>le</relation>
                     <value>17</value>
                 </qualifier>
                 <decVal/>
                 <label xml:lang="de">Startzeit</label>
             </variable>
-            <variable label="Level" CV="16.0.304" default="0" item="ESU FnOut A4 Slider 20" mask="XVVVVVVV">
+            <variable label="Level" CV="16.0.320" default="0" item="ESU FnOut A6 Slider 20" mask="XVVVVVVV">
                 <qualifier>
-                    <variableref>ESU FnOut A4 Mode</variableref>
+                    <variableref>ESU FnOut A6 Mode</variableref>
                     <relation>eq</relation>
                     <value>19</value>
                 </qualifier>
                 <decVal max="127"/>
             </variable>
-            <!-- exclude AUX5 to AUX18 -->
-            <variables exclude="LokPilot 5 micro,LokPilot 5 micro DCC,LokSound 5 micro DCC Direct Atlas Legacy">
-                <!-- AUX5 Mode -->
-                <variable label="AUX5 Mode" CV="16.0.307" default="1" item="ESU FnOut A5 Mode">
+            <!-- exclude AUX7 to AUX18 -->
+            <variables exclude="LokPilot 5 Fx micro,LokPilot 5 Fx micro DCC">
+                <!-- AUX7 Mode -->
+                <variable label="AUX7 Mode" CV="16.0.323" default="1" item="ESU FnOut A7 Mode">
                     <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
                 </variable>
-                <variable label="Function Switch On Delay" CV="16.0.308" default="0" item="ESU FnOut A5 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
+                <variable label="Function Switch On Delay" CV="16.0.324" default="0" item="ESU FnOut A7 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
                     <qualifier>
-                        <variableref>ESU FnOut A5 Mode</variableref>
+                        <variableref>ESU FnOut A7 Mode</variableref>
                         <relation>gt</relation>
                         <value>0</value>
                     </qualifier>
                     <qualifier>
-                        <variableref>ESU FnOut A5 Mode</variableref>
+                        <variableref>ESU FnOut A7 Mode</variableref>
                         <relation>ne</relation>
                         <value>27</value>
                     </qualifier>
                     <decVal max="15"/>
                     <label xml:lang="de">Verzögerung beim Einschalten</label>
                 </variable>
-                <variable label="Function Switch Off Delay" CV="16.0.308" default="0" mask="VVVVXXXX" item="ESU FnOut A5 Slider 2" tooltip="Units = 0.4 sec">
+                <variable label="Function Switch Off Delay" CV="16.0.324" default="0" mask="VVVVXXXX" item="ESU FnOut A7 Slider 2" tooltip="Units = 0.4 sec">
                     <qualifier>
-                        <variableref>ESU FnOut A5 Mode</variableref>
+                        <variableref>ESU FnOut A7 Mode</variableref>
                         <relation>gt</relation>
                         <value>0</value>
                     </qualifier>
                     <qualifier>
-                        <variableref>ESU FnOut A5 Mode</variableref>
+                        <variableref>ESU FnOut A7 Mode</variableref>
                         <relation>ne</relation>
                         <value>27</value>
                     </qualifier>
                     <decVal max="15"/>
                     <label xml:lang="de">Verzögerung beim Ausschalten</label>
                 </variable>
-                <variable label="Function Auto Switch Off" CV="16.0.309" default="0" item="ESU FnOut A5 Slider 3" tooltip="Units = 0.4 sec">
+                <variable label="Function Auto Switch Off" CV="16.0.325" default="0" item="ESU FnOut A7 Slider 3" tooltip="Units = 0.4 sec">
                     <qualifier>
-                        <variableref>ESU FnOut A5 Mode</variableref>
+                        <variableref>ESU FnOut A7 Mode</variableref>
                         <relation>gt</relation>
                         <value>0</value>
                     </qualifier>
                     <qualifier>
-                        <variableref>ESU FnOut A5 Mode</variableref>
+                        <variableref>ESU FnOut A7 Mode</variableref>
                         <relation>ne</relation>
                         <value>27</value>
                     </qualifier>
                     <decVal/>
                     <label xml:lang="de">Ausgang automatisch Ausschalten</label>
                 </variable>
-                <variable item="Brightness CV310" label="Brightness CV" CV="16.0.310" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
+                <variable item="Brightness CV326" label="Brightness CV" CV="16.0.326" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
                     <decVal/>
                 </variable>
-                <variable label="Brightness" CV="16.0.310" default="31" item="ESU FnOut A5 Slider 5" mask="XXXVVVVV">
+                <variable label="Brightness" CV="16.0.326" default="31" item="ESU FnOut A7 Slider 5" mask="XXXVVVVV">
                     <qualifier>
-                        <variableref>ESU FnOut A5 Mode</variableref>
+                        <variableref>ESU FnOut A7 Mode</variableref>
                         <relation>gt</relation>
                         <value>0</value>
                     </qualifier>
                     <qualifier>
-                        <variableref>ESU FnOut A5 Mode</variableref>
+                        <variableref>ESU FnOut A7 Mode</variableref>
                         <relation>le</relation>
                         <value>18</value>
                     </qualifier>
                     <decVal max="31"/>
                     <label xml:lang="de">Helligkeit</label>
                 </variable>
-                <variable label="Mode" CV="16.0.310" default="0" item="ESU FnOut A5 Option 1" mask="XXXXXXXV">
+                <variable label="Mode" CV="16.0.326" default="0" item="ESU FnOut A7 Option 1" mask="XXXXXXXV">
                     <qualifier>
-                        <variableref>ESU FnOut A5 Mode</variableref>
+                        <variableref>ESU FnOut A7 Mode</variableref>
                         <relation>eq</relation>
                         <value>22</value>
                     </qualifier>
@@ -1928,605 +2540,299 @@
                     </enumVal>
                     <label xml:lang="de">Modus</label>
                 </variable>
-                <variable label="Coupler Force" CV="16.0.310" default="31" item="ESU FnOut A5 Slider 7" mask="XXXVVVVV">
+                <variable label="Coupler Force" CV="16.0.326" default="31" item="ESU FnOut A7 Slider 7" mask="XXXVVVVV">
                     <qualifier>
-                        <variableref>ESU FnOut A5 Mode</variableref>
+                        <variableref>ESU FnOut A7 Mode</variableref>
                         <relation>ge</relation>
                         <value>28</value>
                     </qualifier>
                     <qualifier>
-                        <variableref>ESU FnOut A5 Mode</variableref>
+                        <variableref>ESU FnOut A7 Mode</variableref>
                         <relation>ne</relation>
                         <value>29</value>
                     </qualifier>
                     <qualifier>
-                        <variableref>ESU FnOut A5 Mode</variableref>
+                        <variableref>ESU FnOut A7 Mode</variableref>
                         <relation>ne</relation>
                         <value>30</value>
                     </qualifier>
                     <qualifier>
-                        <variableref>ESU FnOut A5 Mode</variableref>
+                        <variableref>ESU FnOut A7 Mode</variableref>
                         <relation>ne</relation>
                         <value>31</value>
                     </qualifier>
                     <qualifier>
-                        <variableref>ESU FnOut A5 Mode</variableref>
+                        <variableref>ESU FnOut A7 Mode</variableref>
                         <relation>ne</relation>
                         <value>32</value>
                     </qualifier>
                     <qualifier>
-                        <variableref>ESU FnOut A5 Mode</variableref>
+                        <variableref>ESU FnOut A7 Mode</variableref>
                         <relation>le</relation>
                         <value>33</value>
                     </qualifier>
                     <decVal max="31"/>
                     <label xml:lang="de">Stärke des Kupplers</label>
                 </variable>
-                <variable label="Fan Speed" CV="16.0.310" default="31" item="ESU FnOut A5 Slider 11" mask="XXXVVVVV">
+                <variable label="Fan Speed" CV="16.0.326" default="31" item="ESU FnOut A7 Slider 11" mask="XXXVVVVV">
                     <qualifier>
-                        <variableref>ESU FnOut A5 Mode</variableref>
+                        <variableref>ESU FnOut A7 Mode</variableref>
                         <relation>eq</relation>
                         <value>23</value>
                     </qualifier>
                     <decVal max="31"/>
                     <label xml:lang="de">Geschwindigkeit</label>
                 </variable>
-                <variable label="Standing heat" CV="16.0.310" default="31" item="ESU FnOut A5 Slider 14" mask="XXXVVVVV">
+                <variable label="Standing heat" CV="16.0.326" default="31" item="ESU FnOut A7 Slider 14" mask="XXXVVVVV">
                     <qualifier>
-                        <variableref>ESU FnOut A5 Mode</variableref>
+                        <variableref>ESU FnOut A7 Mode</variableref>
                         <relation>eq</relation>
                         <value>24</value>
                     </qualifier>
                     <decVal max="31"/>
                     <label xml:lang="de">Heizstufe im Stand</label>
                 </variable>
-                <variable label="Chuff power" CV="16.0.310" default="31" item="ESU FnOut A5 Slider 8" mask="XXXVVVVV">
+                <variable label="Chuff power" CV="16.0.326" default="31" item="ESU FnOut A7 Slider 8" mask="XXXVVVVV">
                     <qualifier>
-                        <variableref>ESU FnOut A5 Mode</variableref>
+                        <variableref>ESU FnOut A7 Mode</variableref>
                         <relation>eq</relation>
                         <value>25</value>
                     </qualifier>
                     <decVal max="31"/>
                     <label xml:lang="de">Dampfstoßstärke</label>
                 </variable>
-                <variable item="Special Function CV311" label="Special Function CV 1" CV="16.0.311" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                <variable item="Special Function CV327" label="Special Function CV 1" CV="16.0.327" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
                     <decVal/>
                 </variable>
-                <variable label="Fan Acceleration rate" CV="16.0.311" default="0" item="ESU FnOut A5 Slider 12" mask="XXXVVVVV">
+                <variable label="Fan Acceleration rate" CV="16.0.327" default="0" item="ESU FnOut A7 Slider 12" mask="XXXVVVVV">
                     <qualifier>
-                        <variableref>ESU FnOut A5 Mode</variableref>
+                        <variableref>ESU FnOut A7 Mode</variableref>
                         <relation>eq</relation>
                         <value>23</value>
                     </qualifier>
                     <decVal max="31"/>
                     <label xml:lang="de">Beschleunigungszeit</label>
                 </variable>
-                <variable label="Minimum driving heat" CV="16.0.311" default="0" item="ESU FnOut A5 Slider 15" mask="XXXVVVVV">
+                <variable label="Minimum driving heat" CV="16.0.327" default="0" item="ESU FnOut A7 Slider 15" mask="XXXVVVVV">
                     <qualifier>
-                        <variableref>ESU FnOut A5 Mode</variableref>
+                        <variableref>ESU FnOut A7 Mode</variableref>
                         <relation>eq</relation>
                         <value>24</value>
                     </qualifier>
                     <decVal max="31"/>
                     <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
                 </variable>
-                <variable label="Fan power" CV="16.0.311" default="0" item="ESU FnOut A5 Slider 9" mask="XXXVVVVV">
+                <variable label="Fan power" CV="16.0.327" default="0" item="ESU FnOut A7 Slider 9" mask="XXXVVVVV">
                     <qualifier>
-                        <variableref>ESU FnOut A5 Mode</variableref>
+                        <variableref>ESU FnOut A7 Mode</variableref>
                         <relation>eq</relation>
                         <value>25</value>
                     </qualifier>
                     <decVal max="31"/>
                     <label xml:lang="de">Stäke des Bläsers</label>
                 </variable>
-                <variable label="Phase Reverse" CV="16.0.311" default="0" item="ESU FnOut A5 Check 6" mask="XXXXXXXV">
+                <variable label="Phase Reverse" CV="16.0.327" default="0" item="ESU FnOut A7 Check 6" mask="XXXXXXXV">
                     <qualifier>
-                        <variableref>ESU FnOut A5 Mode</variableref>
+                        <variableref>ESU FnOut A7 Mode</variableref>
                         <relation>gt</relation>
                         <value>0</value>
                     </qualifier>
                     <qualifier>
-                        <variableref>ESU FnOut A5 Mode</variableref>
+                        <variableref>ESU FnOut A7 Mode</variableref>
                         <relation>le</relation>
                         <value>15</value>
                     </qualifier>
                     <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                     <label xml:lang="de">Phase tauschen</label>
                 </variable>
-                <variable label="Grade Crossing" CV="16.0.311" default="0" item="ESU FnOut A5 Check 1" mask="XXXXXXVX">
+                <variable label="Grade Crossing" CV="16.0.327" default="0" item="ESU FnOut A7 Check 1" mask="XXXXXXVX">
                     <qualifier>
-                        <variableref>ESU FnOut A5 Mode</variableref>
+                        <variableref>ESU FnOut A7 Mode</variableref>
                         <relation>gt</relation>
                         <value>0</value>
                     </qualifier>
                     <qualifier>
-                        <variableref>ESU FnOut A5 Mode</variableref>
+                        <variableref>ESU FnOut A7 Mode</variableref>
                         <relation>le</relation>
                         <value>15</value>
                     </qualifier>
                     <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                 </variable>
-                <variable label="Rule 17 Fwd" CV="16.0.311" default="0" item="ESU FnOut A5 Check 2" mask="XXXXXVXX">
+                <variable label="Rule 17 Fwd" CV="16.0.327" default="0" item="ESU FnOut A7 Check 2" mask="XXXXXVXX">
                     <qualifier>
-                        <variableref>ESU FnOut A5 Mode</variableref>
+                        <variableref>ESU FnOut A7 Mode</variableref>
                         <relation>gt</relation>
                         <value>0</value>
                     </qualifier>
                     <qualifier>
-                        <variableref>ESU FnOut A5 Mode</variableref>
-                        <relation>le</relation>
-                        <value>15</value>
-                    </qualifier>
-                    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                    <label xml:lang="de">Rule 17 vorwärts</label>
-                </variable>
-                <variable label="Rule 17 Rev" CV="16.0.311" default="0" item="ESU FnOut A5 Check 3" mask="XXXXVXXX">
-                    <qualifier>
-                        <variableref>ESU FnOut A5 Mode</variableref>
-                        <relation>gt</relation>
-                        <value>0</value>
-                    </qualifier>
-                    <qualifier>
-                        <variableref>ESU FnOut A5 Mode</variableref>
-                        <relation>le</relation>
-                        <value>15</value>
-                    </qualifier>
-                    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                    <label xml:lang="de">Rule 17 rückwärts</label>
-                </variable>
-                <variable label="Dimmer" CV="16.0.311" default="0" item="ESU FnOut A5 Check 4" mask="XXXVXXXX">
-                    <qualifier>
-                        <variableref>ESU FnOut A5 Mode</variableref>
-                        <relation>gt</relation>
-                        <value>0</value>
-                    </qualifier>
-                    <qualifier>
-                        <variableref>ESU FnOut A5 Mode</variableref>
-                        <relation>le</relation>
-                        <value>15</value>
-                    </qualifier>
-                    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                    <label xml:lang="de">Abdimmen</label>
-                </variable>
-                <variable label="LED Mode" CV="16.0.311" default="0" item="ESU FnOut A5 Check 5" mask="VXXXXXXX">
-                    <qualifier>
-                        <variableref>ESU FnOut A5 Mode</variableref>
-                        <relation>gt</relation>
-                        <value>0</value>
-                    </qualifier>
-                    <qualifier>
-                        <variableref>ESU FnOut A5 Mode</variableref>
-                        <relation>le</relation>
-                        <value>15</value>
-                    </qualifier>
-                    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                    <label xml:lang="de">LED Modus</label>
-                </variable>
-                <variable item="Special Function CV312" label="Special Function CV 2" CV="16.0.312" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
-                    <decVal/>
-                </variable>
-                <variable label="Fan Decceleration rate" CV="16.0.312" default="0" item="ESU FnOut A5 Slider 13" mask="XXXVVVVV">
-                    <qualifier>
-                        <variableref>ESU FnOut A5 Mode</variableref>
-                        <relation>eq</relation>
-                        <value>23</value>
-                    </qualifier>
-                    <decVal max="31"/>
-                    <label xml:lang="de">Bremszeit</label>
-                </variable>
-                <variable label="Maximum driving heat" CV="16.0.312" default="0" item="ESU FnOut A5 Slider 16" mask="XXXVVVVV">
-                    <qualifier>
-                        <variableref>ESU FnOut A5 Mode</variableref>
-                        <relation>eq</relation>
-                        <value>24</value>
-                    </qualifier>
-                    <decVal max="31"/>
-                    <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
-                </variable>
-                <variable label="Timeout" CV="16.0.312" default="0" item="ESU FnOut A5 Slider 10" tooltip="Units = 0.25 sec">
-                    <qualifier>
-                        <variableref>ESU FnOut A5 Mode</variableref>
-                        <relation>eq</relation>
-                        <value>25</value>
-                    </qualifier>
-                    <decVal/>
-                </variable>
-                <variable label="Startup Time" CV="16.0.312" default="0" item="ESU FnOut A5 Slider 6">
-                    <qualifier>
-                        <variableref>ESU FnOut A5 Mode</variableref>
-                        <relation>ge</relation>
-                        <value>16</value>
-                    </qualifier>
-                    <qualifier>
-                        <variableref>ESU FnOut A5 Mode</variableref>
-                        <relation>le</relation>
-                        <value>17</value>
-                    </qualifier>
-                    <decVal/>
-                    <label xml:lang="de">Startzeit</label>
-                </variable>
-                <variable label="Level" CV="16.0.312" default="0" item="ESU FnOut A5 Slider 20" mask="XVVVVVVV">
-                    <qualifier>
-                        <variableref>ESU FnOut A5 Mode</variableref>
-                        <relation>eq</relation>
-                        <value>19</value>
-                    </qualifier>
-                    <decVal max="127"/>
-                </variable>
-                <!-- AUX6 Mode -->
-                <variable label="AUX6 Mode" CV="16.0.315" default="1" item="ESU FnOut A6 Mode">
-                    <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
-                </variable>
-                <variable label="Function Switch On Delay" CV="16.0.316" default="0" item="ESU FnOut A6 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
-                    <qualifier>
-                        <variableref>ESU FnOut A6 Mode</variableref>
-                        <relation>gt</relation>
-                        <value>0</value>
-                    </qualifier>
-                    <qualifier>
-                        <variableref>ESU FnOut A6 Mode</variableref>
-                        <relation>ne</relation>
-                        <value>27</value>
-                    </qualifier>
-                    <decVal max="15"/>
-                    <label xml:lang="de">Verzögerung beim Einschalten</label>
-                </variable>
-                <variable label="Function Switch Off Delay" CV="16.0.316" default="0" mask="VVVVXXXX" item="ESU FnOut A6 Slider 2" tooltip="Units = 0.4 sec">
-                    <qualifier>
-                        <variableref>ESU FnOut A6 Mode</variableref>
-                        <relation>gt</relation>
-                        <value>0</value>
-                    </qualifier>
-                    <qualifier>
-                        <variableref>ESU FnOut A6 Mode</variableref>
-                        <relation>ne</relation>
-                        <value>27</value>
-                    </qualifier>
-                    <decVal max="15"/>
-                    <label xml:lang="de">Verzögerung beim Ausschalten</label>
-                </variable>
-                <variable label="Function Auto Switch Off" CV="16.0.317" default="0" item="ESU FnOut A6 Slider 3" tooltip="Units = 0.4 sec">
-                    <qualifier>
-                        <variableref>ESU FnOut A6 Mode</variableref>
-                        <relation>gt</relation>
-                        <value>0</value>
-                    </qualifier>
-                    <qualifier>
-                        <variableref>ESU FnOut A6 Mode</variableref>
-                        <relation>ne</relation>
-                        <value>27</value>
-                    </qualifier>
-                    <decVal/>
-                    <label xml:lang="de">Ausgang automatisch Ausschalten</label>
-                </variable>
-                <variable item="Brightness CV318" label="Brightness CV" CV="16.0.318" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
-                    <decVal/>
-                </variable>
-                <variable label="Brightness" CV="16.0.318" default="31" item="ESU FnOut A6 Slider 5" mask="XXXVVVVV">
-                    <qualifier>
-                        <variableref>ESU FnOut A6 Mode</variableref>
-                        <relation>gt</relation>
-                        <value>0</value>
-                    </qualifier>
-                    <qualifier>
-                        <variableref>ESU FnOut A6 Mode</variableref>
-                        <relation>le</relation>
-                        <value>18</value>
-                    </qualifier>
-                    <decVal max="31"/>
-                    <label xml:lang="de">Helligkeit</label>
-                </variable>
-                <variable label="Mode" CV="16.0.318" default="0" item="ESU FnOut A6 Option 1" mask="XXXXXXXV">
-                    <qualifier>
-                        <variableref>ESU FnOut A6 Mode</variableref>
-                        <relation>eq</relation>
-                        <value>22</value>
-                    </qualifier>
-                    <enumVal>
-                        <enumChoice choice="Heating control">
-                            <choice>Heating control</choice>
-                            <choice xml:lang="de">Heizungssteuerung</choice>
-                        </enumChoice>
-                        <enumChoice choice="Fan control">
-                            <choice>Fan control</choice>
-                            <choice xml:lang="de">Lüftersteuerung</choice>
-                        </enumChoice>
-                    </enumVal>
-                    <label xml:lang="de">Modus</label>
-                </variable>
-                <variable label="Coupler Force" CV="16.0.318" default="31" item="ESU FnOut A6 Slider 7" mask="XXXVVVVV">
-                    <qualifier>
-                        <variableref>ESU FnOut A6 Mode</variableref>
-                        <relation>ge</relation>
-                        <value>28</value>
-                    </qualifier>
-                    <qualifier>
-                        <variableref>ESU FnOut A6 Mode</variableref>
-                        <relation>ne</relation>
-                        <value>29</value>
-                    </qualifier>
-                    <qualifier>
-                        <variableref>ESU FnOut A6 Mode</variableref>
-                        <relation>ne</relation>
-                        <value>30</value>
-                    </qualifier>
-                    <qualifier>
-                        <variableref>ESU FnOut A6 Mode</variableref>
-                        <relation>ne</relation>
-                        <value>31</value>
-                    </qualifier>
-                    <qualifier>
-                        <variableref>ESU FnOut A6 Mode</variableref>
-                        <relation>ne</relation>
-                        <value>32</value>
-                    </qualifier>
-                    <qualifier>
-                        <variableref>ESU FnOut A6 Mode</variableref>
-                        <relation>le</relation>
-                        <value>33</value>
-                    </qualifier>
-                    <decVal max="31"/>
-                    <label xml:lang="de">Stärke des Kupplers</label>
-                </variable>
-                <variable label="Fan Speed" CV="16.0.318" default="31" item="ESU FnOut A6 Slider 11" mask="XXXVVVVV">
-                    <qualifier>
-                        <variableref>ESU FnOut A6 Mode</variableref>
-                        <relation>eq</relation>
-                        <value>23</value>
-                    </qualifier>
-                    <decVal max="31"/>
-                    <label xml:lang="de">Geschwindigkeit</label>
-                </variable>
-                <variable label="Standing heat" CV="16.0.318" default="31" item="ESU FnOut A6 Slider 14" mask="XXXVVVVV">
-                    <qualifier>
-                        <variableref>ESU FnOut A6 Mode</variableref>
-                        <relation>eq</relation>
-                        <value>24</value>
-                    </qualifier>
-                    <decVal max="31"/>
-                    <label xml:lang="de">Heizstufe im Stand</label>
-                </variable>
-                <variable label="Chuff power" CV="16.0.318" default="31" item="ESU FnOut A6 Slider 8" mask="XXXVVVVV">
-                    <qualifier>
-                        <variableref>ESU FnOut A6 Mode</variableref>
-                        <relation>eq</relation>
-                        <value>25</value>
-                    </qualifier>
-                    <decVal max="31"/>
-                    <label xml:lang="de">Dampfstoßstärke</label>
-                </variable>
-                <variable item="Special Function CV319" label="Special Function CV 1" CV="16.0.319" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
-                    <decVal/>
-                </variable>
-                <variable label="Fan Acceleration rate" CV="16.0.319" default="0" item="ESU FnOut A6 Slider 12" mask="XXXVVVVV">
-                    <qualifier>
-                        <variableref>ESU FnOut A6 Mode</variableref>
-                        <relation>eq</relation>
-                        <value>23</value>
-                    </qualifier>
-                    <decVal max="31"/>
-                    <label xml:lang="de">Beschleunigungszeit</label>
-                </variable>
-                <variable label="Minimum driving heat" CV="16.0.319" default="0" item="ESU FnOut A6 Slider 15" mask="XXXVVVVV">
-                    <qualifier>
-                        <variableref>ESU FnOut A6 Mode</variableref>
-                        <relation>eq</relation>
-                        <value>24</value>
-                    </qualifier>
-                    <decVal max="31"/>
-                    <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
-                </variable>
-                <variable label="Fan power" CV="16.0.319" default="0" item="ESU FnOut A6 Slider 9" mask="XXXVVVVV">
-                    <qualifier>
-                        <variableref>ESU FnOut A6 Mode</variableref>
-                        <relation>eq</relation>
-                        <value>25</value>
-                    </qualifier>
-                    <decVal max="31"/>
-                    <label xml:lang="de">Stäke des Bläsers</label>
-                </variable>
-                <variable label="Phase Reverse" CV="16.0.319" default="0" item="ESU FnOut A6 Check 6" mask="XXXXXXXV">
-                    <qualifier>
-                        <variableref>ESU FnOut A6 Mode</variableref>
-                        <relation>gt</relation>
-                        <value>0</value>
-                    </qualifier>
-                    <qualifier>
-                        <variableref>ESU FnOut A6 Mode</variableref>
-                        <relation>le</relation>
-                        <value>15</value>
-                    </qualifier>
-                    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                    <label xml:lang="de">Phase tauschen</label>
-                </variable>
-                <variable label="Grade Crossing" CV="16.0.319" default="0" item="ESU FnOut A6 Check 1" mask="XXXXXXVX">
-                    <qualifier>
-                        <variableref>ESU FnOut A6 Mode</variableref>
-                        <relation>gt</relation>
-                        <value>0</value>
-                    </qualifier>
-                    <qualifier>
-                        <variableref>ESU FnOut A6 Mode</variableref>
-                        <relation>le</relation>
-                        <value>15</value>
-                    </qualifier>
-                    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                </variable>
-                <variable label="Rule 17 Fwd" CV="16.0.319" default="0" item="ESU FnOut A6 Check 2" mask="XXXXXVXX">
-                    <qualifier>
-                        <variableref>ESU FnOut A6 Mode</variableref>
-                        <relation>gt</relation>
-                        <value>0</value>
-                    </qualifier>
-                    <qualifier>
-                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <variableref>ESU FnOut A7 Mode</variableref>
                         <relation>le</relation>
                         <value>15</value>
                     </qualifier>
                     <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                     <label xml:lang="de">Rule 17 vorwärts</label>
                 </variable>
-                <variable label="Rule 17 Rev" CV="16.0.319" default="0" item="ESU FnOut A6 Check 3" mask="XXXXVXXX">
+                <variable label="Rule 17 Rev" CV="16.0.327" default="0" item="ESU FnOut A7 Check 3" mask="XXXXVXXX">
                     <qualifier>
-                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <variableref>ESU FnOut A7 Mode</variableref>
                         <relation>gt</relation>
                         <value>0</value>
                     </qualifier>
                     <qualifier>
-                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <variableref>ESU FnOut A7 Mode</variableref>
                         <relation>le</relation>
                         <value>15</value>
                     </qualifier>
                     <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                     <label xml:lang="de">Rule 17 rückwärts</label>
                 </variable>
-                <variable label="Dimmer" CV="16.0.319" default="0" item="ESU FnOut A6 Check 4" mask="XXXVXXXX">
+                <variable label="Dimmer" CV="16.0.327" default="0" item="ESU FnOut A7 Check 4" mask="XXXVXXXX">
                     <qualifier>
-                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <variableref>ESU FnOut A7 Mode</variableref>
                         <relation>gt</relation>
                         <value>0</value>
                     </qualifier>
                     <qualifier>
-                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <variableref>ESU FnOut A7 Mode</variableref>
                         <relation>le</relation>
                         <value>15</value>
                     </qualifier>
                     <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                     <label xml:lang="de">Abdimmen</label>
                 </variable>
-                <variable label="LED Mode" CV="16.0.319" default="0" item="ESU FnOut A6 Check 5" mask="VXXXXXXX">
+                <variable label="LED Mode" CV="16.0.327" default="0" item="ESU FnOut A7 Check 5" mask="VXXXXXXX">
                     <qualifier>
-                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <variableref>ESU FnOut A7 Mode</variableref>
                         <relation>gt</relation>
                         <value>0</value>
                     </qualifier>
                     <qualifier>
-                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <variableref>ESU FnOut A7 Mode</variableref>
                         <relation>le</relation>
                         <value>15</value>
                     </qualifier>
                     <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                     <label xml:lang="de">LED Modus</label>
                 </variable>
-                <variable item="Special Function CV320" label="Special Function CV 2" CV="16.0.320" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                <variable item="Special Function CV328" label="Special Function CV 2" CV="16.0.328" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
                     <decVal/>
                 </variable>
-                <variable label="Fan Decceleration rate" CV="16.0.320" default="0" item="ESU FnOut A6 Slider 13" mask="XXXVVVVV">
+                <variable label="Fan Decceleration rate" CV="16.0.328" default="0" item="ESU FnOut A7 Slider 13" mask="XXXVVVVV">
                     <qualifier>
-                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <variableref>ESU FnOut A7 Mode</variableref>
                         <relation>eq</relation>
                         <value>23</value>
                     </qualifier>
                     <decVal max="31"/>
                     <label xml:lang="de">Bremszeit</label>
                 </variable>
-                <variable label="Maximum driving heat" CV="16.0.320" default="0" item="ESU FnOut A6 Slider 16" mask="XXXVVVVV">
+                <variable label="Maximum driving heat" CV="16.0.328" default="0" item="ESU FnOut A7 Slider 16" mask="XXXVVVVV">
                     <qualifier>
-                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <variableref>ESU FnOut A7 Mode</variableref>
                         <relation>eq</relation>
                         <value>24</value>
                     </qualifier>
                     <decVal max="31"/>
                     <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
                 </variable>
-                <variable label="Timeout" CV="16.0.320" default="0" item="ESU FnOut A6 Slider 10" tooltip="Units = 0.25 sec">
+                <variable label="Timeout" CV="16.0.328" default="0" item="ESU FnOut A7 Slider 10" tooltip="Units = 0.25 sec">
                     <qualifier>
-                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <variableref>ESU FnOut A7 Mode</variableref>
                         <relation>eq</relation>
                         <value>25</value>
                     </qualifier>
                     <decVal/>
                 </variable>
-                <variable label="Startup Time" CV="16.0.320" default="0" item="ESU FnOut A6 Slider 6">
+                <variable label="Startup Time" CV="16.0.328" default="0" item="ESU FnOut A7 Slider 6">
                     <qualifier>
-                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <variableref>ESU FnOut A7 Mode</variableref>
                         <relation>ge</relation>
                         <value>16</value>
                     </qualifier>
                     <qualifier>
-                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <variableref>ESU FnOut A7 Mode</variableref>
                         <relation>le</relation>
                         <value>17</value>
                     </qualifier>
                     <decVal/>
                     <label xml:lang="de">Startzeit</label>
                 </variable>
-                <variable label="Level" CV="16.0.320" default="0" item="ESU FnOut A6 Slider 20" mask="XVVVVVVV">
+                <variable label="Level" CV="16.0.328" default="0" item="ESU FnOut A7 Slider 20" mask="XVVVVVVV">
                     <qualifier>
-                        <variableref>ESU FnOut A6 Mode</variableref>
+                        <variableref>ESU FnOut A7 Mode</variableref>
                         <relation>eq</relation>
                         <value>19</value>
                     </qualifier>
                     <decVal max="127"/>
                 </variable>
-                <!-- exclude AUX7 to AUX18 -->
-                <variables exclude="LokPilot 5 Fx micro,LokPilot 5 Fx micro DCC">
-                    <!-- AUX7 Mode -->
-                    <variable label="AUX7 Mode" CV="16.0.323" default="1" item="ESU FnOut A7 Mode">
+                <!-- exclude AUX8 only -->
+                <variables exclude="LokSound 5 Fx,LokSound 5 Fx DCC">
+                    <!-- AUX8 Mode -->
+                    <variable label="AUX8 Mode" CV="16.0.331" default="1" item="ESU FnOut A8 Mode">
                         <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
                     </variable>
-                    <variable label="Function Switch On Delay" CV="16.0.324" default="0" item="ESU FnOut A7 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
+                    <variable label="Function Switch On Delay" CV="16.0.332" default="0" item="ESU FnOut A8 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
                         <qualifier>
-                            <variableref>ESU FnOut A7 Mode</variableref>
+                            <variableref>ESU FnOut A8 Mode</variableref>
                             <relation>gt</relation>
                             <value>0</value>
                         </qualifier>
                         <qualifier>
-                            <variableref>ESU FnOut A7 Mode</variableref>
+                            <variableref>ESU FnOut A8 Mode</variableref>
                             <relation>ne</relation>
                             <value>27</value>
                         </qualifier>
                         <decVal max="15"/>
                         <label xml:lang="de">Verzögerung beim Einschalten</label>
                     </variable>
-                    <variable label="Function Switch Off Delay" CV="16.0.324" default="0" mask="VVVVXXXX" item="ESU FnOut A7 Slider 2" tooltip="Units = 0.4 sec">
+                    <variable label="Function Switch Off Delay" CV="16.0.332" default="0" mask="VVVVXXXX" item="ESU FnOut A8 Slider 2" tooltip="Units = 0.4 sec">
                         <qualifier>
-                            <variableref>ESU FnOut A7 Mode</variableref>
+                            <variableref>ESU FnOut A8 Mode</variableref>
                             <relation>gt</relation>
                             <value>0</value>
                         </qualifier>
                         <qualifier>
-                            <variableref>ESU FnOut A7 Mode</variableref>
+                            <variableref>ESU FnOut A8 Mode</variableref>
                             <relation>ne</relation>
                             <value>27</value>
                         </qualifier>
                         <decVal max="15"/>
                         <label xml:lang="de">Verzögerung beim Ausschalten</label>
                     </variable>
-                    <variable label="Function Auto Switch Off" CV="16.0.325" default="0" item="ESU FnOut A7 Slider 3" tooltip="Units = 0.4 sec">
+                    <variable label="Function Auto Switch Off" CV="16.0.333" default="0" item="ESU FnOut A8 Slider 3" tooltip="Units = 0.4 sec">
                         <qualifier>
-                            <variableref>ESU FnOut A7 Mode</variableref>
+                            <variableref>ESU FnOut A8 Mode</variableref>
                             <relation>gt</relation>
                             <value>0</value>
                         </qualifier>
                         <qualifier>
-                            <variableref>ESU FnOut A7 Mode</variableref>
+                            <variableref>ESU FnOut A8 Mode</variableref>
                             <relation>ne</relation>
                             <value>27</value>
                         </qualifier>
                         <decVal/>
                         <label xml:lang="de">Ausgang automatisch Ausschalten</label>
                     </variable>
-                    <variable item="Brightness CV326" label="Brightness CV" CV="16.0.326" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
+                    <variable item="Brightness CV334" label="Brightness CV" CV="16.0.334" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
                         <decVal/>
                     </variable>
-                    <variable label="Brightness" CV="16.0.326" default="31" item="ESU FnOut A7 Slider 5" mask="XXXVVVVV">
+                    <variable label="Brightness" CV="16.0.334" default="31" item="ESU FnOut A8 Slider 5" mask="XXXVVVVV">
                         <qualifier>
-                            <variableref>ESU FnOut A7 Mode</variableref>
+                            <variableref>ESU FnOut A8 Mode</variableref>
                             <relation>gt</relation>
                             <value>0</value>
                         </qualifier>
                         <qualifier>
-                            <variableref>ESU FnOut A7 Mode</variableref>
+                            <variableref>ESU FnOut A8 Mode</variableref>
                             <relation>le</relation>
                             <value>18</value>
                         </qualifier>
                         <decVal max="31"/>
                         <label xml:lang="de">Helligkeit</label>
                     </variable>
-                    <variable label="Mode" CV="16.0.326" default="0" item="ESU FnOut A7 Option 1" mask="XXXXXXXV">
+                    <variable label="Mode" CV="16.0.334" default="0" item="ESU FnOut A8 Option 1" mask="XXXXXXXV">
                         <qualifier>
-                            <variableref>ESU FnOut A7 Mode</variableref>
+                            <variableref>ESU FnOut A8 Mode</variableref>
                             <relation>eq</relation>
                             <value>22</value>
                         </qualifier>
@@ -2542,286 +2848,1564 @@
                         </enumVal>
                         <label xml:lang="de">Modus</label>
                     </variable>
-                    <variable label="Coupler Force" CV="16.0.326" default="31" item="ESU FnOut A7 Slider 7" mask="XXXVVVVV">
+                    <variable label="Coupler Force" CV="16.0.334" default="31" item="ESU FnOut A8 Slider 7" mask="XXXVVVVV">
                         <qualifier>
-                            <variableref>ESU FnOut A7 Mode</variableref>
+                            <variableref>ESU FnOut A8 Mode</variableref>
                             <relation>ge</relation>
                             <value>28</value>
                         </qualifier>
                         <qualifier>
-                            <variableref>ESU FnOut A7 Mode</variableref>
+                            <variableref>ESU FnOut A8 Mode</variableref>
                             <relation>ne</relation>
                             <value>29</value>
                         </qualifier>
                         <qualifier>
-                            <variableref>ESU FnOut A7 Mode</variableref>
+                            <variableref>ESU FnOut A8 Mode</variableref>
                             <relation>ne</relation>
                             <value>30</value>
                         </qualifier>
                         <qualifier>
-                            <variableref>ESU FnOut A7 Mode</variableref>
+                            <variableref>ESU FnOut A8 Mode</variableref>
                             <relation>ne</relation>
                             <value>31</value>
                         </qualifier>
                         <qualifier>
-                            <variableref>ESU FnOut A7 Mode</variableref>
+                            <variableref>ESU FnOut A8 Mode</variableref>
                             <relation>ne</relation>
                             <value>32</value>
                         </qualifier>
                         <qualifier>
-                            <variableref>ESU FnOut A7 Mode</variableref>
+                            <variableref>ESU FnOut A8 Mode</variableref>
                             <relation>le</relation>
                             <value>33</value>
                         </qualifier>
                         <decVal max="31"/>
                         <label xml:lang="de">Stärke des Kupplers</label>
                     </variable>
-                    <variable label="Fan Speed" CV="16.0.326" default="31" item="ESU FnOut A7 Slider 11" mask="XXXVVVVV">
+                    <variable label="Fan Speed" CV="16.0.334" default="31" item="ESU FnOut A8 Slider 11" mask="XXXVVVVV">
                         <qualifier>
-                            <variableref>ESU FnOut A7 Mode</variableref>
+                            <variableref>ESU FnOut A8 Mode</variableref>
                             <relation>eq</relation>
                             <value>23</value>
                         </qualifier>
                         <decVal max="31"/>
                         <label xml:lang="de">Geschwindigkeit</label>
                     </variable>
-                    <variable label="Standing heat" CV="16.0.326" default="31" item="ESU FnOut A7 Slider 14" mask="XXXVVVVV">
+                    <variable label="Standing heat" CV="16.0.334" default="31" item="ESU FnOut A8 Slider 14" mask="XXXVVVVV">
                         <qualifier>
-                            <variableref>ESU FnOut A7 Mode</variableref>
+                            <variableref>ESU FnOut A8 Mode</variableref>
                             <relation>eq</relation>
                             <value>24</value>
                         </qualifier>
                         <decVal max="31"/>
                         <label xml:lang="de">Heizstufe im Stand</label>
                     </variable>
-                    <variable label="Chuff power" CV="16.0.326" default="31" item="ESU FnOut A7 Slider 8" mask="XXXVVVVV">
+                    <variable label="Chuff power" CV="16.0.334" default="31" item="ESU FnOut A8 Slider 8" mask="XXXVVVVV">
                         <qualifier>
-                            <variableref>ESU FnOut A7 Mode</variableref>
+                            <variableref>ESU FnOut A8 Mode</variableref>
                             <relation>eq</relation>
                             <value>25</value>
                         </qualifier>
                         <decVal max="31"/>
                         <label xml:lang="de">Dampfstoßstärke</label>
                     </variable>
-                    <variable item="Special Function CV327" label="Special Function CV 1" CV="16.0.327" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                    <variable item="Special Function CV335" label="Special Function CV 1" CV="16.0.335" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
                         <decVal/>
                     </variable>
-                    <variable label="Fan Acceleration rate" CV="16.0.327" default="0" item="ESU FnOut A7 Slider 12" mask="XXXVVVVV">
+                    <variable label="Fan Acceleration rate" CV="16.0.335" default="0" item="ESU FnOut A8 Slider 12" mask="XXXVVVVV">
                         <qualifier>
-                            <variableref>ESU FnOut A7 Mode</variableref>
+                            <variableref>ESU FnOut A8 Mode</variableref>
                             <relation>eq</relation>
                             <value>23</value>
                         </qualifier>
                         <decVal max="31"/>
                         <label xml:lang="de">Beschleunigungszeit</label>
                     </variable>
-                    <variable label="Minimum driving heat" CV="16.0.327" default="0" item="ESU FnOut A7 Slider 15" mask="XXXVVVVV">
+                    <variable label="Minimum driving heat" CV="16.0.335" default="0" item="ESU FnOut A8 Slider 15" mask="XXXVVVVV">
                         <qualifier>
-                            <variableref>ESU FnOut A7 Mode</variableref>
+                            <variableref>ESU FnOut A8 Mode</variableref>
                             <relation>eq</relation>
                             <value>24</value>
                         </qualifier>
                         <decVal max="31"/>
                         <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
                     </variable>
-                    <variable label="Fan power" CV="16.0.327" default="0" item="ESU FnOut A7 Slider 9" mask="XXXVVVVV">
+                    <variable label="Fan power" CV="16.0.335" default="0" item="ESU FnOut A8 Slider 9" mask="XXXVVVVV">
                         <qualifier>
-                            <variableref>ESU FnOut A7 Mode</variableref>
+                            <variableref>ESU FnOut A8 Mode</variableref>
                             <relation>eq</relation>
                             <value>25</value>
                         </qualifier>
                         <decVal max="31"/>
                         <label xml:lang="de">Stäke des Bläsers</label>
                     </variable>
-
-                    <variable label="Grade Crossing" CV="16.0.327" default="0" item="ESU FnOut A7 Check 1" mask="XXXXXXVX">
+                    <variable label="Phase Reverse" CV="16.0.335" default="0" item="ESU FnOut A8 Check 6" mask="XXXXXXXV">
                         <qualifier>
-                            <variableref>ESU FnOut A7 Mode</variableref>
+                            <variableref>ESU FnOut A8 Mode</variableref>
                             <relation>gt</relation>
                             <value>0</value>
                         </qualifier>
                         <qualifier>
-                            <variableref>ESU FnOut A7 Mode</variableref>
+                            <variableref>ESU FnOut A8 Mode</variableref>
+                            <relation>le</relation>
+                            <value>15</value>
+                        </qualifier>
+                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                        <label xml:lang="de">Phase tauschen</label>
+                    </variable>
+                    <variable label="Grade Crossing" CV="16.0.335" default="0" item="ESU FnOut A8 Check 1" mask="XXXXXXVX">
+                        <qualifier>
+                            <variableref>ESU FnOut A8 Mode</variableref>
+                            <relation>gt</relation>
+                            <value>0</value>
+                        </qualifier>
+                        <qualifier>
+                            <variableref>ESU FnOut A8 Mode</variableref>
                             <relation>le</relation>
                             <value>15</value>
                         </qualifier>
                         <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                     </variable>
-                    <variable label="Rule 17 Fwd" CV="16.0.327" default="0" item="ESU FnOut A7 Check 2" mask="XXXXXVXX">
+                    <variable label="Rule 17 Fwd" CV="16.0.335" default="0" item="ESU FnOut A8 Check 2" mask="XXXXXVXX">
                         <qualifier>
-                            <variableref>ESU FnOut A7 Mode</variableref>
+                            <variableref>ESU FnOut A8 Mode</variableref>
                             <relation>gt</relation>
                             <value>0</value>
                         </qualifier>
                         <qualifier>
-                            <variableref>ESU FnOut A7 Mode</variableref>
+                            <variableref>ESU FnOut A8 Mode</variableref>
                             <relation>le</relation>
                             <value>15</value>
                         </qualifier>
                         <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                         <label xml:lang="de">Rule 17 vorwärts</label>
                     </variable>
-                    <variable label="Rule 17 Rev" CV="16.0.327" default="0" item="ESU FnOut A7 Check 3" mask="XXXXVXXX">
+                    <variable label="Rule 17 Rev" CV="16.0.335" default="0" item="ESU FnOut A8 Check 3" mask="XXXXVXXX">
                         <qualifier>
-                            <variableref>ESU FnOut A7 Mode</variableref>
+                            <variableref>ESU FnOut A8 Mode</variableref>
                             <relation>gt</relation>
                             <value>0</value>
                         </qualifier>
                         <qualifier>
-                            <variableref>ESU FnOut A7 Mode</variableref>
+                            <variableref>ESU FnOut A8 Mode</variableref>
                             <relation>le</relation>
                             <value>15</value>
                         </qualifier>
                         <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                         <label xml:lang="de">Rule 17 rückwärts</label>
                     </variable>
-                    <variable label="Dimmer" CV="16.0.327" default="0" item="ESU FnOut A7 Check 4" mask="XXXVXXXX">
+                    <variable label="Dimmer" CV="16.0.335" default="0" item="ESU FnOut A8 Check 4" mask="XXXVXXXX">
                         <qualifier>
-                            <variableref>ESU FnOut A7 Mode</variableref>
+                            <variableref>ESU FnOut A8 Mode</variableref>
                             <relation>gt</relation>
                             <value>0</value>
                         </qualifier>
                         <qualifier>
-                            <variableref>ESU FnOut A7 Mode</variableref>
+                            <variableref>ESU FnOut A8 Mode</variableref>
                             <relation>le</relation>
                             <value>15</value>
                         </qualifier>
                         <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                         <label xml:lang="de">Abdimmen</label>
                     </variable>
-                    <variable label="LED Mode" CV="16.0.327" default="0" item="ESU FnOut A7 Check 5" mask="VXXXXXXX">
+                    <variable label="LED Mode" CV="16.0.335" default="0" item="ESU FnOut A8 Check 5" mask="VXXXXXXX">
                         <qualifier>
-                            <variableref>ESU FnOut A7 Mode</variableref>
+                            <variableref>ESU FnOut A8 Mode</variableref>
                             <relation>gt</relation>
                             <value>0</value>
                         </qualifier>
                         <qualifier>
-                            <variableref>ESU FnOut A7 Mode</variableref>
+                            <variableref>ESU FnOut A8 Mode</variableref>
                             <relation>le</relation>
                             <value>15</value>
                         </qualifier>
                         <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                         <label xml:lang="de">LED Modus</label>
                     </variable>
-                    <variable item="Special Function CV328" label="Special Function CV 2" CV="16.0.328" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                    <variable item="Special Function CV336" label="Special Function CV 2" CV="16.0.336" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
                         <decVal/>
                     </variable>
-                    <variable label="Fan Decceleration rate" CV="16.0.328" default="0" item="ESU FnOut A7 Slider 13" mask="XXXVVVVV">
+                    <variable label="Fan Decceleration rate" CV="16.0.336" default="0" item="ESU FnOut A8 Slider 13" mask="XXXVVVVV">
                         <qualifier>
-                            <variableref>ESU FnOut A7 Mode</variableref>
+                            <variableref>ESU FnOut A8 Mode</variableref>
                             <relation>eq</relation>
                             <value>23</value>
                         </qualifier>
                         <decVal max="31"/>
                         <label xml:lang="de">Bremszeit</label>
                     </variable>
-                    <variable label="Maximum driving heat" CV="16.0.328" default="0" item="ESU FnOut A7 Slider 16" mask="XXXVVVVV">
+                    <variable label="Maximum driving heat" CV="16.0.336" default="0" item="ESU FnOut A8 Slider 16" mask="XXXVVVVV">
                         <qualifier>
-                            <variableref>ESU FnOut A7 Mode</variableref>
+                            <variableref>ESU FnOut A8 Mode</variableref>
                             <relation>eq</relation>
                             <value>24</value>
                         </qualifier>
                         <decVal max="31"/>
                         <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
                     </variable>
-                    <variable label="Timeout" CV="16.0.328" default="0" item="ESU FnOut A7 Slider 10" tooltip="Units = 0.25 sec">
+                    <variable label="Timeout" CV="16.0.336" default="0" item="ESU FnOut A8 Slider 10" tooltip="Units = 0.25 sec">
                         <qualifier>
-                            <variableref>ESU FnOut A7 Mode</variableref>
+                            <variableref>ESU FnOut A8 Mode</variableref>
                             <relation>eq</relation>
                             <value>25</value>
                         </qualifier>
                         <decVal/>
                     </variable>
-                    <variable label="Startup Time" CV="16.0.328" default="0" item="ESU FnOut A7 Slider 6">
+                    <variable label="Startup Time" CV="16.0.336" default="0" item="ESU FnOut A8 Slider 6">
                         <qualifier>
-                            <variableref>ESU FnOut A7 Mode</variableref>
+                            <variableref>ESU FnOut A8 Mode</variableref>
                             <relation>ge</relation>
                             <value>16</value>
                         </qualifier>
                         <qualifier>
-                            <variableref>ESU FnOut A7 Mode</variableref>
+                            <variableref>ESU FnOut A8 Mode</variableref>
                             <relation>le</relation>
                             <value>17</value>
                         </qualifier>
                         <decVal/>
                         <label xml:lang="de">Startzeit</label>
                     </variable>
-                    <variable label="Level" CV="16.0.328" default="0" item="ESU FnOut A7 Slider 20" mask="XVVVVVVV">
+                    <variable label="Level" CV="16.0.336" default="0" item="ESU FnOut A8 Slider 20" mask="XVVVVVVV">
                         <qualifier>
-                            <variableref>ESU FnOut A7 Mode</variableref>
+                            <variableref>ESU FnOut A8 Mode</variableref>
                             <relation>eq</relation>
                             <value>19</value>
                         </qualifier>
                         <decVal max="127"/>
                     </variable>
-                    <!-- exclude AUX8 only -->
-                    <variables exclude="LokSound 5 Fx,LokSound 5 Fx DCC">
-                        <!-- AUX8 Mode -->
-                        <variable label="AUX8 Mode" CV="16.0.331" default="1" item="ESU FnOut A8 Mode">
+                </variables>
+                <!-- exclude AUX9 to AUX18 -->
+                <variables exclude="LokSound 5 micro DCC Direct">
+                    <!-- AUX9 Mode -->
+                    <variable label="AUX9 Mode" CV="16.0.339" default="1" item="ESU FnOut A9 Mode">
+                        <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
+                    </variable>
+                    <variable label="Function Switch On Delay" CV="16.0.340" default="0" item="ESU FnOut A9 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
+                        <qualifier>
+                            <variableref>ESU FnOut A9 Mode</variableref>
+                            <relation>gt</relation>
+                            <value>0</value>
+                        </qualifier>
+                        <qualifier>
+                            <variableref>ESU FnOut A9 Mode</variableref>
+                            <relation>ne</relation>
+                            <value>27</value>
+                        </qualifier>
+                        <decVal max="15"/>
+                        <label xml:lang="de">Verzögerung beim Einschalten</label>
+                    </variable>
+                    <variable label="Function Switch Off Delay" CV="16.0.340" default="0" mask="VVVVXXXX" item="ESU FnOut A9 Slider 2" tooltip="Units = 0.4 sec">
+                        <qualifier>
+                            <variableref>ESU FnOut A9 Mode</variableref>
+                            <relation>gt</relation>
+                            <value>0</value>
+                        </qualifier>
+                        <qualifier>
+                            <variableref>ESU FnOut A9 Mode</variableref>
+                            <relation>ne</relation>
+                            <value>27</value>
+                        </qualifier>
+                        <decVal max="15"/>
+                        <label xml:lang="de">Verzögerung beim Ausschalten</label>
+                    </variable>
+                    <variable label="Function Auto Switch Off" CV="16.0.341" default="0" item="ESU FnOut A9 Slider 3" tooltip="Units = 0.4 sec">
+                        <qualifier>
+                            <variableref>ESU FnOut A9 Mode</variableref>
+                            <relation>gt</relation>
+                            <value>0</value>
+                        </qualifier>
+                        <qualifier>
+                            <variableref>ESU FnOut A9 Mode</variableref>
+                            <relation>ne</relation>
+                            <value>27</value>
+                        </qualifier>
+                        <decVal/>
+                        <label xml:lang="de">Ausgang automatisch Ausschalten</label>
+                    </variable>
+                    <variable item="Brightness CV342" label="Brightness CV" CV="16.0.342" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
+                        <decVal/>
+                    </variable>
+                    <variable label="Brightness" CV="16.0.342" default="31" item="ESU FnOut A9 Slider 5" mask="XXXVVVVV">
+                        <qualifier>
+                            <variableref>ESU FnOut A9 Mode</variableref>
+                            <relation>gt</relation>
+                            <value>0</value>
+                        </qualifier>
+                        <qualifier>
+                            <variableref>ESU FnOut A9 Mode</variableref>
+                            <relation>le</relation>
+                            <value>18</value>
+                        </qualifier>
+                        <decVal max="31"/>
+                        <label xml:lang="de">Helligkeit</label>
+                    </variable>
+                    <variable label="Mode" CV="16.0.342" default="0" item="ESU FnOut A9 Option 1" mask="XXXXXXXV">
+                        <qualifier>
+                            <variableref>ESU FnOut A9 Mode</variableref>
+                            <relation>eq</relation>
+                            <value>22</value>
+                        </qualifier>
+                        <enumVal>
+                            <enumChoice choice="Heating control">
+                                <choice>Heating control</choice>
+                                <choice xml:lang="de">Heizungssteuerung</choice>
+                            </enumChoice>
+                            <enumChoice choice="Fan control">
+                                <choice>Fan control</choice>
+                                <choice xml:lang="de">Lüftersteuerung</choice>
+                            </enumChoice>
+                        </enumVal>
+                        <label xml:lang="de">Modus</label>
+                    </variable>
+                    <variable label="Coupler Force" CV="16.0.342" default="31" item="ESU FnOut A9 Slider 7" mask="XXXVVVVV">
+                        <qualifier>
+                            <variableref>ESU FnOut A9 Mode</variableref>
+                            <relation>ge</relation>
+                            <value>28</value>
+                        </qualifier>
+                        <qualifier>
+                            <variableref>ESU FnOut A9 Mode</variableref>
+                            <relation>ne</relation>
+                            <value>29</value>
+                        </qualifier>
+                        <qualifier>
+                            <variableref>ESU FnOut A9 Mode</variableref>
+                            <relation>ne</relation>
+                            <value>30</value>
+                        </qualifier>
+                        <qualifier>
+                            <variableref>ESU FnOut A9 Mode</variableref>
+                            <relation>ne</relation>
+                            <value>31</value>
+                        </qualifier>
+                        <qualifier>
+                            <variableref>ESU FnOut A9 Mode</variableref>
+                            <relation>ne</relation>
+                            <value>32</value>
+                        </qualifier>
+                        <qualifier>
+                            <variableref>ESU FnOut A9 Mode</variableref>
+                            <relation>le</relation>
+                            <value>33</value>
+                        </qualifier>
+                        <decVal max="31"/>
+                        <label xml:lang="de">Stärke des Kupplers</label>
+                    </variable>
+                    <variable label="Fan Speed" CV="16.0.342" default="31" item="ESU FnOut A9 Slider 11" mask="XXXVVVVV">
+                        <qualifier>
+                            <variableref>ESU FnOut A9 Mode</variableref>
+                            <relation>eq</relation>
+                            <value>23</value>
+                        </qualifier>
+                        <decVal max="31"/>
+                        <label xml:lang="de">Geschwindigkeit</label>
+                    </variable>
+                    <variable label="Standing heat" CV="16.0.342" default="31" item="ESU FnOut A9 Slider 14" mask="XXXVVVVV">
+                        <qualifier>
+                            <variableref>ESU FnOut A9 Mode</variableref>
+                            <relation>eq</relation>
+                            <value>24</value>
+                        </qualifier>
+                        <decVal max="31"/>
+                        <label xml:lang="de">Heizstufe im Stand</label>
+                    </variable>
+                    <variable label="Chuff power" CV="16.0.342" default="31" item="ESU FnOut A9 Slider 8" mask="XXXVVVVV">
+                        <qualifier>
+                            <variableref>ESU FnOut A9 Mode</variableref>
+                            <relation>eq</relation>
+                            <value>25</value>
+                        </qualifier>
+                        <decVal max="31"/>
+                        <label xml:lang="de">Dampfstoßstärke</label>
+                    </variable>
+                    <variable item="Special Function CV343" label="Special Function CV 1" CV="16.0.343" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                        <decVal/>
+                    </variable>
+                    <variable label="Fan Acceleration rate" CV="16.0.343" default="0" item="ESU FnOut A9 Slider 12" mask="XXXVVVVV">
+                        <qualifier>
+                            <variableref>ESU FnOut A9 Mode</variableref>
+                            <relation>eq</relation>
+                            <value>23</value>
+                        </qualifier>
+                        <decVal max="31"/>
+                        <label xml:lang="de">Beschleunigungszeit</label>
+                    </variable>
+                    <variable label="Minimum driving heat" CV="16.0.343" default="0" item="ESU FnOut A9 Slider 15" mask="XXXVVVVV">
+                        <qualifier>
+                            <variableref>ESU FnOut A9 Mode</variableref>
+                            <relation>eq</relation>
+                            <value>24</value>
+                        </qualifier>
+                        <decVal max="31"/>
+                        <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
+                    </variable>
+                    <variable label="Fan power" CV="16.0.343" default="0" item="ESU FnOut A9 Slider 9" mask="XXXVVVVV">
+                        <qualifier>
+                            <variableref>ESU FnOut A9 Mode</variableref>
+                            <relation>eq</relation>
+                            <value>25</value>
+                        </qualifier>
+                        <decVal max="31"/>
+                        <label xml:lang="de">Stäke des Bläsers</label>
+                    </variable>
+                    <variable label="Phase Reverse" CV="16.0.343" default="0" item="ESU FnOut A9 Check 6" mask="XXXXXXXV">
+                        <qualifier>
+                            <variableref>ESU FnOut A9 Mode</variableref>
+                            <relation>gt</relation>
+                            <value>0</value>
+                        </qualifier>
+                        <qualifier>
+                            <variableref>ESU FnOut A9 Mode</variableref>
+                            <relation>le</relation>
+                            <value>15</value>
+                        </qualifier>
+                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                        <label xml:lang="de">Phase tauschen</label>
+                    </variable>
+                    <variable label="Grade Crossing" CV="16.0.343" default="0" item="ESU FnOut A9 Check 1" mask="XXXXXXVX">
+                        <qualifier>
+                            <variableref>ESU FnOut A9 Mode</variableref>
+                            <relation>gt</relation>
+                            <value>0</value>
+                        </qualifier>
+                        <qualifier>
+                            <variableref>ESU FnOut A9 Mode</variableref>
+                            <relation>le</relation>
+                            <value>15</value>
+                        </qualifier>
+                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                    </variable>
+                    <variable label="Rule 17 Fwd" CV="16.0.343" default="0" item="ESU FnOut A9 Check 2" mask="XXXXXVXX">
+                        <qualifier>
+                            <variableref>ESU FnOut A9 Mode</variableref>
+                            <relation>gt</relation>
+                            <value>0</value>
+                        </qualifier>
+                        <qualifier>
+                            <variableref>ESU FnOut A9 Mode</variableref>
+                            <relation>le</relation>
+                            <value>15</value>
+                        </qualifier>
+                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                        <label xml:lang="de">Rule 17 vorwärts</label>
+                    </variable>
+                    <variable label="Rule 17 Rev" CV="16.0.343" default="0" item="ESU FnOut A9 Check 3" mask="XXXXVXXX">
+                        <qualifier>
+                            <variableref>ESU FnOut A9 Mode</variableref>
+                            <relation>gt</relation>
+                            <value>0</value>
+                        </qualifier>
+                        <qualifier>
+                            <variableref>ESU FnOut A9 Mode</variableref>
+                            <relation>le</relation>
+                            <value>15</value>
+                        </qualifier>
+                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                        <label xml:lang="de">Rule 17 rückwärts</label>
+                    </variable>
+                    <variable label="Dimmer" CV="16.0.343" default="0" item="ESU FnOut A9 Check 4" mask="XXXVXXXX">
+                        <qualifier>
+                            <variableref>ESU FnOut A9 Mode</variableref>
+                            <relation>gt</relation>
+                            <value>0</value>
+                        </qualifier>
+                        <qualifier>
+                            <variableref>ESU FnOut A9 Mode</variableref>
+                            <relation>le</relation>
+                            <value>15</value>
+                        </qualifier>
+                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                        <label xml:lang="de">Abdimmen</label>
+                    </variable>
+                    <variable label="LED Mode" CV="16.0.343" default="0" item="ESU FnOut A9 Check 5" mask="VXXXXXXX">
+                        <qualifier>
+                            <variableref>ESU FnOut A9 Mode</variableref>
+                            <relation>gt</relation>
+                            <value>0</value>
+                        </qualifier>
+                        <qualifier>
+                            <variableref>ESU FnOut A9 Mode</variableref>
+                            <relation>le</relation>
+                            <value>15</value>
+                        </qualifier>
+                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                        <label xml:lang="de">LED Modus</label>
+                    </variable>
+                    <variable item="Special Function CV344" label="Special Function CV 2" CV="16.0.344" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                        <decVal/>
+                    </variable>
+                    <variable label="Fan Decceleration rate" CV="16.0.344" default="0" item="ESU FnOut A9 Slider 13" mask="XXXVVVVV">
+                        <qualifier>
+                            <variableref>ESU FnOut A9 Mode</variableref>
+                            <relation>eq</relation>
+                            <value>23</value>
+                        </qualifier>
+                        <decVal max="31"/>
+                        <label xml:lang="de">Bremszeit</label>
+                    </variable>
+                    <variable label="Maximum driving heat" CV="16.0.344" default="0" item="ESU FnOut A9 Slider 16" mask="XXXVVVVV">
+                        <qualifier>
+                            <variableref>ESU FnOut A9 Mode</variableref>
+                            <relation>eq</relation>
+                            <value>24</value>
+                        </qualifier>
+                        <decVal max="31"/>
+                        <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
+                    </variable>
+                    <variable label="Timeout" CV="16.0.344" default="0" item="ESU FnOut A9 Slider 10" tooltip="Units = 0.25 sec">
+                        <qualifier>
+                            <variableref>ESU FnOut A9 Mode</variableref>
+                            <relation>eq</relation>
+                            <value>25</value>
+                        </qualifier>
+                        <decVal/>
+                    </variable>
+                    <variable label="Startup Time" CV="16.0.344" default="0" item="ESU FnOut A9 Slider 6">
+                        <qualifier>
+                            <variableref>ESU FnOut A9 Mode</variableref>
+                            <relation>ge</relation>
+                            <value>16</value>
+                        </qualifier>
+                        <qualifier>
+                            <variableref>ESU FnOut A9 Mode</variableref>
+                            <relation>le</relation>
+                            <value>17</value>
+                        </qualifier>
+                        <decVal/>
+                        <label xml:lang="de">Startzeit</label>
+                    </variable>
+                    <variable label="Level" CV="16.0.344" default="0" item="ESU FnOut A9 Slider 20" mask="XVVVVVVV">
+                        <qualifier>
+                            <variableref>ESU FnOut A9 Mode</variableref>
+                            <relation>eq</relation>
+                            <value>19</value>
+                        </qualifier>
+                        <decVal max="127"/>
+                    </variable>
+                    <!-- AUX10 Mode -->
+                    <variable label="AUX10 Mode" CV="16.0.347" default="1" item="ESU FnOut A10 Mode">
+                        <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
+                    </variable>
+                    <variable label="Function Switch On Delay" CV="16.0.348" default="0" item="ESU FnOut A10 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
+                        <qualifier>
+                            <variableref>ESU FnOut A10 Mode</variableref>
+                            <relation>gt</relation>
+                            <value>0</value>
+                        </qualifier>
+                        <qualifier>
+                            <variableref>ESU FnOut A10 Mode</variableref>
+                            <relation>ne</relation>
+                            <value>27</value>
+                        </qualifier>
+                        <decVal max="15"/>
+                        <label xml:lang="de">Verzögerung beim Einschalten</label>
+                    </variable>
+                    <variable label="Function Switch Off Delay" CV="16.0.348" default="0" mask="VVVVXXXX" item="ESU FnOut A10 Slider 2" tooltip="Units = 0.4 sec">
+                        <qualifier>
+                            <variableref>ESU FnOut A10 Mode</variableref>
+                            <relation>gt</relation>
+                            <value>0</value>
+                        </qualifier>
+                        <qualifier>
+                            <variableref>ESU FnOut A10 Mode</variableref>
+                            <relation>ne</relation>
+                            <value>27</value>
+                        </qualifier>
+                        <decVal max="15"/>
+                        <label xml:lang="de">Verzögerung beim Ausschalten</label>
+                    </variable>
+                    <variable label="Function Auto Switch Off" CV="16.0.349" default="0" item="ESU FnOut A10 Slider 3" tooltip="Units = 0.4 sec">
+                        <qualifier>
+                            <variableref>ESU FnOut A10 Mode</variableref>
+                            <relation>gt</relation>
+                            <value>0</value>
+                        </qualifier>
+                        <qualifier>
+                            <variableref>ESU FnOut A10 Mode</variableref>
+                            <relation>ne</relation>
+                            <value>27</value>
+                        </qualifier>
+                        <decVal/>
+                        <label xml:lang="de">Ausgang automatisch Ausschalten</label>
+                    </variable>
+                    <variable item="Brightness CV350" label="Brightness CV" CV="16.0.350" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
+                        <decVal/>
+                    </variable>
+                    <variable label="Brightness" CV="16.0.350" default="31" item="ESU FnOut A10 Slider 5" mask="XXXVVVVV">
+                        <qualifier>
+                            <variableref>ESU FnOut A10 Mode</variableref>
+                            <relation>gt</relation>
+                            <value>0</value>
+                        </qualifier>
+                        <qualifier>
+                            <variableref>ESU FnOut A10 Mode</variableref>
+                            <relation>le</relation>
+                            <value>18</value>
+                        </qualifier>
+                        <decVal max="31"/>
+                        <label xml:lang="de">Helligkeit</label>
+                    </variable>
+                    <variable label="Mode" CV="16.0.350" default="0" item="ESU FnOut A10 Option 1" mask="XXXXXXXV">
+                        <qualifier>
+                            <variableref>ESU FnOut A10 Mode</variableref>
+                            <relation>eq</relation>
+                            <value>22</value>
+                        </qualifier>
+                        <enumVal>
+                            <enumChoice choice="Heating control">
+                                <choice>Heating control</choice>
+                                <choice xml:lang="de">Heizungssteuerung</choice>
+                            </enumChoice>
+                            <enumChoice choice="Fan control">
+                                <choice>Fan control</choice>
+                                <choice xml:lang="de">Lüftersteuerung</choice>
+                            </enumChoice>
+                        </enumVal>
+                        <label xml:lang="de">Modus</label>
+                    </variable>
+                    <variable label="Coupler Force" CV="16.0.350" default="31" item="ESU FnOut A10 Slider 7" mask="XXXVVVVV">
+                        <qualifier>
+                            <variableref>ESU FnOut A10 Mode</variableref>
+                            <relation>ge</relation>
+                            <value>28</value>
+                        </qualifier>
+                        <qualifier>
+                            <variableref>ESU FnOut A10 Mode</variableref>
+                            <relation>ne</relation>
+                            <value>29</value>
+                        </qualifier>
+                        <qualifier>
+                            <variableref>ESU FnOut A10 Mode</variableref>
+                            <relation>ne</relation>
+                            <value>30</value>
+                        </qualifier>
+                        <qualifier>
+                            <variableref>ESU FnOut A10 Mode</variableref>
+                            <relation>ne</relation>
+                            <value>31</value>
+                        </qualifier>
+                        <qualifier>
+                            <variableref>ESU FnOut A10 Mode</variableref>
+                            <relation>ne</relation>
+                            <value>32</value>
+                        </qualifier>
+                        <qualifier>
+                            <variableref>ESU FnOut A10 Mode</variableref>
+                            <relation>le</relation>
+                            <value>33</value>
+                        </qualifier>
+                        <decVal max="31"/>
+                        <label xml:lang="de">Stärke des Kupplers</label>
+                    </variable>
+                    <variable label="Fan Speed" CV="16.0.350" default="31" item="ESU FnOut A10 Slider 11" mask="XXXVVVVV">
+                        <qualifier>
+                            <variableref>ESU FnOut A10 Mode</variableref>
+                            <relation>eq</relation>
+                            <value>23</value>
+                        </qualifier>
+                        <decVal max="31"/>
+                        <label xml:lang="de">Geschwindigkeit</label>
+                    </variable>
+                    <variable label="Standing heat" CV="16.0.350" default="31" item="ESU FnOut A10 Slider 14" mask="XXXVVVVV">
+                        <qualifier>
+                            <variableref>ESU FnOut A10 Mode</variableref>
+                            <relation>eq</relation>
+                            <value>24</value>
+                        </qualifier>
+                        <decVal max="31"/>
+                        <label xml:lang="de">Heizstufe im Stand</label>
+                    </variable>
+                    <variable label="Chuff power" CV="16.0.350" default="31" item="ESU FnOut A10 Slider 8" mask="XXXVVVVV">
+                        <qualifier>
+                            <variableref>ESU FnOut A10 Mode</variableref>
+                            <relation>eq</relation>
+                            <value>25</value>
+                        </qualifier>
+                        <decVal max="31"/>
+                        <label xml:lang="de">Dampfstoßstärke</label>
+                    </variable>
+                    <variable item="Special Function CV351" label="Special Function CV 1" CV="16.0.351" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                        <decVal/>
+                    </variable>
+                    <variable label="Fan Acceleration rate" CV="16.0.351" default="0" item="ESU FnOut A10 Slider 12" mask="XXXVVVVV">
+                        <qualifier>
+                            <variableref>ESU FnOut A10 Mode</variableref>
+                            <relation>eq</relation>
+                            <value>23</value>
+                        </qualifier>
+                        <decVal max="31"/>
+                        <label xml:lang="de">Beschleunigungszeit</label>
+                    </variable>
+                    <variable label="Minimum driving heat" CV="16.0.351" default="0" item="ESU FnOut A10 Slider 15" mask="XXXVVVVV">
+                        <qualifier>
+                            <variableref>ESU FnOut A10 Mode</variableref>
+                            <relation>eq</relation>
+                            <value>24</value>
+                        </qualifier>
+                        <decVal max="31"/>
+                        <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
+                    </variable>
+                    <variable label="Fan power" CV="16.0.351" default="0" item="ESU FnOut A10 Slider 9" mask="XXXVVVVV">
+                        <qualifier>
+                            <variableref>ESU FnOut A10 Mode</variableref>
+                            <relation>eq</relation>
+                            <value>25</value>
+                        </qualifier>
+                        <decVal max="31"/>
+                        <label xml:lang="de">Stäke des Bläsers</label>
+                    </variable>
+                    <variable label="Phase Reverse" CV="16.0.351" default="0" item="ESU FnOut A10 Check 6" mask="XXXXXXXV">
+                        <qualifier>
+                            <variableref>ESU FnOut A10 Mode</variableref>
+                            <relation>gt</relation>
+                            <value>0</value>
+                        </qualifier>
+                        <qualifier>
+                            <variableref>ESU FnOut A10 Mode</variableref>
+                            <relation>le</relation>
+                            <value>15</value>
+                        </qualifier>
+                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                        <label xml:lang="de">Phase tauschen</label>
+                    </variable>
+                    <variable label="Grade Crossing" CV="16.0.351" default="0" item="ESU FnOut A10 Check 1" mask="XXXXXXVX">
+                        <qualifier>
+                            <variableref>ESU FnOut A10 Mode</variableref>
+                            <relation>gt</relation>
+                            <value>0</value>
+                        </qualifier>
+                        <qualifier>
+                            <variableref>ESU FnOut A10 Mode</variableref>
+                            <relation>le</relation>
+                            <value>15</value>
+                        </qualifier>
+                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                    </variable>
+                    <variable label="Rule 17 Fwd" CV="16.0.351" default="0" item="ESU FnOut A10 Check 2" mask="XXXXXVXX">
+                        <qualifier>
+                            <variableref>ESU FnOut A10 Mode</variableref>
+                            <relation>gt</relation>
+                            <value>0</value>
+                        </qualifier>
+                        <qualifier>
+                            <variableref>ESU FnOut A10 Mode</variableref>
+                            <relation>le</relation>
+                            <value>15</value>
+                        </qualifier>
+                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                        <label xml:lang="de">Rule 17 vorwärts</label>
+                    </variable>
+                    <variable label="Rule 17 Rev" CV="16.0.351" default="0" item="ESU FnOut A10 Check 3" mask="XXXXVXXX">
+                        <qualifier>
+                            <variableref>ESU FnOut A10 Mode</variableref>
+                            <relation>gt</relation>
+                            <value>0</value>
+                        </qualifier>
+                        <qualifier>
+                            <variableref>ESU FnOut A10 Mode</variableref>
+                            <relation>le</relation>
+                            <value>15</value>
+                        </qualifier>
+                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                        <label xml:lang="de">Rule 17 rückwärts</label>
+                    </variable>
+                    <variable label="Dimmer" CV="16.0.351" default="0" item="ESU FnOut A10 Check 4" mask="XXXVXXXX">
+                        <qualifier>
+                            <variableref>ESU FnOut A10 Mode</variableref>
+                            <relation>gt</relation>
+                            <value>0</value>
+                        </qualifier>
+                        <qualifier>
+                            <variableref>ESU FnOut A10 Mode</variableref>
+                            <relation>le</relation>
+                            <value>15</value>
+                        </qualifier>
+                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                        <label xml:lang="de">Abdimmen</label>
+                    </variable>
+                    <variable label="LED Mode" CV="16.0.351" default="0" item="ESU FnOut A10 Check 5" mask="VXXXXXXX">
+                        <qualifier>
+                            <variableref>ESU FnOut A10 Mode</variableref>
+                            <relation>gt</relation>
+                            <value>0</value>
+                        </qualifier>
+                        <qualifier>
+                            <variableref>ESU FnOut A10 Mode</variableref>
+                            <relation>le</relation>
+                            <value>15</value>
+                        </qualifier>
+                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                        <label xml:lang="de">LED Modus</label>
+                    </variable>
+                    <variable item="Special Function CV352" label="Special Function CV 2" CV="16.0.352" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                        <decVal/>
+                    </variable>
+                    <variable label="Fan Decceleration rate" CV="16.0.352" default="0" item="ESU FnOut A10 Slider 13" mask="XXXVVVVV">
+                        <qualifier>
+                            <variableref>ESU FnOut A10 Mode</variableref>
+                            <relation>eq</relation>
+                            <value>23</value>
+                        </qualifier>
+                        <decVal max="31"/>
+                        <label xml:lang="de">Bremszeit</label>
+                    </variable>
+                    <variable label="Maximum driving heat" CV="16.0.352" default="0" item="ESU FnOut A10 Slider 16" mask="XXXVVVVV">
+                        <qualifier>
+                            <variableref>ESU FnOut A10 Mode</variableref>
+                            <relation>eq</relation>
+                            <value>24</value>
+                        </qualifier>
+                        <decVal max="31"/>
+                        <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
+                    </variable>
+                    <variable label="Timeout" CV="16.0.352" default="0" item="ESU FnOut A10 Slider 10" tooltip="Units = 0.25 sec">
+                        <qualifier>
+                            <variableref>ESU FnOut A10 Mode</variableref>
+                            <relation>eq</relation>
+                            <value>25</value>
+                        </qualifier>
+                        <decVal/>
+                    </variable>
+                    <variable label="Startup Time" CV="16.0.352" default="0" item="ESU FnOut A10 Slider 6">
+                        <qualifier>
+                            <variableref>ESU FnOut A10 Mode</variableref>
+                            <relation>ge</relation>
+                            <value>16</value>
+                        </qualifier>
+                        <qualifier>
+                            <variableref>ESU FnOut A10 Mode</variableref>
+                            <relation>le</relation>
+                            <value>17</value>
+                        </qualifier>
+                        <decVal/>
+                        <label xml:lang="de">Startzeit</label>
+                    </variable>
+                    <variable label="Level" CV="16.0.352" default="0" item="ESU FnOut A10 Slider 20" mask="XVVVVVVV">
+                        <qualifier>
+                            <variableref>ESU FnOut A10 Mode</variableref>
+                            <relation>eq</relation>
+                            <value>19</value>
+                        </qualifier>
+                        <decVal max="127"/>
+                    </variable>
+                    <!-- AUX11 Mode -->
+                    <variable label="AUX11 Mode" CV="16.0.355" default="1" item="ESU FnOut A11 Mode">
+                        <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
+                        <!--label xml:lang="de">Licht vorn - 2</label-->
+                    </variable>
+                    <variable label="Function Switch On Delay" CV="16.0.356" default="0" item="ESU FnOut A11 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
+                        <qualifier>
+                            <variableref>ESU FnOut A11 Mode</variableref>
+                            <relation>gt</relation>
+                            <value>0</value>
+                        </qualifier>
+                        <decVal max="15"/>
+                        <label xml:lang="de">Verzögerung beim Einschalten</label>
+                    </variable>
+                    <variable label="Function Switch Off Delay" CV="16.0.356" default="0" mask="VVVVXXXX" item="ESU FnOut A11 Slider 2" tooltip="Units = 0.4 sec">
+                        <qualifier>
+                            <variableref>ESU FnOut A11 Mode</variableref>
+                            <relation>gt</relation>
+                            <value>0</value>
+                        </qualifier>
+                        <decVal max="15"/>
+                        <label xml:lang="de">Verzögerung beim Ausschalten</label>
+                    </variable>
+                    <variable label="Function Auto Switch Off" CV="16.0.357" default="0" item="ESU FnOut A11 Slider 3" tooltip="Units = 0.4 sec">
+                        <qualifier>
+                            <variableref>ESU FnOut A11 Mode</variableref>
+                            <relation>gt</relation>
+                            <value>0</value>
+                        </qualifier>
+                        <decVal/>
+                        <label xml:lang="de">Ausgang automatisch Ausschalten</label>
+                    </variable>
+                    <variable item="Brightness CV358" label="Brightness CV" CV="16.0.358" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
+                        <decVal/>
+                    </variable>
+                    <variable label="Brightness" CV="16.0.358" default="31" item="ESU FnOut A11 Slider 5" mask="XXXVVVVV">
+                        <qualifier>
+                            <variableref>ESU FnOut A11 Mode</variableref>
+                            <relation>gt</relation>
+                            <value>0</value>
+                        </qualifier>
+                        <qualifier>
+                            <variableref>ESU FnOut A11 Mode</variableref>
+                            <relation>le</relation>
+                            <value>18</value>
+                        </qualifier>
+                        <decVal max="31"/>
+                        <label xml:lang="de">Helligkeit</label>
+                    </variable>
+                    <variable label="Mode" CV="16.0.358" default="0" item="ESU FnOut A11 Option 1" mask="XXXXXXXV">
+                        <qualifier>
+                            <variableref>ESU FnOut A11 Mode</variableref>
+                            <relation>eq</relation>
+                            <value>22</value>
+                        </qualifier>
+                        <enumVal>
+                            <enumChoice choice="Heating control">
+                                <choice>Heating control</choice>
+                                <choice xml:lang="de">Heizungssteuerung</choice>
+                            </enumChoice>
+                            <enumChoice choice="Fan control">
+                                <choice>Fan control</choice>
+                                <choice xml:lang="de">Lüftersteuerung</choice>
+                            </enumChoice>
+                        </enumVal>
+                        <label xml:lang="de">Modus</label>
+                    </variable>
+                    <variable label="Coupler Force" CV="16.0.358" default="31" item="ESU FnOut A11 Slider 7" mask="XXXVVVVV">
+                        <qualifier>
+                            <variableref>ESU FnOut A11 Mode</variableref>
+                            <relation>ge</relation>
+                            <value>28</value>
+                        </qualifier>
+                        <qualifier>
+                            <variableref>ESU FnOut A11 Mode</variableref>
+                            <relation>ne</relation>
+                            <value>29</value>
+                        </qualifier>
+                        <qualifier>
+                            <variableref>ESU FnOut A11 Mode</variableref>
+                            <relation>ne</relation>
+                            <value>30</value>
+                        </qualifier>
+                        <qualifier>
+                            <variableref>ESU FnOut A11 Mode</variableref>
+                            <relation>ne</relation>
+                            <value>31</value>
+                        </qualifier>
+                        <qualifier>
+                            <variableref>ESU FnOut A11 Mode</variableref>
+                            <relation>ne</relation>
+                            <value>32</value>
+                        </qualifier>
+                        <qualifier>
+                            <variableref>ESU FnOut A11 Mode</variableref>
+                            <relation>le</relation>
+                            <value>33</value>
+                        </qualifier>
+                        <decVal max="31"/>
+                        <label xml:lang="de">Stärke des Kupplers</label>
+                    </variable>
+                    <variable label="Fan Speed" CV="16.0.358" default="31" item="ESU FnOut A11 Slider 11" mask="XXXVVVVV">
+                        <qualifier>
+                            <variableref>ESU FnOut A11 Mode</variableref>
+                            <relation>eq</relation>
+                            <value>23</value>
+                        </qualifier>
+                        <decVal max="31"/>
+                        <label xml:lang="de">Geschwindigkeit</label>
+                    </variable>
+                    <variable label="Standing heat" CV="16.0.358" default="31" item="ESU FnOut A11 Slider 14" mask="XXXVVVVV">
+                        <qualifier>
+                            <variableref>ESU FnOut A11 Mode</variableref>
+                            <relation>eq</relation>
+                            <value>24</value>
+                        </qualifier>
+                        <decVal max="31"/>
+                        <label xml:lang="de">Heizstufe im Stand</label>
+                    </variable>
+                    <variable label="Chuff power" CV="16.0.358" default="31" item="ESU FnOut A11 Slider 8" mask="XXXVVVVV">
+                        <qualifier>
+                            <variableref>ESU FnOut A11 Mode</variableref>
+                            <relation>eq</relation>
+                            <value>25</value>
+                        </qualifier>
+                        <decVal max="31"/>
+                        <label xml:lang="de">Dampfstoßstärke</label>
+                    </variable>
+                    <variable label="Duration (speed) A" CV="16.0.354" default="31" item="ESU FnOut A11 Slider 4" mask="XXVVVVVV">
+                        <qualifier>
+                            <variableref>ESU FnOut A11 Mode</variableref>
+                            <relation>eq</relation>
+                            <value>27</value>
+                        </qualifier>
+                        <decVal max="63"/>
+                        <label xml:lang="de">Dauer (Geschwindigkeit)</label>
+                    </variable>
+                    <variable label="Duration (speed) B" CV="16.0.358" default="31" item="ESU FnOut A11 Slider 17" mask="XXVVVVVV">
+                        <qualifier>
+                            <variableref>ESU FnOut A11 Mode</variableref>
+                            <relation>eq</relation>
+                            <value>27</value>
+                        </qualifier>
+                        <decVal max="63"/>
+                        <label xml:lang="de">Dauer (Geschwindigkeit)</label>
+                    </variable>
+                    <variable item="Special Function CV359" label="Special Function CV 1" CV="16.0.359" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                        <decVal/>
+                    </variable>
+                    <variable label="Fan Acceleration rate" CV="16.0.359" default="0" item="ESU FnOut A11 Slider 12" mask="XXXVVVVV">
+                        <qualifier>
+                            <variableref>ESU FnOut A11 Mode</variableref>
+                            <relation>eq</relation>
+                            <value>23</value>
+                        </qualifier>
+                        <decVal max="31"/>
+                        <label xml:lang="de">Beschleunigungszeit</label>
+                    </variable>
+                    <variable label="Minimum driving heat" CV="16.0.359" default="0" item="ESU FnOut A11 Slider 15" mask="XXXVVVVV">
+                        <qualifier>
+                            <variableref>ESU FnOut A11 Mode</variableref>
+                            <relation>eq</relation>
+                            <value>24</value>
+                        </qualifier>
+                        <decVal max="31"/>
+                        <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
+                    </variable>
+                    <variable label="Position A" CV="16.0.359" default="0" item="ESU FnOut A11 Slider 18" mask="XXVVVVVV">
+                        <qualifier>
+                            <variableref>ESU FnOut A11 Mode</variableref>
+                            <relation>eq</relation>
+                            <value>27</value>
+                        </qualifier>
+                        <decVal max="63"/>
+                    </variable>
+                    <variable label="Fan power" CV="16.0.359" default="0" item="ESU FnOut A11 Slider 9" mask="XXXVVVVV">
+                        <qualifier>
+                            <variableref>ESU FnOut A11 Mode</variableref>
+                            <relation>eq</relation>
+                            <value>25</value>
+                        </qualifier>
+                        <decVal max="31"/>
+                        <label xml:lang="de">Stäke des Bläsers</label>
+                    </variable>
+                    <variable label="Phase Reverse" CV="16.0.359" default="0" item="ESU FnOut A11 Check 6" mask="XXXXXXXV">
+                        <qualifier>
+                            <variableref>ESU FnOut A11 Mode</variableref>
+                            <relation>gt</relation>
+                            <value>0</value>
+                        </qualifier>
+                        <qualifier>
+                            <variableref>ESU FnOut A11 Mode</variableref>
+                            <relation>le</relation>
+                            <value>15</value>
+                        </qualifier>
+                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                        <label xml:lang="de">Phase tauschen</label>
+                    </variable>
+                    <variable label="Grade Crossing" CV="16.0.359" default="0" item="ESU FnOut A11 Check 1" mask="XXXXXXVX">
+                        <qualifier>
+                            <variableref>ESU FnOut A11 Mode</variableref>
+                            <relation>gt</relation>
+                            <value>0</value>
+                        </qualifier>
+                        <qualifier>
+                            <variableref>ESU FnOut A11 Mode</variableref>
+                            <relation>le</relation>
+                            <value>15</value>
+                        </qualifier>
+                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                    </variable>
+                    <variable label="Rule 17 Fwd" CV="16.0.359" default="0" item="ESU FnOut A11 Check 2" mask="XXXXXVXX">
+                        <qualifier>
+                            <variableref>ESU FnOut A11 Mode</variableref>
+                            <relation>gt</relation>
+                            <value>0</value>
+                        </qualifier>
+                        <qualifier>
+                            <variableref>ESU FnOut A11 Mode</variableref>
+                            <relation>le</relation>
+                            <value>15</value>
+                        </qualifier>
+                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                        <label xml:lang="de">Rule 17 vorwärts</label>
+                    </variable>
+                    <variable label="Rule 17 Rev" CV="16.0.359" default="0" item="ESU FnOut A11 Check 3" mask="XXXXVXXX">
+                        <qualifier>
+                            <variableref>ESU FnOut A11 Mode</variableref>
+                            <relation>gt</relation>
+                            <value>0</value>
+                        </qualifier>
+                        <qualifier>
+                            <variableref>ESU FnOut A11 Mode</variableref>
+                            <relation>le</relation>
+                            <value>15</value>
+                        </qualifier>
+                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                        <label xml:lang="de">Rule 17 rückwärts</label>
+                    </variable>
+                    <variable label="Dimmer" CV="16.0.359" default="0" item="ESU FnOut A11 Check 4" mask="XXXVXXXX">
+                        <qualifier>
+                            <variableref>ESU FnOut A11 Mode</variableref>
+                            <relation>gt</relation>
+                            <value>0</value>
+                        </qualifier>
+                        <qualifier>
+                            <variableref>ESU FnOut A11 Mode</variableref>
+                            <relation>le</relation>
+                            <value>15</value>
+                        </qualifier>
+                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                        <label xml:lang="de">Abdimmen</label>
+                    </variable>
+                    <variable label="LED Mode" CV="16.0.359" default="0" item="ESU FnOut A11 Check 5" mask="VXXXXXXX">
+                        <qualifier>
+                            <variableref>ESU FnOut A11 Mode</variableref>
+                            <relation>gt</relation>
+                            <value>0</value>
+                        </qualifier>
+                        <qualifier>
+                            <variableref>ESU FnOut A11 Mode</variableref>
+                            <relation>le</relation>
+                            <value>15</value>
+                        </qualifier>
+                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                        <label xml:lang="de">LED Modus</label>
+                    </variable>
+                    <variable item="Special Function CV360" label="Special Function CV 2" CV="16.0.360" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                        <decVal/>
+                    </variable>
+                    <variable label="Fan Decceleration rate" CV="16.0.360" default="0" item="ESU FnOut A11 Slider 13" mask="XXXVVVVV">
+                        <qualifier>
+                            <variableref>ESU FnOut A11 Mode</variableref>
+                            <relation>eq</relation>
+                            <value>23</value>
+                        </qualifier>
+                        <decVal max="31"/>
+                        <label xml:lang="de">Bremszeit</label>
+                    </variable>
+                    <variable label="Maximum driving heat" CV="16.0.360" default="0" item="ESU FnOut A11 Slider 16" mask="XXXVVVVV">
+                        <qualifier>
+                            <variableref>ESU FnOut A11 Mode</variableref>
+                            <relation>eq</relation>
+                            <value>24</value>
+                        </qualifier>
+                        <decVal max="31"/>
+                        <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
+                    </variable>
+                    <variable label="Timeout" CV="16.0.360" default="0" item="ESU FnOut A11 Slider 10" tooltip="Units = 0.25 sec">
+                        <qualifier>
+                            <variableref>ESU FnOut A11 Mode</variableref>
+                            <relation>eq</relation>
+                            <value>25</value>
+                        </qualifier>
+                        <decVal/>
+                    </variable>
+                    <variable label="Startup Time" CV="16.0.360" default="0" item="ESU FnOut A11 Slider 6">
+                        <qualifier>
+                            <variableref>ESU FnOut A11 Mode</variableref>
+                            <relation>ge</relation>
+                            <value>16</value>
+                        </qualifier>
+                        <qualifier>
+                            <variableref>ESU FnOut A11 Mode</variableref>
+                            <relation>le</relation>
+                            <value>17</value>
+                        </qualifier>
+                        <decVal/>
+                        <label xml:lang="de">Startzeit</label>
+                    </variable>
+                    <variable label="Level" CV="16.0.360" default="0" item="ESU FnOut A11 Slider 20" mask="XVVVVVVV">
+                        <qualifier>
+                            <variableref>ESU FnOut A11 Mode</variableref>
+                            <relation>eq</relation>
+                            <value>19</value>
+                        </qualifier>
+                        <decVal max="127"/>
+                    </variable>
+                    <variable label="Position B" CV="16.0.360" default="0" item="ESU FnOut A11 Slider 19" mask="XXVVVVVV">
+                        <qualifier>
+                            <variableref>ESU FnOut A11 Mode</variableref>
+                            <relation>eq</relation>
+                            <value>27</value>
+                        </qualifier>
+                        <decVal max="63"/>
+                    </variable>
+                    <!-- AUX12 Mode -->
+                    <variable label="AUX12 Mode" CV="16.0.363" default="1" item="ESU FnOut A12 Mode">
+                        <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
+                    </variable>
+                    <variable label="Function Switch On Delay" CV="16.0.364" default="0" item="ESU FnOut A12 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
+                        <qualifier>
+                            <variableref>ESU FnOut A12 Mode</variableref>
+                            <relation>gt</relation>
+                            <value>0</value>
+                        </qualifier>
+                        <decVal max="15"/>
+                        <label xml:lang="de">Verzögerung beim Einschalten</label>
+                    </variable>
+                    <variable label="Function Switch Off Delay" CV="16.0.364" default="0" mask="VVVVXXXX" item="ESU FnOut A12 Slider 2" tooltip="Units = 0.4 sec">
+                        <qualifier>
+                            <variableref>ESU FnOut A12 Mode</variableref>
+                            <relation>gt</relation>
+                            <value>0</value>
+                        </qualifier>
+                        <decVal max="15"/>
+                        <label xml:lang="de">Verzögerung beim Ausschalten</label>
+                    </variable>
+                    <variable label="Function Auto Switch Off" CV="16.0.365" default="0" item="ESU FnOut A12 Slider 3" tooltip="Units = 0.4 sec">
+                        <qualifier>
+                            <variableref>ESU FnOut A12 Mode</variableref>
+                            <relation>gt</relation>
+                            <value>0</value>
+                        </qualifier>
+                        <decVal/>
+                        <label xml:lang="de">Ausgang automatisch Ausschalten</label>
+                    </variable>
+                    <variable item="Brightness CV366" label="Brightness CV" CV="16.0.366" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
+                        <decVal/>
+                    </variable>
+                    <variable label="Brightness" CV="16.0.366" default="31" item="ESU FnOut A12 Slider 5" mask="XXXVVVVV">
+                        <qualifier>
+                            <variableref>ESU FnOut A12 Mode</variableref>
+                            <relation>gt</relation>
+                            <value>0</value>
+                        </qualifier>
+                        <qualifier>
+                            <variableref>ESU FnOut A12 Mode</variableref>
+                            <relation>le</relation>
+                            <value>18</value>
+                        </qualifier>
+                        <decVal max="31"/>
+                        <label xml:lang="de">Helligkeit</label>
+                    </variable>
+                    <variable label="Mode" CV="16.0.366" default="0" item="ESU FnOut A12 Option 1" mask="XXXXXXXV">
+                        <qualifier>
+                            <variableref>ESU FnOut A12 Mode</variableref>
+                            <relation>eq</relation>
+                            <value>22</value>
+                        </qualifier>
+                        <enumVal>
+                            <enumChoice choice="Heating control">
+                                <choice>Heating control</choice>
+                                <choice xml:lang="de">Heizungssteuerung</choice>
+                            </enumChoice>
+                            <enumChoice choice="Fan control">
+                                <choice>Fan control</choice>
+                                <choice xml:lang="de">Lüftersteuerung</choice>
+                            </enumChoice>
+                        </enumVal>
+                        <label xml:lang="de">Modus</label>
+                    </variable>
+                    <variable label="Coupler Force" CV="16.0.366" default="31" item="ESU FnOut A12 Slider 7" mask="XXXVVVVV">
+                        <qualifier>
+                            <variableref>ESU FnOut A12 Mode</variableref>
+                            <relation>ge</relation>
+                            <value>28</value>
+                        </qualifier>
+                        <qualifier>
+                            <variableref>ESU FnOut A12 Mode</variableref>
+                            <relation>ne</relation>
+                            <value>29</value>
+                        </qualifier>
+                        <qualifier>
+                            <variableref>ESU FnOut A12 Mode</variableref>
+                            <relation>ne</relation>
+                            <value>30</value>
+                        </qualifier>
+                        <qualifier>
+                            <variableref>ESU FnOut A12 Mode</variableref>
+                            <relation>ne</relation>
+                            <value>31</value>
+                        </qualifier>
+                        <qualifier>
+                            <variableref>ESU FnOut A12 Mode</variableref>
+                            <relation>ne</relation>
+                            <value>32</value>
+                        </qualifier>
+                        <qualifier>
+                            <variableref>ESU FnOut A12 Mode</variableref>
+                            <relation>le</relation>
+                            <value>33</value>
+                        </qualifier>
+                        <decVal max="31"/>
+                        <label xml:lang="de">Stärke des Kupplers</label>
+                    </variable>
+                    <variable label="Fan Speed" CV="16.0.366" default="31" item="ESU FnOut A12 Slider 11" mask="XXXVVVVV">
+                        <qualifier>
+                            <variableref>ESU FnOut A12 Mode</variableref>
+                            <relation>eq</relation>
+                            <value>23</value>
+                        </qualifier>
+                        <decVal max="31"/>
+                        <label xml:lang="de">Geschwindigkeit</label>
+                    </variable>
+                    <variable label="Standing heat" CV="16.0.366" default="31" item="ESU FnOut A12 Slider 14" mask="XXXVVVVV">
+                        <qualifier>
+                            <variableref>ESU FnOut A12 Mode</variableref>
+                            <relation>eq</relation>
+                            <value>24</value>
+                        </qualifier>
+                        <decVal max="31"/>
+                        <label xml:lang="de">Heizstufe im Stand</label>
+                    </variable>
+                    <variable label="Chuff power" CV="16.0.366" default="31" item="ESU FnOut A12 Slider 8" mask="XXXVVVVV">
+                        <qualifier>
+                            <variableref>ESU FnOut A12 Mode</variableref>
+                            <relation>eq</relation>
+                            <value>25</value>
+                        </qualifier>
+                        <decVal max="31"/>
+                        <label xml:lang="de">Dampfstoßstärke</label>
+                    </variable>
+                    <variable label="Duration (speed) A" CV="16.0.362" default="31" item="ESU FnOut A12 Slider 4" mask="XXVVVVVV">
+                        <qualifier>
+                            <variableref>ESU FnOut A12 Mode</variableref>
+                            <relation>eq</relation>
+                            <value>27</value>
+                        </qualifier>
+                        <decVal max="63"/>
+                        <label xml:lang="de">Dauer (Geschwindigkeit)</label>
+                    </variable>
+                    <variable label="Duration (speed) B" CV="16.0.366" default="31" item="ESU FnOut A12 Slider 17" mask="XXVVVVVV">
+                        <qualifier>
+                            <variableref>ESU FnOut A12 Mode</variableref>
+                            <relation>eq</relation>
+                            <value>27</value>
+                        </qualifier>
+                        <decVal max="63"/>
+                        <label xml:lang="de">Dauer (Geschwindigkeit)</label>
+                    </variable>
+                    <variable item="Special Function CV367" label="Special Function CV 1" CV="16.0.367" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                        <decVal/>
+                    </variable>
+                    <variable label="Fan Acceleration rate" CV="16.0.367" default="0" item="ESU FnOut A12 Slider 12" mask="XXXVVVVV">
+                        <qualifier>
+                            <variableref>ESU FnOut A12 Mode</variableref>
+                            <relation>eq</relation>
+                            <value>23</value>
+                        </qualifier>
+                        <decVal max="31"/>
+                        <label xml:lang="de">Beschleunigungszeit</label>
+                    </variable>
+                    <variable label="Minimum driving heat" CV="16.0.367" default="0" item="ESU FnOut A12 Slider 15" mask="XXXVVVVV">
+                        <qualifier>
+                            <variableref>ESU FnOut A12 Mode</variableref>
+                            <relation>eq</relation>
+                            <value>24</value>
+                        </qualifier>
+                        <decVal max="31"/>
+                        <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
+                    </variable>
+                    <variable label="Position A" CV="16.0.367" default="0" item="ESU FnOut A12 Slider 18" mask="XXVVVVVV">
+                        <qualifier>
+                            <variableref>ESU FnOut A12 Mode</variableref>
+                            <relation>eq</relation>
+                            <value>27</value>
+                        </qualifier>
+                        <decVal max="63"/>
+                    </variable>
+                    <variable label="Fan power" CV="16.0.367" default="0" item="ESU FnOut A12 Slider 9" mask="XXXVVVVV">
+                        <qualifier>
+                            <variableref>ESU FnOut A12 Mode</variableref>
+                            <relation>eq</relation>
+                            <value>25</value>
+                        </qualifier>
+                        <decVal max="31"/>
+                        <label xml:lang="de">Stäke des Bläsers</label>
+                    </variable>
+                    <variable label="Phase Reverse" CV="16.0.367" default="0" item="ESU FnOut A12 Check 6" mask="XXXXXXXV">
+                        <qualifier>
+                            <variableref>ESU FnOut A12 Mode</variableref>
+                            <relation>gt</relation>
+                            <value>0</value>
+                        </qualifier>
+                        <qualifier>
+                            <variableref>ESU FnOut A12 Mode</variableref>
+                            <relation>le</relation>
+                            <value>15</value>
+                        </qualifier>
+                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                        <label xml:lang="de">Phase tauschen</label>
+                    </variable>
+                    <variable label="Grade Crossing" CV="16.0.367" default="0" item="ESU FnOut A12 Check 1" mask="XXXXXXVX">
+                        <qualifier>
+                            <variableref>ESU FnOut A12 Mode</variableref>
+                            <relation>gt</relation>
+                            <value>0</value>
+                        </qualifier>
+                        <qualifier>
+                            <variableref>ESU FnOut A12 Mode</variableref>
+                            <relation>le</relation>
+                            <value>15</value>
+                        </qualifier>
+                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                    </variable>
+                    <variable label="Rule 17 Fwd" CV="16.0.367" default="0" item="ESU FnOut A12 Check 2" mask="XXXXXVXX">
+                        <qualifier>
+                            <variableref>ESU FnOut A12 Mode</variableref>
+                            <relation>gt</relation>
+                            <value>0</value>
+                        </qualifier>
+                        <qualifier>
+                            <variableref>ESU FnOut A12 Mode</variableref>
+                            <relation>le</relation>
+                            <value>15</value>
+                        </qualifier>
+                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                        <label xml:lang="de">Rule 17 vorwärts</label>
+                    </variable>
+                    <variable label="Rule 17 Rev" CV="16.0.367" default="0" item="ESU FnOut A12 Check 3" mask="XXXXVXXX">
+                        <qualifier>
+                            <variableref>ESU FnOut A12 Mode</variableref>
+                            <relation>gt</relation>
+                            <value>0</value>
+                        </qualifier>
+                        <qualifier>
+                            <variableref>ESU FnOut A12 Mode</variableref>
+                            <relation>le</relation>
+                            <value>15</value>
+                        </qualifier>
+                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                        <label xml:lang="de">Rule 17 rückwärts</label>
+                    </variable>
+                    <variable label="Dimmer" CV="16.0.367" default="0" item="ESU FnOut A12 Check 4" mask="XXXVXXXX">
+                        <qualifier>
+                            <variableref>ESU FnOut A12 Mode</variableref>
+                            <relation>gt</relation>
+                            <value>0</value>
+                        </qualifier>
+                        <qualifier>
+                            <variableref>ESU FnOut A12 Mode</variableref>
+                            <relation>le</relation>
+                            <value>15</value>
+                        </qualifier>
+                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                        <label xml:lang="de">Abdimmen</label>
+                    </variable>
+                    <variable label="LED Mode" CV="16.0.367" default="0" item="ESU FnOut A12 Check 5" mask="VXXXXXXX">
+                        <qualifier>
+                            <variableref>ESU FnOut A12 Mode</variableref>
+                            <relation>gt</relation>
+                            <value>0</value>
+                        </qualifier>
+                        <qualifier>
+                            <variableref>ESU FnOut A12 Mode</variableref>
+                            <relation>le</relation>
+                            <value>15</value>
+                        </qualifier>
+                        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                        <label xml:lang="de">LED Modus</label>
+                    </variable>
+                    <variable item="Special Function CV368" label="Special Function CV 2" CV="16.0.368" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                        <decVal/>
+                    </variable>
+                    <variable label="Fan Decceleration rate" CV="16.0.368" default="0" item="ESU FnOut A12 Slider 13" mask="XXXVVVVV">
+                        <qualifier>
+                            <variableref>ESU FnOut A12 Mode</variableref>
+                            <relation>eq</relation>
+                            <value>23</value>
+                        </qualifier>
+                        <decVal max="31"/>
+                        <label xml:lang="de">Bremszeit</label>
+                    </variable>
+                    <variable label="Maximum driving heat" CV="16.0.368" default="0" item="ESU FnOut A12 Slider 16" mask="XXXVVVVV">
+                        <qualifier>
+                            <variableref>ESU FnOut A12 Mode</variableref>
+                            <relation>eq</relation>
+                            <value>24</value>
+                        </qualifier>
+                        <decVal max="31"/>
+                        <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
+                    </variable>
+                    <variable label="Timeout" CV="16.0.368" default="0" item="ESU FnOut A12 Slider 10" tooltip="Units = 0.25 sec">
+                        <qualifier>
+                            <variableref>ESU FnOut A12 Mode</variableref>
+                            <relation>eq</relation>
+                            <value>25</value>
+                        </qualifier>
+                        <decVal/>
+                    </variable>
+                    <variable label="Startup Time" CV="16.0.368" default="0" item="ESU FnOut A12 Slider 6">
+                        <qualifier>
+                            <variableref>ESU FnOut A12 Mode</variableref>
+                            <relation>ge</relation>
+                            <value>16</value>
+                        </qualifier>
+                        <qualifier>
+                            <variableref>ESU FnOut A12 Mode</variableref>
+                            <relation>le</relation>
+                            <value>17</value>
+                        </qualifier>
+                        <decVal/>
+                        <label xml:lang="de">Startzeit</label>
+                    </variable>
+                    <variable label="Level" CV="16.0.368" default="0" item="ESU FnOut A12 Slider 20" mask="XVVVVVVV">
+                        <qualifier>
+                            <variableref>ESU FnOut A12 Mode</variableref>
+                            <relation>eq</relation>
+                            <value>19</value>
+                        </qualifier>
+                        <decVal max="127"/>
+                    </variable>
+                    <variable label="Position B" CV="16.0.368" default="0" item="ESU FnOut A12 Slider 19" mask="XXVVVVVV">
+                        <qualifier>
+                            <variableref>ESU FnOut A12 Mode</variableref>
+                            <relation>eq</relation>
+                            <value>27</value>
+                        </qualifier>
+                        <decVal max="63"/>
+                    </variable>
+                    <!-- exclude AUX13 to AUX18 -->
+                    <variables exclude="LokSound 5 Fx,LokSound 5 Fx DCC,LokPilot 5 Fx,LokPilot 5 Fx DCC">                <!-- AUX13 Mode -->
+                        <variable label="AUX13 Mode" CV="16.0.371" default="1" item="ESU FnOut A13 Mode">
                             <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
                         </variable>
-                        <variable label="Function Switch On Delay" CV="16.0.332" default="0" item="ESU FnOut A8 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
+                        <variable label="Function Switch On Delay" CV="16.0.372" default="0" item="ESU FnOut A13 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A8 Mode</variableref>
+                                <variableref>ESU FnOut A13 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A8 Mode</variableref>
+                                <variableref>ESU FnOut A13 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>27</value>
                             </qualifier>
                             <decVal max="15"/>
                             <label xml:lang="de">Verzögerung beim Einschalten</label>
                         </variable>
-                        <variable label="Function Switch Off Delay" CV="16.0.332" default="0" mask="VVVVXXXX" item="ESU FnOut A8 Slider 2" tooltip="Units = 0.4 sec">
+                        <variable label="Function Switch Off Delay" CV="16.0.372" default="0" mask="VVVVXXXX" item="ESU FnOut A13 Slider 2" tooltip="Units = 0.4 sec">
                             <qualifier>
-                                <variableref>ESU FnOut A8 Mode</variableref>
+                                <variableref>ESU FnOut A13 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A8 Mode</variableref>
+                                <variableref>ESU FnOut A13 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>27</value>
                             </qualifier>
                             <decVal max="15"/>
                             <label xml:lang="de">Verzögerung beim Ausschalten</label>
                         </variable>
-                        <variable label="Function Auto Switch Off" CV="16.0.333" default="0" item="ESU FnOut A8 Slider 3" tooltip="Units = 0.4 sec">
+                        <variable label="Function Auto Switch Off" CV="16.0.373" default="0" item="ESU FnOut A13 Slider 3" tooltip="Units = 0.4 sec">
                             <qualifier>
-                                <variableref>ESU FnOut A8 Mode</variableref>
+                                <variableref>ESU FnOut A13 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A8 Mode</variableref>
+                                <variableref>ESU FnOut A13 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>27</value>
                             </qualifier>
                             <decVal/>
                             <label xml:lang="de">Ausgang automatisch Ausschalten</label>
                         </variable>
-                        <variable item="Brightness CV334" label="Brightness CV" CV="16.0.334" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
+                        <variable item="Brightness CV374" label="Brightness CV" CV="16.0.374" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
                             <decVal/>
                         </variable>
-                        <variable label="Brightness" CV="16.0.334" default="31" item="ESU FnOut A8 Slider 5" mask="XXXVVVVV">
+                        <variable label="Brightness" CV="16.0.374" default="31" item="ESU FnOut A13 Slider 5" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A8 Mode</variableref>
+                                <variableref>ESU FnOut A13 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A8 Mode</variableref>
+                                <variableref>ESU FnOut A13 Mode</variableref>
                                 <relation>le</relation>
                                 <value>18</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Helligkeit</label>
                         </variable>
-                        <variable label="Mode" CV="16.0.334" default="0" item="ESU FnOut A8 Option 1" mask="XXXXXXXV">
+                        <variable label="Mode" CV="16.0.374" default="0" item="ESU FnOut A13 Option 1" mask="XXXXXXXV">
                             <qualifier>
-                                <variableref>ESU FnOut A8 Mode</variableref>
+                                <variableref>ESU FnOut A13 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>22</value>
                             </qualifier>
@@ -2837,300 +4421,297 @@
                             </enumVal>
                             <label xml:lang="de">Modus</label>
                         </variable>
-                        <variable label="Coupler Force" CV="16.0.334" default="31" item="ESU FnOut A8 Slider 7" mask="XXXVVVVV">
+                        <variable label="Coupler Force" CV="16.0.374" default="31" item="ESU FnOut A13 Slider 7" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A8 Mode</variableref>
+                                <variableref>ESU FnOut A13 Mode</variableref>
                                 <relation>ge</relation>
                                 <value>28</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A8 Mode</variableref>
+                                <variableref>ESU FnOut A13 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>29</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A8 Mode</variableref>
+                                <variableref>ESU FnOut A13 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>30</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A8 Mode</variableref>
+                                <variableref>ESU FnOut A13 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>31</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A8 Mode</variableref>
+                                <variableref>ESU FnOut A13 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>32</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A8 Mode</variableref>
+                                <variableref>ESU FnOut A13 Mode</variableref>
                                 <relation>le</relation>
                                 <value>33</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Stärke des Kupplers</label>
                         </variable>
-                        <variable label="Fan Speed" CV="16.0.334" default="31" item="ESU FnOut A8 Slider 11" mask="XXXVVVVV">
+                        <variable label="Fan Speed" CV="16.0.374" default="31" item="ESU FnOut A13 Slider 11" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A8 Mode</variableref>
+                                <variableref>ESU FnOut A13 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>23</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Geschwindigkeit</label>
                         </variable>
-                        <variable label="Standing heat" CV="16.0.334" default="31" item="ESU FnOut A8 Slider 14" mask="XXXVVVVV">
+                        <variable label="Standing heat" CV="16.0.374" default="31" item="ESU FnOut A13 Slider 14" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A8 Mode</variableref>
+                                <variableref>ESU FnOut A13 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>24</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Heizstufe im Stand</label>
                         </variable>
-                        <variable label="Chuff power" CV="16.0.334" default="31" item="ESU FnOut A8 Slider 8" mask="XXXVVVVV">
+                        <variable label="Chuff power" CV="16.0.374" default="31" item="ESU FnOut A13 Slider 8" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A8 Mode</variableref>
+                                <variableref>ESU FnOut A13 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>25</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Dampfstoßstärke</label>
                         </variable>
-                        <variable item="Special Function CV335" label="Special Function CV 1" CV="16.0.335" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                        <variable item="Special Function CV375" label="Special Function CV 1" CV="16.0.375" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
                             <decVal/>
                         </variable>
-                        <variable label="Fan Acceleration rate" CV="16.0.335" default="0" item="ESU FnOut A8 Slider 12" mask="XXXVVVVV">
+                        <variable label="Fan Acceleration rate" CV="16.0.375" default="0" item="ESU FnOut A13 Slider 12" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A8 Mode</variableref>
+                                <variableref>ESU FnOut A13 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>23</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Beschleunigungszeit</label>
                         </variable>
-                        <variable label="Minimum driving heat" CV="16.0.335" default="0" item="ESU FnOut A8 Slider 15" mask="XXXVVVVV">
+                        <variable label="Minimum driving heat" CV="16.0.375" default="0" item="ESU FnOut A13 Slider 15" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A8 Mode</variableref>
+                                <variableref>ESU FnOut A13 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>24</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
                         </variable>
-                        <variable label="Fan power" CV="16.0.335" default="0" item="ESU FnOut A8 Slider 9" mask="XXXVVVVV">
+                        <variable label="Fan power" CV="16.0.375" default="0" item="ESU FnOut A13 Slider 9" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A8 Mode</variableref>
+                                <variableref>ESU FnOut A13 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>25</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Stäke des Bläsers</label>
                         </variable>
-                        <variable label="Phase Reverse" CV="16.0.335" default="0" item="ESU FnOut A8 Check 6" mask="XXXXXXXV">
+                        <variable label="Phase Reverse" CV="16.0.375" default="0" item="ESU FnOut A13 Check 6" mask="XXXXXXXV">
                             <qualifier>
-                                <variableref>ESU FnOut A8 Mode</variableref>
+                                <variableref>ESU FnOut A13 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A8 Mode</variableref>
+                                <variableref>ESU FnOut A13 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                             <label xml:lang="de">Phase tauschen</label>
                         </variable>
-                        <variable label="Grade Crossing" CV="16.0.335" default="0" item="ESU FnOut A8 Check 1" mask="XXXXXXVX">
+                        <variable label="Grade Crossing" CV="16.0.375" default="0" item="ESU FnOut A13 Check 1" mask="XXXXXXVX">
                             <qualifier>
-                                <variableref>ESU FnOut A8 Mode</variableref>
+                                <variableref>ESU FnOut A13 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A8 Mode</variableref>
+                                <variableref>ESU FnOut A13 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                         </variable>
-                        <variable label="Rule 17 Fwd" CV="16.0.335" default="0" item="ESU FnOut A8 Check 2" mask="XXXXXVXX">
+                        <variable label="Rule 17 Fwd" CV="16.0.375" default="0" item="ESU FnOut A13 Check 2" mask="XXXXXVXX">
                             <qualifier>
-                                <variableref>ESU FnOut A8 Mode</variableref>
+                                <variableref>ESU FnOut A13 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A8 Mode</variableref>
+                                <variableref>ESU FnOut A13 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                             <label xml:lang="de">Rule 17 vorwärts</label>
                         </variable>
-                        <variable label="Rule 17 Rev" CV="16.0.335" default="0" item="ESU FnOut A8 Check 3" mask="XXXXVXXX">
+                        <variable label="Rule 17 Rev" CV="16.0.375" default="0" item="ESU FnOut A13 Check 3" mask="XXXXVXXX">
                             <qualifier>
-                                <variableref>ESU FnOut A8 Mode</variableref>
+                                <variableref>ESU FnOut A13 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A8 Mode</variableref>
+                                <variableref>ESU FnOut A13 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                             <label xml:lang="de">Rule 17 rückwärts</label>
                         </variable>
-                        <variable label="Dimmer" CV="16.0.335" default="0" item="ESU FnOut A8 Check 4" mask="XXXVXXXX">
+                        <variable label="Dimmer" CV="16.0.375" default="0" item="ESU FnOut A13 Check 4" mask="XXXVXXXX">
                             <qualifier>
-                                <variableref>ESU FnOut A8 Mode</variableref>
+                                <variableref>ESU FnOut A13 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A8 Mode</variableref>
+                                <variableref>ESU FnOut A13 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                             <label xml:lang="de">Abdimmen</label>
                         </variable>
-                        <variable label="LED Mode" CV="16.0.335" default="0" item="ESU FnOut A8 Check 5" mask="VXXXXXXX">
+                        <variable label="LED Mode" CV="16.0.375" default="0" item="ESU FnOut A13 Check 5" mask="VXXXXXXX">
                             <qualifier>
-                                <variableref>ESU FnOut A8 Mode</variableref>
+                                <variableref>ESU FnOut A13 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A8 Mode</variableref>
+                                <variableref>ESU FnOut A13 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                             <label xml:lang="de">LED Modus</label>
                         </variable>
-                        <variable item="Special Function CV336" label="Special Function CV 2" CV="16.0.336" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                        <variable item="Special Function CV376" label="Special Function CV 2" CV="16.0.376" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
                             <decVal/>
                         </variable>
-                        <variable label="Fan Decceleration rate" CV="16.0.336" default="0" item="ESU FnOut A8 Slider 13" mask="XXXVVVVV">
+                        <variable label="Fan Decceleration rate" CV="16.0.376" default="0" item="ESU FnOut A13 Slider 13" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A8 Mode</variableref>
+                                <variableref>ESU FnOut A13 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>23</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Bremszeit</label>
                         </variable>
-                        <variable label="Maximum driving heat" CV="16.0.336" default="0" item="ESU FnOut A8 Slider 16" mask="XXXVVVVV">
+                        <variable label="Maximum driving heat" CV="16.0.376" default="0" item="ESU FnOut A13 Slider 16" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A8 Mode</variableref>
+                                <variableref>ESU FnOut A13 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>24</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
                         </variable>
-                        <variable label="Timeout" CV="16.0.336" default="0" item="ESU FnOut A8 Slider 10" tooltip="Units = 0.25 sec">
+                        <variable label="Timeout" CV="16.0.376" default="0" item="ESU FnOut A13 Slider 10" tooltip="Units = 0.25 sec">
                             <qualifier>
-                                <variableref>ESU FnOut A8 Mode</variableref>
+                                <variableref>ESU FnOut A13 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>25</value>
                             </qualifier>
                             <decVal/>
                         </variable>
-                        <variable label="Startup Time" CV="16.0.336" default="0" item="ESU FnOut A8 Slider 6">
+                        <variable label="Startup Time" CV="16.0.376" default="0" item="ESU FnOut A13 Slider 6">
                             <qualifier>
-                                <variableref>ESU FnOut A8 Mode</variableref>
+                                <variableref>ESU FnOut A13 Mode</variableref>
                                 <relation>ge</relation>
                                 <value>16</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A8 Mode</variableref>
+                                <variableref>ESU FnOut A13 Mode</variableref>
                                 <relation>le</relation>
                                 <value>17</value>
                             </qualifier>
                             <decVal/>
                             <label xml:lang="de">Startzeit</label>
                         </variable>
-                        <variable label="Level" CV="16.0.336" default="0" item="ESU FnOut A8 Slider 20" mask="XVVVVVVV">
+                        <variable label="Level" CV="16.0.376" default="0" item="ESU FnOut A13 Slider 20" mask="XVVVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A8 Mode</variableref>
+                                <variableref>ESU FnOut A13 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>19</value>
                             </qualifier>
                             <decVal max="127"/>
                         </variable>
-                    </variables>
-                    <!-- exclude AUX9 to AUX18 -->
-                    <variables exclude="LokPilot 5 micro DCC Direct,LokSound 5 micro DCC Direct">
-                        <!-- AUX9 Mode -->
-                        <variable label="AUX9 Mode" CV="16.0.339" default="1" item="ESU FnOut A9 Mode">
+                        <!-- AUX14 Mode -->
+                        <variable label="AUX14 Mode" CV="16.0.379" default="1" item="ESU FnOut A14 Mode">
                             <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
                         </variable>
-                        <variable label="Function Switch On Delay" CV="16.0.340" default="0" item="ESU FnOut A9 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
+                        <variable label="Function Switch On Delay" CV="16.0.380" default="0" item="ESU FnOut A14 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A9 Mode</variableref>
+                                <variableref>ESU FnOut A14 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A9 Mode</variableref>
+                                <variableref>ESU FnOut A14 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>27</value>
                             </qualifier>
                             <decVal max="15"/>
                             <label xml:lang="de">Verzögerung beim Einschalten</label>
                         </variable>
-                        <variable label="Function Switch Off Delay" CV="16.0.340" default="0" mask="VVVVXXXX" item="ESU FnOut A9 Slider 2" tooltip="Units = 0.4 sec">
+                        <variable label="Function Switch Off Delay" CV="16.0.380" default="0" mask="VVVVXXXX" item="ESU FnOut A14 Slider 2" tooltip="Units = 0.4 sec">
                             <qualifier>
-                                <variableref>ESU FnOut A9 Mode</variableref>
+                                <variableref>ESU FnOut A14 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A9 Mode</variableref>
+                                <variableref>ESU FnOut A14 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>27</value>
                             </qualifier>
                             <decVal max="15"/>
                             <label xml:lang="de">Verzögerung beim Ausschalten</label>
                         </variable>
-                        <variable label="Function Auto Switch Off" CV="16.0.341" default="0" item="ESU FnOut A9 Slider 3" tooltip="Units = 0.4 sec">
+                        <variable label="Function Auto Switch Off" CV="16.0.381" default="0" item="ESU FnOut A14 Slider 3" tooltip="Units = 0.4 sec">
                             <qualifier>
-                                <variableref>ESU FnOut A9 Mode</variableref>
+                                <variableref>ESU FnOut A14 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A9 Mode</variableref>
+                                <variableref>ESU FnOut A14 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>27</value>
                             </qualifier>
                             <decVal/>
                             <label xml:lang="de">Ausgang automatisch Ausschalten</label>
                         </variable>
-                        <variable item="Brightness CV342" label="Brightness CV" CV="16.0.342" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
+                        <variable item="Brightness CV382" label="Brightness CV" CV="16.0.382" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
                             <decVal/>
                         </variable>
-                        <variable label="Brightness" CV="16.0.342" default="31" item="ESU FnOut A9 Slider 5" mask="XXXVVVVV">
+                        <variable label="Brightness" CV="16.0.382" default="31" item="ESU FnOut A14 Slider 5" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A9 Mode</variableref>
+                                <variableref>ESU FnOut A14 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A9 Mode</variableref>
+                                <variableref>ESU FnOut A14 Mode</variableref>
                                 <relation>le</relation>
                                 <value>18</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Helligkeit</label>
                         </variable>
-                        <variable label="Mode" CV="16.0.342" default="0" item="ESU FnOut A9 Option 1" mask="XXXXXXXV">
+                        <variable label="Mode" CV="16.0.382" default="0" item="ESU FnOut A14 Option 1" mask="XXXXXXXV">
                             <qualifier>
-                                <variableref>ESU FnOut A9 Mode</variableref>
+                                <variableref>ESU FnOut A14 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>22</value>
                             </qualifier>
@@ -3146,297 +4727,282 @@
                             </enumVal>
                             <label xml:lang="de">Modus</label>
                         </variable>
-                        <variable label="Coupler Force" CV="16.0.342" default="31" item="ESU FnOut A9 Slider 7" mask="XXXVVVVV">
+                        <variable label="Coupler Force" CV="16.0.382" default="31" item="ESU FnOut A14 Slider 7" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A9 Mode</variableref>
+                                <variableref>ESU FnOut A14 Mode</variableref>
                                 <relation>ge</relation>
                                 <value>28</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A9 Mode</variableref>
+                                <variableref>ESU FnOut A14 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>29</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A9 Mode</variableref>
+                                <variableref>ESU FnOut A14 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>30</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A9 Mode</variableref>
+                                <variableref>ESU FnOut A14 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>31</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A9 Mode</variableref>
+                                <variableref>ESU FnOut A14 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>32</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A9 Mode</variableref>
+                                <variableref>ESU FnOut A14 Mode</variableref>
                                 <relation>le</relation>
                                 <value>33</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Stärke des Kupplers</label>
                         </variable>
-                        <variable label="Fan Speed" CV="16.0.342" default="31" item="ESU FnOut A9 Slider 11" mask="XXXVVVVV">
+                        <variable label="Fan Speed" CV="16.0.382" default="31" item="ESU FnOut A14 Slider 11" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A9 Mode</variableref>
+                                <variableref>ESU FnOut A14 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>23</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Geschwindigkeit</label>
                         </variable>
-                        <variable label="Standing heat" CV="16.0.342" default="31" item="ESU FnOut A9 Slider 14" mask="XXXVVVVV">
+                        <variable label="Standing heat" CV="16.0.382" default="31" item="ESU FnOut A14 Slider 14" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A9 Mode</variableref>
+                                <variableref>ESU FnOut A14 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>24</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Heizstufe im Stand</label>
                         </variable>
-                        <variable label="Chuff power" CV="16.0.342" default="31" item="ESU FnOut A9 Slider 8" mask="XXXVVVVV">
+                        <variable label="Chuff power" CV="16.0.382" default="31" item="ESU FnOut A14 Slider 8" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A9 Mode</variableref>
+                                <variableref>ESU FnOut A14 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>25</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Dampfstoßstärke</label>
                         </variable>
-                        <variable item="Special Function CV343" label="Special Function CV 1" CV="16.0.343" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                        <variable item="Special Function CV383" label="Special Function CV 1" CV="16.0.383" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
                             <decVal/>
                         </variable>
-                        <variable label="Fan Acceleration rate" CV="16.0.343" default="0" item="ESU FnOut A9 Slider 12" mask="XXXVVVVV">
+                        <variable label="Fan Acceleration rate" CV="16.0.383" default="0" item="ESU FnOut A14 Slider 12" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A9 Mode</variableref>
+                                <variableref>ESU FnOut A14 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>23</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Beschleunigungszeit</label>
                         </variable>
-                        <variable label="Minimum driving heat" CV="16.0.343" default="0" item="ESU FnOut A9 Slider 15" mask="XXXVVVVV">
+                        <variable label="Minimum driving heat" CV="16.0.383" default="0" item="ESU FnOut A14 Slider 15" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A9 Mode</variableref>
+                                <variableref>ESU FnOut A14 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>24</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
                         </variable>
-                        <variable label="Fan power" CV="16.0.343" default="0" item="ESU FnOut A9 Slider 9" mask="XXXVVVVV">
+                        <variable label="Fan power" CV="16.0.383" default="0" item="ESU FnOut A14 Slider 9" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A9 Mode</variableref>
+                                <variableref>ESU FnOut A14 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>25</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Stäke des Bläsers</label>
                         </variable>
-                        <variable label="Phase Reverse" CV="16.0.343" default="0" item="ESU FnOut A9 Check 6" mask="XXXXXXXV">
+                        <variable label="Phase Reverse" CV="16.0.383" default="0" item="ESU FnOut A14 Check 6" mask="XXXXXXXV">
                             <qualifier>
-                                <variableref>ESU FnOut A9 Mode</variableref>
+                                <variableref>ESU FnOut A14 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A9 Mode</variableref>
+                                <variableref>ESU FnOut A14 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                             <label xml:lang="de">Phase tauschen</label>
                         </variable>
-                        <variable label="Grade Crossing" CV="16.0.343" default="0" item="ESU FnOut A9 Check 1" mask="XXXXXXVX">
+                        <variable label="Grade Crossing" CV="16.0.383" default="0" item="ESU FnOut A14 Check 1" mask="XXXXXXVX">
                             <qualifier>
-                                <variableref>ESU FnOut A9 Mode</variableref>
+                                <variableref>ESU FnOut A14 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A9 Mode</variableref>
+                                <variableref>ESU FnOut A14 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                         </variable>
-                        <variable label="Rule 17 Fwd" CV="16.0.343" default="0" item="ESU FnOut A9 Check 2" mask="XXXXXVXX">
+                        <variable label="Rule 17 Fwd" CV="16.0.383" default="0" item="ESU FnOut A14 Check 2" mask="XXXXXVXX">
                             <qualifier>
-                                <variableref>ESU FnOut A9 Mode</variableref>
+                                <variableref>ESU FnOut A14 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A9 Mode</variableref>
+                                <variableref>ESU FnOut A14 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                             <label xml:lang="de">Rule 17 vorwärts</label>
                         </variable>
-                        <variable label="Rule 17 Rev" CV="16.0.343" default="0" item="ESU FnOut A9 Check 3" mask="XXXXVXXX">
+                        <variable label="Rule 17 Rev" CV="16.0.383" default="0" item="ESU FnOut A14 Check 3" mask="XXXXVXXX">
                             <qualifier>
-                                <variableref>ESU FnOut A9 Mode</variableref>
+                                <variableref>ESU FnOut A14 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A9 Mode</variableref>
+                                <variableref>ESU FnOut A14 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                             <label xml:lang="de">Rule 17 rückwärts</label>
                         </variable>
-                        <variable label="Dimmer" CV="16.0.343" default="0" item="ESU FnOut A9 Check 4" mask="XXXVXXXX">
+                        <variable label="Dimmer" CV="16.0.383" default="0" item="ESU FnOut A14 Check 4" mask="XXXVXXXX">
                             <qualifier>
-                                <variableref>ESU FnOut A9 Mode</variableref>
+                                <variableref>ESU FnOut A14 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A9 Mode</variableref>
+                                <variableref>ESU FnOut A14 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                             <label xml:lang="de">Abdimmen</label>
                         </variable>
-                        <variable label="LED Mode" CV="16.0.343" default="0" item="ESU FnOut A9 Check 5" mask="VXXXXXXX">
+                        <variable label="LED Mode" CV="16.0.383" default="0" item="ESU FnOut A14 Check 5" mask="VXXXXXXX">
                             <qualifier>
-                                <variableref>ESU FnOut A9 Mode</variableref>
+                                <variableref>ESU FnOut A14 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A9 Mode</variableref>
+                                <variableref>ESU FnOut A14 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                             <label xml:lang="de">LED Modus</label>
                         </variable>
-                        <variable item="Special Function CV344" label="Special Function CV 2" CV="16.0.344" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                        <variable item="Special Function CV384" label="Special Function CV 2" CV="16.0.384" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
                             <decVal/>
                         </variable>
-                        <variable label="Fan Decceleration rate" CV="16.0.344" default="0" item="ESU FnOut A9 Slider 13" mask="XXXVVVVV">
+                        <variable label="Fan Decceleration rate" CV="16.0.384" default="0" item="ESU FnOut A14 Slider 13" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A9 Mode</variableref>
+                                <variableref>ESU FnOut A14 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>23</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Bremszeit</label>
                         </variable>
-                        <variable label="Maximum driving heat" CV="16.0.344" default="0" item="ESU FnOut A9 Slider 16" mask="XXXVVVVV">
+                        <variable label="Maximum driving heat" CV="16.0.384" default="0" item="ESU FnOut A14 Slider 16" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A9 Mode</variableref>
+                                <variableref>ESU FnOut A14 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>24</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
                         </variable>
-                        <variable label="Timeout" CV="16.0.344" default="0" item="ESU FnOut A9 Slider 10" tooltip="Units = 0.25 sec">
+                        <variable label="Timeout" CV="16.0.384" default="0" item="ESU FnOut A14 Slider 10" tooltip="Units = 0.25 sec">
                             <qualifier>
-                                <variableref>ESU FnOut A9 Mode</variableref>
+                                <variableref>ESU FnOut A14 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>25</value>
                             </qualifier>
                             <decVal/>
                         </variable>
-                        <variable label="Startup Time" CV="16.0.344" default="0" item="ESU FnOut A9 Slider 6">
+                        <variable label="Startup Time" CV="16.0.384" default="0" item="ESU FnOut A14 Slider 6">
                             <qualifier>
-                                <variableref>ESU FnOut A9 Mode</variableref>
+                                <variableref>ESU FnOut A14 Mode</variableref>
                                 <relation>ge</relation>
                                 <value>16</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A9 Mode</variableref>
+                                <variableref>ESU FnOut A14 Mode</variableref>
                                 <relation>le</relation>
                                 <value>17</value>
                             </qualifier>
                             <decVal/>
                             <label xml:lang="de">Startzeit</label>
                         </variable>
-                        <variable label="Level" CV="16.0.344" default="0" item="ESU FnOut A9 Slider 20" mask="XVVVVVVV">
+                        <variable label="Level" CV="16.0.384" default="0" item="ESU FnOut A14 Slider 20" mask="XVVVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A9 Mode</variableref>
+                                <variableref>ESU FnOut A14 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>19</value>
                             </qualifier>
                             <decVal max="127"/>
                         </variable>
-                        <!-- AUX10 Mode -->
-                        <variable label="AUX10 Mode" CV="16.0.347" default="1" item="ESU FnOut A10 Mode">
+                        <!-- AUX15 Mode -->
+                        <variable label="AUX15 Mode" CV="16.0.387" default="1" item="ESU FnOut A15 Mode">
                             <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
                         </variable>
-                        <variable label="Function Switch On Delay" CV="16.0.348" default="0" item="ESU FnOut A10 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
+                        <variable label="Function Switch On Delay" CV="16.0.388" default="0" item="ESU FnOut A15 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A10 Mode</variableref>
+                                <variableref>ESU FnOut A15 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
-                            </qualifier>
-                            <qualifier>
-                                <variableref>ESU FnOut A10 Mode</variableref>
-                                <relation>ne</relation>
-                                <value>27</value>
                             </qualifier>
                             <decVal max="15"/>
                             <label xml:lang="de">Verzögerung beim Einschalten</label>
                         </variable>
-                        <variable label="Function Switch Off Delay" CV="16.0.348" default="0" mask="VVVVXXXX" item="ESU FnOut A10 Slider 2" tooltip="Units = 0.4 sec">
+                        <variable label="Function Switch Off Delay" CV="16.0.388" default="0" mask="VVVVXXXX" item="ESU FnOut A15 Slider 2" tooltip="Units = 0.4 sec">
                             <qualifier>
-                                <variableref>ESU FnOut A10 Mode</variableref>
+                                <variableref>ESU FnOut A15 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
-                            </qualifier>
-                            <qualifier>
-                                <variableref>ESU FnOut A10 Mode</variableref>
-                                <relation>ne</relation>
-                                <value>27</value>
                             </qualifier>
                             <decVal max="15"/>
                             <label xml:lang="de">Verzögerung beim Ausschalten</label>
                         </variable>
-                        <variable label="Function Auto Switch Off" CV="16.0.349" default="0" item="ESU FnOut A10 Slider 3" tooltip="Units = 0.4 sec">
+                        <variable label="Function Auto Switch Off" CV="16.0.389" default="0" item="ESU FnOut A15 Slider 3" tooltip="Units = 0.4 sec">
                             <qualifier>
-                                <variableref>ESU FnOut A10 Mode</variableref>
+                                <variableref>ESU FnOut A15 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
-                            </qualifier>
-                            <qualifier>
-                                <variableref>ESU FnOut A10 Mode</variableref>
-                                <relation>ne</relation>
-                                <value>27</value>
                             </qualifier>
                             <decVal/>
                             <label xml:lang="de">Ausgang automatisch Ausschalten</label>
                         </variable>
-                        <variable item="Brightness CV350" label="Brightness CV" CV="16.0.350" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
+                        <variable item="Brightness CV390" label="Brightness CV" CV="16.0.390" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
                             <decVal/>
                         </variable>
-                        <variable label="Brightness" CV="16.0.350" default="31" item="ESU FnOut A10 Slider 5" mask="XXXVVVVV">
+                        <variable label="Brightness" CV="16.0.390" default="31" item="ESU FnOut A15 Slider 5" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A10 Mode</variableref>
+                                <variableref>ESU FnOut A15 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A10 Mode</variableref>
+                                <variableref>ESU FnOut A15 Mode</variableref>
                                 <relation>le</relation>
                                 <value>18</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Helligkeit</label>
                         </variable>
-                        <variable label="Mode" CV="16.0.350" default="0" item="ESU FnOut A10 Option 1" mask="XXXXXXXV">
+                        <variable label="Mode" CV="16.0.390" default="0" item="ESU FnOut A15 Option 1" mask="XXXXXXXV">
                             <qualifier>
-                                <variableref>ESU FnOut A10 Mode</variableref>
+                                <variableref>ESU FnOut A15 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>22</value>
                             </qualifier>
@@ -3452,608 +5018,316 @@
                             </enumVal>
                             <label xml:lang="de">Modus</label>
                         </variable>
-                        <variable label="Coupler Force" CV="16.0.350" default="31" item="ESU FnOut A10 Slider 7" mask="XXXVVVVV">
+                        <variable label="Coupler Force" CV="16.0.390" default="31" item="ESU FnOut A15 Slider 7" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A10 Mode</variableref>
+                                <variableref>ESU FnOut A15 Mode</variableref>
                                 <relation>ge</relation>
                                 <value>28</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A10 Mode</variableref>
+                                <variableref>ESU FnOut A15 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>29</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A10 Mode</variableref>
+                                <variableref>ESU FnOut A15 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>30</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A10 Mode</variableref>
+                                <variableref>ESU FnOut A15 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>31</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A10 Mode</variableref>
+                                <variableref>ESU FnOut A15 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>32</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A10 Mode</variableref>
+                                <variableref>ESU FnOut A15 Mode</variableref>
                                 <relation>le</relation>
                                 <value>33</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Stärke des Kupplers</label>
                         </variable>
-                        <variable label="Fan Speed" CV="16.0.350" default="31" item="ESU FnOut A10 Slider 11" mask="XXXVVVVV">
+                        <variable label="Fan Speed" CV="16.0.390" default="31" item="ESU FnOut A15 Slider 11" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A10 Mode</variableref>
+                                <variableref>ESU FnOut A15 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>23</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Geschwindigkeit</label>
                         </variable>
-                        <variable label="Standing heat" CV="16.0.350" default="31" item="ESU FnOut A10 Slider 14" mask="XXXVVVVV">
+                        <variable label="Standing heat" CV="16.0.390" default="31" item="ESU FnOut A15 Slider 14" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A10 Mode</variableref>
+                                <variableref>ESU FnOut A15 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>24</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Heizstufe im Stand</label>
                         </variable>
-                        <variable label="Chuff power" CV="16.0.350" default="31" item="ESU FnOut A10 Slider 8" mask="XXXVVVVV">
+                        <variable label="Chuff power" CV="16.0.390" default="31" item="ESU FnOut A15 Slider 8" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A10 Mode</variableref>
+                                <variableref>ESU FnOut A15 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>25</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Dampfstoßstärke</label>
                         </variable>
-                        <variable item="Special Function CV351" label="Special Function CV 1" CV="16.0.351" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
-                            <decVal/>
-                        </variable>
-                        <variable label="Fan Acceleration rate" CV="16.0.351" default="0" item="ESU FnOut A10 Slider 12" mask="XXXVVVVV">
+                        <variable label="Duration (speed) A" CV="16.0.386" default="31" item="ESU FnOut A15 Slider 4" mask="XXVVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A10 Mode</variableref>
-                                <relation>eq</relation>
-                                <value>23</value>
-                            </qualifier>
-                            <decVal max="31"/>
-                            <label xml:lang="de">Beschleunigungszeit</label>
-                        </variable>
-                        <variable label="Minimum driving heat" CV="16.0.351" default="0" item="ESU FnOut A10 Slider 15" mask="XXXVVVVV">
-                            <qualifier>
-                                <variableref>ESU FnOut A10 Mode</variableref>
-                                <relation>eq</relation>
-                                <value>24</value>
-                            </qualifier>
-                            <decVal max="31"/>
-                            <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
-                        </variable>
-                        <variable label="Fan power" CV="16.0.351" default="0" item="ESU FnOut A10 Slider 9" mask="XXXVVVVV">
-                            <qualifier>
-                                <variableref>ESU FnOut A10 Mode</variableref>
-                                <relation>eq</relation>
-                                <value>25</value>
-                            </qualifier>
-                            <decVal max="31"/>
-                            <label xml:lang="de">Stäke des Bläsers</label>
-                        </variable>
-                        <variable label="Phase Reverse" CV="16.0.351" default="0" item="ESU FnOut A10 Check 6" mask="XXXXXXXV">
-                            <qualifier>
-                                <variableref>ESU FnOut A10 Mode</variableref>
-                                <relation>gt</relation>
-                                <value>0</value>
-                            </qualifier>
-                            <qualifier>
-                                <variableref>ESU FnOut A10 Mode</variableref>
-                                <relation>le</relation>
-                                <value>15</value>
-                            </qualifier>
-                            <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                            <label xml:lang="de">Phase tauschen</label>
-                        </variable>
-                        <variable label="Grade Crossing" CV="16.0.351" default="0" item="ESU FnOut A10 Check 1" mask="XXXXXXVX">
-                            <qualifier>
-                                <variableref>ESU FnOut A10 Mode</variableref>
-                                <relation>gt</relation>
-                                <value>0</value>
-                            </qualifier>
-                            <qualifier>
-                                <variableref>ESU FnOut A10 Mode</variableref>
-                                <relation>le</relation>
-                                <value>15</value>
-                            </qualifier>
-                            <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                        </variable>
-                        <variable label="Rule 17 Fwd" CV="16.0.351" default="0" item="ESU FnOut A10 Check 2" mask="XXXXXVXX">
-                            <qualifier>
-                                <variableref>ESU FnOut A10 Mode</variableref>
-                                <relation>gt</relation>
-                                <value>0</value>
-                            </qualifier>
-                            <qualifier>
-                                <variableref>ESU FnOut A10 Mode</variableref>
-                                <relation>le</relation>
-                                <value>15</value>
-                            </qualifier>
-                            <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                            <label xml:lang="de">Rule 17 vorwärts</label>
-                        </variable>
-                        <variable label="Rule 17 Rev" CV="16.0.351" default="0" item="ESU FnOut A10 Check 3" mask="XXXXVXXX">
-                            <qualifier>
-                                <variableref>ESU FnOut A10 Mode</variableref>
-                                <relation>gt</relation>
-                                <value>0</value>
-                            </qualifier>
-                            <qualifier>
-                                <variableref>ESU FnOut A10 Mode</variableref>
-                                <relation>le</relation>
-                                <value>15</value>
-                            </qualifier>
-                            <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                            <label xml:lang="de">Rule 17 rückwärts</label>
-                        </variable>
-                        <variable label="Dimmer" CV="16.0.351" default="0" item="ESU FnOut A10 Check 4" mask="XXXVXXXX">
-                            <qualifier>
-                                <variableref>ESU FnOut A10 Mode</variableref>
-                                <relation>gt</relation>
-                                <value>0</value>
-                            </qualifier>
-                            <qualifier>
-                                <variableref>ESU FnOut A10 Mode</variableref>
-                                <relation>le</relation>
-                                <value>15</value>
-                            </qualifier>
-                            <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                            <label xml:lang="de">Abdimmen</label>
-                        </variable>
-                        <variable label="LED Mode" CV="16.0.351" default="0" item="ESU FnOut A10 Check 5" mask="VXXXXXXX">
-                            <qualifier>
-                                <variableref>ESU FnOut A10 Mode</variableref>
-                                <relation>gt</relation>
-                                <value>0</value>
-                            </qualifier>
-                            <qualifier>
-                                <variableref>ESU FnOut A10 Mode</variableref>
-                                <relation>le</relation>
-                                <value>15</value>
-                            </qualifier>
-                            <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                            <label xml:lang="de">LED Modus</label>
-                        </variable>
-                        <variable item="Special Function CV352" label="Special Function CV 2" CV="16.0.352" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
-                            <decVal/>
-                        </variable>
-                        <variable label="Fan Decceleration rate" CV="16.0.352" default="0" item="ESU FnOut A10 Slider 13" mask="XXXVVVVV">
-                            <qualifier>
-                                <variableref>ESU FnOut A10 Mode</variableref>
-                                <relation>eq</relation>
-                                <value>23</value>
-                            </qualifier>
-                            <decVal max="31"/>
-                            <label xml:lang="de">Bremszeit</label>
-                        </variable>
-                        <variable label="Maximum driving heat" CV="16.0.352" default="0" item="ESU FnOut A10 Slider 16" mask="XXXVVVVV">
-                            <qualifier>
-                                <variableref>ESU FnOut A10 Mode</variableref>
-                                <relation>eq</relation>
-                                <value>24</value>
-                            </qualifier>
-                            <decVal max="31"/>
-                            <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
-                        </variable>
-                        <variable label="Timeout" CV="16.0.352" default="0" item="ESU FnOut A10 Slider 10" tooltip="Units = 0.25 sec">
-                            <qualifier>
-                                <variableref>ESU FnOut A10 Mode</variableref>
-                                <relation>eq</relation>
-                                <value>25</value>
-                            </qualifier>
-                            <decVal/>
-                        </variable>
-                        <variable label="Startup Time" CV="16.0.352" default="0" item="ESU FnOut A10 Slider 6">
-                            <qualifier>
-                                <variableref>ESU FnOut A10 Mode</variableref>
-                                <relation>ge</relation>
-                                <value>16</value>
-                            </qualifier>
-                            <qualifier>
-                                <variableref>ESU FnOut A10 Mode</variableref>
-                                <relation>le</relation>
-                                <value>17</value>
-                            </qualifier>
-                            <decVal/>
-                            <label xml:lang="de">Startzeit</label>
-                        </variable>
-                        <variable label="Level" CV="16.0.352" default="0" item="ESU FnOut A10 Slider 20" mask="XVVVVVVV">
-                            <qualifier>
-                                <variableref>ESU FnOut A10 Mode</variableref>
-                                <relation>eq</relation>
-                                <value>19</value>
-                            </qualifier>
-                            <decVal max="127"/>
-                        </variable>
-                        <!-- AUX11 Mode -->
-                        <variable label="AUX11 Mode" CV="16.0.355" default="1" item="ESU FnOut A11 Mode">
-                            <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
-                            <!--label xml:lang="de">Licht vorn - 2</label-->
-                        </variable>
-                        <variable label="Function Switch On Delay" CV="16.0.356" default="0" item="ESU FnOut A11 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
-                            <qualifier>
-                                <variableref>ESU FnOut A11 Mode</variableref>
-                                <relation>gt</relation>
-                                <value>0</value>
-                            </qualifier>
-                            <decVal max="15"/>
-                            <label xml:lang="de">Verzögerung beim Einschalten</label>
-                        </variable>
-                        <variable label="Function Switch Off Delay" CV="16.0.356" default="0" mask="VVVVXXXX" item="ESU FnOut A11 Slider 2" tooltip="Units = 0.4 sec">
-                            <qualifier>
-                                <variableref>ESU FnOut A11 Mode</variableref>
-                                <relation>gt</relation>
-                                <value>0</value>
-                            </qualifier>
-                            <decVal max="15"/>
-                            <label xml:lang="de">Verzögerung beim Ausschalten</label>
-                        </variable>
-                        <variable label="Function Auto Switch Off" CV="16.0.357" default="0" item="ESU FnOut A11 Slider 3" tooltip="Units = 0.4 sec">
-                            <qualifier>
-                                <variableref>ESU FnOut A11 Mode</variableref>
-                                <relation>gt</relation>
-                                <value>0</value>
-                            </qualifier>
-                            <decVal/>
-                            <label xml:lang="de">Ausgang automatisch Ausschalten</label>
-                        </variable>
-                        <variable item="Brightness CV358" label="Brightness CV" CV="16.0.358" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
-                            <decVal/>
-                        </variable>
-                        <variable label="Brightness" CV="16.0.358" default="31" item="ESU FnOut A11 Slider 5" mask="XXXVVVVV">
-                            <qualifier>
-                                <variableref>ESU FnOut A11 Mode</variableref>
-                                <relation>gt</relation>
-                                <value>0</value>
-                            </qualifier>
-                            <qualifier>
-                                <variableref>ESU FnOut A11 Mode</variableref>
-                                <relation>le</relation>
-                                <value>18</value>
-                            </qualifier>
-                            <decVal max="31"/>
-                            <label xml:lang="de">Helligkeit</label>
-                        </variable>
-                        <variable label="Mode" CV="16.0.358" default="0" item="ESU FnOut A11 Option 1" mask="XXXXXXXV">
-                            <qualifier>
-                                <variableref>ESU FnOut A11 Mode</variableref>
-                                <relation>eq</relation>
-                                <value>22</value>
-                            </qualifier>
-                            <enumVal>
-                                <enumChoice choice="Heating control">
-                                    <choice>Heating control</choice>
-                                    <choice xml:lang="de">Heizungssteuerung</choice>
-                                </enumChoice>
-                                <enumChoice choice="Fan control">
-                                    <choice>Fan control</choice>
-                                    <choice xml:lang="de">Lüftersteuerung</choice>
-                                </enumChoice>
-                            </enumVal>
-                            <label xml:lang="de">Modus</label>
-                        </variable>
-                        <variable label="Coupler Force" CV="16.0.358" default="31" item="ESU FnOut A11 Slider 7" mask="XXXVVVVV">
-                            <qualifier>
-                                <variableref>ESU FnOut A11 Mode</variableref>
-                                <relation>ge</relation>
-                                <value>28</value>
-                            </qualifier>
-                            <qualifier>
-                                <variableref>ESU FnOut A11 Mode</variableref>
-                                <relation>ne</relation>
-                                <value>29</value>
-                            </qualifier>
-                            <qualifier>
-                                <variableref>ESU FnOut A11 Mode</variableref>
-                                <relation>ne</relation>
-                                <value>30</value>
-                            </qualifier>
-                            <qualifier>
-                                <variableref>ESU FnOut A11 Mode</variableref>
-                                <relation>ne</relation>
-                                <value>31</value>
-                            </qualifier>
-                            <qualifier>
-                                <variableref>ESU FnOut A11 Mode</variableref>
-                                <relation>ne</relation>
-                                <value>32</value>
-                            </qualifier>
-                            <qualifier>
-                                <variableref>ESU FnOut A11 Mode</variableref>
-                                <relation>le</relation>
-                                <value>33</value>
-                            </qualifier>
-                            <decVal max="31"/>
-                            <label xml:lang="de">Stärke des Kupplers</label>
-                        </variable>
-                        <variable label="Fan Speed" CV="16.0.358" default="31" item="ESU FnOut A11 Slider 11" mask="XXXVVVVV">
-                            <qualifier>
-                                <variableref>ESU FnOut A11 Mode</variableref>
-                                <relation>eq</relation>
-                                <value>23</value>
-                            </qualifier>
-                            <decVal max="31"/>
-                            <label xml:lang="de">Geschwindigkeit</label>
-                        </variable>
-                        <variable label="Standing heat" CV="16.0.358" default="31" item="ESU FnOut A11 Slider 14" mask="XXXVVVVV">
-                            <qualifier>
-                                <variableref>ESU FnOut A11 Mode</variableref>
-                                <relation>eq</relation>
-                                <value>24</value>
-                            </qualifier>
-                            <decVal max="31"/>
-                            <label xml:lang="de">Heizstufe im Stand</label>
-                        </variable>
-                        <variable label="Chuff power" CV="16.0.358" default="31" item="ESU FnOut A11 Slider 8" mask="XXXVVVVV">
-                            <qualifier>
-                                <variableref>ESU FnOut A11 Mode</variableref>
-                                <relation>eq</relation>
-                                <value>25</value>
-                            </qualifier>
-                            <decVal max="31"/>
-                            <label xml:lang="de">Dampfstoßstärke</label>
-                        </variable>
-                        <variable label="Duration (speed) A" CV="16.0.354" default="31" item="ESU FnOut A11 Slider 4" mask="XXVVVVVV">
-                            <qualifier>
-                                <variableref>ESU FnOut A11 Mode</variableref>
+                                <variableref>ESU FnOut A15 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>27</value>
                             </qualifier>
                             <decVal max="63"/>
                             <label xml:lang="de">Dauer (Geschwindigkeit)</label>
                         </variable>
-                        <variable label="Duration (speed) B" CV="16.0.358" default="31" item="ESU FnOut A11 Slider 17" mask="XXVVVVVV">
+                        <variable label="Duration (speed) B" CV="16.0.390" default="31" item="ESU FnOut A15 Slider 17" mask="XXVVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A11 Mode</variableref>
+                                <variableref>ESU FnOut A15 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>27</value>
                             </qualifier>
                             <decVal max="63"/>
                             <label xml:lang="de">Dauer (Geschwindigkeit)</label>
                         </variable>
-                        <variable item="Special Function CV359" label="Special Function CV 1" CV="16.0.359" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                        <variable item="Special Function CV391" label="Special Function CV 1" CV="16.0.391" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
                             <decVal/>
                         </variable>
-                        <variable label="Fan Acceleration rate" CV="16.0.359" default="0" item="ESU FnOut A11 Slider 12" mask="XXXVVVVV">
+                        <variable label="Fan Acceleration rate" CV="16.0.391" default="0" item="ESU FnOut A15 Slider 12" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A11 Mode</variableref>
+                                <variableref>ESU FnOut A15 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>23</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Beschleunigungszeit</label>
                         </variable>
-                        <variable label="Minimum driving heat" CV="16.0.359" default="0" item="ESU FnOut A11 Slider 15" mask="XXXVVVVV">
+                        <variable label="Minimum driving heat" CV="16.0.391" default="0" item="ESU FnOut A15 Slider 15" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A11 Mode</variableref>
+                                <variableref>ESU FnOut A15 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>24</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
                         </variable>
-                        <variable label="Position A" CV="16.0.359" default="0" item="ESU FnOut A11 Slider 18" mask="XXVVVVVV">
+                        <variable label="Position A" CV="16.0.391" default="0" item="ESU FnOut A15 Slider 18" mask="XXVVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A11 Mode</variableref>
+                                <variableref>ESU FnOut A15 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>27</value>
                             </qualifier>
                             <decVal max="63"/>
                         </variable>
-                        <variable label="Fan power" CV="16.0.359" default="0" item="ESU FnOut A11 Slider 9" mask="XXXVVVVV">
+                        <variable label="Fan power" CV="16.0.391" default="0" item="ESU FnOut A15 Slider 9" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A11 Mode</variableref>
+                                <variableref>ESU FnOut A15 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>25</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Stäke des Bläsers</label>
                         </variable>
-                        <variable label="Phase Reverse" CV="16.0.359" default="0" item="ESU FnOut A11 Check 6" mask="XXXXXXXV">
+                        <variable label="Phase Reverse" CV="16.0.391" default="0" item="ESU FnOut A15 Check 6" mask="XXXXXXXV">
                             <qualifier>
-                                <variableref>ESU FnOut A11 Mode</variableref>
+                                <variableref>ESU FnOut A15 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A11 Mode</variableref>
+                                <variableref>ESU FnOut A15 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                             <label xml:lang="de">Phase tauschen</label>
                         </variable>
-                        <variable label="Grade Crossing" CV="16.0.359" default="0" item="ESU FnOut A11 Check 1" mask="XXXXXXVX">
+                        <variable label="Grade Crossing" CV="16.0.391" default="0" item="ESU FnOut A15 Check 1" mask="XXXXXXVX">
                             <qualifier>
-                                <variableref>ESU FnOut A11 Mode</variableref>
+                                <variableref>ESU FnOut A15 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A11 Mode</variableref>
+                                <variableref>ESU FnOut A15 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                         </variable>
-                        <variable label="Rule 17 Fwd" CV="16.0.359" default="0" item="ESU FnOut A11 Check 2" mask="XXXXXVXX">
+                        <variable label="Rule 17 Fwd" CV="16.0.391" default="0" item="ESU FnOut A15 Check 2" mask="XXXXXVXX">
                             <qualifier>
-                                <variableref>ESU FnOut A11 Mode</variableref>
+                                <variableref>ESU FnOut A15 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A11 Mode</variableref>
+                                <variableref>ESU FnOut A15 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                             <label xml:lang="de">Rule 17 vorwärts</label>
                         </variable>
-                        <variable label="Rule 17 Rev" CV="16.0.359" default="0" item="ESU FnOut A11 Check 3" mask="XXXXVXXX">
+                        <variable label="Rule 17 Rev" CV="16.0.391" default="0" item="ESU FnOut A15 Check 3" mask="XXXXVXXX">
                             <qualifier>
-                                <variableref>ESU FnOut A11 Mode</variableref>
+                                <variableref>ESU FnOut A15 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A11 Mode</variableref>
+                                <variableref>ESU FnOut A15 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                             <label xml:lang="de">Rule 17 rückwärts</label>
                         </variable>
-                        <variable label="Dimmer" CV="16.0.359" default="0" item="ESU FnOut A11 Check 4" mask="XXXVXXXX">
+                        <variable label="Dimmer" CV="16.0.391" default="0" item="ESU FnOut A15 Check 4" mask="XXXVXXXX">
                             <qualifier>
-                                <variableref>ESU FnOut A11 Mode</variableref>
+                                <variableref>ESU FnOut A15 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A11 Mode</variableref>
+                                <variableref>ESU FnOut A15 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                             <label xml:lang="de">Abdimmen</label>
                         </variable>
-                        <variable label="LED Mode" CV="16.0.359" default="0" item="ESU FnOut A11 Check 5" mask="VXXXXXXX">
+                        <variable label="LED Mode" CV="16.0.391" default="0" item="ESU FnOut A15 Check 5" mask="VXXXXXXX">
                             <qualifier>
-                                <variableref>ESU FnOut A11 Mode</variableref>
+                                <variableref>ESU FnOut A15 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A11 Mode</variableref>
+                                <variableref>ESU FnOut A15 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                             <label xml:lang="de">LED Modus</label>
                         </variable>
-                        <variable item="Special Function CV360" label="Special Function CV 2" CV="16.0.360" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                        <variable item="Special Function CV392" label="Special Function CV 2" CV="16.0.392" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
                             <decVal/>
                         </variable>
-                        <variable label="Fan Decceleration rate" CV="16.0.360" default="0" item="ESU FnOut A11 Slider 13" mask="XXXVVVVV">
+                        <variable label="Fan Decceleration rate" CV="16.0.392" default="0" item="ESU FnOut A15 Slider 13" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A11 Mode</variableref>
+                                <variableref>ESU FnOut A15 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>23</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Bremszeit</label>
                         </variable>
-                        <variable label="Maximum driving heat" CV="16.0.360" default="0" item="ESU FnOut A11 Slider 16" mask="XXXVVVVV">
+                        <variable label="Maximum driving heat" CV="16.0.392" default="0" item="ESU FnOut A15 Slider 16" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A11 Mode</variableref>
+                                <variableref>ESU FnOut A15 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>24</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
                         </variable>
-                        <variable label="Timeout" CV="16.0.360" default="0" item="ESU FnOut A11 Slider 10" tooltip="Units = 0.25 sec">
+                        <variable label="Timeout" CV="16.0.392" default="0" item="ESU FnOut A15 Slider 10" tooltip="Units = 0.25 sec">
                             <qualifier>
-                                <variableref>ESU FnOut A11 Mode</variableref>
+                                <variableref>ESU FnOut A15 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>25</value>
                             </qualifier>
                             <decVal/>
                         </variable>
-                        <variable label="Startup Time" CV="16.0.360" default="0" item="ESU FnOut A11 Slider 6">
+                        <variable label="Startup Time" CV="16.0.392" default="0" item="ESU FnOut A15 Slider 6">
                             <qualifier>
-                                <variableref>ESU FnOut A11 Mode</variableref>
+                                <variableref>ESU FnOut A15 Mode</variableref>
                                 <relation>ge</relation>
                                 <value>16</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A11 Mode</variableref>
+                                <variableref>ESU FnOut A15 Mode</variableref>
                                 <relation>le</relation>
                                 <value>17</value>
                             </qualifier>
                             <decVal/>
                             <label xml:lang="de">Startzeit</label>
                         </variable>
-                        <variable label="Level" CV="16.0.360" default="0" item="ESU FnOut A11 Slider 20" mask="XVVVVVVV">
+                        <variable label="Level" CV="16.0.392" default="0" item="ESU FnOut A15 Slider 20" mask="XVVVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A11 Mode</variableref>
+                                <variableref>ESU FnOut A15 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>19</value>
                             </qualifier>
                             <decVal max="127"/>
                         </variable>
-                        <variable label="Position B" CV="16.0.360" default="0" item="ESU FnOut A11 Slider 19" mask="XXVVVVVV">
+                        <variable label="Position B" CV="16.0.392" default="0" item="ESU FnOut A15 Slider 19" mask="XXVVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A11 Mode</variableref>
+                                <variableref>ESU FnOut A15 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>27</value>
                             </qualifier>
                             <decVal max="63"/>
                         </variable>
-                        <!-- AUX12 Mode -->
-                        <variable label="AUX12 Mode" CV="16.0.363" default="1" item="ESU FnOut A12 Mode">
+                        <!-- AUX16 Mode -->
+                        <variable label="AUX16 Mode" CV="16.0.395" default="1" item="ESU FnOut A16 Mode">
                             <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
                         </variable>
-                        <variable label="Function Switch On Delay" CV="16.0.364" default="0" item="ESU FnOut A12 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
+                        <variable label="Function Switch On Delay" CV="16.0.396" default="0" item="ESU FnOut A16 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A12 Mode</variableref>
+                                <variableref>ESU FnOut A16 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <decVal max="15"/>
                             <label xml:lang="de">Verzögerung beim Einschalten</label>
                         </variable>
-                        <variable label="Function Switch Off Delay" CV="16.0.364" default="0" mask="VVVVXXXX" item="ESU FnOut A12 Slider 2" tooltip="Units = 0.4 sec">
+                        <variable label="Function Switch Off Delay" CV="16.0.396" default="0" mask="VVVVXXXX" item="ESU FnOut A16 Slider 2" tooltip="Units = 0.4 sec">
                             <qualifier>
-                                <variableref>ESU FnOut A12 Mode</variableref>
+                                <variableref>ESU FnOut A16 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <decVal max="15"/>
                             <label xml:lang="de">Verzögerung beim Ausschalten</label>
                         </variable>
-                        <variable label="Function Auto Switch Off" CV="16.0.365" default="0" item="ESU FnOut A12 Slider 3" tooltip="Units = 0.4 sec">
+                        <variable label="Function Auto Switch Off" CV="16.0.397" default="0" item="ESU FnOut A16 Slider 3" tooltip="Units = 0.4 sec">
                             <qualifier>
-                                <variableref>ESU FnOut A12 Mode</variableref>
+                                <variableref>ESU FnOut A16 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <decVal/>
                             <label xml:lang="de">Ausgang automatisch Ausschalten</label>
                         </variable>
-                        <variable item="Brightness CV366" label="Brightness CV" CV="16.0.366" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
+                        <variable item="Brightness CV398" label="Brightness CV" CV="16.0.398" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
                             <decVal/>
                         </variable>
-                        <variable label="Brightness" CV="16.0.366" default="31" item="ESU FnOut A12 Slider 5" mask="XXXVVVVV">
+                        <variable label="Brightness" CV="16.0.398" default="31" item="ESU FnOut A16 Slider 5" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A12 Mode</variableref>
+                                <variableref>ESU FnOut A16 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A12 Mode</variableref>
+                                <variableref>ESU FnOut A16 Mode</variableref>
                                 <relation>le</relation>
                                 <value>18</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Helligkeit</label>
                         </variable>
-                        <variable label="Mode" CV="16.0.366" default="0" item="ESU FnOut A12 Option 1" mask="XXXXXXXV">
+                        <variable label="Mode" CV="16.0.398" default="0" item="ESU FnOut A16 Option 1" mask="XXXXXXXV">
                             <qualifier>
-                                <variableref>ESU FnOut A12 Mode</variableref>
+                                <variableref>ESU FnOut A16 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>22</value>
                             </qualifier>
@@ -4069,2179 +5343,915 @@
                             </enumVal>
                             <label xml:lang="de">Modus</label>
                         </variable>
-                        <variable label="Coupler Force" CV="16.0.366" default="31" item="ESU FnOut A12 Slider 7" mask="XXXVVVVV">
+                        <variable label="Coupler Force" CV="16.0.398" default="31" item="ESU FnOut A16 Slider 7" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A12 Mode</variableref>
+                                <variableref>ESU FnOut A16 Mode</variableref>
                                 <relation>ge</relation>
                                 <value>28</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A12 Mode</variableref>
+                                <variableref>ESU FnOut A16 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>29</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A12 Mode</variableref>
+                                <variableref>ESU FnOut A16 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>30</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A12 Mode</variableref>
+                                <variableref>ESU FnOut A16 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>31</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A12 Mode</variableref>
+                                <variableref>ESU FnOut A16 Mode</variableref>
                                 <relation>ne</relation>
                                 <value>32</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A12 Mode</variableref>
+                                <variableref>ESU FnOut A16 Mode</variableref>
                                 <relation>le</relation>
                                 <value>33</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Stärke des Kupplers</label>
                         </variable>
-                        <variable label="Fan Speed" CV="16.0.366" default="31" item="ESU FnOut A12 Slider 11" mask="XXXVVVVV">
+                        <variable label="Fan Speed" CV="16.0.398" default="31" item="ESU FnOut A16 Slider 11" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A12 Mode</variableref>
+                                <variableref>ESU FnOut A16 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>23</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Geschwindigkeit</label>
                         </variable>
-                        <variable label="Standing heat" CV="16.0.366" default="31" item="ESU FnOut A12 Slider 14" mask="XXXVVVVV">
+                        <variable label="Standing heat" CV="16.0.398" default="31" item="ESU FnOut A16 Slider 14" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A12 Mode</variableref>
+                                <variableref>ESU FnOut A16 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>24</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Heizstufe im Stand</label>
                         </variable>
-                        <variable label="Chuff power" CV="16.0.366" default="31" item="ESU FnOut A12 Slider 8" mask="XXXVVVVV">
+                        <variable label="Chuff power" CV="16.0.398" default="31" item="ESU FnOut A16 Slider 8" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A12 Mode</variableref>
+                                <variableref>ESU FnOut A16 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>25</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Dampfstoßstärke</label>
                         </variable>
-                        <variable label="Duration (speed) A" CV="16.0.362" default="31" item="ESU FnOut A12 Slider 4" mask="XXVVVVVV">
+                        <variable label="Duration (speed) A" CV="16.0.394" default="31" item="ESU FnOut A16 Slider 4" mask="XXVVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A12 Mode</variableref>
+                                <variableref>ESU FnOut A16 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>27</value>
                             </qualifier>
                             <decVal max="63"/>
                             <label xml:lang="de">Dauer (Geschwindigkeit)</label>
                         </variable>
-                        <variable label="Duration (speed) B" CV="16.0.366" default="31" item="ESU FnOut A12 Slider 17" mask="XXVVVVVV">
+                        <variable label="Duration (speed) B" CV="16.0.398" default="31" item="ESU FnOut A16 Slider 17" mask="XXVVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A12 Mode</variableref>
+                                <variableref>ESU FnOut A16 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>27</value>
                             </qualifier>
                             <decVal max="63"/>
                             <label xml:lang="de">Dauer (Geschwindigkeit)</label>
                         </variable>
-                        <variable item="Special Function CV367" label="Special Function CV 1" CV="16.0.367" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                        <variable item="Special Function CV399" label="Special Function CV 1" CV="16.0.399" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
                             <decVal/>
                         </variable>
-                        <variable label="Fan Acceleration rate" CV="16.0.367" default="0" item="ESU FnOut A12 Slider 12" mask="XXXVVVVV">
+                        <variable label="Fan Acceleration rate" CV="16.0.399" default="0" item="ESU FnOut A16 Slider 12" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A12 Mode</variableref>
+                                <variableref>ESU FnOut A16 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>23</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Beschleunigungszeit</label>
                         </variable>
-                        <variable label="Minimum driving heat" CV="16.0.367" default="0" item="ESU FnOut A12 Slider 15" mask="XXXVVVVV">
+                        <variable label="Minimum driving heat" CV="16.0.399" default="0" item="ESU FnOut A16 Slider 15" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A12 Mode</variableref>
+                                <variableref>ESU FnOut A16 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>24</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
                         </variable>
-                        <variable label="Position A" CV="16.0.367" default="0" item="ESU FnOut A12 Slider 18" mask="XXVVVVVV">
+                        <variable label="Position A" CV="16.0.399" default="0" item="ESU FnOut A16 Slider 18" mask="XXVVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A12 Mode</variableref>
+                                <variableref>ESU FnOut A16 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>27</value>
                             </qualifier>
                             <decVal max="63"/>
                         </variable>
-                        <variable label="Fan power" CV="16.0.367" default="0" item="ESU FnOut A12 Slider 9" mask="XXXVVVVV">
+                        <variable label="Fan power" CV="16.0.399" default="0" item="ESU FnOut A16 Slider 9" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A12 Mode</variableref>
+                                <variableref>ESU FnOut A16 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>25</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Stäke des Bläsers</label>
                         </variable>
-                        <variable label="Phase Reverse" CV="16.0.367" default="0" item="ESU FnOut A12 Check 6" mask="XXXXXXXV">
+                        <variable label="Phase Reverse" CV="16.0.399" default="0" item="ESU FnOut A16 Check 6" mask="XXXXXXXV">
                             <qualifier>
-                                <variableref>ESU FnOut A12 Mode</variableref>
+                                <variableref>ESU FnOut A16 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A12 Mode</variableref>
+                                <variableref>ESU FnOut A16 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                             <label xml:lang="de">Phase tauschen</label>
                         </variable>
-                        <variable label="Grade Crossing" CV="16.0.367" default="0" item="ESU FnOut A12 Check 1" mask="XXXXXXVX">
+                        <variable label="Grade Crossing" CV="16.0.399" default="0" item="ESU FnOut A16 Check 1" mask="XXXXXXVX">
                             <qualifier>
-                                <variableref>ESU FnOut A12 Mode</variableref>
+                                <variableref>ESU FnOut A16 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A12 Mode</variableref>
+                                <variableref>ESU FnOut A16 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                         </variable>
-                        <variable label="Rule 17 Fwd" CV="16.0.367" default="0" item="ESU FnOut A12 Check 2" mask="XXXXXVXX">
+                        <variable label="Rule 17 Fwd" CV="16.0.399" default="0" item="ESU FnOut A16 Check 2" mask="XXXXXVXX">
                             <qualifier>
-                                <variableref>ESU FnOut A12 Mode</variableref>
+                                <variableref>ESU FnOut A16 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A12 Mode</variableref>
+                                <variableref>ESU FnOut A16 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                             <label xml:lang="de">Rule 17 vorwärts</label>
                         </variable>
-                        <variable label="Rule 17 Rev" CV="16.0.367" default="0" item="ESU FnOut A12 Check 3" mask="XXXXVXXX">
+                        <variable label="Rule 17 Rev" CV="16.0.399" default="0" item="ESU FnOut A16 Check 3" mask="XXXXVXXX">
                             <qualifier>
-                                <variableref>ESU FnOut A12 Mode</variableref>
+                                <variableref>ESU FnOut A16 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A12 Mode</variableref>
+                                <variableref>ESU FnOut A16 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                             <label xml:lang="de">Rule 17 rückwärts</label>
                         </variable>
-                        <variable label="Dimmer" CV="16.0.367" default="0" item="ESU FnOut A12 Check 4" mask="XXXVXXXX">
+                        <variable label="Dimmer" CV="16.0.399" default="0" item="ESU FnOut A16 Check 4" mask="XXXVXXXX">
                             <qualifier>
-                                <variableref>ESU FnOut A12 Mode</variableref>
+                                <variableref>ESU FnOut A16 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A12 Mode</variableref>
+                                <variableref>ESU FnOut A16 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                             <label xml:lang="de">Abdimmen</label>
                         </variable>
-                        <variable label="LED Mode" CV="16.0.367" default="0" item="ESU FnOut A12 Check 5" mask="VXXXXXXX">
+                        <variable label="LED Mode" CV="16.0.399" default="0" item="ESU FnOut A16 Check 5" mask="VXXXXXXX">
                             <qualifier>
-                                <variableref>ESU FnOut A12 Mode</variableref>
+                                <variableref>ESU FnOut A16 Mode</variableref>
                                 <relation>gt</relation>
                                 <value>0</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A12 Mode</variableref>
+                                <variableref>ESU FnOut A16 Mode</variableref>
                                 <relation>le</relation>
                                 <value>15</value>
                             </qualifier>
                             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                             <label xml:lang="de">LED Modus</label>
                         </variable>
-                        <variable item="Special Function CV368" label="Special Function CV 2" CV="16.0.368" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                        <variable item="Special Function CV400" label="Special Function CV 2" CV="16.0.400" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
                             <decVal/>
                         </variable>
-                        <variable label="Fan Decceleration rate" CV="16.0.368" default="0" item="ESU FnOut A12 Slider 13" mask="XXXVVVVV">
+                        <variable label="Fan Decceleration rate" CV="16.0.400" default="0" item="ESU FnOut A16 Slider 13" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A12 Mode</variableref>
+                                <variableref>ESU FnOut A16 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>23</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Bremszeit</label>
                         </variable>
-                        <variable label="Maximum driving heat" CV="16.0.368" default="0" item="ESU FnOut A12 Slider 16" mask="XXXVVVVV">
+                        <variable label="Maximum driving heat" CV="16.0.400" default="0" item="ESU FnOut A16 Slider 16" mask="XXXVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A12 Mode</variableref>
+                                <variableref>ESU FnOut A16 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>24</value>
                             </qualifier>
                             <decVal max="31"/>
                             <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
                         </variable>
-                        <variable label="Timeout" CV="16.0.368" default="0" item="ESU FnOut A12 Slider 10" tooltip="Units = 0.25 sec">
+                        <variable label="Timeout" CV="16.0.400" default="0" item="ESU FnOut A16 Slider 10" tooltip="Units = 0.25 sec">
                             <qualifier>
-                                <variableref>ESU FnOut A12 Mode</variableref>
+                                <variableref>ESU FnOut A16 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>25</value>
                             </qualifier>
                             <decVal/>
                         </variable>
-                        <variable label="Startup Time" CV="16.0.368" default="0" item="ESU FnOut A12 Slider 6">
+                        <variable label="Startup Time" CV="16.0.400" default="0" item="ESU FnOut A16 Slider 6">
                             <qualifier>
-                                <variableref>ESU FnOut A12 Mode</variableref>
+                                <variableref>ESU FnOut A16 Mode</variableref>
                                 <relation>ge</relation>
                                 <value>16</value>
                             </qualifier>
                             <qualifier>
-                                <variableref>ESU FnOut A12 Mode</variableref>
+                                <variableref>ESU FnOut A16 Mode</variableref>
                                 <relation>le</relation>
                                 <value>17</value>
                             </qualifier>
                             <decVal/>
                             <label xml:lang="de">Startzeit</label>
                         </variable>
-                        <variable label="Level" CV="16.0.368" default="0" item="ESU FnOut A12 Slider 20" mask="XVVVVVVV">
+                        <variable label="Level" CV="16.0.400" default="0" item="ESU FnOut A16 Slider 20" mask="XVVVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A12 Mode</variableref>
+                                <variableref>ESU FnOut A16 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>19</value>
                             </qualifier>
                             <decVal max="127"/>
                         </variable>
-                        <variable label="Position B" CV="16.0.368" default="0" item="ESU FnOut A12 Slider 19" mask="XXVVVVVV">
+                        <variable label="Position B" CV="16.0.400" default="0" item="ESU FnOut A16 Slider 19" mask="XXVVVVVV">
                             <qualifier>
-                                <variableref>ESU FnOut A12 Mode</variableref>
+                                <variableref>ESU FnOut A16 Mode</variableref>
                                 <relation>eq</relation>
                                 <value>27</value>
                             </qualifier>
                             <decVal max="63"/>
                         </variable>
-                        <!-- exclude AUX13 to AUX18 -->
-                        <variables exclude="LokSound 5 Fx,LokSound 5 Fx DCC,LokPilot 5 Fx,LokPilot 5 Fx DCC">                <!-- AUX13 Mode -->
-                            <variable label="AUX13 Mode" CV="16.0.371" default="1" item="ESU FnOut A13 Mode">
-                                <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
-                            </variable>
-                            <variable label="Function Switch On Delay" CV="16.0.372" default="0" item="ESU FnOut A13 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A13 Mode</variableref>
-                                    <relation>gt</relation>
-                                    <value>0</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A13 Mode</variableref>
-                                    <relation>ne</relation>
-                                    <value>27</value>
-                                </qualifier>
-                                <decVal max="15"/>
-                                <label xml:lang="de">Verzögerung beim Einschalten</label>
-                            </variable>
-                            <variable label="Function Switch Off Delay" CV="16.0.372" default="0" mask="VVVVXXXX" item="ESU FnOut A13 Slider 2" tooltip="Units = 0.4 sec">
-                                <qualifier>
-                                    <variableref>ESU FnOut A13 Mode</variableref>
-                                    <relation>gt</relation>
-                                    <value>0</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A13 Mode</variableref>
-                                    <relation>ne</relation>
-                                    <value>27</value>
-                                </qualifier>
-                                <decVal max="15"/>
-                                <label xml:lang="de">Verzögerung beim Ausschalten</label>
-                            </variable>
-                            <variable label="Function Auto Switch Off" CV="16.0.373" default="0" item="ESU FnOut A13 Slider 3" tooltip="Units = 0.4 sec">
-                                <qualifier>
-                                    <variableref>ESU FnOut A13 Mode</variableref>
-                                    <relation>gt</relation>
-                                    <value>0</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A13 Mode</variableref>
-                                    <relation>ne</relation>
-                                    <value>27</value>
-                                </qualifier>
-                                <decVal/>
-                                <label xml:lang="de">Ausgang automatisch Ausschalten</label>
-                            </variable>
-                            <variable item="Brightness CV374" label="Brightness CV" CV="16.0.374" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
-                                <decVal/>
-                            </variable>
-                            <variable label="Brightness" CV="16.0.374" default="31" item="ESU FnOut A13 Slider 5" mask="XXXVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A13 Mode</variableref>
-                                    <relation>gt</relation>
-                                    <value>0</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A13 Mode</variableref>
-                                    <relation>le</relation>
-                                    <value>18</value>
-                                </qualifier>
-                                <decVal max="31"/>
-                                <label xml:lang="de">Helligkeit</label>
-                            </variable>
-                            <variable label="Mode" CV="16.0.374" default="0" item="ESU FnOut A13 Option 1" mask="XXXXXXXV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A13 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>22</value>
-                                </qualifier>
-                                <enumVal>
-                                    <enumChoice choice="Heating control">
-                                        <choice>Heating control</choice>
-                                        <choice xml:lang="de">Heizungssteuerung</choice>
-                                    </enumChoice>
-                                    <enumChoice choice="Fan control">
-                                        <choice>Fan control</choice>
-                                        <choice xml:lang="de">Lüftersteuerung</choice>
-                                    </enumChoice>
-                                </enumVal>
-                                <label xml:lang="de">Modus</label>
-                            </variable>
-                            <variable label="Coupler Force" CV="16.0.374" default="31" item="ESU FnOut A13 Slider 7" mask="XXXVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A13 Mode</variableref>
-                                    <relation>ge</relation>
-                                    <value>28</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A13 Mode</variableref>
-                                    <relation>ne</relation>
-                                    <value>29</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A13 Mode</variableref>
-                                    <relation>ne</relation>
-                                    <value>30</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A13 Mode</variableref>
-                                    <relation>ne</relation>
-                                    <value>31</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A13 Mode</variableref>
-                                    <relation>ne</relation>
-                                    <value>32</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A13 Mode</variableref>
-                                    <relation>le</relation>
-                                    <value>33</value>
-                                </qualifier>
-                                <decVal max="31"/>
-                                <label xml:lang="de">Stärke des Kupplers</label>
-                            </variable>
-                            <variable label="Fan Speed" CV="16.0.374" default="31" item="ESU FnOut A13 Slider 11" mask="XXXVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A13 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>23</value>
-                                </qualifier>
-                                <decVal max="31"/>
-                                <label xml:lang="de">Geschwindigkeit</label>
-                            </variable>
-                            <variable label="Standing heat" CV="16.0.374" default="31" item="ESU FnOut A13 Slider 14" mask="XXXVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A13 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>24</value>
-                                </qualifier>
-                                <decVal max="31"/>
-                                <label xml:lang="de">Heizstufe im Stand</label>
-                            </variable>
-                            <variable label="Chuff power" CV="16.0.374" default="31" item="ESU FnOut A13 Slider 8" mask="XXXVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A13 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>25</value>
-                                </qualifier>
-                                <decVal max="31"/>
-                                <label xml:lang="de">Dampfstoßstärke</label>
-                            </variable>
-                            <variable item="Special Function CV375" label="Special Function CV 1" CV="16.0.375" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
-                                <decVal/>
-                            </variable>
-                            <variable label="Fan Acceleration rate" CV="16.0.375" default="0" item="ESU FnOut A13 Slider 12" mask="XXXVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A13 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>23</value>
-                                </qualifier>
-                                <decVal max="31"/>
-                                <label xml:lang="de">Beschleunigungszeit</label>
-                            </variable>
-                            <variable label="Minimum driving heat" CV="16.0.375" default="0" item="ESU FnOut A13 Slider 15" mask="XXXVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A13 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>24</value>
-                                </qualifier>
-                                <decVal max="31"/>
-                                <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
-                            </variable>
-                            <variable label="Fan power" CV="16.0.375" default="0" item="ESU FnOut A13 Slider 9" mask="XXXVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A13 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>25</value>
-                                </qualifier>
-                                <decVal max="31"/>
-                                <label xml:lang="de">Stäke des Bläsers</label>
-                            </variable>
-                            <variable label="Phase Reverse" CV="16.0.375" default="0" item="ESU FnOut A13 Check 6" mask="XXXXXXXV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A13 Mode</variableref>
-                                    <relation>gt</relation>
-                                    <value>0</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A13 Mode</variableref>
-                                    <relation>le</relation>
-                                    <value>15</value>
-                                </qualifier>
-                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                                <label xml:lang="de">Phase tauschen</label>
-                            </variable>
-                            <variable label="Grade Crossing" CV="16.0.375" default="0" item="ESU FnOut A13 Check 1" mask="XXXXXXVX">
-                                <qualifier>
-                                    <variableref>ESU FnOut A13 Mode</variableref>
-                                    <relation>gt</relation>
-                                    <value>0</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A13 Mode</variableref>
-                                    <relation>le</relation>
-                                    <value>15</value>
-                                </qualifier>
-                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                            </variable>
-                            <variable label="Rule 17 Fwd" CV="16.0.375" default="0" item="ESU FnOut A13 Check 2" mask="XXXXXVXX">
-                                <qualifier>
-                                    <variableref>ESU FnOut A13 Mode</variableref>
-                                    <relation>gt</relation>
-                                    <value>0</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A13 Mode</variableref>
-                                    <relation>le</relation>
-                                    <value>15</value>
-                                </qualifier>
-                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                                <label xml:lang="de">Rule 17 vorwärts</label>
-                            </variable>
-                            <variable label="Rule 17 Rev" CV="16.0.375" default="0" item="ESU FnOut A13 Check 3" mask="XXXXVXXX">
-                                <qualifier>
-                                    <variableref>ESU FnOut A13 Mode</variableref>
-                                    <relation>gt</relation>
-                                    <value>0</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A13 Mode</variableref>
-                                    <relation>le</relation>
-                                    <value>15</value>
-                                </qualifier>
-                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                                <label xml:lang="de">Rule 17 rückwärts</label>
-                            </variable>
-                            <variable label="Dimmer" CV="16.0.375" default="0" item="ESU FnOut A13 Check 4" mask="XXXVXXXX">
-                                <qualifier>
-                                    <variableref>ESU FnOut A13 Mode</variableref>
-                                    <relation>gt</relation>
-                                    <value>0</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A13 Mode</variableref>
-                                    <relation>le</relation>
-                                    <value>15</value>
-                                </qualifier>
-                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                                <label xml:lang="de">Abdimmen</label>
-                            </variable>
-                            <variable label="LED Mode" CV="16.0.375" default="0" item="ESU FnOut A13 Check 5" mask="VXXXXXXX">
-                                <qualifier>
-                                    <variableref>ESU FnOut A13 Mode</variableref>
-                                    <relation>gt</relation>
-                                    <value>0</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A13 Mode</variableref>
-                                    <relation>le</relation>
-                                    <value>15</value>
-                                </qualifier>
-                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                                <label xml:lang="de">LED Modus</label>
-                            </variable>
-                            <variable item="Special Function CV376" label="Special Function CV 2" CV="16.0.376" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
-                                <decVal/>
-                            </variable>
-                            <variable label="Fan Decceleration rate" CV="16.0.376" default="0" item="ESU FnOut A13 Slider 13" mask="XXXVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A13 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>23</value>
-                                </qualifier>
-                                <decVal max="31"/>
-                                <label xml:lang="de">Bremszeit</label>
-                            </variable>
-                            <variable label="Maximum driving heat" CV="16.0.376" default="0" item="ESU FnOut A13 Slider 16" mask="XXXVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A13 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>24</value>
-                                </qualifier>
-                                <decVal max="31"/>
-                                <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
-                            </variable>
-                            <variable label="Timeout" CV="16.0.376" default="0" item="ESU FnOut A13 Slider 10" tooltip="Units = 0.25 sec">
-                                <qualifier>
-                                    <variableref>ESU FnOut A13 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>25</value>
-                                </qualifier>
-                                <decVal/>
-                            </variable>
-                            <variable label="Startup Time" CV="16.0.376" default="0" item="ESU FnOut A13 Slider 6">
-                                <qualifier>
-                                    <variableref>ESU FnOut A13 Mode</variableref>
-                                    <relation>ge</relation>
-                                    <value>16</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A13 Mode</variableref>
-                                    <relation>le</relation>
-                                    <value>17</value>
-                                </qualifier>
-                                <decVal/>
-                                <label xml:lang="de">Startzeit</label>
-                            </variable>
-                            <variable label="Level" CV="16.0.376" default="0" item="ESU FnOut A13 Slider 20" mask="XVVVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A13 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>19</value>
-                                </qualifier>
-                                <decVal max="127"/>
-                            </variable>
-                            <!-- AUX14 Mode -->
-                            <variable label="AUX14 Mode" CV="16.0.379" default="1" item="ESU FnOut A14 Mode">
-                                <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
-                            </variable>
-                            <variable label="Function Switch On Delay" CV="16.0.380" default="0" item="ESU FnOut A14 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A14 Mode</variableref>
-                                    <relation>gt</relation>
-                                    <value>0</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A14 Mode</variableref>
-                                    <relation>ne</relation>
-                                    <value>27</value>
-                                </qualifier>
-                                <decVal max="15"/>
-                                <label xml:lang="de">Verzögerung beim Einschalten</label>
-                            </variable>
-                            <variable label="Function Switch Off Delay" CV="16.0.380" default="0" mask="VVVVXXXX" item="ESU FnOut A14 Slider 2" tooltip="Units = 0.4 sec">
-                                <qualifier>
-                                    <variableref>ESU FnOut A14 Mode</variableref>
-                                    <relation>gt</relation>
-                                    <value>0</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A14 Mode</variableref>
-                                    <relation>ne</relation>
-                                    <value>27</value>
-                                </qualifier>
-                                <decVal max="15"/>
-                                <label xml:lang="de">Verzögerung beim Ausschalten</label>
-                            </variable>
-                            <variable label="Function Auto Switch Off" CV="16.0.381" default="0" item="ESU FnOut A14 Slider 3" tooltip="Units = 0.4 sec">
-                                <qualifier>
-                                    <variableref>ESU FnOut A14 Mode</variableref>
-                                    <relation>gt</relation>
-                                    <value>0</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A14 Mode</variableref>
-                                    <relation>ne</relation>
-                                    <value>27</value>
-                                </qualifier>
-                                <decVal/>
-                                <label xml:lang="de">Ausgang automatisch Ausschalten</label>
-                            </variable>
-                            <variable item="Brightness CV382" label="Brightness CV" CV="16.0.382" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
-                                <decVal/>
-                            </variable>
-                            <variable label="Brightness" CV="16.0.382" default="31" item="ESU FnOut A14 Slider 5" mask="XXXVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A14 Mode</variableref>
-                                    <relation>gt</relation>
-                                    <value>0</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A14 Mode</variableref>
-                                    <relation>le</relation>
-                                    <value>18</value>
-                                </qualifier>
-                                <decVal max="31"/>
-                                <label xml:lang="de">Helligkeit</label>
-                            </variable>
-                            <variable label="Mode" CV="16.0.382" default="0" item="ESU FnOut A14 Option 1" mask="XXXXXXXV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A14 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>22</value>
-                                </qualifier>
-                                <enumVal>
-                                    <enumChoice choice="Heating control">
-                                        <choice>Heating control</choice>
-                                        <choice xml:lang="de">Heizungssteuerung</choice>
-                                    </enumChoice>
-                                    <enumChoice choice="Fan control">
-                                        <choice>Fan control</choice>
-                                        <choice xml:lang="de">Lüftersteuerung</choice>
-                                    </enumChoice>
-                                </enumVal>
-                                <label xml:lang="de">Modus</label>
-                            </variable>
-                            <variable label="Coupler Force" CV="16.0.382" default="31" item="ESU FnOut A14 Slider 7" mask="XXXVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A14 Mode</variableref>
-                                    <relation>ge</relation>
-                                    <value>28</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A14 Mode</variableref>
-                                    <relation>ne</relation>
-                                    <value>29</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A14 Mode</variableref>
-                                    <relation>ne</relation>
-                                    <value>30</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A14 Mode</variableref>
-                                    <relation>ne</relation>
-                                    <value>31</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A14 Mode</variableref>
-                                    <relation>ne</relation>
-                                    <value>32</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A14 Mode</variableref>
-                                    <relation>le</relation>
-                                    <value>33</value>
-                                </qualifier>
-                                <decVal max="31"/>
-                                <label xml:lang="de">Stärke des Kupplers</label>
-                            </variable>
-                            <variable label="Fan Speed" CV="16.0.382" default="31" item="ESU FnOut A14 Slider 11" mask="XXXVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A14 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>23</value>
-                                </qualifier>
-                                <decVal max="31"/>
-                                <label xml:lang="de">Geschwindigkeit</label>
-                            </variable>
-                            <variable label="Standing heat" CV="16.0.382" default="31" item="ESU FnOut A14 Slider 14" mask="XXXVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A14 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>24</value>
-                                </qualifier>
-                                <decVal max="31"/>
-                                <label xml:lang="de">Heizstufe im Stand</label>
-                            </variable>
-                            <variable label="Chuff power" CV="16.0.382" default="31" item="ESU FnOut A14 Slider 8" mask="XXXVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A14 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>25</value>
-                                </qualifier>
-                                <decVal max="31"/>
-                                <label xml:lang="de">Dampfstoßstärke</label>
-                            </variable>
-                            <variable item="Special Function CV383" label="Special Function CV 1" CV="16.0.383" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
-                                <decVal/>
-                            </variable>
-                            <variable label="Fan Acceleration rate" CV="16.0.383" default="0" item="ESU FnOut A14 Slider 12" mask="XXXVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A14 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>23</value>
-                                </qualifier>
-                                <decVal max="31"/>
-                                <label xml:lang="de">Beschleunigungszeit</label>
-                            </variable>
-                            <variable label="Minimum driving heat" CV="16.0.383" default="0" item="ESU FnOut A14 Slider 15" mask="XXXVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A14 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>24</value>
-                                </qualifier>
-                                <decVal max="31"/>
-                                <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
-                            </variable>
-                            <variable label="Fan power" CV="16.0.383" default="0" item="ESU FnOut A14 Slider 9" mask="XXXVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A14 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>25</value>
-                                </qualifier>
-                                <decVal max="31"/>
-                                <label xml:lang="de">Stäke des Bläsers</label>
-                            </variable>
-                            <variable label="Phase Reverse" CV="16.0.383" default="0" item="ESU FnOut A14 Check 6" mask="XXXXXXXV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A14 Mode</variableref>
-                                    <relation>gt</relation>
-                                    <value>0</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A14 Mode</variableref>
-                                    <relation>le</relation>
-                                    <value>15</value>
-                                </qualifier>
-                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                                <label xml:lang="de">Phase tauschen</label>
-                            </variable>
-                            <variable label="Grade Crossing" CV="16.0.383" default="0" item="ESU FnOut A14 Check 1" mask="XXXXXXVX">
-                                <qualifier>
-                                    <variableref>ESU FnOut A14 Mode</variableref>
-                                    <relation>gt</relation>
-                                    <value>0</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A14 Mode</variableref>
-                                    <relation>le</relation>
-                                    <value>15</value>
-                                </qualifier>
-                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                            </variable>
-                            <variable label="Rule 17 Fwd" CV="16.0.383" default="0" item="ESU FnOut A14 Check 2" mask="XXXXXVXX">
-                                <qualifier>
-                                    <variableref>ESU FnOut A14 Mode</variableref>
-                                    <relation>gt</relation>
-                                    <value>0</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A14 Mode</variableref>
-                                    <relation>le</relation>
-                                    <value>15</value>
-                                </qualifier>
-                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                                <label xml:lang="de">Rule 17 vorwärts</label>
-                            </variable>
-                            <variable label="Rule 17 Rev" CV="16.0.383" default="0" item="ESU FnOut A14 Check 3" mask="XXXXVXXX">
-                                <qualifier>
-                                    <variableref>ESU FnOut A14 Mode</variableref>
-                                    <relation>gt</relation>
-                                    <value>0</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A14 Mode</variableref>
-                                    <relation>le</relation>
-                                    <value>15</value>
-                                </qualifier>
-                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                                <label xml:lang="de">Rule 17 rückwärts</label>
-                            </variable>
-                            <variable label="Dimmer" CV="16.0.383" default="0" item="ESU FnOut A14 Check 4" mask="XXXVXXXX">
-                                <qualifier>
-                                    <variableref>ESU FnOut A14 Mode</variableref>
-                                    <relation>gt</relation>
-                                    <value>0</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A14 Mode</variableref>
-                                    <relation>le</relation>
-                                    <value>15</value>
-                                </qualifier>
-                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                                <label xml:lang="de">Abdimmen</label>
-                            </variable>
-                            <variable label="LED Mode" CV="16.0.383" default="0" item="ESU FnOut A14 Check 5" mask="VXXXXXXX">
-                                <qualifier>
-                                    <variableref>ESU FnOut A14 Mode</variableref>
-                                    <relation>gt</relation>
-                                    <value>0</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A14 Mode</variableref>
-                                    <relation>le</relation>
-                                    <value>15</value>
-                                </qualifier>
-                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                                <label xml:lang="de">LED Modus</label>
-                            </variable>
-                            <variable item="Special Function CV384" label="Special Function CV 2" CV="16.0.384" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
-                                <decVal/>
-                            </variable>
-                            <variable label="Fan Decceleration rate" CV="16.0.384" default="0" item="ESU FnOut A14 Slider 13" mask="XXXVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A14 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>23</value>
-                                </qualifier>
-                                <decVal max="31"/>
-                                <label xml:lang="de">Bremszeit</label>
-                            </variable>
-                            <variable label="Maximum driving heat" CV="16.0.384" default="0" item="ESU FnOut A14 Slider 16" mask="XXXVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A14 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>24</value>
-                                </qualifier>
-                                <decVal max="31"/>
-                                <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
-                            </variable>
-                            <variable label="Timeout" CV="16.0.384" default="0" item="ESU FnOut A14 Slider 10" tooltip="Units = 0.25 sec">
-                                <qualifier>
-                                    <variableref>ESU FnOut A14 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>25</value>
-                                </qualifier>
-                                <decVal/>
-                            </variable>
-                            <variable label="Startup Time" CV="16.0.384" default="0" item="ESU FnOut A14 Slider 6">
-                                <qualifier>
-                                    <variableref>ESU FnOut A14 Mode</variableref>
-                                    <relation>ge</relation>
-                                    <value>16</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A14 Mode</variableref>
-                                    <relation>le</relation>
-                                    <value>17</value>
-                                </qualifier>
-                                <decVal/>
-                                <label xml:lang="de">Startzeit</label>
-                            </variable>
-                            <variable label="Level" CV="16.0.384" default="0" item="ESU FnOut A14 Slider 20" mask="XVVVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A14 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>19</value>
-                                </qualifier>
-                                <decVal max="127"/>
-                            </variable>
-                            <!-- AUX15 Mode -->
-                            <variable label="AUX15 Mode" CV="16.0.387" default="1" item="ESU FnOut A15 Mode">
-                                <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
-                            </variable>
-                            <variable label="Function Switch On Delay" CV="16.0.388" default="0" item="ESU FnOut A15 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A15 Mode</variableref>
-                                    <relation>gt</relation>
-                                    <value>0</value>
-                                </qualifier>
-                                <decVal max="15"/>
-                                <label xml:lang="de">Verzögerung beim Einschalten</label>
-                            </variable>
-                            <variable label="Function Switch Off Delay" CV="16.0.388" default="0" mask="VVVVXXXX" item="ESU FnOut A15 Slider 2" tooltip="Units = 0.4 sec">
-                                <qualifier>
-                                    <variableref>ESU FnOut A15 Mode</variableref>
-                                    <relation>gt</relation>
-                                    <value>0</value>
-                                </qualifier>
-                                <decVal max="15"/>
-                                <label xml:lang="de">Verzögerung beim Ausschalten</label>
-                            </variable>
-                            <variable label="Function Auto Switch Off" CV="16.0.389" default="0" item="ESU FnOut A15 Slider 3" tooltip="Units = 0.4 sec">
-                                <qualifier>
-                                    <variableref>ESU FnOut A15 Mode</variableref>
-                                    <relation>gt</relation>
-                                    <value>0</value>
-                                </qualifier>
-                                <decVal/>
-                                <label xml:lang="de">Ausgang automatisch Ausschalten</label>
-                            </variable>
-                            <variable item="Brightness CV390" label="Brightness CV" CV="16.0.390" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
-                                <decVal/>
-                            </variable>
-                            <variable label="Brightness" CV="16.0.390" default="31" item="ESU FnOut A15 Slider 5" mask="XXXVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A15 Mode</variableref>
-                                    <relation>gt</relation>
-                                    <value>0</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A15 Mode</variableref>
-                                    <relation>le</relation>
-                                    <value>18</value>
-                                </qualifier>
-                                <decVal max="31"/>
-                                <label xml:lang="de">Helligkeit</label>
-                            </variable>
-                            <variable label="Mode" CV="16.0.390" default="0" item="ESU FnOut A15 Option 1" mask="XXXXXXXV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A15 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>22</value>
-                                </qualifier>
-                                <enumVal>
-                                    <enumChoice choice="Heating control">
-                                        <choice>Heating control</choice>
-                                        <choice xml:lang="de">Heizungssteuerung</choice>
-                                    </enumChoice>
-                                    <enumChoice choice="Fan control">
-                                        <choice>Fan control</choice>
-                                        <choice xml:lang="de">Lüftersteuerung</choice>
-                                    </enumChoice>
-                                </enumVal>
-                                <label xml:lang="de">Modus</label>
-                            </variable>
-                            <variable label="Coupler Force" CV="16.0.390" default="31" item="ESU FnOut A15 Slider 7" mask="XXXVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A15 Mode</variableref>
-                                    <relation>ge</relation>
-                                    <value>28</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A15 Mode</variableref>
-                                    <relation>ne</relation>
-                                    <value>29</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A15 Mode</variableref>
-                                    <relation>ne</relation>
-                                    <value>30</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A15 Mode</variableref>
-                                    <relation>ne</relation>
-                                    <value>31</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A15 Mode</variableref>
-                                    <relation>ne</relation>
-                                    <value>32</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A15 Mode</variableref>
-                                    <relation>le</relation>
-                                    <value>33</value>
-                                </qualifier>
-                                <decVal max="31"/>
-                                <label xml:lang="de">Stärke des Kupplers</label>
-                            </variable>
-                            <variable label="Fan Speed" CV="16.0.390" default="31" item="ESU FnOut A15 Slider 11" mask="XXXVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A15 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>23</value>
-                                </qualifier>
-                                <decVal max="31"/>
-                                <label xml:lang="de">Geschwindigkeit</label>
-                            </variable>
-                            <variable label="Standing heat" CV="16.0.390" default="31" item="ESU FnOut A15 Slider 14" mask="XXXVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A15 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>24</value>
-                                </qualifier>
-                                <decVal max="31"/>
-                                <label xml:lang="de">Heizstufe im Stand</label>
-                            </variable>
-                            <variable label="Chuff power" CV="16.0.390" default="31" item="ESU FnOut A15 Slider 8" mask="XXXVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A15 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>25</value>
-                                </qualifier>
-                                <decVal max="31"/>
-                                <label xml:lang="de">Dampfstoßstärke</label>
-                            </variable>
-                            <variable label="Duration (speed) A" CV="16.0.386" default="31" item="ESU FnOut A15 Slider 4" mask="XXVVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A15 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>27</value>
-                                </qualifier>
-                                <decVal max="63"/>
-                                <label xml:lang="de">Dauer (Geschwindigkeit)</label>
-                            </variable>
-                            <variable label="Duration (speed) B" CV="16.0.390" default="31" item="ESU FnOut A15 Slider 17" mask="XXVVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A15 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>27</value>
-                                </qualifier>
-                                <decVal max="63"/>
-                                <label xml:lang="de">Dauer (Geschwindigkeit)</label>
-                            </variable>
-                            <variable item="Special Function CV391" label="Special Function CV 1" CV="16.0.391" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
-                                <decVal/>
-                            </variable>
-                            <variable label="Fan Acceleration rate" CV="16.0.391" default="0" item="ESU FnOut A15 Slider 12" mask="XXXVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A15 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>23</value>
-                                </qualifier>
-                                <decVal max="31"/>
-                                <label xml:lang="de">Beschleunigungszeit</label>
-                            </variable>
-                            <variable label="Minimum driving heat" CV="16.0.391" default="0" item="ESU FnOut A15 Slider 15" mask="XXXVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A15 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>24</value>
-                                </qualifier>
-                                <decVal max="31"/>
-                                <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
-                            </variable>
-                            <variable label="Position A" CV="16.0.391" default="0" item="ESU FnOut A15 Slider 18" mask="XXVVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A15 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>27</value>
-                                </qualifier>
-                                <decVal max="63"/>
-                            </variable>
-                            <variable label="Fan power" CV="16.0.391" default="0" item="ESU FnOut A15 Slider 9" mask="XXXVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A15 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>25</value>
-                                </qualifier>
-                                <decVal max="31"/>
-                                <label xml:lang="de">Stäke des Bläsers</label>
-                            </variable>
-                            <variable label="Phase Reverse" CV="16.0.391" default="0" item="ESU FnOut A15 Check 6" mask="XXXXXXXV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A15 Mode</variableref>
-                                    <relation>gt</relation>
-                                    <value>0</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A15 Mode</variableref>
-                                    <relation>le</relation>
-                                    <value>15</value>
-                                </qualifier>
-                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                                <label xml:lang="de">Phase tauschen</label>
-                            </variable>
-                            <variable label="Grade Crossing" CV="16.0.391" default="0" item="ESU FnOut A15 Check 1" mask="XXXXXXVX">
-                                <qualifier>
-                                    <variableref>ESU FnOut A15 Mode</variableref>
-                                    <relation>gt</relation>
-                                    <value>0</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A15 Mode</variableref>
-                                    <relation>le</relation>
-                                    <value>15</value>
-                                </qualifier>
-                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                            </variable>
-                            <variable label="Rule 17 Fwd" CV="16.0.391" default="0" item="ESU FnOut A15 Check 2" mask="XXXXXVXX">
-                                <qualifier>
-                                    <variableref>ESU FnOut A15 Mode</variableref>
-                                    <relation>gt</relation>
-                                    <value>0</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A15 Mode</variableref>
-                                    <relation>le</relation>
-                                    <value>15</value>
-                                </qualifier>
-                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                                <label xml:lang="de">Rule 17 vorwärts</label>
-                            </variable>
-                            <variable label="Rule 17 Rev" CV="16.0.391" default="0" item="ESU FnOut A15 Check 3" mask="XXXXVXXX">
-                                <qualifier>
-                                    <variableref>ESU FnOut A15 Mode</variableref>
-                                    <relation>gt</relation>
-                                    <value>0</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A15 Mode</variableref>
-                                    <relation>le</relation>
-                                    <value>15</value>
-                                </qualifier>
-                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                                <label xml:lang="de">Rule 17 rückwärts</label>
-                            </variable>
-                            <variable label="Dimmer" CV="16.0.391" default="0" item="ESU FnOut A15 Check 4" mask="XXXVXXXX">
-                                <qualifier>
-                                    <variableref>ESU FnOut A15 Mode</variableref>
-                                    <relation>gt</relation>
-                                    <value>0</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A15 Mode</variableref>
-                                    <relation>le</relation>
-                                    <value>15</value>
-                                </qualifier>
-                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                                <label xml:lang="de">Abdimmen</label>
-                            </variable>
-                            <variable label="LED Mode" CV="16.0.391" default="0" item="ESU FnOut A15 Check 5" mask="VXXXXXXX">
-                                <qualifier>
-                                    <variableref>ESU FnOut A15 Mode</variableref>
-                                    <relation>gt</relation>
-                                    <value>0</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A15 Mode</variableref>
-                                    <relation>le</relation>
-                                    <value>15</value>
-                                </qualifier>
-                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                                <label xml:lang="de">LED Modus</label>
-                            </variable>
-                            <variable item="Special Function CV392" label="Special Function CV 2" CV="16.0.392" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
-                                <decVal/>
-                            </variable>
-                            <variable label="Fan Decceleration rate" CV="16.0.392" default="0" item="ESU FnOut A15 Slider 13" mask="XXXVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A15 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>23</value>
-                                </qualifier>
-                                <decVal max="31"/>
-                                <label xml:lang="de">Bremszeit</label>
-                            </variable>
-                            <variable label="Maximum driving heat" CV="16.0.392" default="0" item="ESU FnOut A15 Slider 16" mask="XXXVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A15 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>24</value>
-                                </qualifier>
-                                <decVal max="31"/>
-                                <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
-                            </variable>
-                            <variable label="Timeout" CV="16.0.392" default="0" item="ESU FnOut A15 Slider 10" tooltip="Units = 0.25 sec">
-                                <qualifier>
-                                    <variableref>ESU FnOut A15 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>25</value>
-                                </qualifier>
-                                <decVal/>
-                            </variable>
-                            <variable label="Startup Time" CV="16.0.392" default="0" item="ESU FnOut A15 Slider 6">
-                                <qualifier>
-                                    <variableref>ESU FnOut A15 Mode</variableref>
-                                    <relation>ge</relation>
-                                    <value>16</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A15 Mode</variableref>
-                                    <relation>le</relation>
-                                    <value>17</value>
-                                </qualifier>
-                                <decVal/>
-                                <label xml:lang="de">Startzeit</label>
-                            </variable>
-                            <variable label="Level" CV="16.0.392" default="0" item="ESU FnOut A15 Slider 20" mask="XVVVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A15 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>19</value>
-                                </qualifier>
-                                <decVal max="127"/>
-                            </variable>
-                            <variable label="Position B" CV="16.0.392" default="0" item="ESU FnOut A15 Slider 19" mask="XXVVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A15 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>27</value>
-                                </qualifier>
-                                <decVal max="63"/>
-                            </variable>
-                            <!-- AUX16 Mode -->
-                            <variable label="AUX16 Mode" CV="16.0.395" default="1" item="ESU FnOut A16 Mode">
-                                <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
-                            </variable>
-                            <variable label="Function Switch On Delay" CV="16.0.396" default="0" item="ESU FnOut A16 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A16 Mode</variableref>
-                                    <relation>gt</relation>
-                                    <value>0</value>
-                                </qualifier>
-                                <decVal max="15"/>
-                                <label xml:lang="de">Verzögerung beim Einschalten</label>
-                            </variable>
-                            <variable label="Function Switch Off Delay" CV="16.0.396" default="0" mask="VVVVXXXX" item="ESU FnOut A16 Slider 2" tooltip="Units = 0.4 sec">
-                                <qualifier>
-                                    <variableref>ESU FnOut A16 Mode</variableref>
-                                    <relation>gt</relation>
-                                    <value>0</value>
-                                </qualifier>
-                                <decVal max="15"/>
-                                <label xml:lang="de">Verzögerung beim Ausschalten</label>
-                            </variable>
-                            <variable label="Function Auto Switch Off" CV="16.0.397" default="0" item="ESU FnOut A16 Slider 3" tooltip="Units = 0.4 sec">
-                                <qualifier>
-                                    <variableref>ESU FnOut A16 Mode</variableref>
-                                    <relation>gt</relation>
-                                    <value>0</value>
-                                </qualifier>
-                                <decVal/>
-                                <label xml:lang="de">Ausgang automatisch Ausschalten</label>
-                            </variable>
-                            <variable item="Brightness CV398" label="Brightness CV" CV="16.0.398" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
-                                <decVal/>
-                            </variable>
-                            <variable label="Brightness" CV="16.0.398" default="31" item="ESU FnOut A16 Slider 5" mask="XXXVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A16 Mode</variableref>
-                                    <relation>gt</relation>
-                                    <value>0</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A16 Mode</variableref>
-                                    <relation>le</relation>
-                                    <value>18</value>
-                                </qualifier>
-                                <decVal max="31"/>
-                                <label xml:lang="de">Helligkeit</label>
-                            </variable>
-                            <variable label="Mode" CV="16.0.398" default="0" item="ESU FnOut A16 Option 1" mask="XXXXXXXV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A16 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>22</value>
-                                </qualifier>
-                                <enumVal>
-                                    <enumChoice choice="Heating control">
-                                        <choice>Heating control</choice>
-                                        <choice xml:lang="de">Heizungssteuerung</choice>
-                                    </enumChoice>
-                                    <enumChoice choice="Fan control">
-                                        <choice>Fan control</choice>
-                                        <choice xml:lang="de">Lüftersteuerung</choice>
-                                    </enumChoice>
-                                </enumVal>
-                                <label xml:lang="de">Modus</label>
-                            </variable>
-                            <variable label="Coupler Force" CV="16.0.398" default="31" item="ESU FnOut A16 Slider 7" mask="XXXVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A16 Mode</variableref>
-                                    <relation>ge</relation>
-                                    <value>28</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A16 Mode</variableref>
-                                    <relation>ne</relation>
-                                    <value>29</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A16 Mode</variableref>
-                                    <relation>ne</relation>
-                                    <value>30</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A16 Mode</variableref>
-                                    <relation>ne</relation>
-                                    <value>31</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A16 Mode</variableref>
-                                    <relation>ne</relation>
-                                    <value>32</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A16 Mode</variableref>
-                                    <relation>le</relation>
-                                    <value>33</value>
-                                </qualifier>
-                                <decVal max="31"/>
-                                <label xml:lang="de">Stärke des Kupplers</label>
-                            </variable>
-                            <variable label="Fan Speed" CV="16.0.398" default="31" item="ESU FnOut A16 Slider 11" mask="XXXVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A16 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>23</value>
-                                </qualifier>
-                                <decVal max="31"/>
-                                <label xml:lang="de">Geschwindigkeit</label>
-                            </variable>
-                            <variable label="Standing heat" CV="16.0.398" default="31" item="ESU FnOut A16 Slider 14" mask="XXXVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A16 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>24</value>
-                                </qualifier>
-                                <decVal max="31"/>
-                                <label xml:lang="de">Heizstufe im Stand</label>
-                            </variable>
-                            <variable label="Chuff power" CV="16.0.398" default="31" item="ESU FnOut A16 Slider 8" mask="XXXVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A16 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>25</value>
-                                </qualifier>
-                                <decVal max="31"/>
-                                <label xml:lang="de">Dampfstoßstärke</label>
-                            </variable>
-                            <variable label="Duration (speed) A" CV="16.0.394" default="31" item="ESU FnOut A16 Slider 4" mask="XXVVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A16 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>27</value>
-                                </qualifier>
-                                <decVal max="63"/>
-                                <label xml:lang="de">Dauer (Geschwindigkeit)</label>
-                            </variable>
-                            <variable label="Duration (speed) B" CV="16.0.398" default="31" item="ESU FnOut A16 Slider 17" mask="XXVVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A16 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>27</value>
-                                </qualifier>
-                                <decVal max="63"/>
-                                <label xml:lang="de">Dauer (Geschwindigkeit)</label>
-                            </variable>
-                            <variable item="Special Function CV399" label="Special Function CV 1" CV="16.0.399" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
-                                <decVal/>
-                            </variable>
-                            <variable label="Fan Acceleration rate" CV="16.0.399" default="0" item="ESU FnOut A16 Slider 12" mask="XXXVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A16 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>23</value>
-                                </qualifier>
-                                <decVal max="31"/>
-                                <label xml:lang="de">Beschleunigungszeit</label>
-                            </variable>
-                            <variable label="Minimum driving heat" CV="16.0.399" default="0" item="ESU FnOut A16 Slider 15" mask="XXXVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A16 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>24</value>
-                                </qualifier>
-                                <decVal max="31"/>
-                                <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
-                            </variable>
-                            <variable label="Position A" CV="16.0.399" default="0" item="ESU FnOut A16 Slider 18" mask="XXVVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A16 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>27</value>
-                                </qualifier>
-                                <decVal max="63"/>
-                            </variable>
-                            <variable label="Fan power" CV="16.0.399" default="0" item="ESU FnOut A16 Slider 9" mask="XXXVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A16 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>25</value>
-                                </qualifier>
-                                <decVal max="31"/>
-                                <label xml:lang="de">Stäke des Bläsers</label>
-                            </variable>
-                            <variable label="Phase Reverse" CV="16.0.399" default="0" item="ESU FnOut A16 Check 6" mask="XXXXXXXV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A16 Mode</variableref>
-                                    <relation>gt</relation>
-                                    <value>0</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A16 Mode</variableref>
-                                    <relation>le</relation>
-                                    <value>15</value>
-                                </qualifier>
-                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                                <label xml:lang="de">Phase tauschen</label>
-                            </variable>
-                            <variable label="Grade Crossing" CV="16.0.399" default="0" item="ESU FnOut A16 Check 1" mask="XXXXXXVX">
-                                <qualifier>
-                                    <variableref>ESU FnOut A16 Mode</variableref>
-                                    <relation>gt</relation>
-                                    <value>0</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A16 Mode</variableref>
-                                    <relation>le</relation>
-                                    <value>15</value>
-                                </qualifier>
-                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                            </variable>
-                            <variable label="Rule 17 Fwd" CV="16.0.399" default="0" item="ESU FnOut A16 Check 2" mask="XXXXXVXX">
-                                <qualifier>
-                                    <variableref>ESU FnOut A16 Mode</variableref>
-                                    <relation>gt</relation>
-                                    <value>0</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A16 Mode</variableref>
-                                    <relation>le</relation>
-                                    <value>15</value>
-                                </qualifier>
-                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                                <label xml:lang="de">Rule 17 vorwärts</label>
-                            </variable>
-                            <variable label="Rule 17 Rev" CV="16.0.399" default="0" item="ESU FnOut A16 Check 3" mask="XXXXVXXX">
-                                <qualifier>
-                                    <variableref>ESU FnOut A16 Mode</variableref>
-                                    <relation>gt</relation>
-                                    <value>0</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A16 Mode</variableref>
-                                    <relation>le</relation>
-                                    <value>15</value>
-                                </qualifier>
-                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                                <label xml:lang="de">Rule 17 rückwärts</label>
-                            </variable>
-                            <variable label="Dimmer" CV="16.0.399" default="0" item="ESU FnOut A16 Check 4" mask="XXXVXXXX">
-                                <qualifier>
-                                    <variableref>ESU FnOut A16 Mode</variableref>
-                                    <relation>gt</relation>
-                                    <value>0</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A16 Mode</variableref>
-                                    <relation>le</relation>
-                                    <value>15</value>
-                                </qualifier>
-                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                                <label xml:lang="de">Abdimmen</label>
-                            </variable>
-                            <variable label="LED Mode" CV="16.0.399" default="0" item="ESU FnOut A16 Check 5" mask="VXXXXXXX">
-                                <qualifier>
-                                    <variableref>ESU FnOut A16 Mode</variableref>
-                                    <relation>gt</relation>
-                                    <value>0</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A16 Mode</variableref>
-                                    <relation>le</relation>
-                                    <value>15</value>
-                                </qualifier>
-                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                                <label xml:lang="de">LED Modus</label>
-                            </variable>
-                            <variable item="Special Function CV400" label="Special Function CV 2" CV="16.0.400" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
-                                <decVal/>
-                            </variable>
-                            <variable label="Fan Decceleration rate" CV="16.0.400" default="0" item="ESU FnOut A16 Slider 13" mask="XXXVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A16 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>23</value>
-                                </qualifier>
-                                <decVal max="31"/>
-                                <label xml:lang="de">Bremszeit</label>
-                            </variable>
-                            <variable label="Maximum driving heat" CV="16.0.400" default="0" item="ESU FnOut A16 Slider 16" mask="XXXVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A16 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>24</value>
-                                </qualifier>
-                                <decVal max="31"/>
-                                <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
-                            </variable>
-                            <variable label="Timeout" CV="16.0.400" default="0" item="ESU FnOut A16 Slider 10" tooltip="Units = 0.25 sec">
-                                <qualifier>
-                                    <variableref>ESU FnOut A16 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>25</value>
-                                </qualifier>
-                                <decVal/>
-                            </variable>
-                            <variable label="Startup Time" CV="16.0.400" default="0" item="ESU FnOut A16 Slider 6">
-                                <qualifier>
-                                    <variableref>ESU FnOut A16 Mode</variableref>
-                                    <relation>ge</relation>
-                                    <value>16</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A16 Mode</variableref>
-                                    <relation>le</relation>
-                                    <value>17</value>
-                                </qualifier>
-                                <decVal/>
-                                <label xml:lang="de">Startzeit</label>
-                            </variable>
-                            <variable label="Level" CV="16.0.400" default="0" item="ESU FnOut A16 Slider 20" mask="XVVVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A16 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>19</value>
-                                </qualifier>
-                                <decVal max="127"/>
-                            </variable>
-                            <variable label="Position B" CV="16.0.400" default="0" item="ESU FnOut A16 Slider 19" mask="XXVVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A16 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>27</value>
-                                </qualifier>
-                                <decVal max="63"/>
-                            </variable>
-                            <!-- AUX17 Mode -->
-                            <variable label="AUX17 Mode" CV="16.0.403" default="1" item="ESU FnOut A17 Mode">
-                                <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
-                            </variable>
-                            <variable label="Function Switch On Delay" CV="16.0.404" default="0" item="ESU FnOut A17 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A17 Mode</variableref>
-                                    <relation>gt</relation>
-                                    <value>0</value>
-                                </qualifier>
-                                <decVal max="15"/>
-                                <label xml:lang="de">Verzögerung beim Einschalten</label>
-                            </variable>
-                            <variable label="Function Switch Off Delay" CV="16.0.404" default="0" mask="VVVVXXXX" item="ESU FnOut A17 Slider 2" tooltip="Units = 0.4 sec">
-                                <qualifier>
-                                    <variableref>ESU FnOut A17 Mode</variableref>
-                                    <relation>gt</relation>
-                                    <value>0</value>
-                                </qualifier>
-                                <decVal max="15"/>
-                                <label xml:lang="de">Verzögerung beim Ausschalten</label>
-                            </variable>
-                            <variable label="Function Auto Switch Off" CV="16.0.405" default="0" item="ESU FnOut A17 Slider 3" tooltip="Units = 0.4 sec">
-                                <qualifier>
-                                    <variableref>ESU FnOut A17 Mode</variableref>
-                                    <relation>gt</relation>
-                                    <value>0</value>
-                                </qualifier>
-                                <decVal/>
-                                <label xml:lang="de">Ausgang automatisch Ausschalten</label>
-                            </variable>
-                            <variable item="Brightness CV406" label="Brightness CV" CV="16.0.406" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
-                                <decVal/>
-                            </variable>
-                            <variable label="Brightness" CV="16.0.406" default="31" item="ESU FnOut A17 Slider 5" mask="XXXVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A17 Mode</variableref>
-                                    <relation>gt</relation>
-                                    <value>0</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A17 Mode</variableref>
-                                    <relation>le</relation>
-                                    <value>18</value>
-                                </qualifier>
-                                <decVal max="31"/>
-                                <label xml:lang="de">Helligkeit</label>
-                            </variable>
-                            <variable label="Mode" CV="16.0.406" default="0" item="ESU FnOut A17 Option 1" mask="XXXXXXXV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A17 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>22</value>
-                                </qualifier>
-                                <enumVal>
-                                    <enumChoice choice="Heating control">
-                                        <choice>Heating control</choice>
-                                        <choice xml:lang="de">Heizungssteuerung</choice>
-                                    </enumChoice>
-                                    <enumChoice choice="Fan control">
-                                        <choice>Fan control</choice>
-                                        <choice xml:lang="de">Lüftersteuerung</choice>
-                                    </enumChoice>
-                                </enumVal>
-                                <label xml:lang="de">Modus</label>
-                            </variable>
-                            <variable label="Coupler Force" CV="16.0.406" default="31" item="ESU FnOut A17 Slider 7" mask="XXXVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A17 Mode</variableref>
-                                    <relation>ge</relation>
-                                    <value>28</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A17 Mode</variableref>
-                                    <relation>ne</relation>
-                                    <value>29</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A17 Mode</variableref>
-                                    <relation>ne</relation>
-                                    <value>30</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A17 Mode</variableref>
-                                    <relation>ne</relation>
-                                    <value>31</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A17 Mode</variableref>
-                                    <relation>ne</relation>
-                                    <value>32</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A17 Mode</variableref>
-                                    <relation>le</relation>
-                                    <value>33</value>
-                                </qualifier>
-                                <decVal max="31"/>
-                                <label xml:lang="de">Stärke des Kupplers</label>
-                            </variable>
-                            <variable label="Fan Speed" CV="16.0.406" default="31" item="ESU FnOut A17 Slider 11" mask="XXXVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A17 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>23</value>
-                                </qualifier>
-                                <decVal max="31"/>
-                                <label xml:lang="de">Geschwindigkeit</label>
-                            </variable>
-                            <variable label="Standing heat" CV="16.0.406" default="31" item="ESU FnOut A17 Slider 14" mask="XXXVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A17 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>24</value>
-                                </qualifier>
-                                <decVal max="31"/>
-                                <label xml:lang="de">Heizstufe im Stand</label>
-                            </variable>
-                            <variable label="Chuff power" CV="16.0.406" default="31" item="ESU FnOut A17 Slider 8" mask="XXXVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A17 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>25</value>
-                                </qualifier>
-                                <decVal max="31"/>
-                                <label xml:lang="de">Dampfstoßstärke</label>
-                            </variable>
-                            <variable label="Duration (speed) A" CV="16.0.402" default="31" item="ESU FnOut A17 Slider 4" mask="XXVVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A17 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>27</value>
-                                </qualifier>
-                                <decVal max="63"/>
-                                <label xml:lang="de">Dauer (Geschwindigkeit)</label>
-                            </variable>
-                            <variable label="Duration (speed) B" CV="16.0.406" default="31" item="ESU FnOut A17 Slider 17" mask="XXVVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A17 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>27</value>
-                                </qualifier>
-                                <decVal max="63"/>
-                                <label xml:lang="de">Dauer (Geschwindigkeit)</label>
-                            </variable>
-                            <variable item="Special Function CV407" label="Special Function CV 1" CV="16.0.407" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
-                                <decVal/>
-                            </variable>
-                            <variable label="Fan Acceleration rate" CV="16.0.407" default="0" item="ESU FnOut A17 Slider 12" mask="XXXVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A17 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>23</value>
-                                </qualifier>
-                                <decVal max="31"/>
-                                <label xml:lang="de">Beschleunigungszeit</label>
-                            </variable>
-                            <variable label="Minimum driving heat" CV="16.0.407" default="0" item="ESU FnOut A17 Slider 15" mask="XXXVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A17 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>24</value>
-                                </qualifier>
-                                <decVal max="31"/>
-                                <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
-                            </variable>
-                            <variable label="Position A" CV="16.0.407" default="0" item="ESU FnOut A17 Slider 18" mask="XXVVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A17 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>27</value>
-                                </qualifier>
-                                <decVal max="63"/>
-                            </variable>
-                            <variable label="Fan power" CV="16.0.407" default="0" item="ESU FnOut A17 Slider 9" mask="XXXVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A17 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>25</value>
-                                </qualifier>
-                                <decVal max="31"/>
-                                <label xml:lang="de">Stäke des Bläsers</label>
-                            </variable>
-                            <variable label="Phase Reverse" CV="16.0.407" default="0" item="ESU FnOut A17 Check 6" mask="XXXXXXXV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A17 Mode</variableref>
-                                    <relation>gt</relation>
-                                    <value>0</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A17 Mode</variableref>
-                                    <relation>le</relation>
-                                    <value>15</value>
-                                </qualifier>
-                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                                <label xml:lang="de">Phase tauschen</label>
-                            </variable>
-                            <variable label="Grade Crossing" CV="16.0.407" default="0" item="ESU FnOut A17 Check 1" mask="XXXXXXVX">
-                                <qualifier>
-                                    <variableref>ESU FnOut A17 Mode</variableref>
-                                    <relation>gt</relation>
-                                    <value>0</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A17 Mode</variableref>
-                                    <relation>le</relation>
-                                    <value>15</value>
-                                </qualifier>
-                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                            </variable>
-                            <variable label="Rule 17 Fwd" CV="16.0.407" default="0" item="ESU FnOut A17 Check 2" mask="XXXXXVXX">
-                                <qualifier>
-                                    <variableref>ESU FnOut A17 Mode</variableref>
-                                    <relation>gt</relation>
-                                    <value>0</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A17 Mode</variableref>
-                                    <relation>le</relation>
-                                    <value>15</value>
-                                </qualifier>
-                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                                <label xml:lang="de">Rule 17 vorwärts</label>
-                            </variable>
-                            <variable label="Rule 17 Rev" CV="16.0.407" default="0" item="ESU FnOut A17 Check 3" mask="XXXXVXXX">
-                                <qualifier>
-                                    <variableref>ESU FnOut A17 Mode</variableref>
-                                    <relation>gt</relation>
-                                    <value>0</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A17 Mode</variableref>
-                                    <relation>le</relation>
-                                    <value>15</value>
-                                </qualifier>
-                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                                <label xml:lang="de">Rule 17 rückwärts</label>
-                            </variable>
-                            <variable label="Dimmer" CV="16.0.407" default="0" item="ESU FnOut A17 Check 4" mask="XXXVXXXX">
-                                <qualifier>
-                                    <variableref>ESU FnOut A17 Mode</variableref>
-                                    <relation>gt</relation>
-                                    <value>0</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A17 Mode</variableref>
-                                    <relation>le</relation>
-                                    <value>15</value>
-                                </qualifier>
-                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                                <label xml:lang="de">Abdimmen</label>
-                            </variable>
-                            <variable label="LED Mode" CV="16.0.407" default="0" item="ESU FnOut A17 Check 5" mask="VXXXXXXX">
-                                <qualifier>
-                                    <variableref>ESU FnOut A17 Mode</variableref>
-                                    <relation>gt</relation>
-                                    <value>0</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A17 Mode</variableref>
-                                    <relation>le</relation>
-                                    <value>15</value>
-                                </qualifier>
-                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                                <label xml:lang="de">LED Modus</label>
-                            </variable>
-                            <variable item="Special Function CV408" label="Special Function CV 2" CV="16.0.408" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
-                                <decVal/>
-                            </variable>
-                            <variable label="Fan Decceleration rate" CV="16.0.408" default="0" item="ESU FnOut A17 Slider 13" mask="XXXVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A17 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>23</value>
-                                </qualifier>
-                                <decVal max="31"/>
-                                <label xml:lang="de">Bremszeit</label>
-                            </variable>
-                            <variable label="Maximum driving heat" CV="16.0.408" default="0" item="ESU FnOut A17 Slider 16" mask="XXXVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A17 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>24</value>
-                                </qualifier>
-                                <decVal max="31"/>
-                                <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
-                            </variable>
-                            <variable label="Timeout" CV="16.0.408" default="0" item="ESU FnOut A17 Slider 10" tooltip="Units = 0.25 sec">
-                                <qualifier>
-                                    <variableref>ESU FnOut A17 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>25</value>
-                                </qualifier>
-                                <decVal/>
-                            </variable>
-                            <variable label="Startup Time" CV="16.0.408" default="0" item="ESU FnOut A17 Slider 6">
-                                <qualifier>
-                                    <variableref>ESU FnOut A17 Mode</variableref>
-                                    <relation>ge</relation>
-                                    <value>16</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A17 Mode</variableref>
-                                    <relation>le</relation>
-                                    <value>17</value>
-                                </qualifier>
-                                <decVal/>
-                                <label xml:lang="de">Startzeit</label>
-                            </variable>
-                            <variable label="Level" CV="16.0.408" default="0" item="ESU FnOut A17 Slider 20" mask="XVVVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A17 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>19</value>
-                                </qualifier>
-                                <decVal max="127"/>
-                            </variable>
-                            <variable label="Position B" CV="16.0.408" default="0" item="ESU FnOut A17 Slider 19" mask="XXVVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A17 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>27</value>
-                                </qualifier>
-                                <decVal max="63"/>
-                            </variable>
-                            <!-- AUX18 Mode -->
-                            <variable label="AUX18 Mode" CV="16.0.411" default="1" item="ESU FnOut A18 Mode">
-                                <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
-                            </variable>
-                            <variable label="Function Switch On Delay" CV="16.0.412" default="0" item="ESU FnOut A18 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A18 Mode</variableref>
-                                    <relation>gt</relation>
-                                    <value>0</value>
-                                </qualifier>
-                                <decVal max="15"/>
-                                <label xml:lang="de">Verzögerung beim Einschalten</label>
-                            </variable>
-                            <variable label="Function Switch Off Delay" CV="16.0.412" default="0" mask="VVVVXXXX" item="ESU FnOut A18 Slider 2" tooltip="Units = 0.4 sec">
-                                <qualifier>
-                                    <variableref>ESU FnOut A18 Mode</variableref>
-                                    <relation>gt</relation>
-                                    <value>0</value>
-                                </qualifier>
-                                <decVal max="15"/>
-                                <label xml:lang="de">Verzögerung beim Ausschalten</label>
-                            </variable>
-                            <variable label="Function Auto Switch Off" CV="16.0.413" default="0" item="ESU FnOut A18 Slider 3" tooltip="Units = 0.4 sec">
-                                <qualifier>
-                                    <variableref>ESU FnOut A18 Mode</variableref>
-                                    <relation>gt</relation>
-                                    <value>0</value>
-                                </qualifier>
-                                <decVal/>
-                                <label xml:lang="de">Ausgang automatisch Ausschalten</label>
-                            </variable>
-                            <variable item="Brightness CV414" label="Brightness CV" CV="16.0.414" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
-                                <decVal/>
-                            </variable>
-                            <variable label="Brightness" CV="16.0.414" default="31" item="ESU FnOut A18 Slider 5" mask="XXXVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A18 Mode</variableref>
-                                    <relation>gt</relation>
-                                    <value>0</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A18 Mode</variableref>
-                                    <relation>le</relation>
-                                    <value>18</value>
-                                </qualifier>
-                                <decVal max="31"/>
-                                <label xml:lang="de">Helligkeit</label>
-                            </variable>
-                            <variable label="Mode" CV="16.0.414" default="0" item="ESU FnOut A18 Option 1" mask="XXXXXXXV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A18 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>22</value>
-                                </qualifier>
-                                <enumVal>
-                                    <enumChoice choice="Heating control">
-                                        <choice>Heating control</choice>
-                                        <choice xml:lang="de">Heizungssteuerung</choice>
-                                    </enumChoice>
-                                    <enumChoice choice="Fan control">
-                                        <choice>Fan control</choice>
-                                        <choice xml:lang="de">Lüftersteuerung</choice>
-                                    </enumChoice>
-                                </enumVal>
-                                <label xml:lang="de">Modus</label>
-                            </variable>
-                            <variable label="Coupler Force" CV="16.0.414" default="31" item="ESU FnOut A18 Slider 7" mask="XXXVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A18 Mode</variableref>
-                                    <relation>ge</relation>
-                                    <value>28</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A18 Mode</variableref>
-                                    <relation>ne</relation>
-                                    <value>29</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A18 Mode</variableref>
-                                    <relation>ne</relation>
-                                    <value>30</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A18 Mode</variableref>
-                                    <relation>ne</relation>
-                                    <value>31</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A18 Mode</variableref>
-                                    <relation>ne</relation>
-                                    <value>32</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A18 Mode</variableref>
-                                    <relation>le</relation>
-                                    <value>33</value>
-                                </qualifier>
-                                <decVal max="31"/>
-                                <label xml:lang="de">Stärke des Kupplers</label>
-                            </variable>
-                            <variable label="Fan Speed" CV="16.0.414" default="31" item="ESU FnOut A18 Slider 11" mask="XXXVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A18 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>23</value>
-                                </qualifier>
-                                <decVal max="31"/>
-                                <label xml:lang="de">Geschwindigkeit</label>
-                            </variable>
-                            <variable label="Standing heat" CV="16.0.414" default="31" item="ESU FnOut A18 Slider 14" mask="XXXVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A18 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>24</value>
-                                </qualifier>
-                                <decVal max="31"/>
-                                <label xml:lang="de">Heizstufe im Stand</label>
-                            </variable>
-                            <variable label="Chuff power" CV="16.0.414" default="31" item="ESU FnOut A18 Slider 8" mask="XXXVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A18 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>25</value>
-                                </qualifier>
-                                <decVal max="31"/>
-                                <label xml:lang="de">Dampfstoßstärke</label>
-                            </variable>
-                            <variable label="Duration (speed) A" CV="16.0.410" default="31" item="ESU FnOut A18 Slider 4" mask="XXVVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A18 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>27</value>
-                                </qualifier>
-                                <decVal max="63"/>
-                                <label xml:lang="de">Dauer (Geschwindigkeit)</label>
-                            </variable>
-                            <variable label="Duration (speed) B" CV="16.0.414" default="31" item="ESU FnOut A18 Slider 17" mask="XXVVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A18 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>27</value>
-                                </qualifier>
-                                <decVal max="63"/>
-                                <label xml:lang="de">Dauer (Geschwindigkeit)</label>
-                            </variable>
-                            <variable item="Special Function CV415" label="Special Function CV 1" CV="16.0.415" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
-                                <decVal/>
-                            </variable>
-                            <variable label="Fan Acceleration rate" CV="16.0.415" default="0" item="ESU FnOut A18 Slider 12" mask="XXXVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A18 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>23</value>
-                                </qualifier>
-                                <decVal max="31"/>
-                                <label xml:lang="de">Beschleunigungszeit</label>
-                            </variable>
-                            <variable label="Minimum driving heat" CV="16.0.415" default="0" item="ESU FnOut A18 Slider 15" mask="XXXVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A18 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>24</value>
-                                </qualifier>
-                                <decVal max="31"/>
-                                <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
-                            </variable>
-                            <variable label="Position A" CV="16.0.415" default="0" item="ESU FnOut A18 Slider 18" mask="XXVVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A18 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>27</value>
-                                </qualifier>
-                                <decVal max="63"/>
-                            </variable>
-                            <variable label="Fan power" CV="16.0.415" default="0" item="ESU FnOut A18 Slider 9" mask="XXXVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A18 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>25</value>
-                                </qualifier>
-                                <decVal max="31"/>
-                                <label xml:lang="de">Stäke des Bläsers</label>
-                            </variable>
-                            <variable label="Phase Reverse" CV="16.0.415" default="0" item="ESU FnOut A18 Check 6" mask="XXXXXXXV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A18 Mode</variableref>
-                                    <relation>gt</relation>
-                                    <value>0</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A18 Mode</variableref>
-                                    <relation>le</relation>
-                                    <value>15</value>
-                                </qualifier>
-                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                                <label xml:lang="de">Phase tauschen</label>
-                            </variable>
-                            <variable label="Grade Crossing" CV="16.0.415" default="0" item="ESU FnOut A18 Check 1" mask="XXXXXXVX">
-                                <qualifier>
-                                    <variableref>ESU FnOut A18 Mode</variableref>
-                                    <relation>gt</relation>
-                                    <value>0</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A18 Mode</variableref>
-                                    <relation>le</relation>
-                                    <value>15</value>
-                                </qualifier>
-                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                            </variable>
-                            <variable label="Rule 17 Fwd" CV="16.0.415" default="0" item="ESU FnOut A18 Check 2" mask="XXXXXVXX">
-                                <qualifier>
-                                    <variableref>ESU FnOut A18 Mode</variableref>
-                                    <relation>gt</relation>
-                                    <value>0</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A18 Mode</variableref>
-                                    <relation>le</relation>
-                                    <value>15</value>
-                                </qualifier>
-                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                                <label xml:lang="de">Rule 17 vorwärts</label>
-                            </variable>
-                            <variable label="Rule 17 Rev" CV="16.0.415" default="0" item="ESU FnOut A18 Check 3" mask="XXXXVXXX">
-                                <qualifier>
-                                    <variableref>ESU FnOut A18 Mode</variableref>
-                                    <relation>gt</relation>
-                                    <value>0</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A18 Mode</variableref>
-                                    <relation>le</relation>
-                                    <value>15</value>
-                                </qualifier>
-                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                                <label xml:lang="de">Rule 17 rückwärts</label>
-                            </variable>
-                            <variable label="Dimmer" CV="16.0.415" default="0" item="ESU FnOut A18 Check 4" mask="XXXVXXXX">
-                                <qualifier>
-                                    <variableref>ESU FnOut A18 Mode</variableref>
-                                    <relation>gt</relation>
-                                    <value>0</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A18 Mode</variableref>
-                                    <relation>le</relation>
-                                    <value>15</value>
-                                </qualifier>
-                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                                <label xml:lang="de">Abdimmen</label>
-                            </variable>
-                            <variable label="LED Mode" CV="16.0.415" default="0" item="ESU FnOut A18 Check 5" mask="VXXXXXXX">
-                                <qualifier>
-                                    <variableref>ESU FnOut A18 Mode</variableref>
-                                    <relation>gt</relation>
-                                    <value>0</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A18 Mode</variableref>
-                                    <relation>le</relation>
-                                    <value>15</value>
-                                </qualifier>
-                                <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-                                <label xml:lang="de">LED Modus</label>
-                            </variable>
-                            <variable item="Special Function CV416" label="Special Function CV 2" CV="16.0.416" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
-                                <decVal/>
-                            </variable>
-                            <variable label="Fan Decceleration rate" CV="16.0.416" default="0" item="ESU FnOut A18 Slider 13" mask="XXXVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A18 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>23</value>
-                                </qualifier>
-                                <decVal max="31"/>
-                                <label xml:lang="de">Bremszeit</label>
-                            </variable>
-                            <variable label="Maximum driving heat" CV="16.0.416" default="0" item="ESU FnOut A18 Slider 16" mask="XXXVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A18 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>24</value>
-                                </qualifier>
-                                <decVal max="31"/>
-                                <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
-                            </variable>
-                            <variable label="Timeout" CV="16.0.416" default="0" item="ESU FnOut A18 Slider 10" tooltip="Units = 0.25 sec">
-                                <qualifier>
-                                    <variableref>ESU FnOut A18 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>25</value>
-                                </qualifier>
-                                <decVal/>
-                            </variable>
-                            <variable label="Startup Time" CV="16.0.416" default="0" item="ESU FnOut A18 Slider 6">
-                                <qualifier>
-                                    <variableref>ESU FnOut A18 Mode</variableref>
-                                    <relation>ge</relation>
-                                    <value>16</value>
-                                </qualifier>
-                                <qualifier>
-                                    <variableref>ESU FnOut A18 Mode</variableref>
-                                    <relation>le</relation>
-                                    <value>17</value>
-                                </qualifier>
-                                <decVal/>
-                                <label xml:lang="de">Startzeit</label>
-                            </variable>
-                            <variable label="Level" CV="16.0.416" default="0" item="ESU FnOut A18 Slider 20" mask="XVVVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A18 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>19</value>
-                                </qualifier>
-                                <decVal max="127"/>
-                            </variable>
-                            <variable label="Position B" CV="16.0.416" default="0" item="ESU FnOut A18 Slider 19" mask="XXVVVVVV">
-                                <qualifier>
-                                    <variableref>ESU FnOut A18 Mode</variableref>
-                                    <relation>eq</relation>
-                                    <value>27</value>
-                                </qualifier>
-                                <decVal max="63"/>
-                            </variable>
-                        </variables>
+                        <!-- AUX17 Mode -->
+                        <variable label="AUX17 Mode" CV="16.0.403" default="1" item="ESU FnOut A17 Mode">
+                            <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
+                        </variable>
+                        <variable label="Function Switch On Delay" CV="16.0.404" default="0" item="ESU FnOut A17 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
+                            <qualifier>
+                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <relation>gt</relation>
+                                <value>0</value>
+                            </qualifier>
+                            <decVal max="15"/>
+                            <label xml:lang="de">Verzögerung beim Einschalten</label>
+                        </variable>
+                        <variable label="Function Switch Off Delay" CV="16.0.404" default="0" mask="VVVVXXXX" item="ESU FnOut A17 Slider 2" tooltip="Units = 0.4 sec">
+                            <qualifier>
+                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <relation>gt</relation>
+                                <value>0</value>
+                            </qualifier>
+                            <decVal max="15"/>
+                            <label xml:lang="de">Verzögerung beim Ausschalten</label>
+                        </variable>
+                        <variable label="Function Auto Switch Off" CV="16.0.405" default="0" item="ESU FnOut A17 Slider 3" tooltip="Units = 0.4 sec">
+                            <qualifier>
+                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <relation>gt</relation>
+                                <value>0</value>
+                            </qualifier>
+                            <decVal/>
+                            <label xml:lang="de">Ausgang automatisch Ausschalten</label>
+                        </variable>
+                        <variable item="Brightness CV406" label="Brightness CV" CV="16.0.406" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
+                            <decVal/>
+                        </variable>
+                        <variable label="Brightness" CV="16.0.406" default="31" item="ESU FnOut A17 Slider 5" mask="XXXVVVVV">
+                            <qualifier>
+                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <relation>gt</relation>
+                                <value>0</value>
+                            </qualifier>
+                            <qualifier>
+                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <relation>le</relation>
+                                <value>18</value>
+                            </qualifier>
+                            <decVal max="31"/>
+                            <label xml:lang="de">Helligkeit</label>
+                        </variable>
+                        <variable label="Mode" CV="16.0.406" default="0" item="ESU FnOut A17 Option 1" mask="XXXXXXXV">
+                            <qualifier>
+                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <relation>eq</relation>
+                                <value>22</value>
+                            </qualifier>
+                            <enumVal>
+                                <enumChoice choice="Heating control">
+                                    <choice>Heating control</choice>
+                                    <choice xml:lang="de">Heizungssteuerung</choice>
+                                </enumChoice>
+                                <enumChoice choice="Fan control">
+                                    <choice>Fan control</choice>
+                                    <choice xml:lang="de">Lüftersteuerung</choice>
+                                </enumChoice>
+                            </enumVal>
+                            <label xml:lang="de">Modus</label>
+                        </variable>
+                        <variable label="Coupler Force" CV="16.0.406" default="31" item="ESU FnOut A17 Slider 7" mask="XXXVVVVV">
+                            <qualifier>
+                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <relation>ge</relation>
+                                <value>28</value>
+                            </qualifier>
+                            <qualifier>
+                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <relation>ne</relation>
+                                <value>29</value>
+                            </qualifier>
+                            <qualifier>
+                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <relation>ne</relation>
+                                <value>30</value>
+                            </qualifier>
+                            <qualifier>
+                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <relation>ne</relation>
+                                <value>31</value>
+                            </qualifier>
+                            <qualifier>
+                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <relation>ne</relation>
+                                <value>32</value>
+                            </qualifier>
+                            <qualifier>
+                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <relation>le</relation>
+                                <value>33</value>
+                            </qualifier>
+                            <decVal max="31"/>
+                            <label xml:lang="de">Stärke des Kupplers</label>
+                        </variable>
+                        <variable label="Fan Speed" CV="16.0.406" default="31" item="ESU FnOut A17 Slider 11" mask="XXXVVVVV">
+                            <qualifier>
+                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <relation>eq</relation>
+                                <value>23</value>
+                            </qualifier>
+                            <decVal max="31"/>
+                            <label xml:lang="de">Geschwindigkeit</label>
+                        </variable>
+                        <variable label="Standing heat" CV="16.0.406" default="31" item="ESU FnOut A17 Slider 14" mask="XXXVVVVV">
+                            <qualifier>
+                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <relation>eq</relation>
+                                <value>24</value>
+                            </qualifier>
+                            <decVal max="31"/>
+                            <label xml:lang="de">Heizstufe im Stand</label>
+                        </variable>
+                        <variable label="Chuff power" CV="16.0.406" default="31" item="ESU FnOut A17 Slider 8" mask="XXXVVVVV">
+                            <qualifier>
+                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <relation>eq</relation>
+                                <value>25</value>
+                            </qualifier>
+                            <decVal max="31"/>
+                            <label xml:lang="de">Dampfstoßstärke</label>
+                        </variable>
+                        <variable label="Duration (speed) A" CV="16.0.402" default="31" item="ESU FnOut A17 Slider 4" mask="XXVVVVVV">
+                            <qualifier>
+                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <relation>eq</relation>
+                                <value>27</value>
+                            </qualifier>
+                            <decVal max="63"/>
+                            <label xml:lang="de">Dauer (Geschwindigkeit)</label>
+                        </variable>
+                        <variable label="Duration (speed) B" CV="16.0.406" default="31" item="ESU FnOut A17 Slider 17" mask="XXVVVVVV">
+                            <qualifier>
+                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <relation>eq</relation>
+                                <value>27</value>
+                            </qualifier>
+                            <decVal max="63"/>
+                            <label xml:lang="de">Dauer (Geschwindigkeit)</label>
+                        </variable>
+                        <variable item="Special Function CV407" label="Special Function CV 1" CV="16.0.407" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                            <decVal/>
+                        </variable>
+                        <variable label="Fan Acceleration rate" CV="16.0.407" default="0" item="ESU FnOut A17 Slider 12" mask="XXXVVVVV">
+                            <qualifier>
+                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <relation>eq</relation>
+                                <value>23</value>
+                            </qualifier>
+                            <decVal max="31"/>
+                            <label xml:lang="de">Beschleunigungszeit</label>
+                        </variable>
+                        <variable label="Minimum driving heat" CV="16.0.407" default="0" item="ESU FnOut A17 Slider 15" mask="XXXVVVVV">
+                            <qualifier>
+                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <relation>eq</relation>
+                                <value>24</value>
+                            </qualifier>
+                            <decVal max="31"/>
+                            <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
+                        </variable>
+                        <variable label="Position A" CV="16.0.407" default="0" item="ESU FnOut A17 Slider 18" mask="XXVVVVVV">
+                            <qualifier>
+                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <relation>eq</relation>
+                                <value>27</value>
+                            </qualifier>
+                            <decVal max="63"/>
+                        </variable>
+                        <variable label="Fan power" CV="16.0.407" default="0" item="ESU FnOut A17 Slider 9" mask="XXXVVVVV">
+                            <qualifier>
+                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <relation>eq</relation>
+                                <value>25</value>
+                            </qualifier>
+                            <decVal max="31"/>
+                            <label xml:lang="de">Stäke des Bläsers</label>
+                        </variable>
+                        <variable label="Phase Reverse" CV="16.0.407" default="0" item="ESU FnOut A17 Check 6" mask="XXXXXXXV">
+                            <qualifier>
+                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <relation>gt</relation>
+                                <value>0</value>
+                            </qualifier>
+                            <qualifier>
+                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <relation>le</relation>
+                                <value>15</value>
+                            </qualifier>
+                            <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                            <label xml:lang="de">Phase tauschen</label>
+                        </variable>
+                        <variable label="Grade Crossing" CV="16.0.407" default="0" item="ESU FnOut A17 Check 1" mask="XXXXXXVX">
+                            <qualifier>
+                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <relation>gt</relation>
+                                <value>0</value>
+                            </qualifier>
+                            <qualifier>
+                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <relation>le</relation>
+                                <value>15</value>
+                            </qualifier>
+                            <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                        </variable>
+                        <variable label="Rule 17 Fwd" CV="16.0.407" default="0" item="ESU FnOut A17 Check 2" mask="XXXXXVXX">
+                            <qualifier>
+                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <relation>gt</relation>
+                                <value>0</value>
+                            </qualifier>
+                            <qualifier>
+                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <relation>le</relation>
+                                <value>15</value>
+                            </qualifier>
+                            <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                            <label xml:lang="de">Rule 17 vorwärts</label>
+                        </variable>
+                        <variable label="Rule 17 Rev" CV="16.0.407" default="0" item="ESU FnOut A17 Check 3" mask="XXXXVXXX">
+                            <qualifier>
+                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <relation>gt</relation>
+                                <value>0</value>
+                            </qualifier>
+                            <qualifier>
+                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <relation>le</relation>
+                                <value>15</value>
+                            </qualifier>
+                            <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                            <label xml:lang="de">Rule 17 rückwärts</label>
+                        </variable>
+                        <variable label="Dimmer" CV="16.0.407" default="0" item="ESU FnOut A17 Check 4" mask="XXXVXXXX">
+                            <qualifier>
+                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <relation>gt</relation>
+                                <value>0</value>
+                            </qualifier>
+                            <qualifier>
+                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <relation>le</relation>
+                                <value>15</value>
+                            </qualifier>
+                            <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                            <label xml:lang="de">Abdimmen</label>
+                        </variable>
+                        <variable label="LED Mode" CV="16.0.407" default="0" item="ESU FnOut A17 Check 5" mask="VXXXXXXX">
+                            <qualifier>
+                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <relation>gt</relation>
+                                <value>0</value>
+                            </qualifier>
+                            <qualifier>
+                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <relation>le</relation>
+                                <value>15</value>
+                            </qualifier>
+                            <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                            <label xml:lang="de">LED Modus</label>
+                        </variable>
+                        <variable item="Special Function CV408" label="Special Function CV 2" CV="16.0.408" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                            <decVal/>
+                        </variable>
+                        <variable label="Fan Decceleration rate" CV="16.0.408" default="0" item="ESU FnOut A17 Slider 13" mask="XXXVVVVV">
+                            <qualifier>
+                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <relation>eq</relation>
+                                <value>23</value>
+                            </qualifier>
+                            <decVal max="31"/>
+                            <label xml:lang="de">Bremszeit</label>
+                        </variable>
+                        <variable label="Maximum driving heat" CV="16.0.408" default="0" item="ESU FnOut A17 Slider 16" mask="XXXVVVVV">
+                            <qualifier>
+                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <relation>eq</relation>
+                                <value>24</value>
+                            </qualifier>
+                            <decVal max="31"/>
+                            <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
+                        </variable>
+                        <variable label="Timeout" CV="16.0.408" default="0" item="ESU FnOut A17 Slider 10" tooltip="Units = 0.25 sec">
+                            <qualifier>
+                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <relation>eq</relation>
+                                <value>25</value>
+                            </qualifier>
+                            <decVal/>
+                        </variable>
+                        <variable label="Startup Time" CV="16.0.408" default="0" item="ESU FnOut A17 Slider 6">
+                            <qualifier>
+                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <relation>ge</relation>
+                                <value>16</value>
+                            </qualifier>
+                            <qualifier>
+                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <relation>le</relation>
+                                <value>17</value>
+                            </qualifier>
+                            <decVal/>
+                            <label xml:lang="de">Startzeit</label>
+                        </variable>
+                        <variable label="Level" CV="16.0.408" default="0" item="ESU FnOut A17 Slider 20" mask="XVVVVVVV">
+                            <qualifier>
+                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <relation>eq</relation>
+                                <value>19</value>
+                            </qualifier>
+                            <decVal max="127"/>
+                        </variable>
+                        <variable label="Position B" CV="16.0.408" default="0" item="ESU FnOut A17 Slider 19" mask="XXVVVVVV">
+                            <qualifier>
+                                <variableref>ESU FnOut A17 Mode</variableref>
+                                <relation>eq</relation>
+                                <value>27</value>
+                            </qualifier>
+                            <decVal max="63"/>
+                        </variable>
+                        <!-- AUX18 Mode -->
+                        <variable label="AUX18 Mode" CV="16.0.411" default="1" item="ESU FnOut A18 Mode">
+                            <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
+                        </variable>
+                        <variable label="Function Switch On Delay" CV="16.0.412" default="0" item="ESU FnOut A18 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
+                            <qualifier>
+                                <variableref>ESU FnOut A18 Mode</variableref>
+                                <relation>gt</relation>
+                                <value>0</value>
+                            </qualifier>
+                            <decVal max="15"/>
+                            <label xml:lang="de">Verzögerung beim Einschalten</label>
+                        </variable>
+                        <variable label="Function Switch Off Delay" CV="16.0.412" default="0" mask="VVVVXXXX" item="ESU FnOut A18 Slider 2" tooltip="Units = 0.4 sec">
+                            <qualifier>
+                                <variableref>ESU FnOut A18 Mode</variableref>
+                                <relation>gt</relation>
+                                <value>0</value>
+                            </qualifier>
+                            <decVal max="15"/>
+                            <label xml:lang="de">Verzögerung beim Ausschalten</label>
+                        </variable>
+                        <variable label="Function Auto Switch Off" CV="16.0.413" default="0" item="ESU FnOut A18 Slider 3" tooltip="Units = 0.4 sec">
+                            <qualifier>
+                                <variableref>ESU FnOut A18 Mode</variableref>
+                                <relation>gt</relation>
+                                <value>0</value>
+                            </qualifier>
+                            <decVal/>
+                            <label xml:lang="de">Ausgang automatisch Ausschalten</label>
+                        </variable>
+                        <variable item="Brightness CV414" label="Brightness CV" CV="16.0.414" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
+                            <decVal/>
+                        </variable>
+                        <variable label="Brightness" CV="16.0.414" default="31" item="ESU FnOut A18 Slider 5" mask="XXXVVVVV">
+                            <qualifier>
+                                <variableref>ESU FnOut A18 Mode</variableref>
+                                <relation>gt</relation>
+                                <value>0</value>
+                            </qualifier>
+                            <qualifier>
+                                <variableref>ESU FnOut A18 Mode</variableref>
+                                <relation>le</relation>
+                                <value>18</value>
+                            </qualifier>
+                            <decVal max="31"/>
+                            <label xml:lang="de">Helligkeit</label>
+                        </variable>
+                        <variable label="Mode" CV="16.0.414" default="0" item="ESU FnOut A18 Option 1" mask="XXXXXXXV">
+                            <qualifier>
+                                <variableref>ESU FnOut A18 Mode</variableref>
+                                <relation>eq</relation>
+                                <value>22</value>
+                            </qualifier>
+                            <enumVal>
+                                <enumChoice choice="Heating control">
+                                    <choice>Heating control</choice>
+                                    <choice xml:lang="de">Heizungssteuerung</choice>
+                                </enumChoice>
+                                <enumChoice choice="Fan control">
+                                    <choice>Fan control</choice>
+                                    <choice xml:lang="de">Lüftersteuerung</choice>
+                                </enumChoice>
+                            </enumVal>
+                            <label xml:lang="de">Modus</label>
+                        </variable>
+                        <variable label="Coupler Force" CV="16.0.414" default="31" item="ESU FnOut A18 Slider 7" mask="XXXVVVVV">
+                            <qualifier>
+                                <variableref>ESU FnOut A18 Mode</variableref>
+                                <relation>ge</relation>
+                                <value>28</value>
+                            </qualifier>
+                            <qualifier>
+                                <variableref>ESU FnOut A18 Mode</variableref>
+                                <relation>ne</relation>
+                                <value>29</value>
+                            </qualifier>
+                            <qualifier>
+                                <variableref>ESU FnOut A18 Mode</variableref>
+                                <relation>ne</relation>
+                                <value>30</value>
+                            </qualifier>
+                            <qualifier>
+                                <variableref>ESU FnOut A18 Mode</variableref>
+                                <relation>ne</relation>
+                                <value>31</value>
+                            </qualifier>
+                            <qualifier>
+                                <variableref>ESU FnOut A18 Mode</variableref>
+                                <relation>ne</relation>
+                                <value>32</value>
+                            </qualifier>
+                            <qualifier>
+                                <variableref>ESU FnOut A18 Mode</variableref>
+                                <relation>le</relation>
+                                <value>33</value>
+                            </qualifier>
+                            <decVal max="31"/>
+                            <label xml:lang="de">Stärke des Kupplers</label>
+                        </variable>
+                        <variable label="Fan Speed" CV="16.0.414" default="31" item="ESU FnOut A18 Slider 11" mask="XXXVVVVV">
+                            <qualifier>
+                                <variableref>ESU FnOut A18 Mode</variableref>
+                                <relation>eq</relation>
+                                <value>23</value>
+                            </qualifier>
+                            <decVal max="31"/>
+                            <label xml:lang="de">Geschwindigkeit</label>
+                        </variable>
+                        <variable label="Standing heat" CV="16.0.414" default="31" item="ESU FnOut A18 Slider 14" mask="XXXVVVVV">
+                            <qualifier>
+                                <variableref>ESU FnOut A18 Mode</variableref>
+                                <relation>eq</relation>
+                                <value>24</value>
+                            </qualifier>
+                            <decVal max="31"/>
+                            <label xml:lang="de">Heizstufe im Stand</label>
+                        </variable>
+                        <variable label="Chuff power" CV="16.0.414" default="31" item="ESU FnOut A18 Slider 8" mask="XXXVVVVV">
+                            <qualifier>
+                                <variableref>ESU FnOut A18 Mode</variableref>
+                                <relation>eq</relation>
+                                <value>25</value>
+                            </qualifier>
+                            <decVal max="31"/>
+                            <label xml:lang="de">Dampfstoßstärke</label>
+                        </variable>
+                        <variable label="Duration (speed) A" CV="16.0.410" default="31" item="ESU FnOut A18 Slider 4" mask="XXVVVVVV">
+                            <qualifier>
+                                <variableref>ESU FnOut A18 Mode</variableref>
+                                <relation>eq</relation>
+                                <value>27</value>
+                            </qualifier>
+                            <decVal max="63"/>
+                            <label xml:lang="de">Dauer (Geschwindigkeit)</label>
+                        </variable>
+                        <variable label="Duration (speed) B" CV="16.0.414" default="31" item="ESU FnOut A18 Slider 17" mask="XXVVVVVV">
+                            <qualifier>
+                                <variableref>ESU FnOut A18 Mode</variableref>
+                                <relation>eq</relation>
+                                <value>27</value>
+                            </qualifier>
+                            <decVal max="63"/>
+                            <label xml:lang="de">Dauer (Geschwindigkeit)</label>
+                        </variable>
+                        <variable item="Special Function CV415" label="Special Function CV 1" CV="16.0.415" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                            <decVal/>
+                        </variable>
+                        <variable label="Fan Acceleration rate" CV="16.0.415" default="0" item="ESU FnOut A18 Slider 12" mask="XXXVVVVV">
+                            <qualifier>
+                                <variableref>ESU FnOut A18 Mode</variableref>
+                                <relation>eq</relation>
+                                <value>23</value>
+                            </qualifier>
+                            <decVal max="31"/>
+                            <label xml:lang="de">Beschleunigungszeit</label>
+                        </variable>
+                        <variable label="Minimum driving heat" CV="16.0.415" default="0" item="ESU FnOut A18 Slider 15" mask="XXXVVVVV">
+                            <qualifier>
+                                <variableref>ESU FnOut A18 Mode</variableref>
+                                <relation>eq</relation>
+                                <value>24</value>
+                            </qualifier>
+                            <decVal max="31"/>
+                            <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
+                        </variable>
+                        <variable label="Position A" CV="16.0.415" default="0" item="ESU FnOut A18 Slider 18" mask="XXVVVVVV">
+                            <qualifier>
+                                <variableref>ESU FnOut A18 Mode</variableref>
+                                <relation>eq</relation>
+                                <value>27</value>
+                            </qualifier>
+                            <decVal max="63"/>
+                        </variable>
+                        <variable label="Fan power" CV="16.0.415" default="0" item="ESU FnOut A18 Slider 9" mask="XXXVVVVV">
+                            <qualifier>
+                                <variableref>ESU FnOut A18 Mode</variableref>
+                                <relation>eq</relation>
+                                <value>25</value>
+                            </qualifier>
+                            <decVal max="31"/>
+                            <label xml:lang="de">Stäke des Bläsers</label>
+                        </variable>
+                        <variable label="Phase Reverse" CV="16.0.415" default="0" item="ESU FnOut A18 Check 6" mask="XXXXXXXV">
+                            <qualifier>
+                                <variableref>ESU FnOut A18 Mode</variableref>
+                                <relation>gt</relation>
+                                <value>0</value>
+                            </qualifier>
+                            <qualifier>
+                                <variableref>ESU FnOut A18 Mode</variableref>
+                                <relation>le</relation>
+                                <value>15</value>
+                            </qualifier>
+                            <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                            <label xml:lang="de">Phase tauschen</label>
+                        </variable>
+                        <variable label="Grade Crossing" CV="16.0.415" default="0" item="ESU FnOut A18 Check 1" mask="XXXXXXVX">
+                            <qualifier>
+                                <variableref>ESU FnOut A18 Mode</variableref>
+                                <relation>gt</relation>
+                                <value>0</value>
+                            </qualifier>
+                            <qualifier>
+                                <variableref>ESU FnOut A18 Mode</variableref>
+                                <relation>le</relation>
+                                <value>15</value>
+                            </qualifier>
+                            <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                        </variable>
+                        <variable label="Rule 17 Fwd" CV="16.0.415" default="0" item="ESU FnOut A18 Check 2" mask="XXXXXVXX">
+                            <qualifier>
+                                <variableref>ESU FnOut A18 Mode</variableref>
+                                <relation>gt</relation>
+                                <value>0</value>
+                            </qualifier>
+                            <qualifier>
+                                <variableref>ESU FnOut A18 Mode</variableref>
+                                <relation>le</relation>
+                                <value>15</value>
+                            </qualifier>
+                            <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                            <label xml:lang="de">Rule 17 vorwärts</label>
+                        </variable>
+                        <variable label="Rule 17 Rev" CV="16.0.415" default="0" item="ESU FnOut A18 Check 3" mask="XXXXVXXX">
+                            <qualifier>
+                                <variableref>ESU FnOut A18 Mode</variableref>
+                                <relation>gt</relation>
+                                <value>0</value>
+                            </qualifier>
+                            <qualifier>
+                                <variableref>ESU FnOut A18 Mode</variableref>
+                                <relation>le</relation>
+                                <value>15</value>
+                            </qualifier>
+                            <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                            <label xml:lang="de">Rule 17 rückwärts</label>
+                        </variable>
+                        <variable label="Dimmer" CV="16.0.415" default="0" item="ESU FnOut A18 Check 4" mask="XXXVXXXX">
+                            <qualifier>
+                                <variableref>ESU FnOut A18 Mode</variableref>
+                                <relation>gt</relation>
+                                <value>0</value>
+                            </qualifier>
+                            <qualifier>
+                                <variableref>ESU FnOut A18 Mode</variableref>
+                                <relation>le</relation>
+                                <value>15</value>
+                            </qualifier>
+                            <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                            <label xml:lang="de">Abdimmen</label>
+                        </variable>
+                        <variable label="LED Mode" CV="16.0.415" default="0" item="ESU FnOut A18 Check 5" mask="VXXXXXXX">
+                            <qualifier>
+                                <variableref>ESU FnOut A18 Mode</variableref>
+                                <relation>gt</relation>
+                                <value>0</value>
+                            </qualifier>
+                            <qualifier>
+                                <variableref>ESU FnOut A18 Mode</variableref>
+                                <relation>le</relation>
+                                <value>15</value>
+                            </qualifier>
+                            <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+                            <label xml:lang="de">LED Modus</label>
+                        </variable>
+                        <variable item="Special Function CV416" label="Special Function CV 2" CV="16.0.416" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+                            <decVal/>
+                        </variable>
+                        <variable label="Fan Decceleration rate" CV="16.0.416" default="0" item="ESU FnOut A18 Slider 13" mask="XXXVVVVV">
+                            <qualifier>
+                                <variableref>ESU FnOut A18 Mode</variableref>
+                                <relation>eq</relation>
+                                <value>23</value>
+                            </qualifier>
+                            <decVal max="31"/>
+                            <label xml:lang="de">Bremszeit</label>
+                        </variable>
+                        <variable label="Maximum driving heat" CV="16.0.416" default="0" item="ESU FnOut A18 Slider 16" mask="XXXVVVVV">
+                            <qualifier>
+                                <variableref>ESU FnOut A18 Mode</variableref>
+                                <relation>eq</relation>
+                                <value>24</value>
+                            </qualifier>
+                            <decVal max="31"/>
+                            <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
+                        </variable>
+                        <variable label="Timeout" CV="16.0.416" default="0" item="ESU FnOut A18 Slider 10" tooltip="Units = 0.25 sec">
+                            <qualifier>
+                                <variableref>ESU FnOut A18 Mode</variableref>
+                                <relation>eq</relation>
+                                <value>25</value>
+                            </qualifier>
+                            <decVal/>
+                        </variable>
+                        <variable label="Startup Time" CV="16.0.416" default="0" item="ESU FnOut A18 Slider 6">
+                            <qualifier>
+                                <variableref>ESU FnOut A18 Mode</variableref>
+                                <relation>ge</relation>
+                                <value>16</value>
+                            </qualifier>
+                            <qualifier>
+                                <variableref>ESU FnOut A18 Mode</variableref>
+                                <relation>le</relation>
+                                <value>17</value>
+                            </qualifier>
+                            <decVal/>
+                            <label xml:lang="de">Startzeit</label>
+                        </variable>
+                        <variable label="Level" CV="16.0.416" default="0" item="ESU FnOut A18 Slider 20" mask="XVVVVVVV">
+                            <qualifier>
+                                <variableref>ESU FnOut A18 Mode</variableref>
+                                <relation>eq</relation>
+                                <value>19</value>
+                            </qualifier>
+                            <decVal max="127"/>
+                        </variable>
+                        <variable label="Position B" CV="16.0.416" default="0" item="ESU FnOut A18 Slider 19" mask="XXVVVVVV">
+                            <qualifier>
+                                <variableref>ESU FnOut A18 Mode</variableref>
+                                <relation>eq</relation>
+                                <value>27</value>
+                            </qualifier>
+                            <decVal max="63"/>
+                        </variable>
                     </variables>
                 </variables>
             </variables>
@@ -7170,314 +7180,311 @@
 	    </qualifier>
 	    <decVal max="127"/>
 	</variable>
-        <!-- exclude AUX2 [2] -->
-	<variables exclude="LokSound 5 DCC Direct Atlas S2">
-            <!-- AUX2 [2] Mode -->
-            <variable label="AUX2 [2] Mode" CV="16.0.443" default="1" item="ESU FnOut A2-2 Mode">
-	        <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
-	    </variable>
-	    <variable label="Function Switch On Delay" CV="16.0.444" default="0" item="ESU FnOut A2-2 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
-	        <qualifier>
-		    <variableref>ESU FnOut A2-2 Mode</variableref>
-		    <relation>gt</relation>
-		    <value>0</value>
-	        </qualifier>
-	        <qualifier>
-		    <variableref>ESU FnOut A2-2 Mode</variableref>
-		    <relation>ne</relation>
-		    <value>27</value>
-	        </qualifier>
-	        <decVal max="15"/>
-	        <label xml:lang="de">Verzögerung beim Einschalten</label>
-	    </variable>
-	    <variable label="Function Switch Off Delay" CV="16.0.444" default="0" mask="VVVVXXXX" item="ESU FnOut A2-2 Slider 2" tooltip="Units = 0.4 sec">
-	        <qualifier>
-		    <variableref>ESU FnOut A2-2 Mode</variableref>
-		    <relation>gt</relation>
-		    <value>0</value>
-	        </qualifier>
-	        <qualifier>
-		    <variableref>ESU FnOut A2-2 Mode</variableref>
-		    <relation>ne</relation>
-		    <value>27</value>
-	        </qualifier>
-	        <decVal max="15"/>
-	        <label xml:lang="de">Verzögerung beim Ausschalten</label>
-	    </variable>
-	    <variable label="Function Auto Switch Off" CV="16.0.445" default="0" item="ESU FnOut A2-2 Slider 3" tooltip="Units = 0.4 sec">
-	        <qualifier>
-		    <variableref>ESU FnOut A2-2 Mode</variableref>
-		    <relation>gt</relation>
-		    <value>0</value>
-	        </qualifier>
-	        <qualifier>
-		    <variableref>ESU FnOut A2-2 Mode</variableref>
-		    <relation>ne</relation>
-		    <value>27</value>
-	        </qualifier>
-	        <decVal/>
-	        <label xml:lang="de">Ausgang automatisch Ausschalten</label>
-	    </variable>
-	    <variable item="Brightness CV446" label="Brightness CV" CV="16.0.446" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
-	        <decVal/>
-	    </variable>
-	    <variable label="Brightness" CV="16.0.446" default="31" item="ESU FnOut A2-2 Slider 5" mask="XXXVVVVV">
-	        <qualifier>
-		    <variableref>ESU FnOut A2-2 Mode</variableref>
-		    <relation>gt</relation>
-		    <value>0</value>
-	        </qualifier>
-	        <qualifier>
-		    <variableref>ESU FnOut A2-2 Mode</variableref>
-		    <relation>le</relation>
-		    <value>18</value>
-	        </qualifier>
-	        <decVal max="31"/>
-	        <label xml:lang="de">Helligkeit</label>
-	    </variable>
-	    <variable label="Mode" CV="16.0.446" default="0" item="ESU FnOut A2-2 Option 1" mask="XXXXXXXV">
-	        <qualifier>
-		    <variableref>ESU FnOut A2-2 Mode</variableref>
-		    <relation>eq</relation>
-		    <value>22</value>
-	        </qualifier>
-	        <enumVal>
-		    <enumChoice choice="Heating control">
-		        <choice>Heating control</choice>
-		        <choice xml:lang="de">Heizungssteuerung</choice>
-		    </enumChoice>
-		    <enumChoice choice="Fan control">
-		        <choice>Fan control</choice>
-		        <choice xml:lang="de">Lüftersteuerung</choice>
-		    </enumChoice>
-	        </enumVal>
-	        <label xml:lang="de">Modus</label>
-	    </variable>
-	    <variable label="Coupler Force" CV="16.0.446" default="31" item="ESU FnOut A2-2 Slider 7" mask="XXXVVVVV">
-	        <qualifier>
-		    <variableref>ESU FnOut A2-2 Mode</variableref>
-		    <relation>ge</relation>
-		    <value>28</value>
-	        </qualifier>
-	        <qualifier>
-		    <variableref>ESU FnOut A2-2 Mode</variableref>
-		    <relation>ne</relation>
-		    <value>29</value>
-	        </qualifier>
-	        <qualifier>
-		    <variableref>ESU FnOut A2-2 Mode</variableref>
-		    <relation>ne</relation>
-		    <value>30</value>
-	        </qualifier>
-	        <qualifier>
-		    <variableref>ESU FnOut A2-2 Mode</variableref>
-		    <relation>ne</relation>
-		    <value>31</value>
-	        </qualifier>
-	        <qualifier>
-		    <variableref>ESU FnOut A2-2 Mode</variableref>
-		    <relation>ne</relation>
-		    <value>32</value>
-	        </qualifier>
-	        <qualifier>
-		    <variableref>ESU FnOut A2-2 Mode</variableref>
-		    <relation>le</relation>
-		    <value>33</value>
-	        </qualifier>
-	        <decVal max="31"/>
-	        <label xml:lang="de">Stärke des Kupplers</label>
-	    </variable>
-	    <variable label="Fan Speed" CV="16.0.446" default="31" item="ESU FnOut A2-2 Slider 11" mask="XXXVVVVV">
-	        <qualifier>
-		    <variableref>ESU FnOut A2-2 Mode</variableref>
-		    <relation>eq</relation>
-		    <value>23</value>
-	        </qualifier>
-	        <decVal max="31"/>
-	        <label xml:lang="de">Geschwindigkeit</label>
-	    </variable>
-	    <variable label="Standing heat" CV="16.0.446" default="31" item="ESU FnOut A2-2 Slider 14" mask="XXXVVVVV">
-	        <qualifier>
-		    <variableref>ESU FnOut A2-2 Mode</variableref>
-		    <relation>eq</relation>
-		    <value>24</value>
-	        </qualifier>
-	        <decVal max="31"/>
-	        <label xml:lang="de">Heizstufe im Stand</label>
-	    </variable>
-	    <variable label="Chuff power" CV="16.0.446" default="31" item="ESU FnOut A2-2 Slider 8" mask="XXXVVVVV">
-	        <qualifier>
-		    <variableref>ESU FnOut A2-2 Mode</variableref>
-		    <relation>eq</relation>
-		    <value>25</value>
-	        </qualifier>
-	        <decVal max="31"/>
-	        <label xml:lang="de">Dampfstoßstärke</label>
-	    </variable>
-	    <variable item="Special Function CV447" label="Special Function CV 1" CV="16.0.447" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
-	        <decVal/>
-	    </variable>
-	    <variable label="Fan Acceleration rate" CV="16.0.447" default="0" item="ESU FnOut A2-2 Slider 12" mask="XXXVVVVV">
-	        <qualifier>
-		    <variableref>ESU FnOut A2-2 Mode</variableref>
-		    <relation>eq</relation>
-		    <value>23</value>
-	        </qualifier>
-	        <decVal max="31"/>
-	        <label xml:lang="de">Beschleunigungszeit</label>
-	    </variable>
-	    <variable label="Minimum driving heat" CV="16.0.447" default="0" item="ESU FnOut A2-2 Slider 15" mask="XXXVVVVV">
-	        <qualifier>
-		    <variableref>ESU FnOut A2-2 Mode</variableref>
-		    <relation>eq</relation>
-		    <value>24</value>
-	        </qualifier>
-	        <decVal max="31"/>
-	        <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
-	    </variable>
-	    <variable label="Fan power" CV="16.0.447" default="0" item="ESU FnOut A2-2 Slider 9" mask="XXXVVVVV">
-	        <qualifier>
-		    <variableref>ESU FnOut A2-2 Mode</variableref>
-		    <relation>eq</relation>
-		    <value>25</value>
-	        </qualifier>
-	        <decVal max="31"/>
-	        <label xml:lang="de">Stäke des Bläsers</label>
-	    </variable>
-	    <variable label="Phase Reverse" CV="16.0.447" default="0" item="ESU FnOut A2-2 Check 6" mask="XXXXXXXV">
-	        <qualifier>
-		    <variableref>ESU FnOut A2-2 Mode</variableref>
-		    <relation>gt</relation>
-		    <value>0</value>
-	        </qualifier>
-	        <qualifier>
-		    <variableref>ESU FnOut A2-2 Mode</variableref>
-		    <relation>le</relation>
-		    <value>15</value>
-	        </qualifier>
-	        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-	        <label xml:lang="de">Phase tauschen</label>
-	    </variable>
-	    <variable label="Grade Crossing" CV="16.0.447" default="0" item="ESU FnOut A2-2 Check 1" mask="XXXXXXVX">
-	        <qualifier>
-		    <variableref>ESU FnOut A2-2 Mode</variableref>
-		    <relation>gt</relation>
-		    <value>0</value>
-	        </qualifier>
-	        <qualifier>
-		    <variableref>ESU FnOut A2-2 Mode</variableref>
-		    <relation>le</relation>
-		    <value>15</value>
-	        </qualifier>
-	        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-	    </variable>
-	    <variable label="Rule 17 Fwd" CV="16.0.447" default="0" item="ESU FnOut A2-2 Check 2" mask="XXXXXVXX">
-	        <qualifier>
-		    <variableref>ESU FnOut A2-2 Mode</variableref>
-		    <relation>gt</relation>
-		    <value>0</value>
-	        </qualifier>
-	        <qualifier>
-		    <variableref>ESU FnOut A2-2 Mode</variableref>
-		    <relation>le</relation>
-		    <value>15</value>
-	        </qualifier>
-	        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-	        <label xml:lang="de">Rule 17 vorwärts</label>
-	    </variable>
-	    <variable label="Rule 17 Rev" CV="16.0.447" default="0" item="ESU FnOut A2-2 Check 3" mask="XXXXVXXX">
-	        <qualifier>
-		    <variableref>ESU FnOut A2-2 Mode</variableref>
-		    <relation>gt</relation>
-		    <value>0</value>
-	        </qualifier>
-	        <qualifier>
-		    <variableref>ESU FnOut A2-2 Mode</variableref>
-		    <relation>le</relation>
-		    <value>15</value>
-	        </qualifier>
-	        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-	        <label xml:lang="de">Rule 17 rückwärts</label>
-	    </variable>
-	    <variable label="Dimmer" CV="16.0.447" default="0" item="ESU FnOut A2-2 Check 4" mask="XXXVXXXX">
-	        <qualifier>
-		    <variableref>ESU FnOut A2-2 Mode</variableref>
-		    <relation>gt</relation>
-		    <value>0</value>
-	        </qualifier>
-	        <qualifier>
-		    <variableref>ESU FnOut A2-2 Mode</variableref>
-		    <relation>le</relation>
-		    <value>15</value>
-	        </qualifier>
-	        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-	        <label xml:lang="de">Abdimmen</label>
-	    </variable>
-	    <variable label="LED Mode" CV="16.0.447" default="0" item="ESU FnOut A2-2 Check 5" mask="VXXXXXXX">
-	        <qualifier>
-		    <variableref>ESU FnOut A2-2 Mode</variableref>
-		    <relation>gt</relation>
-		    <value>0</value>
-	        </qualifier>
-	        <qualifier>
-		    <variableref>ESU FnOut A2-2 Mode</variableref>
-		    <relation>le</relation>
-		    <value>15</value>
-	        </qualifier>
-	        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-	        <label xml:lang="de">LED Modus</label>
-	    </variable>
-	    <variable item="Special Function CV448" label="Special Function CV 2" CV="16.0.448" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
-	        <decVal/>
-	    </variable>
-	    <variable label="Fan Decceleration rate" CV="16.0.448" default="0" item="ESU FnOut A2-2 Slider 13" mask="XXXVVVVV">
-	        <qualifier>
-		    <variableref>ESU FnOut A2-2 Mode</variableref>
-		    <relation>eq</relation>
-		    <value>23</value>
-	        </qualifier>
-	        <decVal max="31"/>
-	        <label xml:lang="de">Bremszeit</label>
-	    </variable>
-	    <variable label="Maximum driving heat" CV="16.0.448" default="0" item="ESU FnOut A2-2 Slider 16" mask="XXXVVVVV">
-	        <qualifier>
-		    <variableref>ESU FnOut A2-2 Mode</variableref>
-		    <relation>eq</relation>
-		    <value>24</value>
-	        </qualifier>
-	        <decVal max="31"/>
-	        <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
-	    </variable>
-	    <variable label="Timeout" CV="16.0.448" default="0" item="ESU FnOut A2-2 Slider 10" tooltip="Units = 0.25 sec">
-	        <qualifier>
-		    <variableref>ESU FnOut A2-2 Mode</variableref>
-		    <relation>eq</relation>
-		    <value>25</value>
-	        </qualifier>
-	        <decVal/>
-	    </variable>
-	    <variable label="Startup Time" CV="16.0.448" default="0" item="ESU FnOut A2-2 Slider 6">
-	        <qualifier>
-		    <variableref>ESU FnOut A2-2 Mode</variableref>
-		    <relation>ge</relation>
-		    <value>16</value>
-	        </qualifier>
-	        <qualifier>
-		    <variableref>ESU FnOut A2-2 Mode</variableref>
-		    <relation>le</relation>
-		    <value>17</value>
-	        </qualifier>
-	        <decVal/>
-	        <label xml:lang="de">Startzeit</label>
-	    </variable>
-	    <variable label="Level" CV="16.0.448" default="0" item="ESU FnOut A2-2 Slider 20" mask="XVVVVVVV">
-	        <qualifier>
-		    <variableref>ESU FnOut A2-2 Mode</variableref>
-		    <relation>eq</relation>
-		    <value>19</value>
-	        </qualifier>
-	        <decVal max="127"/>
-	    </variable>
-        </variables>
+	<!-- AUX2 [2] Mode -->
+	<variable label="AUX2 [2] Mode" CV="16.0.443" default="1" item="ESU FnOut A2-2 Mode">
+	    <xi:include href="http://jmri.org/xml/decoders/esu/v4lightEnum.xml"/>
+	</variable>
+	<variable label="Function Switch On Delay" CV="16.0.444" default="0" item="ESU FnOut A2-2 Slider 1" tooltip="Units = 0.4 sec" mask="XXXXVVVV">
+	    <qualifier>
+		<variableref>ESU FnOut A2-2 Mode</variableref>
+		<relation>gt</relation>
+		<value>0</value>
+	    </qualifier>
+	    <qualifier>
+		<variableref>ESU FnOut A2-2 Mode</variableref>
+		<relation>ne</relation>
+		<value>27</value>
+	    </qualifier>
+	    <decVal max="15"/>
+	    <label xml:lang="de">Verzögerung beim Einschalten</label>
+	</variable>
+	<variable label="Function Switch Off Delay" CV="16.0.444" default="0" mask="VVVVXXXX" item="ESU FnOut A2-2 Slider 2" tooltip="Units = 0.4 sec">
+	    <qualifier>
+		<variableref>ESU FnOut A2-2 Mode</variableref>
+		<relation>gt</relation>
+		<value>0</value>
+	    </qualifier>
+	    <qualifier>
+		<variableref>ESU FnOut A2-2 Mode</variableref>
+		<relation>ne</relation>
+		<value>27</value>
+	    </qualifier>
+	    <decVal max="15"/>
+	    <label xml:lang="de">Verzögerung beim Ausschalten</label>
+	</variable>
+	<variable label="Function Auto Switch Off" CV="16.0.445" default="0" item="ESU FnOut A2-2 Slider 3" tooltip="Units = 0.4 sec">
+	    <qualifier>
+		<variableref>ESU FnOut A2-2 Mode</variableref>
+		<relation>gt</relation>
+		<value>0</value>
+	    </qualifier>
+	    <qualifier>
+		<variableref>ESU FnOut A2-2 Mode</variableref>
+		<relation>ne</relation>
+		<value>27</value>
+	    </qualifier>
+	    <decVal/>
+	    <label xml:lang="de">Ausgang automatisch Ausschalten</label>
+	</variable>
+	<variable item="Brightness CV446" label="Brightness CV" CV="16.0.446" default="31" comment="Dummy to work around sheet operations/qualifiers issue">
+	    <decVal/>
+	</variable>
+	<variable label="Brightness" CV="16.0.446" default="31" item="ESU FnOut A2-2 Slider 5" mask="XXXVVVVV">
+	    <qualifier>
+		<variableref>ESU FnOut A2-2 Mode</variableref>
+		<relation>gt</relation>
+		<value>0</value>
+	    </qualifier>
+	    <qualifier>
+		<variableref>ESU FnOut A2-2 Mode</variableref>
+		<relation>le</relation>
+		<value>18</value>
+	    </qualifier>
+	    <decVal max="31"/>
+	    <label xml:lang="de">Helligkeit</label>
+	</variable>
+	<variable label="Mode" CV="16.0.446" default="0" item="ESU FnOut A2-2 Option 1" mask="XXXXXXXV">
+	    <qualifier>
+		<variableref>ESU FnOut A2-2 Mode</variableref>
+		<relation>eq</relation>
+		<value>22</value>
+	    </qualifier>
+	    <enumVal>
+		<enumChoice choice="Heating control">
+		    <choice>Heating control</choice>
+		    <choice xml:lang="de">Heizungssteuerung</choice>
+		</enumChoice>
+		<enumChoice choice="Fan control">
+		    <choice>Fan control</choice>
+		    <choice xml:lang="de">Lüftersteuerung</choice>
+		</enumChoice>
+	    </enumVal>
+	    <label xml:lang="de">Modus</label>
+	</variable>
+	<variable label="Coupler Force" CV="16.0.446" default="31" item="ESU FnOut A2-2 Slider 7" mask="XXXVVVVV">
+	    <qualifier>
+		<variableref>ESU FnOut A2-2 Mode</variableref>
+		<relation>ge</relation>
+		<value>28</value>
+	    </qualifier>
+	    <qualifier>
+		<variableref>ESU FnOut A2-2 Mode</variableref>
+		<relation>ne</relation>
+		<value>29</value>
+	    </qualifier>
+	    <qualifier>
+		<variableref>ESU FnOut A2-2 Mode</variableref>
+		<relation>ne</relation>
+		<value>30</value>
+	    </qualifier>
+	    <qualifier>
+		<variableref>ESU FnOut A2-2 Mode</variableref>
+		<relation>ne</relation>
+		<value>31</value>
+	    </qualifier>
+	    <qualifier>
+		<variableref>ESU FnOut A2-2 Mode</variableref>
+		<relation>ne</relation>
+		<value>32</value>
+	    </qualifier>
+	    <qualifier>
+		<variableref>ESU FnOut A2-2 Mode</variableref>
+		<relation>le</relation>
+		<value>33</value>
+	    </qualifier>
+	    <decVal max="31"/>
+	    <label xml:lang="de">Stärke des Kupplers</label>
+	</variable>
+	<variable label="Fan Speed" CV="16.0.446" default="31" item="ESU FnOut A2-2 Slider 11" mask="XXXVVVVV">
+	    <qualifier>
+		<variableref>ESU FnOut A2-2 Mode</variableref>
+		<relation>eq</relation>
+		<value>23</value>
+	    </qualifier>
+	    <decVal max="31"/>
+	    <label xml:lang="de">Geschwindigkeit</label>
+	</variable>
+	<variable label="Standing heat" CV="16.0.446" default="31" item="ESU FnOut A2-2 Slider 14" mask="XXXVVVVV">
+	    <qualifier>
+		<variableref>ESU FnOut A2-2 Mode</variableref>
+		<relation>eq</relation>
+		<value>24</value>
+	    </qualifier>
+	    <decVal max="31"/>
+	    <label xml:lang="de">Heizstufe im Stand</label>
+	</variable>
+	<variable label="Chuff power" CV="16.0.446" default="31" item="ESU FnOut A2-2 Slider 8" mask="XXXVVVVV">
+	    <qualifier>
+		<variableref>ESU FnOut A2-2 Mode</variableref>
+		<relation>eq</relation>
+		<value>25</value>
+	    </qualifier>
+	    <decVal max="31"/>
+	    <label xml:lang="de">Dampfstoßstärke</label>
+	</variable>
+	<variable item="Special Function CV447" label="Special Function CV 1" CV="16.0.447" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+	    <decVal/>
+	</variable>
+	<variable label="Fan Acceleration rate" CV="16.0.447" default="0" item="ESU FnOut A2-2 Slider 12" mask="XXXVVVVV">
+	    <qualifier>
+		<variableref>ESU FnOut A2-2 Mode</variableref>
+		<relation>eq</relation>
+		<value>23</value>
+	    </qualifier>
+	    <decVal max="31"/>
+	    <label xml:lang="de">Beschleunigungszeit</label>
+	</variable>
+	<variable label="Minimum driving heat" CV="16.0.447" default="0" item="ESU FnOut A2-2 Slider 15" mask="XXXVVVVV">
+	    <qualifier>
+		<variableref>ESU FnOut A2-2 Mode</variableref>
+		<relation>eq</relation>
+		<value>24</value>
+	    </qualifier>
+	    <decVal max="31"/>
+	    <label xml:lang="de">Minimale Heizstufe bei Fahrt</label>
+	</variable>
+	<variable label="Fan power" CV="16.0.447" default="0" item="ESU FnOut A2-2 Slider 9" mask="XXXVVVVV">
+	    <qualifier>
+		<variableref>ESU FnOut A2-2 Mode</variableref>
+		<relation>eq</relation>
+		<value>25</value>
+	    </qualifier>
+	    <decVal max="31"/>
+	    <label xml:lang="de">Stäke des Bläsers</label>
+	</variable>
+	<variable label="Phase Reverse" CV="16.0.447" default="0" item="ESU FnOut A2-2 Check 6" mask="XXXXXXXV">
+	    <qualifier>
+		<variableref>ESU FnOut A2-2 Mode</variableref>
+		<relation>gt</relation>
+		<value>0</value>
+	    </qualifier>
+	    <qualifier>
+		<variableref>ESU FnOut A2-2 Mode</variableref>
+		<relation>le</relation>
+		<value>15</value>
+	    </qualifier>
+	    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+	    <label xml:lang="de">Phase tauschen</label>
+	</variable>
+	<variable label="Grade Crossing" CV="16.0.447" default="0" item="ESU FnOut A2-2 Check 1" mask="XXXXXXVX">
+	    <qualifier>
+		<variableref>ESU FnOut A2-2 Mode</variableref>
+		<relation>gt</relation>
+		<value>0</value>
+	    </qualifier>
+	    <qualifier>
+		<variableref>ESU FnOut A2-2 Mode</variableref>
+		<relation>le</relation>
+		<value>15</value>
+	    </qualifier>
+	    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+	</variable>
+	<variable label="Rule 17 Fwd" CV="16.0.447" default="0" item="ESU FnOut A2-2 Check 2" mask="XXXXXVXX">
+	    <qualifier>
+		<variableref>ESU FnOut A2-2 Mode</variableref>
+		<relation>gt</relation>
+		<value>0</value>
+	    </qualifier>
+	    <qualifier>
+		<variableref>ESU FnOut A2-2 Mode</variableref>
+		<relation>le</relation>
+		<value>15</value>
+	    </qualifier>
+	    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+	    <label xml:lang="de">Rule 17 vorwärts</label>
+	</variable>
+	<variable label="Rule 17 Rev" CV="16.0.447" default="0" item="ESU FnOut A2-2 Check 3" mask="XXXXVXXX">
+	    <qualifier>
+		<variableref>ESU FnOut A2-2 Mode</variableref>
+		<relation>gt</relation>
+		<value>0</value>
+	    </qualifier>
+	    <qualifier>
+		<variableref>ESU FnOut A2-2 Mode</variableref>
+		<relation>le</relation>
+		<value>15</value>
+	    </qualifier>
+	    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+	    <label xml:lang="de">Rule 17 rückwärts</label>
+	</variable>
+	<variable label="Dimmer" CV="16.0.447" default="0" item="ESU FnOut A2-2 Check 4" mask="XXXVXXXX">
+	    <qualifier>
+		<variableref>ESU FnOut A2-2 Mode</variableref>
+		<relation>gt</relation>
+		<value>0</value>
+	    </qualifier>
+	    <qualifier>
+		<variableref>ESU FnOut A2-2 Mode</variableref>
+		<relation>le</relation>
+		<value>15</value>
+	    </qualifier>
+	    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+	    <label xml:lang="de">Abdimmen</label>
+	</variable>
+	<variable label="LED Mode" CV="16.0.447" default="0" item="ESU FnOut A2-2 Check 5" mask="VXXXXXXX">
+	    <qualifier>
+		<variableref>ESU FnOut A2-2 Mode</variableref>
+		<relation>gt</relation>
+		<value>0</value>
+	    </qualifier>
+	    <qualifier>
+		<variableref>ESU FnOut A2-2 Mode</variableref>
+		<relation>le</relation>
+		<value>15</value>
+	    </qualifier>
+	    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+	    <label xml:lang="de">LED Modus</label>
+	</variable>
+	<variable item="Special Function CV448" label="Special Function CV 2" CV="16.0.448" default="0" comment="Dummy to work around sheet operations/qualifiers issue">
+	    <decVal/>
+	</variable>
+	<variable label="Fan Decceleration rate" CV="16.0.448" default="0" item="ESU FnOut A2-2 Slider 13" mask="XXXVVVVV">
+	    <qualifier>
+		<variableref>ESU FnOut A2-2 Mode</variableref>
+		<relation>eq</relation>
+		<value>23</value>
+	    </qualifier>
+	    <decVal max="31"/>
+	    <label xml:lang="de">Bremszeit</label>
+	</variable>
+	<variable label="Maximum driving heat" CV="16.0.448" default="0" item="ESU FnOut A2-2 Slider 16" mask="XXXVVVVV">
+	    <qualifier>
+		<variableref>ESU FnOut A2-2 Mode</variableref>
+		<relation>eq</relation>
+		<value>24</value>
+	    </qualifier>
+	    <decVal max="31"/>
+	    <label xml:lang="de">Maximale Heizstufe bei Fahrt</label>
+	</variable>
+	<variable label="Timeout" CV="16.0.448" default="0" item="ESU FnOut A2-2 Slider 10" tooltip="Units = 0.25 sec">
+	    <qualifier>
+		<variableref>ESU FnOut A2-2 Mode</variableref>
+		<relation>eq</relation>
+		<value>25</value>
+	    </qualifier>
+	    <decVal/>
+	</variable>
+	<variable label="Startup Time" CV="16.0.448" default="0" item="ESU FnOut A2-2 Slider 6">
+	    <qualifier>
+		<variableref>ESU FnOut A2-2 Mode</variableref>
+		<relation>ge</relation>
+		<value>16</value>
+	    </qualifier>
+	    <qualifier>
+		<variableref>ESU FnOut A2-2 Mode</variableref>
+		<relation>le</relation>
+		<value>17</value>
+	    </qualifier>
+	    <decVal/>
+	    <label xml:lang="de">Startzeit</label>
+	</variable>
+	<variable label="Level" CV="16.0.448" default="0" item="ESU FnOut A2-2 Slider 20" mask="XVVVVVVV">
+	    <qualifier>
+		<variableref>ESU FnOut A2-2 Mode</variableref>
+		<relation>eq</relation>
+		<value>19</value>
+	    </qualifier>
+	    <decVal max="127"/>
+	</variable>
     </variables>
 </variables>

--- a/xml/decoders/esu/v5standardCVs.xml
+++ b/xml/decoders/esu/v5standardCVs.xml
@@ -1059,7 +1059,7 @@
     <xi:include href="http://jmri.org/xml/decoders/esu/v5randFuncCVs.xml"/>
     <!-- begin SUSI variables -->
     <!-- note that the exclusions below must be copied to xml/decoders/esu/susiMapPane.xml -->
-    <variables exclude="Essential Sound Unit,LokPilot 5 Fx micro,LokPilot 5 Fx micro DCC,LokPilot 5 micro,LokPilot 5 micro DCC,LokSound 5 micro DCC Direct">
+    <variables exclude="Essential Sound Unit,LokPilot 5 Fx micro,LokPilot 5 Fx micro DCC,LokPilot 5 micro,LokPilot 5 micro DCC,LokPilot 5 micro DCC Direct,LokSound 5 micro DCC Direct,LokSound 5 micro DCC Direct Atlas Legacy,LokSound 5 micro DCC Direct Atlas S2">
         <variable CV="124" mask="XXXXVXXX" default="0" item="ESU V4 Compatibility SUSI">
             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
             <label>Serial User Standard Interface (SUSI Master)</label>


### PR DESCRIPTION
- Added LokPilot 5 micro DCC Direct, LokPilot 5 nano DCC, LokSound 5 micro DCC Direct Atlas S2 and LokSound 5 nano DCC Next18 (untested, don't have the hardware)
- Added a few productIDs to LokPilot 5 L and LokPilot 5 L DCC
- Moved LokSound 5 micro DCC Direct Atlas Legacy definition to match LokProgrammer decoder order
- Removed SUSI function configuration from LokSound 5 micro DCC Direct Atlas Legacy

Should fix #13190 from the JMRI decoder definition side. I believe there's more to rick77337's troubles than just a missing decoder definition, however...

With this PR, all the LokSound 5s and LokPilot 5s in the current-as-of-today LokProgrammer 5.2.9 should be detected and work reasonably well with JMRI with the exception of the LokPilot 5 Basic, which seems to be a totally different beast from all the others.

Note to reviewers: The v5fnOutCVs.xml diff is mostly re-indenting...