### PR TITLE
Cleanup the reminder messages process, phase 1

### DIFF
--- a/java/src/jmri/jmrit/beantable/BeanTableBundle.properties
+++ b/java/src/jmri/jmrit/beantable/BeanTableBundle.properties
@@ -390,6 +390,8 @@ HideNullAudioWarningMessage          = Hide Null Audio Warning Message
 
 DuplicateUserNameWarn                = Hide Duplicate User Name warning message
 HideSaveReminder                     = Hide Save Message reminder
+HideDupUserError                     = Hide Duplicate user name error
+HideDupSysError                      = Hide Duplicate system name error
 IdStoreState                         = Save when and where last seen
 IdUseFastClock                       = Use Fast Clock time
 IncludeUsedHeads                     = Include previously used Signal Heads

--- a/java/src/jmri/jmrit/beantable/LightTableAction.java
+++ b/java/src/jmri/jmrit/beantable/LightTableAction.java
@@ -548,7 +548,6 @@ public class LightTableAction extends AbstractTableAction<Light> {
         }
     }
 
-
     // TODO: Move the next few static String methods to more appropriate place.
     // LightControl.java ?  Multiple Bundle property files will need changing.
 
@@ -631,6 +630,16 @@ public class LightTableAction extends AbstractTableAction<Light> {
     @Override
     public String getClassDescription() {
         return Bundle.getMessage("TitleLightTable");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setMessagePreferencesDetails() {
+        InstanceManager.getDefault(jmri.UserPreferencesManager.class).
+                setPreferenceItemDetails(getClassName(), "remindSaveLight", Bundle.getMessage("HideSaveReminder"));  // NOI18N
+        super.setMessagePreferencesDetails();
     }
 
     /**

--- a/java/src/jmri/jmrit/beantable/MemoryTableAction.java
+++ b/java/src/jmri/jmrit/beantable/MemoryTableAction.java
@@ -99,7 +99,7 @@ public class MemoryTableAction extends AbstractTableAction<Memory> {
             ActionListener cancelListener = (ActionEvent e1) -> {
                 cancelPressed(e1);
             };
-            AddNewBeanPanel anbp = new AddNewBeanPanel(sysNameField, userNameField, numberToAddSpinner, rangeBox, autoSystemNameBox, "ButtonCreate", okListener, cancelListener, statusBarLabel); 
+            AddNewBeanPanel anbp = new AddNewBeanPanel(sysNameField, userNameField, numberToAddSpinner, rangeBox, autoSystemNameBox, "ButtonCreate", okListener, cancelListener, statusBarLabel);
             addFrame.add(anbp);
             addFrame.getRootPane().setDefaultButton(anbp.ok);
             addFrame.setEscapeKeyClosesWindow(true);
@@ -238,6 +238,15 @@ public class MemoryTableAction extends AbstractTableAction<Memory> {
     @Override
     public String getClassDescription() {
         return Bundle.getMessage("TitleMemoryTable");
+    }
+
+    @Override
+    public void setMessagePreferencesDetails() {
+        InstanceManager.getDefault(jmri.UserPreferencesManager.class).
+                setPreferenceItemDetails(getClassName(), "duplicateUserName", Bundle.getMessage("HideDupUserError"));  // NOI18N
+        InstanceManager.getDefault(jmri.UserPreferencesManager.class).
+                setPreferenceItemDetails(getClassName(), "duplicateSystemName", Bundle.getMessage("HideDupSysError"));  // NOI18N
+        super.setMessagePreferencesDetails();
     }
 
     /** {@inheritDoc} */

--- a/java/src/jmri/jmrit/beantable/OBlockTableAction.java
+++ b/java/src/jmri/jmrit/beantable/OBlockTableAction.java
@@ -303,7 +303,7 @@ public class OBlockTableAction extends AbstractTableAction<OBlock> implements Pr
     String systemNameAuto = this.getClass().getName() + ".AutoSystemName";
 
     // Three [Addx...] buttons on tabbed bottom box handlers
-    
+
     @Override
     protected void addPressed(ActionEvent e) {
         log.warn("This should not have happened");
@@ -506,6 +506,15 @@ public class OBlockTableAction extends AbstractTableAction<OBlock> implements Pr
     @Override
     public String getClassDescription() {
         return Bundle.getMessage("TitleOBlockTable");
+    }
+
+    @Override
+    public void setMessagePreferencesDetails() {
+        InstanceManager.getDefault(jmri.UserPreferencesManager.class).
+                setPreferenceItemDetails(getClassName(), "duplicateUserName", Bundle.getMessage("HideDupUserError"));  // NOI18N
+        InstanceManager.getDefault(jmri.UserPreferencesManager.class).
+                setPreferenceItemDetails(getClassName(), "duplicateSystemName", Bundle.getMessage("HideDupSysError"));  // NOI18N
+        super.setMessagePreferencesDetails();
     }
 
 //    @Override

--- a/java/src/jmri/jmrit/beantable/ReporterTableAction.java
+++ b/java/src/jmri/jmrit/beantable/ReporterTableAction.java
@@ -91,7 +91,6 @@ public class ReporterTableAction extends AbstractTableAction<Reporter> {
     private final String systemSelectionCombo = this.getClass().getName() + ".SystemSelected";
     private JButton addButton;
     private final JLabel statusBarLabel = new JLabel(Bundle.getMessage("HardwareAddStatusEnter"), JLabel.LEADING);
-    private final String userNameError = this.getClass().getName() + ".DuplicateUserName"; // only used in this package
     private Manager<Reporter> connectionChoice = null;
     private UserPreferencesManager pref;
     private SystemNameValidator hardwareAddressValidator;

--- a/java/src/jmri/jmrit/beantable/ReporterTableAction.java
+++ b/java/src/jmri/jmrit/beantable/ReporterTableAction.java
@@ -204,7 +204,8 @@ public class ReporterTableAction extends AbstractTableAction<Reporter> {
                     r.setUserName(uName);
                 } else {
                     pref.showErrorMessage(Bundle.getMessage("ErrorTitle"),
-                            Bundle.getMessage("ErrorDuplicateUserName", uName), userNameError, "", false, true);
+                            Bundle.getMessage("ErrorDuplicateUserName", uName),
+                            getClassName(), "duplicateUserName", false, true);
                 }
             }
 
@@ -298,6 +299,13 @@ public class ReporterTableAction extends AbstractTableAction<Reporter> {
     @Override
     public String getClassDescription() {
         return Bundle.getMessage("TitleReporterTable");
+    }
+
+    @Override
+    public void setMessagePreferencesDetails() {
+        InstanceManager.getDefault(jmri.UserPreferencesManager.class).
+                setPreferenceItemDetails(getClassName(), "duplicateUserName", Bundle.getMessage("DuplicateUserNameWarn"));  // NOI18N
+        super.setMessagePreferencesDetails();
     }
 
     // private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ReporterTableAction.class);

--- a/java/src/jmri/jmrit/beantable/RouteTableDataModel.java
+++ b/java/src/jmri/jmrit/beantable/RouteTableDataModel.java
@@ -36,7 +36,7 @@ public class RouteTableDataModel extends BeanTableDataModel<Route> {
         switch (col) {
             case VALUECOL: // no heading on "Edit"
             case SETCOL: // no heading on "Set"
-                return "";  
+                return "";
             case ENABLECOL:
                 return Bundle.getMessage("ColumnHeadEnabled");
             case LOCKCOL:
@@ -200,7 +200,8 @@ public class RouteTableDataModel extends BeanTableDataModel<Route> {
 
     @Override
     protected String getMasterClassName() {
-        return this.getClass().getName();
+        // Use the RouteTabelAction class to combine messages in Preferences -> Messages
+        return RouteTableAction.class.getName();
     }
 
     @Override

--- a/java/src/jmri/jmrit/beantable/SignalGroupTableAction.java
+++ b/java/src/jmri/jmrit/beantable/SignalGroupTableAction.java
@@ -689,7 +689,7 @@ public class SignalGroupTableAction extends AbstractTableAction<SignalGroup> imp
                     InstanceManager.getDefault(jmri.UserPreferencesManager.class).
                             showInfoMessage(Bundle.getMessage("ReminderTitle"),
                                     Bundle.getMessage("ReminderSaveString", Bundle.getMessage("SignalGroup")),
-                                    "beantable.SignalGroupTableAction",
+                                    getClassName(),
                                     "remindSignalGroup"); // NOI18N
                     signalGroupDirty = false;
                 }
@@ -1759,6 +1759,13 @@ public class SignalGroupTableAction extends AbstractTableAction<SignalGroup> imp
     @Override
     public String getClassDescription() {
         return Bundle.getMessage("TitleSignalGroupTable");
+    }
+
+    @Override
+    public void setMessagePreferencesDetails() {
+        InstanceManager.getDefault(jmri.UserPreferencesManager.class).
+                setPreferenceItemDetails(getClassName(), "remindSignalGroup", Bundle.getMessage("HideSaveReminder"));  // NOI18N
+        super.setMessagePreferencesDetails();
     }
 
     private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(SignalGroupTableAction.class);

--- a/java/src/jmri/jmrit/beantable/oblock/OBlockTableModel.java
+++ b/java/src/jmri/jmrit/beantable/oblock/OBlockTableModel.java
@@ -151,7 +151,7 @@ public class OBlockTableModel extends jmri.jmrit.beantable.BeanTableDataModel<OB
      */
     @Override
     protected String getMasterClassName() {
-        return getClassName();
+        return jmri.jmrit.beantable.OBlockTableAction.class.getName();
     }
 
     protected List<OBlock> getBeanList() {

--- a/java/src/jmri/jmrit/beantable/routetable/AbstractRouteAddEditFrame.java
+++ b/java/src/jmri/jmrit/beantable/routetable/AbstractRouteAddEditFrame.java
@@ -74,9 +74,9 @@ public abstract class AbstractRouteAddEditFrame extends JmriJFrame {
             "Veto " + Bundle.getMessage("WhenCondition") + " " + Bundle.getMessage("TurnoutStateClosed"),
             "Veto " + Bundle.getMessage("WhenCondition") + " " + Bundle.getMessage("TurnoutStateThrown")
     };
-    private static String[] turnoutFeedbackModes = new String[]{Bundle.getMessage("TurnoutFeedbackKnown"), 
+    private static String[] turnoutFeedbackModes = new String[]{Bundle.getMessage("TurnoutFeedbackKnown"),
                                                                 Bundle.getMessage("TurnoutFeedbackCommanded")};
-    
+
     private static String[] lockTurnoutInputModes = new String[]{
             Bundle.getMessage("OnCondition") + " " + Bundle.getMessage("TurnoutStateClosed"),
             Bundle.getMessage("OnCondition") + " " + Bundle.getMessage("TurnoutStateThrown"),
@@ -584,11 +584,12 @@ public abstract class AbstractRouteAddEditFrame extends JmriJFrame {
     }
 
     protected void showReminderMessage() {
+        // Use the RouteTabelAction class to combine messages in Preferences -> Messages
         if (checkEnabled) return;
         InstanceManager.getDefault(UserPreferencesManager.class).
                 showInfoMessage(Bundle.getMessage("ReminderTitle"),  // NOI18N
                         Bundle.getMessage("ReminderSaveString", Bundle.getMessage("MenuItemRouteTable")),  // NOI18N
-                        getClassName(), "remindSaveRoute"); // NOI18N
+                        jmri.jmrit.beantable.RouteTableAction.class.getName(), "remindSaveRoute"); // NOI18N
     }
 
     private int sensorModeFromBox(JComboBox<String> box) {
@@ -688,7 +689,7 @@ public abstract class AbstractRouteAddEditFrame extends JmriJFrame {
             // set up Control Turnout state
             g.setControlTurnoutState(turnoutModeFromBox(cTurnoutStateBox));
             g.setControlTurnoutFeedback(cTurnoutFeedbackBox.getSelectedIndex() == 1);
-            
+
         } else {
             // No Control Turnout was entered
             g.setControlTurnout("");
@@ -845,7 +846,7 @@ public abstract class AbstractRouteAddEditFrame extends JmriJFrame {
         cTurnout.setSelectedItem(route.getCtlTurnout());
 
         setTurnoutModeBox(route.getControlTurnoutState(), cTurnoutStateBox);
-        
+
         if (route.getControlTurnoutFeedback()) {
             cTurnoutFeedbackBox.setSelectedIndex(1); // Known
         } else {
@@ -963,7 +964,7 @@ public abstract class AbstractRouteAddEditFrame extends JmriJFrame {
         status1.setText((newRoute ? Bundle.getMessage("RouteAddStatusCreated") :
                 Bundle.getMessage("RouteAddStatusUpdated")) + ": \"" + uName + "\" (" + _includedTurnoutList.size() + " "
                 + Bundle.getMessage("Turnouts") + ", " + _includedSensorList.size() + " " + Bundle.getMessage("Sensors") + ")");
-        
+
         closeFrame();
     }
 

--- a/java/src/jmri/jmrit/beantable/routetable/AbstractRouteAddEditFrame.java
+++ b/java/src/jmri/jmrit/beantable/routetable/AbstractRouteAddEditFrame.java
@@ -891,10 +891,6 @@ public abstract class AbstractRouteAddEditFrame extends JmriJFrame {
         }
     }
 
-    private String getClassName() {
-        return this.getClass().getName();
-    }
-
     List<RouteTurnout> get_turnoutList() {
         return _turnoutList;
     }

--- a/java/src/jmri/jmrit/beantable/turnout/TurnoutTableDataModel.java
+++ b/java/src/jmri/jmrit/beantable/turnout/TurnoutTableDataModel.java
@@ -566,7 +566,8 @@ public class TurnoutTableDataModel extends BeanTableDataModel<Turnout>{
 
     @Override
     protected String getMasterClassName() {
-        return getClassName();
+        // Force message grouping
+        return jmri.jmrit.beantable.TurnoutTableAction.class.getName();
     }
 
     protected String getClassName() {

--- a/java/src/jmri/jmrit/beantable/usermessagepreferences/UserMessagePreferencesPane.java
+++ b/java/src/jmri/jmrit/beantable/usermessagepreferences/UserMessagePreferencesPane.java
@@ -24,6 +24,7 @@ import jmri.jmrit.beantable.LogixTableAction;
 import jmri.jmrit.beantable.MemoryTableAction;
 import jmri.jmrit.beantable.ReporterTableAction;
 import jmri.jmrit.beantable.RouteTableAction;
+import jmri.jmrit.beantable.SectionTableAction;
 import jmri.jmrit.beantable.SensorTableAction;
 import jmri.jmrit.beantable.SignalGroupTableAction;
 import jmri.jmrit.beantable.SignalHeadTableAction;
@@ -71,6 +72,7 @@ public class UserMessagePreferencesPane extends JmriPanel implements Preferences
         p.setClassDescription(ReporterTableAction.class.getName());
         p.setClassDescription(RouteTableAction.class.getName());
 
+        p.setClassDescription(SectionTableAction.class.getName());
         p.setClassDescription(SensorTableAction.class.getName());
         p.setClassDescription(SignalGroupTableAction.class.getName());
         p.setClassDescription(SignalHeadTableAction.class.getName());
@@ -97,6 +99,7 @@ public class UserMessagePreferencesPane extends JmriPanel implements Preferences
 
         ArrayList<String> preferenceClassList = p.getPreferencesClasses();
         for (String strClass : preferenceClassList) {
+
             JPanel classholder = new JPanel();
             classholder.setLayout(new BorderLayout());
 

--- a/java/src/jmri/jmrit/conditional/ConditionalEditBase.java
+++ b/java/src/jmri/jmrit/conditional/ConditionalEditBase.java
@@ -802,7 +802,7 @@ public class ConditionalEditBase {
 
     // ------------ Utility Methods - Data Validation ------------
     /**
-     * Display reminder to save.
+     * Display reminder to save.  The class is set to LogixTableAction.
      */
     void showSaveReminder() {
         if (_showReminder && !_checkEnabled) {
@@ -810,7 +810,7 @@ public class ConditionalEditBase {
                 InstanceManager.getDefault(jmri.UserPreferencesManager.class).
                         showInfoMessage(Bundle.getMessage("ReminderTitle"), Bundle.getMessage("ReminderSaveString", // NOI18N
                                 Bundle.getMessage("MenuItemLogixTable")), // NOI18N
-                                getClassName(),
+                                "jmri.jmrit.beantable.LogixTableAction",
                                 "remindSaveLogix"); // NOI18N
             }
         }

--- a/java/src/jmri/jmrit/conditional/ConditionalTreeEdit.java
+++ b/java/src/jmri/jmrit/conditional/ConditionalTreeEdit.java
@@ -1483,6 +1483,7 @@ public class ConditionalTreeEdit extends ConditionalEditBase {
      * Clean up, notify the parent Logix that edit session is done.
      */
     void donePressed() {
+        showSaveReminder();
         if (_curNodeType != null) {
             switch (_curNodeType) {
                 case "Variable":       // NOI18N
@@ -1832,7 +1833,7 @@ public class ConditionalTreeEdit extends ConditionalEditBase {
     }
 
     /**
-     * Display reminder to save.
+     * Display reminder to finish a node before starting another.  This is a session reminder.
      */
     void showNodeEditMessage() {
         if (InstanceManager.getNullableDefault(jmri.UserPreferencesManager.class) != null) {
@@ -1840,7 +1841,9 @@ public class ConditionalTreeEdit extends ConditionalEditBase {
                     showInfoMessage(Bundle.getMessage("NodeEditTitle"), // NOI18N
                             Bundle.getMessage("NodeEditText"), // NOI18N
                             getClassName(),
-                            "SkipNodeEditMessage"); // NOI18N
+                            "SkipNodeEditMessage", // NOI18N
+                            true,
+                            false);
         }
     }
 

--- a/java/src/jmri/jmrit/display/DisplayBundle.properties
+++ b/java/src/jmri/jmrit/display/DisplayBundle.properties
@@ -404,6 +404,7 @@ Line            = Line
 Circle          = Circle
 Ellipse         = Ellipse
 Bezier          = Bezier
+EntryExitBlockSkip = Skip the Entry/Exit Block Dialog
 
 # From SwitchboardEditor
 SwitchboardDefaultName = Switchboard{0}

--- a/java/src/jmri/jmrit/display/EditorManager.java
+++ b/java/src/jmri/jmrit/display/EditorManager.java
@@ -57,6 +57,8 @@ public class EditorManager extends Bean implements PropertyChangeListener, Insta
                 "jmri.jmrit.display.EditorManager", "skipHideDialog", Bundle.getMessage("PanelHideSkip"));  // NOI18N
         InstanceManager.getDefault(jmri.UserPreferencesManager.class).setPreferenceItemDetails(
                 "jmri.jmrit.display.EditorManager", "skipDupLoadDialog", Bundle.getMessage("DuplicateLoadSkip"));  // NOI18N
+        InstanceManager.getDefault(jmri.UserPreferencesManager.class).setPreferenceItemDetails(
+                "jmri.jmrit.display.EditorManager", "skipEntryExitDialog", Bundle.getMessage("EntryExitBlockSkip"));  // NOI18N
     }
 
     /**

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/LayoutTrackEditor.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/LayoutTrackEditor.java
@@ -105,7 +105,7 @@ abstract public class LayoutTrackEditor {
     /**
      * Display a message describing the reason for the block selection combo box
      * being disabled. An option is provided to hide the message. Note: The
-     * PanelMenu class is being used to satisfy the showInfoMessage requirement
+     * EditorManager class is being used to satisfy the showInfoMessage requirement
      * for a default manager type class.
      *
      * @since 4.11.2
@@ -130,8 +130,8 @@ abstract public class LayoutTrackEditor {
                 showInfoMessage(
                         Bundle.getMessage("BlockSensorTitle"), // NOI18N
                         msg.toString(),
-                        "jmri.jmrit.display.PanelMenu", // NOI18N
-                        "BlockSensorMessage");  // NOI18N
+                        "jmri.jmrit.display.EditorManager", // NOI18N
+                        "skipEntryExitDialog");  // NOI18N
     }
 
 

--- a/java/src/jmri/jmrit/simpleclock/SimpleClockFrame.java
+++ b/java/src/jmri/jmrit/simpleclock/SimpleClockFrame.java
@@ -810,6 +810,22 @@ public class SimpleClockFrame extends JmriJFrame implements PropertyChangeListen
         dispose();
     }
 
+    /**
+     * Get the class description for the UserMessagePreferencesPane.
+     * @return The class description
+     */
+    public String getClassDescription() {
+        return "Fast Clock";
+    }
+
+    /**
+     * Set the item details for the UserMessagePreferencesPane.
+     */
+    public void setMessagePreferencesDetails() {
+        InstanceManager.getDefault(jmri.UserPreferencesManager.class).
+                setPreferenceItemDetails(getClassName(), "remindSaveClock", "HideSaveReminder");  // NOI18N
+    }
+
     protected String getClassName() {
         // The class that is returned must have a default constructor,
         // a constructor with no parameters.

--- a/java/src/jmri/jmrit/timetable/swing/TimeTableFrame.java
+++ b/java/src/jmri/jmrit/timetable/swing/TimeTableFrame.java
@@ -3054,7 +3054,7 @@ public class TimeTableFrame extends jmri.util.JmriJFrame {
                     showInfoMessage( this, Bundle.getMessage("NodeEditTitle"), // NOI18N
                             Bundle.getMessage("NodeEditText"), // NOI18N
                             getClassName(),
-                            "SkipTimeTableEditMessage"); // NOI18N
+                            "SkipTimeTableEditMessage", true, false); // NOI18N
         }
     }
 

--- a/java/src/jmri/managers/JmriUserPreferencesManager.java
+++ b/java/src/jmri/managers/JmriUserPreferencesManager.java
@@ -950,7 +950,7 @@ public class JmriUserPreferencesManager extends Bean implements UserPreferencesM
                     mc.getChildren("option").stream().forEach(option -> {
                         int value = 0;
                         try {
-                            option.getAttribute(VALUE).getIntValue();
+                            value = option.getAttribute(VALUE).getIntValue();
                         } catch (DataConversionException ex) {
                             log.error("failed to convert positional attribute");
                         }


### PR DESCRIPTION
JMRI messages using the `showInfoMessage()` dialog have the option to ignore the message.  The option can be changed using `Preferences -> Messages`.  These are class based messages in user-interface.xml.  

The primary fix is to `JmriUserPreferencesManager` which always returned 0 for `multipleChoice` selections.

The other changes clean up various inconsistent behaviors for other classes.

This is WIP while working through the other classes.  