### PR TITLE
Block - linting / describeState

### DIFF
--- a/java/src/jmri/Block.java
+++ b/java/src/jmri/Block.java
@@ -10,14 +10,12 @@ import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
 import jmri.implementation.AbstractNamedBean;
 import jmri.implementation.SignalSpeedMap;
 import jmri.util.PhysicalLocation;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Represents a particular piece of track, more informally a "Block".
@@ -174,8 +172,8 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
         super(systemName, userName);
     }
 
-    static final public int OCCUPIED = Sensor.ACTIVE;
-    static final public int UNOCCUPIED = Sensor.INACTIVE;
+    public static final int OCCUPIED = Sensor.ACTIVE;
+    public static final int UNOCCUPIED = Sensor.INACTIVE;
 
     /**
      * Undetected status, i.e a "Dark" block.
@@ -187,27 +185,27 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
      * from the block.
      *
      */
-    static final public int UNDETECTED = 0x100;  // bit coded, just in case; really should be enum
+    public static final int UNDETECTED = 0x100;  // bit coded, just in case; really should be enum
 
     /**
      * No Curvature.
      */
-    static final public int NONE = 0x00;
+    public static final int NONE = 0x00;
 
     /**
      * Gradual Curvature.
      */
-    static final public int GRADUAL = 0x01;
+    public static final int GRADUAL = 0x01;
 
     /**
      * Tight Curvature.
      */
-    static final public int TIGHT = 0x02;
+    public static final int TIGHT = 0x02;
 
     /**
      * Severe Curvature.
      */
-    static final public int SEVERE = 0x04;
+    public static final int SEVERE = 0x04;
 
     /**
      * Create a Debug String,
@@ -215,26 +213,8 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
      * @return Block User name, System name, current state as string value.
      */
     public String toDebugString() {
-        String result = getDisplayName(DisplayOptions.USERNAME_SYSTEMNAME) + " ";
-        switch (getState()) {
-            case UNDETECTED: {
-                result += "UNDETECTED";
-                break;
-            }
-            case UNOCCUPIED: {
-                result += "UNOCCUPIED";
-                break;
-            }
-            case OCCUPIED: {
-                result += "OCCUPIED";
-                break;
-            }
-            default: {
-                result += "unknown " + getState();
-                break;
-            }
-        }
-        return result;
+        return getDisplayName(DisplayOptions.USERNAME_SYSTEMNAME)
+            + " " + describeState(getState());
     }
 
     /**
@@ -243,7 +223,7 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
      * old value: Sensor Bean Object if previously set, else null
      * new value: Sensor Bean Object if being set, may be null if Sensor removed.
      */
