### PR TITLE
LocoNet monitor Ops CV

### DIFF
--- a/java/src/jmri/jmrix/lenz/LenzCommandStation.java
+++ b/java/src/jmri/jmrix/lenz/LenzCommandStation.java
@@ -207,7 +207,7 @@ public class LenzCommandStation implements jmri.CommandStation {
                 part3 = part3 >> 1 ;
                 
                 address = part2 | part1 | part3;
-                address = address - 3;
+                address = address + 1;
                 
                 return (address) ;
             }

--- a/java/src/jmri/jmrix/loconet/messageinterp/LocoNetMessageInterpret.java
+++ b/java/src/jmri/jmrix/loconet/messageinterp/LocoNetMessageInterpret.java
@@ -4188,7 +4188,7 @@ public class LocoNetMessageInterpret {
                             * */
                             int addr = getExtendedAccessoryAddressFromDCCPacket(packetInt);
                             log.debug("Long-format Extended Accessory Ops-mode CV access: Extended Acceccory Address {}", addr);
-                            int cvnum = 1 + ((packetInt[2] & 0x03) << 2) + (packetInt[3] & 0xff);
+                            int cvnum = 1 + ((packetInt[2] & 0x03) << 8) + (packetInt[3] & 0xff);
                             switch (packetInt[2] & 0x0C) {
                                 case 0x04:
                                     //  GG=01 Verify byte


### PR DESCRIPTION
Fix of display of CV in the monitor for Ops mode programming. 
Fix of display of addresses with address offset in the XpressNet monitor for Ops mode programming. Now it uses the same method as LocoNet.