### PR TITLE
STL Editor: Implement a shift-click copy process

### DIFF
--- a/help/en/package/jmri/jmrix/openlcb/swing/stleditor/StlEditorPane.shtml
+++ b/help/en/package/jmri/jmrix/openlcb/swing/stleditor/StlEditorPane.shtml
@@ -93,6 +93,11 @@ etc.
       definitions, Mn.n memory variables, etc. The <strong>Comment</strong> column is for comments.
       Note:  Comments take up a lot of room.</p>
 
+      <p><span class="since">since 5.9.6</span>A friendly name from the IQYZ tables can be copied
+      using a <strong>shift-click</strong> on a table row.  Hold the shift key and then click on a
+      table row.  The name field in the logic table will be added/replaced.  Make sure the correct
+      logic row has been selected before doing the copy from a table row.</p>
+
       <div style="margin-left: 2em">
         <a href="images/editor_tab.png"><img src=
         "images/editor_tab.png" alt="stl editor tab"></a>

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -142,7 +142,9 @@
                     STL logic.</li>
                 <li>STL Editor: Implement a view option to provide a preview of the generated
                     STL logic.</li>
-                <li>Improved how UTF-8 is handled in CDI display.
+                <li>STL Editor: Implement shift-click to copy a name from a table row to the current
+                    logic row.</li>
+                <li>Improved how UTF-8 is handled in CDI display.</li>
             </ul>
 
         <h4>Powerline</h4>


### PR DESCRIPTION
The friendly name can be copied from a IQYZ table entry to a logic table entry using a click while holding the shift key.