### PR TITLE
FileUtilSupport / ProfileManager / AutomatSummary Singletons

### DIFF
--- a/java/src/jmri/jmrit/automat/AutomatSummary.java
+++ b/java/src/jmri/jmrit/automat/AutomatSummary.java
@@ -18,18 +18,18 @@ public class AutomatSummary {
     private AutomatSummary() {
     }
 
-    static volatile private AutomatSummary self = null;
+    // Synchronized lazy initialization, default instance created the 1st time requested
+    private static class InstanceHolder {
+        private static final AutomatSummary self = new AutomatSummary();
+    }
 
-    static public AutomatSummary instance() {
-        if (self == null) {
-            self = new AutomatSummary();
-        }
-        return self;
+    public static AutomatSummary instance() {
+        return InstanceHolder.self;
     }
 
     private final ArrayList<AbstractAutomaton> automats = new ArrayList<>();
 
-    java.beans.PropertyChangeSupport prop = new java.beans.PropertyChangeSupport(this);
+    private final java.beans.PropertyChangeSupport prop = new java.beans.PropertyChangeSupport(this);
 
     public void removePropertyChangeListener(java.beans.PropertyChangeListener p) {
         prop.removePropertyChangeListener(p);

--- a/java/src/jmri/profile/ProfileManager.java
+++ b/java/src/jmri/profile/ProfileManager.java
@@ -57,7 +57,7 @@ public class ProfileManager extends Bean {
     private boolean autoStartActiveProfile = false;
     private File defaultSearchPath = new File(FileUtil.getPreferencesPath());
     private int autoStartActiveProfileTimeout = 10;
-    volatile private static ProfileManager defaultInstance = null;
+
     public static final String ACTIVE_PROFILE = "activeProfile"; // NOI18N
     public static final String NEXT_PROFILE = "nextProfile"; // NOI18N
     private static final String AUTO_START = "autoStart"; // NOI18N
@@ -71,6 +71,11 @@ public class ProfileManager extends Bean {
     public static final String DEFAULT_SEARCH_PATH = "defaultSearchPath"; // NOI18N
     public static final String SYSTEM_PROPERTY = "org.jmri.profile"; // NOI18N
     private static final Logger log = LoggerFactory.getLogger(ProfileManager.class);
+
+    // Synchronized lazy initialization, default instance created the 1st time requested
+    private static class InstanceHolder {
+        private static final ProfileManager defaultInstance = new ProfileManager();
+    }
 
     /**
      * Create a new ProfileManager using the default catalog.
@@ -97,10 +102,7 @@ public class ProfileManager extends Bean {
      */
     @Nonnull
     public static ProfileManager getDefault() {
-        if (defaultInstance == null) {
-            defaultInstance = new ProfileManager();
-        }
-        return defaultInstance;
+        return InstanceHolder.defaultInstance;
     }
 
     /**

--- a/java/src/jmri/util/FileUtilSupport.java
+++ b/java/src/jmri/util/FileUtilSupport.java
@@ -83,13 +83,43 @@ public class FileUtilSupport extends Bean {
     // initialize logging
     private static final Logger log = LoggerFactory.getLogger(FileUtilSupport.class);
 
-    // Synchronized lazy initialization, default instance created the 1st time requested
-    private static class InstanceHolder {
-        private static final FileUtilSupport defaultInstance = new FileUtilSupport();
-    }
+    private static volatile FileUtilSupport defaultInstance;
 
     private FileUtilSupport() {
         super(false);
+    }
+
+    /**
+     * Get the default instance of a FileUtilSupport object.
+     * <p>
+     * Unlike most implementations of getDefault(), this does not return an
+     * object held by {@link jmri.InstanceManager} due to the need for this
+     * default instance to be available prior to the creation of an
+     * InstanceManager.
+     *
+     * @return the default FileUtilSupport instance, creating it if necessary
+     */
+    public static FileUtilSupport getDefault() {
+        // 1st pass non-synchronized for lower latency
+        FileUtilSupport checkingInstance = FileUtilSupport.defaultInstance;
+        if ( checkingInstance != null ) {
+            return checkingInstance;
+        }
+
+        // if null, synchronize
+        synchronized ( FileUtilSupport.class ) {
+            if ( FileUtilSupport.defaultInstance == null ) {
+                FileUtilSupport.defaultInstance = new FileUtilSupport();
+            }
+        }
+        return FileUtilSupport.defaultInstance;
+    }
+
+    // for use in JUnitUtil #resetFileUtilSupport
+    protected static void resetInstance() {
+        synchronized ( FileUtilSupport.class ) {
+            FileUtilSupport.defaultInstance = new FileUtilSupport();
+        }
     }
 
     /**
@@ -1742,20 +1772,6 @@ public class FileUtilSupport extends Bean {
             i--;
         }
         this.copy(file, new File(dir, name + "." + i + extension));
-    }
-
-    /**
-     * Get the default instance of a FileUtilSupport object.
-     * <p>
-     * Unlike most implementations of getDefault(), this does not return an
-     * object held by {@link jmri.InstanceManager} due to the need for this
-     * default instance to be available prior to the creation of an
-     * InstanceManager.
-     *
-     * @return the default FileUtilSupport instance, creating it if necessary
-     */
-    public static FileUtilSupport getDefault() {
-        return InstanceHolder.defaultInstance;
     }
 
     /**

--- a/java/src/jmri/util/FileUtilSupport.java
+++ b/java/src/jmri/util/FileUtilSupport.java
@@ -82,8 +82,11 @@ public class FileUtilSupport extends Bean {
 
     // initialize logging
     private static final Logger log = LoggerFactory.getLogger(FileUtilSupport.class);
-    // default instance
-    volatile private static FileUtilSupport defaultInstance = null;
+
+    // Synchronized lazy initialization, default instance created the 1st time requested
+    private static class InstanceHolder {
+        private static final FileUtilSupport defaultInstance = new FileUtilSupport();
+    }
 
     private FileUtilSupport() {
         super(false);
@@ -1752,10 +1755,7 @@ public class FileUtilSupport extends Bean {
      * @return the default FileUtilSupport instance, creating it if necessary
      */
     public static FileUtilSupport getDefault() {
-        if (FileUtilSupport.defaultInstance == null) {
-            FileUtilSupport.defaultInstance = new FileUtilSupport();
-        }
-        return FileUtilSupport.defaultInstance;
+        return InstanceHolder.defaultInstance;
     }
 
     /**

--- a/java/test/jmri/util/JUnitUtil.java
+++ b/java/test/jmri/util/JUnitUtil.java
@@ -676,14 +676,9 @@ public class JUnitUtil {
      * tests of {@code git-working-copy/temp}.
      */
     public static void resetFileUtilSupport() {
-        try {
-            Field field = FileUtilSupport.class.getDeclaredField("defaultInstance");
-            field.setAccessible(true);
-            field.set(null, null);
-            FileUtilSupport.getDefault().setUserFilesPath(ProfileManager.getDefault().getActiveProfile(), FileUtil.getPreferencesPath());
-        } catch (NoSuchFieldException | SecurityException | IllegalArgumentException | IllegalAccessException ex) {
-            log.error("Exception resetting FileUtilSupport", ex);
-        }
+        FileUtilSupport.resetInstance();
+        FileUtilSupport.getDefault().setUserFilesPath(
+            ProfileManager.getDefault().getActiveProfile(), FileUtil.getPreferencesPath());
     }
 
     static public interface ReleaseUntil {


### PR DESCRIPTION
These 3 classes were being flagged by Spotbugs for
SING_SINGLETON_GETTER_NOT_SYNCHRONIZED
https://spotbugs.readthedocs.io/en/latest/bugDescriptions.html#sing-instance-getter-method-of-class-using-singleton-design-pattern-is-not-synchronized-sing-singleton-getter-not-synchronized

This PR synchronises #getDefault ( ProfileManager / AutomatSummary ) by creating the instance from a private static class.
See https://www.baeldung.com/java-singleton-double-checked-locking#2-initialization-on-demand

FileUtilSupport requires the instance to be reset, so these operations have been enclosed within synchronised blocks.