### PR TITLE
Update non-functional <variable> entries in decoder files

### DIFF
--- a/java/test/jmri/jmrit/decoderdefn/MissingTypeTest.java
+++ b/java/test/jmri/jmrit/decoderdefn/MissingTypeTest.java
@@ -13,8 +13,6 @@ import org.jdom2.JDOMException;
 import org.jdom2.filter.ElementFilter;
 import org.junit.jupiter.api.*;
 import org.junit.Assert;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Checks for missing content in a <variable> element
@@ -25,7 +23,7 @@ import org.slf4j.LoggerFactory;
 public class MissingTypeTest {
 
     @Test
-    public void testForDuplicateModels() throws JDOMException, IOException {
+    public void testForMissingTypeElement() throws JDOMException, IOException {
         File dir = new File("xml/decoders/");
         File[] files = dir.listFiles();
         boolean failed = false;
@@ -57,16 +55,19 @@ public class MissingTypeTest {
         boolean failed = false;
         while (iter.hasNext()) {
             Element e = iter.next().clone();
+            
+            // ignore everything _except_ the type element
             e.removeContent(new ElementFilter("label"));
             e.removeContent(new ElementFilter("qualifier"));
             e.removeContent(new ElementFilter("comment"));
             e.removeContent(new ElementFilter("tooltip"));
             e.removeContent(new ElementFilter("defaultItem"));
+            
             if (e.getChildren().size() != 1) {
                 failed = true;
-                log.error(" failed in {}", file);
-                log.error("Children {}", e.getChildren());
-                for (Attribute a: e.getAttributes()) log.error("  Attr {}", a);
+                log.error("Test failed in file: {}", file);
+                log.error("  Element's remaining children {}", e.getChildren());
+                for (Attribute a: e.getAttributes()) log.error("     Attr {}", a);
             }            
         }
         return failed;
@@ -92,5 +93,5 @@ public class MissingTypeTest {
 
     }
 
-    private final static Logger log = LoggerFactory.getLogger(MissingTypeTest.class);
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(MissingTypeTest.class);
 }

--- a/java/test/jmri/jmrit/decoderdefn/MissingTypeTest.java
+++ b/java/test/jmri/jmrit/decoderdefn/MissingTypeTest.java
@@ -1,0 +1,96 @@
+package jmri.jmrit.decoderdefn;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+
+import jmri.jmrit.XmlFile;
+
+import org.jdom2.Attribute;
+import org.jdom2.Element;
+import org.jdom2.JDOMException;
+import org.jdom2.filter.ElementFilter;
+import org.junit.jupiter.api.*;
+import org.junit.Assert;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Checks for missing content in a <variable> element
+ *
+ * @author Bob Jacobsen Copyright 2010
+ * @since 2.9.3
+ */
+public class MissingTypeTest {
+
+    @Test
+    public void testForDuplicateModels() throws JDOMException, IOException {
+        File dir = new File("xml/decoders/");
+        File[] files = dir.listFiles();
+        boolean failed = false;
+        for (File file : files) {
+            if (file.getName().endsWith("xml")) {
+                failed = check(file) || failed;
+            }
+        }
+        log.debug("checked total of{}", models.size());
+        if (failed) {
+            Assert.fail("test failed, see System.err");
+        }
+    }
+
+    ArrayList<String> models = new ArrayList<>();
+
+    boolean check(File file) throws JDOMException, IOException {
+        Element root = readFile(file);
+
+        // check to see if there's a decoder element
+        if (root.getChild("decoder") == null) {
+            log.warn("Does not appear to be a decoder file");
+            return false;
+        }
+
+        Iterator<Element> iter = root.getChild("decoder").getChild("variables")
+                .getDescendants(new ElementFilter("variable"));
+
+        boolean failed = false;
+        while (iter.hasNext()) {
+            Element e = iter.next().clone();
+            e.removeContent(new ElementFilter("label"));
+            e.removeContent(new ElementFilter("qualifier"));
+            e.removeContent(new ElementFilter("comment"));
+            e.removeContent(new ElementFilter("tooltip"));
+            e.removeContent(new ElementFilter("defaultItem"));
+            if (e.getChildren().size() != 1) {
+                failed = true;
+                log.error(" failed in {}", file);
+                log.error("Children {}", e.getChildren());
+                for (Attribute a: e.getAttributes()) log.error("  Attr {}", a);
+            }            
+        }
+        return failed;
+    }
+
+    Element readFile(File file) throws JDOMException, IOException {
+        XmlFile xf = new XmlFile() {
+        };   // odd syntax is due to XmlFile being abstract
+
+        return xf.rootFromFile(file);
+
+    }
+
+    @BeforeEach
+    public void setUp() {
+        jmri.util.JUnitUtil.setUp();
+
+    }
+
+    @AfterEach
+    public void tearDown() {
+        jmri.util.JUnitUtil.tearDown();
+
+    }
+
+    private final static Logger log = LoggerFactory.getLogger(MissingTypeTest.class);
+}

--- a/xml/decoders/Kuehn_T65.xml
+++ b/xml/decoders/Kuehn_T65.xml
@@ -952,6 +952,7 @@
         <label xml:lang="de">Rangiergang mit F4</label>
         <label xml:lang="nl">Rangeergang met F4</label>
       </variable>
+      
       <variable CV="59" mask="XXXXXXXV" item="Global lighting option 3" default="0">
         <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Dimming with F1</label>
@@ -964,6 +965,7 @@
         <tooltip xml:lang="nl">&lt;html&gt;Wil u dat F1 het dimmen activeert?
                                           Stel dan de dimwaarde in, in de ééner stelle van CV-55.&lt;/html&gt;</tooltip>
       </variable>
+
       <variable CV="59" mask="XXXXXXVX" item="Global lighting option 4" default="0">
         <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Dimming with F2</label>
@@ -976,6 +978,7 @@
         <tooltip xml:lang="nl">&lt;html&gt;Wil u dat F2 het dimmen activeert?
                                           Stel dan de dimwaarde in, in de ééner stelle van CV-55.&lt;/html&gt;</tooltip>
       </variable>
+
       <variable CV="59" mask="XXXXXVXX" item="Global lighting option 5" default="0">
         <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>Dimming with F3</label>
@@ -988,6 +991,8 @@
         <tooltip xml:lang="nl">&lt;html&gt;Wil u dat F3 het dimmen activeert?
                                           Stel dan de dimwaarde in, in de ééner stelle van CV-55.&lt;/html&gt;</tooltip>
       </variable>
+      
+<!-- commented out because without a type specification element it doesn't do anything
       <variable CV="59" mask="XXXXVXXX" item="Global lighting option 6" default="0">
         <label>Dimming with F4</label>
         <label xml:lang="de">Abblenden mit F4</label>
@@ -999,6 +1004,7 @@
         <tooltip xml:lang="nl">&lt;html&gt;Wil u dat F4 het dimmen activeert?
                                           Stel dan de dimwaarde in, in de ééner stelle van CV-55.&lt;/html&gt;</tooltip>
       </variable>
+-->
       <variable CV="60" default="0" item="Output 1 effect generated">
         <decVal min="0" max="99"/>
         <label>Dimmvalue Output B / Output A</label>

--- a/xml/decoders/Leb_ACC_4S.xml
+++ b/xml/decoders/Leb_ACC_4S.xml
@@ -76,10 +76,12 @@
       </variable>
 	  -->
 	  
+<!-- commented out because without a type specification element it doesn't do anything
       <variable item="Allumage choix" CV="3" mask="XXXXXXXX" default="0">
 	  <label>Allumage choix</label>
 	  </variable>  
-	  
+-->
+
 <!--
       <variable item="Allumage ID" CV="3" mask="XXXXXXXV" default="0">
 	    <xi:include href="http://jmri.org/xml/decoders/parts/enum-disabledEnabled.xml"/>

--- a/xml/decoders/Leb_DECSIGBF1_OP1.xml
+++ b/xml/decoders/Leb_DECSIGBF1_OP1.xml
@@ -155,12 +155,12 @@
 				<label>Turnout_C_Address_High5</label>
 			</variable>
 			
-			
-			
-			
+<!-- commented out because without a type specification element it doesn't do anything			
 			<variable item="Allumage choix A" CV="4" mask="XXXXXXXX" default="0">
 				<label>Allumage choix A</label>
 			</variable>
+-->
+
 			<variable item="Allumage ID A" CV="4" mask="XXXXXXXV" default="0">
 				<xi:include href="http://jmri.org/xml/decoders/parts/enum-disabledEnabled.xml"/>
 				<label>Allumage ID A</label>
@@ -180,10 +180,12 @@
 				<tooltip>Indication a la mise sous tension A</tooltip>
 			</variable>
 			
-			
+<!-- commented out because without a type specification element it doesn't do anything			
 			<variable item="Allumage choix B" CV="5" mask="XXXXXXXX" default="0">
 				<label>Allumage choix B</label>
 			</variable>
+-->
+
 			<variable item="Allumage ID B" CV="5" mask="XXXXXXXV" default="0">
 				<xi:include href="http://jmri.org/xml/decoders/parts/enum-disabledEnabled.xml"/>
 				<label>Allumage ID B</label>
@@ -203,9 +205,12 @@
 			</variable>
 			
 
+<!-- commented out because without a type specification element it doesn't do anything
 			<variable item="Allumage choix C" CV="6" mask="XXXXXXXX" default="0">
 				<label>Allumage choix C</label>
 			</variable>
+-->
+
 			<variable item="Allumage ID C" CV="6" mask="XXXXXXXV" default="0">
 				<xi:include href="http://jmri.org/xml/decoders/parts/enum-disabledEnabled.xml"/>
 				<label>Allumage ID C</label>

--- a/xml/decoders/Leb_DECSIGBF1_V1.xml
+++ b/xml/decoders/Leb_DECSIGBF1_V1.xml
@@ -73,10 +73,13 @@
         <label>Turnout_Address_High5</label>
       </variable>
 	  
-	  
+
+<!-- commented out because without a type specification element it doesn't do anything
       <variable item="Allumage choix" CV="3" mask="XXXXXXXX" default="0">
 	  <label>Allumage choix</label>
-	  </variable>  
+	  </variable>
+-->
+  
       <variable item="Allumage ID" CV="3" mask="XXXXXXXV" default="0">
 	    <xi:include href="http://jmri.org/xml/decoders/parts/enum-disabledEnabled.xml"/>
         <label>Allumage ID</label>

--- a/xml/decoders/Leb_DECSIGBF1_V2.xml
+++ b/xml/decoders/Leb_DECSIGBF1_V2.xml
@@ -74,11 +74,13 @@
         <splitVal highCV="9" factor="4" offset="+4"/>
         <label>Turnout_Address_High5</label>
       </variable>
-	  
-	  
+
+<!-- commented out because without a type specification element it doesn't do anything
       <variable item="Allumage choix" CV="3" mask="XXXXXXXX" default="0">
 	  <label>Allumage choix</label>
-	  </variable>  
+	  </variable> 
+-->
+ 
       <variable item="Allumage ID" CV="3" mask="XXXXXXXV" default="0">
 	    <xi:include href="http://jmri.org/xml/decoders/parts/enum-disabledEnabled.xml"/>
         <label>Allumage ID</label>

--- a/xml/decoders/Leb_DECSIGBF1_V3.xml
+++ b/xml/decoders/Leb_DECSIGBF1_V3.xml
@@ -67,9 +67,13 @@
 				<splitVal highCV="9" factor="4" offset="+4"/>
 				<label>Turnout_Address_High5</label>
 			</variable>
+			
+<!-- commented out because without a type specification element it doesn't do anything
 			<variable item="Allumage choix" CV="3" mask="XXXXXXXX" default="0">
 				<label>Allumage choix</label>
 			</variable>
+-->
+
 			<variable item="Allumage ID" CV="3" mask="XXXXXXXV" default="0">
 				<xi:include href="http://jmri.org/xml/decoders/parts/enum-disabledEnabled.xml"/>
 				<label>Allumage ID</label>

--- a/xml/decoders/Leb_DECSIGBF1_V4.xml
+++ b/xml/decoders/Leb_DECSIGBF1_V4.xml
@@ -69,9 +69,12 @@
 				<label>Turnout_Address_High6</label>
 			</variable>
 			
+<!-- commented out because without a type specification element it doesn't do anything
 			<variable item="CV 3/515 Allumage choix" CV="3" mask="XXXXXXXX" default="0">
 				<label>CV 3/515 Allumage choix</label>
 			</variable>
+-->
+
 			<variable item="Allumage ID" CV="3" mask="XXXXXXXV" default="0">
 				<xi:include href="http://jmri.org/xml/decoders/parts/enum-disabledEnabled.xml"/>
 				<label>Allumage ID</label>

--- a/xml/decoders/SDD-001.xml
+++ b/xml/decoders/SDD-001.xml
@@ -22,6 +22,8 @@
     <programming direct="yes" paged="no" register="no" ops="yes"/>
 
     <variables>
+    
+<!-- commented out because without a type specification element it doesn't do anything   
       <variable item="Decoder Address lo" CV="1" default="03">
         <label>Decoder address low byte</label>
       </variable>
@@ -45,6 +47,7 @@
       <variable item="Configuration" CV="29" readOnly="yes" default="192">
         <label>Configuration</label>
       </variable>
+-->
 
     </variables>
 

--- a/xml/decoders/TCS_BachmannFT.xml
+++ b/xml/decoders/TCS_BachmannFT.xml
@@ -2825,9 +2825,13 @@
         <decVal/>
         <label>Dynamic Decel Rate</label>
       </variable>
+
+<!-- commented out because without a type specification element it doesn't do anything
       <variable default="3" item="Dynamic brake notch setting" CV="192">
         <label>Dynamic brake notch setting</label>
       </variable>
+-->
+
       <variable default="0" item="Motor Option 1" CV="115">
         <decVal/>
         <label>Motor Delay</label>
@@ -2884,9 +2888,13 @@
         <decVal max="100"/>
         <label>Brake Release</label>
       </variable>
+
+<!-- commented out because without a type specification element it doesn't do anything
       <variable default="0" item="Code Hash Part 4" CV="256">
         <label>Code Hash Part 4</label>
       </variable>
+-->
+
       <variable default="100" item="Sound Setting 13" CV="206">
         <decVal max="100"/>
         <label>Horn Long</label>
@@ -2895,16 +2903,24 @@
         <decVal/>
         <label>Accel 1 Rate</label>
       </variable>
+      
+<!-- commented out because without a type specification element it doesn't do anything
       <variable default="0" item="Code Hash Part 2" CV="254">
         <label>Code Hash Part 2</label>
       </variable>
+-->
+
       <variable default="5" item="Decoder Version" CV="7">
         <decVal/>
         <label>Decoder Version</label>
       </variable>
+
+<!-- commented out because without a type specification element it doesn't do anything
       <variable default="0" item="Code Hash Part 3" CV="255">
         <label>Code Hash Part 3</label>
       </variable>
+-->
+
       <variable default="35" item="Motor Option 2" CV="244">
         <decVal/>
         <label>BEMF Routine Frequency (lower is faster)</label>
@@ -3039,9 +3055,13 @@
         <decVal/>
         <label>User Id #2</label>
       </variable>
+
+<!-- commented out because without a type specification element it doesn't do anything
       <variable default="0" item="Sound Set Version Identifier" CV="248">
         <label>Sound Set Version Identifier</label>
       </variable>
+-->
+
       <variable default="0" item="User Id #1" CV="105">
         <decVal/>
         <label>User Id #1</label>
@@ -3449,9 +3469,13 @@
         <decVal/>
         <label>Decoder ID</label>
       </variable>
+
+<!-- commented out because without a type specification element it doesn't do anything
       <variable default="0" item="Code Hash Part 1" CV="253">
         <label>Code Hash Part 1</label>
       </variable>
+-->
+
       <variable default="32" item="Brake Rate 1" CV="183">
         <decVal/>
         <label>Brake Rate 1</label>

--- a/xml/decoders/TCS_BachmannGP35.xml
+++ b/xml/decoders/TCS_BachmannGP35.xml
@@ -2825,9 +2825,13 @@
         <decVal/>
         <label>Dynamic Decel Rate</label>
       </variable>
+      
+<!-- commented out because without a type specification element it doesn't do anything
       <variable default="4" item="Dynamic brake notch setting" CV="192">
         <label>Dynamic brake notch setting</label>
       </variable>
+-->
+
       <variable default="0" item="Motor Option 1" CV="115">
         <decVal/>
         <label>Motor Delay</label>
@@ -2884,9 +2888,13 @@
         <decVal max="100"/>
         <label>Brake Release</label>
       </variable>
+
+<!-- commented out because without a type specification element it doesn't do anything
       <variable default="14" item="Code Hash Part 4" CV="256">
         <label>Code Hash Part 4</label>
       </variable>
+-->
+
       <variable default="100" item="Sound Setting 13" CV="206">
         <decVal max="100"/>
         <label>Horn Long</label>
@@ -2895,16 +2903,24 @@
         <decVal/>
         <label>Accel 1 Rate</label>
       </variable>
+
+<!-- commented out because without a type specification element it doesn't do anything
       <variable default="65" item="Code Hash Part 2" CV="254">
         <label>Code Hash Part 2</label>
       </variable>
+-->
+
       <variable default="5" item="Decoder Version" CV="7">
         <decVal/>
         <label>Decoder Version</label>
       </variable>
+      
+<!-- commented out because without a type specification element it doesn't do anything
       <variable default="80" item="Code Hash Part 3" CV="255">
         <label>Code Hash Part 3</label>
       </variable>
+-->
+
       <variable default="35" item="Motor Option 2" CV="244">
         <decVal/>
         <label>BEMF Routine Frequency (lower is faster)</label>
@@ -3039,9 +3055,13 @@
         <decVal/>
         <label>User Id #2</label>
       </variable>
+
+<!-- commented out because without a type specification element it doesn't do anything
       <variable default="0" item="Sound Set Version Identifier" CV="248">
         <label>Sound Set Version Identifier</label>
       </variable>
+-->
+
       <variable default="0" item="User Id #1" CV="105">
         <decVal/>
         <label>User Id #1</label>
@@ -3449,9 +3469,13 @@
         <decVal/>
         <label>Decoder ID</label>
       </variable>
+    
+<!-- commented out because without a type specification element it doesn't do anything
       <variable default="106" item="Code Hash Part 1" CV="253">
         <label>Code Hash Part 1</label>
       </variable>
+-->
+
       <variable default="32" item="Brake Rate 1" CV="183">
         <decVal/>
         <label>Brake Rate 1</label>

--- a/xml/decoders/TCS_BachmannRS3.xml
+++ b/xml/decoders/TCS_BachmannRS3.xml
@@ -2859,9 +2859,12 @@
         <decVal/>
         <label>Dynamic Decel Rate</label>
       </variable>
+      
+<!-- commented out because without a type specification element it doesn't do anything
       <variable default="3" item="Dynamic brake notch setting" CV="192">
         <label>Dynamic brake notch setting</label>
       </variable>
+-->      
       <variable default="0" item="Motor Option 1" CV="115">
         <decVal/>
         <label>Motor Delay</label>
@@ -2918,9 +2921,13 @@
         <decVal max="100"/>
         <label>Brake Release</label>
       </variable>
+  
+<!-- commented out because without a type specification element it doesn't do anything
       <variable default="0" item="Code Hash Part 4" CV="256">
         <label>Code Hash Part 4</label>
       </variable>
+-->      
+      
       <variable default="100" item="Sound Setting 13" CV="206">
         <decVal max="100"/>
         <label>Horn Long</label>
@@ -2929,16 +2936,24 @@
         <decVal/>
         <label>Accel 1 Rate</label>
       </variable>
+      
+<!-- commented out because without a type specification element it doesn't do anything
       <variable default="0" item="Code Hash Part 2" CV="254">
         <label>Code Hash Part 2</label>
       </variable>
+-->
+
       <variable default="5" item="Decoder Version" CV="7">
         <decVal/>
         <label>Decoder Version</label>
       </variable>
+
+<!-- commented out because without a type specification element it doesn't do anything
       <variable default="0" item="Code Hash Part 3" CV="255">
         <label>Code Hash Part 3</label>
       </variable>
+-->
+
       <variable default="35" item="Motor Option 2" CV="244">
         <decVal/>
         <label>BEMF Routine Frequency (lower is faster)</label>
@@ -3073,9 +3088,13 @@
         <decVal/>
         <label>User Id #2</label>
       </variable>
+
+<!-- commented out because without a type specification element it doesn't do anything
       <variable default="0" item="Sound Set Version Identifier" CV="248">
         <label>Sound Set Version Identifier</label>
       </variable>
+-->
+
       <variable default="0" item="User Id #1" CV="105">
         <decVal/>
         <label>User Id #1</label>
@@ -3483,9 +3502,13 @@
         <decVal/>
         <label>Decoder ID</label>
       </variable>
+
+<!-- commented out because without a type specification element it doesn't do anything
       <variable default="0" item="Code Hash Part 1" CV="253">
         <label>Code Hash Part 1</label>
       </variable>
+-->
+
       <variable default="32" item="Brake Rate 1" CV="183">
         <decVal/>
         <label>Brake Rate 1</label>

--- a/xml/decoders/TCS_WOWDieselV5-121.xml
+++ b/xml/decoders/TCS_WOWDieselV5-121.xml
@@ -3558,9 +3558,13 @@
         <decVal/>
         <label>Dynamic Decel Rate</label>
       </variable>
+
+<!-- commented out because without a type specification element it doesn't do anything
       <variable default="4" item="Dynamic brake notch setting" CV="192">
         <label>Dynamic brake notch setting</label>
       </variable>
+-->
+
       <variable default="4" item="Motor Option 1" CV="115">
         <decVal/>
         <label>Motor Delay</label>
@@ -3617,9 +3621,13 @@
         <decVal max="100"/>
         <label>Brake Release</label>
       </variable>
+
+<!-- commented out because without a type specification element it doesn't do anything
       <variable default="0" item="Code Hash Part 4" CV="256">
         <label>Code Hash Part 4</label>
       </variable>
+-->
+
       <variable default="100" item="Sound Setting 13" CV="206">
         <decVal max="100"/>
         <label>Horn Long</label>
@@ -3628,16 +3636,24 @@
         <decVal/>
         <label>Accel 1 Rate</label>
       </variable>
+
+<!-- commented out because without a type specification element it doesn't do anything
       <variable default="0" item="Code Hash Part 2" CV="254">
         <label>Code Hash Part 2</label>
       </variable>
+-->
+
       <variable default="5" item="Decoder Version" CV="7">
         <decVal/>
         <label>Decoder Version</label>
       </variable>
+      
+<!-- commented out because without a type specification element it doesn't do anything
       <variable default="0" item="Code Hash Part 3" CV="255">
         <label>Code Hash Part 3</label>
       </variable>
+-->
+
       <variable default="35" item="Motor Option 2" CV="244">
         <decVal/>
         <label>BEMF Routine Frequency (lower is faster)</label>
@@ -3772,9 +3788,13 @@
         <decVal/>
         <label>User Id #2</label>
       </variable>
+
+<!-- commented out because without a type specification element it doesn't do anything
       <variable default="0" item="Sound Set Version Identifier" CV="248">
         <label>Sound Set Version Identifier</label>
       </variable>
+-->
+
       <variable default="0" item="User Id #1" CV="105">
         <decVal/>
         <label>User Id #1</label>
@@ -4214,9 +4234,13 @@
         <decVal/>
         <label>Decoder ID</label>
       </variable>
+
+<!-- commented out because without a type specification element it doesn't do anything
       <variable default="0" item="Code Hash Part 1" CV="253">
         <label>Code Hash Part 1</label>
       </variable>
+-->
+
       <variable default="32" item="Brake Rate 1" CV="183">
         <decVal/>
         <label>Brake Rate 1</label>


### PR DESCRIPTION
In a decoder definition file, a `<variable>` element doesn't do anything in DecoderPro unless it has a functional content element: `<decVal>`, `<enumVal>`, etc.  People occasionally create these non-functional `<variable>` elements within their decoder definition by oversight.

This PR adds a new `MissingTypeTest` which scans decoder files for the condition and fails if any are found.  

In theory, this should be detected by the `<choice>` element in the XML Schema defining the `<variable>` element, but that's not working.  I haven't been able to figure out why.

There are 12 existing decoder definition files with this condition.  I've flagged the non-functional variable definitions in those b y commenting them out with a specific message.   This doesn't change DecoderPro's behavior at all except that a few warning messages will be suppressed.  Perhaps someday somebody will go through these and figure out what their content should be, but not that several of them seem to be defining content that's already in the file elsewhere.

Thanks to Phil Grainger for helping me find and fix this.

Note this follows on from PR #13676. The first few commits here are also there.  That's expected.