### PR TITLE
SpotBugs - Date Formats

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -158,6 +158,11 @@
                 <li></li>
             </ul>
 
+        <h4>SRCP</h4>
+            <ul>
+                <li>Fast-clock TIME commands now use the 00-23 format for the hour value and do not repeat 01-12 in the afternoon.</li>
+            </ul>
+
         <h4>TAMS</h4>
             <ul>
                 <li></li>
@@ -510,7 +515,7 @@
     <h3>Roster</h3>
         <a id="Roster" name="Roster"></a>
         <ul>
-            <li></li>
+            <li>Roster Table - Fixes initial editing of Last Operated date / time values using 1-12hr values instead of 0-23.</li>
         </ul>
 
     <h3>Routes</h3>

--- a/java/src/jmri/jmrit/roster/RosterEntry.java
+++ b/java/src/jmri/jmrit/roster/RosterEntry.java
@@ -599,8 +599,8 @@ public class RosterEntry extends ArbitraryBean implements RosterObject, BasicRos
                 try {
                     setDateModified(customFmt.parse(date));
                 } catch (ParseException ex3) {
-                    // then try with a specific format to handle e.g. "01-Oct-2016 9:13:36"
-                    customFmt = new SimpleDateFormat("dd-MMM-yyyy hh:mm:ss");
+                    // then try with a specific format to handle e.g. "01-Oct-2016 21:13:36"
+                    customFmt = new SimpleDateFormat("dd-MMM-yyyy HH:mm:ss");
                     setDateModified(customFmt.parse(date));
                 }
             }

--- a/java/src/jmri/jmrit/roster/swing/RosterTable.java
+++ b/java/src/jmri/jmrit/roster/swing/RosterTable.java
@@ -440,7 +440,7 @@ public class RosterTable extends JmriPanel implements RosterEntrySelector, Roste
             super();
         }
 
-        private static final String EDITOR_DATE_FORMAT =  "yyyy-MM-dd hh:mm";
+        private static final String EDITOR_DATE_FORMAT =  "yyyy-MM-dd HH:mm";
         private Date startDate = new Date();
 
         @Override

