### PR TITLE
ETCS DMI - Use float for dial speeds

### DIFF
--- a/help/en/package/jmri/jmrit/etcs/index.shtml
+++ b/help/en/package/jmri/jmrit/etcs/index.shtml
@@ -85,6 +85,8 @@ dmiPanel.setActualSpeed(100)<br>
 
     <a href="https://www.era.europa.eu/domains/infrastructure/european-rail-traffic-management-system-ertms_en">European Rail Agency - ERTMS</a>
       <br>
+      <a href="https://www.era.europa.eu/content/braking-curves">ERTMS Brake Curve Spec</a>
+      <br>
       <a href="https://en.wikipedia.org/wiki/European_Train_Control_System">Wikipedia - ETCS</a>
       <br>
       <a href="https://youtu.be/eBnoQ_fGFas?si=5vvOOAglGA_pxqhF">YouTube - UK ERTMS on the Northern City Line</a>

--- a/java/src/jmri/jmrit/cabsignals/package-info.java
+++ b/java/src/jmri/jmrit/cabsignals/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Implements aspects of Cab Signalling.
+ */
+@edu.umd.cs.findbugs.annotations.DefaultAnnotation(value={})
+package jmri.jmrit.cabsignals;

--- a/java/src/jmri/jmrit/etcs/dmi/swing/DmiCircularSpeedGuideSection.java
+++ b/java/src/jmri/jmrit/etcs/dmi/swing/DmiCircularSpeedGuideSection.java
@@ -11,8 +11,8 @@ import org.apiguardian.api.API;
 @API(status=API.Status.EXPERIMENTAL)
 public class DmiCircularSpeedGuideSection {
 
-    final int start;
-    final int stop;
+    final float start;
+    final float stop;
     final int type;
     final Color col;
     final boolean includeHook;
@@ -31,7 +31,7 @@ public class DmiCircularSpeedGuideSection {
      * @param stopSpeed the section End speed.
      * @param hook true to include a hook, else false.
      */
-    public DmiCircularSpeedGuideSection(int csgType, Color colour, int startSpeed, int stopSpeed, boolean hook) {
+    public DmiCircularSpeedGuideSection(int csgType, Color colour, float startSpeed, float stopSpeed, boolean hook) {
         this( csgType, colour, startSpeed, stopSpeed, hook, false);
     }
 
@@ -44,8 +44,8 @@ public class DmiCircularSpeedGuideSection {
      * @param hook true to include a hook, else false.
      * @param includeNegative true to include the negative section.
      */
-    public DmiCircularSpeedGuideSection(int csgType, Color colour, int startSpeed,
-        int stopSpeed, boolean hook, boolean includeNegative ) {
+    public DmiCircularSpeedGuideSection(int csgType, Color colour, float startSpeed,
+        float stopSpeed, boolean hook, boolean includeNegative ) {
         start = startSpeed;
         stop = stopSpeed;
         type = csgType;

--- a/java/src/jmri/jmrit/etcs/dmi/swing/DmiPanel.java
+++ b/java/src/jmri/jmrit/etcs/dmi/swing/DmiPanel.java
@@ -205,7 +205,7 @@ public class DmiPanel extends JPanel {
      * Set the speed value to be displayed by the dial and in centre of dial.
      * @param speed no unit specified.
      */
-    public void setActualSpeed( int speed ) {
+    public void setActualSpeed( float speed ) {
         ThreadingUtil.runOnGUI( () -> panelB.setActualSpeed(speed) );
     }
 
@@ -364,7 +364,7 @@ public class DmiPanel extends JPanel {
      * A negative value hides the icon.
      * @param spd the Limited Supervision Speed.
      */
-    public void setLimitedSupervisionSpeed(int spd) {
+    public void setLimitedSupervisionSpeed(float spd) {
         ThreadingUtil.runOnGUI( () -> panelA.setLimitedSupervisionSpeed(spd) );
     }
 
@@ -374,7 +374,7 @@ public class DmiPanel extends JPanel {
      * Values displayed to nearest 10m.
      * @param distance the distance to set.
      */
-    public void setDistanceToTarget(int distance){
+    public void setDistanceToTarget(float distance){
         ThreadingUtil.runOnGUI( () -> panelA.setDistanceToTarget(distance) );
     }
 

--- a/java/src/jmri/jmrit/etcs/dmi/swing/DmiPanelA.java
+++ b/java/src/jmri/jmrit/etcs/dmi/swing/DmiPanelA.java
@@ -160,11 +160,11 @@ public class DmiPanelA extends JPanel {
         };
     }
 
-    protected void setLimitedSupervisionSpeed(int spd){
+    protected void setLimitedSupervisionSpeed(float spd){
         if ( spd < 0 ) {
             speedString="";
         } else {
-            speedString = (String.valueOf(spd));
+            speedString = (String.valueOf(Math.round(spd)));
         }
         repaint();
     }
@@ -174,8 +174,8 @@ public class DmiPanelA extends JPanel {
         a4Label.setToolTipText(newVal ?  Bundle.getMessage("AdhesionFactorOn") : null);
     }
 
-    protected void setDistanceToTarget(int distance) {
-        distanceToTarget = distance;
+    protected void setDistanceToTarget(float distance) {
+        distanceToTarget = Math.round(distance);
         a2Label.setVisible(distanceToTarget >= 0 );
         int nearestTen = ((distanceToTarget + 5) / 10) * 10;
         a2Label.setText(String.valueOf(nearestTen));

--- a/java/src/jmri/jmrit/etcs/dmi/swing/DmiPanelB.java
+++ b/java/src/jmri/jmrit/etcs/dmi/swing/DmiPanelB.java
@@ -152,7 +152,7 @@ public class DmiPanelB extends JPanel {
         p.setCentreCircleAndDialColor(color);
     }
 
-    protected void setActualSpeed( int speed ) {
+    protected void setActualSpeed( float speed ) {
         p.update(speed);
     }
 
@@ -259,7 +259,7 @@ public class DmiPanelB extends JPanel {
                 b7Label.setToolTipText(Bundle.getMessage("SupervisedManoeuvre"));
                 break;
             default:
-                throw new IllegalArgumentException("Could not set Mode " + newMode);
+                log.error("Could not set Mode {}", newMode);
         }
     }
 

--- a/java/src/jmri/jmrit/etcs/dmi/swing/DmiSpeedoDialPanel.java
+++ b/java/src/jmri/jmrit/etcs/dmi/swing/DmiSpeedoDialPanel.java
@@ -26,7 +26,7 @@ import javax.swing.JPanel;
  */
 public class DmiSpeedoDialPanel extends JPanel {
 
-    private int speed = 0;
+    private float speed = 0;
     private float targetAdviceSpeed = -1; // unset
     private int maxSpeed = 140;
     private int majorSpeedGap = 20; // every 20 mph from 0
@@ -270,7 +270,7 @@ public class DmiSpeedoDialPanel extends JPanel {
         g2.fillOval(-dotSize, -dotSize, dotSize *2, dotSize*2);
 
         // display the speed value in centre of the centre circle
-        String speedString = Integer.toString(speed);
+        String speedString = getSpeedString(speed);
         Font digitsSizedFont = new Font(DmiPanel.FONT_NAME, Font.BOLD, 22);
         g2.setFont(digitsSizedFont);
         g2.setColor( centreCircleAndDialColor==DmiPanel.RED ? Color.WHITE : Color.BLACK);
@@ -279,6 +279,21 @@ public class DmiSpeedoDialPanel extends JPanel {
             g2.drawString(speedString, -digitsFontM.stringWidth(speedString) / 2 , 7);
         } else { // right-align
             g2.drawString(speedString, 18-digitsFontM.stringWidth(speedString) , 7);
+        }
+    }
+
+    /**
+     * Get a String for the Speed value.
+     * Speeds are displayed to nearest whole number.
+     * If the speed is non-zero, the minimum displayable speed is 1 .
+     * @param speed the loco speed.
+     * @return formatted String.
+     */
+    private String getSpeedString(float speed) {
+        if (speed > 0f) { // round to nearest whole number
+            return String.valueOf(Math.max(1, Math.round(speed)));
+        } else {
+            return "0";
         }
     }
 
@@ -349,7 +364,7 @@ public class DmiSpeedoDialPanel extends JPanel {
         if (speed > maxSpeed) {
             log.debug("add code here to move scale up");
         }
-        this.speed = Math.round(speed);
+        this.speed = speed;
         repaint();
     }
 

--- a/java/test/jmri/jmrit/etcs/dmi/swing/DmiSpeedoDialPanelTest.java
+++ b/java/test/jmri/jmrit/etcs/dmi/swing/DmiSpeedoDialPanelTest.java
@@ -43,7 +43,7 @@ public class DmiSpeedoDialPanelTest {
         stepSpeeds(p, 400);
         // stepSpeeds(p, 600);
 
-        jfo.requestClose();
+        JUnitUtil.dispose(jfo.getWindow());
         jfo.waitClosed();
     }
 
@@ -66,7 +66,7 @@ public class DmiSpeedoDialPanelTest {
 
         // JUnitUtil.waitFor(1000);
 
-        jfo.requestClose();
+        JUnitUtil.dispose(jfo.getWindow());
         jfo.waitClosed();
 
     }
@@ -75,7 +75,7 @@ public class DmiSpeedoDialPanelTest {
 
         p.setMaxDialSpeed(maxSpeed);
         // JUnitUtil.waitFor(1000);
-        for (int i = 0; i <= maxSpeed; i++) {
+        for (float i = 0; i <= maxSpeed; i += 0.4f) {
             p.setActualSpeed(i);
 
             DmiCircularSpeedGuideSection csg = new DmiCircularSpeedGuideSection(
@@ -109,7 +109,7 @@ public class DmiSpeedoDialPanelTest {
         // JUnitUtil.waitFor(1000);
     }
 
-    private void setSpeedHookSpeed(int speedHookSpeed, DmiPanel p){
+    private void setSpeedHookSpeed(float speedHookSpeed, DmiPanel p){
     
         ArrayList<DmiCircularSpeedGuideSection> csgSectionList = new ArrayList<>();
         csgSectionList.add(new DmiCircularSpeedGuideSection(DmiCircularSpeedGuideSection.CSG_TYPE_NORMAL,


### PR DESCRIPTION
**ERTMS ETCS DMI Speed Dial** - Accept float values for improved accuracy vs integer.
**DmiPanelB** - avoid exception in constructor
**package-info** - added