### PR TITLE
Add "Close" menu item to Window menus.

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -639,5 +639,5 @@
     <h3>Miscellaneous</h3>
         <a id="Misc" name="Misc"></a>
         <ul>
-            <li></li>
+            <li>Add Close button to menubar Window menu.</li>
         </ul>

--- a/java/src/jmri/util/WindowMenu.java
+++ b/java/src/jmri/util/WindowMenu.java
@@ -32,7 +32,15 @@ public class WindowMenu extends JMenu implements javax.swing.event.MenuListener 
         String windowName;
         framesList = JmriJFrame.getFrameList();
         removeAll();
-
+        
+        add(new AbstractAction(Bundle.getMessage("ButtonClose")) {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                if (parentFrame != null) {
+                    parentFrame.dispose();
+                 }
+            }    
+        });
         add(new AbstractAction(Bundle.getMessage("MenuItemMinimize")) {
             @Override
             public void actionPerformed(ActionEvent e) {

--- a/java/src/jmri/util/WindowMenu.java
+++ b/java/src/jmri/util/WindowMenu.java
@@ -37,7 +37,9 @@ public class WindowMenu extends JMenu implements javax.swing.event.MenuListener 
             @Override
             public void actionPerformed(ActionEvent e) {
                 if (parentFrame != null) {
-                    parentFrame.dispose();
+                    parentFrame.dispatchEvent(
+                              new java.awt.event.WindowEvent(parentFrame, 
+                                        java.awt.event.WindowEvent.WINDOW_CLOSING));
                  }
             }    
         });


### PR DESCRIPTION
This adds a "Close" menu item to the Window menubar menu featured on most JMRI windows.  This adds a convient close option for people who might be using a window manager that does not include a "X" button on their window title bars.

All I did was add an additional menu item ("Close") to the code in java/src/jmri/util/WindowMenu.java that dispose()s the window.

It seems to work just fine.  I am not sure if I need to do anything else.