### PR TITLE
Signal Masts  on hold check, addhoc transits

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -430,7 +430,9 @@
    <h3>Dispatcher</h3>
         <a id="Dispatcher" name="Dispatcher"></a>
         <ul>
-             <li></li>
+             <li>Restore TSA data to the correct place.</li>
+             <li>When checking for a hold mast do not assume the section join is at the end of a section.</li>
+             <li>For AdHoc trains check to see if a transit can be used.</li>
         </ul>
 
     <h3>Dispatcher System</h3>

--- a/java/src/jmri/jmrit/dispatcher/ActivateTrainFrame.java
+++ b/java/src/jmri/jmrit/dispatcher/ActivateTrainFrame.java
@@ -1041,21 +1041,93 @@ public class ActivateTrainFrame extends JmriJFrame {
     private void addNewTrain(ActionEvent e) {
         try {
             validateDialog();
+            trainInfo = new TrainInfo();
+            dialogToTrainInfo(trainInfo);
             if (radioTransitsAdHoc.isSelected()) {
                 int ixStart, ixEnd, ixVia;
                 ixStart = startingBlockBox.getSelectedIndex();
                 ixEnd = destinationBlockBox.getSelectedIndex();
                 ixVia = viaBlockBox.getSelectedIndex();
-                List<LayoutBlock>blockList = _dispatcher.getAdHocRoute(startingBlockBoxList.get(ixStart),
-                        destinationBlockBoxList.get(ixEnd),
-                        viaBlockBoxList.get(ixVia));
-                if (blockList == null ) {
-                    JmriJOptionPane.showMessageDialog(initiateFrame, "Invalid Transit",
-                            Bundle.getMessage("ErrorTitle"), JmriJOptionPane.ERROR_MESSAGE);
-                    return;
+                // search for a transit if ones available.
+                Transit tmpTransit = null;
+                int routeCount = 9999;
+                int startBlockSeq = 0;
+                int endBlockSeq = 0;
+                log.debug("Start[{}]Via[{}]Dest[{}}]",
+                        startingBlockBoxList.get(ixStart).getDisplayName(),
+                        viaBlockBoxList.get(ixVia).getDisplayName(),
+                        destinationBlockBoxList.get(ixEnd).getDisplayName());
+                for (Transit tr : InstanceManager.getDefault(jmri.TransitManager.class)
+                        .getListUsingBlock(startingBlockBoxList.get(ixStart))) {
+                    if (tr.getState() == Transit.IDLE
+                            && tr.containsBlock(startingBlockBoxList.get(ixStart))
+                            && tr.containsBlock(viaBlockBoxList.get(ixVia)) &&
+                            tr.containsBlock(destinationBlockBoxList.get(ixEnd))) {
+                        log.debug("[{}]  contains all blocks", tr.getDisplayName());
+                        int ixCountStart = -1, ixCountVia = -1, ixCountDest = -1, ixCount = 0;
+                        List<Block> transitBlocks = tr.getInternalBlocksList();
+                        List<Integer> transitBlockSeq = tr.getBlockSeqList();
+                        for (Block blk : transitBlocks) {
+                            log.debug("Checking Block[{}] t[{}] BlockSequ[{}]",
+                                    blk.getDisplayName(),
+                                    ixCount,
+                                    transitBlockSeq.get(ixCount));
+                            if (ixCountStart == -1 && blk == startingBlockBoxList.get(ixStart)) {
+                                log.trace("ixOne[{}]block[{}]",ixCount,blk.getDisplayName());
+                                ixCountStart = ixCount;
+                            } else if (ixCountStart != -1 && ixCountVia == -1 && blk == viaBlockBoxList.get(ixVia)) {
+                                log.trace("ixTwo[{}]block[{}]",ixCount,blk.getDisplayName());
+                                if (ixCount != ixCountStart + 1) {
+                                    log.debug("AdHoc {}:via and start not ajacent",tr.getDisplayName());
+                                    break;
+                                }
+                                ixCountVia = ixCount;
+                            } else if (ixCountStart != -1 && ixCountVia != -1 && ixCountDest == -1 && blk == destinationBlockBoxList.get(ixEnd)) {
+                                ixCountDest = ixCount;
+                                log.trace("ixThree[{}]block[{}]",ixCountDest,blk.getDisplayName());
+                                break;
+                            }
+                            ixCount++;
+                        }
+                        if (ixCountVia == (ixCountStart + 1) && ixCountDest > ixCountStart) {
+                            log.debug("Canuse [{}", tr.getDisplayName());
+                            Integer routeBlockLength =
+                                    transitBlockSeq.get(ixCountDest) - transitBlockSeq.get(ixCountStart);
+                            if (routeBlockLength < routeCount) {
+                                routeCount = ixCountDest - ixCountStart;
+                                tmpTransit = tr;
+                                startBlockSeq = transitBlockSeq.get(ixCountStart).intValue();
+                                endBlockSeq = transitBlockSeq.get(ixCountDest).intValue();
+                            }
+                        }
+                    }
+                }
+                if (tmpTransit != null &&
+                        (JmriJOptionPane.showConfirmDialog(this, Bundle.getMessage("Question6",tmpTransit.getDisplayName()),
+                                "Question",
+                                JmriJOptionPane.YES_NO_OPTION,
+                                JmriJOptionPane.QUESTION_MESSAGE) == JmriJOptionPane.YES_OPTION)) {
+                    // use transit found
+                    trainInfo.setDynamicTransit(false);
+                    trainInfo.setTransitName(tmpTransit.getDisplayName());
+                    trainInfo.setTransitId(tmpTransit.getDisplayName());
+                    trainInfo.setStartBlockSeq(startBlockSeq);
+                    trainInfo.setStartBlockName(getBlockName(startingBlockBoxList.get(ixStart)) + "-" + startBlockSeq);
+                    trainInfo.setDestinationBlockSeq(endBlockSeq);
+                    trainInfo.setDestinationBlockName(getBlockName(destinationBlockBoxList.get(ixEnd)) + "-" + endBlockSeq);
+                    trainInfoToDialog(trainInfo);
+                } else {
+                    // use a true ad-hoc
+                    List<LayoutBlock> blockList = _dispatcher.getAdHocRoute(startingBlockBoxList.get(ixStart),
+                            destinationBlockBoxList.get(ixEnd),
+                            viaBlockBoxList.get(ixVia));
+                    if (blockList == null) {
+                        JmriJOptionPane.showMessageDialog(initiateFrame, Bundle.getMessage("Error51"),
+                                Bundle.getMessage("ErrorTitle"), JmriJOptionPane.ERROR_MESSAGE);
+                        return;
+                    }
                 }
             }
-            dialogToTrainInfo(trainInfo);
             _dispatcher.loadTrainFromTrainInfoThrowsException(trainInfo,"NONE","");
         } catch (IllegalArgumentException ex) {
             JmriJOptionPane.showMessageDialog(initiateFrame, ex.getMessage(),
@@ -1093,7 +1165,8 @@ public class ActivateTrainFrame extends JmriJFrame {
 
     private void initializeFreeTrainsCombo() {
         Train prevValue = null;
-        if (trainSelectBox.getSelectedIndex() > -1) {
+        if (trainSelectBox.getSelectedIndex() > 0) {
+            // item zero is a string
             prevValue = (Train)trainSelectBox.getSelectedItem();
         }
         ActionListener[] als = trainSelectBox.getActionListeners();

--- a/java/src/jmri/jmrit/dispatcher/AutoAllocate.java
+++ b/java/src/jmri/jmrit/dispatcher/AutoAllocate.java
@@ -9,6 +9,7 @@ import java.util.Map.Entry;
 import java.util.concurrent.LinkedBlockingQueue;
 
 import jmri.Block;
+import jmri.EntryPoint;
 import jmri.InstanceManager;
 import jmri.Section;
 import jmri.Sensor;
@@ -1617,14 +1618,13 @@ public class AutoAllocate implements Runnable {
 
         Block facingBlock;
         Block protectingBlock;
-        if (ar.getSectionDirection() == jmri.Section.FORWARD) {
-            protectingBlock = sec.getBlockBySequenceNumber(0);
-            facingBlock = lastSec.getBlockBySequenceNumber(lastSec.getNumBlocks() - 1);
-        } else {
-            // Reverse
-            protectingBlock = sec.getBlockBySequenceNumber(sec.getNumBlocks() - 1);
-            facingBlock = lastSec.getBlockBySequenceNumber(0);
+        EntryPoint protectingEP = sec.getEntryPointFromSection(lastSec, ar.getSectionDirection());
+        EntryPoint facingEP =  lastSec.getExitPointToSection(sec, lastSec.getState());
+        if (protectingEP == null || facingEP == null ) {
+            return false;
         }
+        protectingBlock = protectingEP.getBlock();
+        facingBlock = facingEP.getBlock();
         if (protectingBlock == null || facingBlock == null) {
             return false;
         }

--- a/java/src/jmri/jmrit/dispatcher/DispatcherBundle.properties
+++ b/java/src/jmri/jmrit/dispatcher/DispatcherBundle.properties
@@ -322,6 +322,7 @@ Question3 = A Train Info file with the name "{0}" already exists.\nDo you want t
 ButtonReplace = Replace
 Question4 = Section is FREE and UNOCCUPIED, but this Active Train \nhas not yet reached its start time.\nDo you want to override the start time and allocate it?
 Question5 = The Allocated Section "{0}" is OCCUPIED. Do you want to release it? This could cause a collision.
+Question6 = Found transit "{0}" that can be used in part. Do you wish to use it?
 ButtonRelease = Release
 
 Message1 = Complete or cancel Activate New Train pane before Terminating an ActiveTrain.


### PR DESCRIPTION
Do not assume held signal masts is been end to end section join.
Allow adhoc trains to use transits r part of a transit.
