### PR TITLE
Lncv / Lnsv1 DevicesManager tweaks

### DIFF
--- a/java/src/jmri/jmrix/loconet/LncvDevicesManager.java
+++ b/java/src/jmri/jmrix/loconet/LncvDevicesManager.java
@@ -50,6 +50,8 @@ public class LncvDevicesManager extends PropertyChangeSupport
     private final LocoNetSystemConnectionMemo memo;
     @GuardedBy("this")
     private final LncvDevices lncvDevices;
+
+    // constant for thread name, with memo prefix appended.
     static final String ROSTER_THREAD_NAME = "rosterMatchingListLncvDM";
 
     public LncvDevicesManager(@javax.annotation.Nonnull LocoNetSystemConnectionMemo memo) {

--- a/java/src/jmri/jmrix/loconet/LncvDevicesManager.java
+++ b/java/src/jmri/jmrix/loconet/LncvDevicesManager.java
@@ -46,12 +46,13 @@ import jmri.util.swing.JmriJOptionPane;
  */
 
 public class LncvDevicesManager extends PropertyChangeSupport
-        implements LocoNetListener {
+        implements LocoNetListener, jmri.Disposable {
     private final LocoNetSystemConnectionMemo memo;
     @GuardedBy("this")
     private final LncvDevices lncvDevices;
+    static final String ROSTER_THREAD_NAME = "rosterMatchingListLncvDM";
 
-    public LncvDevicesManager(LocoNetSystemConnectionMemo memo) {
+    public LncvDevicesManager(@javax.annotation.Nonnull LocoNetSystemConnectionMemo memo) {
         this.memo = memo;
         if (memo.getLnTrafficController() != null) {
             memo.getLnTrafficController().addLocoNetListener(~0, this);
@@ -154,7 +155,7 @@ public class LncvDevicesManager extends PropertyChangeSupport
                                             } catch (Exception e) {
                                                 log.error("Error creating Roster.matchingList: {}", e.getMessage());
                                             }
-                                        }, "rosterMatchingListLncvDM").start();
+                                        }, ROSTER_THREAD_NAME + memo.getSystemPrefix()).start();
                                         // this will block until the thread completes, either by finishing or by being cancelled
 
 
@@ -247,6 +248,13 @@ public class LncvDevicesManager extends PropertyChangeSupport
 
         t.openPaneOpsProgFrame(re, name, "programmers/Comprehensive.xml", p); // NOI18N
         return ProgrammingResult.SUCCESS_PROGRAMMER_OPENED;
+    }
+
+    @Override
+    public void dispose(){
+        if (memo.getLnTrafficController() != null) {
+            memo.getLnTrafficController().removeLocoNetListener(~0, this);
+        }
     }
 
     public enum ProgrammingResult {

--- a/java/src/jmri/jmrix/loconet/LncvDevicesManager.java
+++ b/java/src/jmri/jmrix/loconet/LncvDevicesManager.java
@@ -154,7 +154,7 @@ public class LncvDevicesManager extends PropertyChangeSupport
                                             } catch (Exception e) {
                                                 log.error("Error creating Roster.matchingList: {}", e.getMessage());
                                             }
-                                        }, "rosterMatchingList").start();
+                                        }, "rosterMatchingListLncvDM").start();
                                         // this will block until the thread completes, either by finishing or by being cancelled
 
 

--- a/java/src/jmri/jmrix/loconet/Lnsv1DevicesManager.java
+++ b/java/src/jmri/jmrix/loconet/Lnsv1DevicesManager.java
@@ -144,7 +144,7 @@ public class Lnsv1DevicesManager extends PropertyChangeSupport
                                     } catch (Exception e) {
                                         log.error("Error creating Roster.matchingList: {}", e.getMessage());
                                     }
-                                }, "rosterMatchingList").start();
+                                }, "rosterMatchingListLnsv1DM").start();
                                 // this will block until the thread completes, either by finishing or by being cancelled
 
                                 // notify listeners of pertinent change to device list

--- a/java/src/jmri/jmrix/loconet/Lnsv1DevicesManager.java
+++ b/java/src/jmri/jmrix/loconet/Lnsv1DevicesManager.java
@@ -44,12 +44,13 @@ import java.util.List;
  */
 
 public class Lnsv1DevicesManager extends PropertyChangeSupport
