### PR TITLE
Check if user has permission to store during shutdown

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -631,6 +631,9 @@
     <h3>Miscellaneous</h3>
         <a id="Misc" name="Misc"></a>
         <ul>
+            <li><strong>Permissions</strong>, which was added in JMRI 5.9.3,
+                has a serious bug. If the user doesn't have permission to store,
+                it can still store when JMRI shutdown. That bug is now fixed.</li>
             <li>Protected against an uncommon error that can happen 
                 when loading a file at startup on Windows.</li>
         </ul>

--- a/java/src/jmri/configurexml/StoreAndCompare.java
+++ b/java/src/jmri/configurexml/StoreAndCompare.java
@@ -47,7 +47,35 @@ public class StoreAndCompare extends AbstractAction {
         requestStoreIfNeeded();
     }
 
+    /**
+     * Check if data has changed and if so, if the user has permission to store.
+     * @return true if user wants to abort shutdown, false otherwise
+     */
+    public static boolean checkPermissionToStoreIfNeeded() {
+        if (InstanceManager.getDefault(PermissionManager.class)
+                .hasPermission(LoadAndStorePermissionOwner.STORE_XML_FILE_PERMISSION)) {
+            // User has permission to store. No need to abort.
+            return false;
+        }
+
+        if (Application.getApplicationName().equals("PanelPro")) {
+            if (_preferences.isStoreCheckEnabled()) {
+                if (dataHasChanged() && !GraphicsEnvironment.isHeadless()) {
+                    return jmri.configurexml.swing.StoreAndCompareDialog.showAbortShutdownDialogPermissionDenied();
+                }
+            }
+        }
+
+        // If here, no need to abort.
+        return false;
+    }
+
     public static void requestStoreIfNeeded() {
+        if (!InstanceManager.getDefault(PermissionManager.class)
+                .hasPermission(LoadAndStorePermissionOwner.STORE_XML_FILE_PERMISSION)) {
+            // User has not permission to store.
+            return;
+        }
         if (Application.getApplicationName().equals("PanelPro")) {
             if (_preferences.isStoreCheckEnabled()) {
                 if (dataHasChanged() && !GraphicsEnvironment.isHeadless()) {

--- a/java/src/jmri/configurexml/swing/Bundle.properties
+++ b/java/src/jmri/configurexml/swing/Bundle.properties
@@ -1,5 +1,9 @@
 # Default properties for the jmri.configurexml.swing package
 
+StoreAndComparePermissionDenied = \
+<html>Table and/or panel changes have been made since the last store but<br> \
+you don't have permission to store. Do you want to abort the shutdown?</html>
+
 StoreAndCompareRequest = <html>Table and/or panel changes have been made since the last store.<br> \
 Do you want to <strong>Store ALL tables and panels</strong>?</html>
 

--- a/java/src/jmri/configurexml/swing/StoreAndCompareDialog.java
+++ b/java/src/jmri/configurexml/swing/StoreAndCompareDialog.java
@@ -5,6 +5,7 @@ import java.awt.HeadlessException;
 import java.awt.Component;
 import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.swing.BorderFactory;
 import javax.swing.BoxLayout;
@@ -23,6 +24,52 @@ import jmri.configurexml.ShutdownPreferences;
 public class StoreAndCompareDialog {
 
     private static ShutdownPreferences _preferences = jmri.InstanceManager.getDefault(ShutdownPreferences.class);
+
+    static public boolean showAbortShutdownDialogPermissionDenied() {
+        AtomicBoolean result = new AtomicBoolean(false);
+        try {
+            // Provide option to invoke the store process before the shutdown.
+            final JDialog dialog = new JDialog();
+            dialog.setTitle(Bundle.getMessage("QuestionTitle"));     // NOI18N
+            dialog.setDefaultCloseOperation(javax.swing.JFrame.DISPOSE_ON_CLOSE);
+            JPanel container = new JPanel();
+            container.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
+            container.setLayout(new BoxLayout(container, BoxLayout.Y_AXIS));
+            JLabel question = new JLabel(Bundle.getMessage("StoreAndComparePermissionDenied"));  // NOI18N
+            question.setAlignmentX(Component.CENTER_ALIGNMENT);
+            container.add(question);
+
+            JButton noButton = new JButton(Bundle.getMessage("ButtonNo"));    // NOI18N
+            JButton yesButton = new JButton(Bundle.getMessage("ButtonYes"));      // NOI18N
+            JPanel button = new JPanel();
+            button.setAlignmentX(Component.CENTER_ALIGNMENT);
+            button.add(noButton);
+            button.add(yesButton);
+            container.add(button);
+
+            noButton.addActionListener((ActionEvent e) -> {
+                dialog.dispose();
+                result.set(false);
+            });
+
+            yesButton.addActionListener((ActionEvent e) -> {
+                dialog.dispose();
+                result.set(true);
+            });
+
+            container.setAlignmentX(Component.CENTER_ALIGNMENT);
+            container.setAlignmentY(Component.CENTER_ALIGNMENT);
+            dialog.getContentPane().add(container);
+            dialog.pack();
+            dialog.setLocation((Toolkit.getDefaultToolkit().getScreenSize().width) / 2 - dialog.getWidth() / 2, (Toolkit.getDefaultToolkit().getScreenSize().height) / 2 - dialog.getHeight() / 2);
+            dialog.setModal(true);
+            dialog.setVisible(true);
+
+        } catch (HeadlessException ex) {
+            // silently do nothig - we can't display a dialog and shutdown continues without a store.
+        }
+        return result.get();
+    }
 
     static public void showDialog() {
         if (_preferences.getDisplayDialog().equals(ShutdownPreferences.DialogDisplayOptions.SkipDialog)) {

--- a/java/src/jmri/managers/DefaultShutDownManager.java
+++ b/java/src/jmri/managers/DefaultShutDownManager.java
@@ -307,7 +307,7 @@ public class DefaultShutDownManager extends Bean implements ShutDownManager {
                 return jmri.configurexml.StoreAndCompare.checkPermissionToStoreIfNeeded();
             });
             if (abort) {
-                log.info("User aborted due to unsaved changes and has not permission to store");
+                log.info("User aborted the shutdown request due to not having permission to store changes");
                 setShuttingDown(false);
                 return;
             }


### PR DESCRIPTION
@dsand47 
John Bauchiero found a [serious bug](https://groups.io/g/jmriusers/message/234176) with the permission system. When JMRI shut down, it asks the user if the user wants to store. I didn't thought about that so JMRI didn't check the user's permission before asking the user.

This PR adds a new dialog box which lets the user to abort the shutdown if data is changed and the user doesn't have permission to store. If the user selects No, the shutdown continues without showing a dialog to store.