### PR TITLE
Default ShutDown Manager / Test tweaks

### DIFF
--- a/java/src/jmri/configurexml/StoreAndCompare.java
+++ b/java/src/jmri/configurexml/StoreAndCompare.java
@@ -48,12 +48,12 @@ public class StoreAndCompare extends AbstractAction {
     }
 
     public static void requestStoreIfNeeded() {
-        if (Application.getApplicationName().equals("PanelPro")) {
-            if (_preferences.isStoreCheckEnabled()) {
-                if (dataHasChanged() && !GraphicsEnvironment.isHeadless()) {
+        if ( Application.getApplicationName().equals("PanelPro") && _preferences.isStoreCheckEnabled()) {
+            jmri.util.ThreadingUtil.runOnGUI( () -> { 
+                if ( dataHasChanged() && !GraphicsEnvironment.isHeadless() ) {
                     jmri.configurexml.swing.StoreAndCompareDialog.showDialog();
                 }
-            }
+            });
         }
     }
 

--- a/java/src/jmri/configurexml/StoreAndCompare.java
+++ b/java/src/jmri/configurexml/StoreAndCompare.java
@@ -71,9 +71,6 @@ public class StoreAndCompare extends AbstractAction {
     }
 
     public static void requestStoreIfNeeded() {
-        if ( Application.getApplicationName().equals("PanelPro") && _preferences.isStoreCheckEnabled()) {
-            jmri.util.ThreadingUtil.runOnGUI( () -> {
-                if ( dataHasChanged() && !GraphicsEnvironment.isHeadless() ) {
         if (!InstanceManager.getDefault(PermissionManager.class)
                 .hasPermission(LoadAndStorePermissionOwner.STORE_XML_FILE_PERMISSION)) {
             // User has not permission to store.
@@ -84,7 +81,7 @@ public class StoreAndCompare extends AbstractAction {
                 if (dataHasChanged() && !GraphicsEnvironment.isHeadless()) {
                     jmri.configurexml.swing.StoreAndCompareDialog.showDialog();
                 }
-            });
+            }
         }
     }
 

--- a/java/src/jmri/configurexml/StoreAndCompare.java
+++ b/java/src/jmri/configurexml/StoreAndCompare.java
@@ -76,12 +76,12 @@ public class StoreAndCompare extends AbstractAction {
             // User has not permission to store.
             return;
         }
-        if (Application.getApplicationName().equals("PanelPro")) {
-            if (_preferences.isStoreCheckEnabled()) {
+        if (Application.getApplicationName().equals("PanelPro") &&_preferences.isStoreCheckEnabled()) {
+            jmri.util.ThreadingUtil.runOnGUI(() -> {
                 if (dataHasChanged() && !GraphicsEnvironment.isHeadless()) {
                     jmri.configurexml.swing.StoreAndCompareDialog.showDialog();
                 }
-            }
+            });
         }
     }
 

--- a/java/src/jmri/managers/DefaultShutDownManager.java
+++ b/java/src/jmri/managers/DefaultShutDownManager.java
@@ -308,9 +308,6 @@ public class DefaultShutDownManager extends Bean implements ShutDownManager {
                 }
             }
 
-
-            closeFrames(start);
-
             boolean abort = jmri.util.ThreadingUtil.runOnGUIwithReturn(() -> {
                 return jmri.configurexml.StoreAndCompare.checkPermissionToStoreIfNeeded();
             });
@@ -319,6 +316,8 @@ public class DefaultShutDownManager extends Bean implements ShutDownManager {
                 setShuttingDown(false);
                 return;
             }
+
+            closeFrames(start);
 
             // wait for parallel tasks to complete
             runShutDownTasks(new HashSet<>(earlyRunnables), "JMRI ShutDown - Early Tasks");

--- a/java/src/jmri/managers/DefaultShutDownManager.java
+++ b/java/src/jmri/managers/DefaultShutDownManager.java
@@ -289,7 +289,7 @@ public class DefaultShutDownManager extends Bean implements ShutDownManager {
     private void doShutdown(int status, boolean exit) {
         log.debug("shutdown called with {} {}", status, exit);
         if (!shuttingDown) {
-            Date start = new Date();
+            long start = System.currentTimeMillis();
             log.debug("Shutting down with {} callable and {} runnable tasks",
                 callables.size(), runnables.size());
             setShuttingDown(true);
@@ -314,13 +314,15 @@ public class DefaultShutDownManager extends Bean implements ShutDownManager {
                     // will get called before windows can close
                     if (frame.isDisplayable()) { // dispose() has not been called
                         log.debug("Closing frame \"{}\", title: \"{}\"", frame.getName(), frame.getTitle());
-                        Date timer = new Date();
+                        long timer = System.currentTimeMillis();
                         frame.dispatchEvent(new WindowEvent(frame, WindowEvent.WINDOW_CLOSING));
-                        log.debug("Frame \"{}\" took {} milliseconds to close", frame.getName(), new Date().getTime() - timer.getTime());
+                        log.debug("Frame \"{}\" took {} milliseconds to close",
+                            frame.getName(), System.currentTimeMillis() - timer);
                     }
                 });
             }
-            log.debug("windows completed closing {} milliseconds after starting shutdown", new Date().getTime() - start.getTime());
+            log.debug("windows completed closing {} milliseconds after starting shutdown",
+                System.currentTimeMillis() - start);
 
             // wait for parallel tasks to complete
             runShutDownTasks(new HashSet<>(earlyRunnables), "JMRI ShutDown - Early Tasks");
@@ -331,7 +333,7 @@ public class DefaultShutDownManager extends Bean implements ShutDownManager {
             runShutDownTasks(runnables, "JMRI ShutDown - Main Tasks");
 
             // success
-            log.debug("Shutdown took {} milliseconds.", new Date().getTime() - start.getTime());
+            log.debug("Shutdown took {} milliseconds.", System.currentTimeMillis() - start);
             log.info("Normal termination complete");
             // and now terminate forcefully
             if (exit) {
@@ -350,27 +352,31 @@ public class DefaultShutDownManager extends Bean implements ShutDownManager {
         // use a custom Executor which checks the Task output for Exceptions.
         ExecutorService executor = new ShutDownThreadPoolExecutor(sDrunnables.size(), threadName);
         List<Future<?>> complete = new ArrayList<>();
-        long timeoutEnd = new Date().getTime()+ tasksTimeOutMilliSec;
-
+        long timeoutEnd = System.currentTimeMillis() + tasksTimeOutMilliSec;
 
         sDrunnables.forEach((runnable) -> complete.add(executor.submit(runnable)));
 
         executor.shutdown(); // no more tasks allowed from here, starts the threads.
-        while (!executor.isTerminated() && ( timeoutEnd > new Date().getTime() )) {
-            try {
-                // awaitTermination blocks the thread, checking occasionally
-                executor.awaitTermination(50, TimeUnit.MILLISECONDS);
-            } catch (InterruptedException e) {
-                // Restore interrupted state...
-                Thread.currentThread().interrupt();
-            }
-        }
 
-        // so we're either all complete or timed out.
-        // check if a task timed out, if so log.
-        for ( Future<?> future : complete) {
-            if ( !future.isDone() ) {
-                log.error("Could not complete Shutdown Task in time: {} ", future );
+         // Handle individual task timeouts
+        for (Future<?> future : complete) {
+            long remainingTime = timeoutEnd - System.currentTimeMillis(); // Calculate remaining time
+
+            if (remainingTime <= 0) {
+                log.error("Timeout reached before all tasks were completed");
+                break;
+            }
+
+            try {
+                // Attempt to get the result of each task within the remaining time
+                future.get(remainingTime, TimeUnit.MILLISECONDS);
+            } catch (TimeoutException te) {
+                log.error("Task timed out: {}", future);
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+                log.error("Task was interrupted: {}", future);
+            } catch (ExecutionException ee) {
+                log.error("Task threw an exception: {}", future, ee.getCause());
             }
         }
 
@@ -414,55 +420,6 @@ public class DefaultShutDownManager extends Bean implements ShutDownManager {
     // package private so tests can reset
     static synchronized void setStaticShuttingDown(boolean state){
         shuttingDown = state;
-    }
-
-    private static class ShutDownThreadPoolExecutor extends ThreadPoolExecutor {
-
-        // use up to 8 threads for parallel tasks
-        // 10 seconds for tasks to enter a thread from queue
-        // set thread name with custom ThreadFactory
-        private ShutDownThreadPoolExecutor(int numberTasks, String threadName) {
-            super(8, 8, 10, TimeUnit.SECONDS,
-                new ArrayBlockingQueue<>(numberTasks), new ShutDownThreadFactory(threadName));
-        }
-
-        @Override
-        public void afterExecute(Runnable r, Throwable t) {
-            super.afterExecute(r, t);
-            // System.out.println("afterExecute "+ r);
-            if (t == null && r instanceof Future<?>) {
-                try {
-                    Future<?> future = (Future<?>) r;
-                    if (future.isDone()) {
-                        future.get();
-                    }
-                } catch (CancellationException ce) {
-                    t = ce;
-                } catch (ExecutionException ee) {
-                    t = ee.getCause();
-                } catch (InterruptedException ie) {
-                    Thread.currentThread().interrupt();
-                }
-            }
-            if (t != null) {
-                log.error("Issue Completing ShutdownTask : {} : {}", r, t.getMessage());
-            }
-        }
-    }
-
-    private static class ShutDownThreadFactory implements ThreadFactory {
-
-        private final String threadName;
-
-        private ShutDownThreadFactory( String threadName ){
-            super();
-            this.threadName = threadName;
-        }
-
-        @Override
-        public Thread newThread(Runnable r) {
-            return new Thread(r, threadName);
-        }
     }
 
     private static class EarlyTask implements Runnable {

--- a/java/src/jmri/managers/ShutDownThreadPoolExecutor.java
+++ b/java/src/jmri/managers/ShutDownThreadPoolExecutor.java
@@ -1,0 +1,60 @@
+package jmri.managers;
+
+import java.util.concurrent.*;
+
+/**
+ * @author Steve Young Copyright (C) 2024
+ */
+public class ShutDownThreadPoolExecutor extends ThreadPoolExecutor {
+
+    public ShutDownThreadPoolExecutor(int poolSize, String threadName) {
+        super(poolSize, poolSize, 10L, TimeUnit.SECONDS,
+              new LinkedBlockingQueue<>(), new ShutDownThreadFactory(threadName));
+
+        // Set a custom RejectedExecutionHandler to handle tasks that are rejected.
+        this.setRejectedExecutionHandler((Runnable r, ThreadPoolExecutor executor) ->
+            log.error("Task was rejected: {}", r));
+    }
+
+    @Override
+    protected void afterExecute(Runnable r, Throwable t) {
+        super.afterExecute(r, t);
+        if (t == null && r instanceof Future<?>) {
+            try {
+                Future<?> future = (Future<?>) r;
+                if (future.isDone() && !future.isCancelled()) {
+                    future.get(); // this will throw any exceptions encountered during execution
+                }
+            } catch (CancellationException ce) {
+                log.error("Task was cancelled: {}", r );
+            } catch (ExecutionException ee) {
+                log.error("Exception in task: {}", r, ee.getCause());
+            } catch (InterruptedException ie) {
+                // Restore interrupted state
+                Thread.currentThread().interrupt();
+            }
+        } else if (t != null) {
+            // Log the exception that occurred during execution
+            log.error("Exception in task execution: {}", r, t);
+        }
+
+    }
+
+    private static class ShutDownThreadFactory implements ThreadFactory {
+
+        private final String threadName;
+
+        private ShutDownThreadFactory( String threadName ){
+            super();
+            this.threadName = threadName;
+        }
+
+        @Override
+        public Thread newThread(Runnable r) {
+            return new Thread(r, threadName);
+        }
+    }
+
+    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ShutDownThreadPoolExecutor.class);
+
+}

--- a/java/src/jmri/util/JmriThreadPoolExecutor.java
+++ b/java/src/jmri/util/JmriThreadPoolExecutor.java
@@ -10,7 +10,7 @@ public class JmriThreadPoolExecutor extends ThreadPoolExecutor {
     private final String threadName;
 
     public JmriThreadPoolExecutor(int poolSize, String threadName) {
-        super(poolSize, poolSize, 10L, TimeUnit.SECONDS,
+        super(poolSize, poolSize, 1, TimeUnit.SECONDS,
               new LinkedBlockingQueue<>(), new ShutDownThreadFactory(threadName));
         this.threadName = threadName;
         // Set a custom RejectedExecutionHandler to handle tasks that are rejected.

--- a/java/test/jmri/managers/DefaultShutDownManagerTest.java
+++ b/java/test/jmri/managers/DefaultShutDownManagerTest.java
@@ -292,7 +292,7 @@ public class DefaultShutDownManagerTest {
     public void testEarlyTasks() {
         concurrentEarlyRuns = new ConcurrentHashMap<>(3);
         concurrentRuns = new ConcurrentHashMap<>(3);
-        dsdm.tasksTimeOutMilliSec = 250;
+        dsdm.tasksTimeOutMilliSec *= 2;
         dsdm.register(new EarlyShutDownTask("testEarlyTasks"));
 
         Thread t1 = new Thread(() -> {

--- a/java/test/jmri/managers/DefaultShutDownManagerTest.java
+++ b/java/test/jmri/managers/DefaultShutDownManagerTest.java
@@ -212,7 +212,9 @@ public class DefaultShutDownManagerTest {
         dsdm.shutdown(0, false);
         assertThat(dsdm.isShuttingDown()).isFalse();
         assertThat(runs).isEqualTo(0);
-        JUnitAppender.assertErrorMessage("Unable to stop");
+
+        JUnitUtil.waitFor(dsdm.tasksTimeOutMilliSec * 4);
+        JUnitAppender.assertErrorMessageStartsWith("Unable to stop");
     }
 
     @Test
@@ -234,30 +236,38 @@ public class DefaultShutDownManagerTest {
     public void testShutDownTaskTakesTooLong() {
         dsdm.register(new TakesOneSecondShutDownTask("testShutDownTaskTakesTooLong"));
         dsdm.shutdown(0, false);
-        JUnitAppender.assertErrorMessageStartsWith("Could not complete Shutdown Task in time:");
+        
         Assertions.assertTrue(dsdm.isShuttingDown());
         JUnitUtil.waitFor(() -> { return runs == 2; } , "Second runs++ call eventually triggered");
         JUnitUtil.waitFor( () -> dsdm.isShutDownComplete(),"ShutDown Completed");
+
+        JUnitUtil.waitFor(dsdm.tasksTimeOutMilliSec * 4);
+        JUnitAppender.assertErrorMessageStartsWith("JMRI ShutDown - Main Tasks Task timed out:");
     }
 
     @Test
     public void testEarlyShutDownTaskTakesTooLong() {
         dsdm.register(new TakesOneSecondEarlyShutDownTask("testEarlyShutDownTaskTakesTooLong"));
         dsdm.shutdown(0, false);
-        JUnitAppender.assertErrorMessageStartsWith("Could not complete Shutdown Task in time:");
+        
         Assertions.assertTrue(dsdm.isShuttingDown());
         JUnitUtil.waitFor(() -> { return runs == 2; } , "Second runs++ call eventually triggered");
         JUnitUtil.waitFor( () -> dsdm.isShutDownComplete(),"ShutDown Completed");
+
+        JUnitUtil.waitFor(dsdm.tasksTimeOutMilliSec * 4);
+        JUnitAppender.assertErrorMessageStartsWith("JMRI ShutDown - Early Tasks Task timed out:");
     }
 
     @Test
     public void testShutDownTaskThrowsException() {
         dsdm.register(new ThrowsExceptionShutDownTask("testShutDownTaskThrowsException"));
         dsdm.shutdown(0, false);
-        JUnitAppender.assertErrorMessageStartsWith("Issue Completing ShutdownTask :");
+
         Assertions.assertTrue(dsdm.isShuttingDown());
         Assertions.assertEquals( 1, runs, "run triggered");
         JUnitUtil.waitFor( () -> dsdm.isShutDownComplete(),"ShutDown Completed");
+        JUnitUtil.waitFor(dsdm.tasksTimeOutMilliSec * 4);
+        JUnitAppender.assertErrorMessageStartsWith("JMRI ShutDown - Main Tasks Exception in task:");
     }
 
     @Test

--- a/java/test/jmri/managers/DefaultShutDownManagerTest.java
+++ b/java/test/jmri/managers/DefaultShutDownManagerTest.java
@@ -191,6 +191,7 @@ public class DefaultShutDownManagerTest {
         dsdm.shutdown(0, false);
         assertThat(dsdm.isShuttingDown()).isTrue();
         assertThat(runs).isEqualTo(1);
+        JUnitUtil.waitFor( () -> dsdm.isShutDownComplete(),"ShutDown Completed");
     }
 
     @Test
@@ -221,6 +222,7 @@ public class DefaultShutDownManagerTest {
         dsdm.shutdown(0, false);
         assertThat(dsdm.isShuttingDown()).isTrue();
         assertThat(runs).isEqualTo(1);
+        JUnitUtil.waitFor( () -> dsdm.isShutDownComplete(),"ShutDown Completed");
     }
 
     @Test
@@ -235,6 +237,7 @@ public class DefaultShutDownManagerTest {
         JUnitAppender.assertErrorMessageStartsWith("Could not complete Shutdown Task in time:");
         Assertions.assertTrue(dsdm.isShuttingDown());
         JUnitUtil.waitFor(() -> { return runs == 2; } , "Second runs++ call eventually triggered");
+        JUnitUtil.waitFor( () -> dsdm.isShutDownComplete(),"ShutDown Completed");
     }
 
     @Test
@@ -244,6 +247,7 @@ public class DefaultShutDownManagerTest {
         JUnitAppender.assertErrorMessageStartsWith("Could not complete Shutdown Task in time:");
         Assertions.assertTrue(dsdm.isShuttingDown());
         JUnitUtil.waitFor(() -> { return runs == 2; } , "Second runs++ call eventually triggered");
+        JUnitUtil.waitFor( () -> dsdm.isShutDownComplete(),"ShutDown Completed");
     }
 
     @Test
@@ -253,6 +257,7 @@ public class DefaultShutDownManagerTest {
         JUnitAppender.assertErrorMessageStartsWith("Issue Completing ShutdownTask :");
         Assertions.assertTrue(dsdm.isShuttingDown());
         Assertions.assertEquals( 1, runs, "run triggered");
+        JUnitUtil.waitFor( () -> dsdm.isShutDownComplete(),"ShutDown Completed");
     }
 
     @Test
@@ -267,6 +272,7 @@ public class DefaultShutDownManagerTest {
         // Assertions.assertEquals(30, runs); // fails often with a few missing
         // JUnitUtil.waitFor times out every now and then, so we use concurrentRuns
         Assertions.assertEquals(30, concurrentRuns.size(),"all runs triggered");
+        JUnitUtil.waitFor( () -> dsdm.isShutDownComplete(),"ShutDown Completed");
     }
 
     @Test
@@ -279,6 +285,7 @@ public class DefaultShutDownManagerTest {
         long testTime = new Date().getTime() - start.getTime();
         Assertions.assertTrue(testTime < dsdm.tasksTimeOutMilliSec*2,
             "Completed before earlytimeout and mainTimeout");
+        JUnitUtil.waitFor( () -> dsdm.isShutDownComplete(),"ShutDown Completed");
     }
 
     @Test
@@ -298,6 +305,7 @@ public class DefaultShutDownManagerTest {
         Assertions.assertEquals(0, concurrentRuns.size(),"early run triggered before main run");
         JUnitUtil.waitFor(() -> concurrentRuns.size() == 1 , "run triggered");
         JUnitUtil.waitFor(()->{return !(t1.isAlive());}, "shutdown thread completed");
+        JUnitUtil.waitFor( () -> dsdm.isShutDownComplete(),"ShutDown Completed");
     }
 
     private class CallTrueShutDownTask extends AbstractShutDownTask {
@@ -410,15 +418,18 @@ public class DefaultShutDownManagerTest {
     @BeforeEach
     public void setUp() {
         JUnitUtil.setUp();
+        JUnitUtil.waitFor(50);
         dsdm = new DefaultShutDownManager();
         dsdm.setBlockingShutdown(true);
-        dsdm.tasksTimeOutMilliSec = 100; // normal default 30000 msecs but this is a test
+        dsdm.tasksTimeOutMilliSec = 200; // normal default 30000 msecs but this is a test
         runs = 0;
         InstanceManager.getDefault(jmri.configurexml.ShutdownPreferences.class).setEnableStoreCheck(false);
     }
 
     @AfterEach
     public void tearDown() {
+        JUnitUtil.waitFor(50);
+        dsdm = null;
         DefaultShutDownManager.setStaticShuttingDown(false);
         JUnitUtil.tearDown();
     }


### PR DESCRIPTION
**DefaultShutDownManager**
add boolean to test when shutDown is complete.
No need to call StoreAndCompare.requestStoreIfNeeded on GUI

**StoreAndCompare**
ensure dataHasChanged() runs OnGUI

**DefaultShutDownManagerTest**
Wait for ShutDown complete flag
Increase tasksTimeOut value
add small wait before / after each test