### PR TITLE
Update the STL Editor to support modified group_logic.csv files.

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -142,8 +142,10 @@
                     </ul>
                 </li>
                 <li>Correctly decode events-with-payload</li>
-                <li>First implementation of LCC Location Services which will decode analog-carrying 
-                    location services reports to drive volt and amp meters.
+                <li>First implementation of LCC Location Services which will decode analog-carrying
+                    location services reports to drive volt and amp meters.</li>
+                <li>Update the STL Editor to support importing a <em>group_logic.csv</em> file
+                that has been modified by a spreadsheet program.</li>
             </ul>
 
         <h4>Powerline</h4>
@@ -663,7 +665,7 @@
         <a id="Misc" name="Misc"></a>
         <ul>
             <li>There's a new "DarkLAF HC" dark-mode setting for the display.
-                To use it, select Settings then Display, then click the 
+                To use it, select Settings then Display, then click the
                 button for "DarkLAF HC". Save preferences and restart.  Note that this
                 puts a dark background with light text on all JMRI windows.
                 You may have to rework your panels for them to look good

--- a/java/src/jmri/jmrix/openlcb/swing/stleditor/StlEditorPane.java
+++ b/java/src/jmri/jmrix/openlcb/swing/stleditor/StlEditorPane.java
@@ -1950,6 +1950,11 @@ public class StlEditorPane extends jmri.util.swing.JmriPanel
         }
     }
 
+    /**
+     * The group logic file contains 16 group rows and a variable number of logic rows for each group.
+     * The exported CSV file has one field for the group rows and 5 fields for the logic rows.
+     * If the CSV file has been modified by a spreadsheet, the group rows will now have 5 fields.
+     */
     private void importGroupLogic() {
         List<CSVRecord> records = getCsvRecords("group_logic.csv");
         if (records.isEmpty()) {
@@ -1967,7 +1972,11 @@ public class StlEditorPane extends jmri.util.swing.JmriPanel
             List<String> values = new ArrayList<>();
             record.forEach(values::add);
 
-            if (values.size() == 1) {
+            if (values.size() == 1 || (values.size() == 5 &&
+                    values.get(1).isEmpty() &&
+                    values.get(2).isEmpty() &&
+                    values.get(3).isEmpty() &&
+                    values.get(4).isEmpty())) {
                 // Create Group
                 groupNumber++;
                 var groupRow = _groupList.get(groupNumber);


### PR DESCRIPTION
When a **group_logic.csv** file is modified by a spreadsheet program, the group name row is extended with four empty fields.

