### PR TITLE
Nce consist tool memory limits

### DIFF
--- a/java/src/jmri/jmrix/nce/NceCmdStationMemory.java
+++ b/java/src/jmri/jmrix/nce/NceCmdStationMemory.java
@@ -50,7 +50,21 @@ public class NceCmdStationMemory {
     public int getConsistHeadAddr() {
         return 0xF500;  // start of NCE CS Consist Head memory
     }
+    
+    /*
+     * give size of consist head table
+     */
+    public int getConsistHeadSize() {
+        return 0x0100;  // size of NCE CS Consist Head memory
+    }
 
+    /*
+     * give addr of consist data
+     */
+    public int getConsistAddr() {
+        return getConsistHeadAddr();    // mostly for the page needed by the USB
+    }
+    
     /*
      * give addr consist tail
      */
@@ -59,24 +73,38 @@ public class NceCmdStationMemory {
     }
     
     /*
+     * give size of consist tail table
+     */
+    public int getConsistTailSize() {
+        return 0x0100;  // size of NCE CS Consist Tail memory
+    }
+    
+    /*
      * give addr consist middle
      */
     public int getConsistMidAddr() {
-        return 0xF700;  // start of NCE CS Consist memory
+        return 0xF700;  // start of NCE CS Consist Middle memory
+    }
+
+    /*
+     * give addr consist middle
+     */
+    public int getConsistMidEntries() {
+        return 4;       // how many middle Consist entries/consist
     }
     
     /*
      * give size of consist mid table
      */
     public int getConsistMidSize() {
-        return 0x0600;  // size of NCE CS Consist memory
+        return 0x0400;  // size of NCE CS Consist Middle memory
     }
     
     /*
      * give minimum consist number
      */
     public int getConsistMin() {
-        return 1;
+        return 0;
     }
     
     /*

--- a/java/src/jmri/jmrix/nce/consist/NceConsistBackup.java
+++ b/java/src/jmri/jmrix/nce/consist/NceConsistBackup.java
@@ -222,52 +222,32 @@ public class NceConsistBackup extends Thread implements jmri.jmrix.nce.NceListen
         return true;
     }
 
-    // USB set cab memory pointer
-    private void setUsbCabMemoryPointer(int cab, int offset) {
-        log.debug("Macro base address: {}, offset: {}", Integer.toHexString(cab), offset);
-        replyLen = NceMessage.REPLY_1; // Expect 1 byte response
-        waiting++;
-        byte[] bl = NceBinaryCommand.usbMemoryPointer(cab, offset);
-        NceMessage m = NceMessage.createBinaryMessage(tc, bl, NceMessage.REPLY_1);
-        tc.sendNceMessage(m, this);
-    }
-
-    // USB Read N bytes of NCE cab memory
-    private void readUsbMemoryN(int num) {
-        switch (num) {
-            case 1:
-                replyLen = NceMessage.REPLY_1; // Expect 1 byte response
-                break;
-            case 2:
-                replyLen = NceMessage.REPLY_2; // Expect 2 byte response
-                break;
-            case 4:
-                replyLen = NceMessage.REPLY_4; // Expect 4 byte response
-                break;
-            default:
-                log.error("Invalid usb read byte count");
-                return;
-        }
-        waiting++;
-        byte[] bl = NceBinaryCommand.usbMemoryRead((byte) num);
-        NceMessage m = NceMessage.createBinaryMessage(tc, bl, replyLen);
-        tc.sendNceMessage(m, this);
-    }
-
-    /**
-     * USB Write 1 byte of NCE memory
-     *
-     * @param value byte being written+
+    /*
+     * // USB set cab memory pointer private void setUsbCabMemoryPointer(int
+     * cab, int offset) { log.debug("Macro base address: {}, offset: {}",
+     * Integer.toHexString(cab), offset); replyLen = NceMessage.REPLY_1; //
+     * Expect 1 byte response waiting++; byte[] bl =
+     * NceBinaryCommand.usbMemoryPointer(cab, offset); NceMessage m =
+     * NceMessage.createBinaryMessage(tc, bl, NceMessage.REPLY_1);
+     * tc.sendNceMessage(m, this); }
+     * 
+     * // USB Read N bytes of NCE cab memory private void readUsbMemoryN(int
+     * num) { switch (num) { case 1: replyLen = NceMessage.REPLY_1; // Expect 1
+     * byte response break; case 2: replyLen = NceMessage.REPLY_2; // Expect 2
+     * byte response break; case 4: replyLen = NceMessage.REPLY_4; // Expect 4
+     * byte response break; default: log.error("Invalid usb read byte count");
+     * return; } waiting++; byte[] bl = NceBinaryCommand.usbMemoryRead((byte)
+     * num); NceMessage m = NceMessage.createBinaryMessage(tc, bl, replyLen);
+     * tc.sendNceMessage(m, this); }
+     * 
+     * // USB Write 1 byte of NCE memory private void writeUsbMemory1(byte
+     * value) { log.debug("Write byte: {}", String.format("%2X", value));
+     * replyLen = NceMessage.REPLY_1; // Expect 1 byte response waiting++;
+     * byte[] bl = NceBinaryCommand.usbMemoryWrite1(value); NceMessage m =
+     * NceMessage.createBinaryMessage(tc, bl, NceMessage.REPLY_1);
+     * tc.sendNceMessage(m, this); }
      */
-    private void writeUsbMemory1(byte value) {
-        log.debug("Write byte: {}", String.format("%2X", value));
-        replyLen = NceMessage.REPLY_1; // Expect 1 byte response
-        waiting++;
-        byte[] bl = NceBinaryCommand.usbMemoryWrite1(value);
-        NceMessage m = NceMessage.createBinaryMessage(tc, bl, NceMessage.REPLY_1);
-        tc.sendNceMessage(m, this);
-    }
-
+    
     // Reads 16 bytes of NCE consist memory
     private NceMessage readConsistMemory(int consistNum) {
 

--- a/java/src/jmri/jmrix/nce/consist/NceConsistBackup.java
+++ b/java/src/jmri/jmrix/nce/consist/NceConsistBackup.java
@@ -44,22 +44,24 @@ import jmri.util.swing.TextFilter;
  */
 public class NceConsistBackup extends Thread implements jmri.jmrix.nce.NceListener {
 
-    private static final int CONSIST_LNTH = 16; // 16 bytes per line
+    private int consistRecLen = 16; // bytes per line
     private int replyLen = 0; // expected byte length
     private int waiting = 0; // to catch responses not intended for this module
     private boolean fileValid = false; // used to flag backup status messages
 
-    private final byte[] nceConsistData = new byte[CONSIST_LNTH];
+    private final byte[] nceConsistData = new byte[consistRecLen];
 
     JLabel textConsist = new JLabel();
     JLabel consistNumber = new JLabel();
 
     private NceTrafficController tc = null;
-    private int workingNumConsists = -1;
+    private int consistStartNum = -1;
+    private int consistEndNum = -1;
 
     public NceConsistBackup(NceTrafficController t) {
         tc = t;
-        workingNumConsists = tc.csm.getConsistMax();
+        consistStartNum = tc.csm.getConsistMin();
+        consistEndNum = tc.csm.getConsistMax();
     }
 
     @Override
@@ -127,23 +129,30 @@ public class NceConsistBackup extends Thread implements jmri.jmrix.nce.NceListen
             waiting = 0; // reset in case there was a previous error
             fileValid = true; // assume we're going to succeed
             // output string to file
+            // head 2 bytes, end 2 bytes, mid num * 2 bytes
+            int consistBytesEach = (tc.csm.getConsistMidEntries() * 2) + 2 + 2;
+            int memOffsetEnd = consistBytesEach * (1 +consistEndNum - consistStartNum);
+            int consistRecNum = 0;
+            int consistNum = consistStartNum;
 
-            for (int consistNum = 0; consistNum < workingNumConsists; consistNum++) {
-
+            for (int memOffset = 0; memOffset < memOffsetEnd; memOffset += consistRecLen) {
+                
+                consistNum = consistStartNum + (memOffset / consistBytesEach);
+                consistRecNum = memOffset / consistRecLen;
                 consistNumber.setText(Integer.toString(consistNum));
                 fstatus.setVisible(true);
 
-                getNceConsist(consistNum);
+                getNceConsist(consistRecNum);
 
                 if (!fileValid) {
-                    consistNum = workingNumConsists; // break out of for loop
+                    memOffset = memOffsetEnd; // break out of for loop
                 }
                 if (fileValid) {
                     StringBuilder buf = new StringBuilder();
                     buf.append(":").append(Integer.toHexString(
-                            tc.csm.getConsistHeadAddr() + (consistNum * CONSIST_LNTH)));
+                            tc.csm.getConsistHeadAddr() + memOffset));
 
-                    for (int i = 0; i < CONSIST_LNTH; i++) {
+                    for (int i = 0; i < consistRecLen; i++) {
                         buf.append(" ").append(StringUtil.twoHexFromInt(nceConsistData[i++]));
                         buf.append(StringUtil.twoHexFromInt(nceConsistData[i]));
                     }
@@ -213,10 +222,56 @@ public class NceConsistBackup extends Thread implements jmri.jmrix.nce.NceListen
         return true;
     }
 
+    // USB set cab memory pointer
+    private void setUsbCabMemoryPointer(int cab, int offset) {
+        log.debug("Macro base address: {}, offset: {}", Integer.toHexString(cab), offset);
+        replyLen = NceMessage.REPLY_1; // Expect 1 byte response
+        waiting++;
+        byte[] bl = NceBinaryCommand.usbMemoryPointer(cab, offset);
+        NceMessage m = NceMessage.createBinaryMessage(tc, bl, NceMessage.REPLY_1);
+        tc.sendNceMessage(m, this);
+    }
+
+    // USB Read N bytes of NCE cab memory
+    private void readUsbMemoryN(int num) {
+        switch (num) {
+            case 1:
+                replyLen = NceMessage.REPLY_1; // Expect 1 byte response
+                break;
+            case 2:
+                replyLen = NceMessage.REPLY_2; // Expect 2 byte response
+                break;
+            case 4:
+                replyLen = NceMessage.REPLY_4; // Expect 4 byte response
+                break;
+            default:
+                log.error("Invalid usb read byte count");
+                return;
+        }
+        waiting++;
+        byte[] bl = NceBinaryCommand.usbMemoryRead((byte) num);
+        NceMessage m = NceMessage.createBinaryMessage(tc, bl, replyLen);
+        tc.sendNceMessage(m, this);
+    }
+
+    /**
+     * USB Write 1 byte of NCE memory
+     *
+     * @param value byte being written+
+     */
+    private void writeUsbMemory1(byte value) {
+        log.debug("Write byte: {}", String.format("%2X", value));
+        replyLen = NceMessage.REPLY_1; // Expect 1 byte response
+        waiting++;
+        byte[] bl = NceBinaryCommand.usbMemoryWrite1(value);
+        NceMessage m = NceMessage.createBinaryMessage(tc, bl, NceMessage.REPLY_1);
+        tc.sendNceMessage(m, this);
+    }
+
     // Reads 16 bytes of NCE consist memory
     private NceMessage readConsistMemory(int consistNum) {
 
-        int nceConsistAddr = (consistNum * CONSIST_LNTH) + tc.csm.getConsistHeadAddr();
+        int nceConsistAddr = (consistNum * consistRecLen) + tc.csm.getConsistHeadAddr();
         replyLen = NceMessage.REPLY_16; // Expect 16 byte response
         waiting++;
         byte[] bl = NceBinaryCommand.accMemoryRead(nceConsistAddr);

--- a/java/src/jmri/jmrix/nce/consist/NceConsistEditPanel.java
+++ b/java/src/jmri/jmrix/nce/consist/NceConsistEditPanel.java
@@ -58,6 +58,14 @@ public class NceConsistEditPanel extends jmri.jmrix.nce.swing.NcePanel implement
     private static final int LOC_ADR_MIN = 0;    // loco address range
     private static final int LOC_ADR_MAX = 9999; // max range for NCE
     private static final int LOC_ADR_REPLACE = 0x3FFF;  // dummy loco address
+    // added for PC, SB5, Twin usb memory
+    Thread nceMemoryThread;
+    private boolean isUsb = false;
+    private boolean consistValid = false;
+    private boolean readRequested = false;
+    private boolean writeRequested = false;
+    
+    private static final int FAILED = -1;
 
     private int consistNum = 0;     // consist being worked
     private boolean newConsist = true;    // new consist is displayed
@@ -192,7 +200,7 @@ public class NceConsistEditPanel extends jmri.jmrix.nce.swing.NcePanel implement
     JButton adrButton6 = new JButton();
     JButton cmdButton6 = new JButton();
     JButton dirButton6 = new JButton();
-
+    
     private NceTrafficController tc = null;
 
     public NceConsistEditPanel() {
@@ -269,6 +277,10 @@ public class NceConsistEditPanel extends jmri.jmrix.nce.swing.NcePanel implement
         this.tc = m.getNceTrafficController();
         CONSIST_MIN = tc.csm.getConsistMin();
         CONSIST_MAX = tc.csm.getConsistMax();
+        if ((tc.getUsbSystem() != NceTrafficController.USB_SYSTEM_NONE) &&
+                (tc.getCmdGroups() & NceTrafficController.CMDS_MEM) != 0) {
+            isUsb = true;
+        }
         // the following code sets the frame's initial state
 
         textConsist.setText(Bundle.getMessage("L_Consist"));
@@ -391,12 +403,14 @@ public class NceConsistEditPanel extends jmri.jmrix.nce.swing.NcePanel implement
         // row 11 Mid Locomotive
         addLocoRow(textLoco4, locoRosterBox4, locoTextField4, adrButton4,
                 dirButton4, cmdButton4, 11);
-        // row 12 Mid Locomotive
-        addLocoRow(textLoco5, locoRosterBox5, locoTextField5, adrButton5,
-                dirButton5, cmdButton5, 12);
-        // row 13 Mid Locomotive
-        addLocoRow(textLoco6, locoRosterBox6, locoTextField6, adrButton6,
-                dirButton6, cmdButton6, 13);
+        if (!isUsb) {
+            // row 12 Mid Locomotive
+            addLocoRow(textLoco5, locoRosterBox5, locoTextField5, adrButton5,
+                    dirButton5, cmdButton5, 12);
+            // row 13 Mid Locomotive
+            addLocoRow(textLoco6, locoRosterBox6, locoTextField6, adrButton6,
+                    dirButton6, cmdButton6, 13);
+        }
 
         // row 15 padding for looks
         addItem(space15, 2, 15);
@@ -405,8 +419,10 @@ public class NceConsistEditPanel extends jmri.jmrix.nce.swing.NcePanel implement
         addItem(clearCancelButton, 1, 16);
         addItem(saveLoadButton, 2, 16);
         addItem(deleteButton, 3, 16);
-        addItem(backUpButton, 4, 16);
-        addItem(restoreButton, 5, 16);
+        if (!isUsb) {
+            addItem(backUpButton, 4, 16);
+            addItem(restoreButton, 5, 16);
+        }
 
         // setup buttons
         addButtonAction(previousButton);
@@ -416,8 +432,10 @@ public class NceConsistEditPanel extends jmri.jmrix.nce.swing.NcePanel implement
         addButtonAction(clearCancelButton);
         addButtonAction(saveLoadButton);
         addButtonAction(deleteButton);
-        addButtonAction(backUpButton);
-        addButtonAction(restoreButton);
+        if (!isUsb) {
+            addButtonAction(backUpButton);
+            addButtonAction(restoreButton);
+        }
 
         // setup checkboxes
         addCheckBoxAction(checkBoxConsist);
@@ -521,12 +539,12 @@ public class NceConsistEditPanel extends jmri.jmrix.nce.swing.NcePanel implement
             // Get Consist
             consistNum = getConsist();
         }
-        if (ae.getSource() == backUpButton) {
+        if (!isUsb && ae.getSource() == backUpButton) {
             Thread mb = new NceConsistBackup(tc);
             mb.setName("Consist Backup");
             mb.start();
         }
-        if (ae.getSource() == restoreButton) {
+        if (!isUsb && ae.getSource() == restoreButton) {
             Thread mr = new NceConsistRestore(tc);
             mr.setName("Consist Restore");
             mr.start();
@@ -787,9 +805,18 @@ public class NceConsistEditPanel extends jmri.jmrix.nce.swing.NcePanel implement
         }
 
         if (consistSearchNext) {
-            readConsistMemory(consistNumber - 7, LEAD);
+            if (!isUsb) {
+                readConsistMemory(consistNumber - 7, LEAD);
+            } else {
+                readConsistMemoryUsb(consistNumber - 7, LEAD);
+            }
         } else {
-            readConsistMemory(consistNumber, LEAD); // Get or Previous button
+            // Get or Previous button
+            if (!isUsb) {
+                readConsistMemory(consistNumber, LEAD);
+            } else {
+                readConsistMemoryUsb(consistNumber, LEAD);
+            }
         }
         return consistNumber;
     }
@@ -2239,6 +2266,183 @@ public class NceConsistEditPanel extends jmri.jmrix.nce.swing.NcePanel implement
                     NceConsistEditPanel.class.getName(),
                     jmri.InstanceManager.getDefault(NceSystemConnectionMemo.class));
         }
+    }
+
+    // USB set memory pointer
+    private void setUsbMemoryPointer(int cab, int offset) {
+        log.debug("Consist base address: {}, offset: {}", Integer.toHexString(cab), offset);
+        replyLen = NceMessage.REPLY_1; // Expect 1 byte response
+        waiting++;
+        byte[] bl = NceBinaryCommand.usbMemoryPointer(cab, offset);
+        NceMessage m = NceMessage.createBinaryMessage(tc, bl, NceMessage.REPLY_1);
+        tc.sendNceMessage(m, this);
+    }
+
+    // USB Read N bytes of NCE cab memory
+    private void readUsbMemoryN(int num) {
+        switch (num) {
+            case 1:
+                replyLen = NceMessage.REPLY_1; // Expect 1 byte response
+                break;
+            case 2:
+                replyLen = NceMessage.REPLY_2; // Expect 2 byte response
+                break;
+            case 4:
+                replyLen = NceMessage.REPLY_4; // Expect 4 byte response
+                break;
+            default:
+                log.error("Invalid usb read byte count");
+                return;
+        }
+        waiting++;
+        byte[] bl = NceBinaryCommand.usbMemoryRead((byte) num);
+        NceMessage m = NceMessage.createBinaryMessage(tc, bl, replyLen);
+        tc.sendNceMessage(m, this);
+    }
+
+    /**
+     * USB Write 1 byte of NCE memory
+     *
+     * @param value byte being written+
+     */
+    private void writeUsbMemory1(byte value) {
+        log.debug("Write byte: {}", String.format("%2X", value));
+        replyLen = NceMessage.REPLY_1; // Expect 1 byte response
+        waiting++;
+        byte[] bl = NceBinaryCommand.usbMemoryWrite1(value);
+        NceMessage m = NceMessage.createBinaryMessage(tc, bl, NceMessage.REPLY_1);
+        tc.sendNceMessage(m, this);
+    }
+/**
+    private void processMemory(boolean doRead, boolean doWrite, int consistId, byte[] consistArray) {
+        final byte[] consistData = new byte[consistSize];
+        consistValid = false;
+        readRequested = false;
+        writeRequested = false;
+
+        if (doRead) {
+            readRequested = true;
+        }
+        if (doWrite) {
+            writeRequested = true;
+            System.arraycopy(consistArray, 0, consistData, 0, consistSize);
+        }
+
+        // Set up a separate thread to access CS memory
+        if (nceMemoryThread != null && nceMemoryThread.isAlive()) {
+            return; // thread is already running
+        }
+        nceMemoryThread = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                if (readRequested) {
+                    consistNum = consistId;
+                    int consistCount = 0;
+                    while (true) {
+                        int entriesRead = readConsistMemoryUsb(consistNum, LEAD);
+                        consistTextField.setText(Integer.toString(consistNum));
+                        if (entriesRead == 0) {
+                            consistStatus.setText(Bundle.getMessage("consistEmpty"));
+                            if (checkBoxEmpty.isSelected()) {
+                                consistValid = true;
+                                consistSearchInc = false;
+                                consistSearchDec = false;
+                                break;
+                            }
+                        } else if (entriesRead < 0) {
+                            consistStatus.setText(Bundle.getMessage("error"));
+                            consistValid = false;
+                            consistSearchInc = false;
+                            consistSearchDec = false;
+                            break;
+                        } else {
+                            consistStatus.setText(Bundle.getMessage("consistFound"));
+                            if (!checkBoxEmpty.isSelected()) {
+                                consistSearchInc = false;
+                                consistSearchDec = false;
+                                consistValid = true;
+                                break;
+                            }
+                        }
+                        if ((consistSearchInc || consistSearchDec) && !consistValid) {
+                            consistCount++;
+                            if (consistCount > maxNumconsists) {
+                                consistSearchInc = false;
+                                consistSearchDec = false;
+                                break;
+                            }
+                            consistNum = getconsist();
+                        }
+                        if (!(consistSearchInc || consistSearchDec)) {
+                            // we were doing a get, not a search
+                            consistValid = true;
+                            break;
+                        }
+                    }
+                }
+                if (writeRequested) {
+                    writeconsistMemoryUsb(consistId, consistData);
+                }
+            }
+        });
+        nceMemoryThread.setName(Bundle.getMessage("ThreadTitle"));
+        nceMemoryThread.setPriority(Thread.MIN_PRIORITY);
+        nceMemoryThread.start();
+    }
+*/
+    
+    /**
+     * Reads 2 or 4 bytes of NCE USB consist memory based on consist number and loco
+     * position in the consist 0=lead 1=rear 2=mid
+     * @return 
+     */
+    private int readConsistMemoryUsb(int consistNum, int engPosition) {
+        locoPosition = engPosition;
+        int memAddr = (tc.csm.getConsistMidEntries() * (-1 * (consistNum - tc.csm.getConsistMax())));
+        if (locoPosition == REAR) {
+            memAddr = (consistNum * 2) + tc.csm.getConsistTailAddr();
+        }
+        if (locoPosition == MID) {
+            memAddr = (consistNum * tc.csm.getConsistMidEntries()) + tc.csm.getConsistMidAddr();
+        }
+        log.debug("Read consist ({}) position ({}) NCE memory address ({})", consistNum, engPosition, Integer.toHexString(memAddr));
+        int consistPage = tc.csm.getConsistAddr();
+        setUsbMemoryPointer(consistPage, memAddr);
+        if (!waitNce()) {
+            return FAILED;
+        }
+        byte[] bl = NceBinaryCommand.accMemoryRead(memAddr);
+        sendNceMessage(bl, NceMessage.REPLY_4);
+        if (!waitNce()) {
+            return FAILED;
+        }
+        return(0);
+    }
+
+    // puts the thread to sleep while we wait for the read CS memory to complete
+    private boolean waitNce() {
+        int count = 100;
+        if (log.isDebugEnabled()) {
+            log.debug("Going to sleep");
+        }
+        while (waiting > 0) {
+            synchronized (this) {
+                try {
+                    wait(100);
+                } catch (InterruptedException e) {
+                    //nothing to see here, move along
+                }
+            }
+            count--;
+            if (count < 0) {
+                consistStatus.setText("Error");
+                return false;
+            }
+        }
+        if (log.isDebugEnabled()) {
+            log.debug("awake!");
+        }
+        return true;
     }
 
     private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(NceConsistEditPanel.class);

--- a/java/src/jmri/jmrix/nce/consist/NceConsistEditPanel.java
+++ b/java/src/jmri/jmrix/nce/consist/NceConsistEditPanel.java
@@ -61,11 +61,11 @@ public class NceConsistEditPanel extends jmri.jmrix.nce.swing.NcePanel implement
     // added for PC, SB5, Twin usb memory
     Thread nceMemoryThread;
     private boolean isUsb = false;
-    private boolean consistValid = false;
-    private boolean readRequested = false;
-    private boolean writeRequested = false;
-    
-    private static final int FAILED = -1;
+    /*
+     * private boolean consistValid = false; private boolean readRequested =
+     * false; private boolean writeRequested = false;
+     */    
+//    private static final int FAILED = -1;
 
     private int consistNum = 0;     // consist being worked
     private boolean newConsist = true;    // new consist is displayed
@@ -808,14 +808,14 @@ public class NceConsistEditPanel extends jmri.jmrix.nce.swing.NcePanel implement
             if (!isUsb) {
                 readConsistMemory(consistNumber - 7, LEAD);
             } else {
-                readConsistMemoryUsb(consistNumber - 7, LEAD);
+                // readConsistMemoryUsb(consistNumber - 7, LEAD);
             }
         } else {
             // Get or Previous button
             if (!isUsb) {
                 readConsistMemory(consistNumber, LEAD);
             } else {
-                readConsistMemoryUsb(consistNumber, LEAD);
+                // readConsistMemoryUsb(consistNumber, LEAD);
             }
         }
         return consistNumber;
@@ -2267,7 +2267,7 @@ public class NceConsistEditPanel extends jmri.jmrix.nce.swing.NcePanel implement
                     jmri.InstanceManager.getDefault(NceSystemConnectionMemo.class));
         }
     }
