### PR TITLE
DisabledIfHeadless Test annotation

### DIFF
--- a/java/test/apps/util/issuereporter/swing/IssueReporterTest.java
+++ b/java/test/apps/util/issuereporter/swing/IssueReporterTest.java
@@ -2,19 +2,26 @@ package apps.util.issuereporter.swing;
 
 import jmri.util.JUnitUtil;
 
-import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.jupiter.api.*;
+
+import org.netbeans.jemmy.operators.JFrameOperator;
 
 /**
  * Minimal test skeleton for IssueReporter class
  */
+@jmri.util.junit.annotations.DisabledIfHeadless
 public class IssueReporterTest {
 
     @Test
     public void testCtor(){
-      Assume.assumeFalse(java.awt.GraphicsEnvironment.isHeadless());
-      Assert.assertNotNull("IssueReporter constructor", new IssueReporter());
+        IssueReporter t = new IssueReporter();
+        Assertions.assertNotNull( t, "IssueReporter constructor");
+        jmri.util.ThreadingUtil.runOnGUI( () -> t.setVisible(true));
+
+        JFrameOperator jfo = new JFrameOperator(t.getTitle());
+        Assertions.assertNotNull(jfo);
+
+        JUnitUtil.dispose(t);
     }
 
     @BeforeEach

--- a/java/test/jmri/util/junit/annotations/DisabledIfHeadless.java
+++ b/java/test/jmri/util/junit/annotations/DisabledIfHeadless.java
@@ -1,0 +1,21 @@
+package jmri.util.junit.annotations;
+
+import java.lang.annotation.*;
+
+/**
+ * Annotation denoting that tests within a class or test method
+ * should not be run if headless.
+ * @author Steve Young Copyright 2024
+ */
+@Retention(RetentionPolicy.RUNTIME)  // For access by JUnit
+@Target({ElementType.METHOD, ElementType.TYPE}) // method and class
+@Documented
+@Inherited
+@org.junit.jupiter.api.extension.ExtendWith(DisabledIfHeadlessExecutionCondition.class)
+public @interface DisabledIfHeadless {
+    /**
+     * The optional reason why the test is not run when headless.
+     */
+    String value() default "";
+
+}

--- a/java/test/jmri/util/junit/annotations/DisabledIfHeadlessClassTest.java
+++ b/java/test/jmri/util/junit/annotations/DisabledIfHeadlessClassTest.java
@@ -1,0 +1,61 @@
+package jmri.util.junit.annotations;
+
+import jmri.util.JUnitUtil;
+
+import org.junit.jupiter.api.*;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * This tests DisabledIfHeadless annotation applied to a whole class.
+ * @author Steve Young Copyright 2024
+ */
+@DisabledIfHeadless
+public class DisabledIfHeadlessClassTest {
+
+    private static boolean isHeadless() {
+        return java.awt.GraphicsEnvironment.isHeadless();
+    }
+
+    private static int methodCalls = 0;
+
+    @Test
+    public void testClassDisabledIfHeadlessTestDoesNotRun() {
+        if ( isHeadless() ) {
+            fail("Test ran, though Class has DisabledIfHeadless annotation.");
+        } else {
+            methodCalls++;
+        }
+    }
+
+    @BeforeEach
+    public void setUp() {
+        if ( isHeadless() ) {
+            fail("BeforeEach ran, though Class Disabled as in headless mode.");
+        }
+        methodCalls++;
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if ( isHeadless() ) {
+            fail("AfterEach ran, though Class Disabled as in headless mode.");
+        }
+        methodCalls++;
+    }
+
+    @BeforeAll
+    public static void beforeAll() {
+        JUnitUtil.setUp();
+        methodCalls = 0;
+    }
+
+    @AfterAll
+    public static void afterAll() {
+        if ( ! isHeadless() ) {
+            Assertions.assertEquals(3, methodCalls, "headed test ran beforeEach, Test, AfterEach");
+        }
+        JUnitUtil.tearDown();
+    }
+
+}

--- a/java/test/jmri/util/junit/annotations/DisabledIfHeadlessExecutionCondition.java
+++ b/java/test/jmri/util/junit/annotations/DisabledIfHeadlessExecutionCondition.java
@@ -1,0 +1,20 @@
+package jmri.util.junit.annotations;
+
+import org.junit.jupiter.api.extension.*;
+
+/**
+ *
+ * @author Steve Young Copyright 2024
+ */
+public class DisabledIfHeadlessExecutionCondition implements ExecutionCondition {
+
+    private static final ConditionEvaluationResult ENABLED = ConditionEvaluationResult.enabled("Test enabled, not in headless mode");
+    private static final ConditionEvaluationResult DISABLED = ConditionEvaluationResult.disabled("Test disabled, in headless mode");
+    private static final boolean IS_HEADLESS = Boolean.parseBoolean(System.getProperty("java.awt.headless", "false"));
+
+    @Override
+    public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+        return IS_HEADLESS ? DISABLED : ENABLED;
+    }
+
+}

