### PR TITLE
New Decoderwerk LokComander decoder definition

### DIFF
--- a/help/en/Acknowledgements.shtml
+++ b/help/en/Acknowledgements.shtml
@@ -411,6 +411,9 @@
         System</a> tools for working with Dispatcher.
         </li>
 
+        <li>Dieter Flunkert, who contributed a decoder definition for the 
+            Decoderwerk LokComander.
+            
         <li>Dan Foltz created the Manifest Creator and Switch List Creator for operations</li>
 
         <li>Marco Forcone, who sacrificed two turnouts motors to the cause of debugging XPressNet

--- a/help/en/Acknowledgements.shtml
+++ b/help/en/Acknowledgements.shtml
@@ -412,7 +412,7 @@
         </li>
 
         <li>Dieter Flunkert, who contributed a decoder definition for the 
-            Decoderwerk LokComander.
+            Decoderwerk LokCommander.
             
         <li>Dan Foltz created the Manifest Creator and Switch List Creator for operations</li>
 

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -250,6 +250,11 @@
                 <li></li>
             </ul>
 
+        <h4>Decoderwerk</h4>
+            <ul>
+                <li>New decoder definition for the Decoderwerk LokCommander 7090x
+            </ul>
+            
         <h4>Digikeijs (Digirails)</h4>
             <ul>
                 <li></li>

--- a/xml/decoderIndex.xml
+++ b/xml/decoderIndex.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet href="/xml/XSLT/DecoderID.xsl" type="text/xsl"?>
 <decoderIndex-config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
-  <!--Written by JMRI version 5.11.4plus+jake+20250330T2056Z+R101f5432f98 on Sun Mar 30 16:56:13 EDT 2025-->
-  <decoderIndex version="633">
+  <!--Written by JMRI version 5.11.4plus+jake+20250331T1027Z+R5297faed912 on Mon Mar 31 06:27:22 EDT 2025-->
+  <decoderIndex version="635">
     <!--The manufacturer list is from the nmra_mfg_list.xml file-->
     <mfgList nmraListDate="2021-03-06" updated="2023-01-25" lastadd="169">
       <manufacturer mfg="NMRA" mfgID="999" />
@@ -38,6 +38,7 @@
       <manufacturer mfg="DCC-Gaspar-Electronic" mfgID="124" />
       <manufacturer mfg="DCCconcepts" mfgID="36" />
       <manufacturer mfg="Dapol Limited" mfgID="154" />
+      <manufacturer mfg="Decoderwerk" mfgID="1004" />
       <manufacturer mfg="Desktop Station" mfgID="140" />
       <manufacturer mfg="Dietz Modellbahntechnik" mfgID="115" />
       <manufacturer mfg="Digi-CZ" mfgID="152" />

--- a/xml/decoderIndex.xml
+++ b/xml/decoderIndex.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet href="/xml/XSLT/DecoderID.xsl" type="text/xsl"?>
 <decoderIndex-config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
-  <!--Written by JMRI version 5.11.3plus+jake+20250307T1826Z+R2d798333238 on Fri Mar 07 13:26:58 EST 2025-->
-  <decoderIndex version="631">
+  <!--Written by JMRI version 5.11.4plus+jake+20250330T2056Z+R101f5432f98 on Sun Mar 30 16:56:13 EDT 2025-->
+  <decoderIndex version="633">
     <!--The manufacturer list is from the nmra_mfg_list.xml file-->
     <mfgList nmraListDate="2021-03-06" updated="2023-01-25" lastadd="169">
       <manufacturer mfg="NMRA" mfgID="999" />
@@ -1470,17 +1470,20 @@
           </output>
         </model>
       </family>
-      <family name="Booster" mfg="Digikeijs" type="stationary" file="Digikeijs_DR5033.xml">
+      <family name="Decoderwerk LokCommander" mfg="Decoderwerk" lowVersionID="0" highVersionID="255" file="Decoderwerk_LokCommander.xml">
+        <model model="LokCommander 7090x" numOuts="8" numFns="68" />
+      </family>
+      <family name="Booster" mfg="Digikeijs" type="stationary" modes="LOCONETLNCVMODE" file="Digikeijs_DR5033.xml">
         <model model="DR5033" productID="5033" comment="3A LocoNet Booster">
           <versionCV />
         </model>
       </family>
-      <family name="LN-CDE Adapter" mfg="Digikeijs" type="stationary" file="Digikeijs_DR5039.xml">
+      <family name="LN-CDE Adapter" mfg="Digikeijs" type="stationary" modes="LOCONETLNCVMODE" file="Digikeijs_DR5039.xml">
         <model model="DR5039" productID="5039" comment="LocoNet B to CDE (Booster) Adapter">
           <versionCV />
         </model>
       </family>
-      <family name="Feedback (Inputs)" mfg="Digikeijs" type="stationary" file="Digikeijs_DR5088.xml">
+      <family name="Feedback (Inputs)" mfg="Digikeijs" type="stationary" modes="LOCONETLNCVMODE" file="Digikeijs_DR5088.xml">
         <model model="DR5088RC" productID="5088" comment="16 port LocoNet Feedback module with RailCom">
           <versionCV />
         </model>
@@ -2756,7 +2759,7 @@
           <output name="4" label="Violet" />
         </model>
       </family>
-      <family name="BDL16x" mfg="Digitrax" file="Digitrax_BDL168.xml">
+      <family name="BDL16x" mfg="Digitrax" modes="LOCONETBDOPSWMODE" file="Digitrax_BDL168.xml">
         <model model="BDL16" />
         <model model="BDL162" />
         <model model="BDL168" />
@@ -2783,31 +2786,31 @@
         <model model="DZ121" numOuts="2" numFns="0" />
         <model model="DN122K2" numOuts="2" numFns="0" />
       </family>
-      <family name="Command Stations" mfg="Digitrax" file="Digitrax_DB150.xml">
+      <family name="Command Stations" mfg="Digitrax" modes="LOCONETCSOPSWMODE" file="Digitrax_DB150.xml">
         <model model="DB150" />
       </family>
-      <family name="Command Stations" mfg="Digitrax" file="Digitrax_DCS240_DCS210.xml">
+      <family name="Command Stations" mfg="Digitrax" modes="LOCONETCSOPSWMODE" file="Digitrax_DCS240_DCS210.xml">
         <model model="DCS210" />
         <model model="DCS240" />
       </family>
-      <family name="Command Stations" mfg="Digitrax" file="Digitrax_DCS52.xml">
+      <family name="Command Stations" mfg="Digitrax" modes="LOCONETCSOPSWMODE" file="Digitrax_DCS52.xml">
         <model model="DCS52" />
       </family>
-      <family name="Command Stations" mfg="Digitrax" file="Digitrax_DCS5x.xml">
+      <family name="Command Stations" mfg="Digitrax" modes="LOCONETCSOPSWMODE" file="Digitrax_DCS5x.xml">
         <model model="DCS50" />
         <model model="DCS51" />
       </family>
-      <family name="Command Stations" mfg="Digitrax" file="Digitrax_DCSx00.xml">
+      <family name="Command Stations" mfg="Digitrax" modes="LOCONETCSOPSWMODE" file="Digitrax_DCSx00.xml">
         <model model="DCS100" />
         <model model="DCS200" />
       </family>
-      <family name="DS64" mfg="Digitrax" file="Digitrax_DS64.xml">
+      <family name="DS64" mfg="Digitrax" modes="LOCONETBDOPSWMODE" file="Digitrax_DS64.xml">
         <model model="DS64" />
       </family>
-      <family name="Series 7 Boards" mfg="Digitrax" file="Digitrax_DS74.xml">
+      <family name="Series 7 Boards" mfg="Digitrax" modes="LOCONETBD7OPSWMODE" file="Digitrax_DS74.xml">
         <model model="DS74" />
       </family>
-      <family name="Series 7 Boards" mfg="Digitrax" file="Digitrax_DS78V.xml">
+      <family name="Series 7 Boards" mfg="Digitrax" modes="LOCONETBD7OPSWMODE" file="Digitrax_DS78V.xml">
         <model model="DS78V" />
       </family>
       <family name="Economy Series 3 with FX3, silent" mfg="Digitrax" lowVersionID="35" highVersionID="36" file="Digitrax_Economy.xml">
@@ -2872,17 +2875,17 @@
           <functionlabel num="6" lockable="true">Switching Speed</functionlabel>
         </functionlabels>
       </family>
-      <family name="PM4x" mfg="Digitrax" file="Digitrax_PM4.xml">
+      <family name="PM4x" mfg="Digitrax" modes="LOCONETBDOPSWMODE" file="Digitrax_PM4.xml">
         <model model="PM4" />
         <model model="PM42" />
       </family>
-      <family name="Series 7 Boards" mfg="Digitrax" file="Digitrax_PM74.xml">
+      <family name="Series 7 Boards" mfg="Digitrax" modes="LOCONETBD7OPSWMODE" file="Digitrax_PM74.xml">
         <model model="PM74" />
       </family>
-      <family name="Series 7 Boards" mfg="Digitrax" file="Digitrax_SE74.xml">
+      <family name="Series 7 Boards" mfg="Digitrax" modes="LOCONETBD7OPSWMODE" file="Digitrax_SE74.xml">
         <model model="SE74" />
       </family>
-      <family name="SE8c" mfg="Digitrax" file="Digitrax_SE8c.xml">
+      <family name="SE8c" mfg="Digitrax" modes="LOCONETBDOPSWMODE" file="Digitrax_SE8c.xml">
         <model model="SE8c" />
       </family>
       <family name="Basic STD" mfg="Digitrax" lowVersionID="33" highVersionID="46" file="Digitrax_STD.xml">
@@ -11581,7 +11584,7 @@
       <family name="LGB MFX decoder" mfg="LGB" file="LGB_v3_MFX.xml">
         <model model="LGB MFX 27-pin sound decoder." lowVersionID="3" highVersionID="3" numOuts="0" numFns="32" productID="199" />
       </family>
-      <family name="Signal and Lighting" mfg="Logic Rail Technologies" file="LRT_LightEFX16.xml">
+      <family name="Signal and Lighting" mfg="Logic Rail Technologies" modes="OPSBYTEMODE" file="LRT_LightEFX16.xml">
         <model model="Light EFX-16">
           <output name="1" label="Light 1" />
           <output name="2" label="Light 2" />
@@ -12310,16 +12313,16 @@
       <family name="DCCACC" mfg="MERG" comment="DCCACC is a stationary decoder, but it can be programmed in the usual way" file="MERG_DCCACC.xml">
         <model model="DCCACC" />
       </family>
-      <family name="BTLocobridge" mfg="Möllehem Gårdsproduktion" type="stationary" comment="Bluetooth LocoNet interface" file="MGP_BT_LocoBridge.xml">
+      <family name="BTLocobridge" mfg="Möllehem Gårdsproduktion" type="stationary" comment="Bluetooth LocoNet interface" modes="LOCONETSV2MODE" file="MGP_BT_LocoBridge.xml">
         <model model="BTLocobridge" lowVersionID="1" />
       </family>
-      <family name="Panel" mfg="Möllehem Gårdsproduktion" type="stationary" comment="Panel, a LocoNet decoder control panels" file="MGP_Panel.xml">
+      <family name="Panel" mfg="Möllehem Gårdsproduktion" type="stationary" comment="Panel, a LocoNet decoder control panels" modes="LOCONETSV2MODE" file="MGP_Panel.xml">
         <model model="Panel" lowVersionID="1" productID="4" />
       </family>
-      <family name="Servo5" mfg="Möllehem Gårdsproduktion" type="stationary" comment="Servo5, a LocoNet decoder for railway switches" file="MGP_Servo5.xml">
+      <family name="Servo5" mfg="Möllehem Gårdsproduktion" type="stationary" comment="Servo5, a LocoNet decoder for railway switches" modes="LOCONETSV2MODE" file="MGP_Servo5.xml">
         <model model="Servo5" lowVersionID="1" productID="9" />
       </family>
-      <family name="Signal10" mfg="Möllehem Gårdsproduktion" type="stationary" comment="Signal, a LocoNet decoder control panels" file="MGP_Signal10.xml">
+      <family name="Signal10" mfg="Möllehem Gårdsproduktion" type="stationary" comment="Signal, a LocoNet decoder control panels" modes="LOCONETSV2MODE" file="MGP_Signal10.xml">
         <model model="Signal10 SE" lowVersionID="1" productID="6" />
         <model model="Signal10 DE" lowVersionID="1" productID="7" />
         <model model="Signal10 DK" lowVersionID="1" productID="8" />
@@ -12328,7 +12331,7 @@
         <model model="Signal10 NO" lowVersionID="1" productID="13" />
         <model model="Signal10 NL" lowVersionID="1" productID="14" />
       </family>
-      <family name="Switch5" mfg="Möllehem Gårdsproduktion" type="stationary" comment="Switch5, a LocoNet decoder for railway switches" file="MGP_Switch5.xml">
+      <family name="Switch5" mfg="Möllehem Gårdsproduktion" type="stationary" comment="Switch5, a LocoNet decoder for railway switches" modes="LOCONETSV2MODE" file="MGP_Switch5.xml">
         <model model="Switch5" lowVersionID="1" productID="9" />
       </family>
       <family name="MRC 14/28/128 step decoders" mfg="MRC" file="MRC_128step.xml">
@@ -14927,7 +14930,7 @@
           <output name="9" label="Pad 9" />
         </model>
       </family>
-      <family name="Signal and Lighting" mfg="North Coast Engineering" file="NCE_Light-It_accessory.xml">
+      <family name="Signal and Lighting" mfg="North Coast Engineering" modes="OPSACCBYTEMODE" file="NCE_Light-It_accessory.xml">
         <model model="Light-It - Accessory mode">
           <output name="1" label="White/Green" />
           <output name="2" label="Yellow" />
@@ -14945,7 +14948,7 @@
           </protocols>
         </model>
       </family>
-      <family name="Signal and Lighting" mfg="North Coast Engineering" file="NCE_Light-It_mobile.xml">
+      <family name="Signal and Lighting" mfg="North Coast Engineering" modes="OPSBYTEMODE" file="NCE_Light-It_mobile.xml">
         <model model="Light-It - Mobile mode">
           <output name="1" label="White/Green" />
           <output name="2" label="Yellow" />
@@ -14963,7 +14966,7 @@
           </protocols>
         </model>
       </family>
-      <family name="Signal and Lighting" mfg="North Coast Engineering" file="NCE_Light-It_signal.xml">
+      <family name="Signal and Lighting" mfg="North Coast Engineering" modes="OPSACCEXTBYTEMODE" file="NCE_Light-It_signal.xml">
         <model model="Light-It - Signal mode">
           <output name="1" label="White/Green" />
           <output name="2" label="Yellow" />
@@ -15166,7 +15169,7 @@
         </model>
       </family>
       <family name="PIKO SmartDecoder XP5.1 (version 1.8+)" mfg="PIKO" lowVersionID="8" highVersionID="15" comment="Decoders not sorted (necessarily) in numerical order" file="Piko_SmartDecoder_XP5.1_Sound_ML4000_v1.8.xml">
-        <model model="PIKO56627-22 KM ML4000-US V1.8" numOuts="9" numFns="68" productID="PIKO56627-22" comment="Piko SmartDecoder XP5.1 Sound KM ML4000 (FW 1.8.0) US Version">
+        <model model="PIKO56627-22 KM ML4000-US V1.8" numOuts="9" numFns="68" productID="PIKO56627-22" comment="Piko SmartDecoder XP5.1 Sound KM ML4000 (FW 1.8.0 - 1.16.0) US Version">
           <output name="1" label="F0(f)" />
           <output name="2" label="F0(r)" />
           <output name="3" label=". A1 ." />
@@ -15214,7 +15217,7 @@
             <soundlabel num="1">Prime Movers</soundlabel>
           </soundlabels>
         </model>
-        <model model="PIKO56627-22 KM ML4000-EU V1.8" numOuts="9" numFns="68" productID="PIKO56627-22" comment="Piko SmartDecoder XP5.1 Sound KM ML4000 (FW 1.8.0) EU Version">
+        <model model="PIKO56627-22 KM ML4000-EU V1.8" numOuts="9" numFns="68" productID="PIKO56627-22" comment="Piko SmartDecoder XP5.1 Sound KM ML4000 (FW 1.8.0 - 1.16.0) EU Version">
           <output name="1" label="F0(f)" />
           <output name="2" label="F0(r)" />
           <output name="3" label=". A1 ." />
@@ -15516,7 +15519,7 @@
       <family name="PpP Decoders" mfg="PpP Digital" lowVersionID="42" highVersionID="42" comment="PpP-Sem4 decoder." file="PpP_Sem4.xml">
         <model model="PpP-Sem4" />
       </family>
