### PR TITLE
fix Label in Set Signal Heads at 3-Way Turnout

### DIFF
--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorTools.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorTools.java
@@ -6339,7 +6339,7 @@ final public class LayoutEditorTools {
 
             JPanel panel31 = new JPanel(new FlowLayout());
             panel31.add(new JLabel(Bundle.getMessage("MakeLabel",
-                    divergingBString)));
+                    divergingAString)));
             panel31.add(b_3WaySignalHeadComboBox);
             b_3WaySignalHeadComboBox.setToolTipText(Bundle.getMessage("SignalHeadNameHint"));
             theContentPane.add(panel31);


### PR DESCRIPTION
Uses correct String on Label.
See https://jmri-developers.groups.io/g/jmri/message/10703 and https://groups.io/g/jmriusers/message/238072

![image](https://github.com/user-attachments/assets/b887e679-f427-4d74-8931-7542ec16e006)