-        implements LocoNetListener {
+        implements LocoNetListener, jmri.Disposable {
     private final LocoNetSystemConnectionMemo memo;
     @GuardedBy("this")
     private final Lnsv1Devices lnsv1Devices;
+    static final String ROSTER_THREAD_NAME = "rosterMatchingListLnsv1DM";
 
-    public Lnsv1DevicesManager(LocoNetSystemConnectionMemo memo) {
+    public Lnsv1DevicesManager(@javax.annotation.Nonnull LocoNetSystemConnectionMemo memo) {
         this.memo = memo;
         if (memo.getLnTrafficController() != null) {
             memo.getLnTrafficController().addLocoNetListener(~0, this);
@@ -144,7 +145,7 @@ public class Lnsv1DevicesManager extends PropertyChangeSupport
                                     } catch (Exception e) {
                                         log.error("Error creating Roster.matchingList: {}", e.getMessage());
                                     }
-                                }, "rosterMatchingListLnsv1DM").start();
+                                }, ROSTER_THREAD_NAME + memo.getSystemPrefix()).start();
                                 // this will block until the thread completes, either by finishing or by being cancelled
 
                                 // notify listeners of pertinent change to device list
@@ -232,6 +233,13 @@ public class Lnsv1DevicesManager extends PropertyChangeSupport
 
         t.openPaneOpsProgFrame(re, name, "programmers/Comprehensive.xml", p); // NOI18N
         return ProgrammingResult.SUCCESS_PROGRAMMER_OPENED;
