### PR TITLE
Improve viewing mode on VSD Manager window

### DIFF
--- a/java/src/jmri/jmrit/vsdecoder/swing/VSDManagerFrame.java
+++ b/java/src/jmri/jmrit/vsdecoder/swing/VSDManagerFrame.java
@@ -73,9 +73,10 @@ public class VSDManagerFrame extends JmriJFrame {
 
     private int master_volume;
 
-    JPanel decoderPane;
-    JPanel volumePane;
-    JPanel decoderBlank;
+    private JPanel decoderPane;
+    private JPanel volumePane;
+    private JPanel decoderBlank;
+    private JButton addButton;
 
     private VSDConfig config;
     private VSDConfigDialog cd;
@@ -83,7 +84,6 @@ public class VSDManagerFrame extends JmriJFrame {
     private boolean is_auto_loading;
     private boolean is_block_using;
     private boolean is_viewing;
-    private List<VSDecoder> vsdlist;
 
     /**
      * Constructor
@@ -119,7 +119,7 @@ public class VSDManagerFrame extends JmriJFrame {
         volumePane = new JPanel();
         volumePane.setLayout(new BoxLayout(volumePane, BoxLayout.LINE_AXIS));
         JToggleButton muteButton = new JToggleButton(Bundle.getMessage("MuteButtonLabel"));
-        JButton addButton = new JButton(Bundle.getMessage("AddButtonLabel"));
+        addButton = new JButton(Bundle.getMessage("AddButtonLabel"));
         final JSlider volume = new JSlider(0, 100);
         volume.setMinorTickSpacing(10);
         volume.setPaintTicks(true);
@@ -168,57 +168,65 @@ public class VSDManagerFrame extends JmriJFrame {
         this.pack();
         this.setVisible(true);
 
-        log.debug("done...");
-
-        // first, check Viewing Mode
         if (is_viewing) {
-            vsdlist = new ArrayList<>(); // List of VSDecoders with uncomplete configuration (no Roster Entry reference)
-            for (VSDecoder vsd : VSDecoderManager.instance().getVSDecoderList()) {
-                if (vsd.getRosterEntry() != null) {
-                    // VSDecoder configuration is complete and will be listed
-                    addButton.doClick(); // simulate an Add-button-click
-                    cd.setRosterItem(vsd.getRosterEntry()); // forward the roster entry
-                } else {
-                    vsdlist.add(vsd); // VSDecoder with uncomplete configuration
-                }
-            }
-            // delete VSDecoder(s) with uncomplete configuration
-            for (VSDecoder v : vsdlist) {
-                VSDecoderManager.instance().deleteDecoder(v.getAddress().toString());
-            }
-            // change back to Edit mode
-            is_viewing = false;
+            this.runViewing();
         } else if (is_auto_loading) {
-            // Auto-Load
-            log.info("Auto-Loading VSDecoder");
-            String vsdRosterGroup = "VSD";
-            String msg = "";
-            if (Roster.getDefault().getRosterGroupList().contains(vsdRosterGroup)) {
-                List<RosterEntry> rosterList;
-                rosterList = Roster.getDefault().getEntriesInGroup(vsdRosterGroup);
-                if (!rosterList.isEmpty()) {
-                    // Allow <max_decoder> roster entries
-                    int entry_counter = 1;
-                    for (RosterEntry entry : rosterList) {
-                        if (entry_counter <= VSDecoderManager.max_decoder) {
-                            addButton.doClick(); // simulate an Add-button-click
-                            cd.setRosterItem(entry); // forward the roster entry
-                            entry_counter++;
-                        } else {
-                            msg = "Only " + VSDecoderManager.max_decoder + " Roster Entries allowed. Discarded "
-                                    + (rosterList.size() - VSDecoderManager.max_decoder);
-                        }
+            this.runAutoLoad();
+        }
+    }
+
+    private void runViewing() {
+        log.debug("Viewing mode");
+        RosterEntry roster;
+        for (VSDecoder vsd : VSDecoderManager.instance().getVSDecoderList()) {
+            if (vsd.getRosterEntry() != null) {
+                // take the existing Roster entry; all is set
+                roster = vsd.getRosterEntry();
+            } else {
+                // take a Roster entry temporarily to trigger the process
+                roster = new RosterEntry(vsd.getAddress().toString());
+                roster.setId(vsd.getId());
+                roster.setDccAddress(String.valueOf(vsd.getAddress().getNumber()));
+                roster.putAttribute("VSDecoder_Path", vsd.getVSDFilePath());
+                roster.putAttribute("VSDecoder_Profile", vsd.getProfileName());
+                roster.putAttribute("VSDecoder_LaunchThrottle", "no");
+            }
+            addButton.doClick(); // simulate an Add-button-click
+            cd.setRosterItem(roster); // forward the roster entry
+        }
+        // change back to Edit mode
+        is_viewing = false;
+    }
+
+    private void runAutoLoad() {
+        log.debug("Auto-Loading VSDecoder");
+        String vsdRosterGroup = "VSD";
+        String msg = "";
+        if (Roster.getDefault().getRosterGroupList().contains(vsdRosterGroup)) {
+            List<RosterEntry> rosterList;
+            rosterList = Roster.getDefault().getEntriesInGroup(vsdRosterGroup);
+            if (!rosterList.isEmpty()) {
+                // Allow <max_decoder> roster entries
+                int entry_counter = 1;
+                for (RosterEntry entry : rosterList) {
+                    if (entry_counter <= VSDecoderManager.max_decoder) {
+                        addButton.doClick(); // simulate an Add-button-click
+                        cd.setRosterItem(entry); // forward the roster entry
+                        entry_counter++;
+                    } else {
+                        msg = "Only " + VSDecoderManager.max_decoder + " Roster Entries allowed. Discarded "
+                                + (rosterList.size() - VSDecoderManager.max_decoder);
                     }
-                } else {
-                    msg = "No Roster Entry found in Roster Group " + vsdRosterGroup;
                 }
             } else {
-                msg = "Roster Group \"" + vsdRosterGroup + "\" not found";
+                msg = "No Roster Entry found in Roster Group " + vsdRosterGroup;
             }
-            if (!msg.isEmpty()) {
-                JmriJOptionPane.showMessageDialog(null, "Auto-Loading: " + msg);
-                log.warn("Auto-Loading VSDecoder aborted");
-            }
+        } else {
+            msg = "Roster Group \"" + vsdRosterGroup + "\" not found";
+        }
+        if (!msg.isEmpty()) {
+            JmriJOptionPane.showMessageDialog(null, "Auto-Loading: " + msg);
+            log.warn("Auto-Loading VSDecoder aborted");
         }
     }
 
@@ -245,12 +253,12 @@ public class VSDManagerFrame extends JmriJFrame {
                     "VSDecoder cannot be created. Maximal number is " + String.valueOf(VSDecoderManager.max_decoder));
         } else if (jmri.InstanceManager.getDefault(jmri.AudioManager.class).
                 getNamedBeanSet(jmri.Audio.BUFFER).size() == jmri.AudioManager.MAX_BUFFERS) {
-            JmriJOptionPane.showMessageDialog(null,
-                    "Decoder cannot be created! No more free buffers.");
+            JmriJOptionPane.showMessageDialog(null, "Decoder cannot be created! No more free buffers.");
         } else {
             config = new VSDConfig(); // Create a new Config for the new VSDecoder.
             // Do something here.  Create a new VSDecoder and add it to the window.
-            cd = new VSDConfigDialog(decoderPane, Bundle.getMessage("NewDecoderConfigPaneTitle"), config, is_auto_loading, is_viewing);
+            cd = new VSDConfigDialog(decoderPane, Bundle.getMessage("NewDecoderConfigPaneTitle"),
+                    config, is_auto_loading, is_viewing);
             cd.addPropertyChangeListener(new PropertyChangeListener() {
                 @Override
                 public void propertyChange(PropertyChangeEvent event) {
@@ -269,12 +277,11 @@ public class VSDManagerFrame extends JmriJFrame {
     protected void addButtonPropertyChange(PropertyChangeEvent event) {
         log.debug("internal config dialog handler");
         // If this decoder already exists, don't create a new Control
-        // In Viewing Mode up to <max_decoder> existing VSDecoders are possible, so skip the check
-        VSDecoder newDecoder = null;
+        // In Viewing Mode up to <max_decoder> existing VSDecoders are allowed, so skip the check
         if (! is_viewing && VSDecoderManager.instance().getVSDecoderByAddress(config.getLocoAddress().toString()) != null) {
             JmriJOptionPane.showMessageDialog(null, Bundle.getMessage("MgrAddDuplicateMessage"));
         } else {
-            newDecoder = VSDecoderManager.instance().getVSDecoder(config);
+            VSDecoder newDecoder = VSDecoderManager.instance().getVSDecoder(config);
             if (newDecoder != null) {
                 VSDControl newControl = new VSDControl(config);
                 // Set the Decoder to listen to PropertyChanges from the control
@@ -367,7 +374,6 @@ public class VSDManagerFrame extends JmriJFrame {
                 if (decoderPane.getComponentCount() == 0) {
                     decoderPane.add(decoderBlank);
                 }
-                //debugPrintDecoderList();
                 decoderPane.revalidate();
                 decoderPane.repaint();
 


### PR DESCRIPTION
When the VSD manager window is closed and opened again, all previously added VSDecoders are displayed.
VSDecoders without a Roster are now also included.