### PR TITLE
Roster Speed Profile lint

### DIFF
--- a/java/src/jmri/SpeedStepMode.java
+++ b/java/src/jmri/SpeedStepMode.java
@@ -45,7 +45,15 @@ public enum SpeedStepMode {
     }
 
     public final String name;
+
+    /**
+     * The Number of steps, e.g. 126 for DCC 128
+     */
     public final int numSteps;
+
+     /**
+     * The increment between steps, e.g. 1 / 126 for DCC 128
+     */
     public final float increment;
     public final String description;
 

--- a/java/src/jmri/jmrit/roster/RosterSpeedProfile.java
+++ b/java/src/jmri/jmrit/roster/RosterSpeedProfile.java
@@ -153,7 +153,7 @@ public class RosterSpeedProfile {
      * @param mms MilliMetres per second
      * @return scale speed in units specified by Warrant Preferences,
      *         unchanged if Warrant preferences are not a speed.
-     * @deprecated use {@link #mmsToScaleSpeed(float mms}
+     * @deprecated use {@link #mmsToScaleSpeed(float mms)}
      */
     @Deprecated (since="5.9.6",forRemoval=true)
     public float MMSToScaleSpeed(float mms) {

--- a/java/src/jmri/jmrit/roster/RosterSpeedProfile.java
+++ b/java/src/jmri/jmrit/roster/RosterSpeedProfile.java
@@ -95,7 +95,9 @@ public class RosterSpeedProfile {
      * @param value true/false
      */
     protected void setTestMode(boolean value) {
-        profileInTestMode = value;
+        synchronized (this){
+            profileInTestMode = value;
+        }
         testSteps = new ArrayList<>();
     }
 
@@ -151,11 +153,23 @@ public class RosterSpeedProfile {
      * @param mms MilliMetres per second
      * @return scale speed in units specified by Warrant Preferences,
      *         unchanged if Warrant preferences are not a speed.
-     * @deprecated use {@link #mmsToScaleSpeed(float mms, boolean factorFastClock)}
+     * @deprecated use {@link #mmsToScaleSpeed(float mms}
      */
     @Deprecated (since="5.9.6",forRemoval=true)
     public float MMSToScaleSpeed(float mms) {
         jmri.util.LoggingUtil.deprecationWarning(log, "MMSToScaleSpeed");
+        return mmsToScaleSpeed(mms);
+    }
+
+    /**
+     * Returns the scale speed as a numeric.
+     * If Warrant preferences are not a speed, value returns unchanged.
+     * Does not factor Fast Clock ratio.
+     * @param mms MilliMetres per second
+     * @return scale speed in units specified by Warrant Preferences,
+     *         unchanged if Warrant preferences are not a speed.
+     */
+    public float mmsToScaleSpeed(float mms) {
         return mmsToScaleSpeed(mms, false);
     }
 

--- a/java/src/jmri/jmrit/roster/RosterSpeedProfile.java
+++ b/java/src/jmri/jmrit/roster/RosterSpeedProfile.java
@@ -151,7 +151,7 @@ public class RosterSpeedProfile {
      * @param mms MilliMetres per second
      * @return scale speed in units specified by Warrant Preferences,
      *         unchanged if Warrant preferences are not a speed.
-     * @deprecated use {@link #mmsToScaleSpeed(float mms)}
+     * @deprecated use {@link #mmsToScaleSpeed(float mms, boolean factorFastClock)}
      */
     @Deprecated (since="5.9.6",forRemoval=true)
     public float MMSToScaleSpeed(float mms) {
@@ -737,8 +737,6 @@ public class RosterSpeedProfile {
 
         calculateStepDetails(speed, distance);
     }
-
-    private int extraTime = 0;
 
     private List<SpeedSetting> testSteps = new ArrayList<>();
     private boolean profileInTestMode = false;

--- a/java/test/jmri/jmrit/roster/RosterSpeedProfileTest.java
+++ b/java/test/jmri/jmrit/roster/RosterSpeedProfileTest.java
@@ -51,41 +51,41 @@ public class RosterSpeedProfileTest {
         Assert.assertNotNull("exists",t);
     }
 
+    private static org.jdom2.Element getLocoElement100() {
+        return new org.jdom2.Element("locomotive")
+            .setAttribute("id", "id info")
+            .setAttribute("fileName", "file here")
+            .setAttribute("roadNumber", "431")
+            .setAttribute("roadName", "SP")
+            .setAttribute("mfg", "Athearn")
+            .setAttribute("dccAddress", "1234")
+            .addContent(new org.jdom2.Element("decoder")
+                .setAttribute("family", "91")
+                .setAttribute("model", "33")
+            )
+            .addContent(new org.jdom2.Element("locoaddress")
+                .addContent(new org.jdom2.Element("number").addContent("1234"))
+                //As there is no throttle manager available all protocols default to dcc short
+                .addContent(new org.jdom2.Element("protocol").addContent("dcc_short"))
+            )
+            .addContent(new org.jdom2.Element("speedprofile")
+                .addContent(new org.jdom2.Element("overRunTimeForward").addContent("0.0"))
+                .addContent(new org.jdom2.Element("overRunTimeReverse").addContent("0.0"))
+                .addContent(new org.jdom2.Element("speeds")
+                    .addContent(new org.jdom2.Element("speed")
+                        .addContent(new org.jdom2.Element("step").addContent("1000"))
+                        .addContent(new org.jdom2.Element("forward").addContent("100.00"))
+                        .addContent(new org.jdom2.Element("reverse").addContent("100.00"))
+                    )
+                )
+            );
+    }
+
     @Test
     public void testSpeedProfileStopFromFiftyPercent() {
         // statics for test objects
-        org.jdom2.Element f1;
-        RosterEntry rF1;
-
-        // create Element
-        f1 = new org.jdom2.Element("locomotive")
-                .setAttribute("id", "id info")
-                .setAttribute("fileName", "file here")
-                .setAttribute("roadNumber", "431")
-                .setAttribute("roadName", "SP")
-                .setAttribute("mfg", "Athearn")
-                .setAttribute("dccAddress", "1234")
-                .addContent(new org.jdom2.Element("decoder")
-                        .setAttribute("family", "91")
-                        .setAttribute("model", "33")
-                )
-                .addContent(new org.jdom2.Element("locoaddress")
-                        .addContent(new org.jdom2.Element("number").addContent("1234"))
-                        //As there is no throttle manager available all protocols default to dcc short
-                        .addContent(new org.jdom2.Element("protocol").addContent("dcc_short"))
-                )
-                .addContent(new org.jdom2.Element("speedprofile")
-                        .addContent(new org.jdom2.Element("overRunTimeForward").addContent("0.0"))
-                        .addContent(new org.jdom2.Element("overRunTimeReverse").addContent("0.0"))
-                        .addContent(new org.jdom2.Element("speeds")
-                                .addContent(new org.jdom2.Element("speed")
-                                        .addContent(new org.jdom2.Element("step").addContent("1000"))
-                                        .addContent(new org.jdom2.Element("forward").addContent("100.00"))
-                                        .addContent(new org.jdom2.Element("reverse").addContent("100.00"))
-                                )
-                        )
-                );
-        rF1 = new RosterEntry(f1) {
+        org.jdom2.Element f1 = getLocoElement100();
+        RosterEntry rF1 = new RosterEntry(f1) {
             @Override
             protected void warnShortLong(String s) {
             }
@@ -106,7 +106,7 @@ public class RosterSpeedProfileTest {
         //Assert.assertEquals("Speed didnt get to a perfect zero", 0.0f, throttle.getSpeedSetting(), 0.0f);
         JUnitUtil.waitFor(()->(throttle.getSpeedSetting() == 0.00f),"Failed to reach requested speed");
         float maxDelta = 1.0f/126.0f/2.0f;  //half step
-        Assert.assertEquals("SpeedStep Table has lincorrect number of entries.", 7, sp.getSpeedStepTrace().size() ) ;
+        Assert.assertEquals("SpeedStep Table has incorrect number of entries.", 7, sp.getSpeedStepTrace().size() ) ;
         int[] correctDuration = {750, 750, 750, 750, 750, 519, 0} ;
         int[] durations = new int[sp.getSpeedStepTrace().size()];
         int ix = 0;
@@ -125,43 +125,15 @@ public class RosterSpeedProfileTest {
         }
         Assert.assertArrayEquals("Speeds are wrong", correctSpeed, speed, maxDelta);
         sp.cancelSpeedChange();
+
+        Assertions.assertEquals(10.0f, sp.mmsToScaleSpeed(10, false), 0.0001);
     }
 
     @Test
     public void testSpeedProfileFromFiftyPercentToTwenty() {
         // statics for test objects
-        org.jdom2.Element f1;
-        RosterEntry rF1;
-
-        // create Element
-        f1 = new org.jdom2.Element("locomotive")
-                .setAttribute("id", "id info")
-                .setAttribute("fileName", "file here")
-                .setAttribute("roadNumber", "431")
-                .setAttribute("roadName", "SP")
-                .setAttribute("mfg", "Athearn")
-                .setAttribute("dccAddress", "1234")
-                .addContent(new org.jdom2.Element("decoder")
-                        .setAttribute("family", "91")
-                        .setAttribute("model", "33")
-                )
-                .addContent(new org.jdom2.Element("locoaddress")
-                        .addContent(new org.jdom2.Element("number").addContent("1234"))
-                        //As there is no throttle manager available all protocols default to dcc short
-                        .addContent(new org.jdom2.Element("protocol").addContent("dcc_short"))
-                )
-                .addContent(new org.jdom2.Element("speedprofile")
-                        .addContent(new org.jdom2.Element("overRunTimeForward").addContent("0.0"))
-                        .addContent(new org.jdom2.Element("overRunTimeReverse").addContent("0.0"))
-                        .addContent(new org.jdom2.Element("speeds")
-                                .addContent(new org.jdom2.Element("speed")
-                                        .addContent(new org.jdom2.Element("step").addContent("1000"))
-                                        .addContent(new org.jdom2.Element("forward").addContent("200.00"))
-                                        .addContent(new org.jdom2.Element("reverse").addContent("200.00"))
-                                )
-                        )
-                );
-        rF1 = new RosterEntry(f1) {
+        org.jdom2.Element f1 = getLocoElement200();
+        RosterEntry rF1 = new RosterEntry(f1) {
             @Override
             protected void warnShortLong(String s) {
             }
@@ -204,46 +176,41 @@ public class RosterSpeedProfileTest {
         sp.cancelSpeedChange();
     }
 
+    private static org.jdom2.Element getLocoElement200() {
+        return new org.jdom2.Element("locomotive")
+            .setAttribute("id", "id info")
+            .setAttribute("fileName", "file here")
+            .setAttribute("roadNumber", "431")
+            .setAttribute("roadName", "SP")
+            .setAttribute("mfg", "Athearn")
+            .setAttribute("dccAddress", "1234")
+            .addContent(new org.jdom2.Element("decoder")
+                .setAttribute("family", "91")
+                .setAttribute("model", "33")
+            )
+            .addContent(new org.jdom2.Element("locoaddress")
+                .addContent(new org.jdom2.Element("number").addContent("1234"))
+                //As there is no throttle manager available all protocols default to dcc short
+                .addContent(new org.jdom2.Element("protocol").addContent("dcc_short"))
+            )
+            .addContent(new org.jdom2.Element("speedprofile")
+                .addContent(new org.jdom2.Element("overRunTimeForward").addContent("0.0"))
+                .addContent(new org.jdom2.Element("overRunTimeReverse").addContent("0.0"))
+                .addContent(new org.jdom2.Element("speeds")
+                    .addContent(new org.jdom2.Element("speed")
+                        .addContent(new org.jdom2.Element("step").addContent("1000"))
+                        .addContent(new org.jdom2.Element("forward").addContent("200.00"))
+                        .addContent(new org.jdom2.Element("reverse").addContent("200.00"))
+                    )
+                )
+            );
+    }
+
     @Test
     public void testSpeedProfileFromFiftyPercentToTwentyShortBlock() {
         // statics for test objects
-        org.jdom2.Element f1;
-        RosterEntry rF1;
-
-        // create Element
-        f1 = new org.jdom2.Element("locomotive")
-                .setAttribute("id", "id info")
-                .setAttribute("fileName", "file here")
-                .setAttribute("roadNumber", "431")
-                .setAttribute("roadName", "SP")
-                .setAttribute("mfg", "Athearn")
-                .setAttribute("dccAddress", "1234")
-                .addContent(new org.jdom2.Element("decoder")
-                        .setAttribute("family", "91")
-                        .setAttribute("model", "33")
-                )
-                .addContent(new org.jdom2.Element("locoaddress")
-                        .addContent(new org.jdom2.Element("number").addContent("1234"))
-                        //As there is no throttle manager available all protocols default to dcc short
-                        .addContent(new org.jdom2.Element("protocol").addContent("dcc_short"))
-                )
-                .addContent(new org.jdom2.Element("speedprofile")
-                        .addContent(new org.jdom2.Element("overRunTimeForward").addContent("0.0"))
-                        .addContent(new org.jdom2.Element("overRunTimeReverse").addContent("0.0"))
-                        .addContent(new org.jdom2.Element("speeds")
-                                .addContent(new org.jdom2.Element("speed")
-                                        .addContent(new org.jdom2.Element("step").addContent("200"))
-                                        .addContent(new org.jdom2.Element("forward").addContent("40.00"))
-                                        .addContent(new org.jdom2.Element("reverse").addContent("40.00"))
-                                )
-                                .addContent(new org.jdom2.Element("speed")
-                                        .addContent(new org.jdom2.Element("step").addContent("1000"))
-                                        .addContent(new org.jdom2.Element("forward").addContent("400.00"))
-                                        .addContent(new org.jdom2.Element("reverse").addContent("400.00"))
-                                )
-                        )
-                );
-        rF1 = new RosterEntry(f1) {
+        org.jdom2.Element f1 = getLocoElement400();
+        RosterEntry rF1 = new RosterEntry(f1) {
             @Override
             protected void warnShortLong(String s) {
             }
@@ -271,6 +238,41 @@ public class RosterSpeedProfileTest {
         sp.cancelSpeedChange();
     }
 
+    private static org.jdom2.Element getLocoElement400 () {
+        return new org.jdom2.Element("locomotive")
+            .setAttribute("id", "id info")
+            .setAttribute("fileName", "file here")
+            .setAttribute("roadNumber", "431")
+            .setAttribute("roadName", "SP")
+            .setAttribute("mfg", "Athearn")
+            .setAttribute("dccAddress", "1234")
+            .addContent(new org.jdom2.Element("decoder")
+                .setAttribute("family", "91")
+                .setAttribute("model", "33")
+            )
+            .addContent(new org.jdom2.Element("locoaddress")
+                .addContent(new org.jdom2.Element("number").addContent("1234"))
+                //As there is no throttle manager available all protocols default to dcc short
+                .addContent(new org.jdom2.Element("protocol").addContent("dcc_short"))
+            )
+            .addContent(new org.jdom2.Element("speedprofile")
+                .addContent(new org.jdom2.Element("overRunTimeForward").addContent("0.0"))
+                .addContent(new org.jdom2.Element("overRunTimeReverse").addContent("0.0"))
+                .addContent(new org.jdom2.Element("speeds")
+                    .addContent(new org.jdom2.Element("speed")
+                        .addContent(new org.jdom2.Element("step").addContent("200"))
+                        .addContent(new org.jdom2.Element("forward").addContent("40.00"))
+                        .addContent(new org.jdom2.Element("reverse").addContent("40.00"))
+                    )
+                    .addContent(new org.jdom2.Element("speed")
+                        .addContent(new org.jdom2.Element("step").addContent("1000"))
+                        .addContent(new org.jdom2.Element("forward").addContent("400.00"))
+                        .addContent(new org.jdom2.Element("reverse").addContent("400.00"))
+                    )
+                )
+            );
+    }
+
     @Test
     public void testconvertThrottleSettingToScaleSpeedWithUnits(){
 
@@ -287,6 +289,43 @@ public class RosterSpeedProfileTest {
         setSpeedInterpretation(ssm, SignalSpeedMap.SPEED_MPH);
         Assertions.assertEquals("0.10 Miles/Hour",RosterSpeedProfile.convertMMSToScaleSpeedWithUnits(0.5f));
 
+    }
+
+    @Test
+    public void testMmsToScaleSpeed(){
+
+        org.jdom2.Element f1 = getLocoElement100();
+        RosterEntry rF1 = new RosterEntry(f1) {
+            @Override
+            protected void warnShortLong(String s) {
+            }
+        };
+        RosterSpeedProfile rsp = rF1.getSpeedProfile();
+
+        SignalSpeedMap ssm = InstanceManager.getDefault(SignalSpeedMap.class);
+        var timeBase = InstanceManager.getDefault(jmri.Timebase.class);
+        timeBase.setRun(false);
+        Assertions.assertDoesNotThrow(() -> { timeBase.userSetRate(1.0d); } );
+
+        setSpeedInterpretation(ssm, SignalSpeedMap.PERCENT_THROTTLE);
+        Assertions.assertEquals(10.0f, rsp.mmsToScaleSpeed(10, false), 0.0001);
+        Assertions.assertEquals(10.0f, rsp.mmsToScaleSpeed(10, true), 0.0001);
+
+        setSpeedInterpretation(ssm, SignalSpeedMap.SPEED_KMPH);
+        Assertions.assertEquals(3.13559f, rsp.mmsToScaleSpeed(10, false), 0.001);
+        Assertions.assertEquals(3.13559f, rsp.mmsToScaleSpeed(10, true), 0.001);
+
+        setSpeedInterpretation(ssm, SignalSpeedMap.SPEED_MPH);
+        Assertions.assertEquals(1.94837f, rsp.mmsToScaleSpeed(10, false), 0.0001);
+        Assertions.assertEquals(1.94837f, rsp.mmsToScaleSpeed(10, true), 0.0001);
+
+        Assertions.assertDoesNotThrow(() -> { timeBase.userSetRate(2.0d); } );
+        Assertions.assertEquals(1.94837f, rsp.mmsToScaleSpeed(10, false), 0.0001);
+        Assertions.assertEquals(3.89675f, rsp.mmsToScaleSpeed(10, true), 0.0001);
+
+        setSpeedInterpretation(ssm, SignalSpeedMap.SPEED_KMPH);
+        Assertions.assertEquals(3.13559f, rsp.mmsToScaleSpeed(10, false), 0.001);
+        Assertions.assertEquals(6.27119f, rsp.mmsToScaleSpeed(10, true), 0.001);
     }
 
     private void setSpeedInterpretation(SignalSpeedMap map, int interpretation) {


### PR DESCRIPTION
**RosterSpeedProfile**

Deprecates `public float MMSToScaleSpeed(float mms)`
to use `public float mmsToScaleSpeed(float mms, boolean factorFastClock)`.
Updates javaDoc.
Marks variables as private.
Removes unused method `void stopLocoTimeOut(DccThrottle t)`.
Adds equals / hashcode to SpeedStep class.
General linting.

**RosterSpeedProfileTest**
Moves loco elements from within single tests to methods ( for re-use in other tests ).
Add testing for mmsToScaleSpeed.

**SpeedStepMode** - javaDoc