### PR TITLE
Tests - null check new instances

### DIFF
--- a/java/test/jmri/implementation/DefaultLogixTest.java
+++ b/java/test/jmri/implementation/DefaultLogixTest.java
@@ -21,13 +21,13 @@ public class DefaultLogixTest extends NamedBeanTest {
     }
 
     @Test
-    public void testCtorDouble() {
-        new DefaultLogix("IX 1", "IX 1 user name");
+    public void testDefaultLogixCtorDouble() {
+        Assertions.assertNotNull( new DefaultLogix("IX 1", "IX 1 user name") );
     }
 
     @Test
-    public void testCtorSingle() {
-        new DefaultLogix("IX 2");
+    public void testDefaultLogixCtorSingle() {
+        Assertions.assertNotNull( new DefaultLogix("IX 2") );
     }
 
     @Test
@@ -45,7 +45,6 @@ public class DefaultLogixTest extends NamedBeanTest {
     @BeforeEach
     public void setUp() throws Exception {
         jmri.util.JUnitUtil.setUp();
-        jmri.util.JUnitUtil.resetInstanceManager();
         jmri.util.JUnitUtil.initInternalTurnoutManager();
         jmri.util.JUnitUtil.initInternalSensorManager();
     }

--- a/java/test/jmri/jmrit/automat/AutomatTest.java
+++ b/java/test/jmri/jmrit/automat/AutomatTest.java
@@ -12,13 +12,12 @@ import org.junit.Assert;
  */
 public class AutomatTest {
 
-    boolean initDone;
-    boolean handleDone;
+    private boolean initDone;
+    private boolean handleDone;
 
     @Test
     public void testCreate() {
-        new AbstractAutomaton() {
-        };
+        Assertions.assertNotNull( new AbstractAutomaton() {} );
     }
 
     @Test

--- a/java/test/jmri/jmrit/blockboss/BlockBossLogicTest.java
+++ b/java/test/jmri/jmrit/blockboss/BlockBossLogicTest.java
@@ -7,9 +7,7 @@ import jmri.SignalHead;
 import jmri.Turnout;
 import jmri.util.JUnitUtil;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -178,21 +176,19 @@ public class BlockBossLogicTest {
     // check for basic not-fail if no signal name was set
     @Test
     public void testSimpleBlockNoSignal() {
-        try {
-            new BlockBossLogic(null);
-        } catch (java.lang.NullPointerException e) {
-            // this is expected
-        }
+        Exception ex = Assertions.assertThrows(NullPointerException.class, () -> {
+            Assertions.assertNull(new BlockBossLogic(null));});
+        Assertions.assertNotNull(ex);
+        Assertions.assertEquals("BlockBossLogic name cannot be null", ex.getMessage());
     }
 
     // check for basic not-fail if empty signal name was set
     @Test
     public void testSimpleBlockEmptyName() {
-        try {
-            new BlockBossLogic("");
-        } catch (java.lang.IllegalArgumentException e) {
-            // this is expected
-        }
+        Exception ex = Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            Assertions.assertNull(new BlockBossLogic(""));});
+        Assertions.assertNotNull(ex);
+        Assertions.assertEquals("SignalHead \"\" does not exist", ex.getMessage());
         jmri.util.JUnitAppender.assertWarnMessage("Signal Head \"\" was not found");
     }
 

--- a/java/test/jmri/jmrit/revhistory/FileHistoryTest.java
+++ b/java/test/jmri/jmrit/revhistory/FileHistoryTest.java
@@ -14,7 +14,7 @@ public class FileHistoryTest{
 
     @Test
     public void testCtor() {
-        new FileHistory();
+        Assertions.assertNotNull( new FileHistory() );
     }
 
     @Test

--- a/java/test/jmri/jmrit/sample/SampleFunctionalClassTest.java
+++ b/java/test/jmri/jmrit/sample/SampleFunctionalClassTest.java
@@ -12,13 +12,12 @@ public class SampleFunctionalClassTest {
     @Test
     // test creation
     public void testCreate() {
-        new SampleFunctionalClass("foo");
+        Assertions.assertNotNull( new SampleFunctionalClass("foo") );
     }
 
     @BeforeEach
     public void setUp() {
         jmri.util.JUnitUtil.setUp();
-        jmri.util.JUnitUtil.resetInstanceManager();
         jmri.util.JUnitUtil.resetProfileManager();
         jmri.util.JUnitUtil.initConfigureManager();
     }

--- a/java/test/jmri/jmrit/sample/configurexml/SampleFunctionalClassXmlTest.java
+++ b/java/test/jmri/jmrit/sample/configurexml/SampleFunctionalClassXmlTest.java
@@ -12,7 +12,7 @@ public class SampleFunctionalClassXmlTest {
     @Test
     // test creation
     public void testCreate() {
-        new SampleFunctionalClassXml();
+        Assertions.assertNotNull( new SampleFunctionalClassXml() );
     }
 
     @BeforeEach

--- a/java/test/jmri/jmrit/sample/swing/SampleConfigPaneTest.java
+++ b/java/test/jmri/jmrit/sample/swing/SampleConfigPaneTest.java
@@ -12,7 +12,7 @@ public class SampleConfigPaneTest {
     @Test
     // test creation
     public void testCreate() {
-        new SampleConfigPane();
+        Assertions.assertNotNull( new SampleConfigPane() );
     }
 
     @BeforeEach

--- a/java/test/jmri/jmrit/sample/swing/SampleConfigStartUpActionFactoryTest.java
+++ b/java/test/jmri/jmrit/sample/swing/SampleConfigStartUpActionFactoryTest.java
@@ -12,7 +12,7 @@ public class SampleConfigStartUpActionFactoryTest {
     @Test
     // test creation
     public void testCreate() {
-        new SampleConfigStartUpActionFactory();
+        Assertions.assertNotNull( new SampleConfigStartUpActionFactory() );
     }
 
     @BeforeEach

--- a/java/test/jmri/jmrit/tracker/StoppingBlockTest.java
+++ b/java/test/jmri/jmrit/tracker/StoppingBlockTest.java
@@ -4,6 +4,8 @@ import org.junit.jupiter.api.Test;
 
 import jmri.Block;
 
+import org.junit.jupiter.api.*;
+
 /**
  * Tests for the StoppingBlock class
  *
@@ -14,6 +16,17 @@ public class StoppingBlockTest {
     @Test
     public void testDirectCreate() {
         // check for exception in ctor
-        new StoppingBlock(new Block("dummy"));
+        Assertions.assertNotNull( new StoppingBlock(new Block("dummy")) );
     }
+
+    @BeforeEach
+    public void setUp() {
+        jmri.util.JUnitUtil.setUp();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        jmri.util.JUnitUtil.tearDown();
+    }
+
 }

--- a/java/test/jmri/jmrit/ussctc/CodeButtonTest.java
+++ b/java/test/jmri/jmrit/ussctc/CodeButtonTest.java
@@ -13,7 +13,7 @@ public class CodeButtonTest {
 
     @Test
     public void testConstruction() {
-        new CodeButton("IS21", "IS22");
+        Assertions.assertNotNull( new CodeButton("IS21", "IS22") );
     }
 
     @BeforeEach

--- a/java/test/jmri/jmrit/ussctc/CodeLineTest.java
+++ b/java/test/jmri/jmrit/ussctc/CodeLineTest.java
@@ -13,7 +13,8 @@ public class CodeLineTest {
 
     @Test
     public void testConstruction() {
-        new CodeLine("Code Indication Start", "Code Send Start", "IT101", "IT102", "IT103", "IT104");
+        Assertions.assertNotNull( new CodeLine("Code Indication Start",
+            "Code Send Start", "IT101", "IT102", "IT103", "IT104"));
     }
         
     @BeforeEach

--- a/java/test/jmri/jmrit/ussctc/ComputerBellTest.java
+++ b/java/test/jmri/jmrit/ussctc/ComputerBellTest.java
@@ -15,7 +15,7 @@ public class ComputerBellTest {
 
     @Test
     public void testNullConstruction() {
-        new ComputerBell(null);
+        Assertions.assertNotNull( new ComputerBell(null) );
     }
 
     @BeforeEach

--- a/java/test/jmri/jmrit/ussctc/OsIndicatorTest.java
+++ b/java/test/jmri/jmrit/ussctc/OsIndicatorTest.java
@@ -18,7 +18,7 @@ public class OsIndicatorTest {
 
     @Test
     public void testCreate() {
-        new OsIndicator("IT12", "IS34", "IS56");
+        Assertions.assertNotNull( new OsIndicator("IT12", "IS34", "IS56"));
     }
 
     @Test

--- a/java/test/jmri/jmrit/ussctc/TurnoutSectionTest.java
+++ b/java/test/jmri/jmrit/ussctc/TurnoutSectionTest.java
@@ -16,7 +16,9 @@ public class TurnoutSectionTest {
 
     @Test
     public void testConstruction() {
-        new TurnoutSection("Sec 1 Layout TO", "Sec1 TO 1 N", "Sec1 TO 1 R", "Sec1 TO 1 N", "Sec1 TO 1 R", station);
+        TurnoutSection t = new TurnoutSection("Sec 1 Layout TO", "Sec1 TO 1 N",
+            "Sec1 TO 1 R", "Sec1 TO 1 N", "Sec1 TO 1 R", station);
+        Assertions.assertNotNull(t);
     }
 
     @Test
@@ -25,7 +27,9 @@ public class TurnoutSectionTest {
         normSensor.setState(Sensor.INACTIVE);
         revSensor.setState(Sensor.INACTIVE);
 
-        new TurnoutSection("Sec 1 Layout TO", "Sec1 TO 1 N", "Sec1 TO 1 R", "Sec1 TO 1 N", "Sec1 TO 1 R", station);
+        TurnoutSection t = new TurnoutSection("Sec 1 Layout TO", "Sec1 TO 1 N",
+            "Sec1 TO 1 R", "Sec1 TO 1 N", "Sec1 TO 1 R", station);
+        Assertions.assertNotNull(t);
 
         // initialization sets indicators to follow actual turnout state
         Assert.assertEquals(Turnout.THROWN, layoutTurnout.getKnownState());
@@ -38,7 +42,9 @@ public class TurnoutSectionTest {
     public void testLayoutMonitoring() throws JmriException {
         layoutTurnout.setCommandedState(Turnout.THROWN);
 
-        new TurnoutSection("Sec 1 Layout TO", "Sec1 TO 1 N", "Sec1 TO 1 R", "Sec1 TO 1 N", "Sec1 TO 1 R", station);
+        TurnoutSection t = new TurnoutSection("Sec 1 Layout TO", "Sec1 TO 1 N",
+             "Sec1 TO 1 R", "Sec1 TO 1 N", "Sec1 TO 1 R", station);
+        Assertions.assertNotNull(t);
 
         layoutTurnout.setCommandedState(Turnout.CLOSED);
 

--- a/java/test/jmri/jmrix/loconet/locoio/LocoIOModeListTest.java
+++ b/java/test/jmri/jmrix/loconet/locoio/LocoIOModeListTest.java
@@ -21,18 +21,18 @@ public class LocoIOModeListTest {
 
     @Test
     public void test() {
-        new LocoIOModeList() {  // just have to create it to test it via initializer
+        Assertions.assertNotNull( new LocoIOModeList() {  // just have to create it to test it via initializer
             {
                 /*
                  * This used to be in main class file, so we run
                  * it as an initializer
                  */
                 log.debug("Starting test sequence"); // NOI18N
-                for (int i = 0; i <= modeList.size() - 1; i++) {
-                    LocoIOMode m = modeList.elementAt(i);
+                for (int ii = 0; ii <= modeList.size() - 1; ii++) {
+                    LocoIOMode m = modeList.elementAt(ii);
 
                     int hadError = 0;
-                    for (i = 1; i <= 2047; i++) {
+                    for (int i = 1; i <= 2047; i++) {
                         int svA = m.getSV();
                         int v1A = addressToValue1(m, i);
                         int v2A = addressToValue2(m, i);
@@ -74,7 +74,7 @@ public class LocoIOModeListTest {
                 }
                 log.debug("Finished test sequence\n"); // NOI18N
             }
-        };
+        });
     }
 
     @BeforeEach

--- a/java/test/jmri/jmrix/loconet/sdf/InitiateSoundTest.java
+++ b/java/test/jmri/jmrix/loconet/sdf/InitiateSoundTest.java
@@ -1,6 +1,6 @@
 package jmri.jmrix.loconet.sdf;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 
 /**
  * Tests for the jmri.jmrix.loconet.sdf.InitiateSound class.
@@ -10,8 +10,18 @@ import org.junit.jupiter.api.Test;
 public class InitiateSoundTest {
 
     @Test
-    public void testCtor() {
-        new InitiateSound((byte) 0, (byte) 0);
+    public void testInitiateSoundCtor() {
+        Assertions.assertNotNull( new InitiateSound((byte) 0, (byte) 0) );
+    }
+
+    @BeforeEach
+    public void setUp() {
+        jmri.util.JUnitUtil.setUp();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        jmri.util.JUnitUtil.tearDown();
     }
 
 }

--- a/java/test/jmri/jmrix/loconet/sdf/PlayTest.java
+++ b/java/test/jmri/jmrix/loconet/sdf/PlayTest.java
@@ -11,8 +11,8 @@ import org.junit.jupiter.api.*;
 public class PlayTest {
 
     @Test
-    public void testCtor() {
-        new Play((byte) 0, (byte) 0);
+    public void testPlayCtor() {
+        Assertions.assertNotNull( new Play((byte) 0, (byte) 0) );
     }
 
     @Test
@@ -77,6 +77,16 @@ public class PlayTest {
         Assert.assertEquals("Brk 2", 2, p.getWaveBrkFlags());
         Assert.assertEquals("Brk 0", "loop_GLOBAL", p.wavebrkFlagsVal());
 
+    }
+
+    @BeforeEach
+    public void setUp() {
+        jmri.util.JUnitUtil.setUp();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        jmri.util.JUnitUtil.tearDown();
     }
 
 }

--- a/java/test/jmri/jmrix/loconet/spjfile/SpjFileTest.java
+++ b/java/test/jmri/jmrix/loconet/spjfile/SpjFileTest.java
@@ -13,11 +13,11 @@ import org.junit.Assert;
 public class SpjFileTest {
 
     @Test
-    public void testCreate() {
-        new SpjFile(new java.io.File("ac4400.spj"));
+    public void testSpjFileCTor() {
+        Assertions.assertNotNull( new SpjFile(new java.io.File("ac4400.spj")) );
     }
 
-    SpjFile testFile = null;
+    private SpjFile testFile = null;
 
     void loadFile() throws java.io.IOException {
         if (testFile == null) {

--- a/java/test/jmri/jmrix/powerline/X10SequenceTest.java
+++ b/java/test/jmri/jmrix/powerline/X10SequenceTest.java
@@ -14,8 +14,8 @@ import org.junit.Assert;
 public class X10SequenceTest {
 
     @Test
-    public void testCtors() {
-        new X10Sequence();
+    public void testX10SequenceCtors() {
+        Assertions.assertNotNull( new X10Sequence());
     }
 
     @Test

--- a/java/test/jmri/jmrix/pricom/downloader/LoaderPaneTest.java
+++ b/java/test/jmri/jmrix/pricom/downloader/LoaderPaneTest.java
@@ -12,7 +12,7 @@ public class LoaderPaneTest {
 
     @Test
     public void testCreate() {
-        new LoaderPane();
+        Assertions.assertNotNull( new LoaderPane() );
     }
 
     @Test

--- a/java/test/jmri/jmrix/pricom/downloader/PdiFileTest.java
+++ b/java/test/jmri/jmrix/pricom/downloader/PdiFileTest.java
@@ -1,6 +1,5 @@
 package jmri.jmrix.pricom.downloader;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.*;
 
 /**
@@ -11,14 +10,18 @@ import org.junit.jupiter.api.*;
 public class PdiFileTest {
 
     @Test
-    public void testCreate() {
-        new PdiFile(null);
+    public void testPdiFileCTor() {
+        Assertions.assertNotNull( new PdiFile(null) );
     }
 
-    // create and show, with some data present
-    @Test
-    public void testOpen() {
-        PdiFile f = new PdiFile(null);
-        Assert.assertNotNull("exists", f);
+    @BeforeEach
+    public void setUp() {
+        jmri.util.JUnitUtil.setUp();
     }
+
+    @AfterEach
+    public void tearDown() {
+        jmri.util.JUnitUtil.tearDown();
+    }
+
 }

--- a/java/test/jmri/jmrix/pricom/pockettester/PacketDataModelTest.java
+++ b/java/test/jmri/jmrix/pricom/pockettester/PacketDataModelTest.java
@@ -12,7 +12,7 @@ public class PacketDataModelTest {
 
     @Test
     public void testCreate() {
-        new PacketDataModel();
+        Assertions.assertNotNull( new PacketDataModel() );
     }
 
     @Test
@@ -47,4 +47,15 @@ public class PacketDataModelTest {
         f.asciiFormattedMessage(TestConstants.speed012A);
         Assert.assertEquals("Still two rows", 2, f.getRowCount());
     }
+
+    @BeforeEach
+    public void setUp() {
+        jmri.util.JUnitUtil.setUp();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        jmri.util.JUnitUtil.tearDown();
+    }
+
 }

--- a/java/test/jmri/jmrix/rps/PositionFileTest.java
+++ b/java/test/jmri/jmrix/rps/PositionFileTest.java
@@ -23,7 +23,7 @@ public class PositionFileTest {
 
     @Test
     public void testCtor() {
-        new PositionFile();
+        Assertions.assertNotNull( new PositionFile() );
     }
 
     @Test

--- a/java/test/jmri/jmrix/rps/RegionTest.java
+++ b/java/test/jmri/jmrix/rps/RegionTest.java
@@ -17,19 +17,21 @@ public class RegionTest {
     @Test
     public void testCtors() {
         // square
-        new Region(new Point3d[]{
+        Region r = new Region(new Point3d[]{
             new Point3d(0., 0., 0.),
             new Point3d(1., 0., 0.),
             new Point3d(1., 1., 0.),
             new Point3d(0., 1., 0.)}
         );
+        Assertions.assertNotNull( r );
 
         // triangle
-        new Region(new Point3d[]{
+        r = new Region(new Point3d[]{
             new Point3d(0., 0., 0.),
             new Point3d(1., 0., 0.),
             new Point3d(1., 1., 0.)}
         );
+        Assertions.assertNotNull( r );
 
     }
 

--- a/java/test/jmri/swing/EditableListTest.java
+++ b/java/test/jmri/swing/EditableListTest.java
@@ -1,6 +1,8 @@
 package jmri.swing;
 
-import org.junit.jupiter.api.Test;
+import jmri.util.JUnitUtil;
+
+import org.junit.jupiter.api.*;
 
 /**
  * Tests for the jmri.swing.EditableList class.
@@ -11,16 +13,26 @@ public class EditableListTest {
 
     @Test
     public void testCtor() {
-        new EditableList<String>();
-        new EditableList<Integer>();
-        new EditableList<Object>();
+        Assertions.assertNotNull( new EditableList<String>() );
+        Assertions.assertNotNull( new EditableList<Integer>() );
+        Assertions.assertNotNull( new EditableList<Object>() );
     }
 
     @Test
     public void testCtorWithMode() {
-        new EditableList<String>(new DefaultEditableListModel<String>());
-        new EditableList<Integer>(new DefaultEditableListModel<Integer>());
-        new EditableList<Object>(new DefaultEditableListModel<Object>());
+        Assertions.assertNotNull( new DefaultEditableListModel<String>() );
+        Assertions.assertNotNull( new DefaultEditableListModel<Integer>() );
+        Assertions.assertNotNull( new DefaultEditableListModel<Object>() );
+    }
+
+    @BeforeEach
+    public void setUp() {
+        JUnitUtil.setUp();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        JUnitUtil.tearDown();
     }
 
 }

--- a/java/test/jmri/util/docbook/RevHistoryTest.java
+++ b/java/test/jmri/util/docbook/RevHistoryTest.java
@@ -14,7 +14,7 @@ public class RevHistoryTest {
 
     @Test
     public void testCtor() {
-        new RevHistory();
+        Assertions.assertNotNull(new RevHistory());
     }
 
     @Test


### PR DESCRIPTION
Unused new instances now asserted for not null.
An ArchUnit bytecode check has these methods as empty.

Adds a few missing setUp / tearDown methods.
Use different variable names for LocoIOModeListTest loop counters