+    }
+
+    @Override
+    public void dispose(){
+        if (memo.getLnTrafficController() != null) {
+            memo.getLnTrafficController().removeLocoNetListener(~0, this);
+        }
     }
 
     public enum ProgrammingResult {

--- a/java/src/jmri/jmrix/loconet/Lnsv1DevicesManager.java
+++ b/java/src/jmri/jmrix/loconet/Lnsv1DevicesManager.java
@@ -48,6 +48,8 @@ public class Lnsv1DevicesManager extends PropertyChangeSupport
     private final LocoNetSystemConnectionMemo memo;
     @GuardedBy("this")
     private final Lnsv1Devices lnsv1Devices;
+
+    // constant for thread name, with memo prefix appended.
     static final String ROSTER_THREAD_NAME = "rosterMatchingListLnsv1DM";
 
     public Lnsv1DevicesManager(@javax.annotation.Nonnull LocoNetSystemConnectionMemo memo) {

--- a/java/test/jmri/jmrix/loconet/LncvDevicesManagerTest.java
+++ b/java/test/jmri/jmrix/loconet/LncvDevicesManagerTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 
 class LncvDevicesManagerTest {
 
-    LocoNetSystemConnectionMemo memo;
+    private LocoNetSystemConnectionMemo memo;
 
     @Test
     public void testCTor() {
@@ -44,6 +44,7 @@ class LncvDevicesManagerTest {
         jmri.util.JUnitUtil.resetInstanceManager();
         memo = new jmri.jmrix.loconet.LocoNetSystemConnectionMemo();
         jmri.InstanceManager.setDefault(jmri.jmrix.loconet.LocoNetSystemConnectionMemo.class, memo);
+        JUnitUtil.initRosterConfigManager();
     }
 
     @AfterEach

--- a/java/test/jmri/jmrix/loconet/LncvDevicesManagerTest.java
+++ b/java/test/jmri/jmrix/loconet/LncvDevicesManagerTest.java
@@ -31,8 +31,8 @@ class LncvDevicesManagerTest {
         LncvDevicesManager lcdm = new LncvDevicesManager(memo);
         Assertions.assertEquals(0, lcdm.getDeviceCount(), "LncvDeviceManager List empty");
         lcdm.message(new LocoNetMessage(new int[] {0xE5, 0x0F, 0x05, 0x49, 0x4B, 0x1F, 0x11, 0x29, 0x13, 0x00, 0x00, 0x08, 0x00, 0x00, 0x4D}));
-        Assertions.assertEquals(1, lcdm.getDeviceCount(), "LncvDeviceManager List added 1");
         JUnitUtil.waitThreadTerminated(LncvDevicesManager.ROSTER_THREAD_NAME+memo.getSystemPrefix());
+        Assertions.assertEquals(1, lcdm.getDeviceCount(), "LncvDeviceManager List added 1");
         lcdm.dispose();
     }
 

--- a/java/test/jmri/jmrix/loconet/LncvDevicesManagerTest.java
+++ b/java/test/jmri/jmrix/loconet/LncvDevicesManagerTest.java
@@ -15,39 +15,48 @@ class LncvDevicesManagerTest {
     public void testCTor() {
         LncvDevicesManager lcdm = new LncvDevicesManager(memo);
         Assertions.assertNotNull(lcdm, "LncvDeviceManager exists");
+        lcdm.dispose();
     }
 
     @Test
     void testGetDeviceList() {
         LncvDevicesManager lcdm = new LncvDevicesManager(memo);
         Assertions.assertNotNull(lcdm.getDeviceList(), "LncvDeviceManager List exists");
+        lcdm.dispose();
     }
 
     @Test
     void testGetDeviceCount() {
+        JUnitUtil.initRosterConfigManager();
         LncvDevicesManager lcdm = new LncvDevicesManager(memo);
         Assertions.assertEquals(0, lcdm.getDeviceCount(), "LncvDeviceManager List empty");
         lcdm.message(new LocoNetMessage(new int[] {0xE5, 0x0F, 0x05, 0x49, 0x4B, 0x1F, 0x11, 0x29, 0x13, 0x00, 0x00, 0x08, 0x00, 0x00, 0x4D}));
         Assertions.assertEquals(1, lcdm.getDeviceCount(), "LncvDeviceManager List added 1");
+        JUnitUtil.waitThreadTerminated(LncvDevicesManager.ROSTER_THREAD_NAME+memo.getSystemPrefix());
+        lcdm.dispose();
     }
 
     @Test
     void testGetDevice() {
         LncvDevicesManager lcdm = new LncvDevicesManager(memo);
         Assertions.assertNull(lcdm.getDevice(5000, 8), "LncvDeviceManager List exists");
+        lcdm.dispose();
     }
 
     @BeforeEach
     public void setUp() {
         JUnitUtil.setUp();
         JUnitUtil.resetInstanceManager();
-        memo = new jmri.jmrix.loconet.LocoNetSystemConnectionMemo();
-        jmri.InstanceManager.setDefault(jmri.jmrix.loconet.LocoNetSystemConnectionMemo.class, memo);
-        JUnitUtil.initRosterConfigManager();
+        memo = new LocoNetSystemConnectionMemo();
+        jmri.InstanceManager.setDefault(LocoNetSystemConnectionMemo.class, memo);
     }
 
     @AfterEach
     public void tearDown() {
+        var tc = memo.getLnTrafficController();
+        if ( tc != null ) {
+            tc.dispose();
+        }
         memo = null;
         JUnitUtil.tearDown();
     }

--- a/java/test/jmri/jmrix/loconet/LncvDevicesManagerTest.java
+++ b/java/test/jmri/jmrix/loconet/LncvDevicesManagerTest.java
@@ -1,7 +1,7 @@
 package jmri.jmrix.loconet;
 
-import jmri.jmrit.roster.RosterConfigManager;
 import jmri.util.JUnitUtil;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -26,7 +26,6 @@ class LncvDevicesManagerTest {
     @Test
     void testGetDeviceCount() {
         LncvDevicesManager lcdm = new LncvDevicesManager(memo);
-        jmri.InstanceManager.setDefault(jmri.jmrit.roster.RosterConfigManager.class, new RosterConfigManager());
         Assertions.assertEquals(0, lcdm.getDeviceCount(), "LncvDeviceManager List empty");
         lcdm.message(new LocoNetMessage(new int[] {0xE5, 0x0F, 0x05, 0x49, 0x4B, 0x1F, 0x11, 0x29, 0x13, 0x00, 0x00, 0x08, 0x00, 0x00, 0x4D}));
         Assertions.assertEquals(1, lcdm.getDeviceCount(), "LncvDeviceManager List added 1");
@@ -41,7 +40,7 @@ class LncvDevicesManagerTest {
     @BeforeEach
     public void setUp() {
         JUnitUtil.setUp();
-        jmri.util.JUnitUtil.resetInstanceManager();
+        JUnitUtil.resetInstanceManager();
         memo = new jmri.jmrix.loconet.LocoNetSystemConnectionMemo();
         jmri.InstanceManager.setDefault(jmri.jmrix.loconet.LocoNetSystemConnectionMemo.class, memo);
         JUnitUtil.initRosterConfigManager();

--- a/java/test/jmri/jmrix/loconet/Lnsv1DevicesManagerTest.java
+++ b/java/test/jmri/jmrix/loconet/Lnsv1DevicesManagerTest.java
@@ -15,26 +15,32 @@ class Lnsv1DevicesManagerTest {
     public void testCTor() {
         Lnsv1DevicesManager lsvm = new Lnsv1DevicesManager(memo);
         Assertions.assertNotNull(lsvm, "Lnsv1DeviceManager exists");
+        lsvm.dispose();
     }
 
     @Test
     void testGetDeviceList() {
         Lnsv1DevicesManager lsvm = new Lnsv1DevicesManager(memo);
         Assertions.assertNotNull(lsvm.getDeviceList(), "Lnsv1DeviceManager List exists");
+        lsvm.dispose();
     }
 
     @Test
     void testGetDeviceCount() {
+        JUnitUtil.initRosterConfigManager();
         Lnsv1DevicesManager lsvm = new Lnsv1DevicesManager(memo);
         Assertions.assertEquals(0, lsvm.getDeviceCount(), "Lnsv1DeviceManager List empty");
         lsvm.message(new LocoNetMessage(new int[] {0xE5, 0x10, 0x04, 0x50, 0x01, 0x06, 0x02, 0x13, 0x16, 0x7B, 0x00, 0x02, 0x00, 0x00, 0x00, 0x27}));
         Assertions.assertEquals(1, lsvm.getDeviceCount(), "Lnsv1DeviceManager List added 1");
+        JUnitUtil.waitThreadTerminated(Lnsv1DevicesManager.ROSTER_THREAD_NAME+memo.getSystemPrefix());
+        lsvm.dispose();
     }
 
     @Test
     void testGetDevice() {
         Lnsv1DevicesManager lsvm = new Lnsv1DevicesManager(memo);
         Assertions.assertNull(lsvm.getDevice(5000, 8), "Lnsv1DeviceManager List exists");
+        lsvm.dispose();
     }
 
     @BeforeEach
@@ -43,11 +49,14 @@ class Lnsv1DevicesManagerTest {
         JUnitUtil.resetInstanceManager();
         memo = new LocoNetSystemConnectionMemo();
         jmri.InstanceManager.setDefault(LocoNetSystemConnectionMemo.class, memo);
-        JUnitUtil.initRosterConfigManager();
     }
 
     @AfterEach
     public void tearDown() {
+        var tc = memo.getLnTrafficController();
+        if ( tc != null ) {
+            tc.dispose();
+        }
         memo = null;
         JUnitUtil.tearDown();
     }

--- a/java/test/jmri/jmrix/loconet/Lnsv1DevicesManagerTest.java
+++ b/java/test/jmri/jmrix/loconet/Lnsv1DevicesManagerTest.java
@@ -31,8 +31,8 @@ class Lnsv1DevicesManagerTest {
         Lnsv1DevicesManager lsvm = new Lnsv1DevicesManager(memo);
         Assertions.assertEquals(0, lsvm.getDeviceCount(), "Lnsv1DeviceManager List empty");
         lsvm.message(new LocoNetMessage(new int[] {0xE5, 0x10, 0x04, 0x50, 0x01, 0x06, 0x02, 0x13, 0x16, 0x7B, 0x00, 0x02, 0x00, 0x00, 0x00, 0x27}));
-        Assertions.assertEquals(1, lsvm.getDeviceCount(), "Lnsv1DeviceManager List added 1");
         JUnitUtil.waitThreadTerminated(Lnsv1DevicesManager.ROSTER_THREAD_NAME+memo.getSystemPrefix());
+        Assertions.assertEquals(1, lsvm.getDeviceCount(), "Lnsv1DeviceManager List added 1");
         lsvm.dispose();
     }
 

--- a/java/test/jmri/jmrix/loconet/Lnsv1DevicesManagerTest.java
+++ b/java/test/jmri/jmrix/loconet/Lnsv1DevicesManagerTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 
 class Lnsv1DevicesManagerTest {
 
-    LocoNetSystemConnectionMemo memo;
+    private LocoNetSystemConnectionMemo memo;
 
     @Test
     public void testCTor() {
@@ -44,6 +44,7 @@ class Lnsv1DevicesManagerTest {
         JUnitUtil.resetInstanceManager();
         memo = new LocoNetSystemConnectionMemo();
         jmri.InstanceManager.setDefault(LocoNetSystemConnectionMemo.class, memo);
+        JUnitUtil.initRosterConfigManager();
     }
 
     @AfterEach

--- a/java/test/jmri/jmrix/loconet/Lnsv1DevicesManagerTest.java
+++ b/java/test/jmri/jmrix/loconet/Lnsv1DevicesManagerTest.java
@@ -1,7 +1,7 @@
 package jmri.jmrix.loconet;
 
-import jmri.jmrit.roster.RosterConfigManager;
 import jmri.util.JUnitUtil;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -26,7 +26,6 @@ class Lnsv1DevicesManagerTest {
     @Test
     void testGetDeviceCount() {
         Lnsv1DevicesManager lsvm = new Lnsv1DevicesManager(memo);
-        jmri.InstanceManager.setDefault(RosterConfigManager.class, new RosterConfigManager());
         Assertions.assertEquals(0, lsvm.getDeviceCount(), "Lnsv1DeviceManager List empty");
         lsvm.message(new LocoNetMessage(new int[] {0xE5, 0x10, 0x04, 0x50, 0x01, 0x06, 0x02, 0x13, 0x16, 0x7B, 0x00, 0x02, 0x00, 0x00, 0x00, 0x27}));
         Assertions.assertEquals(1, lsvm.getDeviceCount(), "Lnsv1DeviceManager List added 1");


### PR DESCRIPTION
**LncvDevicesManager
Lnsv1DevicesManager**
Adds dispose methods.
Roster thread name to constant string with memo prefix.

**LncvDevicesManagerTest
Lnsv1DevicesManagerTest**
Disposes the dm after tests.
Disposes tc after tests.
Waits for roster thread complete.