-      <family name="FREDi" mfg="Public-domain and DIY" file="Public_Domain_FREDi_LNSV2.xml">
+      <family name="FREDi" mfg="Public-domain and DIY" modes="LOCONETSV2MODE" file="Public_Domain_FREDi_LNSV2.xml">
         <model model="FREDi using LNSV2" productID="11" developerID="1" />
       </family>
       <family name="fucik.name DIY" mfg="Public-domain and DIY" file="Public_Domain_Fucik_1.xml">
@@ -15527,7 +15530,7 @@
         <model model="2 ServoDecoder v3.2" lowVersionID="32" highVersionID="32" numOuts="2" />
         <model model="4 ServoDecoder v3.5" lowVersionID="35" highVersionID="35" numOuts="4" />
       </family>
-      <family name="Hans Deloof LocoIO" mfg="Public-domain and DIY" file="Public_Domain_HDL_LocoIO.xml">
+      <family name="Hans Deloof LocoIO" mfg="Public-domain and DIY" modes="LOCONETSV1MODE" file="Public_Domain_HDL_LocoIO.xml">
         <model model="HDL LocoIO v1.54" productID="154" />
         <!--filtering model specific options relies on new exclude/include support in compositeValType-->
         <model model="HDL LocoIO v1.53" productID="153" />
@@ -15571,7 +15574,7 @@
         </model>
         <model model="Original LocoIO" productID="135" />
       </family>
-      <family name="LNSV2-using boards" mfg="Public-domain and DIY" file="Public_Domain_LNSV2_basic.xml">
+      <family name="LNSV2-using boards" mfg="Public-domain and DIY" modes="LOCONETSV2MODE" file="Public_Domain_LNSV2_basic.xml">
         <model model="Basic definition" />
       </family>
       <family name="MERG decoders" mfg="Public-domain and DIY" lowVersionID="104" file="Public_Domain_MERG_DIY_10.xml">
@@ -15604,7 +15607,7 @@
           <output name="5" label="FE " />
         </model>
       </family>
-      <family name="dccdoma.cz" mfg="Public-domain and DIY" file="Public_Domain_dccdoma_ARD_4SERVO.xml">
+      <family name="dccdoma.cz" mfg="Public-domain and DIY" modes="OPSACCEXTBYTEMODE" file="Public_Domain_dccdoma_ARD_4SERVO.xml">
         <model model="ARD-4SERVO" lowVersionID="00" highVersionID="19" productID="16843777" numOuts="4" />
       </family>
       <family name="dccdoma.cz" mfg="Public-domain and DIY" file="Public_Domain_dccdoma_ARD_8SCOM_4VYH_TC.xml">
@@ -15645,7 +15648,7 @@
         <model model="UNI16ARD-NAV-TC" lowVersionID="10" highVersionID="19" productID="16843013" numOuts="16" />
         <model model="UNI16ARD-NAV-TC-2" lowVersionID="20" highVersionID="29" productID="16843013" numOuts="16" />
       </family>
-      <family name="sidlo" mfg="Public-domain and DIY" file="Public_Domain_sidlo_ARD-LN-S88.xml">
+      <family name="sidlo" mfg="Public-domain and DIY" modes="LOCONETSV2MODE" file="Public_Domain_sidlo_ARD-LN-S88.xml">
         <model model="ARD-LN-S88" lowVersionID="10" highVersionID="19" productID="1" developerID="21" />
       </family>
       <family name="QSI Articulated Steam" mfg="QSIndustries" lowVersionID="2" highVersionID="5" file="QSI_Articulated_Steam.xml">
@@ -17052,30 +17055,30 @@
           <output name="8" label="A7" />
         </model>
       </family>
-      <family name="Control Point" mfg="RR-CirKits" type="stationary" comment="The Control Point is normally programmed in OPs mode" file="RR-CirKits-LNCP-basic.xml">
+      <family name="Control Point" mfg="RR-CirKits" type="stationary" comment="The Control Point is normally programmed in OPs mode" modes="LOCONETOPSBOARD" file="RR-CirKits-LNCP-basic.xml">
         <model model="LNCP" comment="LocoNet Control Point" lowVersionID="01" />
       </family>
-      <family name="Decoders" mfg="RR-CirKits" type="stationary" comment="The MotorMan is programmed in OPs mode" file="RR-CirKits-MotorMan.xml">
+      <family name="Decoders" mfg="RR-CirKits" type="stationary" comment="The MotorMan is programmed in OPs mode" modes="LOCONETOPSBOARD" file="RR-CirKits-MotorMan.xml">
         <model model="MotorMan" productID="25" comment="8 Line Output Driver" />
         <model model="MotorMan-II" productID="28" comment="8 Line Output Driver" />
         <model model="MotorMan-III" productID="29" comment="8 Line Output Driver" />
       </family>
-      <family name="Decoders" mfg="RR-CirKits" type="stationary" comment="The SignalMan is normally programmed in OPs mode" file="RR-CirKits-SignalMan-basic.xml">
+      <family name="Decoders" mfg="RR-CirKits" type="stationary" comment="The SignalMan is normally programmed in OPs mode" modes="LOCONETOPSBOARD" file="RR-CirKits-SignalMan-basic.xml">
         <model model="SignalMan" comment="Signal Mast Driver" lowVersionID="10" />
       </family>
-      <family name="Decoders" mfg="RR-CirKits" type="stationary" comment="The SwitchMan is normally programmed in OPs mode" file="RR-CirKits-SwitchMan.xml">
+      <family name="Decoders" mfg="RR-CirKits" type="stationary" comment="The SwitchMan is normally programmed in OPs mode" modes="LOCONETOPSBOARD" file="RR-CirKits-SwitchMan.xml">
         <model model="SwitchMan" comment="16 Line I/O Driver" lowVersionID="10" />
       </family>
-      <family name="Tower Controller" mfg="RR-CirKits" type="stationary" comment="The Tower Controller is normally programmed in OPs mode" file="RR-CirKits-TC-64-basic.xml">
+      <family name="Tower Controller" mfg="RR-CirKits" type="stationary" comment="The Tower Controller is normally programmed in OPs mode" modes="LOCONETOPSBOARD" file="RR-CirKits-TC-64-basic.xml">
         <model model="TC-64" comment="64 line I/O" lowVersionID="06" />
       </family>
-      <family name="Tower Controller" mfg="RR-CirKits" type="stationary" comment="The TowerController Mark-II is normally programmed in OPs mode" file="RR-CirKits-TowerController-Mark-II.xml">
+      <family name="Tower Controller" mfg="RR-CirKits" type="stationary" comment="The TowerController Mark-II is normally programmed in OPs mode" modes="LOCONETOPSBOARD" file="RR-CirKits-TowerController-Mark-II.xml">
         <model model="Mark-II" comment="64 Line I/O Driver" lowVersionID="11" />
       </family>
-      <family name="Decoders" mfg="RR-CirKits" type="stationary" comment="The TowerMan is programmed in OPs mode" file="RR-CirKits-TowerMan-basic.xml">
+      <family name="Decoders" mfg="RR-CirKits" type="stationary" comment="The TowerMan is programmed in OPs mode" modes="LOCONETOPSBOARD" file="RR-CirKits-TowerMan-basic.xml">
         <model model="TowerMan" comment="16 Line I/O Driver" lowVersionID="10" />
       </family>
-      <family name="Decoders" mfg="RR-CirKits" type="stationary" comment="The WatchMan is normally programmed in OPs mode" file="RR-CirKits-WatchMan-basic.xml">
+      <family name="Decoders" mfg="RR-CirKits" type="stationary" comment="The WatchMan is normally programmed in OPs mode" modes="LOCONETOPSBOARD" file="RR-CirKits-WatchMan-basic.xml">
         <model model="WatchMan" comment="8 block detector plus 8 Line I/O Driver" lowVersionID="11" />
       </family>
       <family name="Rampino Loco" mfg="Rampino Elektronik" lowVersionID="0" highVersionID="255" file="RampinoElektronic_Loco.xml">
@@ -29067,29 +29070,29 @@
       <family name="TCS Mx series decoders old" mfg="Train Control Systems" file="TCS_zMx.xml">
         <model show="no" model="M1" numOuts="2" numFns="2" lowVersionID="24" highVersionID="24" replacementModel="M1" replacementFamily="Jan 2000" />
       </family>
-      <family name="BlocD8" mfg="Team Digital, LLC" type="stationary" file="TD_BlocD8.xml">
+      <family name="BlocD8" mfg="Team Digital, LLC" type="stationary" modes="LOCONETOPSBOARD" file="TD_BlocD8.xml">
         <model model="BlocD8" lowVersionID="1" comment="BlocD8 can be programmed in the usual way" />
       </family>
-      <family name="CSC Family" mfg="Team Digital, LLC" type="stationary" comment="The CSC can be programmed in the usual way" file="TD_CSC.xml">
+      <family name="CSC Family" mfg="Team Digital, LLC" type="stationary" comment="The CSC can be programmed in the usual way" modes="LOCONETOPSBOARD" file="TD_CSC.xml">
         <model model="CSC" lowVersionID="10" comment="Original HW" />
         <model model="CSCe" lowVersionID="10" comment="Later HW" />
       </family>
-      <family name="Stationary Decoder" mfg="Team Digital, LLC" type="stationary" file="TD_SC8.xml">
+      <family name="Stationary Decoder" mfg="Team Digital, LLC" type="stationary" modes="LOCONETOPSBOARD" file="TD_SC8.xml">
         <model model="SC8" lowVersionID="1" comment="SC8 is a stationary decoder, but it can be programmed in the usual way" />
       </family>
-      <family name="Stationary Decoder" mfg="Team Digital, LLC" type="stationary" file="TD_SC82.xml">
+      <family name="Stationary Decoder" mfg="Team Digital, LLC" type="stationary" modes="LOCONETOPSBOARD" file="TD_SC82.xml">
         <model model="SC82" lowVersionID="1" comment="SC82 is a stationary decoder, but it can be programmed in the usual way" />
       </family>
       <family name="Stationary Decoder" mfg="Team Digital, LLC" type="stationary" file="TD_SHD2.xml">
         <model model="SHD2" lowVersionID="1" comment="SHD2 is a DCC Signal decoder" />
       </family>
-      <family name="SIC24" mfg="Team Digital, LLC" type="stationary" comment="SIC24 is not stationary decoder, but it can be programmed in the usual way" file="TD_SIC24.xml">
+      <family name="SIC24" mfg="Team Digital, LLC" type="stationary" comment="SIC24 is not stationary decoder, but it can be programmed in the usual way" modes="LOCONETOPSBOARD" file="TD_SIC24.xml">
         <model model="SIC24" lowVersionID="12" />
       </family>
-      <family name="SIC24AD" mfg="Team Digital, LLC" type="stationary" comment="The SIC24AD can be programmed in the usual way" file="TD_SIC24AD.xml">
+      <family name="SIC24AD" mfg="Team Digital, LLC" type="stationary" comment="The SIC24AD can be programmed in the usual way" modes="LOCONETOPSBOARD" file="TD_SIC24AD.xml">
         <model model="SIC24AD" lowVersionID="10" />
       </family>
-      <family name="SIC24e" mfg="Team Digital, LLC" type="stationary" comment="The SIC24e can be programmed in the usual way" file="TD_SIC24e.xml">
+      <family name="SIC24e" mfg="Team Digital, LLC" type="stationary" comment="The SIC24e can be programmed in the usual way" modes="LOCONETOPSBOARD" file="TD_SIC24e.xml">
         <model model="SIC24e" lowVersionID="10" />
       </family>
       <family name="Stationary Decoder" mfg="Team Digital, LLC" type="stationary" file="TD_SMC4.xml">
@@ -29104,28 +29107,28 @@
       <family name="Stationary Decoder" mfg="Team Digital, LLC" type="stationary" file="TD_SMD82.xml">
         <model model="SMD82" lowVersionID="1" comment="SMD82 is a stationary decoder, but it can be programmed in the usual way" />
       </family>
-      <family name="Stationary Decoder" mfg="Team Digital, LLC" type="stationary" file="TD_SMD84.xml">
+      <family name="Stationary Decoder" mfg="Team Digital, LLC" type="stationary" modes="LOCONETOPSBOARD" file="TD_SMD84.xml">
         <model model="SMD84" lowVersionID="1" comment="SMD84 is a stationary decoder, but it can be programmed in the usual way" />
       </family>
-      <family name="Stationary Decoder" mfg="Team Digital, LLC" type="stationary" file="TD_SRC16.xml">
+      <family name="Stationary Decoder" mfg="Team Digital, LLC" type="stationary" modes="LOCONETOPSBOARD" file="TD_SRC16.xml">
         <model model="SRC16" lowVersionID="1" comment="SRC16 is a stationary decoder with serial bus" />
       </family>
-      <family name="Stationary Decoder" mfg="Team Digital, LLC" type="stationary" file="TD_SRC162.xml">
+      <family name="Stationary Decoder" mfg="Team Digital, LLC" type="stationary" modes="LOCONETOPSBOARD" file="TD_SRC162.xml">
         <model model="SRC162" lowVersionID="1" comment="SRC162 is a stationary decoder with serial bus" />
       </family>
-      <family name="SRC8" mfg="Team Digital, LLC" type="stationary" comment="SRC8 is not stationary decoder, but it can be programmed in the usual way" file="TD_SRC8.xml">
+      <family name="SRC8" mfg="Team Digital, LLC" type="stationary" comment="SRC8 is not stationary decoder, but it can be programmed in the usual way" modes="LOCONETOPSBOARD" file="TD_SRC8.xml">
         <model model="SRC8" lowVersionID="12" />
       </family>
       <family name="Stationary Decoder" mfg="Team Digital, LLC" type="stationary" file="TD_Servette.xml">
         <model model="Servette" lowVersionID="1" comment="Servette is a stationary decoder, but it can be programmed in the usual way" />
       </family>
-      <family name="Quad-LN" mfg="Tam Valley Depot" type="stationary" comment="The Quad-LN is programmed in OPs mode except for the address." file="TamValleyDepot_QuadLn.xml">
+      <family name="Quad-LN" mfg="Tam Valley Depot" type="stationary" comment="The Quad-LN is programmed in OPs mode except for the address." modes="LOCONETOPSBOARD" file="TamValleyDepot_QuadLn.xml">
         <model model="Quad-LN" comment="4 Servo Driver" lowVersionID="5" />
       </family>
-      <family name="Quad-LN gen2" mfg="Tam Valley Depot" type="stationary" comment="The Quad-LN is programmed in OPs mode except for the address." file="TamValleyDepot_QuadLn11.xml">
+      <family name="Quad-LN gen2" mfg="Tam Valley Depot" type="stationary" comment="The Quad-LN is programmed in OPs mode except for the address." modes="LOCONETOPSBOARD" file="TamValleyDepot_QuadLn11.xml">
         <model model="Quad-LNv1" comment="4 Servo Driver" lowVersionID="5" />
       </family>
-      <family name="Quad-LN_S" mfg="Tam Valley Depot" type="stationary" comment="The Quad-LN_S is programmed in OPs mode except for the device address." file="TamValleyDepot_QuadLn_S_11.xml">
+      <family name="Quad-LN_S" mfg="Tam Valley Depot" type="stationary" comment="The Quad-LN_S is programmed in OPs mode except for the device address." modes="LOCONETOPSBOARD" file="TamValleyDepot_QuadLn_S_11.xml">
         <model model="Quad-LN_S_v1" comment="4 or 8 Servo Driver with Signaling and Detection options" lowVersionID="6" />
         <model model="Quad-LN_S_v3" comment="4, 8, 12 or 16 Servo Driver with Signaling and Detection options" lowVersionID="7" />
       </family>
@@ -33074,57 +33077,57 @@
           <output name="Start/brake" label="inertia" />
         </model>
       </family>
-      <family name="Feedback Module" mfg="Uhlenbrock Elektronik" type="stationary" file="Uhlenbrock_63320.xml">
+      <family name="Feedback Module" mfg="Uhlenbrock Elektronik" type="stationary" modes="LOCONETLNCVMODE" file="Uhlenbrock_63320.xml">
         <model model="Feedback Module 2-rail 63320" productID="6332" comment="LocoNet 8 block feedback module 2-rail">
           <versionCV />
         </model>
       </family>
-      <family name="Feedback Module" mfg="Uhlenbrock Elektronik" type="stationary" file="Uhlenbrock_63330.xml">
+      <family name="Feedback Module" mfg="Uhlenbrock Elektronik" type="stationary" modes="LOCONETLNCVMODE" file="Uhlenbrock_63330.xml">
         <model model="Feedback Module 3-rail 63330" productID="6333" comment="LocoNet 16 block feedback module 3-rail">
           <versionCV />
         </model>
       </family>
-      <family name="Feedback Module" mfg="Uhlenbrock Elektronik" type="stationary" file="Uhlenbrock_63340.xml">
+      <family name="Feedback Module" mfg="Uhlenbrock Elektronik" type="stationary" modes="LOCONETLNCVMODE" file="Uhlenbrock_63340.xml">
         <model model="Feedback Module 2-rail 63340" productID="6334" comment="LocoNet 8 block feedback module 2-rail">
           <versionCV />
         </model>
       </family>
