### PR TITLE
Atlas decoder fixes

### DIFF
--- a/xml/decoders/Atlas_342.xml
+++ b/xml/decoders/Atlas_342.xml
@@ -103,15 +103,8 @@
         <comment>Controls how headlight dims (CV 52 controls amount)</comment>
       </variable>
       <variable item="Output A dimming" CV="51" comment="Controls how front headlights dim" mask="XXXXXVXX">
-        <enumVal>
-          <enumChoice choice="Output A cannot dim">
-            <choice>Output A cannot dim</choice>
-          </enumChoice>
-          <enumChoice choice="Output A can dim">
-            <choice>Output A can dim</choice>
-          </enumChoice>
-        </enumVal>
-        <label>Output A dimming</label>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>Output A can dim</label>
         <comment>Controls how front headlights dim</comment>
       </variable>
       <variable item="Output A is Gyrolight" CV="51" mask="XXXVXXXX">
@@ -147,15 +140,8 @@
         <label>Output B dimming control</label>
       </variable>
       <variable item="Output B dimming" CV="57" comment="Controls how back headlights dims" mask="XXXXXVXX">
-        <enumVal>
-          <enumChoice choice="Output B cannot dim">
-            <choice>Output B cannot dim</choice>
-          </enumChoice>
-          <enumChoice choice="Output B can dim">
-            <choice>Output B can dim</choice>
-          </enumChoice>
-        </enumVal>
-        <label>Output B dimming</label>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>Output B can dim</label>
         <comment>Controls how back headlights dims</comment>
       </variable>
       <variable item="Output B is Gyrolight" CV="57" mask="XXXVXXXX">
@@ -181,7 +167,7 @@
       </variable>
       <variable item="Output C, D blink rate" CV="56" default="15" minOut="3">
         <decVal min="0" max="255"/>
-        <label>Output C, D blink rate</label>
+        <label>Blink rate</label>
       </variable>
       <variable item="Output C blinks" CV="53" minOut="3" mask="XXXXXXXV">
         <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
@@ -283,9 +269,9 @@
     <column>
       <display item="Directional Headlights"/>
       <label>
-        <text> </text>
+        <text>Output A</text>
       </label>
-      <display item="Output A dimming"/>
+      <display item="Output A dimming" format="checkbox"/>
       <display item="Output A dimming control"/>
       <display item="Output A is Gyrolight" format="checkbox"/>
       <display item="Output A is Mars light" format="checkbox"/>
@@ -295,7 +281,10 @@
       <label>
         <text> </text>
       </label>
-      <display item="Output B dimming"/>
+      <label>
+        <text>Output B</text>
+      </label>
+      <display item="Output B dimming" format="checkbox"/>
       <display item="Output B dimming control"/>
       <display item="Output B is Gyrolight" format="checkbox"/>
       <display item="Output B is Mars light" format="checkbox"/>
@@ -304,10 +293,13 @@
       <display item="Output B dim intensity"/>
     </column>
     <column>
+      <label>
+        <text>Outputs C and D</text>
+      </label>
       <display item="Output C, D blink rate"/>
-      <display item="Output C blinks"/>
-      <display item="Output D blinks"/>
-      <display item="Output C, D are ditch lights"/>
+      <display item="Output C blinks" format="checkbox"/>
+      <display item="Output D blinks" format="checkbox"/>
+      <display item="Output C, D are ditch lights" format="checkbox"/>
       <label>
         <text> </text>
       </label>

--- a/xml/decoders/Atlas_342.xml
+++ b/xml/decoders/Atlas_342.xml
@@ -42,6 +42,8 @@
         <label xml:lang="it">Accellerazione (0-255)</label>
         <label xml:lang="fr">Accelération (0-255)</label>
         <label xml:lang="de">Anfahrverzögerung (0-255)</label>
+        <label xml:lang="nl">Versnelling (0-255)</label>
+        <label xml:lang="es">Aceleración</label>
         <comment>Range 1-255</comment>
       </variable>
       <variable CV="4" item="Decel" default="1" comment="Range 1-255">
@@ -50,6 +52,8 @@
         <label xml:lang="it">Decellerazione (0-255)</label>
         <label xml:lang="fr">Décélération (0-255)</label>
         <label xml:lang="de">Bremszeit (0-255)</label>
+        <label xml:lang="nl">Remvertraging (0-255)</label>
+        <label xml:lang="es">Desaceleración (0-255)</label>
         <comment>Range 1-255</comment>
       </variable>
       <variable CV="7" item="Decoder Version" readOnly="yes">
@@ -58,6 +62,8 @@
         <label xml:lang="it">Versione Decoder: </label>
         <label xml:lang="fr">Version décodeur: </label>
         <label xml:lang="de">Decoder Version: </label>
