### PR TITLE
Fix for initiating edit dialog for scwarrant

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -643,9 +643,10 @@
    <h3>Warrants</h3>
         <a id="Wt" name="Wt"></a>
         <ul>
-            <li>SCWarrants brought back to life with a few fixes. 
-			    One of them being that it is once again possible to create SCWarrants. 
-				Another one that train tracking is now working.</li>
+            <li>SCWarrants brought back to life with a few fixes:  
+			    It is once again possible to create SCWarrants. 
+				Train tracking is now working.
+				Opening the edit dialog for an SCWarrant now whows the correct warrant type.</li>
         </ul>
 
    <h3>Web Access</h3>

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -647,7 +647,7 @@
 	        <ul>
                     <li>It is once again possible to create SCWarrants.</li>
 		    <li>Train tracking is now working.</li>
-		    <li>Opening the edit dialog for an SCWarrant now whows the correct warrant type.</li>
+		    <li>Opening the edit dialog for an SCWarrant now shows the correct warrant type.</li>
 		</ul>
             </li>
         </ul>

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -643,10 +643,13 @@
    <h3>Warrants</h3>
         <a id="Wt" name="Wt"></a>
         <ul>
-            <li>SCWarrants brought back to life with a few fixes:  
-			    It is once again possible to create SCWarrants. 
-				Train tracking is now working.
-				Opening the edit dialog for an SCWarrant now whows the correct warrant type.</li>
+             <li>SCWarrants brought back to life with a few fixes:  
+	        <ul>
+                    <li>It is once again possible to create SCWarrants.</li>
+		    <li>Train tracking is now working.</li>
+		    <li>Opening the edit dialog for an SCWarrant now whows the correct warrant type.</li>
+		</ul>
+            </li>
         </ul>
 
    <h3>Web Access</h3>

--- a/java/src/jmri/jmrit/logix/WarrantFrame.java
+++ b/java/src/jmri/jmrit/logix/WarrantFrame.java
@@ -106,6 +106,12 @@ public class WarrantFrame extends WarrantRoute {
         _warrant = new Warrant(w.getSystemName(), w.getUserName());
         setup(_saveWarrant, false);
         init();
+        if ( _saveWarrant instanceof SCWarrant) {
+            _isSCWarrant.setSelected(true);
+            _showRoute.setSelected(true);
+            showCommands(false);
+            //setPanelEnabled(buttonPanel, false);
+        }
     }
 
     /**


### PR DESCRIPTION
Correct warrant type is now shown.
Route table shown instead of an empty command table.