### PR TITLE
Add LogixNG expression StringIO

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -463,6 +463,8 @@
     <h3>LogixNG</h3>
         <a id="LogixNG" name="LogixNG"></a>
         <ul>
+          <li>The expression <strong>StringIO as string value</strong>
+              has been added.</li>
           <li></li>
         </ul>
 

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionBundle.properties
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionBundle.properties
@@ -341,6 +341,9 @@ StringExpressionMemory_Short        = Memory as string value
 StringExpressionMemory_Long         = Get memory {0} as string value
 # Memory_MemoryInUseMemoryExpressionVeto  = Memory is in use by Memory expression "{0}"
 
+StringExpressionStringIO_Short       = StringIO as string value
+StringExpressionStringIO_Long        = Get StringIO {0} as string value
+
 TimeSinceMidnight_Short             = Minutes since midnight
 TimeSinceMidnight_Long_SystemClock  = Minutes since midnight system clock
 TimeSinceMidnight_Long_FastClock    = Minutes since midnight by fast clock

--- a/java/src/jmri/jmrit/logixng/expressions/StringExpressionStringIO.java
+++ b/java/src/jmri/jmrit/logixng/expressions/StringExpressionStringIO.java
@@ -1,0 +1,131 @@
+package jmri.jmrit.logixng.expressions;
+
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.util.*;
+
+import jmri.*;
+import jmri.jmrit.logixng.*;
+import jmri.jmrit.logixng.util.LogixNG_SelectNamedBean;
+
+/**
+ * Reads a StringIO.
+ *
+ * @author Daniel Bergqvist Copyright 2025
+ */
+public class StringExpressionStringIO extends AbstractStringExpression
+        implements PropertyChangeListener {
+
+    private final LogixNG_SelectNamedBean<StringIO> _selectNamedBean =
+            new LogixNG_SelectNamedBean<>(
+                    this, StringIO.class, InstanceManager.getDefault(StringIOManager.class), this);
+
+    public StringExpressionStringIO(String sys, String user)
+            throws BadUserNameException, BadSystemNameException {
+
+        super(sys, user);
+    }
+
+    @Override
+    public Base getDeepCopy(Map<String, String> systemNames, Map<String, String> userNames) throws JmriException {
+        StringExpressionManager manager = InstanceManager.getDefault(StringExpressionManager.class);
+        String sysName = systemNames.get(getSystemName());
+        String userName = userNames.get(getSystemName());
+        if (sysName == null) sysName = manager.getAutoSystemName();
+        StringExpressionStringIO copy = new StringExpressionStringIO(sysName, userName);
+        copy.setComment(getComment());
+        _selectNamedBean.copy(copy._selectNamedBean);
+        return manager.registerExpression(copy).deepCopyChildren(this, systemNames, userNames);
+    }
+
+    public LogixNG_SelectNamedBean<StringIO> getSelectNamedBean() {
+        return _selectNamedBean;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Category getCategory() {
+        return Category.ITEM;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String evaluate() throws JmriException {
+        StringIO stringIO = _selectNamedBean.evaluateNamedBean(getConditionalNG());
+        if (stringIO != null) {
+            return jmri.util.TypeConversionUtil.convertToString(stringIO.getKnownStringValue(), false);
+        } else {
+            return "";
+        }
+    }
+
+    @Override
+    public FemaleSocket getChild(int index)
+            throws IllegalArgumentException, UnsupportedOperationException {
+        throw new UnsupportedOperationException("Not supported.");
+    }
+
+    @Override
+    public int getChildCount() {
+        return 0;
+    }
+
+    @Override
+    public String getShortDescription(Locale locale) {
+        return Bundle.getMessage(locale, "StringExpressionStringIO_Short");
+    }
+
+    @Override
+    public String getLongDescription(Locale locale) {
+        return Bundle.getMessage(locale, "StringExpressionStringIO_Long", _selectNamedBean.getDescription(locale));
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void setup() {
+        // Do nothing
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void registerListenersForThisClass() {
+        if (!_listenersAreRegistered) {
+            _selectNamedBean.addPropertyChangeListener("KnownValue", this);
+            _selectNamedBean.registerListeners();
+            _listenersAreRegistered = true;
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void unregisterListenersForThisClass() {
+        if (_listenersAreRegistered) {
+            _selectNamedBean.removePropertyChangeListener("KnownValue", this);
+            _selectNamedBean.unregisterListeners();
+            _listenersAreRegistered = false;
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void propertyChange(PropertyChangeEvent evt) {
+        if (getTriggerOnChange()) {
+            getConditionalNG().execute();
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void disposeMe() {
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void getUsageDetail(int level, NamedBean bean, List<NamedBeanUsageReport> report, NamedBean cdl) {
+        log.debug("getUsageReport :: StringExpressionStringIO: bean = {}, report = {}", cdl, report);
+        _selectNamedBean.getUsageDetail(level, bean, report, cdl, this, LogixNG_SelectNamedBean.Type.Expression);
+    }
+
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(StringExpressionStringIO.class);
+
+}

--- a/java/src/jmri/jmrit/logixng/expressions/StringFactory.java
+++ b/java/src/jmri/jmrit/logixng/expressions/StringFactory.java
@@ -20,9 +20,10 @@ public class StringFactory implements StringExpressionFactory {
                 Set.of(
                         new AbstractMap.SimpleEntry<>(Category.ITEM, StringExpressionConstant.class),
                         new AbstractMap.SimpleEntry<>(Category.ITEM, StringExpressionMemory.class),
+                        new AbstractMap.SimpleEntry<>(Category.ITEM, StringExpressionStringIO.class),
                         new AbstractMap.SimpleEntry<>(Category.COMMON, StringFormula.class)
                 );
-        
+
         return stringExpressionClasses;
     }
 

--- a/java/src/jmri/jmrit/logixng/expressions/configurexml/StringExpressionStringIOXml.java
+++ b/java/src/jmri/jmrit/logixng/expressions/configurexml/StringExpressionStringIOXml.java
@@ -1,0 +1,62 @@
+package jmri.jmrit.logixng.expressions.configurexml;
+
+import jmri.*;
+import jmri.configurexml.JmriConfigureXmlException;
+import jmri.jmrit.logixng.StringExpressionManager;
+import jmri.jmrit.logixng.expressions.StringExpressionStringIO;
+import jmri.jmrit.logixng.util.configurexml.LogixNG_SelectNamedBeanXml;
+
+import org.jdom2.Element;
+
+/**
+ * Handle XML configuration for StringExpressionStringIO objects.
+ *
+ * @author Bob Jacobsen Copyright: Copyright (c) 2004, 2008, 2010
+ * @author Daniel Bergqvist Copyright (C) 2025
+ */
+public class StringExpressionStringIOXml extends jmri.managers.configurexml.AbstractNamedBeanManagerConfigXML {
+
+    public StringExpressionStringIOXml() {
+    }
+
+    /**
+     * Default implementation for storing the contents of a SE8cSignalHead
+     *
+     * @param o Object to store, of type TripleLightSignalHead
+     * @return Element containing the complete info
+     */
+    @Override
+    public Element store(Object o) {
+        StringExpressionStringIO p = (StringExpressionStringIO) o;
+
+        Element element = new Element("StringExpressionStringIO");
+        element.setAttribute("class", this.getClass().getName());
+        element.addContent(new Element("systemName").addContent(p.getSystemName()));
+
+        storeCommon(p, element);
+
+        var selectNamedBeanXml = new LogixNG_SelectNamedBeanXml<StringIO>();
+        element.addContent(selectNamedBeanXml.store(p.getSelectNamedBean(), "namedBean"));
+
+        return element;
+    }
+
+    @Override
+    public boolean load(Element shared, Element perNode) throws JmriConfigureXmlException {     // Test class that inherits this class throws exception
+        String sys = getSystemName(shared);
+        String uname = getUserName(shared);
+        StringExpressionStringIO h;
+        h = new StringExpressionStringIO(sys, uname);
+
+        loadCommon(h, shared);
+
+        var selectNamedBeanXml = new LogixNG_SelectNamedBeanXml<StringIO>();
+        selectNamedBeanXml.load(shared.getChild("namedBean"), h.getSelectNamedBean());
+        selectNamedBeanXml.loadLegacy(shared, h.getSelectNamedBean(), "stringIO", null, null, null, null);
+
+        InstanceManager.getDefault(StringExpressionManager.class).registerExpression(h);
+        return true;
+    }
+
+//    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(StringExpressionStringIOXml.class);
+}

--- a/java/src/jmri/jmrit/logixng/expressions/swing/StringExpressionStringIOSwing.java
+++ b/java/src/jmri/jmrit/logixng/expressions/swing/StringExpressionStringIOSwing.java
@@ -1,0 +1,86 @@
+package jmri.jmrit.logixng.expressions.swing;
+
+import java.util.List;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+
+import jmri.*;
+import jmri.jmrit.logixng.Base;
+import jmri.jmrit.logixng.StringExpressionManager;
+import jmri.jmrit.logixng.MaleSocket;
+import jmri.jmrit.logixng.expressions.StringExpressionStringIO;
+import jmri.jmrit.logixng.util.swing.LogixNG_SelectNamedBeanSwing;
+
+/**
+ * Configures an StringExpressionStringIO object with a Swing JPanel.
+ *
+ * @author Daniel Bergqvist Copyright 2025
+ */
+public class StringExpressionStringIOSwing extends AbstractStringExpressionSwing {
+
+    private LogixNG_SelectNamedBeanSwing<StringIO> _selectNamedBeanSwing;
+
+
+    @Override
+    protected void createPanel(@CheckForNull Base object, @Nonnull JPanel buttonPanel) {
+        StringExpressionStringIO action = (StringExpressionStringIO)object;
+
+        panel = new JPanel();
+
+        _selectNamedBeanSwing = new LogixNG_SelectNamedBeanSwing<>(
+                InstanceManager.getDefault(StringIOManager.class), getJDialog(), this);
+
+        JPanel _tabbedPaneNamedBean;
+        if (action != null) {
+            _tabbedPaneNamedBean = _selectNamedBeanSwing.createPanel(action.getSelectNamedBean());
+        } else {
+            _tabbedPaneNamedBean = _selectNamedBeanSwing.createPanel(null);
+        }
+
+        panel.add(new JLabel(Bundle.getMessage("StringExpressionStringIO_Short")));
+        panel.add(_tabbedPaneNamedBean);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean validate(@Nonnull List<String> errorMessages) {
+        StringExpressionStringIO expression = new StringExpressionStringIO("IQSE1", null);
+        _selectNamedBeanSwing.validate(expression.getSelectNamedBean(), errorMessages);
+        return errorMessages.isEmpty();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public MaleSocket createNewObject(@Nonnull String systemName, @CheckForNull String userName) {
+        StringExpressionStringIO expression = new StringExpressionStringIO(systemName, userName);
+        updateObject(expression);
+        return InstanceManager.getDefault(StringExpressionManager.class).registerExpression(expression);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void updateObject(@Nonnull Base object) {
+        if (! (object instanceof StringExpressionStringIO)) {
+            throw new IllegalArgumentException("object must be an StringExpressionStringIO but is a: "+object.getClass().getName());
+        }
+        StringExpressionStringIO expression = (StringExpressionStringIO)object;
+        _selectNamedBeanSwing.updateObject(expression.getSelectNamedBean());
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String toString() {
+        return Bundle.getMessage("StringExpressionStringIO_Short");
+    }
+
+    @Override
+    public void dispose() {
+    }
+
+
+//    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(StringExpressionStringIOSwing.class);
+
+}

--- a/java/test/jmri/jmrit/logixng/CreateLogixNGTreeScaffold.java
+++ b/java/test/jmri/jmrit/logixng/CreateLogixNGTreeScaffold.java
@@ -65,6 +65,7 @@ public class CreateLogixNGTreeScaffold {
     private DestinationPoints dp1;
     private DestinationPoints dp2;
     private NamedTable csvTable;
+    private StringIO stringIO;
 
     private LogixManager logixManager = InstanceManager.getDefault(LogixManager.class);
     private ConditionalManager conditionalManager = InstanceManager.getDefault(ConditionalManager.class);
@@ -192,6 +193,10 @@ public class CreateLogixNGTreeScaffold {
         Warrant warrant = InstanceManager.getDefault(jmri.jmrit.logix.WarrantManager.class).getWarrant("IW99");
         warrant.addBlockOrder(new BlockOrder(InstanceManager.getDefault(jmri.jmrit.logix.OBlockManager.class).getOBlock("OB98")));
         warrant.addBlockOrder(new BlockOrder(InstanceManager.getDefault(jmri.jmrit.logix.OBlockManager.class).getOBlock("OB99")));
+
+        stringIO = InstanceManager.getDefault(StringIOManager.class).provideStringIO("MyStringIO");
+        Assert.assertNotNull(stringIO);
+        Assert.assertEquals("ICMyStringIO", stringIO.getSystemName());
 
         logixNG_Manager = InstanceManager.getDefault(LogixNG_Manager.class);
         conditionalNGManager = InstanceManager.getDefault(ConditionalNG_Manager.class);
@@ -5867,6 +5872,32 @@ public class CreateLogixNGTreeScaffold {
         stringFormula.setFormula("sin(a)*2 + 14");
         maleSocket = stringExpressionManager.registerExpression(stringFormula);
         doStringAction.getChild(0).connect(maleSocket);
+
+        stringActionStringIO = new StringActionStringIO(stringActionManager.getAutoSystemName(), null);
+        stringActionStringIO.getSelectNamedBean().setAddressing(NamedBeanAddressing.Direct);
+        stringActionStringIO.getSelectNamedBean().setNamedBean(stringIO);
+        maleSocket = stringActionManager.registerAction(stringActionStringIO);
+        maleSocket.setEnabled(false);
+        doStringAction.getChild(1).connect(maleSocket);
+
+
+        doStringAction = new DoStringAction(digitalActionManager.getAutoSystemName(), null);
+        maleSocket = digitalActionManager.registerAction(doStringAction);
+        maleSocket.setEnabled(false);
+        actionManySocket.getChild(indexAction++).connect(maleSocket);
+
+        StringExpressionStringIO stringExpressionStringIO = new StringExpressionStringIO(stringExpressionManager.getAutoSystemName(), null);
+        stringExpressionStringIO.setComment("A comment");
+        stringExpressionStringIO.getSelectNamedBean().setNamedBean(stringIO);
+        maleSocket = stringExpressionManager.registerExpression(stringExpressionStringIO);
+        doStringAction.getChild(0).connect(maleSocket);
+
+        stringActionMemory = new StringActionMemory(stringActionManager.getAutoSystemName(), null);
+        stringActionMemory.setComment("A comment");
+        stringActionMemory.getSelectNamedBean().setNamedBean(memory2);
+        stringActionMemory.setValue("Hello");
+        maleSocket = stringActionManager.registerAction(stringActionMemory);
+        doStringAction.getChild(1).connect(maleSocket);
 
 
 

--- a/java/test/jmri/jmrit/logixng/implementation/DefaultFemaleStringExpressionSocketTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/DefaultFemaleStringExpressionSocketTest.java
@@ -89,6 +89,7 @@ public class DefaultFemaleStringExpressionSocketTest extends FemaleSocketTestBas
         List<Class<? extends Base>> classes = new ArrayList<>();
         classes.add(jmri.jmrit.logixng.expressions.StringExpressionConstant.class);
         classes.add(jmri.jmrit.logixng.expressions.StringExpressionMemory.class);
+        classes.add(jmri.jmrit.logixng.expressions.StringExpressionStringIO.class);
         map.put(Category.ITEM, classes);
 
         classes = new ArrayList<>();

--- a/xml/schema/logixng/string-expressions/expression-stringio-5.11.2.xsd
+++ b/xml/schema/logixng/string-expressions/expression-stringio-5.11.2.xsd
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="../schema2xhtml.xsl" type="text/xsl"?>
+
+<!-- This schema is part of JMRI. Copyright 2018.                           -->
+<!--                                                                        -->
+<!-- JMRI is free software; you can redistribute it and/or modify it under  -->
+<!-- the terms of version 2 of the GNU General Public License as published  -->
+<!-- by the Free Software Foundation. See the "COPYING" file for a copy     -->
+<!-- of this license.                                                       -->
+<!--                                                                        -->
+<!-- JMRI is distributed in the hope that it will be useful, but WITHOUT    -->
+<!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
+<!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
+<!-- for more details.                                                      -->
+
+<!-- This file contains definitions for LogixNG                             -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:xsi ="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:docbook="http://docbook.org/ns/docbook"
+           xmlns:jmri="http://jmri.org/xml/schema/JMRIschema"
+           xsi:schemaLocation="
+                http://jmri.org/xml/schema/JMRIschema http://jmri.org/xml/schema/JMRIschema.xsd
+                http://docbook.org/ns/docbook http://jmri.org/xml/schema/docbook/docbook.xsd
+            "
+        >
+
+    <xs:complexType name="LogixNG_StringExpression_StringIOType">
+      <xs:annotation>
+        <xs:documentation>
+          Define the XML stucture for storing the contents of a StringExpressionStringIO class.
+        </xs:documentation>
+        <xs:appinfo>
+            <jmri:usingclass configurexml="true">jmri.jmrit.logixng.string.expressions.configurexml.StringExpressionStringIO</jmri:usingclass>
+        </xs:appinfo>
+      </xs:annotation>
+        
+            <xs:sequence>
+
+              <xs:element name="systemName" type="systemNameType" minOccurs="1" maxOccurs="1"/>
+              <xs:element name="userName" type="userNameType" minOccurs="0" maxOccurs="1"/>
+              <xs:element name="comment" type="commentType" minOccurs="0" maxOccurs="unbounded"/>
+
+              <xs:element name="namedBean" type="LogixNG_SelectNamedBeanType" minOccurs="0" maxOccurs="1" />
+
+              <xs:element name="MaleSocket" type="LogixNG_MaleSocket_Type" minOccurs="0" maxOccurs="1"/>
+
+            </xs:sequence>
+            
+            <xs:attribute name="class" type="classType" use="required"/>
+        
+    </xs:complexType>
+
+</xs:schema>

--- a/xml/schema/logixng/string-expressions/string-expressions-4.23.1.xsd
+++ b/xml/schema/logixng/string-expressions/string-expressions-4.23.1.xsd
@@ -27,6 +27,7 @@
 
   <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/string-expressions/expression-constant-4.23.1.xsd"/>
   <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/string-expressions/expression-memory-4.23.1.xsd"/>
+  <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/string-expressions/expression-stringio-5.11.2.xsd"/>
   <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/string-expressions/formula-4.23.1.xsd"/>
 
     <xs:complexType name="LogixNG_StringExpressionManagerType">
@@ -45,6 +46,7 @@
 
             <xs:element name="StringExpressionConstant"  type="LogixNG_StringExpression_ConstantType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="StringExpressionMemory"    type="LogixNG_StringExpression_MemoryType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="StringExpressionStringIO"  type="LogixNG_StringExpression_StringIOType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="StringFormula"                     type="LogixNG_StringExpression_FormulaType" minOccurs="0" maxOccurs="unbounded" />
 
             <xs:element name="MaleSocket" type="LogixNG_MaleSocket_Type" minOccurs="0" maxOccurs="1"/>


### PR DESCRIPTION
Adds LogixNG support for StringIO. See #13710 and in particular this [comment](https://github.com/JMRI/JMRI/pull/13710#issuecomment-2561943724) for background.

I have tested the expression with this LogixNG:
```
LogixNG: Test StringIO expression
    ConditionalNG: IQC:AUTO:0005 ::: Startup
        ! A
            If Then Else. Execute on change
                ? If
                    Digital Formula: E1 == "14"
                        ?* E1
                            Get StringIO MyStringIO as string value
                ! Then
                    Show dialog: Only text: StringIO is 14

```