### PR TITLE
Fix OBlock duplicate sensor error

### DIFF
--- a/java/src/jmri/jmrit/beantable/beanedit/OBlockEditAction.java
+++ b/java/src/jmri/jmrit/beantable/beanedit/OBlockEditAction.java
@@ -69,7 +69,7 @@ public class OBlockEditAction extends BeanEditAction<OBlock> {
         JComboBoxUtil.setupComboBoxMaxRows(sensorComboBox);
         basic.addItem(new BeanEditItem(sensorComboBox, Bundle.getMessage("BeanNameSensor"), Bundle.getMessage("BlockAssignSensorText")));
 
-        errorSensorComboBox = new NamedBeanComboBox<>(InstanceManager.sensorManagerInstance(), bean.getSensor(), DisplayOptions.DISPLAYNAME);
+        errorSensorComboBox = new NamedBeanComboBox<>(InstanceManager.sensorManagerInstance(), bean.getErrorSensor(), DisplayOptions.DISPLAYNAME);
         errorSensorComboBox.setAllowNull(true);
         JComboBoxUtil.setupComboBoxMaxRows(errorSensorComboBox);
         basic.addItem(new BeanEditItem(errorSensorComboBox, Bundle.getMessage("ErrorSensorCol"), Bundle.getMessage("BlockAssignErrorSensorText")));


### PR DESCRIPTION
The error sensor combo box was using the occupancy sensor as the default selection.