### PR TITLE
SE8C SignalHead duplicate system name notification

### DIFF
--- a/java/src/jmri/jmrit/beantable/BeanTableBundle.properties
+++ b/java/src/jmri/jmrit/beantable/BeanTableBundle.properties
@@ -256,11 +256,13 @@ WarningEdit                          = Please finish editing "{0}" before editin
 WarnExcessBeans                      = You are about to add {1} {0} into the configuration.\nAre you sure?
 
 DuplicateSignalSystemName            = Cannot add because "{0}" already exists. To replace an existing Signal Head, delete it first.
+ErrorReplaceHead                     = To replace an existing Signal Head, delete it first.
 GrapevineSkippingCreation            = Skipping creation of Grapevine signal head because "{0}" does not start with prefix + ''H''.
 se8c4SkippingCreation                = Skipping creation of SE8C 4 Aspect Signal Head because "{0}" is neither a number nor a valid Turnout name.
 se8c4SkippingDueToErrorInFirst       = Skipping creation of SE8C Signal Head because the first Turnout selection isn't valid.
 se8c4SkippingDueToErrorInSecond      = Skipping creation of SE8C Signal Head because the second Turnout selection isn't valid.
 ErrorSe8cAddFailed                   = Could not create SE8C Signal Head with User Name "{0}" (Turnout 1: "{1}", Turnout 2: "{2}")
+ErrorSe8cDuplicateSysName            = Cannot add because "{0}" and "{1}" are already in use by an SE8c Signal Head.
 acelaSkippingCreation                = Skipping creation of Acela Signal Head because "{0}" is not a number or does not start with prefix + ''AH''.
 acelaNoNodeFound                     = Unable to create {0}, no Acela Node found for address {1}.
 signalHeadEntryWarning               = Enter a number in the Signal Head ID field.\nIt can not be empty.

--- a/java/src/jmri/jmrit/beantable/SignalHeadAddEditFrame.java
+++ b/java/src/jmri/jmrit/beantable/SignalHeadAddEditFrame.java
@@ -1602,9 +1602,10 @@ public class SignalHeadAddEditFrame extends JmriJFrame {
                 InstanceManager.getDefault(SignalHeadManager.class).register(s);
             } catch ( jmri.NamedBean.DuplicateSystemNameException ex) {
                 s.dispose();
-                JmriJOptionPane.showMessageDialog(this,
-                    "<html>" + Bundle.getMessage("DuplicateSignalSystemName", s.getDisplayName())
-                        + "<br>" + ex.getLocalizedMessage()+"</html>",
+                JmriJOptionPane.showMessageDialog(this,"<html>"
+                    + Bundle.getMessage("ErrorSe8cDuplicateSysName", t1.getDisplayName(), t2.getDisplayName())
+                    + "<br>" + Bundle.getMessage("ErrorReplaceHead")
+                    + "<br>" + ex.getLocalizedMessage() + "</html>",
                     Bundle.getMessage("WarningTitle"), JmriJOptionPane.ERROR_MESSAGE);
             }
         } else {

--- a/java/src/jmri/jmrit/beantable/SignalHeadAddEditFrame.java
+++ b/java/src/jmri/jmrit/beantable/SignalHeadAddEditFrame.java
@@ -1598,7 +1598,12 @@ public class SignalHeadAddEditFrame extends JmriJFrame {
                         t2.getSystemName(), userNameField.getText());
                 return; // without creating any
             }
