### PR TITLE
TurnoutOperation Editor Dialog tweaks

### DIFF
--- a/java/src/jmri/jmrit/beantable/OBlockTableAction.java
+++ b/java/src/jmri/jmrit/beantable/OBlockTableAction.java
@@ -42,9 +42,9 @@ public class OBlockTableAction extends AbstractTableAction<OBlock> implements Pr
     // - PathTurnoutTable(block)
 
     @Nonnull
-    protected OBlockManager oblockManager = InstanceManager.getDefault(jmri.jmrit.logix.OBlockManager.class);
+    protected OBlockManager oblockManager = InstanceManager.getDefault(OBlockManager.class);
     @Nonnull
-    protected PortalManager portalManager = InstanceManager.getDefault(jmri.jmrit.logix.PortalManager.class);
+    protected PortalManager portalManager = InstanceManager.getDefault(PortalManager.class);
 
     TableFrames tf;
     OBlockTableFrame otf;
@@ -543,6 +543,6 @@ public class OBlockTableAction extends AbstractTableAction<OBlock> implements Pr
         return "package.jmri.jmrit.beantable.OBlockTable";
     }
 
-    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(OBlockTableAction.class);
+    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(OBlockTableAction.class);
 
 }

--- a/java/src/jmri/jmrit/beantable/turnout/TurnoutOperationEditorDialog.java
+++ b/java/src/jmri/jmrit/beantable/turnout/TurnoutOperationEditorDialog.java
@@ -1,5 +1,6 @@
 package jmri.jmrit.beantable.turnout;
 
+
 import javax.annotation.Nonnull;
 import javax.swing.*;
 
