### PR TITLE
Fix error in Dispatcher OptionsMenu

### DIFF
--- a/java/src/jmri/jmrit/dispatcher/DispatcherBundle.properties
+++ b/java/src/jmri/jmrit/dispatcher/DispatcherBundle.properties
@@ -68,6 +68,7 @@ AutoTrainsFrameOnTopOnSpeedChange = On Top when Speed Changes
 AutoDispatchItem = Auto Allocate
 OptionWindowItem = Dispatcher Options
 ReminderSaveOptions = <html>Remember to save your Dispatcher Options settings to disk.<br>(choose Save Options from the Options menu)</html>
+HideSaveReminder = Hide Save Options Reminder
 AutoTurnoutsItem = Auto Set Turnouts
 SaveOptionsItem = Save Options
 UseConnectivity = Use connectivity from Layout Editor panels

--- a/java/src/jmri/jmrit/dispatcher/OptionsMenu.java
+++ b/java/src/jmri/jmrit/dispatcher/OptionsMenu.java
@@ -40,6 +40,10 @@ import jmri.util.swing.JmriJOptionPane;
  */
 public class OptionsMenu extends JMenu {
 
+    // Empty constructor for class based preferences when "Skip message in future?" is enabled.
+    public OptionsMenu() {
+    }
+
     public OptionsMenu(DispatcherFrame f) {
         dispatcher = f;
         this.setText(Bundle.getMessage("MenuOptions"));

--- a/java/src/jmri/jmrit/dispatcher/OptionsMenu.java
+++ b/java/src/jmri/jmrit/dispatcher/OptionsMenu.java
@@ -409,6 +409,22 @@ public class OptionsMenu extends JMenu {
         initializeMenu();
     }
 
+    /**
+     * Get the class description for the UserMessagePreferencesPane.
+     * @return The class description
+     */
+    public String getClassDescription() {
+        return Bundle.getMessage("OptionWindowItem");
+    }
+
+    /**
+     * Set the item details for the UserMessagePreferencesPane.
+     */
+    public void setMessagePreferencesDetails() {
+        InstanceManager.getDefault(jmri.UserPreferencesManager.class).
+                setPreferenceItemDetails(OptionsMenu.class.getName(), "remindSaveDispatcherOptions", Bundle.getMessage("HideSaveReminder"));  // NOI18N
+    }
+
     private void cancelOptions(ActionEvent e) {
         optionsFrame.setVisible(false);
         optionsFrame.dispose(); // prevent this window from being listed in the Window menu.


### PR DESCRIPTION
If **Skip message in future** is enabled after changing Dispatcher options, the following error occurs every time PanelPro is started.
```
22:45:56,216 i.managers.JmriUserPreferencesManager ERROR - setClassDescription(jmri.jmrit.dispatcher.OptionsMenu) failed in newInstance [AWT-EventQueue-0]
java.lang.NoSuchMethodException: jmri.jmrit.dispatcher.OptionsMenu.<init>()
```

Class based user preferences require an empty constructor.