### PR TITLE
Jmrix creation of ListedTableFrame

### DIFF
--- a/java/src/jmri/jmrix/dcc4pc/swing/Dcc4PcMenu.java
+++ b/java/src/jmri/jmrix/dcc4pc/swing/Dcc4PcMenu.java
@@ -32,9 +32,6 @@ public class Dcc4PcMenu extends JMenu {
             }
         }
 
-        if (jmri.InstanceManager.getNullableDefault(jmri.jmrit.beantable.ListedTableFrame.class) == null) {
-            new jmri.jmrit.beantable.ListedTableFrame<jmri.Turnout>();
-        }
     }
 
     Item[] panelItems = new Item[]{

--- a/java/src/jmri/jmrix/ecos/swing/EcosMenu.java
+++ b/java/src/jmri/jmrix/ecos/swing/EcosMenu.java
@@ -5,8 +5,6 @@ import javax.swing.JMenu;
 import jmri.InstanceManager;
 import jmri.jmrix.ecos.EcosSystemConnectionMemo;
 import jmri.util.prefs.JmriPreferencesActionFactory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Create a "Systems" menu containing the Jmri ECoS-specific tools.
@@ -36,15 +34,8 @@ public class EcosMenu extends JMenu {
             }
         }
 
-        if (jmri.InstanceManager.getNullableDefault(jmri.jmrit.beantable.ListedTableFrame.class) == null) {
-            try {
-                new jmri.jmrit.beantable.ListedTableFrame<jmri.Turnout>();
-            } catch (java.lang.NullPointerException ex) {
-                log.error("Unable to register ECoS table");
-            }
-        }
-
-        add(new jmri.jmrit.beantable.ListedTableAction(Bundle.getMessage("MenuItemDatabase"), "jmri.jmrix.ecos.swing.locodatabase.EcosLocoTableTabAction"));
+        add(new jmri.jmrit.beantable.ListedTableAction(Bundle.getMessage("MenuItemDatabase"),
+            "jmri.jmrix.ecos.swing.locodatabase.EcosLocoTableTabAction"));
         add(InstanceManager.getDefault(JmriPreferencesActionFactory.class).
                 getCategorizedAction(Bundle.getMessage("MenuItemECoSPrefs"), "ECoS", title));
         if (memo != null) {
@@ -70,6 +61,6 @@ public class EcosMenu extends JMenu {
         String load;
     }
 
-    private final static Logger log = LoggerFactory.getLogger(EcosMenu.class);
+    // private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(EcosMenu.class);
 
 }

--- a/java/src/jmri/jmrix/marklin/swing/MarklinMenu.java
+++ b/java/src/jmri/jmrix/marklin/swing/MarklinMenu.java
@@ -46,6 +46,6 @@ public class MarklinMenu extends JMenu {
         String load;
     }
 
-    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(MarklinMenu.class);
+    // private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(MarklinMenu.class);
 
 }

--- a/java/src/jmri/jmrix/marklin/swing/MarklinMenu.java
+++ b/java/src/jmri/jmrix/marklin/swing/MarklinMenu.java
@@ -2,11 +2,9 @@ package jmri.jmrix.marklin.swing;
 
 import javax.swing.JMenu;
 import jmri.jmrix.marklin.MarklinSystemConnectionMemo;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
- * Create a "Systems" menu containing the Jmri Marklin-specific tools.
+ * Create a "Systems" menu containing the JMRI Marklin-specific tools.
  *
  * @author Kevin Dickerson
  */
@@ -31,21 +29,13 @@ public class MarklinMenu extends JMenu {
             }
         }
 
-        if (jmri.InstanceManager.getNullableDefault(jmri.jmrit.beantable.ListedTableFrame.class) == null) {
-            try {
-                new jmri.jmrit.beantable.ListedTableFrame<jmri.Turnout>();
-            } catch (java.lang.NullPointerException ex) {
-                log.error("Unable to register Marklin table");
-            }
-        }
-
     }
 
