### PR TITLE
update TimeTable Layout Test

### DIFF
--- a/java/test/jmri/jmrit/timetable/LayoutTest.java
+++ b/java/test/jmri/jmrit/timetable/LayoutTest.java
@@ -1,9 +1,10 @@
 package jmri.jmrit.timetable;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.*;
 
 import jmri.util.JUnitUtil;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests for the Layout Class
@@ -13,41 +14,41 @@ public class LayoutTest {
 
     @Test
     public void testCreate() {
-        new Layout();
+        Assertions.assertNotNull( new Layout() );
     }
 
     @Test
     public void testSettersAndGetters() {
         Layout layout = new Layout();
-        Assert.assertNotNull(layout);
+        assertNotNull(layout);
         layout.setLayoutName("Test Name");  // NOI18N
-        Assert.assertEquals("Test Name", layout.getLayoutName());  // NOI18N
-        Assert.assertEquals("HO", layout.getScale().getScaleName());  // NOI18N
-        try {
-            layout.setFastClock(0);
-        } catch (IllegalArgumentException ex) {
-            Assert.assertEquals(ex.getMessage(), "FastClockLt1");  // NOI18N
-        }
-        try {
-            layout.setFastClock(100);
-        } catch (IllegalArgumentException ex) {
-            Assert.assertEquals(ex.getMessage(), "TimeOutOfRange");  // NOI18N
-        }
-        layout.setFastClock(6);
-        Assert.assertEquals(6, layout.getFastClock());
-        Assert.assertTrue(layout.getRatio() > 0.0f);
-        try {
-            layout.setThrottles(-2);
-        } catch (IllegalArgumentException ex) {
-            Assert.assertEquals(ex.getMessage(), "ThrottlesLt0");  // NOI18N
-        }
+        assertEquals("Test Name", layout.getLayoutName());  // NOI18N
+        assertEquals("HO", layout.getScale().getScaleName());  // NOI18N
+
+        Exception ex = assertThrows(IllegalArgumentException.class, () -> { layout.setFastClock(0); });
+        assertNotNull(ex);
+        assertEquals("FastClockLt1", ex.getMessage());
+
+        // ex = assertThrows(IllegalArgumentException.class, () -> { layout.setFastClock(100); });
+        // assertNotNull(ex);
+        // assertEquals("TimeOutOfRange", ex.getMessage());
+        layout.setFastClock(9999); // does not throw Exception, should it?
+
+        assertDoesNotThrow( () -> layout.setFastClock(6));
+        assertEquals(6, layout.getFastClock());
+        assertTrue(layout.getRatio() > 0.0f);
+
+        ex = assertThrows(IllegalArgumentException.class, () -> { layout.setThrottles( -2 ); });
+        assertNotNull(ex);
+        assertEquals("ThrottlesLt0", ex.getMessage());
+
         layout.setThrottles(3);
-        Assert.assertEquals(3, layout.getThrottles());
+        assertEquals(3, layout.getThrottles());
         layout.setMetric(true);
-        Assert.assertTrue(layout.getMetric());
+        assertTrue(layout.getMetric());
         layout.setScaleMK();
-        Assert.assertEquals(1.914, layout.getScaleMK(), .1);
-        Assert.assertEquals("Test Name", layout.toString());  // NOI18N
+        assertEquals(1.914, layout.getScaleMK(), .1);
+        assertEquals("Test Name", layout.toString());  // NOI18N
     }
 
     @BeforeEach

--- a/java/test/jmri/jmrit/timetable/LayoutTest.java
+++ b/java/test/jmri/jmrit/timetable/LayoutTest.java
@@ -29,10 +29,8 @@ public class LayoutTest {
         assertNotNull(ex);
         assertEquals("FastClockLt1", ex.getMessage());
 
-        // ex = assertThrows(IllegalArgumentException.class, () -> { layout.setFastClock(100); });
-        // assertNotNull(ex);
-        // assertEquals("TimeOutOfRange", ex.getMessage());
-        layout.setFastClock(9999); // does not throw Exception, should it?
+        // supplying ridiculous fast clock values is self correcting since the user gets ridiculous timetable results
+        assertDoesNotThrow( () -> layout.setFastClock(9999));
 
         assertDoesNotThrow( () -> layout.setFastClock(6));
         assertEquals(6, layout.getFastClock());


### PR DESCRIPTION
`layout.setFastClock(9999);` does not throw an Exception, should it @dsand47 ?
No rush to look at this, updated test documents current behaviour.

Asserts new instance not null.
Order of assertEquals