### PR TITLE
Replace the serial port on the fly

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -647,5 +647,10 @@
                 Group. If there is any problem, it could case JMRI to
                 not quit properly, not restart properly or leave Java
                 running when JMRI has quit.</li>
+            <li>It's now possible for a class in JMRI to replace the
+                serial port on the fly, without the rest of JMRI noticing
+                it. It's useful for example for a firmware uploader that
+                needs exclusive access to the serial port. For an
+                example, see jmri.jmrix.loconet.demoport.DemoSerialPortAction.</li>
         </ul>
 

--- a/java/src/jmri/jmrix/AbstractPortController.java
+++ b/java/src/jmri/jmrix/AbstractPortController.java
@@ -561,7 +561,7 @@ abstract public class AbstractPortController implements PortAdapter {
      * @throws IOException if the stream is e.g. closed due to failure to open the port completely
      */
      @SuppressFBWarnings(value = "SR_NOT_CHECKED", justification = "skipping all, don't care what skip() returns")
-     protected static void purgeStream(@Nonnull java.io.InputStream serialStream) throws IOException {
+     public static void purgeStream(@Nonnull java.io.InputStream serialStream) throws IOException {
         int count = serialStream.available();
         log.debug("input stream shows {} bytes available", count);
         while (count > 0) {

--- a/java/src/jmri/jmrix/AbstractSerialPortController.java
+++ b/java/src/jmri/jmrix/AbstractSerialPortController.java
@@ -1,16 +1,10 @@
 package jmri.jmrix;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.*;
-import java.util.Set;
 import java.util.Vector;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import jmri.SystemConnectionMemo;
-import jmri.util.SystemType;
 
 /**
  * Provide an abstract base for *PortController classes.
@@ -102,7 +96,7 @@ abstract public class AbstractSerialPortController extends AbstractPortControlle
      * @return the serial port object for later use
      */
     final protected SerialPort activatePort(String portName, org.slf4j.Logger log) {
-        return activatePort(this.getSystemPrefix(), portName, log, 1, Parity.NONE);
+        return activatePort(this.getSystemPrefix(), portName, log, 1, SerialPort.Parity.NONE);
     }
 
     /**
@@ -121,7 +115,7 @@ abstract public class AbstractSerialPortController extends AbstractPortControlle
      * @return the serial port object for later use
      */
     final protected SerialPort activatePort(String portName, org.slf4j.Logger log, int stop_bits) {
-        return activatePort(this.getSystemPrefix(), portName, log, stop_bits, Parity.NONE);
+        return activatePort(this.getSystemPrefix(), portName, log, stop_bits, SerialPort.Parity.NONE);
     }
 
     /**
@@ -141,7 +135,7 @@ abstract public class AbstractSerialPortController extends AbstractPortControlle
      * @param parity one of the defined parity contants
      * @return the serial port object for later use
      */
-    public static SerialPort activatePort(String systemPrefix, String portName, org.slf4j.Logger log, int stop_bits, Parity parity) {
+    public static SerialPort activatePort(String systemPrefix, String portName, org.slf4j.Logger log, int stop_bits, SerialPort.Parity parity) {
         return SerialPort.activatePort(systemPrefix, portName, log, stop_bits, parity);
     }
 
@@ -181,15 +175,6 @@ abstract public class AbstractSerialPortController extends AbstractPortControlle
             // return (String)getPortNames().elementAt(0);
         }
         return mPort;
-    }
-
-    private static String getSymlinkTarget(File symlink) {
-        try {
-            // Path.toRealPath() follows a symlink
-            return symlink.toPath().toRealPath().toFile().getName();
-        } catch (IOException e) {
-            return null;
-        }
     }
 
     /**
@@ -270,34 +255,6 @@ abstract public class AbstractSerialPortController extends AbstractPortControlle
         NONE,
         RTSCTS,
         XONXOFF
-    }
-
-    /**
-     * Enumerate the possible parity choices
-     */
-    public enum Parity {
-        NONE(com.fazecast.jSerialComm.SerialPort.NO_PARITY),
-        EVEN(com.fazecast.jSerialComm.SerialPort.EVEN_PARITY),
-        ODD(com.fazecast.jSerialComm.SerialPort.ODD_PARITY);
-
-        private final int value;
-
-        Parity(int value) {
-            this.value = value;
-        }
-
-        public int getValue() {
-            return value;
-        }
-
-        public static Parity getParity(int parity) {
-            for (Parity p : Parity.values()) {
-                if (p.value == parity) {
-                    return p;
-                }
-            }
-            throw new IllegalArgumentException("Unknown parity");
-        }
     }
 
     /**
@@ -679,288 +636,6 @@ abstract public class AbstractSerialPortController extends AbstractPortControlle
      */
     @Override
     protected void resetupConnection(){}
-
-
-    public static class SerialPort {
-
-        public static final int LISTENING_EVENT_DATA_AVAILABLE =
-                com.fazecast.jSerialComm.SerialPort.LISTENING_EVENT_DATA_AVAILABLE;
-
-        public static final int ONE_STOP_BIT = com.fazecast.jSerialComm.SerialPort.ONE_STOP_BIT;
-        public static final int NO_PARITY = com.fazecast.jSerialComm.SerialPort.NO_PARITY;
-
-        private final com.fazecast.jSerialComm.SerialPort serialPort;
-
-        private SerialPort(com.fazecast.jSerialComm.SerialPort serialPort) {
-            this.serialPort = serialPort;
-        }
-
-        public void addDataListener(SerialPortDataListener listener) {
-            this.serialPort.addDataListener(new com.fazecast.jSerialComm.SerialPortDataListener() {
-                @Override
-                public int getListeningEvents() {
-                    return listener.getListeningEvents();
-                }
-
-                @Override
-                public void serialEvent(com.fazecast.jSerialComm.SerialPortEvent event) {
-                    listener.serialEvent(new SerialPortEvent(event));
-                }
-            });
-        }
-
-        public InputStream getInputStream() {
-            return this.serialPort.getInputStream();
-        }
-
-        public OutputStream getOutputStream() {
-            return this.serialPort.getOutputStream();
-        }
-
-        public void setRTS() {
-            this.serialPort.setRTS();
-        }
-
-        public void clearRTS() {
-            this.serialPort.clearRTS();
-        }
-
-        public void setBaudRate(int baudrate) {
-            this.serialPort.setBaudRate(baudrate);
-        }
-
-        public int getBaudRate() {
-            return this.serialPort.getBaudRate();
-        }
-
-        public void setNumDataBits(int bits) {
-            this.serialPort.setNumDataBits(bits);
-        }
-
-        public final int getNumDataBits() {
-            return serialPort.getNumDataBits();
-        }
-
-        public void setNumStopBits(int bits) {
-            this.serialPort.setNumStopBits(bits);
-        }
-
-        public final int getNumStopBits() {
-            return serialPort.getNumStopBits();
-        }
-
-        public void setParity(Parity parity) {
-            serialPort.setParity(parity.getValue());  // constants are defined with values for the specific port class
-        }
-
-        public void setDTR() {
-            this.serialPort.setDTR();
-        }
-
-        public void clearDTR() {
-            this.serialPort.clearDTR();
-        }
-
-        public boolean getDTR() {
-            return this.serialPort.getDTR();
-        }
-
-        public boolean getRTS() {
-            return this.serialPort.getRTS();
-        }
-
-        public boolean getDSR() {
-            return this.serialPort.getDSR();
-        }
-
-        public boolean getCTS() {
-            return this.serialPort.getCTS();
-        }
-
-        public boolean getDCD() {
-            return this.serialPort.getDCD();
-        }
-
-        public boolean getRI() {
-            return this.serialPort.getRI();
-        }
-
-        /**
-         * Configure the flow control settings. Keep this in synch with the
-         * FlowControl enum.
-         *
-         * @param flow  set which kind of flow control to use
-         */
-        public final void setFlowControl(FlowControl flow) {
-            boolean result = true;
-
-            if (null == flow) {
-                log.error("Invalid null FlowControl enum member");
-            } else switch (flow) {
-                case RTSCTS:
-                    result = serialPort.setFlowControl(com.fazecast.jSerialComm.SerialPort.FLOW_CONTROL_RTS_ENABLED
-                            | com.fazecast.jSerialComm.SerialPort.FLOW_CONTROL_CTS_ENABLED );
-                    break;
-                case XONXOFF:
-                    result = serialPort.setFlowControl(com.fazecast.jSerialComm.SerialPort.FLOW_CONTROL_XONXOFF_IN_ENABLED
-                            | com.fazecast.jSerialComm.SerialPort.FLOW_CONTROL_XONXOFF_OUT_ENABLED);
-                    break;
-                case NONE:
-                    result = serialPort.setFlowControl(com.fazecast.jSerialComm.SerialPort.FLOW_CONTROL_DISABLED);
-                    break;
-                default:
-                    log.error("Invalid FlowControl enum member: {}", flow);
-                    break;
-            }
-
-            if (!result) log.error("Port did not accept flow control setting {}", flow);
-        }
-
-        public void setBreak() {
-            this.serialPort.setBreak();
-        }
-
-        public void clearBreak() {
-            this.serialPort.clearBreak();
-        }
-
-        public final int getFlowControlSettings() {
-            return serialPort.getFlowControlSettings();
-        }
-
-        public final boolean setComPortTimeouts(int newTimeoutMode, int newReadTimeout, int newWriteTimeout) {
-            return serialPort.setComPortTimeouts(newTimeoutMode, newReadTimeout, newWriteTimeout);
-        }
-
-        public void closePort() {
-            this.serialPort.closePort();
-        }
-
-        public String getDescriptivePortName() {
-            return this.serialPort.getDescriptivePortName();
-        }
-
-        @Override
-        public String toString() {
-            return this.serialPort.toString();
-        }
-
-        /**
-         * Do the formal opening of the port,
-         * set the port for blocking reads without timeout,
-         * set the port to 8 data bits, the indicated number of stop bits and parity,
-         * and purge the port's input stream.
-         * <p>
-         * Does not do the rest of the setup implied in the {@link #openPort} method.
-         * This is usually followed by calls to
-         * {@link #setBaudRate}, {@link #configureLeads} and {@link #setFlowControl}.
-         *
-         * @param systemPrefix the system prefix
-         * @param portName local system name for the desired port
-         * @param log Logger to use for errors, passed so that errors are logged from low-level class'
-         * @param stop_bits The number of stop bits, either 1 or 2
-         * @param parity one of the defined parity contants
-         * @return the serial port object for later use
-         */
-        public static SerialPort activatePort(String systemPrefix, String portName, org.slf4j.Logger log, int stop_bits, Parity parity) {
-            com.fazecast.jSerialComm.SerialPort serialPort;
-
-            // convert the 1 or 2 stop_bits argument to the proper jSerialComm code value
-            int stop_bits_code;
-            switch (stop_bits) {
-                case 1:
-                    stop_bits_code = com.fazecast.jSerialComm.SerialPort.ONE_STOP_BIT;
-                    break;
-                case 2:
-                    stop_bits_code = com.fazecast.jSerialComm.SerialPort.TWO_STOP_BITS;
-                    break;
-                default:
-                    throw new IllegalArgumentException("Incorrect stop_bits argument: "+stop_bits);
-            }
-
-            try {
-                serialPort = com.fazecast.jSerialComm.SerialPort.getCommPort(portName);
-                serialPort.openPort();
-                serialPort.setComPortTimeouts(com.fazecast.jSerialComm.SerialPort.TIMEOUT_READ_BLOCKING, 0, 0);
-                serialPort.setNumDataBits(8);
-                serialPort.setNumStopBits(stop_bits_code);
-                serialPort.setParity(parity.getValue());
-                purgeStream(serialPort.getInputStream());
-            } catch (java.io.IOException | com.fazecast.jSerialComm.SerialPortInvalidPortException ex) {
-                // IOException includes
-                //      com.fazecast.jSerialComm.SerialPortIOException
-                handlePortNotFound(systemPrefix, portName, log, ex);
-                return null;
-            }
-            return new SerialPort(serialPort);
-        }
-
-        /**
-         * Provide the actual serial port names.
-         * As a public static method, this can be accessed outside the jmri.jmrix
-         * package to get the list of names for e.g. context reports.
-         *
-         * @return the port names in the form they can later be used to open the port
-         */
-    //    @SuppressWarnings("UseOfObsoleteCollectionType") // historical interface
-        @SuppressFBWarnings("DMI_HARDCODED_ABSOLUTE_FILENAME")  // /dev/ is not expected to change on Linux and Mac
-        public static Vector<String> getActualPortNames() {
-            // first, check that the comm package can be opened and ports seen
-            var portNameVector = new Vector<String>();
-
-            com.fazecast.jSerialComm.SerialPort[] portIDs = com.fazecast.jSerialComm.SerialPort.getCommPorts();
-                    // find the names of suitable ports
-            for (com.fazecast.jSerialComm.SerialPort portID : portIDs) {
-                portNameVector.addElement(portID.getSystemPortName());
-            }
-
-            // On Linux and Mac, use the system property purejavacomm.portnamepattern
-            // to let the user add additional serial ports
-            String portnamePattern = System.getProperty("purejavacomm.portnamepattern");
-            if ((portnamePattern != null) && (SystemType.isLinux() || SystemType.isMacOSX())) {
-                Pattern pattern = Pattern.compile(portnamePattern);
-
-                File[] files = new File("/dev").listFiles();
-                if (files != null) {
-                    Set<String> ports = Stream.of(files)
-                            .filter(file -> !file.isDirectory()
-                                    && (pattern.matcher(file.getName()).matches()
-                                            || portNameVector.contains(getSymlinkTarget(file)))
-                                    && !portNameVector.contains(file.getName()))
-                            .map(File::getName)
-                            .collect(Collectors.toSet());
-
-                    portNameVector.addAll(ports);
-                }
-
-            }
-
-            return portNameVector;
-        }
-
-    }
-
-
-    public static interface SerialPortDataListener {
-
-        void serialEvent(SerialPortEvent serialPortEvent);
-
-        public int getListeningEvents();
-
-    }
-
-    public static class SerialPortEvent {
-
-        private final com.fazecast.jSerialComm.SerialPortEvent event;
-
-        private SerialPortEvent(com.fazecast.jSerialComm.SerialPortEvent event) {
-            this.event = event;
-        }
-
-        public int getEventType() {
-            return event.getEventType();
-        }
-    }
 
 
     private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(AbstractSerialPortController.class);

--- a/java/src/jmri/jmrix/AbstractSerialPortController.java
+++ b/java/src/jmri/jmrix/AbstractSerialPortController.java
@@ -136,7 +136,7 @@ abstract public class AbstractSerialPortController extends AbstractPortControlle
      * @return the serial port object for later use
      */
     public static SerialPort activatePort(String systemPrefix, String portName, org.slf4j.Logger log, int stop_bits, SerialPort.Parity parity) {
-        return SerialPort.activatePort(systemPrefix, portName, log, stop_bits, parity);
+        return jmri.jmrix.jserialcomm.JSerialPort.activatePort(systemPrefix, portName, log, stop_bits, parity);
     }
 
     final protected void setComPortTimeouts(SerialPort serialPort, Blocking blocking, int timeout) {
@@ -185,7 +185,7 @@ abstract public class AbstractSerialPortController extends AbstractPortControlle
      * @return the port names in the form they can later be used to open the port
      */
     public static Vector<String> getActualPortNames() {
-        return SerialPort.getActualPortNames();
+        return jmri.jmrix.jserialcomm.JSerialPort.getActualPortNames();
     }
 
     /**

--- a/java/src/jmri/jmrix/ReplaceableInputStream.java
+++ b/java/src/jmri/jmrix/ReplaceableInputStream.java
@@ -1,0 +1,102 @@
+package jmri.jmrix;
+
+import java.io.*;
+
+/**
+ * An input stream where the stream can be replaced on the fly.
+ *
+ * @author Daniel Bergqvist (C) 2024
+ */
+public class ReplaceableInputStream extends InputStream {
+
+    private volatile InputStream _stream;
+
+    public void replaceStream(InputStream stream) {
+        this._stream = stream;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int read() throws IOException {
+        return _stream.read();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int read(byte b[]) throws IOException {
+        return _stream.read(b);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int read(byte b[], int off, int len) throws IOException {
+        return _stream.read(b, off, len);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public byte[] readAllBytes() throws IOException {
+        return _stream.readAllBytes();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public byte[] readNBytes(int len) throws IOException {
+        return _stream.readNBytes(len);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int readNBytes(byte[] b, int off, int len) throws IOException {
+        return _stream.readNBytes(b, off, len);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public long skip(long n) throws IOException {
+        return _stream.skip(n);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void skipNBytes(long n) throws IOException {
+        _stream.skipNBytes(n);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int available() throws IOException {
+        return _stream.available();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void close() throws IOException {
+        _stream.close();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public synchronized void mark(int readlimit) {
+        _stream.mark(readlimit);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public synchronized void reset() throws IOException {
+        _stream.reset();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean markSupported() {
+        return _stream.markSupported();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public long transferTo(OutputStream out) throws IOException {
+        return _stream.transferTo(out);
+    }
+
+}

--- a/java/src/jmri/jmrix/ReplaceableInputStream.java
+++ b/java/src/jmri/jmrix/ReplaceableInputStream.java
@@ -59,12 +59,6 @@ public class ReplaceableInputStream extends InputStream {
 
     /** {@inheritDoc} */
     @Override
-    public void skipNBytes(long n) throws IOException {
-        _stream.skipNBytes(n);
-    }
-
-    /** {@inheritDoc} */
-    @Override
     public int available() throws IOException {
         return _stream.available();
     }

--- a/java/src/jmri/jmrix/ReplaceableOutputStream.java
+++ b/java/src/jmri/jmrix/ReplaceableOutputStream.java
@@ -1,0 +1,48 @@
+package jmri.jmrix;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * An output stream where the stream can be replaced on the fly.
+ *
+ * @author Daniel Bergqvist (C) 2024
+ */
+public class ReplaceableOutputStream extends OutputStream {
+
+    private volatile OutputStream _stream;
+
+    public void replaceStream(OutputStream stream) {
+        this._stream = stream;
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+        _stream.write(b);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void write(byte b[]) throws IOException {
+        _stream.write(b);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void write(byte b[], int off, int len) throws IOException {
+        _stream.write(b, off, len);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void flush() throws IOException {
+        _stream.flush();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void close() throws IOException {
+        _stream.close();
+    }
+
+}

--- a/java/src/jmri/jmrix/SerialPort.java
+++ b/java/src/jmri/jmrix/SerialPort.java
@@ -1,0 +1,301 @@
+package jmri.jmrix;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+import java.io.*;
+import java.util.Set;
+import java.util.Vector;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import jmri.util.SystemType;
+
+/**
+ * Serial port
+ *
+ * @author Daniel Bergqvist (C) 2024
+ */
+public class SerialPort {
+
+    public static final int LISTENING_EVENT_DATA_AVAILABLE = com.fazecast.jSerialComm.SerialPort.LISTENING_EVENT_DATA_AVAILABLE;
+    public static final int ONE_STOP_BIT = com.fazecast.jSerialComm.SerialPort.ONE_STOP_BIT;
+    public static final int NO_PARITY = com.fazecast.jSerialComm.SerialPort.NO_PARITY;
+    private final com.fazecast.jSerialComm.SerialPort serialPort;
+
+    /**
+     * Enumerate the possible parity choices
+     */
+    public enum Parity {
+        NONE(com.fazecast.jSerialComm.SerialPort.NO_PARITY),
+        EVEN(com.fazecast.jSerialComm.SerialPort.EVEN_PARITY),
+        ODD(com.fazecast.jSerialComm.SerialPort.ODD_PARITY);
+
+        private final int value;
+
+        Parity(int value) {
+            this.value = value;
+        }
+
+        public int getValue() {
+            return value;
+        }
+
+        public static Parity getParity(int parity) {
+            for (Parity p : Parity.values()) {
+                if (p.value == parity) {
+                    return p;
+                }
+            }
+            throw new IllegalArgumentException("Unknown parity");
+        }
+    }
+
+    private SerialPort(com.fazecast.jSerialComm.SerialPort serialPort) {
+        this.serialPort = serialPort;
+    }
+
+    public void addDataListener(SerialPortDataListener listener) {
+        this.serialPort.addDataListener(new com.fazecast.jSerialComm.SerialPortDataListener() {
+            @Override
+            public int getListeningEvents() {
+                return listener.getListeningEvents();
+            }
+
+            @Override
+            public void serialEvent(com.fazecast.jSerialComm.SerialPortEvent event) {
+                listener.serialEvent(new SerialPortEvent(event));
+            }
+        });
+    }
+
+    public InputStream getInputStream() {
+        return this.serialPort.getInputStream();
+    }
+
+    public OutputStream getOutputStream() {
+        return this.serialPort.getOutputStream();
+    }
+
+    public void setRTS() {
+        this.serialPort.setRTS();
+    }
+
+    public void clearRTS() {
+        this.serialPort.clearRTS();
+    }
+
+    public void setBaudRate(int baudrate) {
+        this.serialPort.setBaudRate(baudrate);
+    }
+
+    public int getBaudRate() {
+        return this.serialPort.getBaudRate();
+    }
+
+    public void setNumDataBits(int bits) {
+        this.serialPort.setNumDataBits(bits);
+    }
+
+    public final int getNumDataBits() {
+        return serialPort.getNumDataBits();
+    }
+
+    public void setNumStopBits(int bits) {
+        this.serialPort.setNumStopBits(bits);
+    }
+
+    public final int getNumStopBits() {
+        return serialPort.getNumStopBits();
+    }
+
+    public void setParity(Parity parity) {
+        serialPort.setParity(parity.getValue()); // constants are defined with values for the specific port class
+    }
+
+    public void setDTR() {
+        this.serialPort.setDTR();
+    }
+
+    public void clearDTR() {
+        this.serialPort.clearDTR();
+    }
+
+    public boolean getDTR() {
+        return this.serialPort.getDTR();
+    }
+
+    public boolean getRTS() {
+        return this.serialPort.getRTS();
+    }
+
+    public boolean getDSR() {
+        return this.serialPort.getDSR();
+    }
+
+    public boolean getCTS() {
+        return this.serialPort.getCTS();
+    }
+
+    public boolean getDCD() {
+        return this.serialPort.getDCD();
+    }
+
+    public boolean getRI() {
+        return this.serialPort.getRI();
+    }
+
+    /**
+     * Configure the flow control settings. Keep this in synch with the
+     * FlowControl enum.
+     *
+     * @param flow  set which kind of flow control to use
+     */
+    public final void setFlowControl(AbstractSerialPortController.FlowControl flow) {
+        boolean result = true;
+        if (null == flow) {
+            log.error("Invalid null FlowControl enum member");
+        } else {
+            switch (flow) {
+                case RTSCTS:
+                    result = serialPort.setFlowControl(com.fazecast.jSerialComm.SerialPort.FLOW_CONTROL_RTS_ENABLED | com.fazecast.jSerialComm.SerialPort.FLOW_CONTROL_CTS_ENABLED);
+                    break;
+                case XONXOFF:
+                    result = serialPort.setFlowControl(com.fazecast.jSerialComm.SerialPort.FLOW_CONTROL_XONXOFF_IN_ENABLED | com.fazecast.jSerialComm.SerialPort.FLOW_CONTROL_XONXOFF_OUT_ENABLED);
+                    break;
+                case NONE:
+                    result = serialPort.setFlowControl(com.fazecast.jSerialComm.SerialPort.FLOW_CONTROL_DISABLED);
+                    break;
+                default:
+                    log.error("Invalid FlowControl enum member: {}", flow);
+                    break;
+            }
+        }
+        if (!result) {
+            log.error("Port did not accept flow control setting {}", flow);
+        }
+    }
+
+    public void setBreak() {
+        this.serialPort.setBreak();
+    }
+
+    public void clearBreak() {
+        this.serialPort.clearBreak();
+    }
+
+    public final int getFlowControlSettings() {
+        return serialPort.getFlowControlSettings();
+    }
+
+    public final boolean setComPortTimeouts(int newTimeoutMode, int newReadTimeout, int newWriteTimeout) {
+        return serialPort.setComPortTimeouts(newTimeoutMode, newReadTimeout, newWriteTimeout);
+    }
+
+    public void closePort() {
+        this.serialPort.closePort();
+    }
+
+    public String getDescriptivePortName() {
+        return this.serialPort.getDescriptivePortName();
+    }
+
+    @Override
+    public String toString() {
+        return this.serialPort.toString();
+    }
+
+    /**
+     * Do the formal opening of the port,
+     * set the port for blocking reads without timeout,
+     * set the port to 8 data bits, the indicated number of stop bits and parity,
+     * and purge the port's input stream.
+     * <p>
+     * Does not do the rest of the setup implied in the {@link #openPort} method.
+     * This is usually followed by calls to
+     * {@link #setBaudRate}, {@link #configureLeads} and {@link #setFlowControl}.
+     *
+     * @param systemPrefix the system prefix
+     * @param portName local system name for the desired port
+     * @param log Logger to use for errors, passed so that errors are logged from low-level class'
+     * @param stop_bits The number of stop bits, either 1 or 2
+     * @param parity one of the defined parity contants
+     * @return the serial port object for later use
+     */
+    public static SerialPort activatePort(String systemPrefix, String portName, org.slf4j.Logger log, int stop_bits, Parity parity) {
+        com.fazecast.jSerialComm.SerialPort serialPort;
+        // convert the 1 or 2 stop_bits argument to the proper jSerialComm code value
+        int stop_bits_code;
+        switch (stop_bits) {
+            case 1:
+                stop_bits_code = com.fazecast.jSerialComm.SerialPort.ONE_STOP_BIT;
+                break;
+            case 2:
+                stop_bits_code = com.fazecast.jSerialComm.SerialPort.TWO_STOP_BITS;
+                break;
+            default:
+                throw new IllegalArgumentException("Incorrect stop_bits argument: " + stop_bits);
+        }
+        try {
+            serialPort = com.fazecast.jSerialComm.SerialPort.getCommPort(portName);
+            serialPort.openPort();
+            serialPort.setComPortTimeouts(com.fazecast.jSerialComm.SerialPort.TIMEOUT_READ_BLOCKING, 0, 0);
+            serialPort.setNumDataBits(8);
+            serialPort.setNumStopBits(stop_bits_code);
+            serialPort.setParity(parity.getValue());
+            AbstractPortController.purgeStream(serialPort.getInputStream());
+        } catch (java.io.IOException | com.fazecast.jSerialComm.SerialPortInvalidPortException ex) {
+            // IOException includes
+            //      com.fazecast.jSerialComm.SerialPortIOException
+            AbstractSerialPortController.handlePortNotFound(systemPrefix, portName, log, ex);
+            return null;
+        }
+        return new SerialPort(serialPort);
+    }
+
+    private static String getSymlinkTarget(File symlink) {
+        try {
+            // Path.toRealPath() follows a symlink
+            return symlink.toPath().toRealPath().toFile().getName();
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Provide the actual serial port names.
+     * As a public static method, this can be accessed outside the jmri.jmrix
+     * package to get the list of names for e.g. context reports.
+     *
+     * @return the port names in the form they can later be used to open the port
+     */
+    //    @SuppressWarnings("UseOfObsoleteCollectionType") // historical interface
+    @SuppressFBWarnings(value = "DMI_HARDCODED_ABSOLUTE_FILENAME")
+    public static Vector<String> getActualPortNames() {
+        // first, check that the comm package can be opened and ports seen
+        java.util.Vector<java.lang.String> portNameVector = new Vector<String>();
+        com.fazecast.jSerialComm.SerialPort[] portIDs = com.fazecast.jSerialComm.SerialPort.getCommPorts();
+        // find the names of suitable ports
+        for (com.fazecast.jSerialComm.SerialPort portID : portIDs) {
+            portNameVector.addElement(portID.getSystemPortName());
+        }
+        // On Linux and Mac, use the system property purejavacomm.portnamepattern
+        // to let the user add additional serial ports
+        String portnamePattern = System.getProperty("purejavacomm.portnamepattern");
+        if ((portnamePattern != null) && (SystemType.isLinux() || SystemType.isMacOSX())) {
+            Pattern pattern = Pattern.compile(portnamePattern);
+            File[] files = new File("/dev").listFiles();
+            if (files != null) {
+                Set<String> ports = Stream.of(files).filter(
+                        file -> !file.isDirectory()
+                                && (pattern.matcher(file.getName()).matches()
+                                        || portNameVector.contains(getSymlinkTarget(file)))
+                                && !portNameVector.contains(file.getName())).map(File::getName).collect(Collectors.toSet());
+                portNameVector.addAll(ports);
+            }
+        }
+        return portNameVector;
+    }
+
+    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(SerialPort.class);
+}

--- a/java/src/jmri/jmrix/SerialPort.java
+++ b/java/src/jmri/jmrix/SerialPort.java
@@ -1,27 +1,18 @@
 package jmri.jmrix;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
-import java.io.*;
-import java.util.Set;
-import java.util.Vector;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import jmri.util.SystemType;
+import java.io.InputStream;
+import java.io.OutputStream;
 
 /**
  * Serial port
  *
  * @author Daniel Bergqvist (C) 2024
  */
-public class SerialPort {
+public interface SerialPort {
 
     public static final int LISTENING_EVENT_DATA_AVAILABLE = com.fazecast.jSerialComm.SerialPort.LISTENING_EVENT_DATA_AVAILABLE;
     public static final int ONE_STOP_BIT = com.fazecast.jSerialComm.SerialPort.ONE_STOP_BIT;
     public static final int NO_PARITY = com.fazecast.jSerialComm.SerialPort.NO_PARITY;
-    private final com.fazecast.jSerialComm.SerialPort serialPort;
 
     /**
      * Enumerate the possible parity choices
@@ -51,99 +42,45 @@ public class SerialPort {
         }
     }
 
-    private SerialPort(com.fazecast.jSerialComm.SerialPort serialPort) {
-        this.serialPort = serialPort;
-    }
+    void addDataListener(SerialPortDataListener listener);
 
-    public void addDataListener(SerialPortDataListener listener) {
-        this.serialPort.addDataListener(new com.fazecast.jSerialComm.SerialPortDataListener() {
-            @Override
-            public int getListeningEvents() {
-                return listener.getListeningEvents();
-            }
+    InputStream getInputStream();
 
-            @Override
-            public void serialEvent(com.fazecast.jSerialComm.SerialPortEvent event) {
-                listener.serialEvent(new SerialPortEvent(event));
-            }
-        });
-    }
+    OutputStream getOutputStream();
 
-    public InputStream getInputStream() {
-        return this.serialPort.getInputStream();
-    }
+    void setRTS();
 
-    public OutputStream getOutputStream() {
-        return this.serialPort.getOutputStream();
-    }
+    void clearRTS();
 
-    public void setRTS() {
-        this.serialPort.setRTS();
-    }
+    void setBaudRate(int baudrate);
 
-    public void clearRTS() {
-        this.serialPort.clearRTS();
-    }
+    int getBaudRate();
 
-    public void setBaudRate(int baudrate) {
-        this.serialPort.setBaudRate(baudrate);
-    }
+    void setNumDataBits(int bits);
 
-    public int getBaudRate() {
-        return this.serialPort.getBaudRate();
-    }
+    int getNumDataBits();
 
-    public void setNumDataBits(int bits) {
-        this.serialPort.setNumDataBits(bits);
-    }
+    void setNumStopBits(int bits);
 
-    public final int getNumDataBits() {
-        return serialPort.getNumDataBits();
-    }
+    int getNumStopBits();
 
-    public void setNumStopBits(int bits) {
-        this.serialPort.setNumStopBits(bits);
-    }
+    void setParity(Parity parity);
 
-    public final int getNumStopBits() {
-        return serialPort.getNumStopBits();
-    }
+    void setDTR();
 
-    public void setParity(Parity parity) {
-        serialPort.setParity(parity.getValue()); // constants are defined with values for the specific port class
-    }
+    void clearDTR();
 
-    public void setDTR() {
-        this.serialPort.setDTR();
-    }
+    boolean getDTR();
 
-    public void clearDTR() {
-        this.serialPort.clearDTR();
-    }
+    boolean getRTS();
 
-    public boolean getDTR() {
-        return this.serialPort.getDTR();
-    }
+    boolean getDSR();
 
-    public boolean getRTS() {
-        return this.serialPort.getRTS();
-    }
+    boolean getCTS();
 
-    public boolean getDSR() {
-        return this.serialPort.getDSR();
-    }
+    boolean getDCD();
 
-    public boolean getCTS() {
-        return this.serialPort.getCTS();
-    }
-
-    public boolean getDCD() {
-        return this.serialPort.getDCD();
-    }
-
-    public boolean getRI() {
-        return this.serialPort.getRI();
-    }
+    boolean getRI();
 
     /**
      * Configure the flow control settings. Keep this in synch with the
@@ -151,151 +88,21 @@ public class SerialPort {
      *
      * @param flow  set which kind of flow control to use
      */
-    public final void setFlowControl(AbstractSerialPortController.FlowControl flow) {
-        boolean result = true;
-        if (null == flow) {
-            log.error("Invalid null FlowControl enum member");
-        } else {
-            switch (flow) {
-                case RTSCTS:
-                    result = serialPort.setFlowControl(com.fazecast.jSerialComm.SerialPort.FLOW_CONTROL_RTS_ENABLED | com.fazecast.jSerialComm.SerialPort.FLOW_CONTROL_CTS_ENABLED);
-                    break;
-                case XONXOFF:
-                    result = serialPort.setFlowControl(com.fazecast.jSerialComm.SerialPort.FLOW_CONTROL_XONXOFF_IN_ENABLED | com.fazecast.jSerialComm.SerialPort.FLOW_CONTROL_XONXOFF_OUT_ENABLED);
-                    break;
-                case NONE:
-                    result = serialPort.setFlowControl(com.fazecast.jSerialComm.SerialPort.FLOW_CONTROL_DISABLED);
-                    break;
-                default:
-                    log.error("Invalid FlowControl enum member: {}", flow);
-                    break;
-            }
-        }
-        if (!result) {
-            log.error("Port did not accept flow control setting {}", flow);
-        }
-    }
+    void setFlowControl(AbstractSerialPortController.FlowControl flow);
 
-    public void setBreak() {
-        this.serialPort.setBreak();
-    }
+    void setBreak();
 
-    public void clearBreak() {
-        this.serialPort.clearBreak();
-    }
+    void clearBreak();
 
-    public final int getFlowControlSettings() {
-        return serialPort.getFlowControlSettings();
-    }
+    int getFlowControlSettings();
 
-    public final boolean setComPortTimeouts(int newTimeoutMode, int newReadTimeout, int newWriteTimeout) {
-        return serialPort.setComPortTimeouts(newTimeoutMode, newReadTimeout, newWriteTimeout);
-    }
+    boolean setComPortTimeouts(int newTimeoutMode, int newReadTimeout, int newWriteTimeout);
 
-    public void closePort() {
-        this.serialPort.closePort();
-    }
+    void closePort();
 
-    public String getDescriptivePortName() {
-        return this.serialPort.getDescriptivePortName();
-    }
+    String getDescriptivePortName();
 
     @Override
-    public String toString() {
-        return this.serialPort.toString();
-    }
+    String toString();
 
-    /**
-     * Do the formal opening of the port,
-     * set the port for blocking reads without timeout,
-     * set the port to 8 data bits, the indicated number of stop bits and parity,
-     * and purge the port's input stream.
-     * <p>
-     * Does not do the rest of the setup implied in the {@link #openPort} method.
-     * This is usually followed by calls to
-     * {@link #setBaudRate}, {@link #configureLeads} and {@link #setFlowControl}.
-     *
-     * @param systemPrefix the system prefix
-     * @param portName local system name for the desired port
-     * @param log Logger to use for errors, passed so that errors are logged from low-level class'
-     * @param stop_bits The number of stop bits, either 1 or 2
-     * @param parity one of the defined parity contants
-     * @return the serial port object for later use
-     */
-    public static SerialPort activatePort(String systemPrefix, String portName, org.slf4j.Logger log, int stop_bits, Parity parity) {
-        com.fazecast.jSerialComm.SerialPort serialPort;
-        // convert the 1 or 2 stop_bits argument to the proper jSerialComm code value
-        int stop_bits_code;
-        switch (stop_bits) {
-            case 1:
-                stop_bits_code = com.fazecast.jSerialComm.SerialPort.ONE_STOP_BIT;
-                break;
-            case 2:
-                stop_bits_code = com.fazecast.jSerialComm.SerialPort.TWO_STOP_BITS;
-                break;
-            default:
-                throw new IllegalArgumentException("Incorrect stop_bits argument: " + stop_bits);
-        }
-        try {
-            serialPort = com.fazecast.jSerialComm.SerialPort.getCommPort(portName);
-            serialPort.openPort();
-            serialPort.setComPortTimeouts(com.fazecast.jSerialComm.SerialPort.TIMEOUT_READ_BLOCKING, 0, 0);
-            serialPort.setNumDataBits(8);
-            serialPort.setNumStopBits(stop_bits_code);
-            serialPort.setParity(parity.getValue());
-            AbstractPortController.purgeStream(serialPort.getInputStream());
-        } catch (java.io.IOException | com.fazecast.jSerialComm.SerialPortInvalidPortException ex) {
-            // IOException includes
-            //      com.fazecast.jSerialComm.SerialPortIOException
-            AbstractSerialPortController.handlePortNotFound(systemPrefix, portName, log, ex);
-            return null;
-        }
-        return new SerialPort(serialPort);
-    }
-
-    private static String getSymlinkTarget(File symlink) {
-        try {
-            // Path.toRealPath() follows a symlink
-            return symlink.toPath().toRealPath().toFile().getName();
-        } catch (IOException e) {
-            return null;
-        }
-    }
-
-    /**
-     * Provide the actual serial port names.
-     * As a public static method, this can be accessed outside the jmri.jmrix
-     * package to get the list of names for e.g. context reports.
-     *
-     * @return the port names in the form they can later be used to open the port
-     */
-    //    @SuppressWarnings("UseOfObsoleteCollectionType") // historical interface
-    @SuppressFBWarnings(value = "DMI_HARDCODED_ABSOLUTE_FILENAME")
-    public static Vector<String> getActualPortNames() {
-        // first, check that the comm package can be opened and ports seen
-        java.util.Vector<java.lang.String> portNameVector = new Vector<String>();
-        com.fazecast.jSerialComm.SerialPort[] portIDs = com.fazecast.jSerialComm.SerialPort.getCommPorts();
-        // find the names of suitable ports
-        for (com.fazecast.jSerialComm.SerialPort portID : portIDs) {
-            portNameVector.addElement(portID.getSystemPortName());
-        }
-        // On Linux and Mac, use the system property purejavacomm.portnamepattern
-        // to let the user add additional serial ports
-        String portnamePattern = System.getProperty("purejavacomm.portnamepattern");
-        if ((portnamePattern != null) && (SystemType.isLinux() || SystemType.isMacOSX())) {
-            Pattern pattern = Pattern.compile(portnamePattern);
-            File[] files = new File("/dev").listFiles();
-            if (files != null) {
-                Set<String> ports = Stream.of(files).filter(
-                        file -> !file.isDirectory()
-                                && (pattern.matcher(file.getName()).matches()
-                                        || portNameVector.contains(getSymlinkTarget(file)))
-                                && !portNameVector.contains(file.getName())).map(File::getName).collect(Collectors.toSet());
-                portNameVector.addAll(ports);
-            }
-        }
-        return portNameVector;
-    }
-
-    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(SerialPort.class);
 }

--- a/java/src/jmri/jmrix/SerialPort.java
+++ b/java/src/jmri/jmrix/SerialPort.java
@@ -66,6 +66,8 @@ public interface SerialPort {
 
     void setParity(Parity parity);
 
+    Parity getParity();
+
     void setDTR();
 
     void clearDTR();

--- a/java/src/jmri/jmrix/SerialPortDataListener.java
+++ b/java/src/jmri/jmrix/SerialPortDataListener.java
@@ -1,0 +1,14 @@
+package jmri.jmrix;
+
+/**
+ * Serial port listener
+ *
+ * @author Daniel Bergqvist (C) 2024
+ */
+public interface SerialPortDataListener {
+
+    void serialEvent(SerialPortEvent serialPortEvent);
+
+    public int getListeningEvents();
+
+}

--- a/java/src/jmri/jmrix/SerialPortEvent.java
+++ b/java/src/jmri/jmrix/SerialPortEvent.java
@@ -5,16 +5,8 @@ package jmri.jmrix;
  *
  * @author Daniel Bergqvist (C) 2024
  */
-public class SerialPortEvent {
+public interface SerialPortEvent {
 
-    private final com.fazecast.jSerialComm.SerialPortEvent event;
-
-    SerialPortEvent(com.fazecast.jSerialComm.SerialPortEvent event) {
-        this.event = event;
-    }
-
-    public int getEventType() {
-        return event.getEventType();
-    }
+    int getEventType();
 
 }

--- a/java/src/jmri/jmrix/SerialPortEvent.java
+++ b/java/src/jmri/jmrix/SerialPortEvent.java
@@ -1,0 +1,20 @@
+package jmri.jmrix;
+
+/**
+ * Serial port event
+ *
+ * @author Daniel Bergqvist (C) 2024
+ */
+public class SerialPortEvent {
+
+    private final com.fazecast.jSerialComm.SerialPortEvent event;
+
+    SerialPortEvent(com.fazecast.jSerialComm.SerialPortEvent event) {
+        this.event = event;
+    }
+
+    public int getEventType() {
+        return event.getEventType();
+    }
+
+}

--- a/java/src/jmri/jmrix/fakeport/FakeInputStream.java
+++ b/java/src/jmri/jmrix/fakeport/FakeInputStream.java
@@ -1,0 +1,25 @@
+package jmri.jmrix.fakeport;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * A fake input stream.
+ *
+ * @author Daniel Bergqvist (C) 2024
+ */
+public class FakeInputStream extends InputStream {
+
+    @Override
+    public int read() throws IOException {
+        try {
+            // This stream will never receive anything. Wait some time
+            // to minimize CPU.
+            Thread.sleep(1000);
+        } catch (InterruptedException ex) {
+            // Do nothing. This method will return -1 anyway.
+        }
+        return -1;
+    }
+
+}

--- a/java/src/jmri/jmrix/fakeport/FakeSerialPort.java
+++ b/java/src/jmri/jmrix/fakeport/FakeSerialPort.java
@@ -1,0 +1,155 @@
+package jmri.jmrix.fakeport;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import jmri.jmrix.*;
+
+/**
+ * Implementation of a fake serial port.
+ *
+ * @author Daniel Bergqvist (C) 2024
+ */
+public class FakeSerialPort implements SerialPort {
+
+    @Override
+    public void addDataListener(SerialPortDataListener listener) {
+        // Do nothing
+    }
+
+    @Override
+    public InputStream getInputStream() {
+        return InputStream.nullInputStream();
+    }
+
+    @Override
+    public OutputStream getOutputStream() {
+        return OutputStream.nullOutputStream();
+    }
+
+    @Override
+    public void setRTS() {
+        // Do nothing
+    }
+
+    @Override
+    public void clearRTS() {
+        // Do nothing
+    }
+
+    @Override
+    public void setBaudRate(int baudrate) {
+        // Do nothing
+    }
+
+    @Override
+    public int getBaudRate() {
+        return 9600;
+    }
+
+    @Override
+    public void setNumDataBits(int bits) {
+        // Do nothing
+    }
+
+    @Override
+    public int getNumDataBits() {
+        return 8;
+    }
+
+    @Override
+    public void setNumStopBits(int bits) {
+        // Do nothing
+    }
+
+    @Override
+    public int getNumStopBits() {
+        return 1;
+    }
+
+    @Override
+    public void setParity(Parity parity) {
+        // Do nothing
+    }
+
+    @Override
+    public Parity getParity() {
+        return Parity.NONE;
+    }
+
+    @Override
+    public void setDTR() {
+        // Do nothing
+    }
+
+    @Override
+    public void clearDTR() {
+        // Do nothing
+    }
+
+    @Override
+    public boolean getDTR() {
+        return false;
+    }
+
+    @Override
+    public boolean getRTS() {
+        return false;
+    }
+
+    @Override
+    public boolean getDSR() {
+        return false;
+    }
+
+    @Override
+    public boolean getCTS() {
+        return false;
+    }
+
+    @Override
+    public boolean getDCD() {
+        return false;
+    }
+
+    @Override
+    public boolean getRI() {
+        return false;
+    }
+
+    @Override
+    public void setFlowControl(AbstractSerialPortController.FlowControl flow) {
+        // Do nothing
+    }
+
+    @Override
+    public void setBreak() {
+        // Do nothing
+    }
+
+    @Override
+    public void clearBreak() {
+        // Do nothing
+    }
+
+    @Override
+    public int getFlowControlSettings() {
+        return 0;
+    }
+
+    @Override
+    public boolean setComPortTimeouts(int newTimeoutMode, int newReadTimeout, int newWriteTimeout) {
+        return true;
+    }
+
+    @Override
+    public void closePort() {
+        // Do nothing
+    }
+
+    @Override
+    public String getDescriptivePortName() {
+        return "FakePort";
+    }
+
+}

--- a/java/src/jmri/jmrix/ieee802154/xbee/XBeeAdapter.java
+++ b/java/src/jmri/jmrix/ieee802154/xbee/XBeeAdapter.java
@@ -7,7 +7,9 @@ import java.util.Arrays;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
-import jmri.jmrix.AbstractSerialPortController.SerialPortDataListener;
+import jmri.jmrix.SerialPort;
+import jmri.jmrix.SerialPortDataListener;
+import jmri.jmrix.SerialPortEvent;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/java/src/jmri/jmrix/jserialcomm/JSerialPort.java
+++ b/java/src/jmri/jmrix/jserialcomm/JSerialPort.java
@@ -1,0 +1,323 @@
+package jmri.jmrix.jserialcomm;
+
+import jmri.jmrix.*;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+import java.io.*;
+import java.util.Set;
+import java.util.Vector;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import jmri.util.SystemType;
+
+/**
+ * Implementation of serial port using jSerialComm.
+ *
+ * @author Daniel Bergqvist (C) 2024
+ */
+public class JSerialPort implements SerialPort {
+
+//    public static final int LISTENING_EVENT_DATA_AVAILABLE = com.fazecast.jSerialComm.SerialPort.LISTENING_EVENT_DATA_AVAILABLE;
+//    public static final int ONE_STOP_BIT = com.fazecast.jSerialComm.SerialPort.ONE_STOP_BIT;
+//    public static final int NO_PARITY = com.fazecast.jSerialComm.SerialPort.NO_PARITY;
+    private final com.fazecast.jSerialComm.SerialPort serialPort;
+
+    /*.*
+     * Enumerate the possible parity choices
+     *./
+    public enum Parity {
+        NONE(com.fazecast.jSerialComm.SerialPort.NO_PARITY),
+        EVEN(com.fazecast.jSerialComm.SerialPort.EVEN_PARITY),
+        ODD(com.fazecast.jSerialComm.SerialPort.ODD_PARITY);
+
+        private final int value;
+
+        Parity(int value) {
+            this.value = value;
+        }
+
+        public int getValue() {
+            return value;
+        }
+
+        public static Parity getParity(int parity) {
+            for (Parity p : Parity.values()) {
+                if (p.value == parity) {
+                    return p;
+                }
+            }
+            throw new IllegalArgumentException("Unknown parity");
+        }
+    }
+*/
+    private JSerialPort(com.fazecast.jSerialComm.SerialPort serialPort) {
+        this.serialPort = serialPort;
+    }
+
+    @Override
+    public void addDataListener(SerialPortDataListener listener) {
+        this.serialPort.addDataListener(new com.fazecast.jSerialComm.SerialPortDataListener() {
+            @Override
+            public int getListeningEvents() {
+                return listener.getListeningEvents();
+            }
+
+            @Override
+            public void serialEvent(com.fazecast.jSerialComm.SerialPortEvent event) {
+                listener.serialEvent(new JSerialPortEvent(event));
+            }
+        });
+    }
+
+    @Override
+    public InputStream getInputStream() {
+        return this.serialPort.getInputStream();
+    }
+
+    @Override
+    public OutputStream getOutputStream() {
+        return this.serialPort.getOutputStream();
+    }
+
+    @Override
+    public void setRTS() {
+        this.serialPort.setRTS();
+    }
+
+    @Override
+    public void clearRTS() {
+        this.serialPort.clearRTS();
+    }
+
+    @Override
+    public void setBaudRate(int baudrate) {
+        this.serialPort.setBaudRate(baudrate);
+    }
+
+    @Override
+    public int getBaudRate() {
+        return this.serialPort.getBaudRate();
+    }
+
+    @Override
+    public void setNumDataBits(int bits) {
+        this.serialPort.setNumDataBits(bits);
+    }
+
+    @Override
+    public final int getNumDataBits() {
+        return serialPort.getNumDataBits();
+    }
+
+    @Override
+    public void setNumStopBits(int bits) {
+        this.serialPort.setNumStopBits(bits);
+    }
+
+    @Override
+    public final int getNumStopBits() {
+        return serialPort.getNumStopBits();
+    }
+
+    @Override
+    public void setParity(Parity parity) {
+        serialPort.setParity(parity.getValue()); // constants are defined with values for the specific port class
+    }
+
+    @Override
+    public void setDTR() {
+        this.serialPort.setDTR();
+    }
+
+    @Override
+    public void clearDTR() {
+        this.serialPort.clearDTR();
+    }
+
+    @Override
+    public boolean getDTR() {
+        return this.serialPort.getDTR();
+    }
+
+    @Override
+    public boolean getRTS() {
+        return this.serialPort.getRTS();
+    }
+
+    @Override
+    public boolean getDSR() {
+        return this.serialPort.getDSR();
+    }
+
+    @Override
+    public boolean getCTS() {
+        return this.serialPort.getCTS();
+    }
+
+    @Override
+    public boolean getDCD() {
+        return this.serialPort.getDCD();
+    }
+
+    @Override
+    public boolean getRI() {
+        return this.serialPort.getRI();
+    }
+
+    /**
+     * Configure the flow control settings. Keep this in synch with the
+     * FlowControl enum.
+     *
+     * @param flow  set which kind of flow control to use
+     */
+    @Override
+    public final void setFlowControl(AbstractSerialPortController.FlowControl flow) {
+        boolean result = true;
+        if (null == flow) {
+            log.error("Invalid null FlowControl enum member");
+        } else {
+            switch (flow) {
+                case RTSCTS:
+                    result = serialPort.setFlowControl(com.fazecast.jSerialComm.SerialPort.FLOW_CONTROL_RTS_ENABLED | com.fazecast.jSerialComm.SerialPort.FLOW_CONTROL_CTS_ENABLED);
+                    break;
+                case XONXOFF:
+                    result = serialPort.setFlowControl(com.fazecast.jSerialComm.SerialPort.FLOW_CONTROL_XONXOFF_IN_ENABLED | com.fazecast.jSerialComm.SerialPort.FLOW_CONTROL_XONXOFF_OUT_ENABLED);
+                    break;
+                case NONE:
+                    result = serialPort.setFlowControl(com.fazecast.jSerialComm.SerialPort.FLOW_CONTROL_DISABLED);
+                    break;
+                default:
+                    log.error("Invalid FlowControl enum member: {}", flow);
+                    break;
+            }
+        }
+        if (!result) {
+            log.error("Port did not accept flow control setting {}", flow);
+        }
+    }
+
+    @Override
+    public void setBreak() {
+        this.serialPort.setBreak();
+    }
+
+    @Override
+    public void clearBreak() {
+        this.serialPort.clearBreak();
+    }
+
+    @Override
+    public final int getFlowControlSettings() {
+        return serialPort.getFlowControlSettings();
+    }
+
+    @Override
+    public final boolean setComPortTimeouts(int newTimeoutMode, int newReadTimeout, int newWriteTimeout) {
+        return serialPort.setComPortTimeouts(newTimeoutMode, newReadTimeout, newWriteTimeout);
+    }
+
+    @Override
+    public void closePort() {
+        this.serialPort.closePort();
+    }
+
+    @Override
+    public String getDescriptivePortName() {
+        return this.serialPort.getDescriptivePortName();
+    }
+
+    @Override
+    public String toString() {
+        return this.serialPort.toString();
+    }
+
+    /**
+     * Open the port.
+     *
+     * @param systemPrefix the system prefix
+     * @param portName local system name for the desired port
+     * @param log Logger to use for errors, passed so that errors are logged from low-level class'
+     * @param stop_bits The number of stop bits, either 1 or 2
+     * @param parity one of the defined parity contants
+     * @return the serial port object for later use
+     */
+    public static JSerialPort activatePort(String systemPrefix, String portName, org.slf4j.Logger log, int stop_bits, Parity parity) {
+        com.fazecast.jSerialComm.SerialPort serialPort;
+        // convert the 1 or 2 stop_bits argument to the proper jSerialComm code value
+        int stop_bits_code;
+        switch (stop_bits) {
+            case 1:
+                stop_bits_code = com.fazecast.jSerialComm.SerialPort.ONE_STOP_BIT;
+                break;
+            case 2:
+                stop_bits_code = com.fazecast.jSerialComm.SerialPort.TWO_STOP_BITS;
+                break;
+            default:
+                throw new IllegalArgumentException("Incorrect stop_bits argument: " + stop_bits);
+        }
+        try {
+            serialPort = com.fazecast.jSerialComm.SerialPort.getCommPort(portName);
+            serialPort.openPort();
+            serialPort.setComPortTimeouts(com.fazecast.jSerialComm.SerialPort.TIMEOUT_READ_BLOCKING, 0, 0);
+            serialPort.setNumDataBits(8);
+            serialPort.setNumStopBits(stop_bits_code);
+            serialPort.setParity(parity.getValue());
+            AbstractPortController.purgeStream(serialPort.getInputStream());
+        } catch (java.io.IOException | com.fazecast.jSerialComm.SerialPortInvalidPortException ex) {
+            // IOException includes
+            //      com.fazecast.jSerialComm.SerialPortIOException
+            AbstractSerialPortController.handlePortNotFound(systemPrefix, portName, log, ex);
+            return null;
+        }
+        return new JSerialPort(serialPort);
+    }
+
+    private static String getSymlinkTarget(File symlink) {
+        try {
+            // Path.toRealPath() follows a symlink
+            return symlink.toPath().toRealPath().toFile().getName();
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Provide the actual serial port names.
+     * As a public static method, this can be accessed outside the jmri.jmrix
+     * package to get the list of names for e.g. context reports.
+     *
+     * @return the port names in the form they can later be used to open the port
+     */
+    //    @SuppressWarnings("UseOfObsoleteCollectionType") // historical interface
+    @SuppressFBWarnings(value = "DMI_HARDCODED_ABSOLUTE_FILENAME")
+    public static Vector<String> getActualPortNames() {
+        // first, check that the comm package can be opened and ports seen
+        java.util.Vector<java.lang.String> portNameVector = new Vector<String>();
+        com.fazecast.jSerialComm.SerialPort[] portIDs = com.fazecast.jSerialComm.SerialPort.getCommPorts();
+        // find the names of suitable ports
+        for (com.fazecast.jSerialComm.SerialPort portID : portIDs) {
+            portNameVector.addElement(portID.getSystemPortName());
+        }
+        // On Linux and Mac, use the system property purejavacomm.portnamepattern
+        // to let the user add additional serial ports
+        String portnamePattern = System.getProperty("purejavacomm.portnamepattern");
+        if ((portnamePattern != null) && (SystemType.isLinux() || SystemType.isMacOSX())) {
+            Pattern pattern = Pattern.compile(portnamePattern);
+            File[] files = new File("/dev").listFiles();
+            if (files != null) {
+                Set<String> ports = Stream.of(files).filter(
+                        file -> !file.isDirectory()
+                                && (pattern.matcher(file.getName()).matches()
+                                        || portNameVector.contains(getSymlinkTarget(file)))
+                                && !portNameVector.contains(file.getName())).map(File::getName).collect(Collectors.toSet());
+                portNameVector.addAll(ports);
+            }
+        }
+        return portNameVector;
+    }
+
+    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(JSerialPort.class);
+}

--- a/java/src/jmri/jmrix/jserialcomm/JSerialPort.java
+++ b/java/src/jmri/jmrix/jserialcomm/JSerialPort.java
@@ -128,6 +128,11 @@ public class JSerialPort implements SerialPort {
     }
 
     @Override
+    public Parity getParity() {
+        return Parity.getParity(serialPort.getParity()); // constants are defined with values for the specific port class
+    }
+
+    @Override
     public void setDTR() {
         this.serialPort.setDTR();
     }

--- a/java/src/jmri/jmrix/jserialcomm/JSerialPortEvent.java
+++ b/java/src/jmri/jmrix/jserialcomm/JSerialPortEvent.java
@@ -1,0 +1,23 @@
+package jmri.jmrix.jserialcomm;
+
+import jmri.jmrix.SerialPortEvent;
+
+/**
+ * Implementation of serial port event using jSerialComm.
+ *
+ * @author Daniel Bergqvist (C) 2024
+ */
+public class JSerialPortEvent implements SerialPortEvent {
+
+    private final com.fazecast.jSerialComm.SerialPortEvent event;
+
+    JSerialPortEvent(com.fazecast.jSerialComm.SerialPortEvent event) {
+        this.event = event;
+    }
+
+    @Override
+    public int getEventType() {
+        return event.getEventType();
+    }
+
+}

--- a/java/src/jmri/jmrix/loconet/demoport/Bundle.java
+++ b/java/src/jmri/jmrix/loconet/demoport/Bundle.java
@@ -1,0 +1,100 @@
+package jmri.jmrix.loconet.demoport;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+import java.util.Locale;
+
+import javax.annotation.CheckReturnValue;
+import javax.annotation.CheckForNull;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
+@CheckReturnValue
+@SuppressFBWarnings(value = "NM_SAME_SIMPLE_NAME_AS_SUPERCLASS", justification = "Desired pattern is repeated class names with package-level access to members")
+
+@javax.annotation.concurrent.Immutable
+
+/**
+ * Provides standard access for resource bundles in a package.
+ *
+ * Convention is to provide a subclass of this name in each package, working off
+ * the local resource bundle name.
+ *
+ * @author Bob Jacobsen Copyright (C) 2012
+ * @since 3.3.1
+ */
+public class Bundle extends jmri.jmrix.loconet.Bundle {
+
+    @CheckForNull
+    private static final String name = "jmri.jmrix.loconet.demoport.Bundle";// NOI18N
+
+    //
+    // below here is boilerplate to be copied exactly
+    //
+    /**
+     * Provides a translated string for a given key from the package resource
+     * bundle or parent.
+     * <p>
+     * Note that this is intentionally package-local access.
+     *
+     * @param key Bundle key to be translated
+     * @return Internationalized text
+     */
+    static String getMessage(String key) {
+        return getBundle().handleGetMessage(key);
+    }
+
+    /**
+     * Merges user data with a translated string for a given key from the
+     * package resource bundle or parent.
+     * <p>
+     * Uses the transformation conventions of the Java MessageFormat utility.
+     * <p>
+     * Note that this is intentionally package-local access.
+     *
+     * @see java.text.MessageFormat
+     * @param key  Bundle key to be translated
+     * @param subs One or more objects to be inserted into the message
+     * @return Internationalized text
+     */
+    static String getMessage(String key, Object... subs) {
+        return getBundle().handleGetMessage(key, subs);
+    }
+
+    /**
+     * Merges user data with a translated string for a given key in a given
+     * locale from the package resource bundle or parent.
+     * <p>
+     * Uses the transformation conventions of the Java MessageFormat utility.
+     * <p>
+     * Note that this is intentionally package-local access.
+     *
+     * @see java.text.MessageFormat
+     * @param locale The locale to be used
+     * @param key    Bundle key to be translated
+     * @param subs   One or more objects to be inserted into the message
+     * @return Internationalized text
+     */
+    static String getMessage(Locale locale, String key, Object... subs) {
+        return getBundle().handleGetMessage(locale, key, subs);
+    }
+
+
+    private final static Bundle b = new Bundle();
+
+    @Override
+    @CheckForNull
+    protected String bundleName() {
+        return name;
+    }
+
+    protected static jmri.Bundle getBundle() {
+        return b;
+    }
+
+    @Override
+    protected String retry(Locale locale, String key) {
+        return super.getBundle().handleGetMessage(locale,key);
+    }
+
+}

--- a/java/src/jmri/jmrix/loconet/demoport/Bundle.properties
+++ b/java/src/jmri/jmrix/loconet/demoport/Bundle.properties
@@ -1,0 +1,7 @@
+# demoport.properties
+
+DemoPanel_Connection            = Connection:
+DemoPanel_ButtonStartTest       = Start test
+DemoPanel_ButtonThrowTurnout1   = Throw turnout 1
+DemoPanel_ButtonThrowTurnout2   = Throw turnout 2
+DemoPanel_LocoNetMonitor        = LocoNet monitor

--- a/java/src/jmri/jmrix/loconet/demoport/DemoPanel.java
+++ b/java/src/jmri/jmrix/loconet/demoport/DemoPanel.java
@@ -87,7 +87,7 @@ class DemoPanel extends JmriPanel {
         c.gridy = 5;
         _textArea = new JTextArea();
         _textArea.setColumns(50);
-        _textArea.setRows(50);
+        _textArea.setRows(30);
         add(_textArea, c);
 
         _locoNetConnection.addActionListener((e)->{

--- a/java/src/jmri/jmrix/loconet/demoport/DemoPanel.java
+++ b/java/src/jmri/jmrix/loconet/demoport/DemoPanel.java
@@ -1,0 +1,155 @@
+package jmri.jmrix.loconet.demoport;
+
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.util.*;
+
+import javax.swing.*;
+
+import jmri.InstanceManager;
+import jmri.SystemConnectionMemo;
+import jmri.jmrix.*;
+import jmri.jmrix.loconet.LocoNetSystemConnectionMemo;
+import jmri.util.swing.JmriPanel;
+
+/**
+ * Demo panel.
+ *
+ * @author Daniel Bergqvist (C) 2024
+ */
+class DemoPanel extends JmriPanel {
+
+    private final Map<SystemConnectionMemo, AbstractSerialPortController> memoMap = new HashMap<>();
+    private DemoSerialPort _demoSerialPort;
+    private LocoNetConnection _connection;
+    private JComboBox<LocoNetConnection> _locoNetConnection;
+    private JTextArea _textArea;
+    private boolean turnoutThrown1;
+    private boolean turnoutThrown2;
+
+    /** {@inheritDoc} */
+    @Override
+    public void initComponents() {
+
+        super.initComponents();
+
+        setLayout(new GridBagLayout());
+        GridBagConstraints c = new GridBagConstraints();
+        c.gridwidth = 1;
+        c.gridheight = 1;
+        c.gridx = 0;
+        c.gridy = 0;
+        c.anchor = GridBagConstraints.EAST;
+        add(new JLabel(Bundle.getMessage("DemoPanel_Connection")), c);
+
+        for (ConnectionConfig cc : InstanceManager.getDefault(ConnectionConfigManager.class)) {
+            if (cc.getAdapter() instanceof AbstractSerialPortController) {
+                AbstractSerialPortController pc = (AbstractSerialPortController) cc.getAdapter();
+                if (pc.isPortOpen()) {
+                    memoMap.put(cc.getAdapter().getSystemConnectionMemo(), pc);
+                }
+            }
+        }
+
+        _locoNetConnection = new JComboBox<>();
+        c.gridx = 1;
+        c.anchor = GridBagConstraints.WEST;
+        add(_locoNetConnection, c);
+
+        c.gridwidth = 2;
+        c.gridx = 0;
+        c.gridy = 1;
+        JButton buttonStartTest = new JButton(Bundle.getMessage("DemoPanel_ButtonStartTest"));
+        buttonStartTest.setEnabled(false);
+        add(buttonStartTest, c);
+
+        c.gridy = 2;
+        JButton buttonThrowTurnout1 = new JButton(Bundle.getMessage("DemoPanel_ButtonThrowTurnout1"));
+        buttonThrowTurnout1.addActionListener((e)->{
+            _demoSerialPort.throwTurnout(1, turnoutThrown1);
+            turnoutThrown1 = !turnoutThrown1;
+        });
+        buttonThrowTurnout1.setEnabled(false);
+        add(buttonThrowTurnout1, c);
+
+        c.gridy = 3;
+        JButton buttonThrowTurnout2 = new JButton(Bundle.getMessage("DemoPanel_ButtonThrowTurnout2"));
+        buttonThrowTurnout2.addActionListener((e)->{
+            _demoSerialPort.throwTurnout(2, turnoutThrown2);
+            turnoutThrown2 = !turnoutThrown2;
+        });
+        buttonThrowTurnout2.setEnabled(false);
+        add(buttonThrowTurnout2, c);
+
+        c.gridy = 4;
+        add(new JLabel(Bundle.getMessage("DemoPanel_LocoNetMonitor")), c);
+
+        c.gridy = 5;
+        _textArea = new JTextArea();
+        _textArea.setColumns(50);
+        _textArea.setRows(50);
+        add(_textArea, c);
+
+        _locoNetConnection.addActionListener((e)->{
+            _connection = _locoNetConnection.getItemAt(_locoNetConnection.getSelectedIndex());
+            buttonStartTest.setEnabled(true);
+        });
+        List<LocoNetSystemConnectionMemo> systemConnections =
+                jmri.InstanceManager.getList(LocoNetSystemConnectionMemo.class);
+        for (LocoNetSystemConnectionMemo memo : systemConnections) {
+            if (memoMap.get(memo) != null) {
+                LocoNetConnection conn = new LocoNetConnection(memo);
+                _locoNetConnection.addItem(conn);
+            }
+        }
+
+        buttonStartTest.addActionListener((e)->{
+            _demoSerialPort = new DemoSerialPort(this, _connection._memo);
+            _demoSerialPort.startDemo();
+            _locoNetConnection.setEnabled(false);
+            buttonStartTest.setEnabled(false);
+            buttonThrowTurnout1.setEnabled(true);
+            buttonThrowTurnout2.setEnabled(true);
+        });
+    }
+
+    public AbstractSerialPortController getPortController() {
+        if (_connection == null) {
+            return null;
+        }
+        return memoMap.get(_connection._memo);
+    }
+
+    public void addMessage(String msg) {
+        _textArea.append(msg);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getTitle() {
+        return "Demo panel"; // this should come from a Bundle in your package
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public List<JMenu> getMenus() {
+        List<JMenu> menuList = new ArrayList<>();
+        return menuList;
+    }
+
+
+    private static class LocoNetConnection {
+
+        private final LocoNetSystemConnectionMemo _memo;
+
+        public LocoNetConnection(LocoNetSystemConnectionMemo memo) {
+            _memo = memo;
+        }
+
+        @Override
+        public String toString() {
+            return _memo.getUserName();
+        }
+    }
+
+}

--- a/java/src/jmri/jmrix/loconet/demoport/DemoSerialPort.java
+++ b/java/src/jmri/jmrix/loconet/demoport/DemoSerialPort.java
@@ -87,7 +87,7 @@ public class DemoSerialPort extends AbstractSerialPortController {
             }
             _outputStream.flush();
         } catch (IOException ex) {
-            log.error(ex.getMessage());
+            log.error("Exception: {}", ex.getMessage());
         }
     }
 
@@ -135,7 +135,7 @@ public class DemoSerialPort extends AbstractSerialPortController {
                 } catch (InterruptedIOException ex) {
                     // Do nothing, just ignore the error
                 } catch (IOException ex) {
-                    log.error("IOException: {}", ex.getMessage());
+                    log.error("Exception: {}", ex.getMessage());
                     return;
                 }
             }

--- a/java/src/jmri/jmrix/loconet/demoport/DemoSerialPort.java
+++ b/java/src/jmri/jmrix/loconet/demoport/DemoSerialPort.java
@@ -1,0 +1,146 @@
+package jmri.jmrix.loconet.demoport;
+
+import java.io.*;
+
+import jmri.SystemConnectionMemo;
+import jmri.jmrix.*;
+import jmri.jmrix.loconet.LnConstants;
+import jmri.jmrix.loconet.LocoNetMessage;
+import jmri.util.ThreadingUtil;
+
+/**
+ * Demonstration of replacing the serial port with a fake port.
+ * This class requires a working LocoNet serial port connection.
+ *
+ * @author Daniel Bergqvist (C) 2024
+ */
+public class DemoSerialPort extends AbstractSerialPortController {
+
+    private final DemoPanel _panel;
+    private BufferedOutputStream _outputStream;
+
+    DemoSerialPort(DemoPanel panel, SystemConnectionMemo memo) {
+        super(memo);
+        this._panel = panel;
+    }
+
+    @Override
+    public void configure() {
+        // Do nothing
+    }
+
+    @Override
+    public String openPort(String portName, String appName) {
+        // get and open the primary port
+        currentSerialPort = activatePort(portName, log);
+        if (currentSerialPort == null) {
+            log.error("failed to connect to {}", portName);
+            return Bundle.getMessage("SerialPortNotFound", portName);
+        }
+        log.info("Connecting via {} {}", portName, currentSerialPort);
+
+        setBaudRate(currentSerialPort, 57600);
+        configureLeads(currentSerialPort, true, true);
+        setFlowControl(currentSerialPort, FlowControl.RTSCTS);
+
+        setComPortTimeouts(currentSerialPort, Blocking.READ_SEMI_BLOCKING, 100);
+
+        // report status
+        reportPortStatus(log, portName);
+
+        opened = true;
+
+        return null; // indicates OK return
+    }
+
+    public void startDemo() {
+        log.error("startDemo()");
+        AbstractSerialPortController pc = _panel.getPortController();
+        if (pc == null) {
+            log.error("startDemo(). PortController is null");
+            return;
+        }
+        String portName = pc.getCurrentPortName();
+        log.error("Serial port: {}", pc.getPortSettingsString());
+        pc.replacePortWithFakePort();
+        String result = openPort(portName, "JMRI app");
+        if (result == null) {
+            _panel.addMessage("Connection successful\n");
+            ThreadingUtil.newThread(new LocoNetListener(getInputStream()),
+                    "Demo serial port")
+                    .start();
+            _outputStream = new BufferedOutputStream(getOutputStream());
+        } else {
+            _panel.addMessage(result);
+        }
+    }
+
+    public void throwTurnout(int turnout, boolean throwTurnout) {
+        try {
+            LocoNetMessage msg = new LocoNetMessage(4);
+            msg.setOpCode(LnConstants.OPC_SW_REQ);
+            msg.setElement(1, turnout-1);
+            msg.setElement(2, throwTurnout ? 0x10 : 0x30);
+            msg.setParity();
+            for (int i=0; i < msg.getNumDataElements(); i++) {
+                _outputStream.write(msg.getElement(i));
+            }
+            _outputStream.flush();
+        } catch (IOException ex) {
+            log.error(ex.getMessage());
+        }
+    }
+
+
+    private final class LocoNetListener implements Runnable {
+
+        private final InputStream _stream;
+        private final int[] data = new int[256];
+        private int pos = 0;
+
+        private LocoNetListener(InputStream stream) {
+            this._stream = stream;
+        }
+
+        private int numBytesInMessage() {
+            switch (data[0] & 0xE0) {
+                case 0x80: return 2;
+                case 0xA0: return 4;
+                case 0xC0: return 6;
+                case 0xE0:
+                    if (pos >= 2) return data[1];
+                    else return 255; // We have only first byte so we don't know length yet.
+                default:
+                    throw new IllegalArgumentException("Unknown length of package");
+            }
+        }
+
+        @Override
+        public void run() {
+            while (! Thread.interrupted() ) {   // loop until asked to stop
+                try {
+                    int b = _stream.read();
+                    _panel.addMessage(String.format("%02X ", b));
+                    if (b < 128 && pos == 0) {
+                        // We are in the middle of a message and have missed
+                        // the beginning of the message. Ignore it.
+                        continue;
+                    }
+                    data[pos++] = b;
+                    if (pos >= numBytesInMessage()) {
+                        LocoNetMessage msg = new LocoNetMessage(data);
+                        _panel.addMessage(msg.toMonitorString());
+                        pos = 0;
+                    }
+                } catch (InterruptedIOException ex) {
+                    // Do nothing, just ignore the error
+                } catch (IOException ex) {
+                    log.error("IOException: {}", ex.getMessage());
+                    return;
+                }
+            }
+        }
+    }
+
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(DemoSerialPort.class);
+}

--- a/java/src/jmri/jmrix/loconet/demoport/DemoSerialPortAction.java
+++ b/java/src/jmri/jmrix/loconet/demoport/DemoSerialPortAction.java
@@ -16,7 +16,7 @@ import jmri.util.swing.WindowInterface;
  */
 
 // Uncomment the line below to test this class
-@org.openide.util.lookup.ServiceProvider(service = jmri.jmrit.swing.ToolsMenuAction.class)
+//@org.openide.util.lookup.ServiceProvider(service = jmri.jmrit.swing.ToolsMenuAction.class)
 
 public class DemoSerialPortAction extends JmriAbstractAction implements ToolsMenuAction {
 

--- a/java/src/jmri/jmrix/loconet/demoport/DemoSerialPortAction.java
+++ b/java/src/jmri/jmrix/loconet/demoport/DemoSerialPortAction.java
@@ -1,0 +1,49 @@
+package jmri.jmrix.loconet.demoport;
+
+import javax.swing.Icon;
+
+import jmri.jmrit.swing.ToolsMenuAction;
+import jmri.util.swing.JmriAbstractAction;
+import jmri.util.swing.JmriPanel;
+import jmri.util.swing.WindowInterface;
+
+/**
+ * Action to launch DemoSerialPort.
+ *
+ * @author Paul Bender       Copyright (C) 2003
+ * @author Bob Jacobsen      Copyright (C) 2023
+ * @author Daniel Bergqvist  Copyright (C) 2024
+ */
+
+// Uncomment the line below to test this class
+@org.openide.util.lookup.ServiceProvider(service = jmri.jmrit.swing.ToolsMenuAction.class)
+
+public class DemoSerialPortAction extends JmriAbstractAction implements ToolsMenuAction {
+
+    public DemoSerialPortAction(String s, WindowInterface wi) {
+        super(s, wi);
+    }
+
+    public DemoSerialPortAction(String s, Icon i, WindowInterface wi) {
+        super(s, i, wi);
+    }
+
+    public DemoSerialPortAction(String s) {
+        super(s);
+    }
+
+    public DemoSerialPortAction() {
+        this("Demo serial port");
+    }
+
+    @Override
+    public JmriPanel makePanel() {
+
+        // create a new panel of your specific type here
+        jmri.jmrix.loconet.demoport.DemoPanel retval = new DemoPanel();
+
+        retval.initComponents();
+        return retval;
+    }
+
+}

--- a/java/src/jmri/jmrix/mrc/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/mrc/serialdriver/SerialDriverAdapter.java
@@ -1,5 +1,6 @@
 package jmri.jmrix.mrc.serialdriver;
 
+import jmri.jmrix.SerialPort;
 import jmri.jmrix.mrc.MrcPacketizer;
 import jmri.jmrix.mrc.MrcPortController;
 import jmri.jmrix.mrc.MrcSystemConnectionMemo;
@@ -25,7 +26,7 @@ public class SerialDriverAdapter extends MrcPortController {
     @Override
     public String openPort(String portName, String appName) {
         // get and open the primary port
-        currentSerialPort = activatePort(this.getSystemPrefix(), portName, log, 1, Parity.ODD);
+        currentSerialPort = activatePort(this.getSystemPrefix(), portName, log, 1, SerialPort.Parity.ODD);
         if (currentSerialPort == null) {
             log.error("failed to connect MRC to {}", portName);
             return Bundle.getMessage("SerialPortNotFound", portName);

--- a/java/src/jmri/jmrix/ncemonitor/NcePacketMonitorPanel.java
+++ b/java/src/jmri/jmrix/ncemonitor/NcePacketMonitorPanel.java
@@ -8,8 +8,9 @@ import java.util.Vector;
 import javax.swing.*;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import jmri.jmrix.AbstractSerialPortController;
-import jmri.jmrix.AbstractSerialPortController.SerialPort;
+import jmri.jmrix.SerialPort;
 import jmri.jmrix.nce.NceSystemConnectionMemo;
 import jmri.jmrix.nce.swing.NcePanelInterface;
 
@@ -483,7 +484,7 @@ public class NcePacketMonitorPanel extends jmri.jmrix.AbstractMonPane implements
         int parity = modelParityValues[modelValue];
         int baudrate = modelBaudRates[modelValue];
         activeSerialPort = AbstractSerialPortController.activatePort(
-                null, portName, log, numStopBits, AbstractSerialPortController.Parity.getParity(parity));
+                null, portName, log, numStopBits, SerialPort.Parity.getParity(parity));
 
         activeSerialPort.setNumDataBits(numDataBits);
         activeSerialPort.setBaudRate(baudrate);

--- a/java/src/jmri/jmrix/powerline/SerialSystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/powerline/SerialSystemConnectionMemo.java
@@ -4,7 +4,7 @@ import java.util.Comparator;
 import java.util.ResourceBundle;
 
 import jmri.*;
-import jmri.jmrix.AbstractSerialPortController.SerialPort;
+import jmri.jmrix.SerialPort;
 import jmri.jmrix.ConfiguringSystemConnectionMemo;
 import jmri.util.NamedBeanComparator;
 

--- a/java/src/jmri/jmrix/powerline/dmx512/SpecificTrafficController.java
+++ b/java/src/jmri/jmrix/powerline/dmx512/SpecificTrafficController.java
@@ -5,7 +5,7 @@ import jmri.jmrix.powerline.SerialTrafficController;
 
 import java.io.IOException;
 
-import jmri.jmrix.AbstractSerialPortController.SerialPort;
+import jmri.jmrix.SerialPort;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/java/src/jmri/jmrix/purejavacomm/CommPortIdentifier.java
+++ b/java/src/jmri/jmrix/purejavacomm/CommPortIdentifier.java
@@ -19,8 +19,8 @@ public class CommPortIdentifier {
 
     public SerialPort open(String appName, int timeout) throws PortInUseException, NoSuchPortException {
         String systemPrefix = appName;
-        AbstractSerialPortController.SerialPort serialPort = AbstractSerialPortController.activatePort(
-                systemPrefix, _portName, log, 1, AbstractSerialPortController.Parity.NONE);
+        jmri.jmrix.SerialPort serialPort = AbstractSerialPortController.activatePort(
+                systemPrefix, _portName, log, 1, jmri.jmrix.SerialPort.Parity.NONE);
 
         if (serialPort != null) {
             return new SerialPort(serialPort);

--- a/java/src/jmri/jmrix/purejavacomm/SerialPort.java
+++ b/java/src/jmri/jmrix/purejavacomm/SerialPort.java
@@ -22,19 +22,19 @@ public class SerialPort {
     public static final int FLOWCONTROL_RTSCTS_IN = 1;
     public static final int FLOWCONTROL_RTSCTS_OUT = 2;
 
-    private AbstractSerialPortController.SerialPort _serialPort;
+    private jmri.jmrix.SerialPort _serialPort;
     private SerialPortEventListener _eventListener;
     private boolean _threadStarted = false;
     private Thread _inputThread;
     private volatile boolean _notifyOnDataAvailable;
 
-    public SerialPort(AbstractSerialPortController.SerialPort serialPort) {
+    public SerialPort(jmri.jmrix.SerialPort serialPort) {
         this._serialPort = serialPort;
 
         Runnable runnable = () -> {
             final int TIMEOUT = Integer.getInteger("purejavacomm.pollperiod", 10);
             InputStream inputStream = _serialPort.getInputStream();
-            
+
             while (true) {
                 try {
                     while (_notifyOnDataAvailable && (_eventListener != null)
@@ -60,17 +60,17 @@ public class SerialPort {
     private void setParity(int parity) {
         switch (parity) {
             case PARITY_NONE:
-                _serialPort.setParity(AbstractSerialPortController.Parity.NONE);
+                _serialPort.setParity(jmri.jmrix.SerialPort.Parity.NONE);
                 break;
-                
+
             case PARITY_EVEN:
-                _serialPort.setParity(AbstractSerialPortController.Parity.EVEN);
+                _serialPort.setParity(jmri.jmrix.SerialPort.Parity.EVEN);
                 break;
-                
+
             case PARITY_ODD:
-                _serialPort.setParity(AbstractSerialPortController.Parity.ODD);
+                _serialPort.setParity(jmri.jmrix.SerialPort.Parity.ODD);
                 break;
-            
+
             default:
                 throw new IllegalArgumentException("Unknown parity: "+Integer.toString(parity));
         }
@@ -106,11 +106,11 @@ public class SerialPort {
             case FLOWCONTROL_NONE:
                 _serialPort.setFlowControl(AbstractSerialPortController.FlowControl.NONE);
                 break;
-                
+
             case (FLOWCONTROL_RTSCTS_IN | FLOWCONTROL_RTSCTS_OUT):
                 _serialPort.setFlowControl(AbstractSerialPortController.FlowControl.RTSCTS);
                 break;
-            
+
             default:
                 throw new IllegalArgumentException("Unknown flow control mode: "+Integer.toString(mode));
         }

--- a/java/src/jmri/jmrix/sprog/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/sprog/serialdriver/SerialDriverAdapter.java
@@ -1,5 +1,6 @@
 package jmri.jmrix.sprog.serialdriver;
 
+import jmri.jmrix.*;
 import jmri.jmrix.sprog.SprogConstants.SprogMode;
 import jmri.jmrix.sprog.SprogPortController;
 import jmri.jmrix.sprog.SprogSystemConnectionMemo;

--- a/java/test/jmri/ArchitectureTest.java
+++ b/java/test/jmri/ArchitectureTest.java
@@ -311,8 +311,8 @@ public class ArchitectureTest {
         .that()
 
         // all the standard serial access should be confined to here:
-        .doNotHaveFullyQualifiedName("jmri.jmrix.AbstractSerialPortController$SerialPort").and()
-        .doNotHaveFullyQualifiedName("jmri.jmrix.AbstractSerialPortController$SerialPortEvent")
+        .doNotHaveFullyQualifiedName("jmri.jmrix.SerialPort").and()
+        .doNotHaveFullyQualifiedName("jmri.jmrix.SerialPortEvent")
 
         .should().accessClassesThat().resideInAPackage("com.fazecast.jSerialComm..");
 

--- a/java/test/jmri/ArchitectureTest.java
+++ b/java/test/jmri/ArchitectureTest.java
@@ -311,8 +311,8 @@ public class ArchitectureTest {
         .that()
 
         // all the standard serial access should be confined to here:
-        .doNotHaveFullyQualifiedName("jmri.jmrix.SerialPort").and()
-        .doNotHaveFullyQualifiedName("jmri.jmrix.SerialPortEvent")
+        .doNotHaveFullyQualifiedName("jmri.jmrix.jserialcomm.JSerialPort").and()
+        .doNotHaveFullyQualifiedName("jmri.jmrix.jserialcomm.JSerialPortEvent")
 
         .should().accessClassesThat().resideInAPackage("com.fazecast.jSerialComm..");
 

--- a/java/test/jmri/ArchitectureTest.java
+++ b/java/test/jmri/ArchitectureTest.java
@@ -311,7 +311,6 @@ public class ArchitectureTest {
         .that()
 
         // all the standard serial access should be confined to here:
-        .doNotHaveFullyQualifiedName("jmri.jmrix.AbstractSerialPortController").and()
         .doNotHaveFullyQualifiedName("jmri.jmrix.AbstractSerialPortController$SerialPort").and()
         .doNotHaveFullyQualifiedName("jmri.jmrix.AbstractSerialPortController$SerialPortEvent")
 


### PR DESCRIPTION
@bobjacobsen @KenC57 

For background: https://jmri-developers.groups.io/g/jmri/message/10441

This PR changes the class `SerialPort` to the interface `jmri.jmrix.SerialPort`. It moves the `jSerialComm` code to the class `jmri.jmrix.jserialcomm.JSerialPort` and adds a fake serial port `jmri.jmrix.fakeport.FakeSerialPort`.

These changes, together with the new method `AbstractSerialPortController.replacePortWithFakePort()`, lets a class in JMRI to replace the serial port on the fly without the rest of JMRI noticing it. It's useful for example for a firmware uploader which needs exclusive access to the serial port.

The input and output streams are handled by the new classes `ReplaceableInputStream` and `ReplaceableOutputStream`. These can switch underlying streams on the fly.

----

This PR also contains a demo: `jmri.jmrix.loconet.demoport.DemoSerialPortAction`. Uncomment the `ServiceProvider` line to make it register the menu item `Tools -> Demo serial port`. Note that the demo requires that JMRI has a LocoNet connection that uses a serial port.

Select the desired connection. Only LocoNet connections that uses an active serial port are shown. (LocoNet simulator does not). And then click `Start test`. The serial port will then be replaced for JMRI so that the demo can open the serial port for its own purposes. The `LocoNet monitor` in the demo will show incomming LocoNet packets. The buttons `Throw turnout 1` and `Throw turnout 2` sends a LocoNet message to throw/close a turnout. The response is shown in the monitor below.

![ReplacePortDemo](https://github.com/user-attachments/assets/7e89bc65-e180-4b29-835d-6a5ed4f86454)

