### PR TITLE
When setting up a new train use detection Entire Train, unless overri…

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -42,7 +42,6 @@
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
 		<attributes>
-			<attribute name="module" value="true"/>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>

--- a/.classpath
+++ b/.classpath
@@ -42,6 +42,7 @@
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
 		<attributes>
+			<attribute name="module" value="true"/>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -438,7 +438,16 @@
    <h3>Dispatcher</h3>
         <a id="Dispatcher" name="Dispatcher"></a>
         <ul>
-             <li></li>
+             <li>When setting up a new train use detection Entire Train, unless overridden by custom defaults.</li>
+             <li>Always check allocation and switch settings before any signaling system.</li>
+             <li>Correctly identify and handle changing position of DoubleXOver switch to prevent switch
+                 changing under a train.</li>
+             <li>Identify conflicting routes when checking allocations thru DoubleXOvers with four blocks.
+                 DoubleXOvers with less than four blocks require no additional checks.</li>
+             <li>When stopping on previous block going unoccupied and speed profile ramping and minimum speed,
+                 use a 75% stopping length factor for the ramp.</li>
+             <li>When a train has been stopped with a missing signal mast attempt to restart use BlockAllocation.</li>
+             <li>When a missing signal mast has been found use BlockAllocation method to stop if next block not allocated.</li>
         </ul>
 
     <h3>Dispatcher System</h3>