-    public final static String OCC_SENSOR_CHANGE = "OccupancySensorChange"; // NOI18N
+    public static final String OCC_SENSOR_CHANGE = "OccupancySensorChange"; // NOI18N
 
     /**
      * Set the sensor by name.
@@ -253,7 +233,7 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
      */
     public boolean setSensor(String pName) {
         Sensor oldSensor = getSensor();
-        if ((pName == null || pName.isEmpty())) {
+        if (pName == null || pName.isEmpty()) {
                 if (oldSensor!=null) {
                     setNamedSensor(null);
                     firePropertyChange(OCC_SENSOR_CHANGE, oldSensor, null);
@@ -266,7 +246,8 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
                 if (sensor.equals(oldSensor)) {
                     return false;
                 }
-                setNamedSensor(InstanceManager.getDefault(NamedBeanHandleManager.class).getNamedBeanHandle(pName, sensor));
+                setNamedSensor(InstanceManager.getDefault(
+                    NamedBeanHandleManager.class).getNamedBeanHandle(pName, sensor));
                 firePropertyChange(OCC_SENSOR_CHANGE, oldSensor, sensor);
                 return true;
             } catch (IllegalArgumentException ex) {
@@ -289,20 +270,19 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
      * If Sensor null, removes PCL on previous Sensor, sets Block status to UNDETECTED.
      * @param s Handle for Sensor.
      */
-    public void setNamedSensor(NamedBeanHandle<Sensor> s) {
-        if (_namedSensor != null) {
-            if (_sensorListener != null) {
-                _namedSensor.getBean().removePropertyChangeListener(_sensorListener);
-                _sensorListener = null;
-            }
+    public void setNamedSensor(@CheckForNull NamedBeanHandle<Sensor> s) {
+        if ( _namedSensor != null && _sensorListener != null) {
+            _namedSensor.getBean().removePropertyChangeListener(_sensorListener);
+            _sensorListener = null;
         }
         _namedSensor = s;
 
         if (_namedSensor != null) {
-            _namedSensor.getBean().addPropertyChangeListener(_sensorListener = (PropertyChangeEvent e) -> {
-                handleSensorChange(e);
-            }, s.getName(), "Block Sensor " + getDisplayName());
-            setState(_namedSensor.getBean().getState()); // At present does NOT route via goingUnknown() / goingActive() etc.
+            _sensorListener = this::handleSensorChange;
+            _namedSensor.getBean().addPropertyChangeListener(_sensorListener,
+                s.getName(), "Block Sensor " + getDisplayName());
+            setState(_namedSensor.getBean().getState());
+            // At present does NOT route via goingUnknown() / goingActive() etc.
         } else {
             setState(UNDETECTED); // Does NOT route via goingUnknown() / goingActive() etc.
         }
@@ -312,6 +292,7 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
      * Get the Block Occupancy Sensor.
      * @return Sensor if one attached to Block, may be null.
      */
+    @CheckForNull
     public Sensor getSensor() {
         if (_namedSensor != null) {
             return _namedSensor.getBean();
@@ -319,6 +300,7 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
         return null;
     }
 
+    @CheckForNull
     public NamedBeanHandle<Sensor> getNamedSensor() {
         return _namedSensor;
     }
@@ -329,7 +311,7 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
      * old value: Sensor Bean Object if previously set, else null
      * new value: Sensor Bean Object if being set, may be null if Sensor removed.
      */
-    public final static String BLOCK_REPORTER_CHANGE = "BlockReporterChange"; // NOI18N
+    public static final String BLOCK_REPORTER_CHANGE = "BlockReporterChange"; // NOI18N
 
     /**
      * Set the Reporter that should provide the data value for this block.
@@ -337,24 +319,19 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
      * @see Reporter
      * @param reporter Reporter object to link, or null to clear
      */
-    public void setReporter(Reporter reporter) {
+    public void setReporter(@CheckForNull Reporter reporter) {
         if (Objects.equals(reporter,_reporter)) {
             return;
         }
-        if (_reporter != null) {
-            // remove reporter listener
-            if (_reporterListener != null) {
-                _reporter.removePropertyChangeListener(_reporterListener);
-                _reporterListener = null;
-            }
+        if (_reporter != null && _reporterListener != null) {
+            _reporter.removePropertyChangeListener(_reporterListener);
+            _reporterListener = null;
         }
         Reporter oldReporter = _reporter;
         _reporter = reporter;
         if (_reporter != null) {
-            // attach listener
-            _reporter.addPropertyChangeListener(_reporterListener = (PropertyChangeEvent e) -> {
-                handleReporterChange(e);
-            });
+            _reporterListener = this::handleReporterChange;
+            _reporter.addPropertyChangeListener( _reporterListener );
         }
         firePropertyChange(BLOCK_REPORTER_CHANGE, oldReporter, reporter);
     }
@@ -365,6 +342,7 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
      * @see Reporter
      * @return linked Reporter object, or null if not linked
      */
+    @CheckForNull
     public Reporter getReporter() {
         return _reporter;
     }
@@ -375,7 +353,7 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
      * old value: previous value, Boolean.
      * new value: new value, Boolean.
      */
-    public final static String BLOCK_REPORTING_CURRENT = "BlockReportingCurrent"; // NOI18N
+    public static final String BLOCK_REPORTING_CURRENT = "BlockReportingCurrent"; // NOI18N
 
     /**
      * Define if the Block's value should be populated from the
@@ -453,7 +431,7 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
      * @return true if Block has the Path, else false.
      */
     public boolean hasPath(Path p) {
-        return paths.stream().anyMatch((t) -> (t.equals(p)));
+        return paths.stream().anyMatch( t -> t.equals(p) );
     }
 
     /**
@@ -484,8 +462,9 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
         try {
             firePropertyChange("state", old, _current);
         } catch (Exception e) {
-            log.error("{} got exception during firePropertyChange({},{}) in thread {} {}", getDisplayName(), old, _current,
-                    Thread.currentThread().getName(), Thread.currentThread().getId(), e);
+            log.error("{} got exception during firePropertyChange({},{}) in thread {} {}",
+                getDisplayName(), old, _current,
+                Thread.currentThread().getName(), Thread.currentThread().getId(), e);
         }
     }
 
@@ -513,6 +492,7 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
      * Get the Block Contents Value.
      * @return object with current value, could be null.
      */
+    @CheckForNull
     public Object getValue() {
         return _value;
     }
@@ -525,7 +505,8 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
     public void setDirection(int direction) {
         //ignore if unchanged
         if (direction != _direction) {
-            log.debug("Block {} direction changed from {} to {}", getDisplayName(), Path.decodeDirection(_direction), Path.decodeDirection(direction));
+            log.debug("Block {} direction changed from {} to {}", getDisplayName(),
+                Path.decodeDirection(_direction), Path.decodeDirection(direction));
             int oldDirection = _direction;
             _direction = direction;
             // this is a bound parameter
@@ -561,14 +542,16 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
         if (blk == null) {
             throw new IllegalArgumentException("addBlockDenyList requests block \"" + pName + "\" exists");
         }
-        NamedBeanHandle<Block> namedBlock = InstanceManager.getDefault(NamedBeanHandleManager.class).getNamedBeanHandle(pName, blk);
+        NamedBeanHandle<Block> namedBlock = InstanceManager.getDefault(
+            NamedBeanHandleManager.class).getNamedBeanHandle(pName, blk);
         if (!blockDenyList.contains(namedBlock)) {
             blockDenyList.add(namedBlock);
         }
     }
 
-    public void addBlockDenyList(Block blk) {
-        NamedBeanHandle<Block> namedBlock = InstanceManager.getDefault(NamedBeanHandleManager.class).getNamedBeanHandle(blk.getDisplayName(), blk);
+    public void addBlockDenyList(@Nonnull Block blk) {
+        NamedBeanHandle<Block> namedBlock = InstanceManager.getDefault(
+            NamedBeanHandleManager.class).getNamedBeanHandle(blk.getDisplayName(), blk);
         if (!blockDenyList.contains(namedBlock)) {
             blockDenyList.add(namedBlock);
         }
@@ -600,18 +583,16 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
 
     public List<String> getDeniedBlocks() {
         List<String> list = new ArrayList<>(blockDenyList.size());
-        blockDenyList.forEach((bean) -> {
-            list.add(bean.getName());
-        });
+        blockDenyList.forEach( bean -> list.add(bean.getName()) );
         return list;
     }
 
     public boolean isBlockDenied(String deny) {
-        return blockDenyList.stream().anyMatch((bean) -> (bean.getName().equals(deny)));
+        return blockDenyList.stream().anyMatch( bean -> bean.getName().equals(deny));
     }
 
     public boolean isBlockDenied(Block deny) {
-        return blockDenyList.stream().anyMatch((bean) -> (bean.getBean() == deny));
+        return blockDenyList.stream().anyMatch( bean -> bean.getBean() == deny);
     }
 
     /**
@@ -623,14 +604,13 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
         return _permissiveWorking;
     }
 
-
     /**
      * Property name change fired when the Block Permissive Status changes.
      * The fired event includes
      * old value: previous permissive status.
      * new value: new permissive status.
      */
-    public final static String BLOCK_PERMISSIVE_CHANGE = "BlockPermissiveWorking"; // NOI18N
+    public static final String BLOCK_PERMISSIVE_CHANGE = "BlockPermissiveWorking"; // NOI18N
 
     /**
      * Set Block as permissive.
@@ -661,7 +641,7 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
      * old value: previous ghost status.
      * new value: new ghost status.
      */
-    public final static String GHOST_CHANGE = "BlockGhost"; // NOI18N
+    public static final String GHOST_CHANGE = "BlockGhost"; // NOI18N
 
     /**
      * Set if the block is a ghost
@@ -682,7 +662,7 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
             return -1;
         }
         String speed = _blockSpeed;
-        if (_blockSpeed.equals("Global")) {
+        if ( "Global".equals( _blockSpeed)) {
             speed = InstanceManager.getDefault(BlockManager.class).getDefaultSpeed();
         }
 
@@ -701,8 +681,9 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
     private String _blockSpeed = "";
 
     public String getBlockSpeed() {
-        if (_blockSpeed.equals("Global")) {
-            return (Bundle.getMessage("UseGlobal", "Global") + " " + InstanceManager.getDefault(BlockManager.class).getDefaultSpeed());
+        if ( "Global".equals( _blockSpeed)) {
+            return (Bundle.getMessage("UseGlobal", "Global") + " "
+                + InstanceManager.getDefault(BlockManager.class).getDefaultSpeed());
             // Ensure the word "Global" is always in the speed name for later comparison
         }
         return _blockSpeed;
@@ -714,7 +695,7 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
      * old value: previous speed String.
      * new value: new speed String.
      */
-    public final static String BLOCK_SPEED_CHANGE = "BlockSpeedChange"; // NOI18N
+    public static final String BLOCK_SPEED_CHANGE = "BlockSpeedChange"; // NOI18N
 
     /**
      * Set the Block Speed Name.
@@ -738,25 +719,27 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
      * @param s Speed String
      * @throws JmriException if Value of requested block speed is not valid.
      */
-    public void setBlockSpeed(String s) throws JmriException {
+    public void setBlockSpeed(final String s) throws JmriException {
         if ((s == null) || (_blockSpeed.equals(s))) {
             return;
         }
+        String newSpeed = s;
         if (s.contains("Global")) {
-            s = "Global";
+            newSpeed = "Global";
         } else {
             try {
-                Float.parseFloat(s);
+                Float.valueOf(s);
             } catch (NumberFormatException nx) {
                 try {
                     InstanceManager.getDefault(SignalSpeedMap.class).getSpeed(s);
                 } catch (IllegalArgumentException ex) {
-                    throw new JmriException("Value of requested block speed is not valid");
+                    throw new JmriException("Block \"" + getDisplayName()
+                        + "\" requested speed value \"" + s + "\" invalid.");
                 }
             }
         }
         String oldSpeed = _blockSpeed;
-        _blockSpeed = s;
+        _blockSpeed = newSpeed;
         firePropertyChange(BLOCK_SPEED_CHANGE, oldSpeed, s);
     }
 
@@ -766,7 +749,7 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
      * old value: previous Block Curvature Constant.
      * new value: new Block Curvature Constant.
      */
-    public final static String BLOCK_CURVATURE_CHANGE = "BlockCurvatureChange"; // NOI18N
+    public static final String BLOCK_CURVATURE_CHANGE = "BlockCurvatureChange"; // NOI18N
 
     /**
      * Set Block Curvature Constant.
@@ -798,7 +781,7 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
      * old value: previous float length (mm).
      * new value: new float length (mm).
      */
-    public final static String BLOCK_LENGTH_CHANGE = "BlockLengthChange"; // NOI18N
+    public static final String BLOCK_LENGTH_CHANGE = "BlockLengthChange"; // NOI18N
 
     /**
      * Set length in millimeters.
@@ -863,7 +846,7 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
             return false;
         }
 
-        if (!(getClass() == obj.getClass())) {
+        if ( getClass() != obj.getClass() ) {
             return false;
         } else {
             Block b = (Block) obj;
@@ -879,7 +862,6 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
 
     // internal data members
     private int _current = UNDETECTED; // state until sensor is set
-    //private Sensor _sensor = null;
     private NamedBeanHandle<Sensor> _namedSensor = null;
     private PropertyChangeListener _sensorListener = null;
     private Object _value;
@@ -901,11 +883,12 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
 
     boolean setAsEntryBlockIfPossible(Block b) {
         for (int i = 0; i < cntOfPossibleEntrancePaths; i++) {
-            Block CandidateBlock = pListOfPossibleEntrancePaths[i].getBlock();
-            if (CandidateBlock == b) {
-                setValue(CandidateBlock.getValue());
+            Block candidateBlock = pListOfPossibleEntrancePaths[i].getBlock();
+            if (candidateBlock == b) {
+                setValue(candidateBlock.getValue());
                 setDirection(pListOfPossibleEntrancePaths[i].getFromBlockDirection());
-                log.info("Block {} gets LATE new value from {}, direction= {}", getDisplayName(), CandidateBlock.getDisplayName(), Path.decodeDirection(getDirection()));
+                log.info("Block {} gets LATE new value from {}, direction= {}",
+                    getDisplayName(), candidateBlock.getDisplayName(), Path.decodeDirection(getDirection()));
                 resetCandidateEntrancePaths();
                 return true;
             }
@@ -922,7 +905,7 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
      */
     void handleSensorChange(PropertyChangeEvent e) {
         Sensor s = getSensor();
-        if (e.getPropertyName().equals("KnownState") && s!=null) {
+        if ( "KnownState".equals( e.getPropertyName()) && s != null ) {
             int state = s.getState();
             switch (state) {
                 case Sensor.ACTIVE:
@@ -957,8 +940,8 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
      * @param e PropertyChangeEvent
      */
     void handleReporterChange(PropertyChangeEvent e) {
-        if ((_reportingCurrent && e.getPropertyName().equals("currentReport"))
-                || (!_reportingCurrent && e.getPropertyName().equals("lastReport"))) {
+        if ((_reportingCurrent && "currentReport".equals(e.getPropertyName()))
+            || (!_reportingCurrent && "lastReport".equals(e.getPropertyName()))) {
             setValue(e.getNewValue());
         }
     }
@@ -982,7 +965,7 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
         _timeLastInactive = Instant.now();
     }
 
-    private final int maxInfoMessages = 5;
+    private static final int MAXINFOMESSAGES = 5;
     private int infoMessageCount = 0;
 
     /**
@@ -1030,23 +1013,31 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
                     // 1. the block has been 'unoccupied' only very briefly
                     // 2. power has just come back on
                     Instant tn = Instant.now();
-                    BlockManager bm = jmri.InstanceManager.getDefault(jmri.BlockManager.class);
-                    if (bm.timeSinceLastLayoutPowerOn() < 5000 || (_timeLastInactive != null && tn.toEpochMilli() - _timeLastInactive.toEpochMilli() < 2000)) {
+                    BlockManager bm = InstanceManager.getDefault(BlockManager.class);
+                    if ( bm.timeSinceLastLayoutPowerOn() < 5000 ||
+                        (_timeLastInactive != null && tn.toEpochMilli() - _timeLastInactive.toEpochMilli() < 2000)) {
                         setValue(_previousValue);
-                        if (infoMessageCount < maxInfoMessages) {
-                            log.debug("Sensor ACTIVE came out of nowhere, no neighbors active for block {}. Restoring previous value.", getDisplayName());
+                        if (infoMessageCount < MAXINFOMESSAGES) {
+                            log.debug("Sensor ACTIVE came out of nowhere, no neighbors active for block {}."
+                                +" Restoring previous value.", getDisplayName());
                             infoMessageCount++;
                         }
                     } else if (log.isDebugEnabled()) {
                         if (null != _timeLastInactive) {
-                            log.debug("not restoring previous value, block {} has been inactive for too long ({}ms) and layout power has not just been restored ({}ms ago)", getDisplayName(), tn.toEpochMilli() - _timeLastInactive.toEpochMilli(), bm.timeSinceLastLayoutPowerOn());
+                            log.debug("not restoring previous value, block {} has been inactive for too long ({}ms)"
+                                + " and layout power has not just been restored ({}ms ago)",
+                                getDisplayName(), tn.toEpochMilli() - _timeLastInactive.toEpochMilli(),
+                                bm.timeSinceLastLayoutPowerOn());
                         } else {
-                            log.debug("not restoring previous value, block {} has been inactive since the start of this session and layout power has not just been restored ({}ms ago)", getDisplayName(), bm.timeSinceLastLayoutPowerOn());
+                            log.debug("not restoring previous value, block {} has been inactive since the "
+                                + "start of this session and layout power has not just been restored ({}ms ago)",
+                                getDisplayName(), bm.timeSinceLastLayoutPowerOn());
                         }
                     }
                 } else {
-                    if (infoMessageCount < maxInfoMessages) {
-                        log.debug("Sensor ACTIVE came out of nowhere, no neighbors active for block {}. Value not set.", getDisplayName());
+                    if (infoMessageCount < MAXINFOMESSAGES) {
+                        log.debug("Sensor ACTIVE came out of nowhere, no neighbors active for block {}. Value not set.",
+                            getDisplayName());
                         infoMessageCount++;
                     }
                 }
@@ -1074,7 +1065,8 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
                 log.debug("Block {} has {} active linked blocks, comparing directions", getDisplayName(), count);
                 next = null;
                 count = 0;
-                boolean allNeighborsAgree = true;  // true until it's found that some neighbor blocks contain different contents (trains)
+                // true until it's found that some neighbor blocks contain different contents (trains)
+                boolean allNeighborsAgree = true;
 
                 // scan for neighbors without matching direction
                 for (int i = 0; i < currPathCnt; i++) {
@@ -1082,10 +1074,13 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
                         log.debug("comparing {} ({}) to {} ({})",
                                 pList[i].getBlock().getDisplayName(), Path.decodeDirection(pDir[i]),
                                 getDisplayName(), Path.decodeDirection(pFromDir[i]));
-                        if ((pDir[i] & pFromDir[i]) > 0) { //use bitwise comparison to support combination directions such as "North, West"
-                            if (next != null && next.getBlock() != null && next.getBlock().getValue() != null &&
-                                    ! next.getBlock().getValue().equals(pList[i].getBlock().getValue())) {
-                                allNeighborsAgree = false;
+                        //use bitwise comparison to support combination directions such as "North, West"
+                        if ((pDir[i] & pFromDir[i]) > 0) {
+                            if (next != null  && next.getBlock() != null ) {
+                                Object value = next.getBlock().getValue();
+                                if ( value != null && !value.equals(pList[i].getBlock().getValue())) {
+                                    allNeighborsAgree = false;
+                                }
                             }
                             count++;
                             next = pList[i];
@@ -1098,9 +1093,11 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
                 if (next == null) {
                     for (int i = 0; i < currPathCnt; i++) {
                         if (isSet[i] && isActive[i]) {
-                            if (next != null && next.getBlock() != null && next.getBlock().getValue() != null &&
-                                    ! next.getBlock().getValue().equals(pList[i].getBlock().getValue())) {
-                                allNeighborsAgree = false;
+                            if (next != null && next.getBlock() != null ) {
+                                Object value = next.getBlock().getValue();
+                                if ( value != null && ! value.equals(pList[i].getBlock().getValue())) {
+                                    allNeighborsAgree = false;
+                                }
                             }
                             count++;
                             next = pList[i];
@@ -1122,7 +1119,9 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
                         setDirection(next.getFromBlockDirection());
                     } else {
                     // don't all agree, so can't determine unique value
-                        log.warn("count of {} ACTIVE neighbors with proper direction can't be handled for block {} but maybe it can be determined when another block becomes free", count, getDisplayName());
+                        log.warn("count of {} ACTIVE neighbors with proper direction can't be handled for"
+                            + " block {} but maybe it can be determined when another block becomes free",
+                            count, getDisplayName());
                         pListOfPossibleEntrancePaths = new Path[currPathCnt];
                         cntOfPossibleEntrancePaths = 0;
                         for (int i = 0; i < currPathCnt; i++) {
@@ -1147,6 +1146,7 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
      *
      * @return the next path
      */
+    @CheckForNull
     public Path findFromPath() {
         // index through the paths, counting
         int count = 0;
@@ -1189,7 +1189,8 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
                     log.debug("comparing {} ({}) to {} ({})",
                             pList[i].getBlock().getDisplayName(), Path.decodeDirection(pDir[i]),
                             getDisplayName(), Path.decodeDirection(pFromDir[i]));
-                    if ((pDir[i] & pFromDir[i]) > 0) { //use bitwise comparison to support combination directions such as "North, West"
+                    // Use bitwise comparison to support combination directions such as "North, West"
+                    if ((pDir[i] & pFromDir[i]) > 0) {
                         count++;
                         next = pList[i];
                     }
@@ -1202,14 +1203,17 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
                 // found one block with proper direction, assume that
             } else {
                 // no unique path with correct direction - this happens frequently from noise in block detectors!!
-                log.warn("count of {} ACTIVE neighbors with proper direction can't be handled for block {}", count, getDisplayName());
+                log.warn("count of {} ACTIVE neighbors with proper direction can't be handled for block {}",
+                    count, getDisplayName());
             }
         }
         // in any case, go OCCUPIED
         if (log.isDebugEnabled()) { // avoid potentially expensive non-logging
-            log.debug("Block {} with direction {} gets new value from {} + (informational. No state change)", getDisplayName(), Path.decodeDirection(getDirection()), (next != null ? next.getBlock().getDisplayName() : "(no next block)"));
+            log.debug("Block {} with direction {} gets new value from {} + (informational. No state change)",
+                getDisplayName(), Path.decodeDirection(getDirection()),
+                (next != null ? next.getBlock().getDisplayName() : "(no next block)"));
         }
-        return (next);
+        return next;
     }
 
     /**
@@ -1245,22 +1249,24 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
         // Defer parsing to our associated Reporter if we can.
         if (rep == null) {
             log.warn("String input is null!");
-            return (null);
+            return null;
         }
-        if ((this.getReporter() != null) && (this.getReporter() instanceof PhysicalLocationReporter)) {
-            return (((PhysicalLocationReporter) this.getReporter()).getLocoAddress(rep));
+        Reporter testReporter = this.getReporter();
+        if ( testReporter instanceof PhysicalLocationReporter ) {
+            return ((PhysicalLocationReporter)testReporter).getLocoAddress(rep);
         } else {
             // Assume a LocoNet-style report.  This is (nascent) support for handling of Faller cars
             // for Dave Merrill's project.
             log.debug("report string: {}", rep);
             // NOTE: This pattern is based on the one defined in LocoNet-specific LnReporter
-            Pattern ln_p = Pattern.compile("(\\d+) (enter|exits|seen)\\s*(northbound|southbound)?");  // Match a number followed by the word "enter".  This is the LocoNet pattern.
-            Matcher m = ln_p.matcher(rep);
+            // Match a number followed by the word "enter".  This is the LocoNet pattern.
+            Pattern lnp = Pattern.compile("(\\d+) (enter|exits|seen)\\s*(northbound|southbound)?");
+            Matcher m = lnp.matcher(rep);
             if (m.find()) {
                 log.debug("Parsed address: {}", m.group(1));
-                return (new DccLocoAddress(Integer.parseInt(m.group(1)), LocoAddress.Protocol.DCC));
+                return new DccLocoAddress(Integer.parseInt(m.group(1)), LocoAddress.Protocol.DCC);
             } else {
-                return (null);
+                return null;
             }
         }
     }
@@ -1283,27 +1289,29 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
             return (null);
         }
         // Defer parsing to our associated Reporter if we can.
-        if ((this.getReporter() != null) && (this.getReporter() instanceof PhysicalLocationReporter)) {
-            return (((PhysicalLocationReporter) this.getReporter()).getDirection(rep));
+        Reporter testReporter = this.getReporter();
+        if ( testReporter instanceof PhysicalLocationReporter ) {
+            return ((PhysicalLocationReporter)testReporter).getDirection(rep);
         } else {
             log.debug("report string: {}", rep);
             // NOTE: This pattern is based on the one defined in LocoNet-specific LnReporter
-            Pattern ln_p = Pattern.compile("(\\d+) (enter|exits|seen)\\s*(northbound|southbound)?");  // Match a number followed by the word "enter".  This is the LocoNet pattern.
-            Matcher m = ln_p.matcher(rep);
+            // Match a number followed by the word "enter".  This is the LocoNet pattern.
+            Pattern lnp = Pattern.compile("(\\d+) (enter|exits|seen)\\s*(northbound|southbound)?");
+            Matcher m = lnp.matcher(rep);
             if (m.find()) {
                 log.debug("Parsed direction: {}", m.group(2));
                 switch (m.group(2)) {
                     case "enter":
                         // LocoNet Enter message
-                        return (PhysicalLocationReporter.Direction.ENTER);
+                        return PhysicalLocationReporter.Direction.ENTER;
                     case "seen":
                         // Lissy message.  Treat them all as "entry" messages.
-                        return (PhysicalLocationReporter.Direction.ENTER);
+                        return PhysicalLocationReporter.Direction.ENTER;
                     default:
-                        return (PhysicalLocationReporter.Direction.EXIT);
+                        return PhysicalLocationReporter.Direction.EXIT;
                 }
             } else {
-                return (PhysicalLocationReporter.Direction.UNKNOWN);
+                return PhysicalLocationReporter.Direction.UNKNOWN;
             }
         }
     }
@@ -1317,7 +1325,7 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
     @Override
     public PhysicalLocation getPhysicalLocation() {
         // We have our won PhysicalLocation. That's the point.  No need to defer to the Reporter.
-        return (PhysicalLocation.getBeanPhysicalLocation(this));
+        return PhysicalLocation.getBeanPhysicalLocation(this);
     }
 
     /**
@@ -1332,32 +1340,28 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
     public PhysicalLocation getPhysicalLocation(String s) {
         // We have our won PhysicalLocation. That's the point.  No need to defer to the Reporter.
         // Intentionally ignore the String s
-        return (PhysicalLocation.getBeanPhysicalLocation(this));
+        return PhysicalLocation.getBeanPhysicalLocation(this);
     }
 
     @Override
     public void vetoableChange(PropertyChangeEvent evt) throws PropertyVetoException {
         if ("CanDelete".equals(evt.getPropertyName())) { // No I18N
-            if (evt.getOldValue() instanceof Sensor) {
-                if (evt.getOldValue().equals(getSensor())) {
-                    throw new PropertyVetoException(getDisplayName(), evt);
-                }
+            if (evt.getOldValue() instanceof Sensor
+                && evt.getOldValue().equals(getSensor())) {
+                throw new PropertyVetoException(getDisplayName(), evt);
             }
-            if (evt.getOldValue() instanceof Reporter) {
-                if (evt.getOldValue().equals(getReporter())) {
-                    throw new PropertyVetoException(getDisplayName(), evt);
-                }
+            if (evt.getOldValue() instanceof Reporter
+                && evt.getOldValue().equals(getReporter())) {
+                throw new PropertyVetoException(getDisplayName(), evt);
             }
         } else if ("DoDelete".equals(evt.getPropertyName())) { // No I18N
-            if (evt.getOldValue() instanceof Sensor) {
-                if (evt.getOldValue().equals(getSensor())) {
-                    setSensor(null);
-                }
+            if (evt.getOldValue() instanceof Sensor
+                && evt.getOldValue().equals(getSensor())) {
+                setSensor(null);
             }
-            if (evt.getOldValue() instanceof Reporter) {
-                if (evt.getOldValue().equals(getReporter())) {
-                    setReporter(null);
-                }
+            if (evt.getOldValue() instanceof Reporter
+                && evt.getOldValue().equals(getReporter())) {
+                setReporter(null);
             }
         }
     }
@@ -1373,11 +1377,11 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
                 report.add(new NamedBeanUsageReport("BlockReporter"));  // NOI18N
             }
             // Block paths
-            getPaths().forEach((path) -> {
+            getPaths().forEach( path -> {
                 if (bean.equals(path.getBlock())) {
                     report.add(new NamedBeanUsageReport("BlockPathNeighbor"));  // NOI18N
                 }
-                path.getSettings().forEach((setting) -> {
+                path.getSettings().forEach( setting -> {
                     if (bean.equals(setting.getBean())) {
                         report.add(new NamedBeanUsageReport("BlockPathTurnout"));  // NOI18N
                     }
@@ -1392,5 +1396,21 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
         return Bundle.getMessage("BeanNameBlock");
     }
 
-    private final static Logger log = LoggerFactory.getLogger(Block.class);
+    /** {@inheritDoc} */
+    @Override
+    @Nonnull
+    public String describeState(int state) {
+        switch (state) {
+            case Block.OCCUPIED:
+                return Bundle.getMessage("BlockOccupied");
+            case Block.UNOCCUPIED:
+                return Bundle.getMessage("BlockUnOccupied");
+            case Block.UNDETECTED:
+                return Bundle.getMessage("BlockUndetected");
+            default:  // state unknown, state inconsistent, state unexpected
+                return super.describeState(state);
+        }
+    }
+
+    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(Block.class);
 }

--- a/java/src/jmri/BlockManager.java
+++ b/java/src/jmri/BlockManager.java
@@ -35,7 +35,8 @@ import jmri.managers.AbstractManager;
  *
  * @author Bob Jacobsen Copyright (C) 2006
  */
-public class BlockManager extends AbstractManager<Block> implements ProvidingManager<Block>, InstanceManagerAutoDefault {
+public class BlockManager extends AbstractManager<Block>
+    implements ProvidingManager<Block>, InstanceManagerAutoDefault {
 
     private final String powerManagerChangeName;
     public final ShutDownTask shutDownTask = new AbstractShutDownTask("Writing Blocks") {
@@ -51,16 +52,20 @@ public class BlockManager extends AbstractManager<Block> implements ProvidingMan
 
     public BlockManager() {
         super();
-        InstanceManager.getDefault(SensorManager.class).addVetoableChangeListener(this);
-        InstanceManager.getDefault(ReporterManager.class).addVetoableChangeListener(this);
-        InstanceManager.getList(PowerManager.class).forEach(pm -> pm.addPropertyChangeListener(this));
+        InstanceManager.getDefault(SensorManager.class).addVetoableChangeListener(BlockManager.this);
+        InstanceManager.getDefault(ReporterManager.class).addVetoableChangeListener(BlockManager.this);
+        InstanceManager.getList(PowerManager.class).forEach(pm -> pm.addPropertyChangeListener(BlockManager.this));
         powerManagerChangeName = InstanceManager.getListPropertyName(PowerManager.class);
-        InstanceManager.addPropertyChangeListener(this);
+        InstanceManager.addPropertyChangeListener(BlockManager.this);
         InstanceManager.getDefault(ShutDownManager.class).register(shutDownTask);
     }
 
     @Override
     public void dispose() {
+        InstanceManager.getDefault(SensorManager.class).removeVetoableChangeListener(this);
+        InstanceManager.getDefault(ReporterManager.class).removeVetoableChangeListener(this);
+        InstanceManager.getList(PowerManager.class).forEach(pm -> pm.removePropertyChangeListener(this));
+        InstanceManager.removePropertyChangeListener(this);
         super.dispose();
         InstanceManager.getDefault(ShutDownManager.class).deregister(shutDownTask);
     }
@@ -202,12 +207,13 @@ public class BlockManager extends AbstractManager<Block> implements ProvidingMan
             retv = this.getBySystemName(key);
         }
         // If it's not in the system list, go ahead and return null
-        return (retv);
+        return retv;
     }
 
     private String defaultSpeed = "Normal";
 
     /**
+     * Set the Default Block Speed.
      * @param speed the speed
      * @throws IllegalArgumentException if provided speed is invalid
      */
@@ -217,12 +223,13 @@ public class BlockManager extends AbstractManager<Block> implements ProvidingMan
         }
 
         try {
-            Float.parseFloat(speed);
+            Float.valueOf(speed);
         } catch (NumberFormatException nx) {
             try {
                 InstanceManager.getDefault(SignalSpeedMap.class).getSpeed(speed);
             } catch (IllegalArgumentException ex) {
-                throw new IllegalArgumentException("Value of requested default block speed \"" + speed + "\" is not valid", ex);
+                throw new IllegalArgumentException("Value of requested default block speed \""
+                    + speed + "\" is not valid", ex);
             }
         }
         String oldSpeed = defaultSpeed;
@@ -259,9 +266,7 @@ public class BlockManager extends AbstractManager<Block> implements ProvidingMan
         getNamedBeanSet().stream().forEach(b -> {
             if (b != null) {
                 Object obj = b.getValue();
-                if ((obj instanceof BasicRosterEntry && obj == re) ||
-                        obj.toString().equals(re.getId()) ||
-                        obj.toString().equals(re.getDccAddress())) {
+                if ( obj != null && blockValueEqualsRosterEntry(obj, re)) {
                     blockList.add(b);
                 }
             }
@@ -269,6 +274,11 @@ public class BlockManager extends AbstractManager<Block> implements ProvidingMan
         return blockList;
     }
 
+    private boolean blockValueEqualsRosterEntry( @Nonnull Object obj, @Nonnull BasicRosterEntry re ){
+        return ( obj instanceof BasicRosterEntry && obj == re) ||
+            obj.toString().equals(re.getId()) ||
+            obj.toString().equals(re.getDccAddress());
+    }
 
     private Instant lastTimeLayoutPowerOn; // the most recent time any power manager had a power ON event
 
@@ -282,14 +292,13 @@ public class BlockManager extends AbstractManager<Block> implements ProvidingMan
      *
      * @param e the change event
      */
-
     @Override
     public void propertyChange(PropertyChangeEvent e) {
         super.propertyChange(e);
-        if (jmri.PowerManager.POWER.equals(e.getPropertyName())) {
+        if ( PowerManager.POWER.equals(e.getPropertyName())) {
             try {
                 PowerManager pm = (PowerManager) e.getSource();
-                if (pm.getPower() == jmri.PowerManager.ON) {
+                if (pm.getPower() == PowerManager.ON) {
                     lastTimeLayoutPowerOn = Instant.now();
                 }
             } catch (NoSuchMethodError xe) {

--- a/java/src/jmri/NamedBeanBundle.properties
+++ b/java/src/jmri/NamedBeanBundle.properties
@@ -165,6 +165,12 @@ SignalHeadStateHeld              = Held
 SignalMastStateLit               = Lit
 SignalMastStateHeld              = Held
 
+# Block
+BlockOccupied                    = Occupied
+BlockUnOccupied                  = UnOccupied
+BlockUndetected                  = Undetected
+
+# OBlock
 TrackClear                       = Clear
 TrackOccupied                    = Occupied
 TrackAllocated                   = Allocated

--- a/java/src/jmri/NamedBeanBundle_ca.properties
+++ b/java/src/jmri/NamedBeanBundle_ca.properties
@@ -116,6 +116,11 @@ SignalHeadStateHeld     = Bloquejada
 SignalMastStateLit      = Enc\u00e8s
 SignalMastStateHeld     = Bloquejat
 
+# Block
+BlockOccupied           = Ocupat
+BlockUnOccupied         = Desocupat
+
+# OBlock
 TrackClear              = Lliure
 TrackOccupied           = Ocupada
 TrackAllocated          = Assigna

--- a/java/src/jmri/NamedBeanBundle_cs.properties
+++ b/java/src/jmri/NamedBeanBundle_cs.properties
@@ -165,6 +165,11 @@ SignalHeadStateHeld = Zadr\u017een\u00fd
 SignalMastStateLit  = Osv\u011btlen\u00fd
 SignalMastStateHeld = Zadr\u017een\u00fd
 
+# Block
+BlockOccupied       = Obsazen\u00fd
+BlockUnOccupied     = Voln\u00fd
+
+# OBlock
 TrackClear          = Voln\u00fd
 TrackOccupied       = Obsazen\u00fd
 TrackAllocated      = P\u0159id\u011blen\u00fd

--- a/java/src/jmri/NamedBeanBundle_da.properties
+++ b/java/src/jmri/NamedBeanBundle_da.properties
@@ -114,6 +114,11 @@ SignalHeadStateHeld = Stop
 SignalMastStateLit      = Lyser
 SignalMastStateHeld     = Stop
 
+# Block
+BlockOccupied           = Optaget
+BlockUnOccupied         = Ikke Optaget
+
+# OBlock
 TrackClear = Klar
 TrackOccupied = Optaget
 TrackAllocated = Allokeret

--- a/java/src/jmri/NamedBeanBundle_de.properties
+++ b/java/src/jmri/NamedBeanBundle_de.properties
@@ -94,6 +94,11 @@ SignalHeadStateHeld = Gehalten
 SignalMastStateLit      = Erleuchtet
 SignalMastStateHeld     = Gehalten
 
+# Block
+BlockOccupied           = Besetzt
+BlockUnOccupied         = Unbesetzt
+
+# OBlock
 TrackClear      = Frei
 TrackOccupied   = Besetzt
 TrackAllocated  = Zugewiesen

--- a/java/src/jmri/NamedBeanBundle_es.properties
+++ b/java/src/jmri/NamedBeanBundle_es.properties
@@ -159,6 +159,11 @@ SignalHeadStateHeld              = Bloqueada
 SignalMastStateLit               = Encendida
 SignalMastStateHeld              = Bloqueada
 
+# Block
+BlockOccupied                    = Ocupado
+BlockUnOccupied                  = Desocupado
+
+# OBlock
 TrackClear                       = Clear
 TrackOccupied                    = Occupied
 TrackAllocated                   = Allocated

--- a/java/src/jmri/NamedBeanBundle_fr.properties
+++ b/java/src/jmri/NamedBeanBundle_fr.properties
@@ -122,6 +122,11 @@ SignalHeadStateHeld     = Maintenue
 SignalMastStateLit      = Allum\u00e9
 SignalMastStateHeld     = Maintenu
 
+# Block
+BlockOccupied           = Occup\u00e9
+BlockUnOccupied         = Inoccup\u00e9
+
+# OBlock
 TrackClear              = Libre
 TrackOccupied           = Occup\u00e9e
 TrackAllocated          = Allou\u00e9e

--- a/java/src/jmri/NamedBeanBundle_it.properties
+++ b/java/src/jmri/NamedBeanBundle_it.properties
@@ -93,6 +93,11 @@ SignalHeadStateHeld = Bloccata
 SignalMastStateLit  = Acceso
 SignalMastStateHeld = Bloccato
 
+# Block
+BlockOccupied       = Occupato
+BlockUnOccupied     = Libero
+
+# OBlock
 TrackClear          = Libero
 TrackOccupied       = Occupato
 TrackAllocated      = Allocato

--- a/java/src/jmri/NamedBeanBundle_nl.properties
+++ b/java/src/jmri/NamedBeanBundle_nl.properties
@@ -166,6 +166,11 @@ SignalHeadStateHeld     = Aangehouden
 SignalMastStateLit      = Verlicht
 SignalMastStateHeld     = Aangehouden
 
+# Block
+BlockOccupied           = Bezet
+BlockUnOccupied         = Vrij
+
+# OBlock
 TrackClear              = Vrij
 TrackOccupied           = Bezet
 TrackAllocated          = Toegewezen

--- a/java/test/jmri/BlockTest.java
+++ b/java/test/jmri/BlockTest.java
@@ -746,7 +746,19 @@ public class BlockTest {
         Assert.assertEquals("new value", 20.0f, (float)listen.getNewValue(1),0.01);
         
     }
-    
+
+    @Test
+    public void testDescribeState() {
+        Block t = new Block("testDescribeState");
+        Assertions.assertEquals("Unknown", t.describeState(Block.UNKNOWN));
+        Assertions.assertEquals("Inconsistent", t.describeState(Block.INCONSISTENT));
+        Assertions.assertEquals("Occupied", t.describeState(Block.OCCUPIED));
+        Assertions.assertEquals("UnOccupied", t.describeState(Block.UNOCCUPIED));
+        Assertions.assertEquals("Undetected", t.describeState(Block.UNDETECTED));
+        Assertions.assertEquals("Unexpected value: 777", t.describeState(777));
+        t.dispose();
+    }
+
     /**
      * Class to log Property Changes.
      */


### PR DESCRIPTION
**Block**
Multiple minor lints.
Implements `public String describeState(int state)`.
Adds CheckForNull annotations.

Adds Block status strings to NamedBean Bundle.
The translations are from BeanTableBundle and will likely be removed from that location in a future PR to avoid duplication.

**BlockManager**
General linting.
Improved nullcheck Block.getValue.
Removes property change listeners on dispose.