### PR TITLE
Make Roster Group Table in DecoderPro sortable

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -399,7 +399,8 @@
     <h3>DecoderPro</h3>
         <a id="DecoderPro" name="DecoderPro"></a>
         <ul>
-            <li></li>
+            <li>You can now choose how to sort the 
+                Roster Group Table.</li>
         </ul>
 
    <h3>Dispatcher</h3>

--- a/java/src/jmri/jmrit/roster/swing/rostergroup/RosterGroupTableAction.java
+++ b/java/src/jmri/jmrit/roster/swing/rostergroup/RosterGroupTableAction.java
@@ -97,35 +97,6 @@ public class RosterGroupTableAction extends jmri.util.swing.JmriAbstractAction {
     @Override
     public void actionPerformed(ActionEvent e) {
         actionPerformed();
-        // create the JTable model, with changes for specific NamedBean
-        //createModel();
-        //final Roster roster = Roster.getDefault();
-        // create the frame
-        //f = new RosterGroupTableFrame(m, helpTarget()){
-        /**
-         * Include an "save" button
-         */
-        /*    void extras() {
-                
-         final JComboBox<Object> selectCombo = roster.rosterGroupBox();
-         //addToTopBox(selectCombo);
-         selectCombo.insertItemAt("",0);
-         selectCombo.setSelectedIndex(-1);
-         JPanel p25 = new JPanel();
-         p25.add(new JLabel("Select Roster Group:"));
-         p25.add(selectCombo);
-         addToTopBox(p25);
-         selectCombo.addActionListener(new ActionListener() {
-         public void actionPerformed(ActionEvent e) {
-         comboSelected(e, selectCombo.getSelectedItem().toString());
-         }
-         });
-         }
-         };
-         setTitle();
-         addToFrame(f);
-         f.pack();
-         f.setVisible(true);*/
     }
 
     public void addToFrame(RosterGroupTableFrame f) {
@@ -136,7 +107,7 @@ public class RosterGroupTableAction extends jmri.util.swing.JmriAbstractAction {
     }
 
     String helpTarget() {
-        return "package.jmri.jmrit.roster.swing"; // NOI18N
+        return "package.jmri.jmrit.roster.swing.RosterGroupTable"; // NOI18N
     }
 
     void comboSelected(ActionEvent e, String group) {

--- a/java/src/jmri/jmrit/roster/swing/rostergroup/RosterGroupTableFrame.java
+++ b/java/src/jmri/jmrit/roster/swing/rostergroup/RosterGroupTableFrame.java
@@ -41,12 +41,14 @@ public class RosterGroupTableFrame extends jmri.util.JmriJFrame {
         dataModel = model;
 
         dataTable = new JTable(dataModel);
+        
+        dataTable.setAutoCreateRowSorter(true);  // user can pick sort column
+        
         TableRowSorter<RosterGroupTableModel> sorter = new TableRowSorter<>(dataModel);
         dataTable.setRowSorter(sorter);
 
         sorter.setComparator(RosterGroupTableModel.IDCOL, new jmri.util.AlphanumComparator());
         sorter.toggleSortOrder(RosterGroupTableModel.IDCOL);
-        dataTable = new JTable(dataModel);
         
         dataScroll = new JScrollPane(dataTable);
 

--- a/java/src/jmri/jmrit/roster/swing/rostergroup/RosterGroupTableModel.java
+++ b/java/src/jmri/jmrit/roster/swing/rostergroup/RosterGroupTableModel.java
@@ -172,8 +172,6 @@ public class RosterGroupTableModel extends javax.swing.table.AbstractTableModel 
             Roster.getDefault().writeRoster();
 
         }
-        //re.updateFile();
-        //Roster.getDefault().writeRosterFile();
     }
 
     public void setGroup(String grp) {


### PR DESCRIPTION
 - Make Roster Group Table in DecoderPro sortable
 - Fix the window-help link for the Roster Group Table
 - minor cleanup of commented code