### PR TITLE
Highlight cursor position on layout editor panels: for touchscreens

### DIFF
--- a/help/en/package/jmri/jmrit/display/LayoutEditor.shtml
+++ b/help/en/package/jmri/jmrit/display/LayoutEditor.shtml
@@ -597,6 +597,17 @@
         the drawn panel, but it does take longer to refresh the panel. Check antialiasing for a
         better looking panel. Uncheck antialiasing for faster refresh.</li>
 
+        <li><strong>Toggle Track labels in Edit mode</strong> - If this item is selected, the
+        panel is displayed with the internal names for track items such as anchor points,
+        track sengments, turnouts, etc.</li>
+
+        <li><strong>Highlight Cursor Position</strong> <span class="since">since 5.11.2</span>
+        - If this item is selected, the cursor will have a colored box drawn around the mouse
+        pointer when the mouse has been clicked and held. This option is not active when the
+        panel is in edit mode. The primary purpose is to provide an enhanced mouse pointer on touch
+        screens. For turnouts, the turnout control circle will also flash a couple of times
+        while the turnout is moving.</li>
+
         <li><strong>New Title...</strong> - Selecting this item brings up a small window that
         allows a new panel window title to be entered.</li>
 

--- a/help/en/package/jmri/jmrit/display/LayoutEditor.shtml
+++ b/help/en/package/jmri/jmrit/display/LayoutEditor.shtml
@@ -601,7 +601,7 @@
         panel is displayed with the internal names for track items such as anchor points,
         track sengments, turnouts, etc.</li>
 
-        <li><strong>Highlight Cursor Position</strong> <span class="since">since 5.11.2</span>
+        <li><strong>Highlight Cursor Position</strong> <span class="since">since 5.11.3</span>
         - If this item is selected, the cursor will have a colored box drawn around the mouse
         pointer when the mouse has been clicked and held. This option is not active when the
         panel is in edit mode. The primary purpose is to provide an enhanced mouse pointer on touch

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -435,7 +435,7 @@
             <li>Fix slip turnout control circle colors when using closed/thrown colors.</li>
         </ul>
         <ul>
-            <li>Added "Immediate Feedback" option to enable immediate drawing of a square around finger/mouse press/drag area. Useful for touchscreens.
+            <li>Added "Highlight cursor position" option to enable drawing of a square around finger/mouse press/drag area. Useful for touchscreens.
         </ul>
 
         <h4>NX - Entry/Exit Tool</h4>

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -434,6 +434,9 @@
         <ul>
             <li>Fix slip turnout control circle colors when using closed/thrown colors.</li>
         </ul>
+        <ul>
+            <li>Added "Immediate Feedback" option to enable immediate drawing of a square around finger/mouse press/drag area. Useful for touchscreens.
+        </ul>
 
         <h4>NX - Entry/Exit Tool</h4>
             <ul>

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
@@ -161,6 +161,7 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
     private JCheckBoxMenuItem turnoutFillControlCirclesCheckBoxMenuItem = null;
     private JCheckBoxMenuItem hideTrackSegmentConstructionLinesCheckBoxMenuItem = null;
     private JCheckBoxMenuItem useDirectTurnoutControlCheckBoxMenuItem = null;
+    private JCheckBoxMenuItem immediateFeedbackCheckBoxMenuItem = null;
     private ButtonGroup turnoutCircleSizeButtonGroup = null;
 
     private boolean turnoutDrawUnselectedLeg = true;
@@ -308,7 +309,7 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
     private double xOverHWid = LayoutTurnout.xOverHWidDefault;
     private double xOverShort = LayoutTurnout.xOverShortDefault;
     private boolean useDirectTurnoutControl = false; // Uses Left click for closing points, Right click for throwing.
-    private boolean immediateFeedback = false; // Highlight mouse press/drag area, good for touchscreens
+    private boolean immediateFeedback = false; // Highlight finger/mouse press/drag area, good for touchscreens
 
     // saved state of options when panel was loaded or created
     private boolean savedEditMode = true;
@@ -1528,6 +1529,15 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
             redrawPanel();
         });
         turnoutDrawUnselectedLegCheckBoxMenuItem.setSelected(turnoutDrawUnselectedLeg);