-      <family name="Feedback Module" mfg="Uhlenbrock Elektronik" type="stationary" file="Uhlenbrock_63350.xml">
+      <family name="Feedback Module" mfg="Uhlenbrock Elektronik" type="stationary" modes="LOCONETLNCVMODE" file="Uhlenbrock_63350.xml">
         <model model="Feedback Module 3-rail 63350" productID="6335" comment="LocoNet 8 block feedback module 3-rail">
           <versionCV />
         </model>
       </family>
-      <family name="Switch Module" mfg="Uhlenbrock Elektronik" type="stationary" file="Uhlenbrock_63400.xml">
+      <family name="Switch Module" mfg="Uhlenbrock Elektronik" type="stationary" modes="LOCONETLNCVMODE" file="Uhlenbrock_63400.xml">
         <model model="Switch Control 63400" productID="6340" comment="LocoNet Switch Control">
           <versionCV />
         </model>
       </family>
-      <family name="Switch Module" mfg="Uhlenbrock Elektronik" type="stationary" file="Uhlenbrock_63410.xml">
+      <family name="Switch Module" mfg="Uhlenbrock Elektronik" type="stationary" modes="LOCONETLNCVMODE" file="Uhlenbrock_63410.xml">
         <model model="63410" productID="6341" comment="LocoNet General Purpose 20 Outputs Switch">
           <versionCV />
         </model>
       </family>
-      <family name="Display Module" mfg="Uhlenbrock Elektronik" type="stationary" file="Uhlenbrock_63450.xml">
+      <family name="Display Module" mfg="Uhlenbrock Elektronik" type="stationary" modes="LOCONETLNCVMODE" file="Uhlenbrock_63450.xml">
         <model model="63450" productID="6345" comment="LocoNet Display">
           <versionCV />
         </model>
       </family>
-      <family name="Servo Decoder" mfg="Uhlenbrock Elektronik" type="stationary" file="Uhlenbrock_63500.xml">
+      <family name="Servo Decoder" mfg="Uhlenbrock Elektronik" type="stationary" modes="LOCONETLNCVMODE" file="Uhlenbrock_63500.xml">
         <model model="Ln Servo Module 63500" productID="6350" comment="LocoNet 4 servo Decoder">
           <versionCV />
         </model>
       </family>
-      <family name="Adapter" mfg="Uhlenbrock Elektronik" type="Adapter" file="Uhlenbrock_63810.xml">
+      <family name="Adapter" mfg="Uhlenbrock Elektronik" type="Adapter" modes="LOCONETLNCVMODE" file="Uhlenbrock_63810.xml">
         <model model="mobile station Adapter 63810" productID="6381" comment="to connect a Märklin mobile station to LocoNet">
           <versionCV />
         </model>
       </family>
-      <family name="Adapter" mfg="Uhlenbrock Elektronik" type="stationary" file="Uhlenbrock_63830.xml">
+      <family name="Adapter" mfg="Uhlenbrock Elektronik" type="stationary" modes="LOCONETLNCVMODE" file="Uhlenbrock_63830.xml">
         <model model="LocoNet IR Receiver 63830" productID="6383" comment="IR Receiver for IRIS Remote and Piko Digi-Fern">
           <versionCV />
         </model>
       </family>
-      <family name="Adapter" mfg="Uhlenbrock Elektronik" type="Adapter" file="Uhlenbrock_63880.xml">
+      <family name="Adapter" mfg="Uhlenbrock Elektronik" type="Adapter" modes="LOCONETLNCVMODE" file="Uhlenbrock_63880.xml">
         <model model="s88-Ln Interface 63880" productID="6388" comment="to connect s88 feedback bus to LocoNet">
           <versionCV />
         </model>
@@ -33132,17 +33135,17 @@
       <family name="Servo Decoder" mfg="Uhlenbrock Elektronik" file="Uhlenbrock_67800.xml">
         <model model="67800" highVersionID="3" lowVersionID="85" comment="67800 is programmable 4 Servo Decoder" />
       </family>
-      <family name="Lissy Receiver" mfg="Uhlenbrock Elektronik" type="stationary" file="Uhlenbrock_68600_Lissy.xml">
+      <family name="Lissy Receiver" mfg="Uhlenbrock Elektronik" type="stationary" modes="LOCONETLNCVMODE" file="Uhlenbrock_68600_Lissy.xml">
         <model model="Lissy Receiver 68600" productID="6860" comment="2 Sensor Lissy Receiver">
           <versionCV />
         </model>
       </family>
-      <family name="Lissy Receiver" mfg="Uhlenbrock Elektronik" type="stationary" file="Uhlenbrock_68610_Lissy.xml">
+      <family name="Lissy Receiver" mfg="Uhlenbrock Elektronik" type="stationary" modes="LOCONETLNCVMODE" file="Uhlenbrock_68610_Lissy.xml">
         <model model="Lissy Receiver 68610" productID="6861" comment="2 Sensor Lissy Receiver">
           <versionCV />
         </model>
       </family>
-      <family name="Lissy Receiver" mfg="Uhlenbrock Elektronik" type="stationary" file="Uhlenbrock_68620_Lissy.xml">
+      <family name="Lissy Receiver" mfg="Uhlenbrock Elektronik" type="stationary" modes="LOCONETLNCVMODE" file="Uhlenbrock_68620_Lissy.xml">
         <model model="Lissy Receiver 68620" productID="6862" comment="Single Sensor Lissy Receiver">
           <versionCV />
         </model>
@@ -33467,63 +33470,63 @@
           <output name="8" label=". A8 ." />
         </model>
       </family>
-      <family name="Command Station" mfg="Uhlenbrock Elektronik" type="Command Station" file="Uhlenbrock_DaisyII.xml">
+      <family name="Command Station" mfg="Uhlenbrock Elektronik" type="Command Station" modes="LOCONETLNCVMODE" file="Uhlenbrock_DaisyII.xml">
         <model model="Daisy II 65200" productID="6520" comment="Daisy II LocoNet Digitalzentrale/Booster">
           <versionCV />
         </model>
       </family>
-      <family name="Command Station" mfg="Uhlenbrock Elektronik" type="Command Station" file="Uhlenbrock_DaisyII65210.xml">
+      <family name="Command Station" mfg="Uhlenbrock Elektronik" type="Command Station" modes="LOCONETLNCVMODE" file="Uhlenbrock_DaisyII65210.xml">
         <model model="Daisy II 65210" productID="6521" comment="Daisy II LocoNet Digitalzentrale/Booster">
           <versionCV />
         </model>
       </family>
-      <family name="Wireless" mfg="Uhlenbrock Elektronik" type="stationary" file="Uhlenbrock_FunkMaster66400.xml">
+      <family name="Wireless" mfg="Uhlenbrock Elektronik" type="stationary" modes="LOCONETLNCVMODE" file="Uhlenbrock_FunkMaster66400.xml">
         <model model="Funk-Master LN 66400" productID="6640" comment="Funk-Master LN Wireless Daisy Hub">
           <versionCV />
         </model>
         <model model="FunkMaster" show="no" replacementModel="Funk-Master LN 66400" replacementFamily="Wireless" productID="6640" comment="file and model renamed without changes" />
       </family>
-      <family name="Wireless" mfg="Uhlenbrock Elektronik" type="stationary" file="Uhlenbrock_FunkMaster66410.xml">
+      <family name="Wireless" mfg="Uhlenbrock Elektronik" type="stationary" modes="LOCONETLNCVMODE" file="Uhlenbrock_FunkMaster66410.xml">
         <model model="Funk-Master LN+DCC 66410" productID="6641" comment="Funk-Master LN+DCC Wireless Hub">
           <versionCV />
         </model>
       </family>
-      <family name="IntelliLight" mfg="Uhlenbrock Elektronik" type="stationary" file="Uhlenbrock_IntelliLight2800.xml">
+      <family name="IntelliLight" mfg="Uhlenbrock Elektronik" type="stationary" modes="LOCONETLNCVMODE" file="Uhlenbrock_IntelliLight2800.xml">
         <model model="Controller" productID="2800" comment="Lighting Controller">
           <versionCV />
         </model>
       </family>
-      <family name="IntelliLight" mfg="Uhlenbrock Elektronik" type="stationary" file="Uhlenbrock_IntelliLight2820.xml">
+      <family name="IntelliLight" mfg="Uhlenbrock Elektronik" type="stationary" modes="LOCONETLNCVMODE" file="Uhlenbrock_IntelliLight2820.xml">
         <model model="LED Controller" productID="2820" comment="LED Lighting Controller">
           <versionCV />
         </model>
       </family>
-      <family name="Booster" mfg="Uhlenbrock Elektronik" type="stationary" file="Uhlenbrock_Power22.xml">
+      <family name="Booster" mfg="Uhlenbrock Elektronik" type="stationary" modes="LOCONETLNCVMODE" file="Uhlenbrock_Power22.xml">
         <model model="Power22" productID="6321" comment="Intelligenter 2.2A Booster">
           <versionCV />
         </model>
       </family>
-      <family name="Booster" mfg="Uhlenbrock Elektronik" type="stationary" file="Uhlenbrock_Power4.xml">
+      <family name="Booster" mfg="Uhlenbrock Elektronik" type="stationary" modes="LOCONETLNCVMODE" file="Uhlenbrock_Power4.xml">
         <model model="Power4" productID="6324" comment="3.5A Multiprotocol Booster">
           <versionCV />
         </model>
       </family>
-      <family name="Booster" mfg="Uhlenbrock Elektronik" type="stationary" file="Uhlenbrock_Power40.xml">
+      <family name="Booster" mfg="Uhlenbrock Elektronik" type="stationary" modes="LOCONETLNCVMODE" file="Uhlenbrock_Power40.xml">
         <model model="Power40" productID="6322" comment="Intelligenter 3.5A Booster">
           <versionCV />
         </model>
       </family>
-      <family name="Booster" mfg="Uhlenbrock Elektronik" type="stationary" file="Uhlenbrock_Power7.xml">
+      <family name="Booster" mfg="Uhlenbrock Elektronik" type="stationary" modes="LOCONETLNCVMODE" file="Uhlenbrock_Power7.xml">
         <model model="Power7" productID="6327" comment="7A Multiprotocol Booster">
           <versionCV />
         </model>
       </family>
-      <family name="Booster" mfg="Uhlenbrock Elektronik" type="stationary" file="Uhlenbrock_Power70.xml">
+      <family name="Booster" mfg="Uhlenbrock Elektronik" type="stationary" modes="LOCONETLNCVMODE" file="Uhlenbrock_Power70.xml">
         <model model="Power70" productID="6323" comment="Intelligenter 6.8A Booster">
           <versionCV />
         </model>
       </family>
-      <family name="Booster" mfg="Uhlenbrock Elektronik" type="stationary" file="Uhlenbrock_Power8.xml">
+      <family name="Booster" mfg="Uhlenbrock Elektronik" type="stationary" modes="LOCONETLNCVMODE" file="Uhlenbrock_Power8.xml">
         <model model="Power8" productID="6328" comment="7A Multiprotocol Booster">
           <versionCV />
         </model>
@@ -33560,12 +33563,12 @@
           <!-- Anfahren/Bremsen -->
         </model>
       </family>
-      <family name="Track-Control" mfg="Uhlenbrock Elektronik" type="stationary" file="Uhlenbrock_TrackControl_6922.xml">
+      <family name="Track-Control" mfg="Uhlenbrock Elektronik" type="stationary" modes="LOCONETLNCVMODE" file="Uhlenbrock_TrackControl_6922.xml">
         <model model="Turnout Module" productID="6922" comment="Control Panel Turnout Activator/Indicator">
           <versionCV />
         </model>
       </family>
-      <family name="Track-Control" mfg="Uhlenbrock Elektronik" type="stationary" file="Uhlenbrock_TrackControl_6923.xml">
+      <family name="Track-Control" mfg="Uhlenbrock Elektronik" type="stationary" modes="LOCONETLNCVMODE" file="Uhlenbrock_TrackControl_6923.xml">
         <model model="Signal Module" productID="6923" comment="Control Panel Signal Indicator">
           <versionCV />
         </model>
@@ -34131,59 +34134,20 @@
           <output name="5" label="FO 3 (+5v)" />
           <output name="6" label="FO 4 (+5v)" />
         </model>
-        <!-- not available yet (2024-05-02)
-      <model model="MS540E24 version 4+" lowVersionID="4" highVersionID="42" maxInputVolts="35V" maxMotorCurrent="0.8A, peak=1.5A" maxTotalCurrent="0.8A" formFactor="HO" numOuts="12" numFns="14" productID="14">
-        <output name="1" label="Front Light">
-          <label xml:lang="de">Lvor</label>
-          <label xml:lang="cs">Přední světla</label>
-        </output>
-        <output name="2" label="Rear Light">
-          <label xml:lang="de">Lrück</label>
-          <label xml:lang="cs">Zadní světla</label>
-        </output>
-        <output name="3" label="FO 1">
-          <label xml:lang="de">FA1</label>
-          <label xml:lang="cs">FV 1</label>
-        </output>
-        <output name="4" label="FO 2">
-          <label xml:lang="de">FA2</label>
-          <label xml:lang="cs">FV 2</label>
-        </output>
-        <output name="5" label="FO 3">
-          <label xml:lang="de">FA3</label>
-          <label xml:lang="cs">FV 3</label>
-        </output>
-        <output name="6" label="FO 4">
-          <label xml:lang="de">FA4</label>
-          <label xml:lang="cs">FV 4</label>
-        </output>
-        <output name="7" label="FO 5">
-          <label xml:lang="de">FA5</label>
-          <label xml:lang="cs">FV 5</label>
-        </output>
-        <output name="8" label="FO 6">
-          <label xml:lang="de">FA6</label>
-          <label xml:lang="cs">FV 6</label>
-        </output>
-        <output name="9" label="FO 7 (+5V)">
-          <label xml:lang="de">FA7 (+5V)</label>
-          <label xml:lang="cs">FV 7 (+5V)</label>
-        </output>
-        <output name="10" label="FO 8 (+5V)">
-          <label xml:lang="de">FA8 (+5V)</label>
-          <label xml:lang="cs">FV 8 (+5V)</label>
-        </output>
-        <output name="11" label="FO 9 (+5V)">
-          <label xml:lang="de">FA9 (+5V)</label>
-          <label xml:lang="cs">FV 9 (+5V)</label>
-        </output>
-        <output name="12" label="FO 10 (+5V)">
-          <label xml:lang="de">FA10 (+5V)</label>
-          <label xml:lang="cs">FV 10 (+5V)</label>
-        </output>
-        <size length="19" width="8.7" height="2.8" units="mm"/>
-      </model>
--->
+        <model model="MS540E24 version 4+" lowVersionID="4" highVersionID="42" numOuts="12" numFns="14" productID="14">
+          <output name="1" label="Front Light" />
+          <output name="2" label="Rear Light" />
+          <output name="3" label="FO 1" />
+          <output name="4" label="FO 2" />
+          <output name="5" label="FO 3" />
+          <output name="6" label="FO 4" />
+          <output name="7" label="FO 5" />
+          <output name="8" label="FO 6" />
+          <output name="9" label="FO 7 (+5V)" />
+          <output name="10" label="FO 8 (+5V)" />
+          <output name="11" label="FO 9 (+5V)" />
+          <output name="12" label="FO 10 (+5V)" />
+        </model>
         <model model="MS560 version 4+" lowVersionID="4" highVersionID="41" numOuts="4" numFns="14" productID="10">
           <output name="1" label="Front Light" />
           <output name="2" label="Rear Light" />
@@ -34209,6 +34173,14 @@
           <output name="6" label="FO 6 (+5v)" />
         </model>
         <model model="MS590N18 version 4+" lowVersionID="4" highVersionID="41" numOuts="6" numFns="14" productID="8">
+          <output name="1" label="Front Light" />
+          <output name="2" label="Rear Light" />
+          <output name="3" label="FO 1" />
+          <output name="4" label="FO 2" />
+          <output name="5" label="FO 3 (+5v)" />
+          <output name="6" label="FO 4 (+5v)" />
+        </model>
+        <model model="MS591N18 version 4+" lowVersionID="4" highVersionID="41" numOuts="6" numFns="14" productID="15">
           <output name="1" label="Front Light" />
           <output name="2" label="Rear Light" />
           <output name="3" label="FO 1" />

--- a/xml/decoderIndex.xml
+++ b/xml/decoderIndex.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet href="/xml/XSLT/DecoderID.xsl" type="text/xsl"?>
 <decoderIndex-config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
-  <!--Written by JMRI version 5.11.4plus+jake+20250331T1027Z+R5297faed912 on Mon Mar 31 06:27:22 EDT 2025-->
-  <decoderIndex version="635">
+  <!--Written by JMRI version 5.11.4plus+jake+20250331T1051Z+R6a624e9293e on Mon Mar 31 06:51:04 EDT 2025-->
+  <decoderIndex version="639">
     <!--The manufacturer list is from the nmra_mfg_list.xml file-->
