### PR TITLE
Sprog SystemConnectionMemo - dispose of TrafficManager

### DIFF
--- a/java/src/jmri/jmrix/sprog/SprogSystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/sprog/SprogSystemConnectionMemo.java
@@ -305,6 +305,9 @@ public class SprogSystemConnectionMemo extends DefaultSystemConnectionMemo imple
 
     @Override
     public void dispose() {
+        if (st != null) {
+            st.dispose();
+        }
         st = null;
         InstanceManager.deregister(this, SprogSystemConnectionMemo.class);
         if (cf != null) {


### PR DESCRIPTION
When dispose is called on the System Connection, also dispose of the TrafficManager