### PR TITLE
more VSD Spotbugs

### DIFF
--- a/java/src/jmri/jmrit/vsdecoder/Diesel3Sound.java
+++ b/java/src/jmri/jmrit/vsdecoder/Diesel3Sound.java
@@ -41,7 +41,7 @@ class Diesel3Sound extends EngineSound {
     private Integer idle_notch;
     private int first_notch;
     int top_speed;
-    final int number_helper_buffers = 5; // in the loop-player is a limit of 2, but the unqueue takes some time too
+    final static int number_helper_buffers = 5; // in the loop-player is a limit of 2, but the unqueue takes some time too
 
     // Common variables
     private int current_notch = 1; // default
@@ -778,7 +778,7 @@ class Diesel3Sound extends EngineSound {
         private int incHelperIndex() {
             helper_index++;
             // Correct for wrap.
-            if (helper_index >= _parent.number_helper_buffers) {
+            if (helper_index >= Diesel3Sound.number_helper_buffers) {
                 helper_index = 0;
             }
             return helper_index;

--- a/java/src/jmri/jmrit/vsdecoder/EngineSoundEvent.java
+++ b/java/src/jmri/jmrit/vsdecoder/EngineSoundEvent.java
@@ -159,11 +159,12 @@ public class EngineSoundEvent extends SoundEvent {
         }
     }
 
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(value="BC_UNCONFIRMED_CAST", justification="DieselPane extends EnginePane")
+    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(value="BC_UNCONFIRMED_CAST",
+            justification="DieselPane extends EnginePane")
     private void setDecoderVolume() {
         // Get decoder volume and pass it to the spinner
         int dv = Math.round(this.getParent().getDecoderVolume() * 100f);
-        ((DieselPane) engine_pane).volume_slider.setValue(dv);
+        ((DieselPane) engine_pane).getVolumeSlider().setValue(dv);
     }
 
     @Override

--- a/java/src/jmri/jmrit/vsdecoder/LoadVSDFileAction.java
+++ b/java/src/jmri/jmrit/vsdecoder/LoadVSDFileAction.java
@@ -96,16 +96,16 @@ public class LoadVSDFileAction extends AbstractAction {
             log.debug("VSD File name: {}", vsdfile.getName());
             if (vsdfile.isInitialized()) {
                 VSDecoderManager.instance().loadProfiles(vsdfile);
+                // Cleanup and close files.
+                vsdfile.close();
+            } else {
+                if (!GraphicsEnvironment.isHeadless()) {
+                    JmriJOptionPane.showMessageDialog(null, vsdfile.getStatusMessage(),
+                            Bundle.getMessage("VSDFileError"), JmriJOptionPane.ERROR_MESSAGE);
+                }
+                vsdfile.close();
+                return false;
             }
-            // Cleanup and close files.
-            vsdfile.close();
-
-            if (!vsdfile.isInitialized() && !GraphicsEnvironment.isHeadless()) {
-                JmriJOptionPane.showMessageDialog(null, vsdfile.getStatusMessage(),
-                        Bundle.getMessage("VSDFileError"), JmriJOptionPane.ERROR_MESSAGE);
-            }
-
-            return vsdfile.isInitialized();
 
         } catch (java.util.zip.ZipException ze) {
             log.error("ZipException opening file {}", fp, ze);
@@ -114,6 +114,7 @@ public class LoadVSDFileAction extends AbstractAction {
             log.error("IOException opening file {}", fp, ze);
             return false;
         }
+        return true;
     }
 
     private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LoadVSDFileAction.class);

--- a/java/src/jmri/jmrit/vsdecoder/SteamSound.java
+++ b/java/src/jmri/jmrit/vsdecoder/SteamSound.java
@@ -87,14 +87,6 @@ class SteamSound extends EngineSound {
         super(name);
     }
 
-    // Responds to throttle loco direction key (see EngineSound.java and EngineSoundEvent.java)
-    @Override
-    public void changeLocoDirection(int d) {
-        // If loco direction was changed we need to set topspeed of the loco to new value
-        // (this is necessary, when topspeed-forward and topspeed-reverse differs)
-        log.debug("loco direction: {}", d);
-    }
-
     @Override
     public void startEngine() {
         log.debug("Starting Engine");
@@ -104,10 +96,14 @@ class SteamSound extends EngineSound {
 
     @Override
     public void stopEngine() {
-        current_rpm_sound.sound.fadeOut();
+        getCurrSound().fadeOut();
         if (current_rpm_sound.use_chuff) {
             current_rpm_sound.stopChuff();
         }
+    }
+
+    private SoundBite getCurrSound() {
+        return current_rpm_sound.sound;
     }
 
     private RPMSound getRPMSound(int rpm) {
@@ -148,7 +144,7 @@ class SteamSound extends EngineSound {
                 // DO something to shut down
                 //t = 0.0f;
                 setActualSpeed(0.0f);
-                current_rpm_sound.sound.fadeOut();
+                getCurrSound().fadeOut();
                 if (current_rpm_sound.use_chuff) {
                     current_rpm_sound.stopChuff();
                 }

--- a/java/src/jmri/jmrit/vsdecoder/VSDFile.java
+++ b/java/src/jmri/jmrit/vsdecoder/VSDFile.java
@@ -14,8 +14,6 @@ import java.util.zip.ZipException;
 import java.util.zip.ZipFile;
 import jmri.jmrit.XmlFile;
 import org.jdom2.Element;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Open a VSD file and validate the configuration part.
@@ -34,6 +32,7 @@ import org.slf4j.LoggerFactory;
  * for more details.
  *
  * @author Mark Underwood Copyright (C) 2011
+ * @author Klaus Killinger Copyright (C) 2025
  */
 public class VSDFile extends ZipFile {
 
@@ -44,28 +43,14 @@ public class VSDFile extends ZipFile {
     }
 
     protected Element root;
-    protected boolean initialized = false;
+    private boolean initialized;
     private String _statusMsg = Bundle.getMessage("ButtonOK"); // File Status = OK
     private String missedFileName;
     private int num_cylinders;
 
-    public VSDFile(File file) throws ZipException, IOException {
-        super(file);
-        initialized = init();
-    }
-
-    public VSDFile(File file, int mode) throws ZipException, IOException {
-        super(file, mode);
-        initialized = init();
-    }
-
     public VSDFile(String name) throws ZipException, IOException {
         super(name);
-        initialized = init();
-    }
-
-    public boolean isInitialized() {
-        return initialized;
+        initialized = false;
     }
 
     public String getStatusMessage() {
@@ -73,8 +58,8 @@ public class VSDFile extends ZipFile {
     }
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings( value="SLF4J_FORMAT_SHOULD_BE_CONST",
-        justification="error text in _statusMsg kept for later use")
-    protected boolean init() {
+            justification="error text in _statusMsg kept for later use")
+    final boolean isInitialized() {
         VSDXmlFile xmlfile = new VSDXmlFile();
         initialized = false;
 
@@ -102,11 +87,11 @@ public class VSDFile extends ZipFile {
             return initialized;
 
         } catch (java.io.IOException ioe) {
-            _statusMsg = "IO Error auto-loading VSD File: " + VSDXmlFileName + " " + ioe.toString();
+            _statusMsg = "IO Error auto-loading VSD File: " + VSDXmlFileName + " " + ioe;
             log.error(_statusMsg);
             return false;
         } catch (org.jdom2.JDOMException ex) {
-            _statusMsg = "JDOM Exception loading VSDecoder from path " + VSDXmlFileName + " " + ex.toString();
+            _statusMsg = "JDOM Exception loading VSDecoder from path " + VSDXmlFileName + " " + ex;
             log.error(_statusMsg);
             return false;
         }
@@ -451,7 +436,7 @@ public class VSDFile extends ZipFile {
     }
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings( value="SLF4J_FORMAT_SHOULD_BE_CONST",
-        justification="error text in _statusMsg kept for later use")
+            justification="error text in _statusMsg kept for later use")
     protected boolean validateFilesNumbers(Element el, String name, String[] fnames, Boolean required) {
         List<Element> elist = el.getChildren(name);
 
@@ -500,6 +485,6 @@ public class VSDFile extends ZipFile {
         return true;
     }
 
-    private final static Logger log = LoggerFactory.getLogger(VSDFile.class);
+    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(VSDFile.class);
 
 }

--- a/java/src/jmri/jmrit/vsdecoder/VSDecoderManager.java
+++ b/java/src/jmri/jmrit/vsdecoder/VSDecoderManager.java
@@ -83,7 +83,7 @@ public class VSDecoderManager implements PropertyChangeListener {
     private HashMap<Integer, VSDecoder> decoderInBlock; // list of active decoders by LocoAddress.getNumber()
     private HashMap<String, String> profiletable; // list of loaded profiles key = profile name, value = path
     HashMap<VSDecoder, Block> currentBlock; // list of active blocks by decoders
-    public HashMap<Block, LayoutEditor> possibleStartBlocks; // list of possible start blocks and their LE panel
+    private HashMap<Block, LayoutEditor> possibleStartBlocks; // list of possible start blocks and their LE panel
     private Timer timer;
 
     private int locoInBlock[][]; // Block status for locos
@@ -158,7 +158,7 @@ public class VSDecoderManager implements PropertyChangeListener {
             blockParameter = gf.getBlockParameter();
             blockPositionlists = gf.getBlockPosition();
             circlelist = gf.getCirclingList();
-            check_time = gf.check_time;
+            check_time = gf.getCheckTime();
             layout_scale = gf.layout_scale;
             models_origin = gf.models_origin;
             possibleStartBlocks = gf.possibleStartBlocks;
@@ -205,6 +205,22 @@ public class VSDecoderManager implements PropertyChangeListener {
      */
     public void setMasterVolume(int mv) {
         getVSDecoderPreferences().setMasterVolume(mv);
+    }
+
+    /**
+     * Check if Block is a possible startblock.
+     * @param blk Block to check
+     * @return true if possible, else false
+     */
+    public boolean checkForPossibleStartblock(Block blk) {
+        if (possibleStartBlocks.containsKey(blk)) {
+            return true;
+        } else {
+            if (geofile_ok) {
+                log.warn("Block {} is not a valid starting block", blk);
+            }
+            return false;
+        }
     }
 
     public void doResume() {
@@ -1034,7 +1050,6 @@ public class VSDecoderManager implements PropertyChangeListener {
                     }
                 }
             }
-            //startSoundPositionTimer(d);
         } else {
            log.warn(" Same PhysicalLocationReporter, position not set!");
         }

--- a/java/src/jmri/jmrit/vsdecoder/VSDecoderPreferences.java
+++ b/java/src/jmri/jmrit/vsdecoder/VSDecoderPreferences.java
@@ -9,8 +9,6 @@ import jmri.jmrit.vsdecoder.listener.ListeningSpot;
 import jmri.util.FileUtil;
 import jmri.util.PhysicalLocation;
 import org.jdom2.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Manage VSDecoder Preferences.
@@ -70,14 +68,17 @@ public class VSDecoderPreferences {
             root = null;
         }
         if (root != null) {
-            load(root.getChild("VSDecoderPreferences"));
+            Element rf = root.getChild("VSDecoderPreferences");
+            jmri.util.ThreadingUtil.runOnGUI(() -> {
+                load(rf);
+            });
         }
     }
 
     public VSDecoderPreferences() {
     }
 
-    public void load(org.jdom2.Element e) {
+    private void load(Element e) {
         if (e == null) {
             return;
         }
@@ -109,7 +110,7 @@ public class VSDecoderPreferences {
         }
         c = e.getChild("ListenerPosition");
         if (c != null) {
-            _listenerPosition = new ListeningSpot(c);
+            _listenerPosition.parseListeningSpot(c);
         } else {
             _listenerPosition = new ListeningSpot();
         }
@@ -243,7 +244,7 @@ public class VSDecoderPreferences {
     }
 
     public ListeningSpot getListenerPosition() {
-        log.debug("getListenerPosition() : {}", _listenerPosition);
+        log.debug("getListenerPosition(): {}", _listenerPosition);
         return _listenerPosition;
     }
 
@@ -305,6 +306,6 @@ public class VSDecoderPreferences {
         }
     }
 
-    private final static Logger log = LoggerFactory.getLogger(VSDecoderPreferences.class);
+    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(VSDecoderPreferences.class);
 
 }

--- a/java/src/jmri/jmrit/vsdecoder/listener/ListeningSpot.java
+++ b/java/src/jmri/jmrit/vsdecoder/listener/ListeningSpot.java
@@ -7,8 +7,6 @@ import javax.vecmath.Vector3d;
 import javax.vecmath.Vector3f;
 import jmri.util.PhysicalLocation;
 import org.jdom2.Element;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Represents a defined spot for viewing (and therefore listening to) a layout.
@@ -27,6 +25,7 @@ import org.slf4j.LoggerFactory;
  * for more details.
  *
  * @author Mark Underwood Copyright (C) 2012
+ * @author Klaus Killinger Copyright (C) 2025
  */
 public class ListeningSpot {
 
@@ -37,10 +36,11 @@ public class ListeningSpot {
 
     private static final Vector3d _atVector = new Vector3d(0.0d, 1.0d, 0.0d);
     private static final Vector3d _upVector = new Vector3d(0.0d, 0.0d, 1.0d);
+    private static final Vector3d _locVector = new Vector3d(0.0d, 0.0d, 0.0d);
 
     public ListeningSpot() {
         _name = null;
-        _location = new Vector3d();
+        _location = _locVector;
         _up = _upVector;
         _lookAt = _atVector;
     }
@@ -52,26 +52,11 @@ public class ListeningSpot {
         _lookAt = _atVector;
     }
 
-    public ListeningSpot(Vector3d position) {
-        this(null, position);
-    }
-
-    public ListeningSpot(String name, Vector3d position) {
-        _name = name;
-        _location = position;
-        _lookAt = _atVector;
-        _up = _upVector;
-    }
-
     public ListeningSpot(String name, Vector3d loc, Vector3d up, Vector3d at) {
         _name = name;
         _location = loc;
         _up = up;
         _lookAt = at;
-    }
-
-    public ListeningSpot(Element e) {
-        this.setXml(e);
     }
 
     public String getName() {
@@ -212,12 +197,12 @@ public class ListeningSpot {
            azimuth = -180.0d - azimuth;
         }
 
-        double y = Math.sin(Math.toRadians(90 - azimuth)) * Math.cos(Math.toRadians(bearing)); 
+        double y = Math.sin(Math.toRadians(90 - azimuth)) * Math.cos(Math.toRadians(bearing));
         double x = Math.sin(Math.toRadians(90 - azimuth)) * Math.sin(Math.toRadians(bearing));
         double z = Math.cos(Math.toRadians(90 - azimuth));
         _lookAt = new Vector3d(x, y, z);
         _up = calcUpFromLookAt(_lookAt);
- 
+
         _lookAt.x = roundDecimal(_lookAt.x);
         _lookAt.y = roundDecimal(_lookAt.y);
         _lookAt.z = roundDecimal(_lookAt.z);
@@ -277,8 +262,14 @@ public class ListeningSpot {
         if ((_location == null) || (_lookAt == null) || (_up == null)) {
             return "ListeningSpot (undefined)";
         } else {
-            return ("ListeningSpot Name: " + _name + " Location: " + _location.toString() + " LookAt: " + _lookAt.toString() + " Up: " + _up.toString());
+            return ("ListeningSpot Name: " + _name + " Location: " + _location.toString() +
+                    " LookAt: " + _lookAt.toString() + " Up: " + _up.toString());
         }
+    }
+
+    public ListeningSpot parseListeningSpot(Element e) {
+        setXml(e);
+        return new ListeningSpot(_name, _location, _up, _lookAt);
     }
 
     public Element getXml(String elementName) {
@@ -292,11 +283,12 @@ public class ListeningSpot {
 
     public void setXml(Element e) {
         if (e != null) {
-            log.debug("ListeningSpot: {}", e.getAttributeValue("name"));
             _name = e.getAttributeValue("name");
             _location = parseVector3d(e.getAttributeValue("location"));
             _up = parseVector3d(e.getAttributeValue("up"));
             _lookAt = parseVector3d(e.getAttributeValue("look_at"));
+            log.debug("ListeningSpot: name: {}, location: {}, up: {}, lookAt: {}",
+                    _name, _location, _up, _lookAt);
         }
     }
 
@@ -312,6 +304,6 @@ public class ListeningSpot {
         return value;
     }
 
-    private static final Logger log = LoggerFactory.getLogger(ListeningSpot.class);
+    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ListeningSpot.class);
 
 }

--- a/java/src/jmri/jmrit/vsdecoder/swing/DieselPane.java
+++ b/java/src/jmri/jmrit/vsdecoder/swing/DieselPane.java
@@ -50,7 +50,7 @@ public class DieselPane extends EnginePane {
     public static final String VOLUME = "VSDDP:Volume"; // NOI18N
 
     JSpinner throttle_spinner;
-    public JSlider volume_slider;
+    private JSlider volume_slider;
     JToggleButton start_button;
 
     int throttle_setting;
@@ -173,7 +173,7 @@ public class DieselPane extends EnginePane {
 
     // Respond to a start button press with stateChanged
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings( value="SLF4J_FORMAT_SHOULD_BE_CONST",
-        justification="I18N of Headless Info Message")
+            justification="I18N of Headless Info Message")
     public void startButtonStateChange(ChangeEvent ev) {
         AbstractButton abstractButton = (AbstractButton) ev.getSource();
         ButtonModel buttonModel = abstractButton.getModel();
@@ -266,6 +266,14 @@ public class DieselPane extends EnginePane {
     @Override
     public void setSpeed(float s) {
         lastSpeed = s;
+    }
+
+    /**
+     * Get Volume Slider.
+     * @return current volume slider.
+     */
+    public JSlider getVolumeSlider() {
+        return volume_slider;
     }
 
     private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(DieselPane.class);

--- a/java/src/jmri/jmrit/vsdecoder/swing/VSDManagerFrame.java
+++ b/java/src/jmri/jmrit/vsdecoder/swing/VSDManagerFrame.java
@@ -168,11 +168,13 @@ public class VSDManagerFrame extends JmriJFrame {
         this.pack();
         this.setVisible(true);
 
-        if (is_viewing) {
-            this.runViewing();
-        } else if (is_auto_loading) {
-            this.runAutoLoad();
-        }
+        jmri.util.ThreadingUtil.runOnGUI(() -> {
+            if (is_viewing) {
+                this.runViewing();
+            } else if (is_auto_loading) {
+                this.runAutoLoad();
+            }
+        });
     }
 
     private void runViewing() {
@@ -325,7 +327,7 @@ public class VSDManagerFrame extends JmriJFrame {
     private void getStartBlock(VSDecoder vsd) {
         jmri.Block start_block = null;
         for (jmri.Block blk : jmri.InstanceManager.getDefault(jmri.BlockManager.class).getNamedBeanSet()) {
-            if (VSDecoderManager.instance().possibleStartBlocks.containsKey(blk)) {
+            if (VSDecoderManager.instance().checkForPossibleStartblock(blk)) {
                 int locoAddress = VSDecoderManager.instance().getLocoAddr(blk);
                 if (locoAddress == vsd.getAddress().getNumber()) {
                     log.debug("found start block: {}, loco address: {}", blk, locoAddress);


### PR DESCRIPTION
No functional changes.

Spotbugs 4.8.6, package jmri.jmrit.vsdecoder:
```
8 UUF_UNUSED_FIELD				ok
1 SS_SHOULD_BE_STATIC				ok
9 CT_CONSTRUCTOR_THROW				ok
3 URF_UNREAD_FIELD				ok
2 UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR	ok
1 PA_PUBLIC_PRIMITIVE_ATTRIBUTE			ok
1 SING_SINGLETON_GETTER_NOT_SYNCHRONIZED	ok

25 total
```
See also PR 13873 VSD Spotbugs.