-    Item[] panelItems = new Item[]{
+    private static final Item[] panelItems = new Item[]{
         new Item("MenuItemMarklinMonitor", "jmri.jmrix.marklin.swing.monitor.MarklinMonPane"),
         new Item("MenuItemSendPacket", "jmri.jmrix.marklin.swing.packetgen.PacketGenPanel"),};
 
-    static class Item {
+    private static class Item {
 
         Item(String name, String load) {
             this.name = name;
@@ -56,6 +46,6 @@ public class MarklinMenu extends JMenu {
         String load;
     }
 
-    private final static Logger log = LoggerFactory.getLogger(MarklinMenu.class);
+    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(MarklinMenu.class);
 
 }

--- a/java/src/jmri/jmrix/tams/swing/TamsMenu.java
+++ b/java/src/jmri/jmrix/tams/swing/TamsMenu.java
@@ -1,10 +1,7 @@
 package jmri.jmrix.tams.swing;
 
 import javax.swing.JMenu;
-import jmri.Turnout;
 import jmri.jmrix.tams.TamsSystemConnectionMemo;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Create a "Systems" menu containing the Tams-specific tools.
@@ -33,13 +30,6 @@ public class TamsMenu extends JMenu {
             }
         }
 
-        if (jmri.InstanceManager.getNullableDefault(jmri.jmrit.beantable.ListedTableFrame.class) == null) {
-            try {
-                new jmri.jmrit.beantable.ListedTableFrame<Turnout>();
-            } catch (java.lang.NullPointerException ex) {
-                log.error("Unable to register Tams table");
-            }
-        }
     }
 
     Item[] panelItems = new Item[]{
@@ -59,6 +49,6 @@ public class TamsMenu extends JMenu {
         String load;
     }
 
-    private final static Logger log = LoggerFactory.getLogger(TamsMenu.class);
+    // private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(TamsMenu.class);
 
 }

--- a/java/test/jmri/jmrix/sprog/SPROGCSMenuTest.java
+++ b/java/test/jmri/jmrix/sprog/SPROGCSMenuTest.java
@@ -1,12 +1,8 @@
 package jmri.jmrix.sprog;
 
-import java.awt.GraphicsEnvironment;
-
 import jmri.util.JUnitUtil;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.*;
-import org.junit.Assume;
 
 /**
  * Test simple functioning of SPROGCSMenu.
@@ -16,13 +12,10 @@ import org.junit.Assume;
 public class SPROGCSMenuTest {
 
     @Test
+    @jmri.util.junit.annotations.DisabledIfHeadless
     public void testCtor() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless()); 
-        // the constructor looks for the default ListedTableFrame class, 
-        // which is set by the ListedTableFrame constructor.
-        new jmri.jmrit.beantable.ListedTableFrame();
         SPROGCSMenu action = new SPROGCSMenu(new jmri.jmrix.sprog.SprogSystemConnectionMemo());
-        Assert.assertNotNull("exists", action);
+        Assertions.assertNotNull( action, "exists");
     }
 
     @BeforeEach
@@ -32,6 +25,8 @@ public class SPROGCSMenuTest {
     }
 
     @AfterEach
-    public void tearDown() {        JUnitUtil.tearDown();    }
+    public void tearDown() {
+        JUnitUtil.tearDown();
+    }
 
 }

--- a/java/test/jmri/jmrix/sprog/SPROGMenuTest.java
+++ b/java/test/jmri/jmrix/sprog/SPROGMenuTest.java
@@ -1,12 +1,8 @@
 package jmri.jmrix.sprog;
 
-import java.awt.GraphicsEnvironment;
-
 import jmri.util.JUnitUtil;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.*;
-import org.junit.Assume;
 
 /**
  * Test simple functioning of SPROGMenu.
@@ -16,13 +12,10 @@ import org.junit.Assume;
 public class SPROGMenuTest {
 
     @Test
+    @jmri.util.junit.annotations.DisabledIfHeadless
     public void testCtor() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless()); 
-        // the constructor looks for the default ListedTableFrame class, 
-        // which is set by the ListedTableFrame constructor.
-        new jmri.jmrit.beantable.ListedTableFrame();
         SPROGMenu action = new SPROGMenu(new jmri.jmrix.sprog.SprogSystemConnectionMemo());
-        Assert.assertNotNull("exists", action);
+        Assertions.assertNotNull( action, "exists");
     }
 
     @BeforeEach
@@ -32,6 +25,8 @@ public class SPROGMenuTest {
     }
 
     @AfterEach
-    public void tearDown() {        JUnitUtil.tearDown();    }
+    public void tearDown() {
+        JUnitUtil.tearDown();
+    }
 
 }

--- a/java/test/jmri/jmrix/tams/swing/TamsMenuTest.java
+++ b/java/test/jmri/jmrix/tams/swing/TamsMenuTest.java
@@ -1,12 +1,8 @@
 package jmri.jmrix.tams.swing;
 
-import java.awt.GraphicsEnvironment;
-
 import jmri.util.JUnitUtil;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.*;
-import org.junit.Assume;
 
 /**
  * Test simple functioning of TamsMenu
@@ -15,15 +11,11 @@ import org.junit.Assume;
  */
 public class TamsMenuTest {
 
-
     @Test
+    @jmri.util.junit.annotations.DisabledIfHeadless
     public void testCtor() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless()); 
-        // the constructor looks for the default ListedTableFrame class, 
-        // which is set by the ListedTableFrame constructor.
-        new jmri.jmrit.beantable.ListedTableFrame();
         TamsMenu action = new TamsMenu(new jmri.jmrix.tams.TamsSystemConnectionMemo());
-        Assert.assertNotNull("exists", action);
+        Assertions.assertNotNull( action, "exists");
     }
 
     @BeforeEach
@@ -33,5 +25,8 @@ public class TamsMenuTest {
     }
 
     @AfterEach
-    public void tearDown() {        JUnitUtil.tearDown();    }
+    public void tearDown() {
+        JUnitUtil.tearDown();
+    }
+
 }


### PR DESCRIPTION
**Dcc4PcMenu
EcosMenu
MarklinMenu
TamsMenu**
No longer create a new ListedTableFrame&lt;Turnout&gt; on system menu creation.

The EcosLocoAddressManager still ensures a ListedTableFrame is present for Ecos connections.

**SPROGCSMenuTest
SPROGMenuTest
TamsMenuTest**
No longer create a new ListedTableFrame&lt;Turnout&gt; before creating / testing system menu.