-    <mfgList nmraListDate="2021-03-06" updated="2023-01-25" lastadd="169">
+    <mfgList nmraListDate="2024-12-10" updated="2025-03-30" lastadd="171">
       <manufacturer mfg="NMRA" mfgID="999" />
       <manufacturer mfg="A-Train Electronics" mfgID="137" />
       <manufacturer mfg="AE Electronic Ltd" mfgID="169" />
@@ -180,6 +180,7 @@
       <manufacturer mfg="Wm. K. Walthers, Inc" mfgID="150" />
       <manufacturer mfg="ZTC" mfgID="132" />
       <manufacturer mfg="Zimo" mfgID="145" />
+      <manufacturer mfg="bogobit" mfgID="171" />
       <manufacturer mfg="csikos-muhely" mfgID="120" />
       <manufacturer mfg="drM" mfgID="164" />
     </mfgList>

--- a/xml/decoders/Decoderwerk_LokCommander.xml
+++ b/xml/decoders/Decoderwerk_LokCommander.xml
@@ -1,0 +1,1582 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="../XSLT/decoder.xsl"?>
+<!-- Copyright (C) JMRI 2025 All rights reserved                            -->
+<!--                                                                        -->
+<!-- JMRI is free software; you can redistribute it and/or modify it under  -->
+<!-- the terms of version 2 of the GNU General Public License as published  -->
+<!-- by the Free Software Foundation. See the "COPYING" file for a copy     -->
+<!-- of this license.                                                       -->
+<!--                                                                        -->
+<!-- JMRI is distributed in the hope that it will be useful, but WITHOUT    -->
+<!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
+<!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
+<!-- for more details.                                                      -->
+<decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd" showEmptyPanes="no">    
+        
+ <version author="dieter.flunkert@experimentalme.com" version="1" lastUpdated="20250321" />
+   <decoder>
+      <family name="Decoderwerk LokCommander" mfg="Decoderwerk" lowVersionID="0" highVersionID="255">
+         <model model="LokCommander 7090x" numOuts="8" numFns="68">
+            <size length="24" width="14" height="4" units="mm" />
+         </model>
+      </family>
+      <programming direct="yes" paged="yes" register="yes" ops="yes" />
+      <variables>
+
+         <xi:include href="http://jmri.org/xml/decoders/nmra/shortAndLongAddress.xml" />
+         <xi:include href="http://jmri.org/xml/decoders/nmra/mfgVersionId.xml" />
+         <variable item="Vstart" default="5" CV="2">
+            <decVal min="0" max="255" />
+            <label>Vstart</label>
+            <label xml:lang="it">Velocità Partenza</label>
+            <label xml:lang="fr">V démarr.</label>
+            <label xml:lang="de">Minimale Geschwindigkeit</label>
+            <comment>A value of 255 corresponds to 100%</comment>
+            <comment xml:lang="it">Un Valore di 255 corrisponde al 100%</comment>
+            <comment xml:lang="de">Der Wert 255 entspricht 100%</comment>
+         </variable>
+         <variable item="Vhigh" default="250" CV="5">
+            <decVal min="0" max="255" />
+            <label>Vhigh</label>
+            <label xml:lang="it">Velocità Massimi</label>
+            <label xml:lang="fr">Vmax</label>
+            <label xml:lang="de">Maximale Geschwindigkeit</label>
+         </variable>
+         <variable item="Vmid" default="80" CV="6">
+            <decVal min="0" max="255" />
+            <label>Vmid</label>
+            <label xml:lang="it">Velocità Intermedi</label>
+            <label xml:lang="fr">Vmoy</label>
+            <label xml:lang="de">Mittlere Geschwindigkeit</label>
+         </variable>
+         <variable CV="3" item="Accel" default="10" comment="Range 0-255">
+            <decVal min="0" max="255" />
+            <label>Acceleration Rate</label>
+            <label xml:lang="it">Accellerazione</label>
+            <label xml:lang="fr">Accelération</label>
+            <label xml:lang="de">Beschleunigungsrate</label>
+            <comment>Range 0-255</comment>
+            <comment xml:lang="it">Valori 0-255</comment>
+            <comment xml:lang="fr">Valeur 0-255</comment>
+            <comment xml:lang="de">Wert 0-255</comment>
+         </variable>
+         <variable CV="4" item="Decel" default="10" comment="Range 0-255">
+            <decVal min="0" max="255" />
+            <label>Deceleration Rate</label>
+            <label xml:lang="it">Decellerazione</label>
+            <label xml:lang="fr">Décélération</label>
+            <label xml:lang="de">Bremsrate</label>
+            <comment>Range 0-255</comment>
+            <comment xml:lang="it">Valori 0-255</comment>
+            <comment xml:lang="fr">Valeur 0-255</comment>
+            <comment xml:lang="de">Wert 0-255</comment>
+         </variable>
+      <variable item="EMF Static Config" CV="49" mask="XXXXXXXV" default="1">
+        <enumVal>
+          <enumChoice choice="Off">
+            <choice>Off</choice>
+          </enumChoice>
+          <enumChoice choice="On">
+            <choice>On</choice>
+          </enumChoice>
+        </enumVal>
+        <label>EMF Active</label>
+        <label xml:lang="de">Lastregelung aktiv</label>
+      </variable>
+
+         <variable CV="11" item="Packet Time-out Value" default="50">
+            <decVal min="30" max="255" />
+            <label>Packet Time-out Value (1ms each value)</label>
+            <label xml:lang="de">Datenpaket Time-out (1ms pro Wert)</label>
+            <label xml:lang="fr">Valeur du Time-out de paquet</label>
+            <label xml:lang="it">Valore Time-out Packet</label>
+         </variable>
+
+         <xi:include href="http://jmri.org/xml/decoders/nmra/consistAddrDirection.xml" />
+         <xi:include href="http://jmri.org/xml/decoders/nmra/cv29direction.xml" />
+         <xi:include href="http://jmri.org/xml/decoders/nmra/cv29speedSteps.xml" />
+         <xi:include href="http://jmri.org/xml/decoders/nmra/cv29analog.xml" />
+         <xi:include href="http://jmri.org/xml/decoders/nmra/cv29table3-28.xml" />
+         <xi:include href="http://jmri.org/xml/decoders/nmra/cv67speedTableBasic.xml" />
+
+         
+         <!-- Railcom® support -->
+         <variable item="Advanced Group 1 Option 4" CV="29" mask="XXXXVXXX" default="0">
+             <xi:include href="http://jmri.org/xml/decoders/parts/enum-disabledEnabled.xml"/>
+             <label>Enable RailCom</label>
+             <label xml:lang="fr">RailCom®</label>
+             <label xml:lang="de">RailCom®</label>
+             <label xml:lang="it">Abilita RailCom®</label>
+         </variable>
+        <variable item="Advanced Group 1 Option 5" CV="28" mask="VXXXXXXX" default="0">
+             <xi:include href="http://jmri.org/xml/decoders/parts/enum-disabledEnabled.xml"/>
+             <label>RailCom® Plus</label>
+             <label xml:lang="de">Railcom® Plus</label>
+         </variable>
+        <variable item="Advanced Group 1 Option 6" CV="28" mask="XXXXXXXV" default="0">
+             <xi:include href="http://jmri.org/xml/decoders/parts/enum-disabledEnabled.xml"/>
+             <label>RailCom® Channel 1 Address Broadcast</label>
+             <label xml:lang="de">RailCom® Kanal 1 Address Broadcast</label>
+         </variable>
+        <variable item="Advanced Group 1 Option 7" CV="28" mask="XXXXXXVX" default="0">
+             <xi:include href="http://jmri.org/xml/decoders/parts/enum-disabledEnabled.xml"/>
+             <label>RailCom® Channel 2 Data Transmission</label>
+             <label xml:lang="de">RailCom® Kanal 2 Data Transmission</label>
+         </variable>
+     
+         <variable item="Function 13 effect generated" CV="31" default="64">
+            <decVal />
+            <label>Function key for Frontlight suppression (0-68)</label>
+            <label xml:lang="de">Funktionskey zur Vorderlicht Unterdrückung</label>
+         </variable>
+         <variable item="Function 14 effect generated" CV="32" default="64">
+            <decVal />
+            <label>Function key for Backlight suppression (0-64)</label>
+            <label xml:lang="de">Funktionskey zur Rücklich Unterdrückung</label>
+         </variable>
+         
+         <!-- Motor control -->
+         <variable item="EMF Option 3" CV="60" default="35" comment="P component of the PID controller for load control">
+             <decVal min="1" max="255" />
+             <label>PID P controller</label>
+             <label xml:lang="de">Lastregelung: Nachregelung</label>
+         </variable>
+         <variable item="EMF Option 4" CV="62" default="20" comment="I component of the PID controller for load control">
+             <decVal min="1" max="255" />
+             <label>PID I controller</label>
+             <label xml:lang="de">Lastregelung:Verzögerung</label>
+         </variable>
+         <variable item="EMF Option 5" CV="61" default="10" comment="D component of the PID controller for load control">
+             <decVal min="1" max="255" />
+             <label>PID D controller</label>
+             <label xml:lang="de">Lastregelung:Begrenzung</label>
+         </variable>
+         
+         <variable item="Advanced Group 1 Option 1" CV="10" mask="XXXXXXVV" default="1">
+             <enumVal>
+                 <enumChoice choice="Automatic" value="1">
+                     <choice>Automatic</choice>
+                 </enumChoice>
+                 <enumChoice choice="only DCC" value="2">
+                     <choice>only DCC</choice>
+                 </enumChoice>
+                 <enumChoice choice="only MM" value="3">
+                     <choice>only MM</choice>
+                 </enumChoice>
+             </enumVal>
+             <label>Protocol</label>
+             <label xml:lang="de">Protokol</label>
+         </variable>
+         <variable item="Motor Option 1" CV="9" mask="XXXXXVVV" default="0">
+             <enumVal>
+                 <enumChoice choice="16kHz" value="0">
+                     <choice>16kHz</choice>
+                 </enumChoice>
+                 <enumChoice choice="2kHz" value="1">
+                     <choice>2kHz</choice>
+                 </enumChoice>
+                 <enumChoice choice="250Hz" value="2">
+                     <choice>250Hz</choice>
+                 </enumChoice>
+                 <enumChoice choice="60Hz" value="3">
+                     <choice>60Hz</choice>
+                 </enumChoice>
+                 <enumChoice choice="100kHz" value="4">
+                     <choice>100kHz</choice>
+                 </enumChoice>
+             </enumVal>
+             <label>Motor PWM frequency</label>
+             <label xml:lang="de">Motorfrequenz</label>
+         </variable>
+         <variable item="Motor Option 2" CV="66" default="255">
+           <decVal min="1" max="255" />
+           <label>Forward-Trim (Value*CV5/255)</label>
+           <label xml:lang="de">Vorwärts-Trim (Wert*CV5/255)</label>
+         </variable>
+         <variable item="Motor Option 3" CV="95" default="255">
+           <decVal min="1" max="255" />
+           <label>Backward-Trim (Value*CV5/255)</label>
+           <label xml:lang="de">Rückwärts-Trim Wert*CV5/255)</label>
+         </variable>
+         
+         <!-- Decoder Lock -->
+         
+         <variable item="Advanced Group 1 Option 2" CV="15" default="205">
+           <decVal/>
+           <label>Decoder Lock (1) (To unlock set it to the value below)</label>
+           <label xml:lang="it">Blocco Decoder (1)</label>
+           <label xml:lang="de">Decoder Lock (1)</label>
+           <label xml:lang="nl">Decoder Lock (1)</label>
+         </variable>
+ 
+         <variable item="Advanced Group 1 Option 3" CV="16" default="205" readOnly="yes">
+           <decVal/>
+           <label>Decoder Lock (2)</label>
+           <label xml:lang="it">Blocco Decoder (2)</label>
+           <label xml:lang="de">Decoder Lock (2)</label>
+           <label xml:lang="nl">Decoder Lock (2)</label>
+         </variable>
+         
+         <!-- ABC braking -->
+         <variable item="Advanced Group 2 Option 11" CV="27" mask="XXXXXXXV" default="0">
+             <xi:include href="http://jmri.org/xml/decoders/parts/enum-disabledEnabled.xml"/>
+             <label>Automatic stop with asymmetrical DCC signal right track</label>
+             <label xml:lang="de">Stop DCC rechts</label>
+         </variable>
+         <variable item="Advanced Group 2 Option 12" CV="27" mask="XXXXXXVX" default="0">
+             <xi:include href="http://jmri.org/xml/decoders/parts/enum-disabledEnabled.xml"/>
+             <label>Automatic stop with asymmetrical DCC signal left track</label>
+             <label xml:lang="de">Stop DCC links</label>
+         </variable>
+         
+         <!-- ZIMO HLU -->
+         <variable item="Advanced Group 2 Option 13" CV="27" mask="XXXXXVXX" default="0">
+             <xi:include href="http://jmri.org/xml/decoders/parts/enum-disabledEnabled.xml"/>
+             <label>Automatic stop ZIMO HLU System</label>
+             <label xml:lang="de">Automatischer Stop ZIMO HLU System</label>
+         </variable>
+         
+         <!-- Märklin braking -->
+         <variable item="Advanced Group 2 Option 14" CV="27" mask="XXXVXXXX" default="0">
+             <xi:include href="http://jmri.org/xml/decoders/parts/enum-disabledEnabled.xml"/>
+             <label>Automatic stop with positiv DC signal right track</label>
+             <label xml:lang="de">Automatischer Halt bei postivem DC Signal rechte Schiene</label>
+         </variable>
+         <variable item="Advanced Group 2 Option 15" CV="27" mask="XXVXXXXX" default="0">
+             <xi:include href="http://jmri.org/xml/decoders/parts/enum-disabledEnabled.xml"/>
+             <label>Automatic stop with positiv DC signal left track</label>
+             <label xml:lang="de">Automatischer Halt bei positivem DC Signal linke Schiene</label>
+         </variable>
+
+         <variable item="AUX Option 1" CV="53" default="0">
+             <enumVal>
+                 <enumChoice choice="Normal" value="0">
+                     <choice>Normal</choice>
+                 </enumChoice>
+                 <enumChoice choice="Flash symetric" value="1">
+                     <choice>Flash symetric</choice>
+                 </enumChoice>
+                 <enumChoice choice="Flashing short" value="2">
+                     <choice>Flashing short</choice>
+                 </enumChoice>
+                 <enumChoice choice="Flashin long" value="3">
+                     <choice>Flashing long</choice>
+                 </enumChoice>
+                 <enumChoice choice="Photographer flash" value="4">
+                     <choice>Photographer flash</choice>
+                 </enumChoice>
+                 <enumChoice choice="Monoflop" value="5">
+                     <choice>Monoflop</choice>
+                 </enumChoice>
+                 <enumChoice choice="Switch on delayed" value="6">
+                     <choice>Switch on delayed</choice>
+                 </enumChoice>
+                 <enumChoice choice="Firebox" value="7">
+                     <choice>Firebox</choice>
+                 </enumChoice>
+                 <enumChoice choice="TV flickering" value="8">
+                     <choice>TV flickering</choice>
+                 </enumChoice>
+                 <enumChoice choice="Petrolium flickering" value="9">
+                     <choice>Petrolium flickering</choice>
+                 </enumChoice>
+                 <enumChoice choice="Flourescent tube" value="10">
+                     <choice>Flourescent tube</choice>
+                 </enumChoice>
+                 <enumChoice choice="Defective flourescent tube" value="11">
+                     <choice>Defective flourescent tube</choice>
+                 </enumChoice>
+                 <enumChoice choice="Alternating flash to paired output" value="12">
+                     <choice>Alternating flash to paired output</choice>
+                     <comment>Combination of A1-A2, A3-A4 etc </comment>
+                 </enumChoice>             
+                 <enumChoice choice="US strobe light" value="13">
+                     <choice>US strobe light</choice>
+                 </enumChoice>
+                 <enumChoice choice="US double strobe light" value="14">
+                     <choice>US double strobe light</choice>
+                 </enumChoice>
+                 <enumChoice choice="US marslight" value="15">
+                     <choice>US marslight</choice>
+                 </enumChoice>
+                 <enumChoice choice="US ditch light" value="16">
+                     <choice>US ditch light</choice>
+                 </enumChoice>
+                 <enumChoice choice="Sodium lamp" value="17">
+                     <choice>Sodium lamp</choice>
+                 </enumChoice>
+                 <enumChoice choice="Welding light" value="18">
+                     <choice>Welding light</choice>
+                 </enumChoice>
+                 <enumChoice choice="Buffercontrol BC" value="20">
+                     <choice>Buffercontrol BC</choice>
+                 </enumChoice>
+                 <enumChoice choice="Clock simulation" value="21">
+                     <choice>Clock simulation</choice>
+                 </enumChoice>
+                 <enumChoice choice="Pulsed smoke unit control Steam" value="22">
+                     <choice>Pulsed smoke unit control Steam</choice>
+                 </enumChoice>
+                 <enumChoice choice="Pulsed smoke unit control Diesel" value="23">
+                     <choice>Pulsed smoke unit control Diesel</choice>
+                 </enumChoice>
+                 <enumChoice choice="Cuppler" value="24">
+                     <choice>Cuppler</choice>
+                 </enumChoice>
+             </enumVal>
+             <label>Effect Frontlight</label>
+             <label xml:lang="de">Vorderlicht Effekt</label>
+            </variable>
+         <variable item="AUX Option 2" CV="58" default="0">
+             <enumVal>
+                 <enumChoice choice="Normal" value="0">
+                     <choice>Normal</choice>
+                 </enumChoice>
+                 <enumChoice choice="Flash symetric" value="1">
+                     <choice>Flash symetric</choice>
+                 </enumChoice>
+                 <enumChoice choice="Flashing short" value="2">
+                     <choice>Flashing short</choice>
+                 </enumChoice>
+                 <enumChoice choice="Flashin long" value="3">
+                     <choice>Flashing long</choice>
+                 </enumChoice>
+                 <enumChoice choice="Photographer flash" value="4">
+                     <choice>Photographer flash</choice>
+                 </enumChoice>
+                 <enumChoice choice="Monoflop" value="5">
+                     <choice>Monoflop</choice>
+                 </enumChoice>
+                 <enumChoice choice="Switch on delayed" value="6">
+                     <choice>Switch on delayed</choice>
+                 </enumChoice>
+                 <enumChoice choice="Firebox" value="7">
+                     <choice>Firebox</choice>
+                 </enumChoice>
+                 <enumChoice choice="TV flickering" value="8">
+                     <choice>TV flickering</choice>
+                 </enumChoice>
+                 <enumChoice choice="Petrolium flickering" value="9">
+                     <choice>Petrolium flickering</choice>
+                 </enumChoice>
+                 <enumChoice choice="Flourescent tube" value="10">
+                     <choice>Flourescent tube</choice>
+                 </enumChoice>
+                 <enumChoice choice="Defective flourescent tube" value="11">
+                     <choice>Defective flourescent tube</choice>
+                 </enumChoice>
+                 <enumChoice choice="Alternating flash to paired output" value="12">
+                     <choice>Alternating flash to paired output</choice>
+                     <comment>Combination of A1-A2, A3-A4 etc </comment>
+                 </enumChoice>             
+                 <enumChoice choice="US strobe light" value="13">
+                     <choice>US strobe light</choice>
+                 </enumChoice>
+                 <enumChoice choice="US double strobe light" value="14">
+                     <choice>US double strobe light</choice>
+                 </enumChoice>
+                 <enumChoice choice="US marslight" value="15">
+                     <choice>US marslight</choice>
+                 </enumChoice>
+                 <enumChoice choice="US ditch light" value="16">
+                     <choice>US ditch light</choice>
+                 </enumChoice>
+                 <enumChoice choice="Sodium lamp" value="17">
+                     <choice>Sodium lamp</choice>
+                 </enumChoice>
+                 <enumChoice choice="Welding light" value="18">
+                     <choice>Welding light</choice>
+                 </enumChoice>
+                 <enumChoice choice="Buffercontrol BC" value="20">
+                     <choice>Buffercontrol BC</choice>
+                 </enumChoice>
+                 <enumChoice choice="Clock simulation" value="21">
+                     <choice>Clock simulation</choice>
+                 </enumChoice>
+                 <enumChoice choice="Pulsed smoke unit control Steam" value="22">
+                     <choice>Pulsed smoke unit control Steam</choice>
+                 </enumChoice>
+                 <enumChoice choice="Pulsed smoke unit control Diesel" value="23">
+                     <choice>Pulsed smoke unit control Diesel</choice>
+                 </enumChoice>
+                 <enumChoice choice="Cuppler" value="24">
+                     <choice>Cuppler</choice>
+                 </enumChoice>
+             </enumVal>
+             <label>Effect Rearlight</label>
+             <label xml:lang="de">Rücklicht Effekt</label>
+         </variable>
+         <variable item="AUX Option 3" CV="123" default="0">
+             <enumVal>
+                 <enumChoice choice="Normal" value="0">
+                     <choice>Normal</choice>
+                 </enumChoice>
+                 <enumChoice choice="Flash symetric" value="1">
+                     <choice>Flash symetric</choice>
+                 </enumChoice>
+                 <enumChoice choice="Flashing short" value="2">
+                     <choice>Flashing short</choice>
+                 </enumChoice>
+                 <enumChoice choice="Flashin long" value="3">
+                     <choice>Flashing long</choice>
+                 </enumChoice>
+                 <enumChoice choice="Photographer flash" value="4">
+                     <choice>Photographer flash</choice>
+                 </enumChoice>
+                 <enumChoice choice="Monoflop" value="5">
+                     <choice>Monoflop</choice>
+                 </enumChoice>
+                 <enumChoice choice="Switch on delayed" value="6">
+                     <choice>Switch on delayed</choice>
+                 </enumChoice>
+                 <enumChoice choice="Firebox" value="7">
+                     <choice>Firebox</choice>
+                 </enumChoice>
+                 <enumChoice choice="TV flickering" value="8">
+                     <choice>TV flickering</choice>
+                 </enumChoice>
+                 <enumChoice choice="Petrolium flickering" value="9">
+                     <choice>Petrolium flickering</choice>
+                 </enumChoice>
+                 <enumChoice choice="Flourescent tube" value="10">
+                     <choice>Flourescent tube</choice>
+                 </enumChoice>
+                 <enumChoice choice="Defective flourescent tube" value="11">
+                     <choice>Defective flourescent tube</choice>
+                 </enumChoice>
+                 <enumChoice choice="Alternating flash to paired output" value="12">
+                     <choice>Alternating flash to paired output</choice>
+                     <comment>Combination of A1-A2, A3-A4 etc </comment>
+                 </enumChoice>             
+                 <enumChoice choice="US strobe light" value="13">
+                     <choice>US strobe light</choice>
+                 </enumChoice>
+                 <enumChoice choice="US double strobe light" value="14">
+                     <choice>US double strobe light</choice>
+                 </enumChoice>
+                 <enumChoice choice="US marslight" value="15">
+                     <choice>US marslight</choice>
+                 </enumChoice>
+                 <enumChoice choice="US ditch light" value="16">
+                     <choice>US ditch light</choice>
+                 </enumChoice>
+                 <enumChoice choice="Sodium lamp" value="17">
+                     <choice>Sodium lamp</choice>
+                 </enumChoice>
+                 <enumChoice choice="Welding light" value="18">
+                     <choice>Welding light</choice>
+                 </enumChoice>
+                 <enumChoice choice="Buffercontrol BC" value="20">
+                     <choice>Buffercontrol BC</choice>
+                 </enumChoice>
+                 <enumChoice choice="Clock simulation" value="21">
+                     <choice>Clock simulation</choice>
+                 </enumChoice>
+                 <enumChoice choice="Pulsed smoke unit control Steam" value="22">
+                     <choice>Pulsed smoke unit control Steam</choice>
+                 </enumChoice>
+                 <enumChoice choice="Pulsed smoke unit control Diesel" value="23">
+                     <choice>Pulsed smoke unit control Diesel</choice>
+                 </enumChoice>
+                 <enumChoice choice="Cuppler" value="24">
+                     <choice>Cuppler</choice>
+                 </enumChoice>
+             </enumVal>
+             <label>Effect AUX1</label>
+             <label xml:lang="de">AUX1 Effekt</label>
+         </variable>
+         <variable item="AUX Option 4" CV="133" default="0">
+             <enumVal>
+                 <enumChoice choice="Normal" value="0">
+                     <choice>Normal</choice>
+                 </enumChoice>
+                 <enumChoice choice="Flash symetric" value="1">
+                     <choice>Flash symetric</choice>
+                 </enumChoice>
+                 <enumChoice choice="Flashing short" value="2">
+                     <choice>Flashing short</choice>
+                 </enumChoice>
+                 <enumChoice choice="Flashin long" value="3">
+                     <choice>Flashing long</choice>
+                 </enumChoice>
+                 <enumChoice choice="Photographer flash" value="4">
+                     <choice>Photographer flash</choice>
+                 </enumChoice>
+                 <enumChoice choice="Monoflop" value="5">
+                     <choice>Monoflop</choice>
+                 </enumChoice>
+                 <enumChoice choice="Switch on delayed" value="6">
+                     <choice>Switch on delayed</choice>
+                 </enumChoice>
+                 <enumChoice choice="Firebox" value="7">
+                     <choice>Firebox</choice>
+                 </enumChoice>
+                 <enumChoice choice="TV flickering" value="8">
+                     <choice>TV flickering</choice>
+                 </enumChoice>
+                 <enumChoice choice="Petrolium flickering" value="9">
+                     <choice>Petrolium flickering</choice>
+                 </enumChoice>
+                 <enumChoice choice="Flourescent tube" value="10">
+                     <choice>Flourescent tube</choice>
+                 </enumChoice>
+                 <enumChoice choice="Defective flourescent tube" value="11">
+                     <choice>Defective flourescent tube</choice>
+                 </enumChoice>
+                 <enumChoice choice="Alternating flash to paired output" value="12">
+                     <choice>Alternating flash to paired output</choice>
+                     <comment>Combination of A1-A2, A3-A4 etc </comment>
+                 </enumChoice>             
+                 <enumChoice choice="US strobe light" value="13">
+                     <choice>US strobe light</choice>
+                 </enumChoice>
+                 <enumChoice choice="US double strobe light" value="14">
+                     <choice>US double strobe light</choice>
+                 </enumChoice>
+                 <enumChoice choice="US marslight" value="15">
+                     <choice>US marslight</choice>
+                 </enumChoice>
+                 <enumChoice choice="US ditch light" value="16">
+                     <choice>US ditch light</choice>
+                 </enumChoice>
+                 <enumChoice choice="Sodium lamp" value="17">
+                     <choice>Sodium lamp</choice>
+                 </enumChoice>
+                 <enumChoice choice="Welding light" value="18">
+                     <choice>Welding light</choice>
+                 </enumChoice>
+                 <enumChoice choice="Buffercontrol BC" value="20">
+                     <choice>Buffercontrol BC</choice>
+                 </enumChoice>
+                 <enumChoice choice="Clock simulation" value="21">
+                     <choice>Clock simulation</choice>
+                 </enumChoice>
+                 <enumChoice choice="Pulsed smoke unit control Steam" value="22">
+                     <choice>Pulsed smoke unit control Steam</choice>
+                 </enumChoice>
+                 <enumChoice choice="Pulsed smoke unit control Diesel" value="23">
+                     <choice>Pulsed smoke unit control Diesel</choice>
+                 </enumChoice>
+                 <enumChoice choice="Cuppler" value="24">
+                     <choice>Cuppler</choice>
+                 </enumChoice>
+             </enumVal>
+             <label>Effect AUX2</label>
+             <label xml:lang="de">AUX 2 Effekt</label>
+         </variable>
+         <variable item="AUX Option 5" CV="143" default="0">
+             <enumVal>
+                 <enumChoice choice="Normal" value="0">
+                     <choice>Normal</choice>
+                 </enumChoice>
+                 <enumChoice choice="Flash symetric" value="1">
+                     <choice>Flash symetric</choice>
+                 </enumChoice>
+                 <enumChoice choice="Flashing short" value="2">
+                     <choice>Flashing short</choice>
+                 </enumChoice>
+                 <enumChoice choice="Flashin long" value="3">
+                     <choice>Flashing long</choice>
+                 </enumChoice>
+                 <enumChoice choice="Photographer flash" value="4">
+                     <choice>Photographer flash</choice>
+                 </enumChoice>
+                 <enumChoice choice="Monoflop" value="5">
+                     <choice>Monoflop</choice>
+                 </enumChoice>
+                 <enumChoice choice="Switch on delayed" value="6">
+                     <choice>Switch on delayed</choice>
+                 </enumChoice>
+                 <enumChoice choice="Firebox" value="7">
+                     <choice>Firebox</choice>
+                 </enumChoice>
+                 <enumChoice choice="TV flickering" value="8">
+                     <choice>TV flickering</choice>
+                 </enumChoice>
+                 <enumChoice choice="Petrolium flickering" value="9">
+                     <choice>Petrolium flickering</choice>
+                 </enumChoice>
+                 <enumChoice choice="Flourescent tube" value="10">
+                     <choice>Flourescent tube</choice>
+                 </enumChoice>
+                 <enumChoice choice="Defective flourescent tube" value="11">
+                     <choice>Defective flourescent tube</choice>
+                 </enumChoice>
+                 <enumChoice choice="Alternating flash to paired output" value="12">
+                     <choice>Alternating flash to paired output</choice>
+                     <comment>Combination of A1-A2, A3-A4 etc </comment>
+                 </enumChoice>             
+                 <enumChoice choice="US strobe light" value="13">
+                     <choice>US strobe light</choice>
+                 </enumChoice>
+                 <enumChoice choice="US double strobe light" value="14">
+                     <choice>US double strobe light</choice>
+                 </enumChoice>
+                 <enumChoice choice="US marslight" value="15">
+                     <choice>US marslight</choice>
+                 </enumChoice>
+                 <enumChoice choice="US ditch light" value="16">
+                     <choice>US ditch light</choice>
+                 </enumChoice>
+                 <enumChoice choice="Sodium lamp" value="17">
+                     <choice>Sodium lamp</choice>
+                 </enumChoice>
+                 <enumChoice choice="Welding light" value="18">
+                     <choice>Welding light</choice>
+                 </enumChoice>
+                 <enumChoice choice="Buffercontrol BC" value="20">
+                     <choice>Buffercontrol BC</choice>
+                 </enumChoice>
+                 <enumChoice choice="Clock simulation" value="21">
+                     <choice>Clock simulation</choice>
+                 </enumChoice>
+                 <enumChoice choice="Pulsed smoke unit control Steam" value="22">
+                     <choice>Pulsed smoke unit control Steam</choice>
+                 </enumChoice>
+                 <enumChoice choice="Pulsed smoke unit control Diesel" value="23">
+                     <choice>Pulsed smoke unit control Diesel</choice>
+                 </enumChoice>
+                 <enumChoice choice="Cuppler" value="24">
+                     <choice>Cuppler</choice>
+                 </enumChoice>
+             </enumVal>
+             <label>Effect AUX3</label>
+             <label xml:lang="de">AUX3 Effekt</label>
+         </variable>
+         <variable item="AUX Option 6" CV="153" default="0">
+             <enumVal>
+                 <enumChoice choice="Normal" value="0">
+                     <choice>Normal</choice>
+                 </enumChoice>
+                 <enumChoice choice="Flash symetric" value="1">
+                     <choice>Flash symetric</choice>
+                 </enumChoice>
+                 <enumChoice choice="Flashing short" value="2">
+                     <choice>Flashing short</choice>
+                 </enumChoice>
+                 <enumChoice choice="Flashin long" value="3">
+                     <choice>Flashing long</choice>
+                 </enumChoice>
+                 <enumChoice choice="Photographer flash" value="4">
+                     <choice>Photographer flash</choice>
+                 </enumChoice>
+                 <enumChoice choice="Monoflop" value="5">
+                     <choice>Monoflop</choice>
+                 </enumChoice>
+                 <enumChoice choice="Switch on delayed" value="6">
+                     <choice>Switch on delayed</choice>
+                 </enumChoice>
+                 <enumChoice choice="Firebox" value="7">
+                     <choice>Firebox</choice>
+                 </enumChoice>
+                 <enumChoice choice="TV flickering" value="8">
+                     <choice>TV flickering</choice>
+                 </enumChoice>
+                 <enumChoice choice="Petrolium flickering" value="9">
+                     <choice>Petrolium flickering</choice>
+                 </enumChoice>
+                 <enumChoice choice="Flourescent tube" value="10">
+                     <choice>Flourescent tube</choice>
+                 </enumChoice>
+                 <enumChoice choice="Defective flourescent tube" value="11">
+                     <choice>Defective flourescent tube</choice>
+                 </enumChoice>
+                 <enumChoice choice="Alternating flash to paired output" value="12">
+                     <choice>Alternating flash to paired output</choice>
+                     <comment>Combination of A1-A2, A3-A4 etc </comment>
+                 </enumChoice>             
+                 <enumChoice choice="US strobe light" value="13">
+                     <choice>US strobe light</choice>
+                 </enumChoice>
+                 <enumChoice choice="US double strobe light" value="14">
+                     <choice>US double strobe light</choice>
+                 </enumChoice>
+                 <enumChoice choice="US marslight" value="15">
+                     <choice>US marslight</choice>
+                 </enumChoice>
+                 <enumChoice choice="US ditch light" value="16">
+                     <choice>US ditch light</choice>
+                 </enumChoice>
+                 <enumChoice choice="Sodium lamp" value="17">
+                     <choice>Sodium lamp</choice>
+                 </enumChoice>
+                 <enumChoice choice="Welding light" value="18">
+                     <choice>Welding light</choice>
+                 </enumChoice>
+                 <enumChoice choice="Buffercontrol BC" value="20">
+                     <choice>Buffercontrol BC</choice>
+                 </enumChoice>
+                 <enumChoice choice="Clock simulation" value="21">
+                     <choice>Clock simulation</choice>
+                 </enumChoice>
+                 <enumChoice choice="Pulsed smoke unit control Steam" value="22">
+                     <choice>Pulsed smoke unit control Steam</choice>
+                 </enumChoice>
+                 <enumChoice choice="Pulsed smoke unit control Diesel" value="23">
+                     <choice>Pulsed smoke unit control Diesel</choice>
+                 </enumChoice>
+                 <enumChoice choice="Cuppler" value="24">
+                     <choice>Cuppler</choice>
+                 </enumChoice>
+             </enumVal>
+             <label>Effect AUX4</label>
+             <label xml:lang="de">AUX4 Effekt</label>
+         </variable>
+         <variable item="AUX Option 7" CV="163" default="0">
+             <enumVal>
+                 <enumChoice choice="Normal" value="0">
+                     <choice>Normal</choice>
+                 </enumChoice>
+                 <enumChoice choice="Flash symetric" value="1">
+                     <choice>Flash symetric</choice>
+                 </enumChoice>
+                 <enumChoice choice="Flashing short" value="2">
+                     <choice>Flashing short</choice>
+                 </enumChoice>
+                 <enumChoice choice="Flashin long" value="3">
+                     <choice>Flashing long</choice>
+                 </enumChoice>
+                 <enumChoice choice="Photographer flash" value="4">
+                     <choice>Photographer flash</choice>
+                 </enumChoice>
+                 <enumChoice choice="Monoflop" value="5">
+                     <choice>Monoflop</choice>
+                 </enumChoice>
+                 <enumChoice choice="Switch on delayed" value="6">
+                     <choice>Switch on delayed</choice>
+                 </enumChoice>
+                 <enumChoice choice="Firebox" value="7">
+                     <choice>Firebox</choice>
+                 </enumChoice>
+                 <enumChoice choice="TV flickering" value="8">
+                     <choice>TV flickering</choice>
+                 </enumChoice>
+                 <enumChoice choice="Petrolium flickering" value="9">
+                     <choice>Petrolium flickering</choice>
+                 </enumChoice>
+                 <enumChoice choice="Flourescent tube" value="10">
+                     <choice>Flourescent tube</choice>
+                 </enumChoice>
+                 <enumChoice choice="Defective flourescent tube" value="11">
+                     <choice>Defective flourescent tube</choice>
+                 </enumChoice>
+                 <enumChoice choice="Alternating flash to paired output" value="12">
+                     <choice>Alternating flash to paired output</choice>
+                     <comment>Combination of A1-A2, A3-A4 etc </comment>
+                 </enumChoice>             
+                 <enumChoice choice="US strobe light" value="13">
+                     <choice>US strobe light</choice>
+                 </enumChoice>
+                 <enumChoice choice="US double strobe light" value="14">
+                     <choice>US double strobe light</choice>
+                 </enumChoice>
+                 <enumChoice choice="US marslight" value="15">
+                     <choice>US marslight</choice>
+                 </enumChoice>
+                 <enumChoice choice="US ditch light" value="16">
+                     <choice>US ditch light</choice>
+                 </enumChoice>
+                 <enumChoice choice="Sodium lamp" value="17">
+                     <choice>Sodium lamp</choice>
+                 </enumChoice>
+                 <enumChoice choice="Welding light" value="18">
+                     <choice>Welding light</choice>
+                 </enumChoice>
+                 <enumChoice choice="Buffercontrol BC" value="20">
+                     <choice>Buffercontrol BC</choice>
+                 </enumChoice>
+                 <enumChoice choice="Clock simulation" value="21">
+                     <choice>Clock simulation</choice>
+                 </enumChoice>
+                 <enumChoice choice="Pulsed smoke unit control Steam" value="22">
+                     <choice>Pulsed smoke unit control Steam</choice>
+                 </enumChoice>
+                 <enumChoice choice="Pulsed smoke unit control Diesel" value="23">
+                     <choice>Pulsed smoke unit control Diesel</choice>
+                 </enumChoice>
+                 <enumChoice choice="Cuppler" value="24">
+                     <choice>Cuppler</choice>
+                 </enumChoice>
+             </enumVal>
+             <label>Effect AUX5</label>
+             <label xml:lang="de">AUX5 Effekt</label>
+         </variable>
+
+         <variable item="AUX Option 8" CV="173" default="0">
+             <enumVal>
+                 <enumChoice choice="Normal" value="0">
+                     <choice>Normal</choice>
+                 </enumChoice>
+                 <enumChoice choice="Flash symetric" value="1">
+                     <choice>Flash symetric</choice>
+                 </enumChoice>
+                 <enumChoice choice="Flashing short" value="2">
+                     <choice>Flashing short</choice>
+                 </enumChoice>
+                 <enumChoice choice="Flashin long" value="3">
+                     <choice>Flashing long</choice>
+                 </enumChoice>
+                 <enumChoice choice="Photographer flash" value="4">
+                     <choice>Photographer flash</choice>
+                 </enumChoice>
+                 <enumChoice choice="Monoflop" value="5">
+                     <choice>Monoflop</choice>
+                 </enumChoice>
+                 <enumChoice choice="Switch on delayed" value="6">
+                     <choice>Switch on delayed</choice>
+                 </enumChoice>
+                 <enumChoice choice="Firebox" value="7">
+                     <choice>Firebox</choice>
+                 </enumChoice>
+                 <enumChoice choice="TV flickering" value="8">
+                     <choice>TV flickering</choice>
+                 </enumChoice>
+                 <enumChoice choice="Petrolium flickering" value="9">
+                     <choice>Petrolium flickering</choice>
+                 </enumChoice>
+                 <enumChoice choice="Flourescent tube" value="10">
+                     <choice>Flourescent tube</choice>
+                 </enumChoice>
+                 <enumChoice choice="Defective flourescent tube" value="11">
+                     <choice>Defective flourescent tube</choice>
+                 </enumChoice>
+                 <enumChoice choice="Alternating flash to paired output" value="12">
+                     <choice>Alternating flash to paired output</choice>
+                     <comment>Combination of A1-A2, A3-A4 etc </comment>
+                 </enumChoice>             
+                 <enumChoice choice="US strobe light" value="13">
+                     <choice>US strobe light</choice>
+                 </enumChoice>
+                 <enumChoice choice="US double strobe light" value="14">
+                     <choice>US double strobe light</choice>
+                 </enumChoice>
+                 <enumChoice choice="US marslight" value="15">
+                     <choice>US marslight</choice>
+                 </enumChoice>
+                 <enumChoice choice="US ditch light" value="16">
+                     <choice>US ditch light</choice>
+                 </enumChoice>
+                 <enumChoice choice="Sodium lamp" value="17">
+                     <choice>Sodium lamp</choice>
+                 </enumChoice>
+                 <enumChoice choice="Welding light" value="18">
+                     <choice>Welding light</choice>
+                 </enumChoice>
+                 <enumChoice choice="Buffercontrol BC" value="20">
+                     <choice>Buffercontrol BC</choice>
+                 </enumChoice>
+                 <enumChoice choice="Clock simulation" value="21">
+                     <choice>Clock simulation</choice>
+                 </enumChoice>
+                 <enumChoice choice="Pulsed smoke unit control Steam" value="22">
+                     <choice>Pulsed smoke unit control Steam</choice>
+                 </enumChoice>
+                 <enumChoice choice="Pulsed smoke unit control Diesel" value="23">
+                     <choice>Pulsed smoke unit control Diesel</choice>
+                 </enumChoice>
+                 <enumChoice choice="Cuppler" value="24">
+                     <choice>Cuppler</choice>
+                 </enumChoice>
+             </enumVal>
+             <label>Effect AUX6</label>
+             <label xml:lang="de">AUX6 Effekt</label>
+         </variable>
+         
+         <variable item="Time Option 1" CV="54" default="10">
+           <decVal />
+           <label>Time base (0.1s/value) for special function (Frontlight)</label> 
+           <label xml:lang="de">Timer (0,1s/Wert) Vorderlicht Effekt</label>         
+         </variable>
+         <variable item="Time Option 2" CV="59" default="10">
+           <decVal />
+           <label>Time base (0.1s/value) for special function (Rearlight)</label> 
+           <label xml:lang="de">Timer (0,1s/Wert) Rücklicht Effekt</label>         
+         </variable>
+         <variable item="Time Option 3" CV="124" default="10">
+           <decVal />
+           <label>Time base (0.1s/value) for special function (AUX 1)</label> 
+           <label xml:lang="de">Timer (0,1s/Wert) AUX1 Effekt</label>         
+         </variable>
+         <variable item="Time Option 4" CV="134" default="10">
+           <decVal />
+           <label>Time base (0.1s/value) for special function (AUX 2)</label> 
+           <label xml:lang="de">Timer (0,1s/Wert) AUX2 Effekt</label>         
+         </variable>
+         <variable item="Time Option 5" CV="144" default="10">
+           <decVal />
+           <label>Time base (0.1s/value) for special function (AUX 3)</label> 
+           <label xml:lang="de">Timer (0,1s/Wert) AUX3 Effekt</label>         
+         </variable>
+         <variable item="Time Option 6" CV="154" default="10">
+           <decVal />
+           <label>Time base (0.1s/value) for special function (AUX 4)</label>
+           <label xml:lang="de">Timer (0,1s/Wert) AUX4 Effekt</label>         
+         </variable>
+         <variable item="Time Option 7" CV="164" default="10">
+           <decVal />
+           <label>Time base (0.1s/value) for special function (AUX 5)</label>
+           <label xml:lang="de">Timer (0,1s/Wert) AUX5 Effekt</label>          
+         </variable>
+         <variable item="Time Option 8" CV="174" default="10">
+           <decVal />
+           <label>Time base (0.1s/value) for special function (AUX 6)</label>
+           <label xml:lang="de">Timer (0,1s/Wert) AUX6 Effekt</label>          
+         </variable>
+
+         <!-- Dummy variables for CVs that will be implemented in a future update of the decoder definition -->
+         <variable item="Dummy 20" CV="20">
+           <decVal />
+           <label>Dummy 20</label>
+         </variable>
+         <variable item="Dummy 23" CV="23">
+           <decVal />
+           <label>Dummy 23</label>
+         </variable>
+         <variable item="Dummy 24" CV="24">
+            <decVal />
+            <label>Dummy 24</label>
+         </variable>
+         <variable item="Dummy 26" CV="26">
+            <decVal />
+            <label>Dummy 26</label>
+         </variable>
+         <variable item="Dummy 30" CV="30">
+            <decVal />
+            <label>Dummy 30</label> 
+         </variable>        
+         <variable item="Dummy 34" CV="34">
+            <decVal />
+            <label>Dummy 34</label>
+         </variable>
+         <variable item="Dummy 39" CV="39">
+            <decVal />
+            <label>Dummy 39</label>
+         </variable>
+         <variable item="Dummy 40" CV="40">
+           <decVal />
+           <label>Dummy 40</label>
+         </variable>
+         <variable item="Dummy 41" CV="41">
+           <decVal />
+           <label>Dummy 41</label>
+         </variable>
+         <variable item="Dummy 42" CV="42">
+            <decVal />
+            <label>Dummy 42</label>
+         </variable>
+         <variable item="Dummy 43" CV="43">
+            <decVal />
+            <label>Dummy 43</label>
+         </variable>
+         <variable item="Dummy 44" CV="44">
+            <decVal />
+            <label>Dummy 44</label>
+         </variable>
+         <variable item="Dummy 45" CV="45">
+            <decVal />
+            <label>Dummy 45</label>
+         </variable>
+        <variable item="Dummy 46" CV="46">
+            <decVal />
+            <label>Dummy 46</label>
+         </variable>
+        <variable item="Dummy 47" CV="47">
+            <decVal />
+            <label>Dummy 47</label>
+		</variable>
+        <variable item="Dummy 63" CV="63">
+            <decVal />
+            <label>Dummy 63</label>
+         </variable>
+        <variable item="Dummy 64" CV="64">
+            <decVal />
+            <label>Dummy 64</label>
+		</variable>
+        <variable item="Dummy 96" CV="96">
+            <decVal />
+            <label>Dummy 96</label>
+		</variable>	
+        <variable item="Dummy 98" CV="98">
+            <decVal />
+            <label>Dummy 98</label>
+		</variable>	
+        <variable item="Dummy 99" CV="99">
+            <decVal />
+            <label>Dummy 99</label>
+		</variable>	
+        <variable item="Dummy 100" CV="100">
+            <decVal />
+            <label>Dummy 100</label>
+		</variable>	
+        <variable item="Dummy 101" CV="101">
+            <decVal />
+            <label>Dummy 101</label>
+		</variable>	
+        <variable item="Dummy 102" CV="102">
+            <decVal />
+            <label>Dummy 102</label>
+		</variable>	
+        <variable item="Dummy 103" CV="103">
+            <decVal />
+            <label>Dummy 103</label>
+		</variable>	
+        <variable item="Dummy 104" CV="104">
+            <decVal />
+            <label>Dummy 104</label>
+		</variable>	
+        <variable item="Dummy 107" CV="107">
+            <decVal />
+            <label>Dummy 107</label>
+		</variable>	
+        <variable item="Dummy 108" CV="108">
+            <decVal />
+            <label>Dummy 108</label>
+		</variable>	
+        <variable item="Dummy 109" CV="109">
+            <decVal />
+            <label>Dummy 109</label>
+		</variable>	
+        <variable item="Dummy 110" CV="110">
+            <decVal />
+            <label>Dummy 110</label>
+		</variable>	
+        <variable item="Dummy 112" CV="112">
+            <decVal />
+            <label>Dummy 112</label>
+		</variable>	
+        <variable item="Dummy 113" CV="113">
+            <decVal />
+            <label>Dummy 113</label>
+		</variable>	
+        <variable item="Dummy 114" CV="114">
+            <decVal />
+            <label>Dummy 114</label>
+		</variable>	
+        <variable item="Dummy 115" CV="115">
+            <decVal />
+            <label>Dummy 115</label>
+		</variable>	
+        <variable item="Dummy 116" CV="116">
+            <decVal />
+            <label>Dummy 116</label>
+		</variable>	
+																																	
+         <!-- Lights Dimming -->
+         <variable item="Function F0F option 1" CV="51" default="100" minOut="1">
+            <decVal max="100" />
+            <label>Dimming Frontlight</label>
+            <label xml:lang="de">Dimmen für Frontlicht</label>
+            <tooltip>&lt;html&gt;Reduces the voltage on the function output in Percent.&lt;br&gt; A value of “0” corresponds to the smallest,&lt;br&gt; a value of “100” to the maximal voltage.&lt;/html&gt;</tooltip>
+            <tooltip xml:lang="de">&lt;html&gt;Reduzierung der Spannung in Prozent, die am Ausgang anliegt.&lt;br&gt; Der Wert “0” entspricht der kleinsten,&lt;br&gt; 100 der maximalen Spannung.&lt;/html&gt;</tooltip>
+         </variable>
+         <variable item="Function F0R option 1" CV="56" default="100" minOut="2">
+            <decVal max="100" />
+            <label>Dimming Rearlight</label>
+            <label xml:lang="de">Dimmen für Rücklicht</label>
+            <tooltip>&lt;html&gt;Reduces the voltage on the function output in Percent.&lt;br&gt; A value of “0” corresponds to the smallest,&lt;br&gt; a value of “100” to the maximal voltage.&lt;/html&gt;</tooltip>
+            <tooltip xml:lang="de">&lt;html&gt;Reduzierung der Spannung, die am Ausgang anliegt.&lt;br&gt; Der Wert “0” entspricht der kleinsten,&lt;br&gt; 100 der maximalen Spannung in Prozent.&lt;/html&gt;</tooltip>
+         </variable>
+         <variable item="Function 1 option 1" CV="121" default="100" minOut="3">
+            <decVal max="100" />
+            <label>Dimming AUX 1</label>
+            <label xml:lang="de">Dimmen für AUX 1</label>
+            <tooltip>&lt;html&gt;Reduces the voltage on the function output in Percent.&lt;br&gt; A value of “0” corresponds to the smallest,&lt;br&gt; a value of “100” to the maximal voltage.&lt;/html&gt;</tooltip>
+            <tooltip xml:lang="de">&lt;html&gt;Reduzierung der Spannung, die am Ausgang anliegt.&lt;br&gt; Der Wert “0” entspricht der kleinsten,&lt;br&gt; 100 der maximalen Spannung in Prozent.&lt;/html&gt;</tooltip>
+         </variable>
+         <variable item="Function 2 option 1" CV="131" default="100" minOut="4">
+            <decVal max="100" />
+            <label>Dimming AUX 2</label>
+            <label xml:lang="de">Dimmen für AUX 2</label>
+            <tooltip>&lt;html&gt;Reduces the voltage on the function output in Prozent.&lt;br&gt; A value of “0” corresponds to the smallest,&lt;br&gt; a value of “15” to the maximal voltage.&lt;/html&gt;</tooltip>
+            <tooltip xml:lang="de">&lt;html&gt;Reduzierung der Spannung, die am Ausgang anliegt.&lt;br&gt; Der Wert “0” entspricht der kleinsten,&lt;br&gt; 100 der maximalen Spannung in Prozent.&lt;/html&gt;</tooltip>
+         </variable>
+         <variable item="Function 3 option 1" CV="141" default="100" minOut="3">
+            <decVal max="100" />
+            <label>Dimming AUX 3</label>
+            <label xml:lang="de">Dimmen für AUX 3</label>
+            <tooltip>&lt;html&gt;Reduces the voltage on the function output in Percent.&lt;br&gt; A value of “0” corresponds to the smallest,&lt;br&gt; a value of “100” to the maximal voltage.&lt;/html&gt;</tooltip>
+            <tooltip xml:lang="de">&lt;html&gt;Reduzierung der Spannung, die am Ausgang anliegt.&lt;br&gt; Der Wert “0” entspricht der kleinsten,&lt;br&gt; 100 der maximalen Spannung in Prozent.&lt;/html&gt;</tooltip>
+         </variable>
+         <variable item="Function 4 option 1" CV="151" default="100" minOut="4">
+            <decVal max="100" />
+            <label>Dimming AUX 4</label>
+            <label xml:lang="de">Dimmen für AUX 4</label>
+            <tooltip>&lt;html&gt;Reduces the voltage on the function output in Prozent.&lt;br&gt; A value of “0” corresponds to the smallest,&lt;br&gt; a value of “15” to the maximal voltage.&lt;/html&gt;</tooltip>
+            <tooltip xml:lang="de">&lt;html&gt;Reduzierung der Spannung, die am Ausgang anliegt.&lt;br&gt; Der Wert “0” entspricht der kleinsten,&lt;br&gt; 100 der maximalen Spannung in Prozent.&lt;/html&gt;</tooltip>
+         </variable>
+         <variable item="Function 5 option 1" CV="161" default="100" minOut="3">
+            <decVal max="100" />
+            <label>Dimming AUX 5</label>
+            <label xml:lang="de">Dimmen für AUX 5</label>
+            <tooltip>&lt;html&gt;Reduces the voltage on the function output in Percent.&lt;br&gt; A value of “0” corresponds to the smallest,&lt;br&gt; a value of “100” to the maximal voltage.&lt;/html&gt;</tooltip>
+            <tooltip xml:lang="de">&lt;html&gt;Reduzierung der Spannung, die am Ausgang anliegt.&lt;br&gt; Der Wert “0” entspricht der kleinsten,&lt;br&gt; 100 der maximalen Spannung in Prozent.&lt;/html&gt;</tooltip>
+         </variable>
+         <variable item="Function 6 option 1" CV="171" default="100" minOut="4">
+            <decVal max="100" />
+            <label>Dimming AUX 6</label>
+            <label xml:lang="de">Dimmen für AUX 6</label>
+            <tooltip>&lt;html&gt;Reduces the voltage on the function output in Prozent.&lt;br&gt; A value of “0” corresponds to the smallest,&lt;br&gt; a value of “15” to the maximal voltage.&lt;/html&gt;</tooltip>
+            <tooltip xml:lang="de">&lt;html&gt;Reduzierung der Spannung, die am Ausgang anliegt.&lt;br&gt; Der Wert “0” entspricht der kleinsten,&lt;br&gt; 100 der maximalen Spannung in Prozent.&lt;/html&gt;</tooltip>
+         </variable> 
+         <variable item="Function 11 effect generated" CV="97" default="14">  
+           <decVal max="68" />
+           <label>Function key for High beam (0-68)</label>
+           <label xml:lang="de">Funktions key Fernlicht (0-68)</label>           
+         </variable>    
+         <variable item="Fn Option 1" CV="50" default="0">
+           <decVal max="68" />
+           <label>Frontlight Function key number (0-68)</label>
+           <label xml:lang="de">Funktions key Vorderlicht (0-68)</label>         
+         </variable>
+         <variable item="Fn Option 2" CV="55" default="0">
+           <decVal max="68" />
+           <label>Rearlight Function key number (0-68)</label>
+           <label xml:lang="de">Funktions key Rücklicht (0-68)</label>
+         </variable>
+         <variable item="Fn Option 3" CV="120" default="0">
+           <decVal max="68" />
+           <label>Function key number for AUX 1 (0-68)</label>
+           <label xml:lang="de">Funktions key AUX1 (0-68)</label>
+         </variable>
+         <variable item="Fn Option 4" CV="130" default="0">
+           <decVal max="68" />
+           <label>Function key number for AUX 2 (0-68)</label>
+            <label xml:lang="de">Funktions key AUX2 (0-68)</label>
+         </variable>         
+         <variable item="Fn Option 5" CV="140" default="0">
+           <decVal max="68" />
+           <label>Function key number for AUX 3 (0-68)</label>
+           <label xml:lang="de">Funktions key AUX3 (0-68)</label>
+         </variable>
+         <variable item="Fn Option 6" CV="150" default="0">
+           <decVal max="68" />
+           <label>Function key number for AUX 4 (0-68)</label>
+           <label xml:lang="de">Funktions key AUX4 (0-68)</label>
+         </variable>         
+         <variable item="Fn Option 7" CV="160" default="0">
+           <decVal max="68" />
+           <label>Function key number for AUX 5 (0-68)</label>           
+           <label xml:lang="de">Funktions key AUX5 (0-68)</label></variable>
+         <variable item="Fn Option 8" CV="170" default="0">
+           <decVal max="68" />
+           <label>Function key number for AUX 6 (0-68)</label>
+           <label xml:lang="de">Funktions key AUX6 (0-68)</label>
+         </variable>
+         
+<!-- Analog Modus -->
+    <variable item="Analog Mode Function Status - F1" CV="13" mask="XXXXXXXV" minFn="1">
+      <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+      <label>Analog Mode Function Status - F1</label>
+      <label xml:lang="it">Stato Funzioni in analogico - F1</label>
+      <label xml:lang="cs">Stav funkce v analogovém režimu - F1</label>
+      <label xml:lang="fr">État de la fonction en analogique - F1</label>
+      <label xml:lang="de">Funktionsstatus im Analogbetrieb - F1</label>
+      <label xml:lang="nl">Funktiestatus Analoog - F1</label>
+      <label xml:lang="es">Estado de la función en modo análogo - F1</label>
+      <tooltip>Check to enable function F1 when the unit is operating in Analog power mode</tooltip>
+      <tooltip xml:lang="cs">Zkontroluje zdali je povolena fukce F1 když jednotka je provozována v režimu analogového napájení</tooltip>
+      <tooltip xml:lang="de">Auswählen um Function F1 zu aktivieren im Analogbetrieb</tooltip>
+      <tooltip xml:lang="nl">Selecteer om functie F1 te activeren tijdens Analoog rijden</tooltip>
+      <tooltip xml:lang="es">Marque para habilitar la función F1 cuando se use en modo análogo</tooltip>
+    </variable>
+    <variable item="Analog Mode Function Status - F2" CV="13" mask="XXXXXXVX" minFn="2">
+      <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+      <label>Analog Mode Function Status - F2</label>
+      <label xml:lang="it">Stato Funzioni in analogico - F2</label>
+      <label xml:lang="cs">Stav funkce v analogovém režimu - F2</label>
+      <label xml:lang="fr">État de la fonction en analogique - F2</label>
+      <label xml:lang="de">Funktionsstatus im Analogbetrieb - F2</label>
+      <label xml:lang="nl">Funktiestatus Analoog - F2</label>
+      <label xml:lang="es">Estado de la función en modo análogo - F2</label>
+      <tooltip>Check to enable function F2 when the unit is operating in Analog power mode</tooltip>
+      <tooltip xml:lang="cs">Zkontroluje zdali je povolena fukce F2 když jednotka je provozována v režimu analogového napájení</tooltip>
+      <tooltip xml:lang="de">Auswählen um Function F2 zu aktivieren im Analogbetrieb</tooltip>
+      <tooltip xml:lang="nl">Selecteer om functie F2 te activeren tijdens Analoog rijden</tooltip>
+      <tooltip xml:lang="es">Marque para habilitar la función F2 cuando se use en modo análogo</tooltip>
+    </variable>
+    <variable item="Analog Mode Function Status - F3" CV="13" mask="XXXXXVXX" minFn="3">
+      <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+      <label>Analog Mode Function Status - F3</label>
+      <label xml:lang="it">Stato Funzioni in analogico - F3</label>
+      <label xml:lang="cs">Stav funkce v analogovém režimu - F3</label>
+      <label xml:lang="fr">État de la fonction en analogique - F3</label>
+      <label xml:lang="de">Funktionsstatus im Analogbetrieb - F3</label>
+      <label xml:lang="nl">Funktiestatus Analoog - F3</label>
+      <label xml:lang="es">Estado de la función en modo análogo - F3</label>
+      <tooltip>Check to enable function F3 when the unit is operating in Analog power mode</tooltip>
+      <tooltip xml:lang="cs">Zkontroluje zdali je povolena fukce F3 když jednotka je provozována v režimu analogového napájení</tooltip>
+      <tooltip xml:lang="de">Auswählen um Function F3 zu aktivieren im Analogbetrieb</tooltip>
+      <tooltip xml:lang="nl">Selecteer om functie F3 te activeren tijdens Analoog rijden</tooltip>
+      <tooltip xml:lang="es">Marque para habilitar la función F3 cuando se use en modo análogo</tooltip>
+    </variable>
+    <variable item="Analog Mode Function Status - F4" CV="13" mask="XXXXVXXX" minFn="4">
+      <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+      <label>Analog Mode Function Status - F4</label>
+      <label xml:lang="it">Stato Funzioni in analogico - F4</label>
+      <label xml:lang="cs">Stav funkce v analogovém režimu - F4</label>
+      <label xml:lang="fr">État de la fonction en analogique - F4</label>
+      <label xml:lang="de">Funktionsstatus im Analogbetrieb - F4</label>
+      <label xml:lang="nl">Funktiestatus Analoog - F4</label>
+      <label xml:lang="es">Estado de la función en modo análogo - F4</label>
+      <tooltip>Check to enable function F4 when the unit is operating in Analog power mode</tooltip>
+      <tooltip xml:lang="cs">Zkontroluje zdali je povolena fukce F4 když jednotka je provozována v režimu analogového napájení</tooltip>
+      <tooltip xml:lang="de">Auswählen um Function F4 zu aktivieren im Analogbetrieb</tooltip>
+      <tooltip xml:lang="nl">Selecteer om functie F4 te activeren tijdens Analoog rijden</tooltip>
+      <tooltip xml:lang="es">Marque para habilitar la función F4 cuando se use en modo análogo</tooltip>
+    </variable>
+    <variable item="Analog Mode Function Status - F5" CV="13" mask="XXXVXXXX" minFn="5">
+      <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+      <label>Analog Mode Function Status - F5</label>
+      <label xml:lang="it">Stato Funzioni in analogico - F5</label>
+      <label xml:lang="cs">Stav funkce v analogovém režimu - F5</label>
+      <label xml:lang="fr">État de la fonction en analogique - F5</label>
+      <label xml:lang="de">Funktionsstatus im Analogbetrieb - F5</label>
+      <label xml:lang="nl">Funktiestatus Analoog - F5</label>
+      <label xml:lang="es">Estado de la función en modo análogo - F5</label>
+
+      <tooltip>Check to enable function F5 when the unit is operating in Analog power mode</tooltip>
+      <tooltip xml:lang="cs">Zkontroluje zdali je povolena fukce F5 když jednotka je provozována v režimu analogového napájení</tooltip>
+      <tooltip xml:lang="de">Auswählen um Function F5 zu aktivieren im Analogbetrieb</tooltip>
+      <tooltip xml:lang="nl">Selecteer om functie F5 te activeren tijdens Analoog rijden</tooltip>
+      <tooltip xml:lang="es">Marque para habilitar la función F5 cuando se use en modo análogo</tooltip>
+    </variable>
+    <variable item="Analog Mode Function Status - F6" CV="13" mask="XXVXXXXX" minFn="6">
+      <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+      <label>Analog Mode Function Status - F6</label>
+      <label xml:lang="it">Stato Funzioni in analogico - F6</label>
+      <label xml:lang="cs">Stav funkce v analogovém režimu - F6</label>
+      <label xml:lang="fr">État de la fonction en analogique - F6</label>
+      <label xml:lang="de">Funktionsstatus im Analogbetrieb - F6</label>
+      <label xml:lang="nl">Funktiestatus Analoog - F6</label>
+      <label xml:lang="es">Estado de la función en modo análogo - F6</label>
+      <tooltip>Check to enable function F6 when the unit is operating in Analog power mode</tooltip>
+      <tooltip xml:lang="cs">Zkontroluje zdali je povolena fukce F6 když jednotka je provozována v režimu analogového napájení</tooltip>
+      <tooltip xml:lang="de">Auswählen um Function F6 zu aktivieren im Analogbetrieb</tooltip>
+      <tooltip xml:lang="nl">Selecteer om functie F6 te activeren tijdens Analoog rijden</tooltip>
+      <tooltip xml:lang="es">Marque para habilitar la función F6 cuando se use en modo análogo</tooltip>
+    </variable>
+    
+    <variable item="Condition Option 1" CV="52" default="1">
+    <enumVal>
+      <enumChoice choice="Normal" value="0">
+        <choice>Normal</choice>
+      </enumChoice>
+      <enumChoice choice="Forward" value="1">
+        <choice>Forward</choice>
+      </enumChoice>
+      <enumChoice choice="Backward" value="2">
+        <choice>Backward</choice>
+      </enumChoice>
+      <enumChoice choice="Standig" value="3">
+        <choice>Standing</choice>
+      </enumChoice>
+      <enumChoice choice="Standing Forward" value="4">
+        <choice>Standing Forward</choice>
+      </enumChoice>
+      <enumChoice choice="Standing Backward" value="5">
+        <choice>Standing Backward</choice>
+      </enumChoice>
+      <enumChoice choice="Driving" value="6">
+        <choice>Driving</choice>
+      </enumChoice>
+      <enumChoice choice="Drinving Forward" value="7">
+        <choice>Driving Forward</choice>
+      </enumChoice>
+      <enumChoice choice="Driving Backward" value="8">
+        <choice>Driving Backward</choice>
+      </enumChoice>
+    </enumVal>
+    <label>Frontlight Condition</label> 
+    <label xml:lang="de">Vorderlicht Bedingung</label>   
+    </variable>
+    <variable item="Condition Option 2" CV="57" default="2">
+    <enumVal>
+      <enumChoice choice="Normal" value="0">
+        <choice>Normal</choice>
+      </enumChoice>
+      <enumChoice choice="Forward" value="1">
+        <choice>Forward</choice>
+      </enumChoice>
+      <enumChoice choice="Backward" value="2">
+        <choice>Backward</choice>
+      </enumChoice>
+      <enumChoice choice="Standig" value="3">
+        <choice>Standing</choice>
+      </enumChoice>
+      <enumChoice choice="Standing Forward" value="4">
+        <choice>Standing Forward</choice>
+      </enumChoice>
+      <enumChoice choice="Standing Backward" value="5">
+        <choice>Standing Backward</choice>
+      </enumChoice>
+      <enumChoice choice="Driving" value="6">
+        <choice>Driving</choice>
+      </enumChoice>
+      <enumChoice choice="Drinving Forward" value="7">
+        <choice>Driving Forward</choice>
+      </enumChoice>
+      <enumChoice choice="Driving Backward" value="8">
+        <choice>Driving Backward</choice>
+      </enumChoice>
+    </enumVal>
+    <label>Rearlight Condition</label>
+    <label xml:lang="de">Rücklicht Bedingung</label>     
+    </variable>
+    <variable item="Condition Option 3" CV="122" default="0">
+    <enumVal>
+      <enumChoice choice="Normal" value="0">
+        <choice>Normal</choice>
+      </enumChoice>
+      <enumChoice choice="Forward" value="1">
+        <choice>Forward</choice>
+      </enumChoice>
+      <enumChoice choice="Backward" value="2">
+        <choice>Backward</choice>
+      </enumChoice>
+      <enumChoice choice="Standig" value="3">
+        <choice>Standing</choice>
+      </enumChoice>
+      <enumChoice choice="Standing Forward" value="4">
+        <choice>Standing Forward</choice>
+      </enumChoice>
+      <enumChoice choice="Standing Backward" value="5">
+        <choice>Standing Backward</choice>
+      </enumChoice>
+      <enumChoice choice="Driving" value="6">
+        <choice>Driving</choice>
+      </enumChoice>
+      <enumChoice choice="Drinving Forward" value="7">
+        <choice>Driving Forward</choice>
+      </enumChoice>
+      <enumChoice choice="Driving Backward" value="8">
+        <choice>Driving Backward</choice>
+      </enumChoice>
+    </enumVal>
+    <label>AUX1 Condition</label>
+    <label xml:lang="de">AUX1 Bedingung</label>     
+    </variable>
+    <variable item="Condition Option 4" CV="132" default="0">
+    <enumVal>
+      <enumChoice choice="Normal" value="0">
+        <choice>Normal</choice>
+      </enumChoice>
+      <enumChoice choice="Forward" value="1">
+        <choice>Forward</choice>
+      </enumChoice>
+      <enumChoice choice="Backward" value="2">
+        <choice>Backward</choice>
+      </enumChoice>
+      <enumChoice choice="Standig" value="3">
+        <choice>Standing</choice>
+      </enumChoice>
+      <enumChoice choice="Standing Forward" value="4">
+        <choice>Standing Forward</choice>
+      </enumChoice>
+      <enumChoice choice="Standing Backward" value="5">
+        <choice>Standing Backward</choice>
+      </enumChoice>
+      <enumChoice choice="Driving" value="6">
+        <choice>Driving</choice>
+      </enumChoice>
+      <enumChoice choice="Drinving Forward" value="7">
+        <choice>Driving Forward</choice>
+      </enumChoice>
+      <enumChoice choice="Driving Backward" value="8">
+        <choice>Driving Backward</choice>
+      </enumChoice>
+    </enumVal>
+    <label>AUX2 Condition</label> 
+    <label xml:lang="de">AUX2 Bedingung</label>   
+    </variable>
+    <variable item="Condition Option 5" CV="142" default="0">
+    <enumVal>
+      <enumChoice choice="Normal" value="0">
+        <choice>Normal</choice>
+      </enumChoice>
+      <enumChoice choice="Forward" value="1">
+        <choice>Forward</choice>
+      </enumChoice>
+      <enumChoice choice="Backward" value="2">
+        <choice>Backward</choice>
+      </enumChoice>
+      <enumChoice choice="Standig" value="3">
+        <choice>Standing</choice>
+      </enumChoice>
+      <enumChoice choice="Standing Forward" value="4">
+        <choice>Standing Forward</choice>
+      </enumChoice>
+      <enumChoice choice="Standing Backward" value="5">
+        <choice>Standing Backward</choice>
+      </enumChoice>
+      <enumChoice choice="Driving" value="6">
+        <choice>Driving</choice>
+      </enumChoice>
+      <enumChoice choice="Drinving Forward" value="7">
+        <choice>Driving Forward</choice>
+      </enumChoice>
+      <enumChoice choice="Driving Backward" value="8">
+        <choice>Driving Backward</choice>
+      </enumChoice>
+    </enumVal>
+    <label>AUX3 Condition</label>
+    <label xml:lang="de">AUX3 Bedingung</label>    
+    </variable>
+    <variable item="Condition Option 6" CV="152" default="0">
+    <enumVal>
+      <enumChoice choice="Normal" value="0">
+        <choice>Normal</choice>
+      </enumChoice>
+      <enumChoice choice="Forward" value="1">
+        <choice>Forward</choice>
+      </enumChoice>
+      <enumChoice choice="Backward" value="2">
+        <choice>Backward</choice>
+      </enumChoice>
+      <enumChoice choice="Standig" value="3">
+        <choice>Standing</choice>
+      </enumChoice>
+      <enumChoice choice="Standing Forward" value="4">
+        <choice>Standing Forward</choice>
+      </enumChoice>
+      <enumChoice choice="Standing Backward" value="5">
+        <choice>Standing Backward</choice>
+      </enumChoice>
+      <enumChoice choice="Driving" value="6">
+        <choice>Driving</choice>
+      </enumChoice>
+      <enumChoice choice="Drinving Forward" value="7">
+        <choice>Driving Forward</choice>
+      </enumChoice>
+      <enumChoice choice="Driving Backward" value="8">
+        <choice>Driving Backward</choice>
+      </enumChoice>
+    </enumVal>
+    <label>AUX4 Condition</label>
+    <label xml:lang="de">AUX4 Bedingung</label>    
+    </variable>
+    <variable item="Condition Option 7" CV="162" default="0">
+    <enumVal>
+      <enumChoice choice="Normal" value="0">
+        <choice>Normal</choice>
+      </enumChoice>
+      <enumChoice choice="Forward" value="1">
+        <choice>Forward</choice>
+      </enumChoice>
+      <enumChoice choice="Backward" value="1">
+        <choice>Backward</choice>
+      </enumChoice>
+      <enumChoice choice="Standig" value="3">
+        <choice>Standing</choice>
+      </enumChoice>
+      <enumChoice choice="Standing Forward" value="4">
+        <choice>Standing Forward</choice>
+      </enumChoice>
+      <enumChoice choice="Standing Backward" value="5">
+        <choice>Standing Backward</choice>
+      </enumChoice>
+      <enumChoice choice="Driving" value="6">
+        <choice>Driving</choice>
+      </enumChoice>
+      <enumChoice choice="Drinving Forward" value="7">
+        <choice>Driving Forward</choice>
+      </enumChoice>
+      <enumChoice choice="Driving Backward" value="8">
+        <choice>Driving Backward</choice>
+      </enumChoice>
+    </enumVal>
+    <label>AUX5 Condition</label>
+    <label xml:lang="de">AUX5 Bedingung</label>    
+    </variable>
+    <variable item="Condition Option 8" CV="172" default="0">
+    <enumVal>
+      <enumChoice choice="Normal" value="0">
+        <choice>Normal</choice>
+      </enumChoice>
+      <enumChoice choice="Forward" value="1">
+        <choice>Forward</choice>
+      </enumChoice>
+      <enumChoice choice="Backward" value="2">
+        <choice>Backward</choice>
+      </enumChoice>
+      <enumChoice choice="Standig" value="3">
+        <choice>Standing</choice>
+      </enumChoice>
+      <enumChoice choice="Standing Forward" value="4">
+        <choice>Standing Forward</choice>
+      </enumChoice>
+      <enumChoice choice="Standing Backward" value="5">
+        <choice>Standing Backward</choice>
+      </enumChoice>
+      <enumChoice choice="Driving" value="6">
+        <choice>Driving</choice>
+      </enumChoice>
+      <enumChoice choice="Drinving Forward" value="7">
+        <choice>Driving Forward</choice>
+      </enumChoice>
+      <enumChoice choice="Driving Backward" value="8">
+        <choice>Driving Backward</choice>
+      </enumChoice>
+    </enumVal>
+    <label>AUX6 Condition</label>
+    <label xml:lang="de">AUX6 Bedingung</label>    
+    </variable>   
+    
+    </variables>      
+   </decoder>
+<pane>
+  <name>Output Control</name>
+  <name xml:lang="cs">Output Control</name>
+  <name xml:lang="de">Output Control</name>
+  <name xml:lang="fr">Output Control</name>
+  <name xml:lang="it">Output Control</name>
+  <name xml:lang="nl">Output Control</name>
+  <name xml:lang="es">Output Control</name>
+
+  <column>
+    <display item="AUX Option 1"/>
+    <display item="AUX Option 2"/>
+    <display item="AUX Option 3"/>
+    <display item="AUX Option 4"/>
+    <display item="AUX Option 5"/>
+    <display item="AUX Option 6"/>
+    <display item="AUX Option 7"/>
+    <display item="AUX Option 8"/>
+    <display item="AUX Option 9"/>
+    <display item="AUX Option 10"/>
+  </column>
+    <column>
+    <display item="Condition Option 1"/>
+    <display item="Condition Option 2"/>
+    <display item="Condition Option 3"/>
+    <display item="Condition Option 4"/>
+    <display item="Condition Option 5"/>
+    <display item="Condition Option 6"/>
+    <display item="Condition Option 7"/>
+    <display item="Condition Option 8"/>
+    <display item="Condition Option 9"/>
+    <display item="Condition Option 10"/>
+  </column>
+  <column>
+    <display item="Time Option 1"/>
+    <display item="Time Option 2"/>    
+    <display item="Time Option 3"/>    
+    <display item="Time Option 4"/>    
+    <display item="Time Option 5"/>    
+    <display item="Time Option 6"/>    
+    <display item="Time Option 7"/>    
+    <display item="Time Option 8"/>    
+  </column>  
+  <column>
+    <display item="Fn Option 1"/>
+    <display item="Fn Option 2"/>
+    <display item="Fn Option 3"/>
+    <display item="Fn Option 4"/>
+    <display item="Fn Option 5"/>
+    <display item="Fn Option 6"/>
+    <display item="Fn Option 7"/>
+    <display item="Fn Option 8"/>
+    <display item="Fn Option 9"/>
+    <display item="Fn Option 10"/>    
+  </column>
+</pane>
+</decoder-config>