-
+    /**
     // USB set memory pointer
     private void setUsbMemoryPointer(int cab, int offset) {
         log.debug("Consist base address: {}, offset: {}", Integer.toHexString(cab), offset);
@@ -2300,11 +2300,7 @@ public class NceConsistEditPanel extends jmri.jmrix.nce.swing.NcePanel implement
         tc.sendNceMessage(m, this);
     }
 
-    /**
-     * USB Write 1 byte of NCE memory
-     *
-     * @param value byte being written+
-     */
+    // USB Write 1 byte of NCE memory
     private void writeUsbMemory1(byte value) {
         log.debug("Write byte: {}", String.format("%2X", value));
         replyLen = NceMessage.REPLY_1; // Expect 1 byte response
@@ -2313,7 +2309,7 @@ public class NceConsistEditPanel extends jmri.jmrix.nce.swing.NcePanel implement
         NceMessage m = NceMessage.createBinaryMessage(tc, bl, NceMessage.REPLY_1);
         tc.sendNceMessage(m, this);
     }
-/**
+
     private void processMemory(boolean doRead, boolean doWrite, int consistId, byte[] consistArray) {
         final byte[] consistData = new byte[consistSize];
         consistValid = false;
@@ -2389,13 +2385,9 @@ public class NceConsistEditPanel extends jmri.jmrix.nce.swing.NcePanel implement
         nceMemoryThread.setPriority(Thread.MIN_PRIORITY);
         nceMemoryThread.start();
     }
-*/
     