--- a/java/src/jmri/jmrit/dispatcher/ActivateTrainFrame.java
+++ b/java/src/jmri/jmrit/dispatcher/ActivateTrainFrame.java
@@ -416,6 +416,7 @@ public class ActivateTrainFrame extends JmriJFrame {
                 @Override
                 public void itemStateChanged(ItemEvent e)  {
                     if (e.getStateChange() == ItemEvent.SELECTED) {
+                        checkAdvancedRouting();
                         transitSelectBox.setEnabled(false);
                         //adHocCloseLoop.setEnabled(true);
                         inTransitBox.setEnabled(false);
@@ -2099,6 +2100,24 @@ public class ActivateTrainFrame extends JmriJFrame {
             }
         }
     }
+
+    /*
+     * Check Advanced routing
+    */
+    private boolean checkAdvancedRouting() {
+        if (!InstanceManager.getDefault(LayoutBlockManager.class).isAdvancedRoutingEnabled()) {
+            int response = JmriJOptionPane.showConfirmDialog(this, Bundle.getMessage("AdHocNeedsEnableBlockRouting"),
+                    Bundle.getMessage("AdHocNeedsBlockRouting"), JmriJOptionPane.YES_NO_OPTION);
+            if (response == 0) {
+                InstanceManager.getDefault(LayoutBlockManager.class).enableAdvancedRouting(true);
+                JmriJOptionPane.showMessageDialog(this, Bundle.getMessage("AdhocNeedsBlockRoutingEnabled"));
+            } else {
+                return false;
+            }
+        }
+        return true;
+    }
+
     /*
      * ComboBox item.
      */

--- a/java/src/jmri/jmrit/dispatcher/AutoActiveTrain.java
+++ b/java/src/jmri/jmrit/dispatcher/AutoActiveTrain.java
@@ -107,7 +107,7 @@ public class AutoActiveTrain implements ThrottleListener {
     private long _MaxTrainLength = 600; // default train length mm.
     private float _stopBySpeedProfileAdjust = 1.0f;
     private boolean _stopBySpeedProfile = false;
-    private boolean _useSpeedProfile = true;
+    private boolean _useSpeedProfileRequested = true;
 
     // accessor functions
     public ActiveTrain getActiveTrain() {
@@ -252,11 +252,11 @@ public class AutoActiveTrain implements ThrottleListener {
     }
 
     public void setUseSpeedProfile(boolean tf) {
-        _useSpeedProfile = tf;
+        _useSpeedProfileRequested = tf;
     }
 
     public boolean getUseSpeedProfile() {
-        return _useSpeedProfile;
+        return _useSpeedProfileRequested;
     }
 
     public void setStopBySpeedProfile(boolean tf) {
@@ -336,13 +336,13 @@ public class AutoActiveTrain implements ThrottleListener {
             if (_activeTrain.getRosterEntry() != null) {
                 re = _activeTrain.getRosterEntry();
                 ok = InstanceManager.throttleManagerInstance().requestThrottle(re, this, false);
-                if (_useSpeedProfile) {
+                if (_useSpeedProfileRequested) {
                     if (re.getSpeedProfile() != null && re.getSpeedProfile().getProfileSize() > 0) {
                         useSpeedProfile = true;
                     }
                 }
-                log.debug("{}: requested roster entry '{}', address={}, use speed profile={}",
-                        _activeTrain.getTrainName(), re.getId(), _address, useSpeedProfile);
+                log.debug("{}: requested roster entry '{}', address={}, use speed profile requested={} usespeedprofile set={}",
+                        _activeTrain.getTrainName(), re.getId(), _address, _useSpeedProfileRequested, useSpeedProfile);
             } else {
                 ok = InstanceManager.throttleManagerInstance().requestThrottle(addressForRequest, this, false);
                 log.debug("{}: requested throttle address={}, roster entry not found", _activeTrain.getTrainName(), _address);
@@ -374,7 +374,7 @@ public class AutoActiveTrain implements ThrottleListener {
         log.debug("{}: New AutoEngineer, address={}, length (mm)={}, factor={}, useSpeedProfile={}",
                 _activeTrain.getTrainName(),
                 _throttle.getLocoAddress(),
-                getMaxTrainLengthMM(), _speedFactor, _useSpeedProfile);
+                getMaxTrainLengthMM(), _speedFactor, useSpeedProfile);
         // get off this thread ASAP, some throttles does not completely initialize
         // until this thread finishes
         jmri.util.ThreadingUtil.runOnLayoutDelayed(() -> {
@@ -674,6 +674,18 @@ public class AutoActiveTrain implements ThrottleListener {
         return _currentAllocatedSection;
     }
 
+    /*
+     * Reverse lookup for allocated section.
+     */
+    protected AllocatedSection getAllocatedSectionForSection(Section s) {
+        for (AllocatedSection allocatedSection : _activeTrain.getAllocatedSectionList()) {
+            if (allocatedSection.getSection() == s) {
+                return allocatedSection;
+            }
+        }
+        return null;
+    }
+
     protected void allocateAFresh() {
         //Reset initialized flag
         _initialized = false;
@@ -784,12 +796,11 @@ public class AutoActiveTrain implements ThrottleListener {
                 });
                 _activeTrain.setControlingSignal(_controllingSignal, _controllingSignalPrev);
                 log.debug("new current signal = {}", sh.getDisplayName(USERSYS));
-                setSpeedBySignal();
             } else {
                 // Note: null signal head will result when exiting throat-to-throat blocks.
-                log.debug("new current signal is null - sometimes OK");
-                checkForGhost();
+                log.warn("new current signal is null - sometimes OK");
             }
+            setSpeedBySignal();
         } else if (_activeTrain.getSignalType() == DispatcherFrame.SIGNALMAST) {
             //SignalMast
             SignalMast sm = null;
@@ -832,10 +843,18 @@ public class AutoActiveTrain implements ThrottleListener {
                 } else {
                     checkForGhost();
                 }
-            } // Note: null signal head will result when exiting throat-to-throat blocks.
-            else {
-                log.debug("{}: new current signalmast is null for section {} - sometimes OK", _activeTrain.getTrainName(),
+            } else {
+                // There is a missing signal mast at a block boundary.
+                // If the next block is allocated to this train we can continue.
+                // If the train was stopped here we can try and restart it. Either way we use
+                // setting setSpeedBySectionsAllocated as a way out of the dilemma.
+                log.info("{}: new current signalmast is null for section {} - sometimes OK", _activeTrain.getTrainName(),
                         as == null ? "Null" : as.getSection().getDisplayName(USERSYS));
+                if (_nextBlock == null || ! _activeTrain.getBlockList().contains(_nextBlock) ||  _autoEngineer.isStopped()) {
+                    log.warn("{}: new current signalmast is null for section {} and next block is not this trains. Temporarily continuing by allocations", _activeTrain.getTrainName(),
+                            as == null ? "Null" : as.getSection().getDisplayName(USERSYS));
+                    setSpeedBySectionsAllocated();
+                }
                 checkForGhost();
             }
         } else {
@@ -917,22 +936,24 @@ public class AutoActiveTrain implements ThrottleListener {
     // called by above or when resuming after stopped action
     protected synchronized void setSpeedBySignal() {
         log.trace("Set Speed by Signal");
-        if (_pausingActive || ((_activeTrain.getStatus() != ActiveTrain.RUNNING)
-                && (_activeTrain.getStatus() != ActiveTrain.WAITING)) || ((_controllingSignal == null)
-                && _activeTrain.getSignalType() == DispatcherFrame.SIGNALHEAD)
-                || (_activeTrain.getSignalType() == DispatcherFrame.SIGNALMAST && (_controllingSignalMast == null
-                || (_activeTrain.getStatus() == ActiveTrain.WAITING && !_activeTrain.getStarted())))
+        if (_pausingActive
+                || ((_activeTrain.getStatus() != ActiveTrain.RUNNING)
+                    && (_activeTrain.getStatus() != ActiveTrain.WAITING)
+                    && !_activeTrain.getStarted())
                 || (_activeTrain.getMode() != ActiveTrain.AUTOMATIC)) {
-            // train is pausing or not RUNNING or WAITING in AUTOMATIC mode, or no controlling signal,
+            // train is pausing or not RUNNING or WAITING or started and in AUTOMATIC mode
             //   don't set speed based on controlling signal
             log.trace("Skip Set Speed By Signal");
             return;
         }
         // only bother to check signal if the next allocation is ours.
-        if (checkAllocationsAhead()) {
-            if (_activeTrain.getSignalType() == DispatcherFrame.SIGNALHEAD) {
+        // and the turnouts have been set
+        if (checkAllocationsAhead() && checkTurn(getAllocatedSectionForSection(_nextSection))) {
+            if (_activeTrain.getSignalType() == DispatcherFrame.SIGNALHEAD
+                    && _controllingSignal != null) {
                 setSpeedBySignalHead();
-            } else if (_activeTrain.getSignalType() == DispatcherFrame.SIGNALMAST) {
+            } else if (_activeTrain.getSignalType() == DispatcherFrame.SIGNALMAST
+                    && _controllingSignalMast != null) {
                 setSpeedBySignalMast();
             } else {
                 log.trace("{}:Set Speed by BlocksAllocated",_activeTrain.getActiveTrainName());
@@ -993,18 +1014,13 @@ public class AutoActiveTrain implements ThrottleListener {
             return;
         }
         int sectionsAhead = 0;
-        AllocatedSection as = null;
         for (AllocatedSection allocatedSection : _activeTrain.getAllocatedSectionList()) {
-            if (allocatedSection.getSection() == _nextSection) {
-                as = allocatedSection;
-            }
             if (!allocatedSection.getEntered()) {
                 sectionsAhead++;
             }
         }
         float newSpeed = 0.0f;
         log.debug("[{}:SectionsAhead[{}]",_activeTrain.getActiveTrainName() ,sectionsAhead);
-        if (checkTurn(as)) {
             switch (sectionsAhead) {
                 case 0:
                     newSpeed = 0.0f;
@@ -1040,12 +1056,12 @@ public class AutoActiveTrain implements ThrottleListener {
                     newSpeed = speed;
                 }
             }
-        }
         if (newSpeed > 0) {
             log.trace("setSpeedBySectionsAllocated isStopping[{}]",isStopping());
             cancelStopInCurrentSection();
             setTargetSpeed(getThrottleSettingFromSpeed(newSpeed));
         } else {
+            waitingOnAllocation = true;
             stopInCurrentSection(NO_TASK);
         }
     }
@@ -1076,6 +1092,11 @@ public class AutoActiveTrain implements ThrottleListener {
 
     private void setSpeedBySignalMast() {
         //Set speed using SignalMasts;
+        if (_controllingSignalMast == null) {
+            // temporarily revert to by sections allocated
+            setSpeedBySectionsAllocated();
+            return;
+        }
         String displayedAspect = _controllingSignalMast.getAspect();
         if (log.isTraceEnabled()) {
             log.trace("{}: Controlling mast {} ({})", _activeTrain.getTrainName(), _controllingSignalMast.getDisplayName(USERSYS), displayedAspect);
@@ -1173,6 +1194,7 @@ public class AutoActiveTrain implements ThrottleListener {
             stopInCurrentSection(NO_TASK);
             return;
         }
+        
 
         if (useSpeedProfile) {
             // find speed from signal.
@@ -1203,7 +1225,7 @@ public class AutoActiveTrain implements ThrottleListener {
             if (useSpeed < 0.01f) {
                 checkForSignalPassedOrStop(_controllingSignal.getDisplayName(USERSYS));
             } else {
-                setTargetSpeedByProfile(useSpeed);
+                setTargetSpeedByProfile(useSpeed,_stopBySpeedProfileAdjust,true);
             }
         } else {
             switch (_controllingSignal.getAppearance()) {
@@ -1331,7 +1353,7 @@ public class AutoActiveTrain implements ThrottleListener {
                 });
                 _stoppingBySensor = true;
             }
-        } else if (_useSpeedProfile && _stopBySpeedProfile) {
+        } else if (useSpeedProfile && _stopBySpeedProfile) {
             log.debug("{}: Section [{}] Section Length[{}] Max Train Length [{}] StopBySpeedProfile [{}]. setStopNow", _activeTrain.getTrainName(),
                     _currentAllocatedSection.getSection().getDisplayName(USERSYS), _currentAllocatedSection.getActualLength(), getMaxTrainLengthMM(), _stopBySpeedProfile);
             // stopping by speed profile uses section length to stop
@@ -1586,18 +1608,25 @@ public class AutoActiveTrain implements ThrottleListener {
             log.error("Missing [{}] from Speed table - defaulting to 25",
                     _dispatcher.getStoppingSpeedName());
         }
-        setToAMaximumThrottle(getThrottleSettingFromSpeed(signalSpeed));
-    }
-
-    /**
-     * Sets the throttle percent unless it is already less than the new setting
-     * @param throttleSetting  Max ThrottleSetting required.
-     */
-    private synchronized void setToAMaximumThrottle(float throttleSetting) {
-        if (throttleSetting < getTargetSpeed()) {
-            setTargetSpeed(throttleSetting);
+        if (getThrottleSettingFromSpeed(signalSpeed) < getTargetSpeed()) {
+            if (useSpeedProfile) {
+                // use 75 percent or normal amount, dont clear isstopping for ramping.
+                setTargetSpeedByProfile(signalSpeed,_stopBySpeedProfileAdjust*0.75f,false);
+            } else {
+                setTargetSpeed(signalSpeed/100.0f);
+            }
         }
     }
+
+    ///**
+    // * Sets the throttle percent unless it is already less than the new setting
+    // * @param throttleSetting  Max ThrottleSetting required.
+    // */
+    //private synchronized void setToAMaximumThrottle(float throttleSetting) {
+    //    if (throttleSetting < getTargetSpeed()) {
+    //        setTargetSpeed(throttleSetting);
+    //    }
+    //}
 
     /**
      * Calculates the throttle setting for a given speed.
@@ -1644,7 +1673,7 @@ public class AutoActiveTrain implements ThrottleListener {
         _autoEngineer.slowToStop(false);
         if (speedState > STOP_SPEED) {
             cancelStopInCurrentSection();
-            if (_currentRampRate == RAMP_SPEEDPROFILE && _useSpeedProfile) {
+            if (_currentRampRate == RAMP_SPEEDPROFILE && useSpeedProfile) {
                 // we are going to ramp up  / down using section length and speed profile
                 _autoEngineer.setTargetSpeed(_currentAllocatedSection.getLengthRemaining(_currentBlock) * _stopBySpeedProfileAdjust, speedState);
             } else {
@@ -1660,7 +1689,7 @@ public class AutoActiveTrain implements ThrottleListener {
         }
     }
 
-    private synchronized void setTargetSpeedByProfile(float speedState) {
+    private synchronized void setTargetSpeedByProfile(float speedState, float stopBySpeedProfileAdjust, boolean cancelStopping) {
         // the speed comes in as units of warrents (mph, kph, mm/s etc)
             try {
                 float throttleSetting = _activeTrain.getRosterEntry().getSpeedProfile().getThrottleSettingFromSignalMapSpeed(speedState, getForward());
@@ -1668,16 +1697,16 @@ public class AutoActiveTrain implements ThrottleListener {
                         _activeTrain.getTrainName(),
                         throttleSetting,
                         speedState);
-                if (throttleSetting > 0.009 && _currentRampRate != RAMP_SPEEDPROFILE && _useSpeedProfile) {
-                    cancelStopInCurrentSection();
+                if (throttleSetting > 0.009 && _currentRampRate != RAMP_SPEEDPROFILE && useSpeedProfile) {
+                    if (cancelStopping) {cancelStopInCurrentSection();}
                     setTargetSpeed(throttleSetting); // apply speed factor and max
                 } else if (throttleSetting > 0.009) {
-                    cancelStopInCurrentSection();
-                    _autoEngineer.setTargetSpeed(_currentAllocatedSection.getLengthRemaining(_currentBlock)  * _stopBySpeedProfileAdjust , throttleSetting);
+                    if (cancelStopping) {cancelStopInCurrentSection();}
+                    _autoEngineer.setTargetSpeed(_currentAllocatedSection.getLengthRemaining(_currentBlock)  * stopBySpeedProfileAdjust , throttleSetting);
                 } else if (useSpeedProfile && _stopBySpeedProfile) {
                     setTargetSpeed(0.0f);
                     _stoppingUsingSpeedProfile = true;
-                    _autoEngineer.setTargetSpeed(_currentAllocatedSection.getLengthRemaining(_currentBlock)  * _stopBySpeedProfileAdjust, 0.0f);
+                    _autoEngineer.setTargetSpeed(_currentAllocatedSection.getLengthRemaining(_currentBlock)  * stopBySpeedProfileAdjust, 0.0f);
                 } else {
                     _autoEngineer.slowToStop(false);
                     setTargetSpeed(0.0f);
@@ -1698,7 +1727,7 @@ public class AutoActiveTrain implements ThrottleListener {
     private synchronized void setTargetSpeedValue(float speed) {
         log.debug("{}: setTargetSpeedValue: Speed[{}]",_activeTrain.getTrainName(),speed);
         if (useSpeedProfile) {
-            setTargetSpeedByProfile(speed);
+            setTargetSpeedByProfile(speed,_stopBySpeedProfileAdjust,true);
             return;
         }
         _autoEngineer.slowToStop(false);

--- a/java/src/jmri/jmrit/dispatcher/AutoActiveTrain.java
+++ b/java/src/jmri/jmrit/dispatcher/AutoActiveTrain.java
@@ -848,7 +848,7 @@ public class AutoActiveTrain implements ThrottleListener {
                 // If the next block is allocated to this train we can continue.
                 // If the train was stopped here we can try and restart it. Either way we use
                 // setting setSpeedBySectionsAllocated as a way out of the dilemma.
-                log.info("{}: new current signalmast is null for section {} - sometimes OK", _activeTrain.getTrainName(),
+                log.debug("{}: new current signalmast is null for section {} - sometimes OK", _activeTrain.getTrainName(),
                         as == null ? "Null" : as.getSection().getDisplayName(USERSYS));
                 if (_nextBlock == null || ! _activeTrain.getBlockList().contains(_nextBlock) ||  _autoEngineer.isStopped()) {
                     log.warn("{}: new current signalmast is null for section {} and next block is not this trains. Temporarily continuing by allocations", _activeTrain.getTrainName(),

--- a/java/src/jmri/jmrit/dispatcher/AutoTurnouts.java
+++ b/java/src/jmri/jmrit/dispatcher/AutoTurnouts.java
@@ -11,6 +11,8 @@ import jmri.Turnout;
 import jmri.NamedBean.DisplayOptions;
 import jmri.jmrit.display.layoutEditor.ConnectivityUtil;
 import jmri.jmrit.display.layoutEditor.LayoutDoubleXOver;
+import jmri.jmrit.display.layoutEditor.LayoutLHXOver;
+import jmri.jmrit.display.layoutEditor.LayoutRHXOver;
 import jmri.jmrit.display.layoutEditor.LayoutSlip;
 import jmri.jmrit.display.layoutEditor.LayoutTrackExpectedState;
 import jmri.jmrit.display.layoutEditor.LayoutTurnout;
@@ -404,7 +406,40 @@ public class AutoTurnouts {
                         (setting == Turnout.CLOSED ? closedText : thrownText));
                 return(false);
             }
+        } else if (layoutTurnout instanceof LayoutRHXOver) {
+            LayoutRHXOver lds = (LayoutRHXOver) layoutTurnout;
+            if ((lds.getLayoutBlock().getBlock().getState() == Block.OCCUPIED)
+                    || (lds.getLayoutBlockC().getBlock().getState() == Block.OCCUPIED)) {
+                log.debug("{}: turnout {} cannot be set to {} RHXOver occupied.",
+                        at.getTrainName(),layoutTurnout.getTurnout().getDisplayName(),
+                        (setting == Turnout.CLOSED ? closedText : thrownText));
+                return(false);
+            }
+            if ((_dispatcher.checkForBlockInAllocatedSection(lds.getLayoutBlock().getBlock(), s))
+                    || (_dispatcher.checkForBlockInAllocatedSection(lds.getLayoutBlockC().getBlock(), s))) {
+                log.debug("{}: turnout {} cannot be set to {} RHXOver already allocated to another train.",
+                        at.getTrainName(), layoutTurnout.getTurnout().getDisplayName(),
+                        (setting == Turnout.CLOSED ? closedText : thrownText));
+                return(false);
+            }
+        } else if (layoutTurnout instanceof LayoutLHXOver) {
+            LayoutLHXOver lds = (LayoutLHXOver) layoutTurnout;
+            if ((lds.getLayoutBlockB().getBlock().getState() == Block.OCCUPIED)
+                    || (lds.getLayoutBlockD().getBlock().getState() == Block.OCCUPIED)) {
+                log.debug("{}: turnout {} cannot be set to {} LHXOver occupied.",
+                        at.getTrainName(),layoutTurnout.getTurnout().getDisplayName(),
+                        (setting == Turnout.CLOSED ? closedText : thrownText));
+                return(false);
+            }
+            if ((_dispatcher.checkForBlockInAllocatedSection(lds.getLayoutBlockB().getBlock(), s))
+                    || (_dispatcher.checkForBlockInAllocatedSection(lds.getLayoutBlockD().getBlock(), s))) {
+                log.debug("{}: turnout {} cannot be set to {} RHXOver already allocated to another train.",
+                        at.getTrainName(), layoutTurnout.getTurnout().getDisplayName(),
+                        (setting == Turnout.CLOSED ? closedText : thrownText));
+                return(false);
+            }
         }
+
         if (s.getState() == Section.FREE && b.getState() != Block.OCCUPIED) {
             return true;
         }

--- a/java/src/jmri/jmrit/dispatcher/AutoTurnouts.java
+++ b/java/src/jmri/jmrit/dispatcher/AutoTurnouts.java
@@ -10,6 +10,7 @@ import jmri.Transit;
 import jmri.Turnout;
 import jmri.NamedBean.DisplayOptions;
 import jmri.jmrit.display.layoutEditor.ConnectivityUtil;
+import jmri.jmrit.display.layoutEditor.LayoutDoubleXOver;
 import jmri.jmrit.display.layoutEditor.LayoutSlip;
 import jmri.jmrit.display.layoutEditor.LayoutTrackExpectedState;
 import jmri.jmrit.display.layoutEditor.LayoutTurnout;
@@ -270,26 +271,30 @@ public class AutoTurnouts {
                     setting = ((LayoutSlip) turnoutList.get(i).getObject()).getTurnoutState(turnoutList.get(i).getExpectedState());
                 }
                 // check or ignore current setting based on flag, set in Options
-                if (!trustKnownTurnouts) {
+                if (!trustKnownTurnouts && set) {
                     log.debug("{}: setting turnout {} to {}", at.getTrainName(), to.getDisplayName(USERSYS),
                             (setting == Turnout.CLOSED ? closedText : thrownText));
-                    if (useTurnoutConnectionDelay) {
-                        to.setCommandedStateAtInterval(setting);
-                    } else {
-                        to.setCommandedState(setting);
+                    if (checkTurnoutsCanBeSet(turnoutList.get(i).getObject(), setting, s, curBlock, at)) {
+                        log.debug("{}: setting turnout {} to {}", at.getTrainName(), to.getDisplayName(USERSYS),
+                                (setting == Turnout.CLOSED ? closedText : thrownText));
+                        if (useTurnoutConnectionDelay) {
+                            to.setCommandedStateAtInterval(setting);
+                        } else {
+                            to.setCommandedState(setting);
+                        }
+                        try {
+                            Thread.sleep(100);
+                        } catch (InterruptedException ex) {
+                        } //TODO: Check if this is needed, shouldnt turnout delays be handled at a lower level.
                     }
-                    try {
-                        Thread.sleep(100);
-                    } catch (InterruptedException ex) {
-                    }  //TODO: move this to separate thread
                 } else {
                     if (to.getKnownState() != setting) {
                         // turnout is not set correctly
                         if (set) {
                             // setting has been requested, is Section free and Block unoccupied
-                            if ((s.getState() == Section.FREE) && (curBlock.getState() != Block.OCCUPIED)) {
+                            if (checkTurnoutsCanBeSet(turnoutList.get(i).getObject(), setting, s, curBlock, at)) {
                                 // send setting command
-                                log.debug("{}: turnout {} commanded to {}", at.getTrainName(), to.getDisplayName(USERSYS),
+                                log.debug("{}: turnout {} commanded to {}", at.getTrainName(), to.getDisplayName(),
                                         (setting == Turnout.CLOSED ? closedText : thrownText));
                                 if (useTurnoutConnectionDelay) {
                                     to.setCommandedStateAtInterval(setting);
@@ -373,6 +378,37 @@ public class AutoTurnouts {
             return turnoutListForAllocatedSection;
         }
         return null;
+    }
+
+    /*
+     * Check that the turnout is safe to change.
+     */
+    private boolean checkTurnoutsCanBeSet(LayoutTurnout layoutTurnout, int setting, Section s, Block b, ActiveTrain at) {
+        if (layoutTurnout instanceof LayoutDoubleXOver) {
+            LayoutDoubleXOver lds = (LayoutDoubleXOver) layoutTurnout;
+            if ((lds.getLayoutBlock().getBlock().getState() == Block.OCCUPIED)
+                    || (lds.getLayoutBlockB().getBlock().getState() == Block.OCCUPIED)
+                    || (lds.getLayoutBlockC().getBlock().getState() == Block.OCCUPIED)
+                    || (lds.getLayoutBlockD().getBlock().getState() == Block.OCCUPIED)) {
+                log.debug("{}: turnout {} cannot be set to {} DoubleXOver occupied.",
+                        at.getTrainName(),layoutTurnout.getTurnout().getDisplayName(),
+                        (setting == Turnout.CLOSED ? closedText : thrownText));
+                return(false);
+            }
+            if ((_dispatcher.checkForBlockInAllocatedSection(lds.getLayoutBlock().getBlock(), s))
+                    || (_dispatcher.checkForBlockInAllocatedSection(lds.getLayoutBlockB().getBlock(), s))
+                    || (_dispatcher.checkForBlockInAllocatedSection(lds.getLayoutBlockC().getBlock(), s))
+                    || (_dispatcher.checkForBlockInAllocatedSection(lds.getLayoutBlockD().getBlock(), s))) {
+                log.debug("{}: turnout {} cannot be set to {} DoubleXOver already allocated to another train.",
+                        at.getTrainName(), layoutTurnout.getTurnout().getDisplayName(),
+                        (setting == Turnout.CLOSED ? closedText : thrownText));
+                return(false);
+            }
+        }
+        if (s.getState() == Section.FREE && b.getState() != Block.OCCUPIED) {
+            return true;
+        }
+        return false;
     }
 
     private final static Logger log = LoggerFactory.getLogger(AutoTurnouts.class);

--- a/java/src/jmri/jmrit/dispatcher/DispatcherBundle.properties
+++ b/java/src/jmri/jmrit/dispatcher/DispatcherBundle.properties
@@ -18,6 +18,10 @@ CancelRestartButtonHint = Press to bring up a window to cancel automatic restart
 CancelRestartChoice = Please select an Active Train to cancel automatic restart.
 CancelRestartTitle = Cancel Auto Restart
 
+AdHocNeedsBlockRouting  = Layout Editor Panel Block Routing
+AdHocNeedsEnableBlockRouting = Adhoc needs Block Routing for best results and is not enabled.\nDo you want to enable it?
+AdhocNeedsBlockRoutingEnabled = Layout Editor Block routing has been enabled.
+
 TransitColumnSysTitle = Transit ID
 TransitColumnTitle = Transit
 TrainColumnTitle = Train

--- a/java/src/jmri/jmrit/dispatcher/DispatcherFrame.java
+++ b/java/src/jmri/jmrit/dispatcher/DispatcherFrame.java
@@ -7,8 +7,10 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.HashSet;
 import java.util.List;
 
+import javax.annotation.Nonnull;
 import javax.swing.BoxLayout;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
@@ -39,6 +41,7 @@ import jmri.Timebase;
 import jmri.Transit;
 import jmri.TransitManager;
 import jmri.TransitSection;
+import jmri.Turnout;
 import jmri.NamedBean.DisplayOptions;
 import jmri.Transit.TransitType;
 import jmri.jmrit.dispatcher.TaskAllocateRelease.TaskAction;
@@ -1913,7 +1916,7 @@ public class DispatcherFrame extends jmri.util.JmriJFrame implements InstanceMan
      *           section, of if an extra section is being allocated
      * @return the allocated section or null if not successful
      */
-    public AllocatedSection allocateSection(AllocationRequest ar, Section ns) {
+    public AllocatedSection allocateSection(@Nonnull AllocationRequest ar, Section ns) {
         log.trace("{}: Checking Section [{}]", ar.getActiveTrain().getTrainName(), (ns != null ? ns.getDisplayName(USERSYS) : "auto"));
         AllocatedSection as = null;
         Section nextSection = null;
@@ -2397,6 +2400,26 @@ public class DispatcherFrame extends jmri.util.JmriJFrame implements InstanceMan
         return _levelXingList;
     }
 
+    /*
+     * returns a list of double XOvers  (0 to n) in a list of blocks
+     */
+    private List<LayoutTurnout> containedDoubleXOver( Section s ) {
+        List<LayoutTurnout> _XOverList = new ArrayList<>();
+        LayoutBlockManager lbm = InstanceManager.getDefault(jmri.jmrit.display.layoutEditor.LayoutBlockManager.class);
+        for (var panel : editorManager.getAll(LayoutEditor.class)) {
+            for (Block blk: s.getBlockList()) {
+                LayoutBlock lb = lbm.getLayoutBlock(blk);
+                List<LayoutTurnout> turnoutsInBlock = panel.getConnectivityUtil().getAllTurnoutsThisBlock(lb);
+                for (LayoutTurnout lt: turnoutsInBlock) {
+                    if (lt.isTurnoutTypeXover() && !_XOverList.contains(lt)) {
+                        _XOverList.add(lt);
+                    }
+                }
+            }
+        }
+        return _XOverList;
+    }
+
     /**
      * Checks for a block in allocated section, except one
      * @param b - The Block
@@ -2418,6 +2441,10 @@ public class DispatcherFrame extends jmri.util.JmriJFrame implements InstanceMan
      * This is used to determine if the blocks in a section we want to allocate are already allocated to a section, or if they are now free.
      */
     protected Section checkBlocksNotInAllocatedSection(Section s, AllocationRequest ar) {
+        ActiveTrain at = null;
+        if (ar != null) {
+            at = ar.getActiveTrain();
+        }
         for (AllocatedSection as : allocatedSections) {
             if (as.getSection() != s) {
                 List<Block> blas = as.getSection().getBlockList();
@@ -2470,6 +2497,34 @@ public class DispatcherFrame extends jmri.util.JmriJFrame implements InstanceMan
                             bls.add(bBD);
                         }
                     }
+                    for (LayoutTurnout lx : containedDoubleXOver(s)) {
+                        HashSet<Block> bhs = new HashSet<Block>(4);
+                        /* quickest way to count number of unique blocks */
+                        bhs.add(lx.getLayoutBlock().getBlock());
+                        bhs.add(lx.getLayoutBlockB().getBlock());
+                        bhs.add(lx.getLayoutBlockC().getBlock());
+                        bhs.add(lx.getLayoutBlockD().getBlock());
+                        if (bhs.size() == 4) {
+                            for (Block b : bhs) {
+                                if ( checkBlockInAnyAllocatedSection(b, at)
+                                        || b.getState() == Block.OCCUPIED) {
+                                    // the die is cast and switch can not be changed.
+                                    // Check diagonal. If we are going continuing or divergeing
+                                    // we need to check the diagonal.
+                                    if (lx.getTurnout().getKnownState() != Turnout.CLOSED) {
+                                        if (bls.contains(lx.getLayoutBlock().getBlock()) ||
+                                                bls.contains(lx.getLayoutBlockC().getBlock())) {
+                                            bls.add(lx.getLayoutBlockB().getBlock());
+                                            bls.add(lx.getLayoutBlockD().getBlock());
+                                        } else {
+                                            bls.add(lx.getLayoutBlock().getBlock());
+                                            bls.add(lx.getLayoutBlockC().getBlock());
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
                 }
 
                 for (Block b : bls) {
@@ -2486,7 +2541,7 @@ public class DispatcherFrame extends jmri.util.JmriJFrame implements InstanceMan
                                     return as.getSection();
                                 }
                             }
-                        } else if (as.getActiveTrain().getTrainDetection() != TrainDetection.TRAINDETECTION_WHOLETRAIN) {
+                        } else if (at != as.getActiveTrain() && as.getActiveTrain().getTrainDetection() != TrainDetection.TRAINDETECTION_WHOLETRAIN) {
                             return as.getSection();
                         }
                         if (as.getSection().getOccupancy() == Block.OCCUPIED) {
@@ -2527,6 +2582,16 @@ public class DispatcherFrame extends jmri.util.JmriJFrame implements InstanceMan
             }
         }
         return null;
+    }
+
+    // check if block is being used by anyone else but us
+    private boolean checkBlockInAnyAllocatedSection(Block b, ActiveTrain at) {
+        for (AllocatedSection as : allocatedSections) {
+            if (as.getActiveTrain() != at && as.getSection().getBlockList().contains(b)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     // automatically make a choice of next section

--- a/java/src/jmri/jmrit/dispatcher/DispatcherFrame.java
+++ b/java/src/jmri/jmrit/dispatcher/DispatcherFrame.java
@@ -50,6 +50,7 @@ import jmri.jmrit.display.EditorManager;
 import jmri.jmrit.display.layoutEditor.LayoutBlock;
 import jmri.jmrit.display.layoutEditor.LayoutBlockConnectivityTools;
 import jmri.jmrit.display.layoutEditor.LayoutBlockManager;
+import jmri.jmrit.display.layoutEditor.LayoutDoubleXOver;
 import jmri.jmrit.display.layoutEditor.LayoutEditor;
 import jmri.jmrit.display.layoutEditor.LayoutTrackExpectedState;
 import jmri.jmrit.display.layoutEditor.LayoutTurnout;
@@ -2401,9 +2402,9 @@ public class DispatcherFrame extends jmri.util.JmriJFrame implements InstanceMan
     }
 
     /*
-     * returns a list of double XOvers  (0 to n) in a list of blocks
+     * returns a list of XOvers  (0 to n) in a list of blocks
      */
-    private List<LayoutTurnout> containedDoubleXOver( Section s ) {
+    private List<LayoutTurnout> containedXOver( Section s ) {
         List<LayoutTurnout> _XOverList = new ArrayList<>();
         LayoutBlockManager lbm = InstanceManager.getDefault(jmri.jmrit.display.layoutEditor.LayoutBlockManager.class);
         for (var panel : editorManager.getAll(LayoutEditor.class)) {
@@ -2497,32 +2498,39 @@ public class DispatcherFrame extends jmri.util.JmriJFrame implements InstanceMan
                             bls.add(bBD);
                         }
                     }
-                    for (LayoutTurnout lx : containedDoubleXOver(s)) {
-                        HashSet<Block> bhs = new HashSet<Block>(4);
-                        /* quickest way to count number of unique blocks */
-                        bhs.add(lx.getLayoutBlock().getBlock());
-                        bhs.add(lx.getLayoutBlockB().getBlock());
-                        bhs.add(lx.getLayoutBlockC().getBlock());
-                        bhs.add(lx.getLayoutBlockD().getBlock());
-                        if (bhs.size() == 4) {
-                            for (Block b : bhs) {
-                                if ( checkBlockInAnyAllocatedSection(b, at)
-                                        || b.getState() == Block.OCCUPIED) {
-                                    // the die is cast and switch can not be changed.
-                                    // Check diagonal. If we are going continuing or divergeing
-                                    // we need to check the diagonal.
-                                    if (lx.getTurnout().getKnownState() != Turnout.CLOSED) {
-                                        if (bls.contains(lx.getLayoutBlock().getBlock()) ||
-                                                bls.contains(lx.getLayoutBlockC().getBlock())) {
-                                            bls.add(lx.getLayoutBlockB().getBlock());
-                                            bls.add(lx.getLayoutBlockD().getBlock());
-                                        } else {
-                                            bls.add(lx.getLayoutBlock().getBlock());
-                                            bls.add(lx.getLayoutBlockC().getBlock());
+                    for (LayoutTurnout lx : containedXOver(s)) {
+                        if (lx instanceof LayoutDoubleXOver) {
+                            HashSet<Block> bhs = new HashSet<Block>(4);
+                            /* quickest way to count number of unique blocks */
+                            bhs.add(lx.getLayoutBlock().getBlock());
+                            bhs.add(lx.getLayoutBlockB().getBlock());
+                            bhs.add(lx.getLayoutBlockC().getBlock());
+                            bhs.add(lx.getLayoutBlockD().getBlock());
+                            if (bhs.size() == 4) {
+                                for (Block b : bhs) {
+                                    if ( checkBlockInAnyAllocatedSection(b, at)
+                                            || b.getState() == Block.OCCUPIED) {
+                                        // the die is cast and switch can not be changed.
+                                        // Check diagonal. If we are going continuing or divergeing
+                                        // we need to check the diagonal.
+                                        if (lx.getTurnout().getKnownState() != Turnout.CLOSED) {
+                                            if (bls.contains(lx.getLayoutBlock().getBlock()) ||
+                                                    bls.contains(lx.getLayoutBlockC().getBlock())) {
+                                                bls.add(lx.getLayoutBlockB().getBlock());
+                                                bls.add(lx.getLayoutBlockD().getBlock());
+                                            } else {
+                                                bls.add(lx.getLayoutBlock().getBlock());
+                                                bls.add(lx.getLayoutBlockC().getBlock());
+                                            }
                                         }
                                     }
                                 }
                             }
+ /*                     If further processing needed for other crossover types it goes here.
+                        } else if (lx instanceof LayoutRHXOver) {
+                        } else if (lx instanceof LayoutLHXOver) {
+                        } else {
+*/
                         }
                     }
                 }

--- a/java/src/jmri/jmrit/dispatcher/TrainInfo.java
+++ b/java/src/jmri/jmrit/dispatcher/TrainInfo.java
@@ -79,7 +79,7 @@ public class TrainInfo {
     private float maxSpeed = 1.0f;
     private float minReliableOperatingSpeed = 0.0f;
     private String rampRate = Bundle.getMessage("RAMP_NONE");
-    private TrainDetection trainDetection = TrainDetection.TRAINDETECTION_HEADONLY;
+    private TrainDetection trainDetection = TrainDetection.TRAINDETECTION_WHOLETRAIN;
     private boolean runInReverse = false;
     private boolean soundDecoder = false;
     private float maxTrainLength = 100.0f;


### PR DESCRIPTION
When setting up a new train use detection Entire Train, unless overridden by custom defaults.
Always check allocation and switch settings before any signaling system. Correctly identify and handle changing position of DoubleXOver switch to prevent switch changing under a train.
Identify conflicting routes when checking allocations thru DoubleXOvers with four blocks. DoubleXOvers with less than four blocks require no additional checks.
When stopping on previous block going unoccupied and speed profile ramping and minimum speed, use a 75% stopping length factor for the ramp.
When a train has been stopped with a missing signal mast attempt to restart use BlockAllocation. When a missing signal mast has been found use BlockAllocation method to stop if next block not allocated.
No changes to SML or SSL.