--- a/xml/nmra_mfg_list.xml
+++ b/xml/nmra_mfg_list.xml
@@ -224,6 +224,7 @@
       <!-- not registered, provide custom numbers -->
       <manufacturer mfg="LEB" mfgID="1002" />
       <manufacturer mfg="Logic Rail Technologies" mfgID="1003" />
+      <manufacturer mfg="Decoderwerk" mfgID="1004" />
       
 
 </mfgList>

--- a/xml/nmra_mfg_list.xml
+++ b/xml/nmra_mfg_list.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet href="/xml/XSLT/mfgID.xsl" type="text/xsl"?>
-<mfgList nmraListDate="2021-03-06" updated="2023-01-25" lastadd="169"
+<mfgList nmraListDate="2024-12-10" updated="2025-03-30" lastadd="171"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/nmra_mfg_list-4-19-1.xsd">
 
   <!--
@@ -43,7 +43,7 @@
     with the NMRAs very idiosyncratic form.
   -->
       <manufacturer mfg="NMRA" mfgID="999" />
-      <manufacturer mfg="A-Train Electronics" mfgID="137" />
+      <manufacturer mfg="A-Train Electronics" mfgID="137" /><!-- no longer in NMRA list-->
       <manufacturer mfg="Advance IC Engineering, Inc." mfgID="17" />
       <manufacturer mfg="AE Electronic Ltd" mfgID="169" />
       <manufacturer mfg="AMW" mfgID="19" />