-    /**
-     * Reads 2 or 4 bytes of NCE USB consist memory based on consist number and loco
-     * position in the consist 0=lead 1=rear 2=mid
-     * @return 
-     */
+    // Reads 2 or 4 bytes of NCE USB consist memory based on consist number and loco
+    // position in the consist 0=lead 1=rear 2=mid
     private int readConsistMemoryUsb(int consistNum, int engPosition) {
         locoPosition = engPosition;
         int memAddr = (tc.csm.getConsistMidEntries() * (-1 * (consistNum - tc.csm.getConsistMax())));
@@ -2444,6 +2436,8 @@ public class NceConsistEditPanel extends jmri.jmrix.nce.swing.NcePanel implement
         }
         return true;
     }
+
+*/
 
     private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(NceConsistEditPanel.class);
 

--- a/java/src/jmri/jmrix/nce/consist/NceConsistRestore.java
+++ b/java/src/jmri/jmrix/nce/consist/NceConsistRestore.java
@@ -204,52 +204,48 @@ public class NceConsistRestore extends Thread implements jmri.jmrix.nce.NceListe
             // this is the end of the try-with-resources that opens in.
         }
     }
-
-    // USB set cab memory pointer
-    private void setUsbCabMemoryPointer(int cab, int offset) {
-        log.debug("Macro base address: {}, offset: {}", Integer.toHexString(cab), offset);
-        replyLen = NceMessage.REPLY_1; // Expect 1 byte response
-        waiting++;
-        byte[] bl = NceBinaryCommand.usbMemoryPointer(cab, offset);
-        NceMessage m = NceMessage.createBinaryMessage(tc, bl, NceMessage.REPLY_1);
-        tc.sendNceMessage(m, this);
-    }
-
-    // USB Read N bytes of NCE cab memory
-    private void readUsbMemoryN(int num) {
-        switch (num) {
-            case 1:
-                replyLen = NceMessage.REPLY_1; // Expect 1 byte response
-                break;
-            case 2:
-                replyLen = NceMessage.REPLY_2; // Expect 2 byte response
-                break;
-            case 4:
-                replyLen = NceMessage.REPLY_4; // Expect 4 byte response
-                break;
-            default:
-                log.error("Invalid usb read byte count");
-                return;
-        }
-        waiting++;
-        byte[] bl = NceBinaryCommand.usbMemoryRead((byte) num);
-        NceMessage m = NceMessage.createBinaryMessage(tc, bl, replyLen);
-        tc.sendNceMessage(m, this);
-    }
-
-    /**
-     * USB Write 1 byte of NCE memory
-     *
-     * @param value byte being written+
-     */
-    private void writeUsbMemory1(byte value) {
-        log.debug("Write byte: {}", String.format("%2X", value));
-        replyLen = NceMessage.REPLY_1; // Expect 1 byte response
-        waiting++;
-        byte[] bl = NceBinaryCommand.usbMemoryWrite1(value);
-        NceMessage m = NceMessage.createBinaryMessage(tc, bl, NceMessage.REPLY_1);
-        tc.sendNceMessage(m, this);
-    }
+//
+//    // USB set cab memory pointer
+//    private void setUsbCabMemoryPointer(int cab, int offset) {
+//        log.debug("Macro base address: {}, offset: {}", Integer.toHexString(cab), offset);
+//        replyLen = NceMessage.REPLY_1; // Expect 1 byte response
+//        waiting++;
+//        byte[] bl = NceBinaryCommand.usbMemoryPointer(cab, offset);
+//        NceMessage m = NceMessage.createBinaryMessage(tc, bl, NceMessage.REPLY_1);
+//        tc.sendNceMessage(m, this);
+//    }
+//
+//    // USB Read N bytes of NCE cab memory
+//    private void readUsbMemoryN(int num) {
+//        switch (num) {
+//            case 1:
+//                replyLen = NceMessage.REPLY_1; // Expect 1 byte response
+//                break;
+//            case 2:
+//                replyLen = NceMessage.REPLY_2; // Expect 2 byte response
+//                break;
+//            case 4:
+//                replyLen = NceMessage.REPLY_4; // Expect 4 byte response
+//                break;
+//            default:
+//                log.error("Invalid usb read byte count");
+//                return;
+//        }
+//        waiting++;
+//        byte[] bl = NceBinaryCommand.usbMemoryRead((byte) num);
+//        NceMessage m = NceMessage.createBinaryMessage(tc, bl, replyLen);
+//        tc.sendNceMessage(m, this);
+//    }
+//
+//    // USB Write 1 byte of NCE memory
+//    private void writeUsbMemory1(byte value) {
+//        log.debug("Write byte: {}", String.format("%2X", value));
+//        replyLen = NceMessage.REPLY_1; // Expect 1 byte response
+//        waiting++;
+//        byte[] bl = NceBinaryCommand.usbMemoryWrite1(value);
+//        NceMessage m = NceMessage.createBinaryMessage(tc, bl, NceMessage.REPLY_1);
+//        tc.sendNceMessage(m, this);
+//    }
 
     // writes 16 bytes of NCE consist memory
     private NceMessage writeNceConsistMemory(int curConsist, byte[] b) {

--- a/java/src/jmri/jmrix/nce/consist/NceConsistRestore.java
+++ b/java/src/jmri/jmrix/nce/consist/NceConsistRestore.java
@@ -10,6 +10,8 @@ import java.io.IOException;
 import javax.swing.JFileChooser;
 import javax.swing.JPanel;
 
+import org.python.jline.internal.Log;
+
 import jmri.jmrix.nce.NceBinaryCommand;
 import jmri.jmrix.nce.NceMessage;
 import jmri.jmrix.nce.NceReply;
@@ -87,6 +89,9 @@ public class NceConsistRestore extends Thread implements jmri.jmrix.nce.NceListe
             int curConsist = tc.csm.getConsistHeadAddr(); // load the start address of the NCE consist memory
             byte[] consistData = new byte[CONSIST_LNTH]; // NCE Consist data
             String line;
+            int consistMemMim = tc.csm.getConsistHeadAddr();
+            int consistMemMax = consistMemMim + 0x100 + 0x100 + tc.csm.getConsistMidSize();
+            int consistMemAddr;
 
             while (true) {
                 line = in.readLine();
@@ -107,6 +112,27 @@ public class NceConsistRestore extends Thread implements jmri.jmrix.nce.NceListe
                 // check for end of consist terminator
                 if (consistLine[0].equalsIgnoreCase(":0000")) {
                     fileValid = true; // success!
+                    break;
+                }
+                
+                // check for consistLine our of range
+                consistMemAddr = Integer.parseUnsignedInt(consistLine[0].replace(":", ""), 16);
+                if (consistMemAddr < consistMemMim) {
+                    log.warn("consist mem file out of range, ending restore, got: {} mimimum: {} ",
+                            Integer.toHexString(consistMemAddr), Integer.toHexString(consistMemMim));
+                    fileValid = true;
+                    break;
+                }
+                if (consistMemAddr >= consistMemMax ) {
+                    log.warn("consist mem file out of range, ending restore, got: {} maximum: {} ",
+                            Integer.toHexString(consistMemAddr), Integer.toHexString(consistMemMax));
+                    fileValid = true;
+                    break;
+                }
+                if (consistMemAddr != curConsist) {
+                    log.warn("consist mem file out of range, ending restore, got: {} expected: {} ",
+                            Integer.toHexString(consistMemAddr), Integer.toHexString(curConsist));
+                    fileValid = true;
                     break;
                 }
 
@@ -179,6 +205,52 @@ public class NceConsistRestore extends Thread implements jmri.jmrix.nce.NceListe
         } catch (IOException e) {
             // this is the end of the try-with-resources that opens in.
         }
+    }
+
+    // USB set cab memory pointer
+    private void setUsbCabMemoryPointer(int cab, int offset) {
+        log.debug("Macro base address: {}, offset: {}", Integer.toHexString(cab), offset);
+        replyLen = NceMessage.REPLY_1; // Expect 1 byte response
+        waiting++;
+        byte[] bl = NceBinaryCommand.usbMemoryPointer(cab, offset);
+        NceMessage m = NceMessage.createBinaryMessage(tc, bl, NceMessage.REPLY_1);
+        tc.sendNceMessage(m, this);
+    }
+
+    // USB Read N bytes of NCE cab memory
+    private void readUsbMemoryN(int num) {
+        switch (num) {
+            case 1:
+                replyLen = NceMessage.REPLY_1; // Expect 1 byte response
+                break;
+            case 2:
+                replyLen = NceMessage.REPLY_2; // Expect 2 byte response
+                break;
+            case 4:
+                replyLen = NceMessage.REPLY_4; // Expect 4 byte response
+                break;
+            default:
+                log.error("Invalid usb read byte count");
+                return;
+        }
+        waiting++;
+        byte[] bl = NceBinaryCommand.usbMemoryRead((byte) num);
+        NceMessage m = NceMessage.createBinaryMessage(tc, bl, replyLen);
+        tc.sendNceMessage(m, this);
+    }
+
+    /**
+     * USB Write 1 byte of NCE memory
+     *
+     * @param value byte being written+
+     */
+    private void writeUsbMemory1(byte value) {
+        log.debug("Write byte: {}", String.format("%2X", value));
+        replyLen = NceMessage.REPLY_1; // Expect 1 byte response
+        waiting++;
+        byte[] bl = NceBinaryCommand.usbMemoryWrite1(value);
+        NceMessage m = NceMessage.createBinaryMessage(tc, bl, NceMessage.REPLY_1);
+        tc.sendNceMessage(m, this);
     }
 
     // writes 16 bytes of NCE consist memory