+
+        // add "enable immediate feedback" - useful for touchscreens
+        immediateFeedbackCheckBoxMenuItem = new JCheckBoxMenuItem(Bundle.getMessage("ImmediateFeedback"));
+        turnoutOptionsMenu.add(immediateFeedbackCheckBoxMenuItem);
+        immediateFeedbackCheckBoxMenuItem.addActionListener((ActionEvent event) -> {
+            immediateFeedback = immediateFeedbackCheckBoxMenuItem.isSelected();
+            redrawPanel();
+        });
+        immediateFeedbackCheckBoxMenuItem.setSelected(immediateFeedback);
 
         return optionMenu;
     }
@@ -7526,6 +7536,10 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
         return turnoutDrawUnselectedLeg;
     }
 
+    public boolean isImmediateFeedback() {
+        return immediateFeedback;
+    }
+
     public String getLayoutName() {
         return layoutName;
     }
@@ -7736,6 +7750,19 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
         if (turnoutDrawUnselectedLeg != state) {
             turnoutDrawUnselectedLeg = state;
             turnoutDrawUnselectedLegCheckBoxMenuItem.setSelected(turnoutDrawUnselectedLeg);
+        }
+    }
+
+    /**
+     * Should only be invoked on the GUI (Swing) thread.
+     *
+     * @param state true to enable immediate feedback
+     */
+    @InvokeOnGuiThread
+    public void setImmediateFeedback(boolean state) {
+        if (immediateFeedback != state) {
+            immediateFeedback = state;
+            immediateFeedbackCheckBoxMenuItem.setSelected(immediateFeedback);
         }
     }
 
@@ -8059,14 +8086,6 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
     // TODO: Java standard pattern for boolean getters is "isShowHelpBar()"
     public boolean getDirectTurnoutControl() {
         return useDirectTurnoutControl;
-    }
-
-    public void setImmediateFeedback(boolean imm) {
-        immediateFeedback = imm;
-    }
-
-    public boolean isImmediateFeedback() {
-        return immediateFeedback;
     }
 
     // final initialization routine for loading a LayoutEditor

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
@@ -3509,13 +3509,15 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
     public void mouseReleased(JmriMouseEvent event) {
         super.setToolTip(null);
 
-        if (!isEditable() && _highlightcomponent != null && immediateFeedback) {
-            _highlightcomponent = null;
-            redrawPanel();
-        }
-
         // initialize mouse position
         calcLocation(event);
+
+        if (!isEditable() && _highlightcomponent != null && immediateFeedback) {
+            _highlightcomponent = null;
+            // see if we moused up on an object
+            checkControls(true);
+            redrawPanel();
+        }
 
         // if alt modifier is down invert the snap to grid behaviour
         snapToGridInvert = event.isAltDown();

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
@@ -1106,6 +1106,15 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
         });
         drawLayoutTracksLabelCheckBoxMenuItem.setSelected(drawLayoutTracksLabel);
 
+        // add "enable immediate feedback" - useful for touchscreens
+        immediateFeedbackCheckBoxMenuItem = new JCheckBoxMenuItem(Bundle.getMessage("ImmediateFeedback"));
+        optionMenu.add(immediateFeedbackCheckBoxMenuItem);
+        immediateFeedbackCheckBoxMenuItem.addActionListener((ActionEvent event) -> {
+            immediateFeedback = immediateFeedbackCheckBoxMenuItem.isSelected();
+            redrawPanel();
+        });
+        immediateFeedbackCheckBoxMenuItem.setSelected(immediateFeedback);
+
         //
         // edit title
         //
@@ -1529,15 +1538,6 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
             redrawPanel();
         });
         turnoutDrawUnselectedLegCheckBoxMenuItem.setSelected(turnoutDrawUnselectedLeg);