@@ -60,6 +60,7 @@
       <manufacturer mfg="BLOCKsignalling" mfgID="148" />
       <manufacturer mfg="Bluecher-Electronic" mfgID="60" />
       <manufacturer mfg="Blue Digital" mfgID="225" />
+      <manufacturer mfg="bogobit" mfgID="171" />
       <manufacturer mfg="Brelec" mfgID="31" />
       <manufacturer mfg="BRAWA Modellspielwaren GmbH" mfgID="186" />
       <manufacturer mfg="Broadway Limited Imports, LLC" mfgID="38" />
@@ -80,7 +81,7 @@
       <manufacturer mfg="Dietz Modellbahntechnik" mfgID="115" />
       <manufacturer mfg="Digi-CZ" mfgID="152" />
       <manufacturer mfg="Digikeijs" mfgID="42" />
-      <manufacturer mfg="Digirails" mfgID="42" />
+      <manufacturer mfg="Digirails" mfgID="42" /><!-- note duplicates 42; not in NMRA listing -->
       <manufacturer mfg="Digital Bahn" mfgID="64" />
       <manufacturer mfg="Digitools Elektronika, Kft" mfgID="75" />
       <manufacturer mfg="Digitrax" mfgID="129" />
@@ -92,8 +93,8 @@
       <manufacturer mfg="Electronic Solutions Ulm GmbH" mfgID="151" />
       <manufacturer mfg="Electroniscript, inc" mfgID="94" />
       <manufacturer mfg="E-Modell" mfgID="69" />
