### PR TITLE
Apps tests tweaks

### DIFF
--- a/java/test/apps/FileLocationPaneTest.java
+++ b/java/test/apps/FileLocationPaneTest.java
@@ -8,8 +8,6 @@ import jmri.util.JUnitUtil;
 import org.junit.jupiter.api.*;
 import org.mockito.Mockito;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 /**
  *
  * @author Paul Bender Copyright (C) 2017
@@ -27,7 +25,7 @@ public class FileLocationPaneTest extends PreferencesPanelTestBase<FileLocationP
     @Override
     @Test
     public void isPersistant() {
-        assertThat(prefsPanel.isPersistant()).isTrue();
+        Assertions.assertTrue( prefsPanel.isPersistant() );
     }
 
     // private final static Logger log = LoggerFactory.getLogger(FileLocationPaneTest.class);

--- a/java/test/apps/JmriFacelessTest.java
+++ b/java/test/apps/JmriFacelessTest.java
@@ -47,6 +47,9 @@ public class JmriFacelessTest {
         Assert.assertNotNull(a);
         // shutdown the application
         AppsBase.handleQuit();
+        JUnitUtil.waitFor( () ->
+           ((jmri.managers.DefaultShutDownManager)jmri.InstanceManager.getDefault(jmri.ShutDownManager.class)).
+            isShutDownComplete(),"Shutdown complete");
     }
 
     @BeforeEach

--- a/java/test/apps/ManagerDefaultsConfigPaneTest.java
+++ b/java/test/apps/ManagerDefaultsConfigPaneTest.java
@@ -5,8 +5,6 @@ import jmri.util.JUnitUtil;
 
 import org.junit.jupiter.api.*;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 /**
  *
  * @author Paul Bender Copyright (C) 2017
@@ -26,7 +24,7 @@ public class ManagerDefaultsConfigPaneTest extends PreferencesPanelTestBase<Mana
     @Override
     @Test
     public void isPersistant() {
-        assertThat(prefsPanel.isPersistant()).isTrue();
+        Assertions.assertTrue(prefsPanel.isPersistant());
     }
 
     // private final static Logger log = LoggerFactory.getLogger(ManagerDefaultsConfigPaneTest.class);

--- a/java/test/apps/gui3/FirstTimeStartUpWizardTest.java
+++ b/java/test/apps/gui3/FirstTimeStartUpWizardTest.java
@@ -1,30 +1,28 @@
 package apps.gui3;
 
+import apps.gui3.dp3.DecoderPro3;
+
 import java.io.File;
 import java.io.IOException;
 
 import jmri.InstanceManager;
 import jmri.jmrit.roster.RosterConfigManager;
 import jmri.util.JUnitAppender;
-
-import apps.gui3.dp3.DecoderPro3;
-
 import jmri.util.JUnitUtil;
 import jmri.util.gui.GuiLafPreferencesManager;
 
-import org.netbeans.jemmy.operators.*;
 import org.junit.jupiter.api.*;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.junit.jupiter.api.io.TempDir;
+import org.netbeans.jemmy.operators.*;
 
 import static org.junit.jupiter.api.Assertions.*;
-import org.junit.jupiter.api.io.TempDir;
 
 /**
  *
  * @author Paul Bender Copyright (C) 2017
  * @author Steve Young Copyright (C) 2022
  */
