### PR TITLE
Bachrus speed step tweaks

### DIFF
--- a/java/src/jmri/jmrix/bachrus/SpeedoConsoleFrame.java
+++ b/java/src/jmri/jmrix/bachrus/SpeedoConsoleFrame.java
@@ -355,7 +355,7 @@ public class SpeedoConsoleFrame extends JmriJFrame implements SpeedoListener,
     protected JLabel speedStepScaleSpeedMatchWarmUpReverseUnit = new JLabel(Bundle.getMessage("SpeedMatchSecondsLabel"));
 
     protected JLabel speedStepScaleMaxSpeedTargetLabel = new JLabel(Bundle.getMessage("AdvancedSpeedMatchMaxSpeed"));
-    protected JComboBox<SpeedTableStepSpeed> speedStepScaleSpeedMatchMaxSpeedField = new JComboBox<>();
+    private final JComboBox<SpeedTableStepSpeed> speedStepScaleSpeedMatchMaxSpeedField = new JComboBox<>();
     protected JLabel speedStepScaleSpeedMatchMaxSpeedUnit = new JLabel(Bundle.getMessage("SpeedMatchMPHLabel"));
     protected JButton speedStepScaleSpeedMatchStartStopButton = new JButton(Bundle.getMessage(("SpeedMatchStartBtn")));
     protected JLabel speedStepScaleMaxSpeedActualLabel = new JLabel(Bundle.getMessage("AdvancedSpeedMatchActualMaxSpeed"), SwingConstants.RIGHT);

--- a/java/src/jmri/jmrix/bachrus/speedmatcher/speedStepScale/SpeedStepScaleESUTableSpeedMatcher.java
+++ b/java/src/jmri/jmrix/bachrus/speedmatcher/speedStepScale/SpeedStepScaleESUTableSpeedMatcher.java
@@ -1,5 +1,7 @@
 package jmri.jmrix.bachrus.speedmatcher.speedStepScale;
 
+import java.util.Locale;
+
 import jmri.DccThrottle;
 import jmri.jmrix.bachrus.Speed;
 
@@ -118,7 +120,7 @@ public class SpeedStepScaleESUTableSpeedMatcher extends SpeedStepScaleSpeedMatch
 
         speedMatcherState = SpeedMatcherState.WAIT_FOR_THROTTLE;
 
-        actualMaxSpeedField.setText(String.format("___"));
+        actualMaxSpeedField.setText("___");
 
         if (!initializeAndStartSpeedMatcher(e -> speedMatchTimeout())) {
             cleanUpSpeedMatcher();
@@ -291,7 +293,9 @@ public class SpeedStepScaleESUTableSpeedMatcher extends SpeedStepScaleSpeedMatch
                 } else {
                     measuredMaxSpeedKPH = currentSpeedKPH;
 
-                    String statusMessage = String.format("Measured maximum speed = %.1f KPH (%.1f MPH)", measuredMaxSpeedKPH, Speed.kphToMph(measuredMaxSpeedKPH));
+                    String statusMessage = String.format(Locale.getDefault(),
+                        "Measured maximum speed = %.1f KPH (%.1f MPH)",
+                            measuredMaxSpeedKPH, Speed.kphToMph(measuredMaxSpeedKPH));
                     logger.info(statusMessage);
                     
                     float speedMatchMaxSpeed;
@@ -307,7 +311,7 @@ public class SpeedStepScaleESUTableSpeedMatcher extends SpeedStepScaleSpeedMatch
                         speedMatchMaxSpeedKPH = speedUnit == Speed.Unit.MPH ? Speed.mphToKph(speedMatchMaxSpeed): speedMatchMaxSpeed;
                     }
                     
-                    actualMaxSpeedField.setText(String.format("%.1f", speedMatchMaxSpeed));
+                    actualMaxSpeedField.setText(String.format(Locale.getDefault(), "%.1f", speedMatchMaxSpeed));
                     
                     initNextSpeedMatcherState(SpeedMatcherState.FORWARD_SPEED_MATCH_VHIGH, 30);
                 }

