### PR TITLE
Fix for:  Error in Reset values in Train-o-matic decoders #13772 Open

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -353,7 +353,7 @@
 
         <h4>Technologistic (train-O-matic)</h4>
             <ul>
-                <li></li>
+                <li>Fix for resetting Train-O-Matic decoders</li>
             </ul>
 
         <h4>Trix Modelleisenbahn</h4>

--- a/xml/decoders/TrainOMatic_FD.xml
+++ b/xml/decoders/TrainOMatic_FD.xml
@@ -1543,7 +1543,7 @@
     </variables>
 
     <resets>
-      <factReset CV="8" default="78">
+      <factReset CV="8" default="8">
           <label>HARD RESET all CVs reset to default values</label>
           <label xml:lang="cs">HARD RESET všechny CV se resetují na výchozí hodnoty</label>
       </factReset>

--- a/xml/decoders/TrainOMatic_FD.xml
+++ b/xml/decoders/TrainOMatic_FD.xml
@@ -18,6 +18,7 @@
 <!-- Based on decoder manual 0.0.11. With support of Train-O-Matic.         -->
 
   <version author="lbijlsma@pobox.com" version="1" lastUpdated="20231107"/>
+  <version author="lbijlsma@pobox.com" version="2" lastUpdated="20250116"/> <!-- factReset CV8 -->
   <decoder>
     <family name="Function Decoders" mfg="Tehnologistic (train-O-matic)">
       <model model="FD Micro" numOuts="6" numFns="32" lowVersionID="1" highVersionID="7" productID="2010106,2010107,2010108,2010109,2010110,2010111,2010112">

--- a/xml/decoders/TrainOMatic_FD2.xml
+++ b/xml/decoders/TrainOMatic_FD2.xml
@@ -18,6 +18,7 @@
 <!-- Based on decoder manual 0.1.24. With support of Train-O-Matic.         -->
 
   <version author="lbijlsma@pobox.com" version="1" lastUpdated="20241107"/>
+  <version author="lbijlsma@pobox.com" version="2" lastUpdated="20250116"/>
   <decoder>
     <family name="Function Decoders" mfg="Tehnologistic (train-O-matic)">
       <model model="FD Micro II" numOuts="8" numFns="32" lowVersionID="1" highVersionID="7" productID="2010115,2010116,2010117,2010118,2010119,2010120,2010121">
@@ -1916,7 +1917,7 @@
     </variables>
 
     <resets>
-      <factReset CV="8" default="78">
+      <factReset CV="8" default="8">
           <label>HARD RESET all CVs reset to default values</label>
           <label xml:lang="cs">HARD RESET všechny CV se resetují na výchozí hodnoty</label>
       </factReset>

--- a/xml/decoders/TrainOMatic_Lokommander_2.xml
+++ b/xml/decoders/TrainOMatic_Lokommander_2.xml
@@ -20,6 +20,7 @@
   <version author="lbijlsma@pobox.com" version="1" lastUpdated="20220729"/>
   <version author="Petr Šídlo sidlo64@hotmail.com" version="2" lastUpdated="20220814"/> <!-- factReset CV30 -->
   <version author="lbijlsma@pobox.com" version="3" lastUpdated="20240422"/> <!-- CV114-CV116 changes        -->
+  <version author="lbijlsma@pobox.com" version="4" lastUpdated="20250116"/> <!-- factReset CV8 -->
   <decoder>
     <family name="Lokommander 2 v3" mfg="Tehnologistic (train-O-matic)">
       <model model="Lokommander 2 Micro" numOuts="6" numFns="15" lowVersionID="3" highVersionID="3" connector="Wires/NEM651" productID="2010220,2010221,2010222,2010223,2010227">
@@ -99,7 +100,7 @@
     </variables>
 
     <resets>
-      <factReset CV="8" default="78">
+      <factReset CV="8" default="8">
           <label>HARD RESET all CVs reset to default values</label>
           <label xml:lang="cs">HARD RESET všechny CV se resetují na výchozí hodnoty</label>
       </factReset>

--- a/xml/decoders/TrainOMatic_Lokommander_2_p22.xml
+++ b/xml/decoders/TrainOMatic_Lokommander_2_p22.xml
@@ -22,6 +22,7 @@
   <version author="lbijlsma@pobox.com" version="1" lastUpdated="20220729"/>
   <version author="Petr Šídlo sidlo64@hotmail.com" version="2" lastUpdated="20220814"/> <!-- factReset CV30 -->
   <version author="lbijlsma@pobox.com" version="3" lastUpdated="20240422"/> <!-- CV114-CV116 changes        -->  
+  <version author="lbijlsma@pobox.com" version="4" lastUpdated="20250116"/> <!-- factReset CV8 -->
   <decoder>
     <family name="Lokommander 2 v3" mfg="Tehnologistic (train-O-matic)">
        <model model="Lokommander 2 Mini P22" numOuts="12" numFns="15" lowVersionID="3" highVersionID="3" connector="PluX22" productID="2010217">
@@ -77,7 +78,7 @@
     </variables>
 
     <resets>
-      <factReset CV="8" default="78">
+      <factReset CV="8" default="8">
           <label>HARD RESET all CVs reset to default values</label>
           <label xml:lang="cs">HARD RESET všechny CV se resetují na výchozí hodnoty</label>
       </factReset>

