### PR TITLE
feat/socketservice change railroad name example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,8 @@ local.properties
 *.original~
 .metadata
 RemoteSystemsTempFiles
+.idea/codeStyles/Project.xml
+.idea/jarRepositories.xml
 .idea/libraries/**
 .idea/sonarlint/issuestore
 .factorypath

--- a/java/src/jmri/server/json/util/JsonUtilHttpService.java
+++ b/java/src/jmri/server/json/util/JsonUtilHttpService.java
@@ -51,6 +51,8 @@ import jmri.util.node.NodeIdentity;
 import jmri.util.zeroconf.ZeroConfService;
 import jmri.util.zeroconf.ZeroConfServiceManager;
 import jmri.web.server.WebServerPreferences;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author Randall Wood Copyright 2016, 2017, 2018
@@ -58,6 +60,7 @@ import jmri.web.server.WebServerPreferences;
 public class JsonUtilHttpService extends JsonHttpService {
 
     private static final String RESOURCE_PATH = "jmri/server/json/util/";
+    private static final Logger log = LoggerFactory.getLogger(JsonUtilHttpService.class);
 
     public JsonUtilHttpService(ObjectMapper mapper) {
         super(mapper);
@@ -145,6 +148,14 @@ public class JsonUtilHttpService extends JsonHttpService {
     // Use @CheckForNull to override non-null requirement of superclass
     public JsonNode doPost(String type, @CheckForNull String name,
             JsonNode data, JsonRequest request) throws JsonException {
+        log.debug("doPost(type='{}', name='{}', data='{}')", type, name, data);
+        // This will be expanded with more cases and warrants a CASE rather than an IF
+        switch (type) {
+            case JSON.RAILROAD:
+                InstanceManager.getDefault(WebServerPreferences.class).setRailroadName(name);
+                break;
+        }
+        // Implicitly answer all doPost the way an equivalent doGet would be answered.
         return this.doGet(type, name, data, request);
     }
 

--- a/java/src/jmri/server/json/util/JsonUtilHttpService.java
+++ b/java/src/jmri/server/json/util/JsonUtilHttpService.java
@@ -154,6 +154,9 @@ public class JsonUtilHttpService extends JsonHttpService {
             case JSON.RAILROAD:
                 InstanceManager.getDefault(WebServerPreferences.class).setRailroadName(name);
                 break;
+            default:
+                log.debug("Received unexpected POST command: '{}'", type);
+                break;
         }
         // Implicitly answer all doPost the way an equivalent doGet would be answered.
         return this.doGet(type, name, data, request);

--- a/java/src/jmri/server/json/util/railroad-client.json
+++ b/java/src/jmri/server/json/util/railroad-client.json
@@ -9,6 +9,5 @@
       "description": "Railroad name the client wants to update on the server"
     }
   },
-  "additionalProperties": false,
-  "required": []
+  "additionalProperties": false
 }

--- a/java/src/jmri/server/json/util/railroad-client.json
+++ b/java/src/jmri/server/json/util/railroad-client.json
@@ -1,9 +1,14 @@
 {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "title": "jmri-json-railroad-client-message",
-    "type": "object",
-    "description": "Schema data object in message from client to JMRI for type \"railroad\"",
-    "properties": {
-    },
-    "additionalProperties": false
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "jmri-json-railroad-client-message",
+  "type": "object",
+  "description": "Schema data object in message from client to JMRI for type \"railroad\"",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Railroad name the client wants to update on the server"
+    }
+  },
+  "additionalProperties": false,
+  "required": []
 }

--- a/java/src/jmri/web/server/RailroadNamePreferencesPanel.java
+++ b/java/src/jmri/web/server/RailroadNamePreferencesPanel.java
@@ -15,13 +15,18 @@ import jmri.swing.JTitledSeparator;
 import jmri.swing.PreferencesPanel;
 import org.openide.util.lookup.ServiceProvider;
 
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.io.IOException;
+
 @ServiceProvider(service = PreferencesPanel.class)
-public class RailroadNamePreferencesPanel extends JPanel implements PreferencesPanel {
+public class RailroadNamePreferencesPanel extends JPanel implements PreferencesPanel, PropertyChangeListener {
 
     private JTextField railroadName;
     private WebServerPreferences preferences;
     public RailroadNamePreferencesPanel() {
         preferences = InstanceManager.getDefault(WebServerPreferences.class);
+        preferences.addPropertyChangeListener(this);
         initGUI();
         setGUI();
     }
@@ -103,5 +108,12 @@ public class RailroadNamePreferencesPanel extends JPanel implements PreferencesP
     @Override
     public boolean isPreferencesValid() {
         return true; // no validity checking performed
+    }
+
+    public void propertyChange(PropertyChangeEvent evt) {
+        String newRrName = evt.getNewValue().toString();
+        if (evt.getPropertyName().equals(WebServerPreferences.RAILROAD_NAME) && !this.railroadName.getText().equals(newRrName)) {
+            this.railroadName.setText(newRrName);
+        }
     }
 }

--- a/java/src/jmri/web/server/RailroadNamePreferencesPanel.java
+++ b/java/src/jmri/web/server/RailroadNamePreferencesPanel.java
@@ -17,7 +17,6 @@ import org.openide.util.lookup.ServiceProvider;
 
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
-import java.io.IOException;
 
 @ServiceProvider(service = PreferencesPanel.class)
 public class RailroadNamePreferencesPanel extends JPanel implements PreferencesPanel, PropertyChangeListener {

--- a/web/js/jquery.jmri.js
+++ b/web/js/jquery.jmri.js
@@ -456,8 +456,17 @@
                     });
                 }
             };
+            // React to live updates on railroad name via socket
             jmri.getRailroad = function (name) {
-                jmri.socket.send("railroad", { name: name });
+                jmri.socket.send("railroad", { name: name } );
+            };
+            // Change Railroad name
+            jmri.setRailroad = function (name) {
+                if (jmri.socket) {
+                    jmri.socket.send("railroad", { name: name }, 'post');
+                } else {
+                    jmri.warn("Tried to send change railroad name message but socket is unavailable and no fallback implemented");
+                }
             };
             jmri.getReporter = function (name) {
                 if (jmri.socket) {

--- a/web/js/jquery.jmri.js
+++ b/web/js/jquery.jmri.js
@@ -1021,6 +1021,9 @@
                 power: function (e) {
                     jmri.power(e.data.state);
                 },
+                railroad: function (e) {
+                    jmri.railroad(e.data.name);
+                },
                 reporter: function (e) {
                     jmri.reporter(e.data.name, e.data.value, e.data);
                 },
@@ -1147,7 +1150,7 @@
                                 } else if (!o.type) {
                                     log.error("ERROR: missing type property in " + o);
                                 } else if (!h) {
-                                    jmri.log("Ignoring JSON type '" + o.type + "'");
+                                    jmri.log("Ignoring unhandled JSON type '" + o.type + "'");
                                 }
                             })
                         } else {
@@ -1158,7 +1161,7 @@
                             } else if (!m.type) {
                                 log.error("ERROR: missing type property in " + m);
                             } else if (!h) {
-                                jmri.log("Ignoring JSON type '" + m.type + "'");
+                                jmri.log("Ignoring unhandled JSON type '" + m.type + "'");
                             }
                         }
                     }

--- a/web/railroad.html
+++ b/web/railroad.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="UTF-8" />
+        <title>JSON Read/Write Railroad Demonstration</title>
+        <style>
+            html {background-color:#eeeeee}
+            body {
+                background-color:#ccffcc;
+                font-family:Tahoma,Arial,Helvetica,sans-serif;
+                font-size:12px;
+                margin-left:15%;
+                margin-right:15%;
+                border:3px groove #006600;
+                padding:15px
+            }
+            h1   {
+                text-align:left;
+                font-size:1.5em;
+                font-weight:bold
+            }
+        </style>
+        <!-- include the jquery.jmri library and its dependencies -->
+        <script src="/js/jquery-2.2.4.min.js"></script>
+        <script src="/js/json2.js"></script>
+        <script src="/js/jquery.websocket.js"></script>
+        <script src="/js/logger.js"></script>
+        <script src="/js/jquery.jmri.js"></script>
+        <script type="text/javascript">
+            // set the jmri global variable to null
+            var jmri = null;
+            $(document).ready(function() {
+                // once the document is loaded, assign a $.JMRI object to
+                // the jmri variable and overload two functions:
+                // open() and power(state)
+                jmri = $.JMRI({
+                    // call getRailroad() when the JMRI WebSocket connection opens
+                    // getRailroad() does two things: it requests the current power
+                    // status from JMRI and it starts the railroad attribute monitor
+                    // on the JMRI server.
+                    open: function() {
+                        jmri.getRailroad();
+                    },
+                    // when the JMRI object receives an update to the railroad name, call this
+                    // function, regardless of source of update
+                    railroad: function(state) {
+                        railroadName = state;
+                        $('#railroadName').text(railroadName);
+                    }
+                });
+                // trigger the initial connection to the JMRI server; this
+                // method call ensures the jmri.open() method is called after
+                // a timeout to begin using fall back methods for monitoring
+                // items on the JMRI server even if a WebSocket connection
+                // cannot be established
+                jmri.connect();
+                // make it possible to click on the power button to turn track
+                // power on or off without using a javascript URI
+            });
+        </script>
+
+    </head>
+    <body>
+        <h1>JSON Socket Read and Write Railroad Name Demonstration</h1>
+        <hr />
+        <p>This sample page loads the railroad name from the socket server and listens if the railroad name is changed through JMRI's menu</p>
+        <p>It also provides a button to change the railroad name. You can change it here and check in JMRI to see it really changed.</p>
+        <p>Railroad name below will update in browser if changed in the application window</p>
+        <p id="railroadName"></p>
+    </body>
+</html>

--- a/web/railroad.html
+++ b/web/railroad.html
@@ -40,10 +40,13 @@
                     // on the JMRI server.
                     open: function() {
                         jmri.getRailroad();
+                        // Keep this for learner's visibility - this is not production code
+                        console.log("getRailroad fired");
                     },
                     // when the JMRI object receives an update to the railroad name, call this
                     // function, regardless of source of update
                     railroad: function(state) {
+                        console.log(state);
                         railroadName = state;
                         $('#railroadName').text(railroadName);
                     }
@@ -54,8 +57,6 @@
                 // items on the JMRI server even if a WebSocket connection
                 // cannot be established
                 jmri.connect();
-                // make it possible to click on the power button to turn track
-                // power on or off without using a javascript URI
             });
         </script>
 

--- a/web/railroad.html
+++ b/web/railroad.html
@@ -48,7 +48,7 @@
                     railroad: function(state) {
                         console.log(state);
                         railroadName = state;
-                        $('#railroadName').text(railroadName);
+                        $('#railroadName').val(railroadName);
                     }
                 });
                 // trigger the initial connection to the JMRI server; this
@@ -57,6 +57,11 @@
                 // items on the JMRI server even if a WebSocket connection
                 // cannot be established
                 jmri.connect();
+                $("input[name=changeRailroadNameButton]" ).on( "click", function() {
+                  newName = $('#railroadName').val();
+                  console.log("Firing outgoing message for railroad name change to '" + newName + "'");
+                  jmri.setRailroad(newName);
+                } );
             });
         </script>
 
@@ -67,6 +72,10 @@
         <p>This sample page loads the railroad name from the socket server and listens if the railroad name is changed through JMRI's menu</p>
         <p>It also provides a button to change the railroad name. You can change it here and check in JMRI to see it really changed.</p>
         <p>Railroad name below will update in browser if changed in the application window</p>
-        <p id="railroadName"></p>
+        <p><form name="changeRailroadNameForm" action="" method="get">
+          <input id="railroadName" type="text" name="railroadName" value="">
+          <input type="button" name="changeRailroadNameButton" value="Change Name">
+        </form>
+        </p>
     </body>
 </html>


### PR DESCRIPTION
This is a first change related to issue #13765

By intention I kept the commits very granular so I can reference the different changes in an upcoming documentation file on how this works. 

- **My IDEA locally modifies this file but I don't want to mess with the project's official configuration**
- **First iteration: Demo page**
- **Add event handler for live updates of railroad name from the UI to the web client**
- **Upgrade client side to allow POSTing a new railroad name to the UI**
- **Modify JSON server to actually change railroad name in JMRI from a socket client command**
- **Update schema info for client message to server - support changed name attribute for client to server messages**

The PR needed rebasing after initial push, it somehow contained unrelated changes. I think I confused the L10N bot...