### PR TITLE
Add new CPE/PE panel to the Editor Manager when doing a CPE/PE switch

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -687,5 +687,5 @@
         <ul>
             <li>The pop-up menu in the various Tables now has an entry
                 for "Copy System Name".</li>
-            <li>Add new editor panel to the Editor Manager when doing a CPE/PE switch.</li>
+            <li>Bug fix: Add new editor panel to the Editor Manager when doing a CPE/PE switch.</li>
         </ul>

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -687,4 +687,5 @@
         <ul>
             <li>The pop-up menu in the various Tables now has an entry
                 for "Copy System Name".</li>
+            <li>Add new editor panel to the Editor Manager when doing a CPE/PE switch.</li>
         </ul>

--- a/java/src/jmri/jmrit/display/Editor.java
+++ b/java/src/jmri/jmrit/display/Editor.java
@@ -1060,6 +1060,7 @@ abstract public class Editor extends JmriJFrameWithPermissions
 //            ed.pack();
             ed.setVisible(true);
             dispose();
+            InstanceManager.getDefault(EditorManager.class).add(ed);
             return ed;
         } catch (ClassNotFoundException | InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException cnfe) {
             log.error("changeView exception {}", cnfe.toString());


### PR DESCRIPTION
The old panel has been removed during the dispose process.