--- a/xml/decoders/TrainOMatic_Lokommander_2_p22_v6.xml
+++ b/xml/decoders/TrainOMatic_Lokommander_2_p22_v6.xml
@@ -23,6 +23,7 @@
   <version author="Petr Šídlo sidlo64@hotmail.com" version="2" lastUpdated="20220814"/> <!-- factReset CV30 -->
   <version author="lbijlsma@pobox.com" version="3" lastUpdated="20230921"/> <!-- v6 firmware specific panes -->
   <version author="lbijlsma@pobox.com" version="4" lastUpdated="20240422"/> <!-- CV114-CV116 changes        -->
+  <version author="lbijlsma@pobox.com" version="5" lastUpdated="20250116"/> <!-- factReset CV8 -->
 
   <decoder>
     <family name="Lokommander 2 v6" mfg="Tehnologistic (train-O-matic)">
@@ -81,7 +82,7 @@
     </variables>
 
     <resets>
-      <factReset CV="8" default="78">
+      <factReset CV="8" default="8">
           <label>HARD RESET all CVs reset to default values</label>
           <label xml:lang="cs">HARD RESET všechny CV se resetují na výchozí hodnoty</label>
       </factReset>

--- a/xml/decoders/TrainOMatic_Lokommander_2_v6.xml
+++ b/xml/decoders/TrainOMatic_Lokommander_2_v6.xml
@@ -19,6 +19,9 @@
 
   <version author="lbijlsma@pobox.com" version="1" lastUpdated="20230913"/>
   <version author="lbijlsma@pobox.com" version="2" lastUpdated="20240422"/>
+  <version author="lbijlsma@pobox.com" version="3" lastUpdated="20250116"/>
+  <version author="lbijlsma@pobox.com" version="4" lastUpdated="20250116"/> <!-- factReset CV8 -->
+
   <decoder>
     <family name="Lokommander 2 v6" mfg="Tehnologistic (train-O-matic)">
       <model model="Lokommander 2 Micro" numOuts="6" numFns="15" lowVersionID="5" highVersionID="6" connector="Wires/NEM651" productID="2010220,2010221,2010222,2010223,2010227">
@@ -101,7 +104,7 @@
     </variables>
 
     <resets>
-      <factReset CV="8" default="78">
+      <factReset CV="8" default="8">
           <label>HARD RESET all CVs reset to default values</label>
           <label xml:lang="cs">HARD RESET všechny CV se resetují na výchozí hodnoty</label>
       </factReset>

--- a/xml/decoders/TrainOMatic_Lokommander_2_v6.xml
+++ b/xml/decoders/TrainOMatic_Lokommander_2_v6.xml
@@ -19,8 +19,7 @@
 
   <version author="lbijlsma@pobox.com" version="1" lastUpdated="20230913"/>
   <version author="lbijlsma@pobox.com" version="2" lastUpdated="20240422"/>
-  <version author="lbijlsma@pobox.com" version="3" lastUpdated="20250116"/>
-  <version author="lbijlsma@pobox.com" version="4" lastUpdated="20250116"/> <!-- factReset CV8 -->
+  <version author="lbijlsma@pobox.com" version="3" lastUpdated="20250116"/> <!-- factReset CV8 -->
 
   <decoder>
     <family name="Lokommander 2 v6" mfg="Tehnologistic (train-O-matic)">

--- a/xml/decoders/TrainOMatic_NMJ_224.xml
+++ b/xml/decoders/TrainOMatic_NMJ_224.xml
@@ -19,10 +19,13 @@
 <!-- Version 2 - Incorporated the other decoders from the same family after info from tOm                        -->
 <!-- Version 3 - Based on information from tOm, correct version information and added productID                  -->
 <!-- Version 4 - Some updates and actually added productID                                                       -->
+<!-- Version 4 - factory reset fix                                                                               -->
 
   <version author="lbijlsma@pobox.com" version="2" lastUpdated="20160403"/>
   <version author="lbijlsma@pobox.com" version="3" lastUpdated="20220730"/>
   <version author="lbijlsma@pobox.com" version="4" lastUpdated="20230914"/>
+  <version author="lbijlsma@pobox.com" version="5" lastUpdated="20250116"/> <!-- factReset CV8 -->
+
   <decoder>
     <family name="Lokommander" mfg="Tehnologistic (train-O-matic)">
       <model model="Lokommander Mini" numOuts="4" lowVersionID="23" highVersionID="255">
@@ -1068,7 +1071,7 @@
     </variables>
 
     <resets>
-      <factReset CV="8" default="78">
+      <factReset CV="8" default="8">
           <label>HARD RESET all CVs reset to default values</label>
           <label xml:lang="cs">HARD RESET nastaví všechny CV na výchozí hodnoty</label>
       </factReset>

--- a/xml/decoders/TrainOMatic_NMJ_224.xml
+++ b/xml/decoders/TrainOMatic_NMJ_224.xml
@@ -19,7 +19,7 @@
 <!-- Version 2 - Incorporated the other decoders from the same family after info from tOm                        -->
 <!-- Version 3 - Based on information from tOm, correct version information and added productID                  -->
 <!-- Version 4 - Some updates and actually added productID                                                       -->
-<!-- Version 4 - factory reset fix                                                                               -->
+<!-- Version 5 - factory reset fix                                                                               -->
 
   <version author="lbijlsma@pobox.com" version="2" lastUpdated="20160403"/>
   <version author="lbijlsma@pobox.com" version="3" lastUpdated="20220730"/>


### PR DESCRIPTION
Updated the relevant Train-O-Matic decoder definitions to make sure the decoder reset is working properly.