--- a/java/src/jmri/jmrix/nce/consist/NceConsistRestore.java
+++ b/java/src/jmri/jmrix/nce/consist/NceConsistRestore.java
@@ -10,8 +10,6 @@ import java.io.IOException;
 import javax.swing.JFileChooser;
 import javax.swing.JPanel;
 
-import org.python.jline.internal.Log;
-
 import jmri.jmrix.nce.NceBinaryCommand;
 import jmri.jmrix.nce.NceMessage;
 import jmri.jmrix.nce.NceReply;

--- a/java/src/jmri/jmrix/nce/simulator/SimulatorAdapter.java
+++ b/java/src/jmri/jmrix/nce/simulator/SimulatorAdapter.java
@@ -447,7 +447,8 @@ public class SimulatorAdapter extends NcePortController implements Runnable {
             }
             return reply;
         }
-        if (nceMemoryAddress >= tc.csm.getConsistHeadAddr() && nceMemoryAddress < tc.csm.getConsistHeadAddr() + tc.csm.getConsistMidSize()) {
+        if (nceMemoryAddress >= tc.csm.getConsistHeadAddr() && nceMemoryAddress < tc.csm.getConsistHeadAddr() 
+                + tc.csm.getConsistMidSize()) {
             log.debug("Reading consist memory: {}", Integer.toHexString(nceMemoryAddress));
             int offset = nceMemoryAddress - tc.csm.getConsistHeadAddr();
 

--- a/java/src/jmri/jmrix/nce/usbdriver/UsbCmdStationMemory.java
+++ b/java/src/jmri/jmrix/nce/usbdriver/UsbCmdStationMemory.java
@@ -8,13 +8,37 @@ package jmri.jmrix.nce.usbdriver;
 public class UsbCmdStationMemory extends jmri.jmrix.nce.NceCmdStationMemory {
 
     /*
-     * give maximum consist number
+     * give cab addr consist table
+     */
+    @Override
+    public int getConsistAddr() {
+        return 0x0D; // start of NCE CS Consist memory 
+    }
+
+    /*
+     * give minimum consist number
      */
     @Override
     public int getConsistMin() {
         return 112;
     }
-        
+
+    /*
+     * give # of consist middle locos
+     */
+    @Override
+    public int getConsistMidEntries() {
+        return 2;       // how many middle Consist entries/consist
+    }
+
+    /*
+     * give consist num lines
+     */
+    @Override
+    public int getConsistNumLines() {
+        return 8;   // number of lines in the file
+    }
+     
     /*
      * give max cab id
      */


### PR DESCRIPTION
Note these files included some work towards the consist tool working for the USB systems: PowerCab, SB5, Twin. Mostly commented out. I was working along on that (slowly) when this issue came up.

The issue effects 5.8 through 5.11.3. If you make a backup of the consist memory, it was including other memory spaces outside of the consist tables. Worse, the restore wasn't testing to insure the addresses in the backup file were restricted to the consist tables. It looks like the command station buffers for AIU and Serial information could be corrupted by using these faulty files.

This pull has much more testing in the restore to insure it only writes to the consist tables and correctly limits to making the backup of only the consist tables.