-
-        // add "enable immediate feedback" - useful for touchscreens
-        immediateFeedbackCheckBoxMenuItem = new JCheckBoxMenuItem(Bundle.getMessage("ImmediateFeedback"));
-        turnoutOptionsMenu.add(immediateFeedbackCheckBoxMenuItem);
-        immediateFeedbackCheckBoxMenuItem.addActionListener((ActionEvent event) -> {
-            immediateFeedback = immediateFeedbackCheckBoxMenuItem.isSelected();
-            redrawPanel();
-        });
-        immediateFeedbackCheckBoxMenuItem.setSelected(immediateFeedback);
 
         return optionMenu;
     }

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
@@ -2955,6 +2955,29 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
     }
 
     /**
+     * Check for immediate mode feedback.
+     *
+     * If in "immediate" mode, draw a square at the location of the
+     * event. If there was already a square, just move its location.
+     * In either case, redraw the panel so the previous square will
+     * disappear and the new one will appear immediately.
+     */
+    private void checkImmediate() {
+        if (!isEditable() && immediateFeedback) {
+            // rectangle size based on turnout circle size: rectangle should
+            // be bigger so it can more easily surround turnout on screen
+            int halfSize = (int)(circleRadius) + 8;
+            if (_highlightcomponent == null) {
+                _highlightcomponent = new Rectangle(
+                        xLoc - halfSize, yLoc - halfSize, halfSize * 2, halfSize * 2);
+            } else {
+                _highlightcomponent.setLocation(xLoc - halfSize, yLoc - halfSize);
+            }
+            redrawPanel();
+        }
+    }
+
+    /**
      * Handle a mouse pressed event
      * <p>
      * Side-effects on _anchorX, _anchorY,_lastX, _lastY, xLoc, yLoc, dLoc,
@@ -2971,15 +2994,7 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
         _lastY = _anchorY;
         calcLocation(event);
 
-        if (!isEditable() && immediateFeedback) {
-            if (_highlightcomponent == null) {
-                // TODO: rectangle size based on turnout circle size
-                _highlightcomponent = new Rectangle(xLoc - 20, yLoc - 20, 40, 40);
-            } else {
-                _highlightcomponent.setLocation(xLoc - 20, yLoc - 20);
-            }
-            redrawPanel();
-        }
+        checkImmediate();
 
         // TODO: Add command-click on nothing to pan view?
         if (isEditable()) {
@@ -4869,15 +4884,7 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
         // initialize mouse position
         calcLocation(event);
 
-        if (!isEditable() && immediateFeedback) {
-            if (_highlightcomponent == null) {
-                // TODO: rectangle size based on turnout circle size
-                _highlightcomponent = new Rectangle(xLoc - 20, yLoc - 20, 40, 40);
-            } else {
-                _highlightcomponent.setLocation(xLoc - 20, yLoc - 20);
-            }
-            redrawPanel();
-        }
+        checkImmediate();
 
         // ignore this event if still at the original point
         if ((!isDragging) && (xLoc == getAnchorX()) && (yLoc == getAnchorY())) {

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
@@ -3674,7 +3674,7 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
                     timer.addActionListener(new ActionListener(){
                         int count = 1;
                         public void actionPerformed(ActionEvent ae){
-                          if(count % 2 == 1) t.setDisabled(true);
+                          if(count % 2 != 0) t.setDisabled(true);
                           else t.setDisabled(false);
                           if(++count > 8) timer.stop();
                         }

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
@@ -3668,6 +3668,19 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
                 t.setState(Turnout.CLOSED);
             } else {
                 t.toggleTurnout();
+                if (immediateFeedback && !t.isDisabled()) {
+                    // flash the turnout circle a few times so the user knows it's being toggled
+                    javax.swing.Timer timer = new javax.swing.Timer(150, null);
+                    timer.addActionListener(new ActionListener(){
+                        int count = 1;
+                        public void actionPerformed(ActionEvent ae){
+                          if(count % 2 == 1) t.setDisabled(true);
+                          else t.setDisabled(false);
+                          if(++count > 8) timer.stop();
+                        }
+                    });
+                    timer.start();
+                }
             }
         } else if ((selectedObject != null) && ((selectedHitPointType == HitPointType.SLIP_LEFT)
                 || (selectedHitPointType == HitPointType.SLIP_RIGHT))

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
@@ -161,7 +161,7 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
     private JCheckBoxMenuItem turnoutFillControlCirclesCheckBoxMenuItem = null;
     private JCheckBoxMenuItem hideTrackSegmentConstructionLinesCheckBoxMenuItem = null;
     private JCheckBoxMenuItem useDirectTurnoutControlCheckBoxMenuItem = null;
-    private JCheckBoxMenuItem immediateFeedbackCheckBoxMenuItem = null;
+    private JCheckBoxMenuItem highlightCursorCheckBoxMenuItem = null;
     private ButtonGroup turnoutCircleSizeButtonGroup = null;
 
     private boolean turnoutDrawUnselectedLeg = true;
@@ -309,7 +309,7 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
     private double xOverHWid = LayoutTurnout.xOverHWidDefault;
     private double xOverShort = LayoutTurnout.xOverShortDefault;
     private boolean useDirectTurnoutControl = false; // Uses Left click for closing points, Right click for throwing.
-    private boolean immediateFeedback = false; // Highlight finger/mouse press/drag area, good for touchscreens
+    private boolean highlightCursor = false; // Highlight finger/mouse press/drag area, good for touchscreens
 
     // saved state of options when panel was loaded or created
     private boolean savedEditMode = true;
@@ -1106,14 +1106,14 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
         });
         drawLayoutTracksLabelCheckBoxMenuItem.setSelected(drawLayoutTracksLabel);
 
-        // add "enable immediate feedback" - useful for touchscreens
-        immediateFeedbackCheckBoxMenuItem = new JCheckBoxMenuItem(Bundle.getMessage("ImmediateFeedback"));
-        optionMenu.add(immediateFeedbackCheckBoxMenuItem);
-        immediateFeedbackCheckBoxMenuItem.addActionListener((ActionEvent event) -> {
-            immediateFeedback = immediateFeedbackCheckBoxMenuItem.isSelected();
+        // add "Highlight cursor position" - useful for touchscreens
+        highlightCursorCheckBoxMenuItem = new JCheckBoxMenuItem(Bundle.getMessage("HighlightCursor"));
+        optionMenu.add(highlightCursorCheckBoxMenuItem);
+        highlightCursorCheckBoxMenuItem.addActionListener((ActionEvent event) -> {
+            highlightCursor = highlightCursorCheckBoxMenuItem.isSelected();
             redrawPanel();
         });
-        immediateFeedbackCheckBoxMenuItem.setSelected(immediateFeedback);
+        highlightCursorCheckBoxMenuItem.setSelected(highlightCursor);
 
         //
         // edit title
@@ -2965,15 +2965,15 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
     }
 
     /**
-     * Check for immediate mode feedback.
+     * Check for highlighting of cursor position.
      *
-     * If in "immediate" mode, draw a square at the location of the
+     * If in "highlight" mode, draw a square at the location of the
      * event. If there was already a square, just move its location.
      * In either case, redraw the panel so the previous square will
      * disappear and the new one will appear immediately.
      */
