### PR TITLE
Update Jython to version 2.7.4

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -147,7 +147,7 @@
         <pathelement location="${libdir}/jlfgr-1_0.jar"/>
         <pathelement location="${libdir}/joal.jar"/>
         <pathelement location="${libdir}/jsoup-1.15.3.jar"/>
-        <pathelement location="${libdir}/jython-standalone-2.7.2.jar"/>
+        <pathelement location="${libdir}/jython-standalone-2.7.4.jar"/>
         <pathelement location="${libdir}/slf4j-api-2.0.7.jar"/><!-- sl4fj API -->
         <pathelement location="${libdir}/jul-to-slf4j-2.0.7.jar"/><!-- java.util.logging to sl4fj -->
         <pathelement location="${libdir}/log4j-slf4j2-impl-2.20.0.jar"/><!-- sl4fj to log4j2 -->

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -519,7 +519,7 @@
     <h3>Scripting</h3>
         <a id="Scripting" name="Scripting"></a>
         <ul>
-            <li></li>
+            <li>The Jython library has been updated to version 2.7.4</li>
         </ul>
 
     <h3>Signals</h3>

--- a/pom.xml
+++ b/pom.xml
@@ -1383,7 +1383,7 @@
         <dependency>
             <groupId>org.python</groupId>
             <artifactId>jython-standalone</artifactId>
-            <version>2.7.2</version>
+            <version>2.7.4</version>
         </dependency>
         <!--
         <dependency>


### PR DESCRIPTION
This update is needed to because the Apple signing applications will no longer accept Python 2.7.2:  It's internal libraries are compiled with too-old a toolchain.  

The [differences between 2.7.2 and 2.7.4](https://github.com/jython/jython/blob/v2.7.4/NEWS) should not be visible to user scripting.  