### PR TITLE
Merge 5.10 branch to master

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Test:
 [![Test release](https://img.shields.io/github/release/JMRI/JMRI.svg)](https://www.jmri.org/download/index.shtml#test-rel)
 [![Test release](https://img.shields.io/github/downloads/JMRI/JMRI/latest/total.svg)](https://www.jmri.org/download/index.shtml#test-rel)
 Production:
-[![Production release](https://img.shields.io/github/downloads/JMRI/JMRI/v5.8/total.svg)](https://www.jmri.org/download/index.shtml#prod-rel)
+[![Production release](https://img.shields.io/github/downloads/JMRI/JMRI/v5.10/total.svg)](https://www.jmri.org/download/index.shtml#prod-rel)
 Total (since 9/2017):
 [![Totals since 9/2017](https://img.shields.io/github/downloads/JMRI/JMRI/total.svg)](https://www.jmri.org/download/index.shtml)
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <name>JMRI</name>
     <groupId>org.jmri</groupId>
     <artifactId>jmri</artifactId>
-    <version>5.9.8-SNAPSHOT</version>
+    <version>5.10-SNAPSHOT</version>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <release.build_user>${user.name}</release.build_user>

--- a/release.properties
+++ b/release.properties
@@ -4,8 +4,8 @@
 
 # these are the numbers for the MOST RECENT release from this branch
 release.major=5
-release.minor=9
-release.build=8
+release.minor=10
+release.build=0
 
 # additional release descriptor for a long-running experimental difference
 # from what is produced by building JMRI/master (e.g. "pjc"). Should not contain


### PR DESCRIPTION
Now that production release 5.10 has been tagged v5.10 and released, we need to merge that branch (which also contained 5.9.8) back into master.  

That way, if somebody someday starts a branch from tag v5.10, it will be in the direct line from master and won't have the version control files show as changes, which in turn will revert them when that new branch is merged.  

This should be merged before the branch for release 5.11.1 is created to keep the version information in the right sequence on master.