-    private void checkImmediate() {
-        if (!isEditable() && immediateFeedback) {
+    private void checkHighlightCursor() {
+        if (!isEditable() && highlightCursor) {
             // rectangle size based on turnout circle size: rectangle should
             // be bigger so it can more easily surround turnout on screen
             int halfSize = (int)(circleRadius) + 8;
@@ -3004,7 +3004,7 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
         _lastY = _anchorY;
         calcLocation(event);
 
-        checkImmediate();
+        checkHighlightCursor();
 
         // TODO: Add command-click on nothing to pan view?
         if (isEditable()) {
@@ -3537,7 +3537,7 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
         // initialize mouse position
         calcLocation(event);
 
-        if (!isEditable() && _highlightcomponent != null && immediateFeedback) {
+        if (!isEditable() && _highlightcomponent != null && highlightCursor) {
             _highlightcomponent = null;
             // see if we moused up on an object
             checkControls(true);
@@ -3693,7 +3693,7 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
                 t.setState(Turnout.CLOSED);
             } else {
                 t.toggleTurnout();
-                if (immediateFeedback && !t.isDisabled()) {
+                if (highlightCursor && !t.isDisabled()) {
                     // flash the turnout circle a few times so the user knows it's being toggled
                     javax.swing.Timer timer = new javax.swing.Timer(150, null);
                     timer.addActionListener(new ActionListener(){
@@ -4049,7 +4049,7 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
         // initialize mouse position
         calcLocation(event);
 
-        if (!isEditable() && _highlightcomponent != null && immediateFeedback) {
+        if (!isEditable() && _highlightcomponent != null && highlightCursor) {
             _highlightcomponent = null;
             redrawPanel();
         }
@@ -4894,7 +4894,7 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
         // initialize mouse position
         calcLocation(event);
 
-        checkImmediate();
+        checkHighlightCursor();
 
         // ignore this event if still at the original point
         if ((!isDragging) && (xLoc == getAnchorX()) && (yLoc == getAnchorY())) {
@@ -7536,8 +7536,8 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
         return turnoutDrawUnselectedLeg;
     }
 
-    public boolean isImmediateFeedback() {
-        return immediateFeedback;
+    public boolean isHighlightCursor() {
+        return highlightCursor;
     }
 
     public String getLayoutName() {
@@ -7756,13 +7756,13 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
     /**
      * Should only be invoked on the GUI (Swing) thread.
      *
-     * @param state true to enable immediate feedback
+     * @param state true to enable highlighting the cursor (mouse/finger press/drag)
      */
     @InvokeOnGuiThread
-    public void setImmediateFeedback(boolean state) {
-        if (immediateFeedback != state) {
-            immediateFeedback = state;
-            immediateFeedbackCheckBoxMenuItem.setSelected(immediateFeedback);
+    public void setHighlightCursor(boolean state) {
+        if (highlightCursor != state) {
+            highlightCursor = state;
+            highlightCursorCheckBoxMenuItem.setSelected(highlightCursor);
         }
     }
 

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorBundle.properties
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorBundle.properties
@@ -406,6 +406,7 @@ AntialiasingOn = Enable antialiasing (Smoother lines)
 DrawLayoutTracksLabel = Toggle Track labels in Edit mode
 DrawLayoutTracksMnemonic = T
 DrawLayoutTracksAccelerator = T
+HighlightCursor = Highlight Cursor Position
 NewTitle = New Title
 EditTitle = Edit Title
 
@@ -434,7 +435,6 @@ TurnoutCircleSize = Set Turnout Circle Size
 TurnoutDrawUnselectedLeg = Draw Unselected Turnout Leg
 TurnoutFillControlCircles = Fill Turnout Circles
 UseDefaultTrackColor = Use Default Track Color
-ImmediateFeedback = Enable Immediate Feedback
 
 # items specific to Layout Editor tools
 ResetTurnoutSize = Use Program Default Turnout Size

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorBundle.properties
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorBundle.properties
@@ -434,6 +434,7 @@ TurnoutCircleSize = Set Turnout Circle Size
 TurnoutDrawUnselectedLeg = Draw Unselected Turnout Leg
 TurnoutFillControlCircles = Fill Turnout Circles
 UseDefaultTrackColor = Use Default Track Color
+ImmediateFeedback = Enable Immediate Feedback
 
 # items specific to Layout Editor tools
 ResetTurnoutSize = Use Program Default Turnout Size

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorViewContext.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorViewContext.java
@@ -272,7 +272,7 @@ Probably not View graphical:
 
       <xs:attribute name="openDispatcher" type="yesNoType" default="no"/>
       <xs:attribute name="useDirectTurnoutControl" type="yesNoType" default="no"/>
-      <xs:attribute name="immediateFeedback" type="yesNoType" default="no"/>
+      <xs:attribute name="highlightCursor" type="yesNoType" default="no"/>
 
  */
 

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorViewContext.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorViewContext.java
@@ -272,6 +272,7 @@ Probably not View graphical:
 
       <xs:attribute name="openDispatcher" type="yesNoType" default="no"/>
       <xs:attribute name="useDirectTurnoutControl" type="yesNoType" default="no"/>
+      <xs:attribute name="immediateFeedback" type="yesNoType" default="no"/>
 
  */
 

--- a/java/src/jmri/jmrit/display/layoutEditor/configurexml/LayoutEditorXml.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/configurexml/LayoutEditorXml.java
@@ -115,8 +115,8 @@ public class LayoutEditorXml extends AbstractXmlAdapter {
         p.resetDirty();
         panel.setAttribute("openDispatcher", p.getOpenDispatcherOnLoad() ? "yes" : "no");
         panel.setAttribute("useDirectTurnoutControl", p.getDirectTurnoutControl() ? "yes" : "no");
-        if (p.isImmediateFeedback()) {
-            panel.setAttribute("immediateFeedback", "yes");
+        if (p.isHighlightCursor()) {
+            panel.setAttribute("highlightCursor", "yes");
         }
 
         // store layout track drawing options
@@ -605,11 +605,11 @@ public class LayoutEditorXml extends AbstractXmlAdapter {
         }
 
         try {
-            panel.setImmediateFeedback(shared.getAttribute("immediateFeedback").getBooleanValue());
+            panel.setHighlightCursor(shared.getAttribute("highlightCursor").getBooleanValue());
         } catch (DataConversionException e) {
-            log.warn("unable to convert immediateFeedback attribute");
+            log.warn("unable to convert highlightCursor attribute");
         } catch (NullPointerException e) {  // considered normal if the attribute is not present
-            log.debug("missing immediateFeedback attribute");
+            log.debug("missing highlightCursor attribute");
         }
 
 

--- a/java/src/jmri/jmrit/display/layoutEditor/configurexml/LayoutEditorXml.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/configurexml/LayoutEditorXml.java
@@ -115,6 +115,9 @@ public class LayoutEditorXml extends AbstractXmlAdapter {
         p.resetDirty();
         panel.setAttribute("openDispatcher", p.getOpenDispatcherOnLoad() ? "yes" : "no");
         panel.setAttribute("useDirectTurnoutControl", p.getDirectTurnoutControl() ? "yes" : "no");
+        if (p.isImmediateFeedback()) {
+            panel.setAttribute("immediateFeedback", "yes");
+        }
 
         // store layout track drawing options
         try {
@@ -590,7 +593,7 @@ public class LayoutEditorXml extends AbstractXmlAdapter {
         } catch (DataConversionException e) {
             log.warn("Could not parse color attributes!");
         } catch (NullPointerException e) {  // considered normal if the attributes are not present
-            log.debug("missing backbround color attributes");
+            log.debug("missing background color attributes");
         }
 
         try {
@@ -600,6 +603,15 @@ public class LayoutEditorXml extends AbstractXmlAdapter {
         } catch (NullPointerException e) {  // considered normal if the attribute is not present
             log.debug("missing useDirectTurnoutControl attribute");
         }
+
+        try {
+            panel.setImmediateFeedback(shared.getAttribute("immediateFeedback").getBooleanValue());
+        } catch (DataConversionException e) {
+            log.warn("unable to convert immediateFeedback attribute");
+        } catch (NullPointerException e) {  // considered normal if the attribute is not present
+            log.debug("missing immediateFeedback attribute");
+        }
+
 
         // Set editor's option flags, load content after
         // this so that individual item flags are set as saved

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorTest.java
@@ -804,7 +804,7 @@ public class LayoutEditorTest extends AbstractEditorTestBase<LayoutEditor> {
     public void checkOptionsMenuExists() {
         JMenuOperator jmo = new JMenuOperator(jfo, Bundle.getMessage("MenuOptions"));
         Assert.assertNotNull("Options Menu Exists", jmo);
-        Assert.assertEquals("Menu Item Count", 19, jmo.getItemCount());
+        Assert.assertEquals("Menu Item Count", 20, jmo.getItemCount());
     }
 
     @Test

--- a/xml/schema/types/layouteditor.xsd
+++ b/xml/schema/types/layouteditor.xsd
@@ -129,7 +129,7 @@
       <xs:attribute name="gridSize2nd" type="xs:integer"/>
       <xs:attribute name="openDispatcher" type="yesNoType" default="no"/>
       <xs:attribute name="useDirectTurnoutControl" type="yesNoType" default="no"/>
-      <xs:attribute name="immediateFeedback" type="yesNoType" default="no"/>
+      <xs:attribute name="highlightCursor" type="yesNoType" default="no"/>
       <xs:attribute name="zoom" type="xs:float" default="1.0"/>
     </xs:complexType>
 

--- a/xml/schema/types/layouteditor.xsd
+++ b/xml/schema/types/layouteditor.xsd
@@ -129,6 +129,7 @@
       <xs:attribute name="gridSize2nd" type="xs:integer"/>
       <xs:attribute name="openDispatcher" type="yesNoType" default="no"/>
       <xs:attribute name="useDirectTurnoutControl" type="yesNoType" default="no"/>
+      <xs:attribute name="immediateFeedback" type="yesNoType" default="no"/>
       <xs:attribute name="zoom" type="xs:float" default="1.0"/>
     </xs:complexType>
 


### PR DESCRIPTION
This mode allows for immediate feedback when a user places a finger on a touchscreen in a panel. A square appears
where the finger is pressed. It can be dragged around (typically to select a turnout), and when released it will trigger a mouseClicked event where the release happened.

If the release was over a controllable turnout, the square flashes on and off a few times to indicate that the turnout change of state is in progress.

This gives much better feedback to users of touchscreens, so they can see if they actually clicked a turnout correctly.
It also gives better feedback when using a mouse, but it isn't as necessary in that case.

I've been using/testing this at our club for the past couple months. Works well with a raspberry pi 4b attached to a ViewSonic 223 touchscreen.

This feature is currently hidden. The only way to enable it is to hand-edit the panel xml file. If the powers that be think this
is a good feature, I can add a checkbox to one of the panel editor menu items to enable this mode on a panel.