-@DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
+@jmri.util.junit.annotations.DisabledIfHeadless
 public class FirstTimeStartUpWizardTest {
 
     @Test
@@ -38,6 +36,9 @@ public class FirstTimeStartUpWizardTest {
         JUnitUtil.waitFor(() -> {
             return JUnitAppender.checkForMessageStartingWith("No pre-existing config file found, searched for ") != null;
         }, "no existing config Info line seen");
+
+        JUnitUtil.waitThreadTerminated("Start-Up Wizard Connect");
+
     }
 
     @Test
@@ -222,6 +223,7 @@ public class FirstTimeStartUpWizardTest {
     public void tearDown() {
         JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.resetApplication();
+        JUnitUtil.resetWindows(false, false);
         JUnitUtil.tearDown();
     }
 

--- a/java/test/apps/gui3/mdi/MDITest.java
+++ b/java/test/apps/gui3/mdi/MDITest.java
@@ -59,8 +59,9 @@ public class MDITest {
 
         jmri.util.swing.JemmyUtil.pressButton(wizardOperator, "Cancel");
 
-        JFrameOperator jfo = new JFrameOperator("JMRI GUI3 Demo");
-        Assertions.assertNotNull(jfo);
+        // struggles to find Frame in Win CI
+        // JFrameOperator jfo = new JFrameOperator("JMRI GUI3 Demo");
+        // Assertions.assertNotNull(jfo);
 
         // shutdown the application
         jmri.InstanceManager.getDefault(jmri.configurexml.ShutdownPreferences.class).setEnableStoreCheck(false);

--- a/java/test/apps/gui3/mdi/MDITest.java
+++ b/java/test/apps/gui3/mdi/MDITest.java
@@ -1,14 +1,16 @@
 package apps.gui3.mdi;
 
-import apps.AppsBase;
+import java.io.File;
+import java.io.IOException;
 
-import java.awt.GraphicsEnvironment;
+import apps.AppsBase;
 
 import jmri.util.JUnitUtil;
 
 import org.junit.jupiter.api.*;
-import org.junit.Assert;
-import org.junit.Assume;
+import org.junit.jupiter.api.io.TempDir;
+
+import org.netbeans.jemmy.operators.JFrameOperator;
 
 /**
  *
@@ -19,8 +21,8 @@ import org.junit.Assume;
 public class MDITest {
 
     @Test
+    @jmri.util.junit.annotations.DisabledIfHeadless
     public void testCtor() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         String[] args = {"DecoderProConfig3.xml"};
         AppsBase a = new MDI(args) {
             // force the application to not actually start.
@@ -50,16 +52,41 @@ public class MDITest {
                 JUnitUtil.initDebugThrottleManager();
             }
         };
-        Assert.assertNotNull(a);
+        Assertions.assertNotNull(a);
+
+        JFrameOperator wizardOperator = new JFrameOperator("DecoderPro Wizard");
+        Assertions.assertNotNull(wizardOperator);
+
+        jmri.util.swing.JemmyUtil.pressButton(wizardOperator, "Cancel");
+
+        JFrameOperator jfo = new JFrameOperator("JMRI GUI3 Demo");
+        Assertions.assertNotNull(jfo);
+
         // shutdown the application
-        AppsBase.handleQuit();
+        jmri.InstanceManager.getDefault(jmri.configurexml.ShutdownPreferences.class).setEnableStoreCheck(false);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
+
+        //   jfo.requestClose(); // fails to close
+        Assertions.assertFalse(AppsBase.handleQuit());
+
+        JUnitUtil.waitFor( () ->
+            ((jmri.managers.DefaultShutDownManager)jmri.InstanceManager.getDefault(
+            jmri.ShutDownManager.class)).isShutDownComplete(),"Shutdown complete");
+
+        // JUnitUtil.disposeFrame("JMRI GUI3 Demo", false, true); // still leaves Frame present ?
+
     }
 
     @BeforeEach
-    public void setUp() {
+    public void setUp(@TempDir File folder) {
         JUnitUtil.setUp();
         JUnitUtil.resetApplication();
-        JUnitUtil.resetProfileManager();
+        try {
+            JUnitUtil.resetProfileManager(new jmri.profile.NullProfile(folder));
+        } catch (IOException ioe) {
+            Assertions.fail("failed to reset the profile", ioe);
+        }
+        jmri.InstanceManager.setDefault(jmri.ShutDownManager.class, new jmri.util.MockShutDownManager());
     }
 
     @AfterEach

--- a/java/test/apps/gui3/paned/PanedTest.java
+++ b/java/test/apps/gui3/paned/PanedTest.java
@@ -11,14 +11,13 @@ import jmri.util.JUnitUtil;
 
 import org.junit.jupiter.api.*;
 import org.junit.Assert;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.io.TempDir;
 
 /**
  *
  * @author Paul Bender Copyright (C) 2017
  */
-@DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
+@jmri.util.junit.annotations.DisabledIfHeadless
 public class PanedTest {
 
     @Test
@@ -58,12 +57,16 @@ public class PanedTest {
         };
         Assert.assertNotNull(a);
         // shutdown the application
-        AppsBase.handleQuit();
+        Assertions.assertFalse(AppsBase.handleQuit());
         JUnitUtil.disposeFrame("DecoderPro Wizard", true, true);
         
         JUnitUtil.waitFor(() -> {
             return JUnitAppender.checkForMessageStartingWith("No pre-existing config file found, searched for ") != null;
         }, "no existing config Info line seen");
+
+        JUnitUtil.waitFor( () ->
+            ((jmri.managers.DefaultShutDownManager)jmri.InstanceManager.getDefault(
+            jmri.ShutDownManager.class)).isShutDownComplete(),"Shutdown complete");
     }
 
     @BeforeEach

--- a/java/test/apps/jmrit/log/Log4JTreePaneTest.java
+++ b/java/test/apps/jmrit/log/Log4JTreePaneTest.java
@@ -5,7 +5,7 @@ import jmri.util.JUnitUtil;
 import org.apache.logging.log4j.LogManager;
 
 import org.junit.jupiter.api.*;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
 import org.netbeans.jemmy.operators.*;
 import org.slf4j.LoggerFactory;
 
@@ -15,7 +15,7 @@ import org.slf4j.LoggerFactory;
  * @author Bob Jacobsen Copyright 2003, 2010
  * @author Steve Young Copyright(C) 2023
  */
-@DisabledIfSystemProperty(named = "java.awt.headless", matches = "true")
+@jmri.util.junit.annotations.DisabledIfHeadless
 public class Log4JTreePaneTest extends jmri.util.swing.JmriPanelTest {
 
     @Test
@@ -24,14 +24,15 @@ public class Log4JTreePaneTest extends jmri.util.swing.JmriPanelTest {
         LoggerFactory.getLogger("apps.foo");
         LoggerFactory.getLogger("jmri.util");
 
-        new jmri.util.swing.JmriNamedPaneAction("Log4J Tree",
+        jmri.util.ThreadingUtil.runOnGUI( () ->
+            new jmri.util.swing.JmriNamedPaneAction("Log4J Tree",
                 new jmri.util.swing.sdi.JmriJFrameInterface(),
-                "apps.jmrit.log.Log4JTreePane").actionPerformed(null);
+                "apps.jmrit.log.Log4JTreePane").actionPerformed(null));
         
         JFrameOperator jfo = new JFrameOperator(Bundle.getMessage("MenuItemLogTreeAction"));
         Assertions.assertNotNull(jfo);
 
-        jfo.requestClose();
+        JUnitUtil.dispose( jfo.getWindow() );
         jfo.waitClosed();
         
     }
@@ -40,9 +41,10 @@ public class Log4JTreePaneTest extends jmri.util.swing.JmriPanelTest {
     public void testChangeALoggingLevel(){
         String testLoggerName = "apps.jmrit.log.Log4JTreePaneTest.testChangeALoggingLevel";
 
-        new jmri.util.swing.JmriNamedPaneAction("Log4J Tree",
+        jmri.util.ThreadingUtil.runOnGUI( () ->
+            new jmri.util.swing.JmriNamedPaneAction("Log4J Tree",
                 new jmri.util.swing.sdi.JmriJFrameInterface(),
-                "apps.jmrit.log.Log4JTreePane").actionPerformed(null);
+                "apps.jmrit.log.Log4JTreePane").actionPerformed(null));
 
         JFrameOperator jfo = new JFrameOperator(Bundle.getMessage("MenuItemLogTreeAction"));
         Assertions.assertNotNull(jfo);
@@ -66,7 +68,7 @@ public class Log4JTreePaneTest extends jmri.util.swing.JmriPanelTest {
         JUnitUtil.waitFor(() -> !LogManager.getLogger(testLoggerName).isTraceEnabled() , "log level changed to error");
         Assertions.assertFalse(LogManager.getLogger(testLoggerName).isTraceEnabled());
 
-        jfo.requestClose();
+        JUnitUtil.dispose( jfo.getWindow() );
         jfo.waitClosed();
 
     }
@@ -75,7 +77,6 @@ public class Log4JTreePaneTest extends jmri.util.swing.JmriPanelTest {
     @Override
     public void setUp() {
         JUnitUtil.setUp();
-        JUnitUtil.resetInstanceManager();
         JUnitUtil.resetProfileManager();
 
         panel = new Log4JTreePane();

--- a/java/test/apps/swing/AboutDialogTest.java
+++ b/java/test/apps/swing/AboutDialogTest.java
@@ -7,7 +7,7 @@ import jmri.util.ThreadingUtil;
 
 import org.junit.Assert;
 import org.junit.jupiter.api.*;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
 import org.netbeans.jemmy.operators.JDialogOperator;
 
 /**
@@ -15,10 +15,10 @@ import org.netbeans.jemmy.operators.JDialogOperator;
  *
  * @author Paul Bender Copyright (C) 2017
  */
+@jmri.util.junit.annotations.DisabledIfHeadless
 public class AboutDialogTest {
 
     @Test
-    @DisabledIfSystemProperty(named = "java.awt.headless", matches = "true")
     public void testCtor() {
         // create a frame to be the dialog parent so that nothing attempts to
         // remove the SwingUtilities$SharedOwnerFrame instance
@@ -30,7 +30,6 @@ public class AboutDialogTest {
     }
 
     @Test
-    @DisabledIfSystemProperty(named = "java.awt.headless", matches = "true")
     public void testShowAndClose() {
         JFrame frame = new JFrame();
         AboutDialog dialog = new AboutDialog(frame, true);
@@ -38,7 +37,8 @@ public class AboutDialogTest {
         Thread t = new Thread(() -> {
             // constructor for jdo will wait until the dialog is visible
             JDialogOperator jdo = new JDialogOperator(Bundle.getMessage("TitleAbout", jmri.Application.getApplicationName()));
-            jdo.close();
+            jdo.requestClose();
+            jdo.waitClosed();
         });
         t.setName("About Dialog Close Thread");
         t.start();
@@ -46,7 +46,7 @@ public class AboutDialogTest {
             dialog.setVisible(true);
         });
         JUnitUtil.waitFor(() -> {
-            return !dialog.isVisible();
+            return !t.isAlive();
         }, "About dialog did not close");
         JUnitUtil.dispose(dialog);
         JUnitUtil.dispose(frame);


### PR DESCRIPTION
Add waits for Thread / shutDownManager to complete.
Use temp directories.

AboutDialogTest -
remove deprecated JDialogOperator close()
Wait for Thread to complete, not Dialog closed.