### PR TITLE
Fix OpenLCB well-known turnout addressing

### DIFF
--- a/java/src/jmri/jmrix/openlcb/OlcbAddress.java
+++ b/java/src/jmri/jmrix/openlcb/OlcbAddress.java
@@ -108,11 +108,10 @@ public final class OlcbAddress {
                 from = 0;
             }
 
-            int DD = (from-1) & 0x3;
-            int aaaaaa = (( (from-1) >> 2)+1 ) & 0x3F;
-            int AAA = ( (from) >> 8) & 0x7;
-            long event = 0x0101020000FF0000L | (AAA << 9) | (aaaaaa << 3) | (DD << 1);
-
+            if (from >= 2045) from = from-2045;
+            else from = from + 3;
+            long event = 0x0101020000FF0000L | (from<<1);
+            
             s = String.format("%016X;%016X", event, event+1);
             log.trace(" Turnout form converted to {}", s);
         } else if (s.startsWith("S")) {

--- a/java/test/jmri/jmrix/openlcb/OlcbAddressTest.java
+++ b/java/test/jmri/jmrix/openlcb/OlcbAddressTest.java
@@ -46,6 +46,16 @@ public class OlcbAddressTest {
     }
 
     @Test
+    public void testTurnoutAddressing() {
+        OlcbAddress addr;
+        assertEquals(new OlcbAddress("T1",    null).toString(),  "0101020000FF0008;0101020000FF0009");
+        assertEquals(new OlcbAddress("T2044", null).toString(),  "0101020000FF0FFE;0101020000FF0FFF");
+        assertEquals(new OlcbAddress("T2045", null).toString(),  "0101020000FF0000;0101020000FF0001");
+        assertEquals(new OlcbAddress("T2048", null).toString(),  "0101020000FF0006;0101020000FF0007");
+        assertEquals(new OlcbAddress("T509",  null).toString(),  "0101020000FF0400;0101020000FF0401");
+    }
+    
+    @Test
     public void testCbusIdParseMatchReply() {
         CanReply c = new CanReply(
                 new int[]{0x12, 0x34, 0x56, 0x78,

--- a/java/test/jmri/jmrix/openlcb/OlcbAddressTest.java
+++ b/java/test/jmri/jmrix/openlcb/OlcbAddressTest.java
@@ -47,7 +47,6 @@ public class OlcbAddressTest {
 
     @Test
     public void testTurnoutAddressing() {
-        OlcbAddress addr;
         assertEquals(new OlcbAddress("T1",    null).toString(),  "0101020000FF0008;0101020000FF0009");
         assertEquals(new OlcbAddress("T2044", null).toString(),  "0101020000FF0FFE;0101020000FF0FFF");
         assertEquals(new OlcbAddress("T2045", null).toString(),  "0101020000FF0000;0101020000FF0001");


### PR DESCRIPTION
There are two forms of NMRA turnout addressing: Linear and non-linear.  This PR changes JMRI's MTT-style addressing to the linear form.