### PR TITLE
Operations Tests - Wait for Threads

### DIFF
--- a/java/test/jmri/jmrit/operations/XmlLoadTest.java
+++ b/java/test/jmri/jmrit/operations/XmlLoadTest.java
@@ -32,8 +32,11 @@ public class XmlLoadTest extends OperationsTestCase {
     @Test
     public void testDemoLoad() {
         runTest("java/test/jmri/jmrit/operations/xml/DemoFiles/", 12, 12, 10, 210, 19);
-        jmri.jmrit.operations.setup.AutoSave.stop();
-        JUnitUtil.waitThreadTerminated("Operations Auto Save");
+        Assertions.assertDoesNotThrow( () -> {
+            //shut down the AutoSave thread as it is running.
+            jmri.jmrit.operations.setup.Setup.setAutoSaveEnabled(false);
+            JUnitUtil.waitThreadTerminated("Operations Auto Save");
+        });
     }
 
     // load a set of operations files with trains that have been built.
@@ -41,8 +44,11 @@ public class XmlLoadTest extends OperationsTestCase {
     @Test
     public void testDemoWithBuildLoad() {
         runTest("java/test/jmri/jmrit/operations/xml/DemoFilesWithBuiltTrains/", 12, 12, 10, 210, 19);
-        jmri.jmrit.operations.setup.AutoSave.stop();
-        JUnitUtil.waitThreadTerminated("Operations Auto Save");
+        Assertions.assertDoesNotThrow( () -> {
+            //shut down the AutoSave thread as it is running.
+            jmri.jmrit.operations.setup.Setup.setAutoSaveEnabled(false);
+            JUnitUtil.waitThreadTerminated("Operations Auto Save");
+        });
     }
 
     /*

--- a/java/test/jmri/jmrit/operations/XmlLoadTest.java
+++ b/java/test/jmri/jmrit/operations/XmlLoadTest.java
@@ -32,6 +32,8 @@ public class XmlLoadTest extends OperationsTestCase {
     @Test
     public void testDemoLoad() {
         runTest("java/test/jmri/jmrit/operations/xml/DemoFiles/", 12, 12, 10, 210, 19);
+        jmri.jmrit.operations.setup.AutoSave.stop();
+        JUnitUtil.waitThreadTerminated("Operations Auto Save");
     }
 
     // load a set of operations files with trains that have been built.
@@ -39,6 +41,8 @@ public class XmlLoadTest extends OperationsTestCase {
     @Test
     public void testDemoWithBuildLoad() {
         runTest("java/test/jmri/jmrit/operations/xml/DemoFilesWithBuiltTrains/", 12, 12, 10, 210, 19);
+        jmri.jmrit.operations.setup.AutoSave.stop();
+        JUnitUtil.waitThreadTerminated("Operations Auto Save");
     }
 
     /*

--- a/java/test/jmri/jmrit/operations/automation/AutomationManagerTest.java
+++ b/java/test/jmri/jmrit/operations/automation/AutomationManagerTest.java
@@ -187,5 +187,8 @@ public class AutomationManagerTest extends OperationsTestCase {
         
         // confirm two automations restored
         Assert.assertEquals("number of automations", 2,  automationManager.getSize());
+
+        jmri.util.JUnitUtil.waitThreadTerminated("Startup Scripts"); // TrainManager.java
+
     }
 }

--- a/java/test/jmri/jmrit/operations/automation/actions/BuildTrainActionTest.java
+++ b/java/test/jmri/jmrit/operations/automation/actions/BuildTrainActionTest.java
@@ -1,10 +1,7 @@
 package jmri.jmrit.operations.automation.actions;
 
-import java.awt.GraphicsEnvironment;
-
 import org.junit.Assert;
 import org.junit.jupiter.api.*;
-import org.junit.Assume;
 
 import jmri.InstanceManager;
 import jmri.jmrit.operations.OperationsTestCase;
@@ -25,7 +22,7 @@ public class BuildTrainActionTest extends OperationsTestCase {
         BuildTrainAction t = new BuildTrainAction();
         Assert.assertNotNull("exists",t);
     }
-    
+
     @Test
     public void testActionNoAutomationItem() {
         BuildTrainAction action = new BuildTrainAction();
@@ -33,52 +30,52 @@ public class BuildTrainActionTest extends OperationsTestCase {
         // does nothing, no automationItem
         action.doAction();
     }
-    
+
     @Test
     public void testGetActionName() {
         BuildTrainAction action = new BuildTrainAction();
         Assert.assertEquals("name", Bundle.getMessage("BuildTrain"), action.getName());
     }
-    
+
     @Test
     public void testAction() {
         JUnitOperationsUtil.initOperationsData();
         TrainManager tmanager = InstanceManager.getDefault(TrainManager.class);
         Train train1 = tmanager.getTrainById("1");
         Assert.assertNotNull(train1);
-        
+
         BuildTrainAction action = new BuildTrainAction();
         Assert.assertNotNull("exists",action);
         AutomationItem automationItem = new AutomationItem("TestId");
         automationItem.setAction(action);
         Assert.assertEquals("confirm registered", automationItem, action.getAutomationItem());
-        
+
         // does nothing, no train assignment
         action.doAction();       
         Assert.assertFalse(train1.isBuilt());
         Assert.assertFalse(automationItem.isActionSuccessful());
-        
+
         automationItem.setTrain(train1);
         action.doAction();       
         Assert.assertTrue(train1.isBuilt());
         Assert.assertTrue(automationItem.isActionSuccessful());
-        
+
         //try again
         action.doAction();
         Assert.assertFalse(automationItem.isActionSuccessful());
-        
+
         JUnitOperationsUtil.checkOperationsShutDownTask();
 
     }
-    
+
     @Test
+    @jmri.util.junit.annotations.DisabledIfHeadless
     public void testActionMessages() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         JUnitOperationsUtil.initOperationsData();
         TrainManager tmanager = InstanceManager.getDefault(TrainManager.class);
         Train train1 = tmanager.getTrainById("1");
         Assert.assertNotNull(train1);
-        
+
         BuildTrainAction action = new BuildTrainAction();
         Assert.assertNotNull("exists",action);
         AutomationItem automationItem = new AutomationItem("TestId");
@@ -87,47 +84,41 @@ public class BuildTrainActionTest extends OperationsTestCase {
         automationItem.setTrain(train1);
         automationItem.setMessage("Show this message when successful");
         automationItem.setMessageFail("Show this message when fail");
-        
+
         // should cause dialog to appear
-        Thread doAction = new Thread(new Runnable() {
-            @Override
-            public void run() {
-                action.doAction();
-            }
-        });
+        Thread doAction = new Thread(action::doAction);
         doAction.setName("Do Action"); // NOI18N
         doAction.start();
 
         jmri.util.JUnitUtil.waitFor(() -> {
             return doAction.getState().equals(Thread.State.WAITING);
         }, "wait for prompt");
-        
+
         String title = automationItem.getId() + "  " + action.getActionString();
         JemmyUtil.pressDialogButton(title, Bundle.getMessage("ButtonOK"));
-        
+
+        jmri.util.JUnitUtil.waitFor(() -> !doAction.isAlive(), "wait for doAction to complete");
+
         Assert.assertTrue(train1.isBuilt());
         Assert.assertTrue(automationItem.isActionSuccessful());
-        
+
         //try again
         // should dialog to appear
-        Thread doAction2 = new Thread(new Runnable() {
-            @Override
-            public void run() {
-                action.doAction();
-            }
-        });
+        Thread doAction2 = new Thread(action::doAction);
         doAction2.setName("Do Action 2"); // NOI18N
         doAction2.start();
-        
+
         jmri.util.JUnitUtil.waitFor(() -> {
             return doAction2.getState().equals(Thread.State.WAITING);
         }, "wait for prompt");
-        
+
         title = automationItem.getId() + " " + Bundle.getMessage("Failed") + " " + action.getActionString();
         JemmyUtil.pressDialogButton(title, Bundle.getMessage("Halt"));
-        
+
+        jmri.util.JUnitUtil.waitFor(() -> !doAction2.isAlive(), "wait for doAction2 to complete");
+
         Assert.assertFalse(automationItem.isActionSuccessful());
-        
+
         JUnitOperationsUtil.checkOperationsShutDownTask();
 
     }

--- a/java/test/jmri/jmrit/operations/locations/schedules/tools/ExportSchedulesActionTest.java
+++ b/java/test/jmri/jmrit/operations/locations/schedules/tools/ExportSchedulesActionTest.java
@@ -1,10 +1,8 @@
 package jmri.jmrit.operations.locations.schedules.tools;
 
-import java.awt.GraphicsEnvironment;
 import java.awt.event.ActionEvent;
 
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.jupiter.api.Test;
 
 import jmri.jmrit.operations.OperationsTestCase;
@@ -14,21 +12,20 @@ import jmri.util.swing.JemmyUtil;
  *
  * @author Paul Bender Copyright (C) 2017
  */
+@jmri.util.junit.annotations.DisabledIfHeadless
 public class ExportSchedulesActionTest extends OperationsTestCase {
 
     @Test
     public void testCTor() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         ExportSchedulesAction t = new ExportSchedulesAction();
         Assert.assertNotNull("exists",t);
     }
-    
+
     @Test
     public void testAction() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         ExportSchedulesAction a = new ExportSchedulesAction();
         Assert.assertNotNull("exists", a);
-              
+
         // should cause dialog to appear
         Thread doAction = new Thread(new Runnable() {
             @Override
@@ -42,13 +39,15 @@ public class ExportSchedulesActionTest extends OperationsTestCase {
         jmri.util.JUnitUtil.waitFor(() -> {
             return doAction.getState().equals(Thread.State.WAITING);
         }, "wait for prompt");
-                
+
         JemmyUtil.pressDialogButton(Bundle.getMessage("ExportComplete"), Bundle.getMessage("ButtonOK"));
-        
+
+        jmri.util.JUnitUtil.waitFor(() -> !doAction.isAlive(), "wait for doAction to complete");
+
         java.io.File file = new java.io.File(ExportSchedules.defaultOperationsFilename());
         Assert.assertTrue("Confirm file creation", file.exists());
-    }
 
+    }
 
     // private final static Logger log = LoggerFactory.getLogger(ExportCarRosterActionTest.class);
 

--- a/java/test/jmri/jmrit/operations/locations/schedules/tools/ExportSchedulesTest.java
+++ b/java/test/jmri/jmrit/operations/locations/schedules/tools/ExportSchedulesTest.java
@@ -1,9 +1,6 @@
 package jmri.jmrit.operations.locations.schedules.tools;
 
-import java.awt.GraphicsEnvironment;
-
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.jupiter.api.Test;
 
 import jmri.InstanceManager;
@@ -25,44 +22,42 @@ public class ExportSchedulesTest extends OperationsTestCase{
         ExportSchedules t = new ExportSchedules();
         Assert.assertNotNull("exists", t);
     }
-    
+
     @Test
+    @jmri.util.junit.annotations.DisabledIfHeadless
     public void testCreateFile() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+
         ExportSchedules exportLoc = new ExportSchedules();
         Assert.assertNotNull("exists", exportLoc);
-        
+
         JUnitOperationsUtil.loadFiveLocations(); //only Test Loc E has a track
-        
+
         LocationManager lManager = InstanceManager.getDefault(LocationManager.class);
         Location l1 = lManager.getLocationByName("Test Loc E");
         Track track = l1.getTrackByName("Test Track", Track.SPUR);
-        
+
         // create schedule with one item
         ScheduleManager sManager = InstanceManager.getDefault(ScheduleManager.class);
         Schedule schedule = sManager.newSchedule("test schedule");
         schedule.addItem("Boxcar");
-        
+
         track.setSchedule(schedule);
-        
+
         // should cause export complete dialog to appear
-        Thread export = new Thread(new Runnable() {
-            @Override
-            public void run() {
-                exportLoc.writeOperationsScheduleFile();
-            }
-        });
+        Thread export = new Thread(exportLoc::writeOperationsScheduleFile);
         export.setName("Export Schedules"); // NOI18N
         export.start();
 
         jmri.util.JUnitUtil.waitFor(() -> {
             return export.getState().equals(Thread.State.WAITING);
         }, "wait for prompt");
-        
+
         JemmyUtil.pressDialogButton(Bundle.getMessage("ExportComplete"), Bundle.getMessage("ButtonOK"));
-        
+
+        jmri.util.JUnitUtil.waitFor(() -> !export.isAlive(), "wait for export to complete");
+
         java.io.File file = new java.io.File(ExportSchedules.defaultOperationsFilename());   
-        Assert.assertTrue("Confirm file creation", file.exists());        
+        Assert.assertTrue("Confirm file creation", file.exists());
     }
 
     // private final static Logger log = LoggerFactory.getLogger(ExportCarsTest.class);

--- a/java/test/jmri/jmrit/operations/locations/tools/ExportLocationsRosterActionTest.java
+++ b/java/test/jmri/jmrit/operations/locations/tools/ExportLocationsRosterActionTest.java
@@ -1,10 +1,8 @@
 package jmri.jmrit.operations.locations.tools;
 
-import java.awt.GraphicsEnvironment;
 import java.awt.event.ActionEvent;
 
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.jupiter.api.Test;
 
 import jmri.jmrit.operations.OperationsTestCase;
@@ -14,21 +12,20 @@ import jmri.util.swing.JemmyUtil;
  *
  * @author Paul Bender Copyright (C) 2017
  */
+@jmri.util.junit.annotations.DisabledIfHeadless
 public class ExportLocationsRosterActionTest extends OperationsTestCase {
 
     @Test
     public void testCTor() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         ExportLocationsRosterAction t = new ExportLocationsRosterAction();
         Assert.assertNotNull("exists",t);
     }
-    
+
     @Test
     public void testAction() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         ExportLocationsRosterAction a = new ExportLocationsRosterAction();
         Assert.assertNotNull("exists", a);
-              
+
         // should cause dialog to appear
         Thread doAction = new Thread(new Runnable() {
             @Override
@@ -42,9 +39,11 @@ public class ExportLocationsRosterActionTest extends OperationsTestCase {
         jmri.util.JUnitUtil.waitFor(() -> {
             return doAction.getState().equals(Thread.State.WAITING);
         }, "wait for prompt");
-                
+
         JemmyUtil.pressDialogButton(Bundle.getMessage("ExportComplete"), Bundle.getMessage("ButtonOK"));
-        
+
+        jmri.util.JUnitUtil.waitFor(() -> !doAction.isAlive(), "wait for doAction to complete");
+
         java.io.File file = new java.io.File(ExportLocations.defaultOperationsFilename());
         Assert.assertTrue("Confirm file creation", file.exists());
     }

--- a/java/test/jmri/jmrit/operations/locations/tools/ExportLocationsTest.java
+++ b/java/test/jmri/jmrit/operations/locations/tools/ExportLocationsTest.java
@@ -1,12 +1,11 @@
 package jmri.jmrit.operations.locations.tools;
 
-import java.awt.GraphicsEnvironment;
 import jmri.jmrit.operations.OperationsTestCase;
 import jmri.util.JUnitOperationsUtil;
 import jmri.util.swing.JemmyUtil;
+
 import org.junit.Assert;
 import org.junit.jupiter.api.*;
-import org.junit.Assume;
 
 /**
  *
@@ -19,33 +18,31 @@ public class ExportLocationsTest extends OperationsTestCase {
         ExportLocations t = new ExportLocations();
         Assert.assertNotNull("exists", t);
     }
-    
+
     @Test
+    @jmri.util.junit.annotations.DisabledIfHeadless
     public void testCreateFile() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+
         ExportLocations exportLoc = new ExportLocations();
         Assert.assertNotNull("exists", exportLoc);
-        
+
         JUnitOperationsUtil.loadFiveLocations(); //only Test Loc E has a track
-        
+
         // should cause export complete dialog to appear
-        Thread export = new Thread(new Runnable() {
-            @Override
-            public void run() {
-                exportLoc.writeOperationsLocationFile();
-            }
-        });
+        Thread export = new Thread(exportLoc::writeOperationsLocationFile);
         export.setName("Export Locations"); // NOI18N
         export.start();
 
         jmri.util.JUnitUtil.waitFor(() -> {
             return export.getState().equals(Thread.State.WAITING);
         }, "wait for prompt");
-        
+
         JemmyUtil.pressDialogButton(Bundle.getMessage("ExportComplete"), Bundle.getMessage("ButtonOK"));
-        
+
+        jmri.util.JUnitUtil.waitFor(() -> !export.isAlive(), "wait for export to complete");
+
         java.io.File file = new java.io.File(ExportLocations.defaultOperationsFilename());   
-        Assert.assertTrue("Confirm file creation", file.exists());        
+        Assert.assertTrue("Confirm file creation", file.exists());
     }
 
     // private final static Logger log = LoggerFactory.getLogger(ExportCarsTest.class);

--- a/java/test/jmri/jmrit/operations/rollingstock/engines/tools/ExportEnginesTest.java
+++ b/java/test/jmri/jmrit/operations/rollingstock/engines/tools/ExportEnginesTest.java
@@ -5,9 +5,6 @@ import org.junit.jupiter.api.*;
 import jmri.jmrit.operations.OperationsTestCase;
 import jmri.util.JUnitOperationsUtil;
 import jmri.util.swing.JemmyUtil;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  *
@@ -18,22 +15,17 @@ public class ExportEnginesTest extends OperationsTestCase {
     @Test
     public void testCTor() {
         ExportEngines t = new ExportEngines();
-        assertThat(t).withFailMessage("exists").isNotNull();
+        Assertions.assertNotNull(t, "exists");
     }
-    
+
     @Test
-    @DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
+    @jmri.util.junit.annotations.DisabledIfHeadless
     public void testCreateFile() {
         JUnitOperationsUtil.initOperationsData();
         ExportEngines exportEngines = new ExportEngines();
 
         // should cause export complete dialog to appear
-        Thread export = new Thread(new Runnable() {
-            @Override
-            public void run() {
-                exportEngines.writeOperationsEngineFile();
-            }
-        });
+        Thread export = new Thread(exportEngines::writeOperationsEngineFile);
         export.setName("Export Engines"); // NOI18N
         export.start();
 
@@ -43,8 +35,10 @@ public class ExportEnginesTest extends OperationsTestCase {
 
         JemmyUtil.pressDialogButton(Bundle.getMessage("ExportComplete"), Bundle.getMessage("ButtonOK"));
 
+        jmri.util.JUnitUtil.waitFor(() -> !export.isAlive(), "wait for export to complete");
+
         java.io.File file = new java.io.File(ExportEngines.defaultOperationsFilename());
-        assertThat(file.exists()).withFailMessage("Confirm file creation").isTrue();
+        Assertions.assertTrue(file.exists(), "Confirm file creation");
     }
 
     // private final static Logger log = LoggerFactory.getLogger(ExportEnginesTest.class);

--- a/java/test/jmri/jmrit/operations/routes/RouteEditFrameTest.java
+++ b/java/test/jmri/jmrit/operations/routes/RouteEditFrameTest.java
@@ -1,13 +1,11 @@
 package jmri.jmrit.operations.routes;
 
 import java.awt.Dimension;
-import java.awt.GraphicsEnvironment;
 import java.util.List;
 
 import javax.swing.JComboBox;
 
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.jupiter.api.Test;
 import org.netbeans.jemmy.operators.*;
 
@@ -26,11 +24,11 @@ import jmri.util.swing.JemmyUtil;
  *
  * @author Paul Bender Copyright (C) 2017
  */
+@jmri.util.junit.annotations.DisabledIfHeadless
 public class RouteEditFrameTest extends OperationsTestCase {
 
     @Test
     public void testCTor() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         RouteEditFrame t = new RouteEditFrame();
         Assert.assertNotNull("exists", t);
         JUnitUtil.dispose(t);
@@ -38,7 +36,6 @@ public class RouteEditFrameTest extends OperationsTestCase {
     
     @Test
     public void testRouteNameTooLong() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
 
         // The default route name is too long
         Route route = JUnitOperationsUtil.createFiveLocationRoute();
@@ -52,7 +49,6 @@ public class RouteEditFrameTest extends OperationsTestCase {
     
     @Test
     public void testRouteNameMissing() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
 
         RouteEditFrame f = new RouteEditFrame();
         f.initComponents(null);
@@ -67,8 +63,7 @@ public class RouteEditFrameTest extends OperationsTestCase {
      */
     @Test
     public void testNewRoute() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        
+
         TrainManager tManager = InstanceManager.getDefault(TrainManager.class);
         Train train = tManager.newTrain("Test Train");
 
@@ -96,7 +91,7 @@ public class RouteEditFrameTest extends OperationsTestCase {
      */
     @Test
     public void testRouteEditFrameNoSelection() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+
         RouteEditFrame f = new RouteEditFrame();
         f.setTitle("Test Add Route Frame");
         f.initComponents(null);
@@ -116,7 +111,7 @@ public class RouteEditFrameTest extends OperationsTestCase {
 
     @Test
     public void testRouteEditFrame() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+
         RouteEditFrame f = new RouteEditFrame();
         f.setTitle("Test Add Route Frame");
         f.initComponents(null);
@@ -188,7 +183,6 @@ public class RouteEditFrameTest extends OperationsTestCase {
 
     @Test
     public void testRouteLocationComment() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
 
         // create a route
         Route route = JUnitOperationsUtil.createFiveLocationRoute();
@@ -231,7 +225,6 @@ public class RouteEditFrameTest extends OperationsTestCase {
 
     @Test
     public void testRouteLocationDelete() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
 
         // create a route
         Route route = JUnitOperationsUtil.createFiveLocationRoute();
@@ -262,7 +255,6 @@ public class RouteEditFrameTest extends OperationsTestCase {
 
     @Test
     public void testButtonDown() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
 
         // create a route
         Route route = JUnitOperationsUtil.createFiveLocationRoute();
@@ -294,7 +286,6 @@ public class RouteEditFrameTest extends OperationsTestCase {
     
     @Test
     public void testButtonUp() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
 
         // create a route
         Route route = JUnitOperationsUtil.createFiveLocationRoute();
@@ -331,7 +322,6 @@ public class RouteEditFrameTest extends OperationsTestCase {
 
     @Test
     public void testWait() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
 
         // create a route
         Route route = JUnitOperationsUtil.createFiveLocationRoute();
@@ -356,7 +346,7 @@ public class RouteEditFrameTest extends OperationsTestCase {
         JFrameOperator jfo = new JFrameOperator(f);
         JTableOperator tbl = new JTableOperator(jfo);
 
-        Assert.assertEquals("Travel Time", 4, tbl.getValueAt(0, tbl.findColumn(Bundle.getMessage("Travel"))));
+        Assert.assertEquals("Travel Time", 4, (int)tbl.getValueAt(0, tbl.findColumn(Bundle.getMessage("Travel"))));
         tbl.setValueAt(20, 0, tbl.findColumn(Bundle.getMessage("Travel")));
         JemmyUtil.enterClickAndLeave(f.saveRouteButton);
         // wait = travel - time
@@ -367,7 +357,6 @@ public class RouteEditFrameTest extends OperationsTestCase {
 
     @Test
     public void testDeputureTime() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
 
         // create a route
         Route route = JUnitOperationsUtil.createFiveLocationRoute();
@@ -399,7 +388,6 @@ public class RouteEditFrameTest extends OperationsTestCase {
 
     @Test
     public void testMaxMoves() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
 
         // create a route
         Route route = JUnitOperationsUtil.createFiveLocationRoute();
@@ -426,7 +414,6 @@ public class RouteEditFrameTest extends OperationsTestCase {
 
     @Test
     public void testSetXY() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
 
         // create a route
         Route route = JUnitOperationsUtil.createFiveLocationRoute();
@@ -458,7 +445,6 @@ public class RouteEditFrameTest extends OperationsTestCase {
 
     @Test
     public void testGrade() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
 
         // create a route
         Route route = JUnitOperationsUtil.createFiveLocationRoute();
@@ -486,7 +472,6 @@ public class RouteEditFrameTest extends OperationsTestCase {
 
     @Test
     public void testMaxTrainLength() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
 
         // create a route
         Route route = JUnitOperationsUtil.createFiveLocationRoute();
@@ -513,7 +498,6 @@ public class RouteEditFrameTest extends OperationsTestCase {
     
     @Test
     public void testMinTrainLength() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
 
         // create a route
         Route route = JUnitOperationsUtil.createFiveLocationRoute();
@@ -529,14 +513,16 @@ public class RouteEditFrameTest extends OperationsTestCase {
         // confirm default value
         Assert.assertEquals("Max Length", 1000, rl.getMaxTrainLength());
         
-        JemmyUtil.createModalDialogOperatorThread(Bundle.getMessage("WarningTooShort"), Bundle.getMessage("ButtonCancel"));           
+        Thread t = JemmyUtil.createModalDialogOperatorThread(Bundle.getMessage("WarningTooShort"), Bundle.getMessage("ButtonCancel"));
         JFrameOperator jfo = new JFrameOperator(f);
         JTableOperator tbl = new JTableOperator(jfo);
-        tbl.setValueAt(499, 0, tbl.findColumn(Bundle.getMessage("MaxLength")));   
+        tbl.setValueAt(499, 0, tbl.findColumn(Bundle.getMessage("MaxLength")));
+        JUnitUtil.waitFor(() -> !t.isAlive(),"TooShort Cancel dialog");
         Assert.assertEquals("Old Max Length", 1000, rl.getMaxTrainLength());
         
-        JemmyUtil.createModalDialogOperatorThread(Bundle.getMessage("WarningTooShort"), Bundle.getMessage("ButtonOK"));
+        Thread tt = JemmyUtil.createModalDialogOperatorThread(Bundle.getMessage("WarningTooShort"), Bundle.getMessage("ButtonOK"));
         tbl.setValueAt(499, 0, tbl.findColumn(Bundle.getMessage("MaxLength")));
+        JUnitUtil.waitFor(() -> !tt.isAlive(),"TooShort OK dialog");
         Assert.assertEquals("New Max Length", 499, rl.getMaxTrainLength());
 
         JUnitUtil.dispose(f);
@@ -544,7 +530,7 @@ public class RouteEditFrameTest extends OperationsTestCase {
 
     @Test
     public void testRouteEditFrameRead() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+
         JUnitOperationsUtil.loadFiveRoutes();
         RouteManager rManager = InstanceManager.getDefault(RouteManager.class);
         Route route = rManager.getRouteByName("Test Route C");
@@ -560,7 +546,7 @@ public class RouteEditFrameTest extends OperationsTestCase {
 
     @Test
     public void testCloseWindowOnSave() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+
         RouteManager rManager = InstanceManager.getDefault(RouteManager.class);
         Route route = rManager.newRoute("Test Route");
         RouteEditFrame f = new RouteEditFrame();

--- a/java/test/jmri/jmrit/operations/routes/tools/ExportRoutesTest.java
+++ b/java/test/jmri/jmrit/operations/routes/tools/ExportRoutesTest.java
@@ -1,9 +1,6 @@
 package jmri.jmrit.operations.routes.tools;
 
-import java.awt.GraphicsEnvironment;
-
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.jupiter.api.Test;
 
 import jmri.jmrit.operations.OperationsTestCase;
@@ -24,20 +21,15 @@ public class ExportRoutesTest extends OperationsTestCase {
     }
 
     @Test
+    @jmri.util.junit.annotations.DisabledIfHeadless
     public void testCreateFile() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         ExportRoutes exportRoutes = new ExportRoutes();
         Assert.assertNotNull("exists", exportRoutes);
 
         JUnitOperationsUtil.initOperationsData();
 
         // next should cause export complete dialog to appear
-        Thread export = new Thread(new Runnable() {
-            @Override
-            public void run() {
-                exportRoutes.writeOperationsRoutesFile();
-            }
-        });
+        Thread export = new Thread(exportRoutes::writeOperationsRoutesFile);
         export.setName("Export Routes"); // NOI18N
         export.start();
 
@@ -47,9 +39,10 @@ public class ExportRoutesTest extends OperationsTestCase {
 
         JemmyUtil.pressDialogButton(Bundle.getMessage("ExportComplete"), Bundle.getMessage("ButtonOK"));
 
+        jmri.util.JUnitUtil.waitFor(() -> !export.isAlive(), "wait for export to complete");
+
         java.io.File file = new java.io.File(ExportRoutes.defaultOperationsFilename());
         Assert.assertTrue("Confirm file creation", file.exists());
-        
 
     }
 

--- a/java/test/jmri/jmrit/operations/trains/TrainEditFrameTest.java
+++ b/java/test/jmri/jmrit/operations/trains/TrainEditFrameTest.java
@@ -1,10 +1,8 @@
 package jmri.jmrit.operations.trains;
 
-import java.awt.GraphicsEnvironment;
 import java.text.MessageFormat;
 
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -20,11 +18,11 @@ import jmri.util.swing.JemmyUtil;
  *
  * @author Paul Bender Copyright (C) 2017
  */
+@jmri.util.junit.annotations.DisabledIfHeadless
 public class TrainEditFrameTest extends OperationsTestCase {
 
     @Test
     public void testCTor() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         Train train1 = new Train("TESTTRAINID", "TESTTRAINNAME");
         TrainEditFrame f = new TrainEditFrame(train1);
         Assert.assertNotNull("exists", f);
@@ -33,7 +31,6 @@ public class TrainEditFrameTest extends OperationsTestCase {
 
     @Test
     public void testTrainEditFrame() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         TrainEditFrame trainEditFrame = new TrainEditFrame(null);
         trainEditFrame.setTitle("Test Edit Train Frame");
         ThreadingUtil.runOnGUI(() -> {
@@ -200,7 +197,6 @@ public class TrainEditFrameTest extends OperationsTestCase {
 
     @Test
     public void testTrainEditFrameAddButton() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         TrainEditFrame trainEditFrame = new TrainEditFrame(null);
         trainEditFrame.setTitle("Test Add Button Train Frame");
         // fill in name and description fields
@@ -243,7 +239,6 @@ public class TrainEditFrameTest extends OperationsTestCase {
 
     @Test
     public void testTrainEditFrameAddButtonTrainNameTooLong() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         TrainEditFrame trainEditFrame = new TrainEditFrame(null);
         trainEditFrame.setTitle("Test Add Button Train Frame");
         // fill in name and description fields
@@ -265,7 +260,6 @@ public class TrainEditFrameTest extends OperationsTestCase {
 
     @Test
     public void testTrainEditFrameAddButtonTrainNameSpecialCharacter() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         TrainEditFrame trainEditFrame = new TrainEditFrame(null);
         trainEditFrame.setTitle("Test Add Button Train Frame");
         // fill in name and description fields
@@ -293,7 +287,6 @@ public class TrainEditFrameTest extends OperationsTestCase {
      */
     @Test
     public void testTrainEditFrameSaveExistingTrain() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         TrainManager tmanager = InstanceManager.getDefault(TrainManager.class);
         Train train = tmanager.getTrainByName("Test_Train 1");
         Assert.assertNotNull(train);
@@ -317,7 +310,6 @@ public class TrainEditFrameTest extends OperationsTestCase {
 
     @Test
     public void testTrainEditFrameSaveButton() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         // create a train
         TrainManager tmanager = InstanceManager.getDefault(TrainManager.class);
         Train train = tmanager.newTrain("Test Train Save Button");
@@ -456,7 +448,6 @@ public class TrainEditFrameTest extends OperationsTestCase {
 
     @Test
     public void testTrainEditFrameNoRoute() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         // create a train
         TrainManager tmanager = InstanceManager.getDefault(TrainManager.class);
         Train train = tmanager.newTrain("Test Train No Route");
@@ -474,7 +465,6 @@ public class TrainEditFrameTest extends OperationsTestCase {
 
     @Test
     public void testTrainEditFrameNoName() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         // create a train
         TrainManager tmanager = InstanceManager.getDefault(TrainManager.class);
         Train train = tmanager.newTrain("Test Train No Name");
@@ -504,7 +494,6 @@ public class TrainEditFrameTest extends OperationsTestCase {
      */
     @Test
     public void testTrainEditFrameDelete() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         TrainManager tmanager = InstanceManager.getDefault(TrainManager.class);
         Train train = tmanager.getTrainByName("Test_Train 1");
         Assert.assertNotNull(train);
@@ -534,7 +523,6 @@ public class TrainEditFrameTest extends OperationsTestCase {
      */
     @Test
     public void testTrainEditFrameReset() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
 
         JUnitOperationsUtil.initOperationsData();
         TrainManager tmanager = InstanceManager.getDefault(TrainManager.class);
@@ -570,7 +558,6 @@ public class TrainEditFrameTest extends OperationsTestCase {
 
     @Test
     public void testCloseWindowOnSave() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         Train train = new Train("TESTTRAINID", "TESTTRAINNAME");
         Route route = new Route("ROUTEID","ROUTENAME");
         train.setRoute(route);

--- a/java/test/jmri/jmrit/operations/trains/XmlTest.java
+++ b/java/test/jmri/jmrit/operations/trains/XmlTest.java
@@ -664,10 +664,11 @@ public class XmlTest extends OperationsTestCase {
         Assert.assertEquals("Move script", 0, t3.getMoveScripts().size());
         Assert.assertEquals("Termination script", 0, t3.getTerminationScripts().size());
 
+        jmri.util.JUnitUtil.waitThreadTerminated("Startup Scripts"); // TrainManager.java
+
     }
 
     // from here down is testing infrastructure
-    // Ensure minimal setup for log4J
     @Override
     @BeforeEach
     public void setUp() {

--- a/java/test/jmri/jmrit/operations/trains/tools/ExportTimetableActionTest.java
+++ b/java/test/jmri/jmrit/operations/trains/tools/ExportTimetableActionTest.java
@@ -1,10 +1,8 @@
 package jmri.jmrit.operations.trains.tools;
 
-import java.awt.GraphicsEnvironment;
 import java.awt.event.ActionEvent;
 
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.jupiter.api.Test;
 
 import jmri.jmrit.operations.OperationsTestCase;
@@ -15,18 +13,19 @@ import jmri.util.swing.JemmyUtil;
  * @author Paul Bender Copyright (C) 2017
  */
 public class ExportTimetableActionTest extends OperationsTestCase {
+
     @Test
     public void testCTor() {
         ExportTimetableAction t = new ExportTimetableAction();
         Assert.assertNotNull("exists",t);
     }
-    
+
     @Test
+    @jmri.util.junit.annotations.DisabledIfHeadless
     public void testAction() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         ExportTimetableAction a = new ExportTimetableAction();
         Assert.assertNotNull("exists", a);
-              
+
         // should cause dialog to appear
         Thread doAction = new Thread(new Runnable() {
             @Override
@@ -40,9 +39,11 @@ public class ExportTimetableActionTest extends OperationsTestCase {
         jmri.util.JUnitUtil.waitFor(() -> {
             return doAction.getState().equals(Thread.State.WAITING);
         }, "wait for prompt");
-                
+
         JemmyUtil.pressDialogButton(Bundle.getMessage("ExportComplete"), Bundle.getMessage("ButtonOK"));
-        
+
+        jmri.util.JUnitUtil.waitFor(() -> !doAction.isAlive(), "wait for doAction to complete");
+
         java.io.File file = new java.io.File(ExportTimetable.defaultOperationsFilename());
         Assert.assertTrue("Confirm file creation", file.exists());
     }

--- a/java/test/jmri/jmrit/operations/trains/tools/ExportTimetableTest.java
+++ b/java/test/jmri/jmrit/operations/trains/tools/ExportTimetableTest.java
@@ -1,10 +1,7 @@
 package jmri.jmrit.operations.trains.tools;
 
-import java.awt.GraphicsEnvironment;
-
 import org.junit.Assert;
 import org.junit.jupiter.api.*;
-import org.junit.Assume;
 
 import jmri.jmrit.operations.OperationsTestCase;
 import jmri.util.JUnitOperationsUtil;
@@ -24,20 +21,15 @@ public class ExportTimetableTest extends OperationsTestCase {
     }
 
     @Test
+    @jmri.util.junit.annotations.DisabledIfHeadless
     public void testCreateFile() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         ExportTimetable exportTimetable = new ExportTimetable();
         Assert.assertNotNull("exists", exportTimetable);
 
         JUnitOperationsUtil.initOperationsData();
 
         // next should cause export complete dialog to appear
-        Thread export = new Thread(new Runnable() {
-            @Override
-            public void run() {
-                exportTimetable.writeOperationsTimetableFile();
-            }
-        });
+        Thread export = new Thread(exportTimetable::writeOperationsTimetableFile);
         export.setName("Export Trains"); // NOI18N
         export.start();
 
@@ -47,9 +39,10 @@ public class ExportTimetableTest extends OperationsTestCase {
 
         JemmyUtil.pressDialogButton(Bundle.getMessage("ExportComplete"), Bundle.getMessage("ButtonOK"));
 
+        jmri.util.JUnitUtil.waitFor(() -> !export.isAlive(), "wait for export to complete");
+
         java.io.File file = new java.io.File(ExportTimetable.defaultOperationsFilename());
         Assert.assertTrue("Confirm file creation", file.exists());
-        
 
     }
 

--- a/java/test/jmri/jmrit/operations/trains/tools/ExportTrainLineupsActionTest.java
+++ b/java/test/jmri/jmrit/operations/trains/tools/ExportTrainLineupsActionTest.java
@@ -1,10 +1,8 @@
 package jmri.jmrit.operations.trains.tools;
 
-import java.awt.GraphicsEnvironment;
 import java.awt.event.ActionEvent;
 
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.jupiter.api.Test;
 
 import jmri.jmrit.operations.OperationsTestCase;
@@ -15,18 +13,19 @@ import jmri.util.swing.JemmyUtil;
  * @author Paul Bender Copyright (C) 2017
  */
 public class ExportTrainLineupsActionTest extends OperationsTestCase {
+
     @Test
     public void testCTor() {
         ExportTrainLineupsAction t = new ExportTrainLineupsAction();
         Assert.assertNotNull("exists",t);
     }
-    
+
     @Test
+    @jmri.util.junit.annotations.DisabledIfHeadless
     public void testAction() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         ExportTrainLineupsAction a = new ExportTrainLineupsAction();
         Assert.assertNotNull("exists", a);
-              
+
         // should cause dialog to appear
         Thread doAction = new Thread(new Runnable() {
             @Override
@@ -40,9 +39,11 @@ public class ExportTrainLineupsActionTest extends OperationsTestCase {
         jmri.util.JUnitUtil.waitFor(() -> {
             return doAction.getState().equals(Thread.State.WAITING);
         }, "wait for prompt");
-                
+
         JemmyUtil.pressDialogButton(Bundle.getMessage("ExportComplete"), Bundle.getMessage("ButtonOK"));
-        
+
+        jmri.util.JUnitUtil.waitFor(() -> !doAction.isAlive(), "wait for doAction to complete");
+
         java.io.File file = new java.io.File(ExportTrainLineups.defaultOperationsFilename());
         Assert.assertTrue("Confirm file creation", file.exists());
     }

--- a/java/test/jmri/jmrit/operations/trains/tools/ExportTrainRosterActionTest.java
+++ b/java/test/jmri/jmrit/operations/trains/tools/ExportTrainRosterActionTest.java
@@ -1,10 +1,8 @@
 package jmri.jmrit.operations.trains.tools;
 
-import java.awt.GraphicsEnvironment;
 import java.awt.event.ActionEvent;
 
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.jupiter.api.Test;
 
 import jmri.jmrit.operations.OperationsTestCase;
@@ -15,18 +13,19 @@ import jmri.util.swing.JemmyUtil;
  * @author Paul Bender Copyright (C) 2017
  */
 public class ExportTrainRosterActionTest extends OperationsTestCase {
+
     @Test
     public void testCTor() {
         ExportTrainRosterAction t = new ExportTrainRosterAction();
         Assert.assertNotNull("exists",t);
     }
-    
+
     @Test
+    @jmri.util.junit.annotations.DisabledIfHeadless
     public void testAction() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         ExportTrainRosterAction a = new ExportTrainRosterAction();
         Assert.assertNotNull("exists", a);
-              
+
         // should cause dialog to appear
         Thread doAction = new Thread(new Runnable() {
             @Override
@@ -40,9 +39,11 @@ public class ExportTrainRosterActionTest extends OperationsTestCase {
         jmri.util.JUnitUtil.waitFor(() -> {
             return doAction.getState().equals(Thread.State.WAITING);
         }, "wait for prompt");
-                
+
         JemmyUtil.pressDialogButton(Bundle.getMessage("ExportComplete"), Bundle.getMessage("ButtonOK"));
-        
+
+        jmri.util.JUnitUtil.waitFor(() -> !doAction.isAlive(), "wait for doAction to complete");
+
         java.io.File file = new java.io.File(ExportTrains.defaultOperationsFilename());
         Assert.assertTrue("Confirm file creation", file.exists());
     }

--- a/java/test/jmri/jmrit/operations/trains/tools/ExportTrainsTest.java
+++ b/java/test/jmri/jmrit/operations/trains/tools/ExportTrainsTest.java
@@ -1,11 +1,9 @@
 package jmri.jmrit.operations.trains.tools;
 
-import java.awt.GraphicsEnvironment;
 import java.io.File;
 
 import org.junit.Assert;
 import org.junit.jupiter.api.*;
-import org.junit.Assume;
 
 import jmri.InstanceManager;
 import jmri.jmrit.operations.OperationsTestCase;
@@ -28,8 +26,8 @@ public class ExportTrainsTest extends OperationsTestCase {
     }
 
     @Test
+    @jmri.util.junit.annotations.DisabledIfHeadless
     public void testCreateFile() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         ExportTrains exportTrains = new ExportTrains();
         Assert.assertNotNull("exists", exportTrains);
 
@@ -50,6 +48,8 @@ public class ExportTrainsTest extends OperationsTestCase {
         }, "wait for prompt");
 
         JemmyUtil.pressDialogButton(Bundle.getMessage("ExportComplete"), Bundle.getMessage("ButtonOK"));
+
+        jmri.util.JUnitUtil.waitFor(() -> !export.isAlive(), "wait for export to complete");
 
         File file = new File(ExportTrains.defaultOperationsFilename());
         Assert.assertTrue("Confirm file creation", file.exists());

--- a/java/test/jmri/jmrit/operations/trains/tools/PrintSavedTrainManifestActionTest.java
+++ b/java/test/jmri/jmrit/operations/trains/tools/PrintSavedTrainManifestActionTest.java
@@ -1,10 +1,8 @@
 package jmri.jmrit.operations.trains.tools;
 
-import java.awt.GraphicsEnvironment;
 import java.awt.event.ActionEvent;
 
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.jupiter.api.Test;
 import org.netbeans.jemmy.operators.JFileChooserOperator;
 
@@ -29,8 +27,8 @@ public class PrintSavedTrainManifestActionTest extends OperationsTestCase {
     }
 
     @Test
+    @jmri.util.junit.annotations.DisabledIfHeadless
     public void testPrintAction() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
 
         JUnitOperationsUtil.initOperationsData();
         TrainManager tmanager = InstanceManager.getDefault(TrainManager.class);
@@ -65,7 +63,9 @@ public class PrintSavedTrainManifestActionTest extends OperationsTestCase {
         Assert.assertTrue(text.contains("manifestsBackups"));
         Assert.assertTrue(text.contains("STF"));
         fco.cancelSelection();
-        
+
+        jmri.util.JUnitUtil.waitFor(() -> !printAction.isAlive(), "wait for printAction to complete");
+
         JUnitOperationsUtil.checkOperationsShutDownTask();
 
     }


### PR DESCRIPTION
Wait for Threads to complete before Tests complete.
Improves performance of headless testing by moving `assumeFalse(GraphicsEnvironment.isHeadless())` to `DisabledIfHeadless` annotation.