### PR TITLE
Do not release allocated sections from a train with know presence.

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -405,7 +405,7 @@
    <h3>Dispatcher</h3>
         <a id="Dispatcher" name="Dispatcher"></a>
         <ul>
-             <li></li>
+             <li>Do not release any allocated section from a train if the position of the train is not known.</li>
         </ul>
 
     <h3>Dispatcher System</h3>


### PR DESCRIPTION
Do not release any allocated section from a train if it has no occupied allocated section as the position of the train is not known.