@@ -27,12 +28,13 @@ public class TurnoutOperationEditorDialog extends JDialog {
     /**
      * Pop up a TurnoutOperationConfig Dialog for the turnout.
      *
-     * @param op TunoutOperation to edit.
-     * @param t   turnout
-     * @param box JComboBox that triggered the edit, currently unused.
+     * @param op TunoutOperation to edit, not null.
+     * @param t  The turnout.
+     * @param window  Parent Window for the Dialog, can be null.
      */
-    TurnoutOperationEditorDialog( @Nonnull TurnoutOperation op, Turnout t, JComboBox<String> box, java.awt.Window w) {
-        super(w);
+    TurnoutOperationEditorDialog( @Nonnull TurnoutOperation op, @Nonnull Turnout t,
+            @javax.annotation.CheckForNull java.awt.Window window) {
+        super(window);
         self = this;
         myOp = op;
         myTurnout = t;

--- a/java/src/jmri/jmrit/beantable/turnout/TurnoutOperationEditorDialog.java
+++ b/java/src/jmri/jmrit/beantable/turnout/TurnoutOperationEditorDialog.java
@@ -9,9 +9,6 @@ import static jmri.jmrit.beantable.turnout.TurnoutTableDataModel.editingOps;
 import jmri.jmrit.turnoutoperations.TurnoutOperationConfig;
 import jmri.util.swing.JmriJOptionPane;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
  * Display a TurnoutOperationConfig Dialog for the turnout.
  * 
@@ -34,22 +31,22 @@ public class TurnoutOperationEditorDialog extends JDialog {
      * @param t   turnout
      * @param box JComboBox that triggered the edit, currently unused.
      */
-    TurnoutOperationEditorDialog( @Nonnull TurnoutOperation op, Turnout t, JComboBox<String> box) {
-        super();
+    TurnoutOperationEditorDialog( @Nonnull TurnoutOperation op, Turnout t, JComboBox<String> box, java.awt.Window w) {
+        super(w);
         self = this;
         myOp = op;
         myTurnout = t;
         init();
     }
-        
+
     private void init() {
-        
+
         myOp.addPropertyChangeListener(evt -> {
             if (evt.getPropertyName().equals("Deleted")) {
                 setVisible(false);
             }
         });
-        
+
         TurnoutOperationConfig config = TurnoutOperationConfig.getConfigPanel(myOp);
         setTitle();
         log.debug("TurnoutOpsEditDialog title set");
@@ -116,7 +113,7 @@ public class TurnoutOperationEditorDialog extends JDialog {
         setTitle(title);
     }
 
-    private final static Logger log = LoggerFactory.getLogger(TurnoutOperationEditorDialog.class);
+    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(TurnoutOperationEditorDialog.class);
 
 }
 

--- a/java/src/jmri/jmrit/beantable/turnout/TurnoutTableDataModel.java
+++ b/java/src/jmri/jmrit/beantable/turnout/TurnoutTableDataModel.java
@@ -721,7 +721,7 @@ public class TurnoutTableDataModel extends BeanTableDataModel<Turnout>{
      * @param t   turnout
      * @param box JComboBox that triggered the edit
      */
-    protected void editTurnoutOperation(Turnout t, JComboBox<String> box) {
+    protected void editTurnoutOperation( @Nonnull Turnout t, JComboBox<String> box) {
         if (!editingOps.getAndSet(true)) { // don't open a second edit ops pane
             TurnoutOperation op = t.getTurnoutOperation();
             if (op == null) {
@@ -738,7 +738,7 @@ public class TurnoutTableDataModel extends BeanTableDataModel<Turnout>{
                 // make and show edit dialog
                 log.debug("TurnoutOpsEditDialog starting");
                 java.awt.Window w = JmriJOptionPane.findWindowForObject(box);
-                TurnoutOperationEditorDialog dialog = new TurnoutOperationEditorDialog(op, t, box, w);
+                TurnoutOperationEditorDialog dialog = new TurnoutOperationEditorDialog(op, t, w);
                 dialog.setVisible(true);
             } else {
                 JmriJOptionPane.showMessageDialog(box, Bundle.getMessage("TurnoutOperationErrorDialog"),
@@ -777,7 +777,7 @@ public class TurnoutTableDataModel extends BeanTableDataModel<Turnout>{
      * @param t  turnout being configured
      * @param cb JComboBox for ops for t in the TurnoutTable
      */
-    protected void setTurnoutOperation(Turnout t, JComboBox<String> cb) {
+    protected void setTurnoutOperation( @Nonnull Turnout t, JComboBox<String> cb) {
         switch (cb.getSelectedIndex()) {
             case 0:   // Off
                 t.setInhibitOperation(true);

--- a/java/src/jmri/jmrit/beantable/turnout/TurnoutTableDataModel.java
+++ b/java/src/jmri/jmrit/beantable/turnout/TurnoutTableDataModel.java
@@ -737,7 +737,8 @@ public class TurnoutTableDataModel extends BeanTableDataModel<Turnout>{
                 }
                 // make and show edit dialog
                 log.debug("TurnoutOpsEditDialog starting");
-                TurnoutOperationEditorDialog dialog = new TurnoutOperationEditorDialog(op, t, box);
+                java.awt.Window w = JmriJOptionPane.findWindowForObject(box);
+                TurnoutOperationEditorDialog dialog = new TurnoutOperationEditorDialog(op, t, box, w);
                 dialog.setVisible(true);
             } else {
                 JmriJOptionPane.showMessageDialog(box, Bundle.getMessage("TurnoutOperationErrorDialog"),

--- a/java/test/jmri/jmrit/beantable/turnout/TurnoutOperationEditorDialogTest.java
+++ b/java/test/jmri/jmrit/beantable/turnout/TurnoutOperationEditorDialogTest.java
@@ -5,7 +5,6 @@ import jmri.util.JUnitUtil;
 
 import org.junit.Assert;
 import org.junit.jupiter.api.*;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 /**
  *
@@ -13,14 +12,14 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
  */
 public class TurnoutOperationEditorDialogTest {
     
-    @DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
+    @jmri.util.junit.annotations.DisabledIfHeadless
     @Test
     public void testCTor() {
         Turnout testedTurnout = InstanceManager.getDefault(TurnoutManager.class).provide("IS1");
         TurnoutOperation proto = InstanceManager.getDefault(TurnoutOperationManager.class).getMatchingOperationAlways(testedTurnout);
         Assert.assertNotNull("proto exists",proto);
-        
-        TurnoutOperationEditorDialog t = new TurnoutOperationEditorDialog(proto,testedTurnout,null);
+
+        TurnoutOperationEditorDialog t = new TurnoutOperationEditorDialog(proto,testedTurnout,null, null);
         Assert.assertNotNull("exists",t);
         
         t.dispose();

--- a/java/test/jmri/jmrit/beantable/turnout/TurnoutOperationEditorDialogTest.java
+++ b/java/test/jmri/jmrit/beantable/turnout/TurnoutOperationEditorDialogTest.java
@@ -19,7 +19,7 @@ public class TurnoutOperationEditorDialogTest {
         TurnoutOperation proto = InstanceManager.getDefault(TurnoutOperationManager.class).getMatchingOperationAlways(testedTurnout);
         Assert.assertNotNull("proto exists",proto);
 
-        TurnoutOperationEditorDialog t = new TurnoutOperationEditorDialog(proto,testedTurnout,null, null);
+        TurnoutOperationEditorDialog t = new TurnoutOperationEditorDialog(proto,testedTurnout,null);
         Assert.assertNotNull("exists",t);
         
         t.dispose();


### PR DESCRIPTION
**TurnoutOperationEditorDialog**
Constructor - Remove JComboBox, add Window, pass Window to super.
Even if null, saves creating a hidden nameless Frame to support the Dialog.
Does not affect Modailty ( still non-Modal )

**TurnoutTableDataModel**
Find Window and use updated constructor.
Nonnull annotation