### PR TITLE
Panels can be read only

### DIFF
--- a/java/src/jmri/jmrit/display/DisplayBundle.properties
+++ b/java/src/jmri/jmrit/display/DisplayBundle.properties
@@ -594,3 +594,6 @@ EditorPermissions_EditorPermission_ReadWriteEdit   = Read, write and edit
 
 Editor_PermissionDenied     = Permission denied
 Editor_LoginToViewPanel     = Login to view the panel
+
+JmriJFrameWithPermissions_TitleError    = Error
+JmriJFrameWithPermissions_PanelReadOnly = Panel is read only

--- a/java/src/jmri/jmrit/display/JmriJFrameWithPermissions.java
+++ b/java/src/jmri/jmrit/display/JmriJFrameWithPermissions.java
@@ -1,12 +1,14 @@
 package jmri.jmrit.display;
 
 import java.awt.*;
+import java.awt.event.*;
 
 import javax.swing.*;
 
 import jmri.InstanceManager;
 import jmri.PermissionManager;
 import jmri.util.JmriJFrame;
+import jmri.util.swing.JmriJOptionPane;
 
 /**
  * A JmriJFrame with permissions.
@@ -43,6 +45,7 @@ public class JmriJFrameWithPermissions extends JmriJFrame {
         if (!InstanceManager.getDefault(PermissionManager.class).isEnabled()) {
             return;
         }
+        setGlassPane(new MyGlassPane().init());
         _hiddenPane.setLayout(new GridBagLayout());  // Center innerPanel
         JPanel innerPanel = new JPanel();
         innerPanel.setLayout(new BoxLayout(innerPanel, BoxLayout.Y_AXIS));
@@ -69,11 +72,17 @@ public class JmriJFrameWithPermissions extends JmriJFrame {
         if (! InstanceManager.getDefault(PermissionManager.class)
                 .hasAtLeastPermission(EditorPermissions.EDITOR_PERMISSION,
                         EditorPermissions.EditorPermissionEnum.Read)) {
+            super.getGlassPane().setVisible(false);
             super.setContentPane(_hiddenPane);
             super.setJMenuBar(_hiddenMenuBar);
         } else {
             super.setContentPane(_contentPane);
             super.setJMenuBar(_menuBar);
+            super.getGlassPane().setVisible(
+                    ! InstanceManager.getDefault(PermissionManager.class)
+                            .hasAtLeastPermission(EditorPermissions.EDITOR_PERMISSION,
+                                    EditorPermissions.EditorPermissionEnum.ReadWrite)
+            );
         }
         // Save the bounds before pack() since pack() might resize the panel
         Rectangle bounds = getBounds();
@@ -139,6 +148,73 @@ public class JmriJFrameWithPermissions extends JmriJFrame {
      */
     public final void setKeepSize(boolean keepSize) {
         this._keepSize = keepSize;
+    }
+
+
+    /**
+     * This pane consumes all the mouse events and key events when visible.
+     * It's used when the panel is read only.
+     */
+    private static class MyGlassPane extends JPanel
+            implements MouseListener, KeyListener {
+
+        private MyGlassPane init() {
+            setOpaque(false);
+            addMouseListener(this);
+            addKeyListener(this);
+            return this;
+        }
+
+        private void showReadOnly() {
+            JmriJOptionPane.showMessageDialog(this,
+                    Bundle.getMessage("JmriJFrameWithPermissions_PanelReadOnly"),
+                    Bundle.getMessage("JmriJFrameWithPermissions_TitleError"),
+                    JmriJOptionPane.ERROR_MESSAGE);
+        }
+
+        @Override
+        public void mouseClicked(MouseEvent e) {
+            // Do nothing
+        }
+
+        @Override
+        public void mousePressed(MouseEvent e) {
+            e.consume();
+            requestFocusInWindow();
+            showReadOnly();
+        }
+
+        @Override
+        public void mouseReleased(MouseEvent e) {
+            // Do nothing
+        }
+
+        @Override
+        public void mouseEntered(MouseEvent e) {
+            // Do nothing
+        }
+
+        @Override
+        public void mouseExited(MouseEvent e) {
+            // Do nothing
+        }
+
+        @Override
+        public void keyTyped(KeyEvent e) {
+            e.consume();
+            showReadOnly();
+        }
+
+        @Override
+        public void keyPressed(KeyEvent e) {
+            // Do nothing
+        }
+
+        @Override
+        public void keyReleased(KeyEvent e) {
+            // Do nothing
+        }
+
     }
 
 }

--- a/java/src/jmri/jmrit/display/JmriJFrameWithPermissions.java
+++ b/java/src/jmri/jmrit/display/JmriJFrameWithPermissions.java
@@ -8,7 +8,7 @@ import javax.swing.*;
 import jmri.InstanceManager;
 import jmri.PermissionManager;
 import jmri.util.JmriJFrame;
-import jmri.util.swing.JmriJOptionPane;
+import jmri.util.swing.*;
 
 /**
  * A JmriJFrame with permissions.
@@ -156,11 +156,11 @@ public class JmriJFrameWithPermissions extends JmriJFrame {
      * It's used when the panel is read only.
      */
     private static class MyGlassPane extends JPanel
-            implements MouseListener, KeyListener {
+            implements JmriMouseListener, KeyListener {
 
         private MyGlassPane init() {
             setOpaque(false);
-            addMouseListener(this);
+            addMouseListener(JmriMouseListener.adapt(this));
             addKeyListener(this);
             return this;
         }
@@ -173,29 +173,29 @@ public class JmriJFrameWithPermissions extends JmriJFrame {
         }
 
         @Override
-        public void mouseClicked(MouseEvent e) {
+        public void mouseClicked(JmriMouseEvent e) {
             // Do nothing
         }
 
         @Override
-        public void mousePressed(MouseEvent e) {
+        public void mousePressed(JmriMouseEvent e) {
             e.consume();
             requestFocusInWindow();
             showReadOnly();
         }
 
         @Override
-        public void mouseReleased(MouseEvent e) {
+        public void mouseReleased(JmriMouseEvent e) {
             // Do nothing
         }
 
         @Override
-        public void mouseEntered(MouseEvent e) {
+        public void mouseEntered(JmriMouseEvent e) {
             // Do nothing
         }
 
         @Override
-        public void mouseExited(MouseEvent e) {
+        public void mouseExited(JmriMouseEvent e) {
             // Do nothing
         }
 

--- a/java/src/jmri/util/swing/JmriMouseEvent.java
+++ b/java/src/jmri/util/swing/JmriMouseEvent.java
@@ -496,4 +496,12 @@ public class JmriMouseEvent {
         return event.getSource();
     }
 
+    /**
+     * Consumes this event so that it will not be processed
+     * in the default manner by the source which originated it.
+     */
+    public void consume() {
+        event.consume();
+    }
+
 }


### PR DESCRIPTION
If the user has the permission `Read` for panels but not have permission `Read and write`, this PR consumes mouse and keyboard events so that the user cannot change anything on the panel.

Note that this also means that the user cannot control the scrollbars on the panel.