### PR TITLE
Tests - Windowoperator close deprecated

### DIFF
--- a/java/test/jmri/jmrit/beantable/signalmast/AddSignalMastPanelTest.java
+++ b/java/test/jmri/jmrit/beantable/signalmast/AddSignalMastPanelTest.java
@@ -32,23 +32,27 @@ public class AddSignalMastPanelTest {
     }
 
     @Test
+    @jmri.util.junit.annotations.DisabledIfHeadless
     @Disabled("possible cause of 'No output has been received in the last 10m0s' failure")    
     public void testIssueWarningUserName() {
         Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+
         // show and cancel each of the error dialogs
         AddSignalMastPanel a = new AddSignalMastPanel();
 
         jmri.util.ThreadingUtil.runOnLayoutEventually(() -> { a.issueWarningUserName("user name");});
-        new JDialogOperator("Warning").close();
+        JDialogOperator jdo = new JDialogOperator("Warning");
+        jdo.requestClose();
+        jdo.waitClosed();
         JUnitAppender.assertErrorMessage("User Name \"user name\" is already in use");
     }
     
     @Test
+    @jmri.util.junit.annotations.DisabledIfHeadless
     @Disabled("possible cause of 'No output has been received in the last 10m0s' failure")    
     public void testIssueWarningUserNameAsSystem() {
         Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+
         // show and cancel each of the error dialogs
         AddSignalMastPanel a = new AddSignalMastPanel();
 
@@ -58,10 +62,11 @@ public class AddSignalMastPanelTest {
     }
     
     @Test
+    @jmri.util.junit.annotations.DisabledIfHeadless
     @Disabled("possible cause of 'No output has been received in the last 10m0s' failure")
     public void testIssueNoUserNameGiven() {
         Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+
         // show and cancel each of the error dialogs
         AddSignalMastPanel a = new AddSignalMastPanel();
 
@@ -70,6 +75,7 @@ public class AddSignalMastPanelTest {
     }
     
     @Test
+    @jmri.util.junit.annotations.DisabledIfHeadless
     @Disabled("possible cause of 'No output has been received in the last 10m0s' failure")
     public void testIssueDialogFailMessage() {
         Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));

--- a/java/test/jmri/jmrit/blockboss/BlockBossActionTest.java
+++ b/java/test/jmri/jmrit/blockboss/BlockBossActionTest.java
@@ -1,13 +1,10 @@
 package jmri.jmrit.blockboss;
 
 import jmri.util.JUnitUtil;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
-import org.netbeans.jemmy.operators.JFrameOperator;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.*;
+
+import org.netbeans.jemmy.operators.JFrameOperator;
 
 /**
  *
@@ -18,17 +15,18 @@ public class BlockBossActionTest {
     @Test
     public void testCtor() {
         BlockBossAction t = new BlockBossAction();
-        assertThat(t).withFailMessage("exists").isNotNull();
+        Assertions.assertNotNull(t, "exists");
     }
 
     @Test
-    @DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
+    @jmri.util.junit.annotations.DisabledIfHeadless
     public void testAction() {
         BlockBossAction t = new BlockBossAction();
         t.actionPerformed(new java.awt.event.ActionEvent(this,1,"test action event"));
 
         JFrameOperator fo = new JFrameOperator(Bundle.getMessage("Simple_Signal_Logic"));
-        fo.close();
+        JUnitUtil.dispose(fo.getWindow());
+        fo.waitClosed();
     }
 
     @BeforeEach

--- a/java/test/jmri/jmrit/ctc/editor/CtcEditorSignalHeadsTest.java
+++ b/java/test/jmri/jmrit/ctc/editor/CtcEditorSignalHeadsTest.java
@@ -1,6 +1,5 @@
 package jmri.jmrit.ctc.editor;
 
-import java.awt.GraphicsEnvironment;
 import java.io.File;
 import java.io.IOException;
 
@@ -12,7 +11,6 @@ import jmri.profile.NullProfile;
 import jmri.util.JUnitUtil;
 
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.io.TempDir;
 import org.netbeans.jemmy.EventTool;
@@ -23,16 +21,16 @@ import org.netbeans.jemmy.operators.*;
  *
  * @author Dave Sand Copyright (C) 2019
  */
+@jmri.util.junit.annotations.DisabledIfHeadless
 public class CtcEditorSignalHeadsTest {
 
-    JFrameOperator _jfo = null;
+    private JFrameOperator _jfo = null;
 
     static int DELAY = 0;  // if this is final, get dead code warnings
     static final boolean PAUSE = false;
 
     @Test
     public void testEditor() throws Exception {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
 
         // Load the test panel and initialize Logix and advanced block routing
         java.io.File f = new java.io.File("java/test/jmri/jmrit/ctc/configurexml/load/CTC_Test_Heads-SSL.xml");  // NOI18N
@@ -359,7 +357,8 @@ public class CtcEditorSignalHeadsTest {
         JFrameOperator frmRulesLeft = new JFrameOperator("Edit Left traffic locking rules");  // NOI18N
         Assert.assertNotNull(frmRulesLeft);
         if (PAUSE) JUnitUtil.waitFor(2000);
-        frmRulesLeft.close();
+        frmRulesLeft.requestClose();
+        frmRulesLeft.waitClosed();
 
         // Close the TRL summary
         new JButtonOperator(frmTRL, Bundle.getMessage("ButtonOK")).doClick();
@@ -520,8 +519,10 @@ public class CtcEditorSignalHeadsTest {
 
     @Test
     public void testMakePanel() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        Assert.assertThrows(IllegalArgumentException.class, () -> new CtcEditorAction().makePanel());
+
+        Exception ex = Assertions.assertThrows(IllegalArgumentException.class, () ->
+            new CtcEditorAction().makePanel());
+        Assertions.assertNotNull(ex);
     }
 
     @BeforeEach

--- a/java/test/jmri/jmrit/ctc/editor/CtcEditorSignalMastsTest.java
+++ b/java/test/jmri/jmrit/ctc/editor/CtcEditorSignalMastsTest.java
@@ -1,6 +1,5 @@
 package jmri.jmrit.ctc.editor;
 
-import java.awt.GraphicsEnvironment;
 import java.io.File;
 import java.io.IOException;
 
@@ -12,7 +11,6 @@ import jmri.profile.NullProfile;
 import jmri.util.JUnitUtil;
 
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.io.TempDir;
 import org.netbeans.jemmy.EventTool;
@@ -23,16 +21,16 @@ import org.netbeans.jemmy.operators.*;
  *
  * @author Dave Sand Copyright (C) 2019
  */
+@jmri.util.junit.annotations.DisabledIfHeadless
 public class CtcEditorSignalMastsTest {
 
-    JFrameOperator _jfo = null;
+    private JFrameOperator _jfo = null;
 
     static int DELAY = 0;  // if this is final, get dead code warnings
     static final boolean PAUSE = false;
 
     @Test
     public void testEditor() throws Exception {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
 
         // Load the test panel and initialize Logix and advanced block routing
         java.io.File f = new java.io.File("java/test/jmri/jmrit/ctc/configurexml/load/CTC_Test_Masts-SML.xml");  // NOI18N
@@ -400,7 +398,8 @@ public class CtcEditorSignalMastsTest {
         JFrameOperator frmRulesLeft = new JFrameOperator("Edit Left traffic locking rules");  // NOI18N
         Assert.assertNotNull(frmRulesLeft);
         if (PAUSE) JUnitUtil.waitFor(2000);
-        frmRulesLeft.close();
+        frmRulesLeft.requestClose();
+        frmRulesLeft.waitClosed();
 
         // Close the TRL summary
         new JButtonOperator(frmTRL, Bundle.getMessage("ButtonOK")).doClick();
@@ -572,8 +571,9 @@ public class CtcEditorSignalMastsTest {
 
     @Test
     public void testMakePanel() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        Assert.assertThrows(IllegalArgumentException.class, () -> new CtcEditorAction().makePanel());
+        Exception ex = Assertions.assertThrows(IllegalArgumentException.class, () ->
+            new CtcEditorAction().makePanel());
+        Assertions.assertNotNull(ex);
     }
 
     @BeforeEach

--- a/java/test/jmri/jmrit/logix/OpSessionLogTest.java
+++ b/java/test/jmri/jmrit/logix/OpSessionLogTest.java
@@ -1,9 +1,7 @@
 package jmri.jmrit.logix;
 
-import java.awt.GraphicsEnvironment;
 import jmri.util.JUnitUtil;
-import org.junit.Assert;
-import org.junit.Assume;
+
 import org.junit.jupiter.api.*;
 import org.netbeans.jemmy.operators.JDialogOperator;
 
@@ -13,22 +11,23 @@ import org.netbeans.jemmy.operators.JDialogOperator;
  */
 public class OpSessionLogTest {
 
-    jmri.util.JmriJFrame f;
-    boolean retval;
-    
+    private jmri.util.JmriJFrame f;
+    private boolean retval;
+
     @Test
+    @jmri.util.junit.annotations.DisabledIfHeadless
     public void openAndClose() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-                
+
         // create the window and make the log file on Swing thread
         jmri.util.ThreadingUtil.runOnGUI(() -> {
             f = new jmri.util.JmriJFrame("OpSessionLog Chooser Test");
-            
+
             // create a thread that waits to close the dialog box opened later
             Thread t = new Thread(() -> {
                 // constructor for jdo will wait until the dialog is visible
                 JDialogOperator jdo = new JDialogOperator(Bundle.getMessage("logSession"));
-                jdo.close();
+                jdo.requestClose();
+                jdo.waitClosed();
             });
             t.setName("OpSessionLog File Chooser Dialog Close Thread");
             t.start();
@@ -36,18 +35,18 @@ public class OpSessionLogTest {
             // get the result of closing
             retval = OpSessionLog.makeLogFile(f);
         });
-        
+
         // check results
-        Assert.assertFalse(retval);
-        
+        Assertions.assertFalse(retval);
+
         // done
         f.dispose();
     }
 
     @Test
     @Disabled("needs more thought")
+    @jmri.util.junit.annotations.DisabledIfHeadless
     public void makeLogFileCheck() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
        // This is going to be a graphical check.
        // make sure the log file is correctly chosen and created.
     }

--- a/java/test/jmri/util/AbstractFrameActionTest.java
+++ b/java/test/jmri/util/AbstractFrameActionTest.java
@@ -1,10 +1,8 @@
 package jmri.util;
 
-import java.awt.GraphicsEnvironment;
-
 import org.junit.Assert;
 import org.junit.jupiter.api.*;
-import org.junit.Assume;
+
 import org.netbeans.jemmy.operators.JFrameOperator;
 
 /**
@@ -21,9 +19,8 @@ public class AbstractFrameActionTest {
     }
 
     @Test
-    @SuppressWarnings("deprecation") // WindowOperations.close()
+    @jmri.util.junit.annotations.DisabledIfHeadless
     public void testAction() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         AbstractFrameAction t = new AbstractFrameAction("TestAction","jmri.util.JmriJFrame"){
         };
         t.actionPerformed(new java.awt.event.ActionEvent(this,1,"test action event"));
@@ -32,7 +29,8 @@ public class AbstractFrameActionTest {
         Assert.assertNotNull("found output frame", f);
         // then close the frame.
         JFrameOperator fo = new JFrameOperator(f);
-        fo.close();
+        fo.requestClose();
+        fo.waitClosed();
 
     }
 


### PR DESCRIPTION
WindowOperator close is deprecated.
Updates tests currently using this method.