### PR TITLE
Signalhead - describeState

### DIFF
--- a/java/src/jmri/implementation/AbstractSignalHead.java
+++ b/java/src/jmri/implementation/AbstractSignalHead.java
@@ -250,7 +250,7 @@ public abstract class AbstractSignalHead extends AbstractNamedBean
      * Can include multiple head states, with exception of DARK,
      * the only state which must exist on its own.
      * Includes the HELD state if present.
-     * @see SignalHead#getAppearanceName(java.lang.Integer)
+     * @see SignalHead#getAppearanceName(int)
      * @param state the state to describe.
      * @return description of state from Bundle.
      */

--- a/java/src/jmri/implementation/AbstractSignalHead.java
+++ b/java/src/jmri/implementation/AbstractSignalHead.java
@@ -1,8 +1,11 @@
 package jmri.implementation;
 
 import java.util.Arrays;
+
 import jmri.SignalHead;
 import jmri.Turnout;
+import jmri.util.ArrayUtil;
+import jmri.util.StringUtil;
 
 import javax.annotation.Nonnull;
 
@@ -51,7 +54,7 @@ public abstract class AbstractSignalHead extends AbstractNamedBean
     @Nonnull
     @Override
     public String getAppearanceKey(int appearance) {
-        String ret = jmri.util.StringUtil.getNameFromState(
+        String ret = StringUtil.getNameFromState(
                 appearance, getValidStates(), getValidStateKeys());
         if (ret != null) {
             return ret;
@@ -242,30 +245,31 @@ public abstract class AbstractSignalHead extends AbstractNamedBean
 
     /**
      * Describe SignalHead state.
-     * Does not have to be a valid state for this SignalHead instance.
-     * SignalHead.RED uses NamedBean.UNKNOWN ( 0x01 )
-     * SignalHead.FLASHYELLOW uses NamedBean.INCONSISTENT ( 0x08 )
-     * Includes SignalHead.HELD
+     * Does not have to be a valid state for this SignalHead instance hence
+     * suitable for state error logging.
+     * Can include multiple head states, with exception of DARK,
+     * the only state which must exist on its own.
+     * Includes the HELD state if present.
+     * @see SignalHead#getAppearanceName(java.lang.Integer)
      * @param state the state to describe.
      * @return description of state from Bundle.
      */
     @Override
     public String describeState(int state) {
-
-        int index = java.util.stream.IntStream.range(0, validStates.length)
-                         .filter(i -> validStates[i] == state)
-                         .findFirst()
-                         .orElse(-1);
-
-        if (index != -1) {
-            return Bundle.getMessage(validStateKeys[index]);
+        var bundleStrings = StringUtil.getNamesFromState(state, allStateNumbers, allStateNames);
+        StringBuilder sb = new StringBuilder();
+        for (String str : bundleStrings) {
+            sb.append(Bundle.getMessage(str));
+            sb.append(" ");
         }
-
-        if ( state == SignalHead.HELD ) {
-                return Bundle.getMessage("SignalHeadStateHeld");
-        }
-        return "Unknown SignalHead State: " + state;
+        return sb.toString().trim();
     }
+
+    // all states, including HELD
+    private static final int[] allStateNumbers = ArrayUtil.appendArray(validStates, new int[]{HELD});
+
+    // all state names, including HELD
+    private static final String[] allStateNames = ArrayUtil.appendArray(validStateKeys, new String[]{"SignalHeadStateHeld"});
 
     /**
      * Check if a given turnout is used on this head.

--- a/java/src/jmri/implementation/AbstractSignalHead.java
+++ b/java/src/jmri/implementation/AbstractSignalHead.java
@@ -241,6 +241,33 @@ public abstract class AbstractSignalHead extends AbstractNamedBean
     }
 
     /**
+     * Describe SignalHead state.
+     * Does not have to be a valid state for this SignalHead instance.
+     * SignalHead.RED uses NamedBean.UNKNOWN ( 0x01 )
+     * SignalHead.FLASHYELLOW uses NamedBean.INCONSISTENT ( 0x08 )
+     * Includes SignalHead.HELD
+     * @param state the state to describe.
+     * @return description of state from Bundle.
+     */
+    @Override
+    public String describeState(int state) {
+
+        int index = java.util.stream.IntStream.range(0, validStates.length)
+                         .filter(i -> validStates[i] == state)
+                         .findFirst()
+                         .orElse(-1);
+
+        if (index != -1) {
+            return Bundle.getMessage(validStateKeys[index]);
+        }
+
+        if ( state == SignalHead.HELD ) {
+                return Bundle.getMessage("SignalHeadStateHeld");
+        }
+        return "Unknown SignalHead State: " + state;
+    }
+
+    /**
      * Check if a given turnout is used on this head.
      *
      * @param t Turnout object to check

--- a/java/src/jmri/implementation/SingleTurnoutSignalHead.java
+++ b/java/src/jmri/implementation/SingleTurnoutSignalHead.java
@@ -6,8 +6,6 @@ import java.beans.PropertyChangeListener;
 import jmri.NamedBeanHandle;
 import jmri.SignalHead;
 import jmri.Turnout;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Drive a single signal head via one "Turnout" object.
@@ -112,7 +110,8 @@ public class SingleTurnoutSignalHead extends DefaultSignalHead implements Proper
             } else if ((mAppearance == mOnAppearance) || (mAppearance == (mOnAppearance * 2))) {
                 setTurnoutState(Turnout.THROWN);
             } else {
-                log.warn("Unexpected new appearance: {}", mAppearance);
+                log.warn("Unexpected: Single Output Red / Green SignalHeads cannot display new appearance: {}",
+                    describeState(mAppearance));
             }
         }
     }
@@ -292,6 +291,6 @@ public class SingleTurnoutSignalHead extends DefaultSignalHead implements Proper
         }
     }
 
-    private final static Logger log = LoggerFactory.getLogger(SingleTurnoutSignalHead.class);
+    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(SingleTurnoutSignalHead.class);
 
 }

--- a/java/src/jmri/util/ArrayUtil.java
+++ b/java/src/jmri/util/ArrayUtil.java
@@ -107,5 +107,37 @@ public final class ArrayUtil {
         return results;
     }
 
+    /**
+     * Combines two String arrays into a single array.
+     * No sorting, first comes before second.
+     * @param first  the first String array to be combined
+     * @param second the second String array to be combined
+     * @return a new String array containing all elements from both input arrays
+     */
+    @Nonnull
+    public static String[] appendArray( @Nonnull String[] first, @Nonnull String[] second){
+        int length = first.length + second.length;
+        String[] result = new String[length];
+        System.arraycopy(first, 0, result, 0, first.length);
+        System.arraycopy(second, 0, result, first.length, second.length);
+        return result;
+    }
+
+    /**
+     * Combines two int arrays into a single array.
+     * No sorting, first comes before second.
+     * @param first the first int array to be combined
+     * @param second the second int array to be combined
+     * @return new int array containing all elements from both input arrays
+     */
+    @Nonnull
+    public static int[] appendArray(@Nonnull int[] first, @Nonnull int[] second){
+        int length = first.length + second.length;
+        int[] result = new int[length];
+        System.arraycopy(first, 0, result, 0, first.length);
+        System.arraycopy(second, 0, result, first.length, second.length);
+        return result;
+    }
+
     // private transient final static Logger log = LoggerFactory.getLogger(ArrayUtil.class);
 }

--- a/java/src/jmri/util/StringUtil.java
+++ b/java/src/jmri/util/StringUtil.java
@@ -102,6 +102,8 @@ public class StringUtil {
     /**
      * Starting with two arrays, one of names, one of corresponding numeric
      * state values, find the name string(s) that match a given state value.
+     * <p>State is considered to be bit-encoded, so that its bits are taken to
+     * represent multiple independent states.
      * <p>e.g. for 3, [1, 2, 4], ["A","B","C"], the method would return ["A","B"]</p>
      * <p>Values of 0 are only included if the state is 0, zero is NOT
      * matched for all numbers.</p>

--- a/java/src/jmri/util/StringUtil.java
+++ b/java/src/jmri/util/StringUtil.java
@@ -22,6 +22,9 @@ import javax.annotation.Nonnull;
  */
 public class StringUtil {
 
+    // class only supplies static methods.
+    private StringUtil(){}
+
     public static final String HTML_CLOSE_TAG = "</html>";
     public static final String HTML_OPEN_TAG = "<html>";
     public static final String LINEBREAK = "\n";
@@ -36,7 +39,7 @@ public class StringUtil {
      * @return the state or -1 if none found
      */
     @CheckReturnValue
-    public static int getStateFromName(String name, int[] states, String[] names) {
+    public static int getStateFromName(String name, @Nonnull int[] states, @Nonnull String[] names) {
         for (int i = 0; i < states.length; i++) {
             if (name.equals(names[i])) {
                 return states[i];
@@ -56,8 +59,10 @@ public class StringUtil {
      * @param names  the state names
      * @return names matching the given state or an empty array
      */
+    @Nonnull
     @CheckReturnValue
-    public static String[] getNamesFromStateMasked(int state, int[] states, int[] masks, String[] names) {
+    public static String[] getNamesFromStateMasked(int state, @Nonnull int[] states,
+        @Nonnull int[] masks, @Nonnull String[] names) {
         // first pass to count, get refs
         int count = 0;
         String[] temp = new String[states.length];
@@ -92,6 +97,36 @@ public class StringUtil {
             }
         }
         return null;
+    }
+
+    /**
+     * Starting with two arrays, one of names, one of corresponding numeric
+     * state values, find the name string(s) that match a given state value.
+     * <p>e.g. for 3, [1, 2, 4], ["A","B","C"], the method would return ["A","B"]</p>
+     * <p>Values of 0 are only included if the state is 0, zero is NOT
+     * matched for all numbers.</p>
+     * @param state  the given state
+     * @param states the state values
+     * @param names  the state names
+     * @return names matching the given state or an empty array
+     */
+    @Nonnull
+    @CheckReturnValue
+    public static String[] getNamesFromState(int state, @Nonnull int[] states, @Nonnull String[] names) {
+        // first pass to count, get refs
+        int count = 0;
+        String[] temp = new String[states.length];
+
+        for (int i = 0; i < states.length; i++) {
+            if ( ( state == 0 && states[i] == 0) || ((state & states[i]) != 0)) {
+                temp[count] = names[i];
+                count++;
+            }
+        }
+        // second pass to create output array
+        String[] output = new String[count];
+        System.arraycopy(temp, 0, output, 0, count);
+        return output;
     }
 
     private static final char[] HEX_CHARS = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};

--- a/java/test/jmri/implementation/AbstractSignalHeadTestBase.java
+++ b/java/test/jmri/implementation/AbstractSignalHeadTestBase.java
@@ -135,4 +135,20 @@ public abstract class AbstractSignalHeadTestBase {
          Assert.assertEquals("bean type",s.getBeanType(),Bundle.getMessage("BeanNameSignalHead"));
     }
 
+    @Test
+    public void testDescribeState() {
+        SignalHead s = getHeadToTest();
+        Assertions.assertEquals(Bundle.getMessage("SignalHeadStateDark"), s.describeState(SignalHead.DARK) );
+        Assertions.assertEquals(Bundle.getMessage("SignalHeadStateRed"), s.describeState(SignalHead.RED) );
+        Assertions.assertEquals(Bundle.getMessage("SignalHeadStateFlashingRed"), s.describeState(SignalHead.FLASHRED) );
+        Assertions.assertEquals(Bundle.getMessage("SignalHeadStateYellow"), s.describeState(SignalHead.YELLOW) );
+        Assertions.assertEquals(Bundle.getMessage("SignalHeadStateFlashingYellow"), s.describeState(SignalHead.FLASHYELLOW) );
+        Assertions.assertEquals(Bundle.getMessage("SignalHeadStateGreen"), s.describeState(SignalHead.GREEN) );
+        Assertions.assertEquals(Bundle.getMessage("SignalHeadStateFlashingGreen"), s.describeState(SignalHead.FLASHGREEN) );
+        Assertions.assertEquals(Bundle.getMessage("SignalHeadStateLunar"), s.describeState(SignalHead.LUNAR) );
+        Assertions.assertEquals(Bundle.getMessage("SignalHeadStateFlashingLunar"), s.describeState(SignalHead.FLASHLUNAR) );
+        Assertions.assertEquals(Bundle.getMessage("SignalHeadStateHeld"), s.describeState(SignalHead.HELD) );
+        Assertions.assertEquals("Unknown SignalHead State: 999", s.describeState(999) );
+    }
+
 }

--- a/java/test/jmri/implementation/AbstractSignalHeadTestBase.java
+++ b/java/test/jmri/implementation/AbstractSignalHeadTestBase.java
@@ -148,7 +148,12 @@ public abstract class AbstractSignalHeadTestBase {
         Assertions.assertEquals(Bundle.getMessage("SignalHeadStateLunar"), s.describeState(SignalHead.LUNAR) );
         Assertions.assertEquals(Bundle.getMessage("SignalHeadStateFlashingLunar"), s.describeState(SignalHead.FLASHLUNAR) );
         Assertions.assertEquals(Bundle.getMessage("SignalHeadStateHeld"), s.describeState(SignalHead.HELD) );
-        Assertions.assertEquals("Unknown SignalHead State: 999", s.describeState(999) );
+        Assertions.assertEquals(
+            Bundle.getMessage("SignalHeadStateYellow") + " " + Bundle.getMessage("SignalHeadStateHeld"),
+            s.describeState( SignalHead.YELLOW + SignalHead.HELD ) );
+        Assertions.assertEquals(
+            Bundle.getMessage("SignalHeadStateRed") + " " + Bundle.getMessage("SignalHeadStateFlashingRed"),
+            s.describeState( SignalHead.RED + SignalHead.FLASHRED ) );
     }
 
 }

--- a/java/test/jmri/util/ArrayUtilTest.java
+++ b/java/test/jmri/util/ArrayUtilTest.java
@@ -86,5 +86,25 @@ public class ArrayUtilTest {
         Assert.assertEquals(stringArray.length, reversedStringArray.length);
     }
 
+    @Test
+    public void testAppendIntArrays() {
+        int[] arrayA = new int[]{0};
+        int[] arrayB = new int[]{1};
+        int[] t = ArrayUtil.appendArray(arrayA, arrayB);
+        Assertions.assertEquals(2, t.length);
+        Assertions.assertEquals( 0, t[0] );
+        Assertions.assertEquals( 1, t[1] );
+    }
+
+    @Test
+    public void testAppendStringArrays() {
+        String[] arrayA = new String[]{"A"};
+        String[] arrayB = new String[]{"B"};
+        String[] t = ArrayUtil.appendArray(arrayA, arrayB);
+        Assertions.assertEquals(2, t.length);
+        Assertions.assertEquals( "A", t[0] );
+        Assertions.assertEquals( "B", t[1] );
+    }
+
     // private final static Logger log = LoggerFactory.getLogger(ArrayUtilTest.class);
 }

--- a/java/test/jmri/util/StringUtilTest.java
+++ b/java/test/jmri/util/StringUtilTest.java
@@ -71,6 +71,27 @@ public class StringUtilTest {
     }
 
     @Test
+    public void testGetNamesFromState() {
+
+        String[] s = new String[]{"A", "B", "C", "D"};
+        int[] num = new int[]{0, 1, 2, 4};
+
+        Assertions.assertEquals( 1, StringUtil.getNamesFromState(0, num, s).length);
+        Assertions.assertEquals( "A", StringUtil.getNamesFromState(0, num, s)[0]);
+
+        Assertions.assertEquals( 1, StringUtil.getNamesFromState(1, num, s).length);
+        Assertions.assertEquals( "B", StringUtil.getNamesFromState(1, num, s)[0]);
+
+        Assertions.assertEquals( 1, StringUtil.getNamesFromState(2, num, s).length);
+        Assertions.assertEquals( "C", StringUtil.getNamesFromState(2, num, s)[0]);
+
+        Assertions.assertEquals( 2, StringUtil.getNamesFromState(3, num, s).length);
+        Assertions.assertEquals( "B", StringUtil.getNamesFromState(3, num, s)[0]);
+        Assertions.assertEquals( "C", StringUtil.getNamesFromState(3, num, s)[1]);
+
+    }
+
+    @Test
     public void testFindState() {
         String[] s = new String[]{"A", "B", "C"};
         int[] n = new int[]{20, 30, 40};


### PR DESCRIPTION
**AbstractSignalHead** - implement describeState
describeState(int) can describe multiple states

**SingleTurnoutSignalHead** - use describeState in warning message

**AbstractSignalHeadTestBase** - test describeState

**StringUtil**
Adds getNamesFromState for matching binary states
NonNull annotation.
Private constructor, only static methods.

**ArrayUtil** Adds appendArray(String[], String[]) and appendArray(int[], int[])