### PR TITLE
JUnitUtil / LocoNetThrottledTransmitter Test

### DIFF
--- a/java/test/jmri/jmrix/loconet/LocoNetThrottledTransmitterTest.java
+++ b/java/test/jmri/jmrix/loconet/LocoNetThrottledTransmitterTest.java
@@ -20,6 +20,7 @@ public class LocoNetThrottledTransmitterTest {
         LocoNetThrottledTransmitter q = new LocoNetThrottledTransmitter(new LocoNetInterfaceScaffold(memo), false);
         q.dispose();
         JUnitUtil.waitFor(()->{return !q.running;}, "stopped");
+        JUnitUtil.waitThreadTerminated(q.theServiceThread);
     }
 
     @Test
@@ -30,6 +31,7 @@ public class LocoNetThrottledTransmitterTest {
 
         q.dispose();
         JUnitUtil.waitFor(()->{return !q.running;}, "stopped");
+        JUnitUtil.waitThreadTerminated(q.theServiceThread);
     }
 
     @Test
@@ -63,6 +65,7 @@ public class LocoNetThrottledTransmitterTest {
 
         q.dispose();
         JUnitUtil.waitFor(()->{return !q.running;}, "stopped");
+        JUnitUtil.waitThreadTerminated(q.theServiceThread);
     }
 
     @Test
@@ -85,6 +88,7 @@ public class LocoNetThrottledTransmitterTest {
 
         q.dispose();
         JUnitUtil.waitFor(()->{return !q.running;}, "stopped");
+        JUnitUtil.waitThreadTerminated(q.theServiceThread);
     }
 
     @Test
@@ -114,6 +118,7 @@ public class LocoNetThrottledTransmitterTest {
 
         q.dispose();
         JUnitUtil.waitFor(()->{return !q.running;}, "stopped");
+        JUnitUtil.waitThreadTerminated(q.theServiceThread);
     }
 
     @Test
@@ -142,6 +147,7 @@ public class LocoNetThrottledTransmitterTest {
 
         q.dispose();
         JUnitUtil.waitFor(()->{return !q.running;}, "stopped");
+        JUnitUtil.waitThreadTerminated(q.theServiceThread);
     }
 
     private LocoNetSystemConnectionMemo memo;
@@ -156,7 +162,6 @@ public class LocoNetThrottledTransmitterTest {
     public void tearDown() {
         Assertions.assertNotNull(memo);
         memo.dispose();
-        JUnitUtil.waitThreadTerminated(memo.getUserName() + LocoNetThrottledTransmitter.SERVICE_THREAD_NAME);
         memo = null;
         JUnitUtil.tearDown();
     }

--- a/java/test/jmri/util/JUnitUtil.java
+++ b/java/test/jmri/util/JUnitUtil.java
@@ -1433,6 +1433,15 @@ public class JUnitUtil {
     }
 
     /**
+     * Wait for a thread to terminate, ie is no longer alive.
+     * A Thread which does not complete in time is a test failure.
+     * @param thread the Thread to wait for.
+     */
+    public static void waitThreadTerminated( @Nonnull Thread thread ) {
+        waitFor( () -> !thread.isAlive(), "Thread \"" + thread.getName() + "\" is still alive");
+    }
+
+    /**
      * Get a Thread by matching the name.
      * @param threadName Starting characters of the Thread name.
      * @return the Thread, null if no Thread found.


### PR DESCRIPTION
**JUnitUtil**
adds waitThreadTerminated( @nonnull Thread thread )

**LocoNetThrottledTransmitterTest**
waitFor Thread instance, not Thread name.