--- a/java/test/jmri/util/junit/annotations/DisabledIfHeadlessTest.java
+++ b/java/test/jmri/util/junit/annotations/DisabledIfHeadlessTest.java
@@ -1,0 +1,61 @@
+package jmri.util.junit.annotations;
+
+import jmri.util.JUnitUtil;
+
+import org.junit.jupiter.api.*;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Test DisabledIfHeadless annotation applied to a test method.
+ * @author Steve Young Copyright 2024
+ */
+public class DisabledIfHeadlessTest {
+
+    private static boolean isHeadless() {
+        return java.awt.GraphicsEnvironment.isHeadless();
+    }
+
+    private static int methodCalls = 0;
+
+    @Test
+    @DisabledIfHeadless
+    public void testNotApplicableTestDoesNotRun() {
+        if ( isHeadless() ) {
+            fail("Test ran, though has DisabledIfHeadless annotation.");
+        } else {
+            methodCalls++;
+        }
+    }
+
+    @BeforeEach
+    public void setUp() {
+        if ( isHeadless() ) {
+            fail("BeforeEach ran, though test Disabled as in headless mode.");
+        }
+        methodCalls++;
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if ( isHeadless() ) {
+            fail("AfterEach ran, though test Disabled as in headless mode.");
+        }
+        methodCalls++;
+    }
+
+    @BeforeAll
+    public static void beforeAll() {
+        JUnitUtil.setUp();
+        methodCalls = 0;
+    }
+
+    @AfterAll
+    public static void afterAll() {
+        if ( ! isHeadless() ) {
+            Assertions.assertEquals(3, methodCalls, "headed test ran beforeEach, Test, AfterEach");
+        }
+        JUnitUtil.tearDown();
+    }
+
+}

--- a/java/test/jmri/util/swing/multipane/MultiJfcUnitTest.java
+++ b/java/test/jmri/util/swing/multipane/MultiJfcUnitTest.java
@@ -8,7 +8,6 @@ import jmri.util.swing.SamplePane;
 
 import org.junit.Assert;
 import org.junit.jupiter.api.*;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import org.netbeans.jemmy.operators.JButtonOperator;
 import org.netbeans.jemmy.operators.JFrameOperator;
@@ -21,7 +20,7 @@ import org.netbeans.jemmy.operators.JFrameOperator;
 public class MultiJfcUnitTest {
 
     @Test
-    @DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
+    @jmri.util.junit.annotations.DisabledIfHeadless
     public void testShow() throws Exception {
 
         // show the window
@@ -37,6 +36,9 @@ public class MultiJfcUnitTest {
 
         // Load the license
         JUnitUtil.pressButton(f1, "License");
+        JFrameOperator jfl = new JFrameOperator("JMRI License");
+        jfl.requestClose();
+        jfl.waitClosed();        
 
         // Find the button that opens a sample panel
         JButton samplebutton = JButtonOperator.findJButton(f1, "Sample", true, true);


### PR DESCRIPTION
**&#64;DisabledIfHeadless**
Annotation denoting that tests within a class or test method should not be run if headless.
Adds unit tests for class and method annotation.

**MultiJfcUnitTest**
Ensure license frame is opened, then close it.
Use DisabledIfHeadless in method annotation.

**IssueReporterTest**
Assert frame can be set visible.
Use DisabledIfHeadless in class annotation.