### PR TITLE
Separate finding symlinks and user-specified ports

### DIFF
--- a/java/src/jmri/jmrix/jserialcomm/JSerialPort.java
+++ b/java/src/jmri/jmrix/jserialcomm/JSerialPort.java
@@ -306,19 +306,27 @@ public class JSerialPort implements SerialPort {
         for (com.fazecast.jSerialComm.SerialPort portID : portIDs) {
             portNameVector.addElement(portID.getSystemPortName());
         }
-        // On Linux and Mac, use the system property purejavacomm.portnamepattern
-        // to let the user add additional serial ports
-        String portnamePattern = System.getProperty("purejavacomm.portnamepattern");
-        if ((portnamePattern != null) && (SystemType.isLinux() || SystemType.isMacOSX())) {
-            Pattern pattern = Pattern.compile(portnamePattern);
+        // On Linux and Mac, try to find symlinks and to use the system property purejavacomm.portnamepattern
+        if (SystemType.isLinux() || SystemType.isMacOSX()) {
             File[] files = new File("/dev").listFiles();
-            if (files != null) {
-                Set<String> ports = Stream.of(files).filter(
-                        file -> !file.isDirectory()
-                                && (pattern.matcher(file.getName()).matches()
-                                        || portNameVector.contains(getSymlinkTarget(file)))
-                                && !portNameVector.contains(file.getName())).map(File::getName).collect(Collectors.toSet());
-                portNameVector.addAll(ports);
+            if (files != null ) {
+                // Find symlinks linked to real ports
+                Set<String> symlinkPorts = Stream.of(files).filter(file -> !file.isDirectory()
+                        && portNameVector.contains(getSymlinkTarget(file))
+                        && !portNameVector.contains(file.getName())).map(File::getName).collect(Collectors.toSet());
+                portNameVector.addAll(symlinkPorts);
+                log.info("Adding symlink port {}", symlinkPorts);
+
+                // Let the user add additional serial ports
+                String portnamePattern = System.getProperty("purejavacomm.portnamepattern");
+                if (portnamePattern != null) {
+                    Pattern pattern = Pattern.compile(portnamePattern);
+                    Set<String> ports = Stream.of(files).filter(file -> !file.isDirectory()
+                            && pattern.matcher(file.getName()).matches()
+                            && !portNameVector.contains(file.getName())).map(File::getName).collect(Collectors.toSet());
+                    portNameVector.addAll(ports);
+                    log.info("Adding user-specified ports {} matching pattern {}", ports, portnamePattern);
+                }
             }
         }
         return portNameVector;


### PR DESCRIPTION
The prior code found symlinks only on Linux and Mac systems and only if user-specified pattern was in place, but the pattern was ignored when a viable symlink was found.  The pattern string was needed to search for symlinks, but the pattern was not used for matching the symlink name.

The new code separates the symlink checking and pattern matching.  On Linux and Mac systems, the files in the /dev directory are searched first for any viable symlinks, whether or not a pattern is specified, and then searched for files matching the pattern.  If is either a symlink or matches the pattern, it is presented as an option for use.