### PR TITLE
Fix problem with locale in Java 21

### DIFF
--- a/java/src/jmri/jmrit/logixng/util/LogixNG_SelectDouble.java
+++ b/java/src/jmri/jmrit/logixng/util/LogixNG_SelectDouble.java
@@ -246,7 +246,7 @@ public class LogixNG_SelectDouble implements VetoableChangeListener {
      * @return speed formatted as %1.3f
      */
     public String formatValue(double value) {
-        return String.format(String.format("%%1.%df", _numDecimals), value);
+        return String.format(Locale.US, String.format("%%1.%df", _numDecimals), value);
     }
 
     public String getDescription(Locale locale) {


### PR DESCRIPTION
In Java 17, String.format() uses the English locale for decimal numbers. But in Java 21, String.format() uses the computer locale instead. This might cause localized numbers to be stored in the tables and panels xml file which then cannot be read. For example, the number 1.000 becomes 1,000 on a Swedish computer.