### PR TITLE
Update Roster.java Roster Group Deletion not updating roster files issue

### DIFF
--- a/java/src/jmri/jmrit/roster/Roster.java
+++ b/java/src/jmri/jmrit/roster/Roster.java
@@ -1394,6 +1394,7 @@ public class Roster extends XmlFile implements RosterGroupSelector, PropertyChan
         String str = Roster.getRosterGroupProperty(rg);
         group.getEntries().stream().forEach((re) -> {
             re.deleteAttribute(str);
+            re.updateFile();
         });
         firePropertyChange(ROSTER_GROUP_REMOVED, rg, null);
     }


### PR DESCRIPTION
re.UpdateFile() missing from delRosterGroupList function so although roster group was deleted the RosterGroup attribute was left in the roster entry xml files.  If RebuildRoster was then used the deleted roster group would reappear.  I raised on groups.io (https://groups.io/g/jmriusers/topic/110697382#msg238871) but now I've had chance to look at and find the issue