+        <label xml:lang="nl">Decoderversie: </label>
+        <label xml:lang="es">Verción del decodificador: </label>
       </variable>
       <variable CV="8" readOnly="yes" item="Manufacturer" comment="Atlas - 127">
         <decVal/>
@@ -65,6 +71,8 @@
         <label xml:lang="it">ID Costruttore: </label>
         <label xml:lang="fr">ID constructeur: </label>
         <label xml:lang="de">Hersteller ID: </label>
+        <label xml:lang="nl">Fabrikant-ID: </label>
+        <label xml:lang="es">ID del fabricante: </label>
         <comment>Atlas - 127</comment>
         <comment xml:lang="it">Atlas - 127</comment>
       </variable>

--- a/xml/decoders/Atlas_342.xml
+++ b/xml/decoders/Atlas_342.xml
@@ -105,7 +105,7 @@
       <variable item="Output A dimming" CV="51" comment="Controls how front headlights dim" mask="XXXXXVXX">
         <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Output A can dim</label>
-        <comment>Controls how front headlights dim</comment>
+        <comment>Controls whether front headlights dim</comment>
       </variable>
       <variable item="Output A is Gyrolight" CV="51" mask="XXXVXXXX">
         <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
@@ -142,7 +142,7 @@
       <variable item="Output B dimming" CV="57" comment="Controls how back headlights dims" mask="XXXXXVXX">
         <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Output B can dim</label>
-        <comment>Controls how back headlights dims</comment>
+        <comment>Controls whether back headlights dim</comment>
       </variable>
       <variable item="Output B is Gyrolight" CV="57" mask="XXXVXXXX">
         <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
@@ -268,6 +268,9 @@
     <name>Atlas</name>
     <column>
       <display item="Directional Headlights"/>
+      <label>
+        <text> </text>
+      </label>
       <label>
         <text>Output A</text>
       </label>

--- a/xml/decoders/Atlas_345.xml
+++ b/xml/decoders/Atlas_345.xml
@@ -39,17 +39,21 @@
       <variable CV="3" item="Accel" default="1" comment="Range 1-255">
         <decVal max="255"/>
         <label>Acceleration momentum</label>
-        <label xml:lang="it">Accellerazione (0-255)</label>
-        <label xml:lang="fr">Accelération (0-255)</label>
-        <label xml:lang="de">Anfahrverzögerung (0-255)</label>
+        <label xml:lang="it">Accellerazione (1-255)</label>
+        <label xml:lang="fr">Accelération (1-255)</label>
+        <label xml:lang="de">Anfahrverzögerung (1-255)</label>
+        <label xml:lang="nl">Versnelling (1-255)</label>
+        <label xml:lang="es">Aceleración (1-255)</label>
         <comment>Range 1-255</comment>
       </variable>
       <variable CV="4" item="Decel" default="1" comment="Range 1-255">
         <decVal max="255"/>
         <label>Brake momentum</label>
-        <label xml:lang="it">Decellerazione (0-255)</label>
-        <label xml:lang="fr">Décélération (0-255)</label>
-        <label xml:lang="de">Bremszeit (0-255)</label>
+        <label xml:lang="it">Decellerazione (1-255)</label>
+        <label xml:lang="fr">Décélération (1-255)</label>
+        <label xml:lang="de">Bremszeit (1-255)</label>
+        <label xml:lang="nl">Remvertraging (1-255)</label>
+        <label xml:lang="es">Desaceleración</label>
         <comment>Range 1-255</comment>
       </variable>
       <variable CV="7" item="Decoder Version" readOnly="yes">
@@ -58,6 +62,8 @@
         <label xml:lang="it">Versione Decoder: </label>
         <label xml:lang="fr">Version décodeur: </label>
         <label xml:lang="de">Decoder Version: </label>
+        <label xml:lang="nl">Decoderversie: </label>
+        <label xml:lang="es">Verción del decodificador: </label>
       </variable>
       <variable CV="8" readOnly="yes" item="Manufacturer" default="127" comment="Atlas - 127">
         <decVal/>
@@ -65,6 +71,8 @@
         <label xml:lang="it">ID Costruttore: </label>
         <label xml:lang="fr">ID constructeur: </label>
         <label xml:lang="de">Hersteller ID: </label>
+        <label xml:lang="nl">Fabrikant-ID: </label>
+        <label xml:lang="es">ID del fabricante: </label>
         <comment>Atlas - 127</comment>
         <comment xml:lang="it">Atlas - 127</comment>
       </variable>

--- a/xml/decoders/Atlas_345.xml
+++ b/xml/decoders/Atlas_345.xml
@@ -103,16 +103,9 @@
         <comment>Controls how headlight dims (CV 52 controls amount)</comment>
       </variable>
       <variable item="Output A dimming" CV="51" comment="Controls how front headlights dim" mask="XXXXXVXX">
-        <enumVal>
-          <enumChoice choice="Output A cannot dim">
-            <choice>Output A cannot dim</choice>
-          </enumChoice>
-          <enumChoice choice="Output A can dim">
-            <choice>Output A can dim</choice>
-          </enumChoice>
-        </enumVal>
-        <label>Output A dimming</label>
-        <comment>Controls how front headlights dim</comment>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>Output A can dim</label>
+        <comment>Controls whether front headlights dim</comment>
       </variable>
       <variable item="Output A is Gyrolight" CV="51" mask="XXXVXXXX">
         <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
@@ -147,16 +140,9 @@
         <label>Output B dimming control</label>
       </variable>
       <variable item="Output B dimming" CV="57" comment="Controls how back headlights dims" mask="XXXXXVXX">
-        <enumVal>
-          <enumChoice choice="Output B cannot dim">
-            <choice>Output B cannot dim</choice>
-          </enumChoice>
-          <enumChoice choice="Output B can dim">
-            <choice>Output B can dim</choice>
-          </enumChoice>
-        </enumVal>
-        <label>Output B dimming</label>
-        <comment>Controls how back headlights dims</comment>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>Output B can dim</label>
+        <comment>Controls whether back headlights dim</comment>
       </variable>
       <variable item="Output B is Gyrolight" CV="57" mask="XXXVXXXX">
         <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
@@ -234,7 +220,10 @@
       <label>
         <text> </text>
       </label>
-      <display item="Output A dimming"/>
+      <label>
+        <text>Output A</text>
+      </label>
+      <display item="Output A dimming" format="checkbox"/>
       <display item="Output A dimming control"/>
       <display item="Output A is Gyrolight" format="checkbox"/>
       <display item="Output A is Mars light" format="checkbox"/>
@@ -244,7 +233,10 @@
       <label>
         <text> </text>
       </label>
-      <display item="Output B dimming"/>
+      <label>
+        <text>Output B</text>
+      </label>
+      <display item="Output B dimming" format="checkbox"/>
       <display item="Output B dimming control"/>
       <display item="Output B is Gyrolight" format="checkbox"/>
       <display item="Output B is Mars light" format="checkbox"/>

--- a/xml/decoders/Atlas_DualMode.xml
+++ b/xml/decoders/Atlas_DualMode.xml
@@ -14,7 +14,7 @@
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
   <version author="Peter Ulvestad" version="6" lastUpdated="20091027"/>
   <version author="Michael Mosher" version="5" lastUpdated="20030706"/>
-  <!-- V3 add versionID range -->
+  <!-- V3 - add versionID range -->
   <!-- V4 - add consist direction - jake -->
   <!-- V5 - renamed and few tweeks to co-exist with four function decoder, fixed vstart bug -->
   <!-- V6 - Added factory reset, added CV2 max value -->
@@ -77,14 +77,7 @@
       <xi:include href="http://jmri.org/xml/decoders/nmra/userId.xml"/>
       <!-- Atlas-specific variables -->
       <variable CV="50" mask="XXXXXXVX" item="Consist Adjustments Active">
-        <enumVal>
-          <enumChoice choice="Not Active">
-            <choice>Not Active</choice>
-          </enumChoice>
-          <enumChoice choice="Active">
-            <choice>Active</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Consist Accel and Decel Trims</label>
       </variable>
       <variable CV="50" mask="XXXXXVXX" item="DC Brake Momentum">

--- a/xml/decoders/Atlas_Lenz_N.xml
+++ b/xml/decoders/Atlas_Lenz_N.xml
@@ -169,16 +169,7 @@
       <xi:include href="http://jmri.org/xml/decoders/nmra/cv29table3-28.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/nmra/cv29address.xml"/>
       <variable item="Accel/Decel Trim" CV="50" mask="XXXXXXXV" comment="Governs how loco acts in DC track block">
-        <enumVal>
-          <enumChoice choice="Accel/Decel trim OFF">
-            <choice>Accel/Decel trim OFF</choice>
-            <choice xml:lang="it">Regolaz. Accell/Frenata OFF</choice>
-          </enumChoice>
-          <enumChoice choice="Accel/Decel trim ON">
-            <choice>Accel/Decel trim ON</choice>
-            <choice xml:lang="it">Regolaz. Accell/Frenata ON</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Accel/Decel Trim</label>
         <label xml:lang="it">Regolazione Accell/Decell.</label>
         <comment>Governs how loco acts in DC track block</comment>
@@ -332,7 +323,7 @@
   <pane>
     <name>Lenz</name>
     <column>
-      <display item="Accel/Decel Trim"/>
+      <display item="Accel/Decel Trim" format="checkbox"/>
       <label>
         <text> </text>
       </label>

