### PR TITLE
Improve speed changes when running under NoSignals.

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -409,7 +409,10 @@
    <h3>Dispatcher</h3>
         <a id="Dispatcher" name="Dispatcher"></a>
         <ul>
-             <li></li>
+             <li>Speed Setting NoSignals.</li>
+             <li>  After setting speed by Sections ahead. Check Block speeds.</li>
+             <li>  If next block slower than current block set speed down before entering next block.</li>
+             <li>  Do not increase speed beyond the minimum speed of any occupied block.</li>
         </ul>
 
     <h3>Dispatcher System</h3>

--- a/java/src/jmri/jmrit/dispatcher/AutoActiveTrain.java
+++ b/java/src/jmri/jmrit/dispatcher/AutoActiveTrain.java
@@ -994,13 +994,23 @@ public class AutoActiveTrain implements ThrottleListener {
                     // .getSpeed(InstanceManager.getDefault(DispatcherFrame.class).getStoppingSpeedName());
                     _activeTrain.setStatus(ActiveTrain.RUNNING);
             }
-            // If the train has no _currentAllocatedSection it is in a first block outside transit.
-            if (_currentAllocatedSection != null ) {
-                for (Block block : _currentAllocatedSection.getSection().getBlockList()) {
-                    float speed = getSpeedFromBlock(block);
-                    if (speed > 0 && speed < newSpeed) {
-                        newSpeed = speed;
+            // get slowest speed of any entered and not released section.
+            // This then covers off HEADONLY.
+            for (AllocatedSection asE : _activeTrain.getAllocatedSectionList()) {
+                if (asE.getEntered()) {
+                    for (Block b : asE.getSection().getBlockList()) {
+                        if (getSpeedFromBlock(b) < newSpeed) {
+                            newSpeed = getSpeedFromBlock(b);
+                        }
                     }
+                }
+            }
+            // see if needs to slow for next block.
+            if (newSpeed > 0 && _nextBlock != null) {
+                float speed = getSpeedFromBlock(_nextBlock);
+                if (speed < newSpeed) {
+                    // slow for next block
+                    newSpeed = speed;
                 }
             }
         }


### PR DESCRIPTION
After setting speed by Sections ahead. Check Block speeds.  If next block slower than current block set speed down before entering next block. Do not increase speed beyond the minimum speed of any occupied block.