--- a/java/src/jmri/jmrix/bachrus/speedmatcher/speedStepScale/SpeedStepScaleSpeedTableSpeedMatcher.java
+++ b/java/src/jmri/jmrix/bachrus/speedmatcher/speedStepScale/SpeedStepScaleSpeedTableSpeedMatcher.java
@@ -1,5 +1,7 @@
 package jmri.jmrix.bachrus.speedmatcher.speedStepScale;
 
+import java.util.Locale;
+
 import jmri.DccThrottle;
 import jmri.jmrix.bachrus.Speed;
 
@@ -99,7 +101,7 @@ public class SpeedStepScaleSpeedTableSpeedMatcher extends SpeedStepScaleSpeedMat
 
         speedMatcherState = SpeedMatcherState.WAIT_FOR_THROTTLE;
 
-        actualMaxSpeedField.setText(String.format("___"));
+        actualMaxSpeedField.setText("___");
 
         if (!initializeAndStartSpeedMatcher(e -> speedMatchTimeout())) {
             cleanUpSpeedMatcher();
@@ -259,7 +261,9 @@ public class SpeedStepScaleSpeedTableSpeedMatcher extends SpeedStepScaleSpeedMat
                 } else {
                     measuredMaxSpeedKPH = currentSpeedKPH;
 
-                    String statusMessage = String.format("Measured maximum speed = %.1f KPH (%.1f MPH)", measuredMaxSpeedKPH, Speed.kphToMph(measuredMaxSpeedKPH));
+                    String statusMessage = String.format(Locale.getDefault(),
+                        "Measured maximum speed = %.1f KPH (%.1f MPH)",
+                            measuredMaxSpeedKPH, Speed.kphToMph(measuredMaxSpeedKPH));
                     logger.info(statusMessage);
                     
                     float speedMatchMaxSpeed;
@@ -275,7 +279,7 @@ public class SpeedStepScaleSpeedTableSpeedMatcher extends SpeedStepScaleSpeedMat
                         speedMatchMaxSpeedKPH = speedUnit == Speed.Unit.MPH ? Speed.mphToKph(speedMatchMaxSpeed): speedMatchMaxSpeed;
                     }
                     
-                    actualMaxSpeedField.setText(String.format("%.1f", speedMatchMaxSpeed));
+                    actualMaxSpeedField.setText(String.format(Locale.getDefault(), "%.1f", speedMatchMaxSpeed));
                     
                     initNextSpeedMatcherState(SpeedMatcherState.FORWARD_SPEED_MATCH_STEP28, 30);
                 }

--- a/java/src/jmri/jmrix/bachrus/speedmatcher/speedStepScale/SpeedTableStepSpeed.java
+++ b/java/src/jmri/jmrix/bachrus/speedmatcher/speedStepScale/SpeedTableStepSpeed.java
@@ -1,5 +1,7 @@
 package jmri.jmrix.bachrus.speedmatcher.speedStepScale;
 
+import java.util.Locale;
+
 import jmri.jmrix.bachrus.speedmatcher.SpeedMatcher.SpeedTableStep;
 import static jmri.jmrix.bachrus.speedmatcher.speedStepScale.SpeedStepScaleSpeedMatcher.getSpeedForSpeedTableStep;
 
@@ -40,11 +42,11 @@ public class SpeedTableStepSpeed {
     }
 
     /**
-     * Converts this SpeedTableStepSpeed to a string
+     * Converts this SpeedTableStepSpeed to an I18N string.
      * @return a single decimal string of this SpeedTableStepSpeed's speed
      */
     @Override
     public String toString() {
-        return String.format("%.1f", this.speed);
+        return String.format(Locale.getDefault(), "%.1f", this.speed);
     }
 }


### PR DESCRIPTION
**SpeedoConsoleFrame** 
private JComboBox only use of SpeedTableStepSpeed toString

**SpeedTableStepSpeed** 
I18N of toString for use in JComboBox String

**SpeedStepScaleSpeedTableSpeedMatcher
SpeedTableStepSpeed**
Does not use string format to set underscore  text.
ok to use I18N in actualMaxSpeedField