### PR TITLE
Use actions/upload-artifact@v4 for Windows CI

### DIFF
--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -34,7 +34,7 @@ jobs:
         # run all tests using maven
         mvn test "-Djmri.skipTestsRequiringSeparateRunning=true" "-Dsurefire.printSummary=false"
     - name: Upload generated screenshots artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: ${{ always() }}
       with:
         name: screenshots


### PR DESCRIPTION
### Deprecation notice: v1, v2, and v3 of the artifact actions
We use `actions/upload-artifact@v3` for Windows CI, but this artifact is deprecated and will be removed.
This PR updates Windows CI to use `actions/upload-artifact@v4` instead.

https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes

