### PR TITLE
Fix bad XML schema. Add testing of schema

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -452,6 +452,11 @@
     <h3>LogixNG</h3>
         <a id="LogixNG" name="LogixNG"></a>
         <ul>
+          <li>A bug is fixed in the LogixNG action SignalMast.
+              The options <strong>Permissive Sml Disabled</strong>
+              and <strong>Permissive Sml Not Disabled</strong> caused
+              an error when storing and loading the tables and panels
+              file.</li>
           <li></li>
         </ul>
 

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -452,7 +452,7 @@
     <h3>LogixNG</h3>
         <a id="LogixNG" name="LogixNG"></a>
         <ul>
-          <li>A bug is fixed in the LogixNG action SignalMast.
+          <li>A bug is fixed in the LogixNG action <strong>Signal Mast</strong>.
               The options <strong>Permissive Sml Disabled</strong>
               and <strong>Permissive Sml Not Disabled</strong> caused
               an error when storing and loading the tables and panels

--- a/java/test/jmri/jmrit/logixng/CreateLogixNGTreeScaffold.java
+++ b/java/test/jmri/jmrit/logixng/CreateLogixNGTreeScaffold.java
@@ -1877,6 +1877,56 @@ public class CreateLogixNGTreeScaffold {
         maleSocket = digitalActionManager.registerAction(actionSignalHead);
         actionManySocket.getChild(indexAction++).connect(maleSocket);
 
+        actionSignalHead = new ActionSignalHead(digitalActionManager.getAutoSystemName(), null);
+        actionSignalHead.getSelectNamedBean().setNamedBean("IH1");
+        actionSignalHead.getSelectNamedBean().setAddressing(NamedBeanAddressing.Direct);
+        actionSignalHead.setOperationAddressing(NamedBeanAddressing.Direct);
+        actionSignalHead.setOperationType(ActionSignalHead.OperationType.Appearance);
+        actionSignalHead.setAppearanceAddressing(NamedBeanAddressing.Direct);
+        actionSignalHead.setAppearance(SignalHead.FLASHYELLOW);
+        maleSocket = digitalActionManager.registerAction(actionSignalHead);
+        actionManySocket.getChild(indexAction++).connect(maleSocket);
+
+        actionSignalHead = new ActionSignalHead(digitalActionManager.getAutoSystemName(), null);
+        actionSignalHead.getSelectNamedBean().setNamedBean("IH1");
+        actionSignalHead.getSelectNamedBean().setAddressing(NamedBeanAddressing.Direct);
+        actionSignalHead.setOperationAddressing(NamedBeanAddressing.Direct);
+        actionSignalHead.setOperationType(ActionSignalHead.OperationType.Lit);
+        actionSignalHead.setAppearanceAddressing(NamedBeanAddressing.Direct);
+        actionSignalHead.setAppearance(SignalHead.FLASHYELLOW);
+        maleSocket = digitalActionManager.registerAction(actionSignalHead);
+        actionManySocket.getChild(indexAction++).connect(maleSocket);
+
+        actionSignalHead = new ActionSignalHead(digitalActionManager.getAutoSystemName(), null);
+        actionSignalHead.getSelectNamedBean().setNamedBean("IH1");
+        actionSignalHead.getSelectNamedBean().setAddressing(NamedBeanAddressing.Direct);
+        actionSignalHead.setOperationAddressing(NamedBeanAddressing.Direct);
+        actionSignalHead.setOperationType(ActionSignalHead.OperationType.NotLit);
+        actionSignalHead.setAppearanceAddressing(NamedBeanAddressing.Direct);
+        actionSignalHead.setAppearance(SignalHead.FLASHYELLOW);
+        maleSocket = digitalActionManager.registerAction(actionSignalHead);
+        actionManySocket.getChild(indexAction++).connect(maleSocket);
+
+        actionSignalHead = new ActionSignalHead(digitalActionManager.getAutoSystemName(), null);
+        actionSignalHead.getSelectNamedBean().setNamedBean("IH1");
+        actionSignalHead.getSelectNamedBean().setAddressing(NamedBeanAddressing.Direct);
+        actionSignalHead.setOperationAddressing(NamedBeanAddressing.Direct);
+        actionSignalHead.setOperationType(ActionSignalHead.OperationType.Held);
+        actionSignalHead.setAppearanceAddressing(NamedBeanAddressing.Direct);
+        actionSignalHead.setAppearance(SignalHead.FLASHYELLOW);
+        maleSocket = digitalActionManager.registerAction(actionSignalHead);
+        actionManySocket.getChild(indexAction++).connect(maleSocket);
+
+        actionSignalHead = new ActionSignalHead(digitalActionManager.getAutoSystemName(), null);
+        actionSignalHead.getSelectNamedBean().setNamedBean("IH1");
+        actionSignalHead.getSelectNamedBean().setAddressing(NamedBeanAddressing.Direct);
+        actionSignalHead.setOperationAddressing(NamedBeanAddressing.Direct);
+        actionSignalHead.setOperationType(ActionSignalHead.OperationType.NotHeld);
+        actionSignalHead.setAppearanceAddressing(NamedBeanAddressing.Direct);
+        actionSignalHead.setAppearance(SignalHead.FLASHYELLOW);
+        maleSocket = digitalActionManager.registerAction(actionSignalHead);
+        actionManySocket.getChild(indexAction++).connect(maleSocket);
+
 
         ActionSignalMast actionSignalMast = new ActionSignalMast(digitalActionManager.getAutoSystemName(), null);
         maleSocket = digitalActionManager.registerAction(actionSignalMast);
@@ -1957,6 +2007,55 @@ public class CreateLogixNGTreeScaffold {
         actionSignalMast.setAspectFormula("\"IT\"+index3");
         actionSignalMast.setAspectLocalVariable("index3");
         actionSignalMast.setAspectReference("{IM3}");
+        maleSocket = digitalActionManager.registerAction(actionSignalMast);
+        actionManySocket.getChild(indexAction++).connect(maleSocket);
+
+        actionSignalMast = new ActionSignalMast(digitalActionManager.getAutoSystemName(), null);
+        actionSignalMast.getSelectNamedBean().setAddressing(NamedBeanAddressing.Direct);
+        actionSignalMast.setOperationAddressing(NamedBeanAddressing.Direct);
+        actionSignalMast.setOperationType(ActionSignalMast.OperationType.Aspect);
+        maleSocket = digitalActionManager.registerAction(actionSignalMast);
+        actionManySocket.getChild(indexAction++).connect(maleSocket);
+
+        actionSignalMast = new ActionSignalMast(digitalActionManager.getAutoSystemName(), null);
+        actionSignalMast.getSelectNamedBean().setAddressing(NamedBeanAddressing.Direct);
+        actionSignalMast.setOperationAddressing(NamedBeanAddressing.Direct);
+        actionSignalMast.setOperationType(ActionSignalMast.OperationType.Lit);
+        maleSocket = digitalActionManager.registerAction(actionSignalMast);
+        actionManySocket.getChild(indexAction++).connect(maleSocket);
+
+        actionSignalMast = new ActionSignalMast(digitalActionManager.getAutoSystemName(), null);
+        actionSignalMast.getSelectNamedBean().setAddressing(NamedBeanAddressing.Direct);
+        actionSignalMast.setOperationAddressing(NamedBeanAddressing.Direct);
+        actionSignalMast.setOperationType(ActionSignalMast.OperationType.NotLit);
+        maleSocket = digitalActionManager.registerAction(actionSignalMast);
+        actionManySocket.getChild(indexAction++).connect(maleSocket);
+
+        actionSignalMast = new ActionSignalMast(digitalActionManager.getAutoSystemName(), null);
+        actionSignalMast.getSelectNamedBean().setAddressing(NamedBeanAddressing.Direct);
+        actionSignalMast.setOperationAddressing(NamedBeanAddressing.Direct);
+        actionSignalMast.setOperationType(ActionSignalMast.OperationType.Held);
+        maleSocket = digitalActionManager.registerAction(actionSignalMast);
+        actionManySocket.getChild(indexAction++).connect(maleSocket);
+
+        actionSignalMast = new ActionSignalMast(digitalActionManager.getAutoSystemName(), null);
+        actionSignalMast.getSelectNamedBean().setAddressing(NamedBeanAddressing.Direct);
+        actionSignalMast.setOperationAddressing(NamedBeanAddressing.Direct);
+        actionSignalMast.setOperationType(ActionSignalMast.OperationType.NotHeld);
+        maleSocket = digitalActionManager.registerAction(actionSignalMast);
+        actionManySocket.getChild(indexAction++).connect(maleSocket);
+
+        actionSignalMast = new ActionSignalMast(digitalActionManager.getAutoSystemName(), null);
+        actionSignalMast.getSelectNamedBean().setAddressing(NamedBeanAddressing.Direct);
+        actionSignalMast.setOperationAddressing(NamedBeanAddressing.Direct);
+        actionSignalMast.setOperationType(ActionSignalMast.OperationType.PermissiveSmlDisabled);
+        maleSocket = digitalActionManager.registerAction(actionSignalMast);
+        actionManySocket.getChild(indexAction++).connect(maleSocket);
+
+        actionSignalMast = new ActionSignalMast(digitalActionManager.getAutoSystemName(), null);
+        actionSignalMast.getSelectNamedBean().setAddressing(NamedBeanAddressing.Direct);
+        actionSignalMast.setOperationAddressing(NamedBeanAddressing.Direct);
+        actionSignalMast.setOperationType(ActionSignalMast.OperationType.PermissiveSmlNotDisabled);
         maleSocket = digitalActionManager.registerAction(actionSignalMast);
         actionManySocket.getChild(indexAction++).connect(maleSocket);
 
@@ -4928,6 +5027,66 @@ public class CreateLogixNGTreeScaffold {
         maleSocket = digitalExpressionManager.registerExpression(expressionSignalHead);
         and.getChild(indexExpr++).connect(maleSocket);
 
+        expressionSignalHead = new ExpressionSignalHead(digitalExpressionManager.getAutoSystemName(), null);
+        expressionSignalHead.getSelectNamedBean().setNamedBean("IH1");
+        expressionSignalHead.getSelectNamedBean().setAddressing(NamedBeanAddressing.Direct);
+        expressionSignalHead.setQueryAddressing(NamedBeanAddressing.Direct);
+        expressionSignalHead.setQueryType(ExpressionSignalHead.QueryType.Appearance);
+        expressionSignalHead.setAppearanceAddressing(NamedBeanAddressing.Direct);
+        expressionSignalHead.setAppearance(SignalHead.FLASHYELLOW);
+        maleSocket = digitalExpressionManager.registerExpression(expressionSignalHead);
+        and.getChild(indexExpr++).connect(maleSocket);
+
+        expressionSignalHead = new ExpressionSignalHead(digitalExpressionManager.getAutoSystemName(), null);
+        expressionSignalHead.getSelectNamedBean().setNamedBean("IH1");
+        expressionSignalHead.getSelectNamedBean().setAddressing(NamedBeanAddressing.Direct);
+        expressionSignalHead.setQueryAddressing(NamedBeanAddressing.Direct);
+        expressionSignalHead.setQueryType(ExpressionSignalHead.QueryType.NotAppearance);
+        expressionSignalHead.setAppearanceAddressing(NamedBeanAddressing.Direct);
+        expressionSignalHead.setAppearance(SignalHead.FLASHYELLOW);
+        maleSocket = digitalExpressionManager.registerExpression(expressionSignalHead);
+        and.getChild(indexExpr++).connect(maleSocket);
+
+        expressionSignalHead = new ExpressionSignalHead(digitalExpressionManager.getAutoSystemName(), null);
+        expressionSignalHead.getSelectNamedBean().setNamedBean("IH1");
+        expressionSignalHead.getSelectNamedBean().setAddressing(NamedBeanAddressing.Direct);
+        expressionSignalHead.setQueryAddressing(NamedBeanAddressing.Direct);
+        expressionSignalHead.setQueryType(ExpressionSignalHead.QueryType.Lit);
+        expressionSignalHead.setAppearanceAddressing(NamedBeanAddressing.Direct);
+        expressionSignalHead.setAppearance(SignalHead.FLASHYELLOW);
+        maleSocket = digitalExpressionManager.registerExpression(expressionSignalHead);
+        and.getChild(indexExpr++).connect(maleSocket);
+
+        expressionSignalHead = new ExpressionSignalHead(digitalExpressionManager.getAutoSystemName(), null);
+        expressionSignalHead.getSelectNamedBean().setNamedBean("IH1");
+        expressionSignalHead.getSelectNamedBean().setAddressing(NamedBeanAddressing.Direct);
+        expressionSignalHead.setQueryAddressing(NamedBeanAddressing.Direct);
+        expressionSignalHead.setQueryType(ExpressionSignalHead.QueryType.NotLit);
+        expressionSignalHead.setAppearanceAddressing(NamedBeanAddressing.Direct);
+        expressionSignalHead.setAppearance(SignalHead.FLASHYELLOW);
+        maleSocket = digitalExpressionManager.registerExpression(expressionSignalHead);
+        and.getChild(indexExpr++).connect(maleSocket);
+
+        expressionSignalHead = new ExpressionSignalHead(digitalExpressionManager.getAutoSystemName(), null);
+        expressionSignalHead.getSelectNamedBean().setNamedBean("IH1");
+        expressionSignalHead.getSelectNamedBean().setAddressing(NamedBeanAddressing.Direct);
+        expressionSignalHead.setQueryAddressing(NamedBeanAddressing.Direct);
+        expressionSignalHead.setQueryType(ExpressionSignalHead.QueryType.Held);
+        expressionSignalHead.setAppearanceAddressing(NamedBeanAddressing.Direct);
+        expressionSignalHead.setAppearance(SignalHead.FLASHYELLOW);
+        maleSocket = digitalExpressionManager.registerExpression(expressionSignalHead);
+        and.getChild(indexExpr++).connect(maleSocket);
+
+        expressionSignalHead = new ExpressionSignalHead(digitalExpressionManager.getAutoSystemName(), null);
+        expressionSignalHead.getSelectNamedBean().setNamedBean("IH1");
+        expressionSignalHead.getSelectNamedBean().setAddressing(NamedBeanAddressing.Direct);
+        expressionSignalHead.setQueryAddressing(NamedBeanAddressing.Direct);
+        expressionSignalHead.setQueryType(ExpressionSignalHead.QueryType.NotHeld);
+        expressionSignalHead.setAppearanceAddressing(NamedBeanAddressing.Direct);
+        expressionSignalHead.setAppearance(SignalHead.FLASHYELLOW);
+        maleSocket = digitalExpressionManager.registerExpression(expressionSignalHead);
+        and.getChild(indexExpr++).connect(maleSocket);
+
 
         ExpressionSignalMast expressionSignalMast = new ExpressionSignalMast(digitalExpressionManager.getAutoSystemName(), null);
         maleSocket = digitalExpressionManager.registerExpression(expressionSignalMast);
@@ -5008,6 +5167,86 @@ public class CreateLogixNGTreeScaffold {
         expressionSignalMast.setAspectFormula("\"IT\"+index3");
         expressionSignalMast.setAspectLocalVariable("index3");
         expressionSignalMast.setAspectReference("{IM3}");
+        maleSocket = digitalExpressionManager.registerExpression(expressionSignalMast);
+        and.getChild(indexExpr++).connect(maleSocket);
+
+        expressionSignalMast = new ExpressionSignalMast(digitalExpressionManager.getAutoSystemName(), null);
+        expressionSignalMast.getSelectNamedBean().setNamedBean("IF$shsm:AAR-1946:CPL(IH1)");
+        expressionSignalMast.getSelectNamedBean().setAddressing(NamedBeanAddressing.Direct);
+        expressionSignalMast.setQueryAddressing(NamedBeanAddressing.Direct);
+        expressionSignalMast.setQueryType(ExpressionSignalMast.QueryType.Aspect);
+        expressionSignalMast.setAspectAddressing(NamedBeanAddressing.Direct);
+        expressionSignalMast.setAspect("Medium Approach Slow");
+        maleSocket = digitalExpressionManager.registerExpression(expressionSignalMast);
+        and.getChild(indexExpr++).connect(maleSocket);
+
+        expressionSignalMast = new ExpressionSignalMast(digitalExpressionManager.getAutoSystemName(), null);
+        expressionSignalMast.getSelectNamedBean().setNamedBean("IF$shsm:AAR-1946:CPL(IH1)");
+        expressionSignalMast.getSelectNamedBean().setAddressing(NamedBeanAddressing.Direct);
+        expressionSignalMast.setQueryAddressing(NamedBeanAddressing.Direct);
+        expressionSignalMast.setQueryType(ExpressionSignalMast.QueryType.NotAspect);
+        expressionSignalMast.setAspectAddressing(NamedBeanAddressing.Direct);
+        expressionSignalMast.setAspect("Medium Approach Slow");
+        maleSocket = digitalExpressionManager.registerExpression(expressionSignalMast);
+        and.getChild(indexExpr++).connect(maleSocket);
+
+        expressionSignalMast = new ExpressionSignalMast(digitalExpressionManager.getAutoSystemName(), null);
+        expressionSignalMast.getSelectNamedBean().setNamedBean("IF$shsm:AAR-1946:CPL(IH1)");
+        expressionSignalMast.getSelectNamedBean().setAddressing(NamedBeanAddressing.Direct);
+        expressionSignalMast.setQueryAddressing(NamedBeanAddressing.Direct);
+        expressionSignalMast.setQueryType(ExpressionSignalMast.QueryType.Lit);
+        expressionSignalMast.setAspectAddressing(NamedBeanAddressing.Direct);
+        expressionSignalMast.setAspect("Medium Approach Slow");
+        maleSocket = digitalExpressionManager.registerExpression(expressionSignalMast);
+        and.getChild(indexExpr++).connect(maleSocket);
+
+        expressionSignalMast = new ExpressionSignalMast(digitalExpressionManager.getAutoSystemName(), null);
+        expressionSignalMast.getSelectNamedBean().setNamedBean("IF$shsm:AAR-1946:CPL(IH1)");
+        expressionSignalMast.getSelectNamedBean().setAddressing(NamedBeanAddressing.Direct);
+        expressionSignalMast.setQueryAddressing(NamedBeanAddressing.Direct);
+        expressionSignalMast.setQueryType(ExpressionSignalMast.QueryType.NotLit);
+        expressionSignalMast.setAspectAddressing(NamedBeanAddressing.Direct);
+        expressionSignalMast.setAspect("Medium Approach Slow");
+        maleSocket = digitalExpressionManager.registerExpression(expressionSignalMast);
+        and.getChild(indexExpr++).connect(maleSocket);
+
+        expressionSignalMast = new ExpressionSignalMast(digitalExpressionManager.getAutoSystemName(), null);
+        expressionSignalMast.getSelectNamedBean().setNamedBean("IF$shsm:AAR-1946:CPL(IH1)");
+        expressionSignalMast.getSelectNamedBean().setAddressing(NamedBeanAddressing.Direct);
+        expressionSignalMast.setQueryAddressing(NamedBeanAddressing.Direct);
+        expressionSignalMast.setQueryType(ExpressionSignalMast.QueryType.Held);
+        expressionSignalMast.setAspectAddressing(NamedBeanAddressing.Direct);
+        expressionSignalMast.setAspect("Medium Approach Slow");
+        maleSocket = digitalExpressionManager.registerExpression(expressionSignalMast);
+        and.getChild(indexExpr++).connect(maleSocket);
+
+        expressionSignalMast = new ExpressionSignalMast(digitalExpressionManager.getAutoSystemName(), null);
+        expressionSignalMast.getSelectNamedBean().setNamedBean("IF$shsm:AAR-1946:CPL(IH1)");
+        expressionSignalMast.getSelectNamedBean().setAddressing(NamedBeanAddressing.Direct);
+        expressionSignalMast.setQueryAddressing(NamedBeanAddressing.Direct);
+        expressionSignalMast.setQueryType(ExpressionSignalMast.QueryType.NotHeld);
+        expressionSignalMast.setAspectAddressing(NamedBeanAddressing.Direct);
+        expressionSignalMast.setAspect("Medium Approach Slow");
+        maleSocket = digitalExpressionManager.registerExpression(expressionSignalMast);
+        and.getChild(indexExpr++).connect(maleSocket);
+
+        expressionSignalMast = new ExpressionSignalMast(digitalExpressionManager.getAutoSystemName(), null);
+        expressionSignalMast.getSelectNamedBean().setNamedBean("IF$shsm:AAR-1946:CPL(IH1)");
+        expressionSignalMast.getSelectNamedBean().setAddressing(NamedBeanAddressing.Direct);
+        expressionSignalMast.setQueryAddressing(NamedBeanAddressing.Direct);
+        expressionSignalMast.setQueryType(ExpressionSignalMast.QueryType.IsPermissiveSmlDisabled);
+        expressionSignalMast.setAspectAddressing(NamedBeanAddressing.Direct);
+        expressionSignalMast.setAspect("Medium Approach Slow");
+        maleSocket = digitalExpressionManager.registerExpression(expressionSignalMast);
+        and.getChild(indexExpr++).connect(maleSocket);
+
+        expressionSignalMast = new ExpressionSignalMast(digitalExpressionManager.getAutoSystemName(), null);
+        expressionSignalMast.getSelectNamedBean().setNamedBean("IF$shsm:AAR-1946:CPL(IH1)");
+        expressionSignalMast.getSelectNamedBean().setAddressing(NamedBeanAddressing.Direct);
+        expressionSignalMast.setQueryAddressing(NamedBeanAddressing.Direct);
+        expressionSignalMast.setQueryType(ExpressionSignalMast.QueryType.IsPermissiveSmlNotDisabled);
+        expressionSignalMast.setAspectAddressing(NamedBeanAddressing.Direct);
+        expressionSignalMast.setAspect("Medium Approach Slow");
         maleSocket = digitalExpressionManager.registerExpression(expressionSignalMast);
         and.getChild(indexExpr++).connect(maleSocket);
 

--- a/xml/schema/logixng/digital-actions/action-signalmast-4.23.1.xsd
+++ b/xml/schema/logixng/digital-actions/action-signalmast-4.23.1.xsd
@@ -61,8 +61,8 @@
                     <xs:enumeration value="NotLit"/>
                     <xs:enumeration value="Held"/>
                     <xs:enumeration value="NotHeld"/>
-                    <xs:enumeration value="IsPermissiveSmlDisabled"/>
-                    <xs:enumeration value="IsPermissiveSmlNotDisabled"/>
+                    <xs:enumeration value="PermissiveSmlDisabled"/>
+                    <xs:enumeration value="PermissiveSmlNotDisabled"/>
                   </xs:restriction>
                 </xs:simpleType>
               </xs:element>


### PR DESCRIPTION
@bobjacobsen @dsand47 

This PR fixes this bug:
https://groups.io/g/jmriusers/message/236892

The bug fix is in the xml schema file:
xml/schema/logixng/digital-actions/action-signalmast-4.23.1.xsd

The changes to CreateLogixNGTreeScaffold.java are added tests to check the xml schema for the various options for these LogixNG actions and expressions.