--- a/java/src/jmri/jmrix/can/cbus/swing/eventtable/CbusEventTable.java
+++ b/java/src/jmri/jmrix/can/cbus/swing/eventtable/CbusEventTable.java
@@ -41,7 +41,7 @@ public class CbusEventTable extends JScrollPane implements TableModelListener {
     private CbusTableRowEventDnDHandler eventDragHandler;
     private TableRowSorter<CbusEventTableDataModel> sorter;
 
-    private final DateFormat DATE_FORMAT = new SimpleDateFormat("HH:mm:ss EEE d MMM YYYY"); // NOI18N
+    private final DateFormat DATE_FORMAT = new SimpleDateFormat("HH:mm:ss EEE d MMM yyyy"); // NOI18N
     /**
      * Create a new CBUS Node Event Table Pane
      * @param mainPane main Event Table Pane

--- a/java/src/jmri/jmrix/dccpp/simulator/DCCppSimulatorAdapter.java
+++ b/java/src/jmri/jmrix/dccpp/simulator/DCCppSimulatorAdapter.java
@@ -25,6 +25,8 @@ import jmri.util.ImmediatePipedOutputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import edu.umd.cs.findbugs.annotations.*;
+
 /**
  * Provide access to a simulated DCC++ system.
  *
@@ -256,6 +258,7 @@ public class DCCppSimulatorAdapter extends DCCppSimulatorPortController implemen
 
     // generateReply is the heart of the simulation.  It translates an
     // incoming DCCppMessage into an outgoing DCCppReply.
+    @SuppressFBWarnings( value="FS_BAD_DATE_FORMAT_FLAG_COMBO", justification = "both am/pm and 24hr flags present ok as only used for display output")
     private DCCppReply generateReply(DCCppMessage msg) {
         String s, r = null;
         Pattern p;

--- a/java/src/jmri/jmrix/srcp/SRCPClockControl.java
+++ b/java/src/jmri/jmrix/srcp/SRCPClockControl.java
@@ -42,7 +42,6 @@ public class SRCPClockControl extends DefaultClockControl {
         String text = "INIT " + _memo.getBus() + " TIME 1 " + newRate;
         // create and send the message itself
         _tc.sendSRCPMessage(new SRCPMessage(text), null);
-        return;
     }
 
     @Override
@@ -56,15 +55,15 @@ public class SRCPClockControl extends DefaultClockControl {
     /**
      * Set and get the fast clock time For the default implementation,set time
      * is ignored and getTime returns the time of the internal clock;
+     * Date format sent as yyyyDDD HH mm ss , YearJulDay Hour Minute Seconds
      */
     @Override
     public void setTime(Date now) {
-        // prepare to format the date as <JulDay> <Hour> <Minute> <Seconds>
-        java.text.SimpleDateFormat sdf = new java.text.SimpleDateFormat("yyyyDDD hh mm ss");
+        // prepare to format the date as <Year><JulDay> <Hour> <Minute> <Seconds>
+        java.text.SimpleDateFormat sdf = new java.text.SimpleDateFormat("yyyyDDD HH mm ss");
         String text = "SET " + _memo.getBus() + " TIME " + sdf.format(now);
         // create and send the message itself
         _tc.sendSRCPMessage(new SRCPMessage(text), null);
-        return;
     }
 
     @Override
@@ -86,12 +85,10 @@ public class SRCPClockControl extends DefaultClockControl {
     @Override
     public void startHardwareClock(Date now) {
         setTime(now);
-        return;
     }
 
     @Override
     public void stopHardwareClock() {
-        return;
     }
 
     /**
@@ -102,7 +99,6 @@ public class SRCPClockControl extends DefaultClockControl {
      */
     @Override
     public void initializeHardwareClock(double rate, Date now, boolean getTime) {
-        return;
     }
 }
 

--- a/java/src/jmri/jmrix/srcp/SRCPClockControl.java
+++ b/java/src/jmri/jmrix/srcp/SRCPClockControl.java
@@ -6,7 +6,7 @@ import jmri.implementation.DefaultClockControl;
 
 /**
  * Class providing SRCP Clock Control to the SRCP client.
- *
+ * @see <a href="https://srcpd.sourceforge.net/srcp/srcp-084.html#TIME">SRCP TIME documentation</a>
  * @author Paul Bender Copyright (C) 2014
  */
 public class SRCPClockControl extends DefaultClockControl {
@@ -101,5 +101,3 @@ public class SRCPClockControl extends DefaultClockControl {
     public void initializeHardwareClock(double rate, Date now, boolean getTime) {
     }
 }
-
-

--- a/java/test/jmri/jmrix/srcp/SRCPClockControlTest.java
+++ b/java/test/jmri/jmrix/srcp/SRCPClockControlTest.java
@@ -1,9 +1,14 @@
 package jmri.jmrix.srcp;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Collections;
+import java.util.Date;
+
+import jmri.*;
 import jmri.util.JUnitUtil;
 
 import org.junit.jupiter.api.*;
-import org.junit.Assert;
 
 /**
  * SRCPClockControlTest.java
@@ -14,25 +19,76 @@ import org.junit.Assert;
  */
 public class SRCPClockControlTest {
 
+    private Timebase tb;
+    private SRCPClockControl t;
+    private SRCPBusConnectionMemo sm;
+    private SRCPTrafficControllerImpl tc;
+
     @Test
     public void testCtor() {
-        SRCPBusConnectionMemo sm = new SRCPBusConnectionMemo(new SRCPTrafficController() {
-            @Override
-            public void sendSRCPMessage(SRCPMessage m, SRCPListener reply) {
-            }
-        }, "A", 1);
-        SRCPClockControl m = new SRCPClockControl(sm);
-        Assert.assertNotNull(m);
+        Assertions.assertNotNull(t);
+    }
+
+    @Test
+    public void testSendATime() {
+
+        Assertions.assertNotNull(t);
+        InstanceManager.setDefault(ClockControl.class, t);
+        // Assertions.assertEquals( 0, tc.getSentMessages().size() );
+
+        tb = jmri.InstanceManager.getDefault(Timebase.class);
+        tb.setRun(false);
+
+        tb.setInternalMaster(true, false);
+        tb.setSynchronize(true, true);
+        
+        LocalDateTime specificDate = LocalDateTime.of(2020, 04, 24, 17, 57, 41);
+        tb.setTime(Date.from( specificDate.atZone( ZoneId.systemDefault()).toInstant())); // a Friday
+        Assertions.assertEquals( 2, tc.getSentMessages().size() );
+
+        SRCPMessage m = tc.getSentMessages().get(1);
+        Assertions.assertEquals("SET 1 TIME 2020115 17 57 41", m.toString());
+
+        sm.getTrafficController().terminateThreads();
+        sm.dispose();
+
+    }
+
+    private static class SRCPTrafficControllerImpl extends SRCPTrafficController {
+
+        private final java.util.List<SRCPMessage> lastSent = new java.util.ArrayList<>();
+
+        @Override
+        public void sendSRCPMessage(SRCPMessage m, SRCPListener reply) {
+            lastSent.add(m);
+        }
+
+        java.util.List<SRCPMessage> getSentMessages(){
+            return Collections.unmodifiableList(lastSent);
+        }
+
     }
 
     @BeforeEach
     public void setUp() {
         JUnitUtil.setUp();
+        tc = new SRCPTrafficControllerImpl();
+        sm = new SRCPBusConnectionMemo( tc , "A", 1);
+        t = new SRCPClockControl(sm);
     }
 
     @AfterEach
     public void tearDown() {
-        JUnitUtil.clearShutDownManager(); // put in place because AbstractMRTrafficController implementing subclass was not terminated properly
+        tb = jmri.InstanceManager.getNullableDefault(Timebase.class);
+        if (tb !=null){
+            tb.dispose();
+            tb = null;
+        }
+        tc.terminateThreads();
+        tc = null;
+        sm.dispose();
+        sm = null;
+
         JUnitUtil.tearDown();
     }
 }


### PR DESCRIPTION
Fixes instances of odd date formatting, found via Spotbugs 4.9.0

https://spotbugs.readthedocs.io/en/latest/bugDescriptions.html#fs-date-format-strings-may-lead-to-unexpected-behavior-fs-bad-date-format-flag-combo

https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/text/SimpleDateFormat.html


**RosterEntry**
Uses 24hr format when converting from a legacy date format.

**RosterTable**
Uses 24hr format for initial editing of last operated time.

**CbusEventTable**
Displays year, not week year.

**DCCppSimulatorAdapter**
Suppresses date string warning, only used in display.

**SRCPClockControl**
Uses 24hr, not 12hr date format, see SRCP TIME documentation.
Updates SRCPClockControlTest for correct time format sent.