--- a/xml/decoders/Bachmann_EZDCC.xml
+++ b/xml/decoders/Bachmann_EZDCC.xml
@@ -141,9 +141,9 @@
             <choice>Loco runs under DC analog voltage control</choice>
             <choice xml:lang="cs">Lokomotiva používá pro řízení analogové stejnosměrné napětí</choice>
             <choice xml:lang="fr">Loco roule sous contrôle analogique</choice>
-            <choice xml:lang="de">Lok fährt unter DC Analogspannung weiter</choice>
+            <choice xml:lang="de">Lok läuft unter DC Analogspannung weiter</choice>
             <choice xml:lang="it">Loco va in Analogico</choice>
-            <choice xml:lang="nl">Lok rijd onder DC analoog spanning</choice>
+            <choice xml:lang="nl">Loc rijdt onder DC analoog spanning</choice>
           </enumChoice>
           <enumChoice choice="Loco brakes to a stop using momentum set in CV4">
             <choice>Loco brakes to a stop using momentum set in CV4</choice>

--- a/xml/decoders/Lenz_51.xml
+++ b/xml/decoders/Lenz_51.xml
@@ -378,7 +378,7 @@
             <choice xml:lang="it">Loco usa Tensione in Analogico</choice>
             <choice xml:lang="de">Lok läuft unter DC-Analogspannung</choice>
             <choice xml:lang="cs">Lokomotiva používá pro řízení analogové stejnosměrné napětí</choice>
-            <choice xml:lang="nl">Loc rijd onder DC analoge spanning</choice>
+            <choice xml:lang="nl">Loc rijdt onder DC analoge spanning</choice>
           </enumChoice>
           <enumChoice choice="Loco brakes to a stop using momentum set in CV4">
             <choice>Loco brakes to a stop using momentum set in CV4</choice>

--- a/xml/decoders/Lenz_LE077XF.xml
+++ b/xml/decoders/Lenz_LE077XF.xml
@@ -119,16 +119,7 @@
      <xi:include href="http://jmri.org/xml/decoders/nmra/cv29analog.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/nmra/cv29table1-28.xml"/>
       <variable item="Accel/Decel Trim" CV="50" mask="XXXXXXXV" comment="Governs how loco acts in DC track block">
-        <enumVal>
-          <enumChoice choice="Accel/Decel trim OFF">
-            <choice>Accel/Decel trim OFF</choice>
-            <choice xml:lang="de">Accel/Decel trim OFF</choice>
-          </enumChoice>
-          <enumChoice choice="Accel/Decel trim ON">
-            <choice>Accel/Decel trim ON</choice>
-            <choice xml:lang="de">Accel/Decel trim ON</choice>
-          </enumChoice>
-        </enumVal>
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Accel/Decel Trim</label>
         <comment>Governs how loco acts in DC track block</comment>
         <label xml:lang="de">Accel/Decel Trim</label>
@@ -292,7 +283,7 @@
     <name>Lenz</name>
     <name xml:lang="de">Lenz</name>
     <column>
-      <display item="Accel/Decel Trim"/>
+      <display item="Accel/Decel Trim" format="checkbox"/>
       <label>
         <text> </text>
       </label>

--- a/xml/decoders/nmra/cv50_DCbrake.xml
+++ b/xml/decoders/nmra/cv50_DCbrake.xml
@@ -56,9 +56,9 @@
             <choice>Loco runs under DC analog voltage control</choice>
             <choice xml:lang="cs">Lokomotiva používá pro řízení analogové stejnosměrné napětí</choice>
             <choice xml:lang="fr">Loco roule sous contrôle analogique</choice>
-            <choice xml:lang="de">Lok fahrt unter DC Analogspannung</choice>
+            <choice xml:lang="de">Lok läuft unter DC Analogspannung</choice>
             <choice xml:lang="it">Loco va in Analogico</choice>
-            <choice xml:lang="nl">Lok rijd onder DC analoog spanning</choice>
+            <choice xml:lang="nl">Loc rijdt onder DC analoog spanning</choice>
             <choice xml:lang="es">La locomotora funciona con control de voltaje analógico de CC</choice>
           </enumChoice>
           <enumChoice choice="Loco brakes to a stop using momentum set in CV4">

--- a/xml/decoders/nmra/mfgVersionId.xml
+++ b/xml/decoders/nmra/mfgVersionId.xml
@@ -72,7 +72,7 @@
     <label xml:lang="it">ID Costruttore: </label>
     <label xml:lang="fr">ID constructeur: </label>
     <label xml:lang="de">Hersteller ID: </label>
-    <label xml:lang="nl">Fabrikant ID: </label>
+    <label xml:lang="nl">Fabrikant-ID: </label>
     <label xml:lang="es">ID del fabricante: </label>
   </variable>
 </variables>


### PR DESCRIPTION
Use checkbox for y/n, copy NL and ES translations from include to DualMode defs, fix an obvious Dutch spelling error showing up in a couple of defs