-      <manufacturer mfg="ECCO GmbH" mfgID="121" />
-      <manufacturer mfg="Fleischmann" mfgID="155" />
+      <manufacturer mfg="ECCO GmbH" mfgID="121" /><!-- no longer in NMRA listing -->
+      <manufacturer mfg="Fleischmann" mfgID="155" /><!-- no longer in NMRA listing -->
       <manufacturer mfg="Frateschi Model Trains" mfgID="128" />
       <manufacturer mfg="Fucik" mfgID="158" />
       <manufacturer mfg="Gaugemaster" mfgID="65" />
@@ -120,13 +121,13 @@
       <manufacturer mfg="KRES GmbH" mfgID="58" />
       <manufacturer mfg="Krois-Modell" mfgID="52" />
       <manufacturer mfg="Kuehn Ing." mfgID="157" />
+      <manufacturer mfg="Lahti Associates" mfgID="14" /><!-- not in NMRA listing-->
+      <manufacturer mfg="LaisDCC" mfgID="134" />
+      <manufacturer mfg="Lenz" mfgID="99" />
       <manufacturer mfg="LDH" mfgID="56" />
       <manufacturer mfg="LGB" mfgID="159" />
       <manufacturer mfg="LSdigital" mfgID="112" />
       <manufacturer mfg="LS Models Sprl" mfgID="77" />