-            InstanceManager.getDefault(SignalHeadManager.class).register(s);
+            try {
+                InstanceManager.getDefault(SignalHeadManager.class).register(s);
+            } catch ( jmri.NamedBean.DuplicateSystemNameException ex) {
+                s.dispose();
+                handleCreateException(ex, s.getSystemName());
+            }
         } else {
             // couldn't create turnouts, error
             String msg;

--- a/java/src/jmri/jmrit/beantable/SignalHeadAddEditFrame.java
+++ b/java/src/jmri/jmrit/beantable/SignalHeadAddEditFrame.java
@@ -1603,7 +1603,7 @@ public class SignalHeadAddEditFrame extends JmriJFrame {
             } catch ( jmri.NamedBean.DuplicateSystemNameException ex) {
                 s.dispose();
                 JmriJOptionPane.showMessageDialog(this,
-                        "<html>" + Bundle.getMessage("DuplicateSignalSystemName", s.getDisplayName())
+                    "<html>" + Bundle.getMessage("DuplicateSignalSystemName", s.getDisplayName())
                         + "<br>" + ex.getLocalizedMessage()+"</html>",
                     Bundle.getMessage("WarningTitle"), JmriJOptionPane.ERROR_MESSAGE);
             }

--- a/java/src/jmri/jmrit/beantable/SignalHeadAddEditFrame.java
+++ b/java/src/jmri/jmrit/beantable/SignalHeadAddEditFrame.java
@@ -1602,7 +1602,10 @@ public class SignalHeadAddEditFrame extends JmriJFrame {
                 InstanceManager.getDefault(SignalHeadManager.class).register(s);
             } catch ( jmri.NamedBean.DuplicateSystemNameException ex) {
                 s.dispose();
-                handleCreateException(ex, s.getSystemName());
+                JmriJOptionPane.showMessageDialog(this,
+                        "<html>" + Bundle.getMessage("DuplicateSignalSystemName", s.getDisplayName())
+                        + "<br>" + ex.getLocalizedMessage()+"</html>",
+                    Bundle.getMessage("WarningTitle"), JmriJOptionPane.ERROR_MESSAGE);
             }
         } else {
             // couldn't create turnouts, error

--- a/java/test/jmri/jmrit/beantable/SignalHeadAddEditFrameTest.java
+++ b/java/test/jmri/jmrit/beantable/SignalHeadAddEditFrameTest.java
@@ -16,7 +16,6 @@ import jmri.util.ThreadingUtil;
 import jmri.util.swing.JemmyUtil;
 
 import org.junit.jupiter.api.*;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import org.netbeans.jemmy.operators.*;
 
@@ -24,7 +23,7 @@ import org.netbeans.jemmy.operators.*;
  * Tests for SignalHeadAddEditFrame
  * @author Steve Young Copyright (C) 2023
  */
-@DisabledIfSystemProperty(named = "java.awt.headless", matches = "true")
+@jmri.util.junit.annotations.DisabledIfHeadless
 public class SignalHeadAddEditFrameTest extends jmri.util.JmriJFrameTestBase {
 
     @Test
@@ -431,7 +430,8 @@ public class SignalHeadAddEditFrameTest extends jmri.util.JmriJFrameTestBase {
 
       //  new JTextFieldOperator((JTextField) new JLabelOperator(jfo,Bundle.getMessage("LabelSystemName"))
       //      .getLabelFor()).setText("IH123");
-      
+
+        new JTextFieldOperator(jfo, 0).setText("My se8c UserName");
         new JTextFieldOperator(jfo, 1).setText("11");
         new JTextFieldOperator(jfo, 2).setText("12");
         
@@ -445,9 +445,47 @@ public class SignalHeadAddEditFrameTest extends jmri.util.JmriJFrameTestBase {
         SignalHead newHead = InstanceManager.getDefault(SignalHeadManager.class).getBySystemName("IH:SE8c:\"IT11\";\"IT12\"");
         Assertions.assertNotNull(newHead);
         Assertions.assertInstanceOf(jmri.implementation.SE8cSignalHead.class, newHead);
+        Assertions.assertEquals( "My se8c UserName", newHead.getUserName());
 
         new JButtonOperator(jfo,Bundle.getMessage("ButtonCancel")).push();
         jfo.waitClosed();
+
+
+        // again but fail to create duplicate
+        frame = new SignalHeadAddEditFrame(null);
+        ThreadingUtil.runOnGUI(() -> {
+            frame.initComponents();
+        });
+
+        jfo = new JFrameOperator( frame.getTitle() );
+        typeOperator = new JComboBoxOperator(jfo, 0);
+        typeOperator.selectItem(Bundle.getMessage("StringSE8c4aspect"));
+        typeOperator.getQueueTool().waitEmpty();
+
+        new JTextFieldOperator(jfo, 0).setText("My se8c UserName 2");
+        JComboBoxOperator it1 = new JComboBoxOperator(jfo, 1);
+        it1.setSelectedIndex(1);
+        it1.getQueueTool().waitEmpty();
+
+        JComboBoxOperator it2 = new JComboBoxOperator(jfo, 2);
+        it2.setSelectedIndex(2);
+        it2.getQueueTool().waitEmpty();
+
+        Thread t = ThreadingUtil.newThread( () -> {
+            // constructor for jdo will wait until the dialog is visible
+            JDialogOperator jdo = new JDialogOperator(Bundle.getMessage("WarningTitle"));
+            jdo.requestClose();
+            jdo.waitClosed();
+        }, "Warning Dialog Close Thread");
+        t.start();
+
+        new JButtonOperator(jfo,Bundle.getMessage("ButtonCreate")).push();
+        jfo.getQueueTool().waitEmpty();
+        JUnitUtil.waitFor(() -> !t.isAlive(), "warning dialog closed");
+
+        Assertions.assertEquals(1, InstanceManager.getDefault(SignalHeadManager.class).getNamedBeanSet().size());
+        Assertions.assertEquals(2, InstanceManager.getDefault(TurnoutManager.class).getNamedBeanSet().size());
+        JUnitAppender.assertErrorMessage("systemName is already registered: IH:SE8c:\"IT11\";\"IT12\"");
 
 
         frame = new SignalHeadAddEditFrame(newHead);


### PR DESCRIPTION
Improved user notification on SE8C SignalHead duplicate system name.
fixes #13659 

![image](https://github.com/user-attachments/assets/05525ad9-b3bd-4944-811a-6d4020f345f0)
