### PR TITLE
Fix: SCWarrant start with un-occupied start block

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -648,13 +648,13 @@
    <h3>Warrants</h3>
         <a id="Wt" name="Wt"></a>
         <ul>
-             <li>SCWarrants brought back to life with a few fixes:  
+            <li>SCWarrants brought back to life with a few fixes:  
 	        <ul>
-                    <li>It is once again possible to create SCWarrants.</li>
-		    <li>Train tracking is now working.</li>
-		    <li>Opening the edit dialog for an SCWarrant now shows the correct warrant type.</li>
-		</ul>
-            </li>
+                <li>It is once again possible to create SCWarrants.</li>
+		        <li>Train tracking is now working.</li>
+		        <li>Opening the edit dialog for an SCWarrant now shows the correct warrant type.</li>
+				<li>Starting an SCWarrants with an un-occupied starting block once agin works as it should, i.e. it is delyed until the starting block become occupied.</li>
+		    </ul>
         </ul>
 
    <h3>Web Access</h3>

--- a/java/src/jmri/jmrit/logix/SCWarrant.java
+++ b/java/src/jmri/jmrit/logix/SCWarrant.java
@@ -188,6 +188,9 @@ public class SCWarrant extends Warrant {
         } else if (_runMode != MODE_RUN) {
             return ("Idle");
         } else {
+            if (getBlockOrderAt(getCurrentOrderIndex()) == null) {
+                return ("Uninitialized");
+            }
             String block = getBlockOrderAt(getCurrentOrderIndex()).getBlock().getDisplayName();
             String signal = "no signal";
             String aspect = "none";
@@ -219,7 +222,6 @@ public class SCWarrant extends Warrant {
      * This is "the main loop" for running a Signal Controlled Warrant
      ******************************************************************************************************/
     protected void runSignalControlledTrain () {
-        waitForStartblockToGetOccupied();
         allocateBlocksAndSetTurnouts(0);
         setTrainDirection();
         SCTrainRunner thread = new SCTrainRunner(this);
@@ -412,6 +414,32 @@ public class SCWarrant extends Warrant {
         }
     }
 
+    @Override
+    public String setRunMode(int mode, DccLocoAddress address,
+            LearnThrottleFrame student,
+            List<ThrottleSetting> commands, boolean runBlind) {
+        if (log.isDebugEnabled()) {
+            log.debug("{}: SCWarrant::setRunMode({}) ({}) called with _runMode= {}.",
+                  getDisplayName(), mode, MODES[mode], MODES[_runMode]);
+        }
+        _message = null;
+        if (_runMode != MODE_NONE) {
+            _message = getRunModeMessage();
+            log.error("{} called setRunMode when mode= {}. {}", getDisplayName(), MODES[_runMode],  _message);
+            return _message;
+        }
+        if (mode == MODE_RUN) {
+            // set mode before setStoppingBlock and callback to notifyThrottleFound are called
+            _runMode = mode;
+        } else {
+            deAllocate();
+            return _message;
+        }
+        getBlockAt(0)._entryTime = System.currentTimeMillis();
+        _message = acquireThrottle();
+        return _message;
+    } // end setRunMode
+
     /**
      * Block in the route going active.
      * Make sure to allocate the rest of the route, update our present location and then tell
@@ -420,18 +448,22 @@ public class SCWarrant extends Warrant {
     @Override
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(value = "NN_NAKED_NOTIFY", justification="NotifyAll call triggers recomputation")
     protected void goingActive(OBlock block) {
-        int activeIdx = getIndexOfBlockAfter(block, getCurrentOrderIndex());
-        log.debug("{} **Block \"{}\" goingActive. activeIdx= {}"
-                    + ", getCurrentOrderIndex()= {}"
-                    + " - warrant= {} _runMode = {} _throttle==null: {}",_trainName,block.getDisplayName(),activeIdx,getCurrentOrderIndex(),getDisplayName(),_runMode,(_throttle==null));
+        log.debug("{} **Block \"{}\" goingActive. "
+                    + " - warrant= {} _runMode = {} _throttle==null: {}",_trainName,block.getDisplayName(),getDisplayName(),_runMode,(_throttle==null));
         if (_runMode != MODE_RUN) {
             // if we are not running, we must not think that we are going to the next block - it must be another train
+            log.debug("_runMode != MODE_RUN - ignored");
             return;
         }
         if (_throttle == null || _throttle.getSpeedSetting() == SPEED_STOP) {
             // if we are not running, we must not think that we are going to the next block - it must be another train
+            log.debug("Train is not running - ignored");
             return;
         }
+        int activeIdx = getIndexOfBlockAfter(block, getCurrentOrderIndex());
+        log.debug("{} **Block \"{}\" goingActive. activeIdx= {}"
+                    + ", getCurrentOrderIndex()= {}"
+                    + " - warrant= {} _runMode = {} _throttle==null: {}",_trainName,block.getDisplayName(),activeIdx,getCurrentOrderIndex(),getDisplayName(),_runMode,(_throttle==null));
         if (activeIdx <= 0) {
             // The block going active is not part of our route ahead
             log.debug("{} Block going active is not part of this trains route forward",_trainName);
@@ -656,6 +688,8 @@ public class SCWarrant extends Warrant {
         @Override
         public void run() {
             synchronized(_warrant) {
+
+                waitForStartblockToGetOccupied();
 
                 // Make sure the entire route is allocated before attemting to start the train
                 if (!_allowShallowAllocation) {

--- a/java/src/jmri/jmrit/logix/SCWarrant.java
+++ b/java/src/jmri/jmrit/logix/SCWarrant.java
@@ -425,7 +425,7 @@ public class SCWarrant extends Warrant {
         _message = null;
         if (_runMode != MODE_NONE) {
             _message = getRunModeMessage();
-            log.error("{} called setRunMode when mode= {}. {}", getDisplayName(), MODES[_runMode],  _message);
+            log.debug("setRunMode called, but SCWarrant is already running");
             return _message;
         }
         if (mode == MODE_RUN) {


### PR DESCRIPTION
Starting an SCWarrant from the warrant list window would cause the UI thread to lock if the start block was un-occupied, because waiting for the start block to become occupied was done from within the UI thread.