-      <manufacturer mfg="LaisDCC" mfgID="134" />
-      <manufacturer mfg="Lahti Associates" mfgID="14" />
-      <manufacturer mfg="Lenz" mfgID="99" />
       <manufacturer mfg="Maison de DCC" mfgID="166" />
       <manufacturer mfg="Massoth Elektronik, GmbH" mfgID="123" />
       <manufacturer mfg="MAWE Elektronik" mfgID="68" />
@@ -151,7 +152,7 @@
       <manufacturer mfg="Ngineering" mfgID="43" />
       <manufacturer mfg="NMRA Reserved" mfgID="238" />
       <manufacturer mfg="Noarail" mfgID="63" />
-      <manufacturer mfg="Nucky" mfgID="156" />
+      <manufacturer mfg="Nucky" mfgID="156" /><!--  Also earlier in NMRA listing-->
       <manufacturer mfg="NYRS" mfgID="136" />
       <manufacturer mfg="Opherline1" mfgID="106" />
       <manufacturer mfg="Passmann" mfgID="41" />
@@ -177,7 +178,7 @@
       <manufacturer mfg="Regal Way Co. Ltd" mfgID="32" />
       <manufacturer mfg="Rock Junction Controls" mfgID="149" />
       <manufacturer mfg="Rocrail" mfgID="70" />
-      <manufacturer mfg="Roco Modelspielwaren" mfgID="161" />
+      <manufacturer mfg="Roco Modelspielwaren" mfgID="161" /><!-- NMRA lists under another name-->
       <manufacturer mfg="RR-CirKits" mfgID="87" />
       <manufacturer mfg="S Helper Service" mfgID="23" />
       <manufacturer mfg="Sanda Kan Industrial" mfgID="95" />
@@ -185,9 +186,9 @@
       <manufacturer mfg="SLOMO Railroad Models" mfgID="142" />
       <manufacturer mfg="Spectrum Engineering" mfgID="80" />
       <manufacturer mfg="SPROG DCC" mfgID="44" />
-      <manufacturer mfg="Signaling Solution" mfgID="119" />
-      <manufacturer mfg="Silicon Railway" mfgID="33" />
-      <manufacturer mfg="SoundTraxx (Throttle-Up)" mfgID="141" />
+      <manufacturer mfg="Signaling Solution" mfgID="119" /><!-- not in NMRA listing -->
+      <manufacturer mfg="Silicon Railway" mfgID="33" /><!-- not in NMRA listing -->
+      <manufacturer mfg="SoundTraxx (Throttle-Up)" mfgID="141" /><!-- NMRA lists under another name-->
       <manufacturer mfg="T4T - Technology for Trains GmbH" mfgID="20" />
       <manufacturer mfg="Tam Valley Depot" mfgID="59" />
       <manufacturer mfg="Tams Elektronik GmbH" mfgID="62" />

--- a/xml/schema/decoder-4-15-2.xsd
+++ b/xml/schema/decoder-4-15-2.xsd
@@ -632,6 +632,7 @@
     <xs:attribute name="highVersionID" type="xs:int" />
     <xs:attribute name="type" type="xs:string" />
     <xs:attribute name="comment" type="xs:string" />
+    <xs:attribute name="modes" type="xs:string" />
 
     <xs:attribute name="uid" type="xs:string" default="">
       <xs:annotation><xs:documentation>Globally unique ID used by DCCwiki; JMRI does not check for nor maintain uniqueness</xs:documentation></xs:annotation>


### PR DESCRIPTION
See Issue #13993

Also updates the NMRA manufacturer ID list to current contents

Also also fixes a schema incompatibility in the decoder index inadvertently created by #13927