### PR TITLE
Intl Utilities - add intValue, strip whitespace.

### DIFF
--- a/help/en/html/doc/Technical/I8N.shtml
+++ b/help/en/html/doc/Technical/I8N.shtml
@@ -386,7 +386,7 @@ attribute. "Null" will be returned if nothing is found.
       <h3 id="numbers">Numbers</h3>
 
       <p>The number "10*10*10+2+3/10" is written in different ways in different places: "1002.3",
-      "1,002.3", "1.002,3" and perhaps other ways.</p>
+      "1,002.3", "1.002,3", "1 002.3", "1 002,3", "1002.30", and perhaps other ways.</p>
 
       <p>JMRI provides a helpful utility for handling this on input:</p>
 
@@ -394,6 +394,7 @@ attribute. "Null" will be returned if nothing is found.
   <pre>
 double d = jmri.util.IntlUtilities.doubleValue("1,002.3");
 float  f = jmri.util.IntlUtilities.floatValue("1,002.3");
+int    i = jmri.util.IntlUtilities.intValue("1 002");
 </pre>
 </div>
 
@@ -403,10 +404,17 @@ so handling that is part of your user-error handling.
 <pre>
 String s = jmri.util.IntlUtilities.valueOf(1002.3);
 </pre>
+
+      <p><a href="../../../../../../JavaDoc/doc/jmri/util/IntlUtilities.html">IntlUtilities</a>
+      should only be used within the GUI.</p>
+
       <p><strong>Note: You should still store and load values in XML files in Java's default
       coding, without using these formatting tools. That way, the files can be moved from one user
       to another without worrying about whether they are using the same Locale.</strong>
       </p>
+
+      <p><code>String.format()</code> uses English locale for numbers in Java 17 but the computer locale for
+      numbers on Java 21. Care should be taken with this method within both GUI and XML.</p>
 
       <h3 id="testing">Testing</h3>
       <p>You should check that you've properly internationalized your code. We provide a tool for

--- a/java/src/jmri/util/IntlUtilities.java
+++ b/java/src/jmri/util/IntlUtilities.java
@@ -1,5 +1,10 @@
 package jmri.util;
 
+import java.text.NumberFormat;
+import java.text.ParseException;
+
+import javax.annotation.Nonnull;
+
 /**
  * Common utility methods for Internationalization (I18N) and Localization
  * (L12N) in the default {@link java.util.Locale}.
@@ -7,22 +12,27 @@ package jmri.util;
  * See http://jmri.org/help/en/html/doc/Technical/I8N.shtml
  *
  * @author Bob Jacobsen Copyright 2014
+ * @author Steve Young Copyright 2025
  * @since 3.9.3
  */
 public class IntlUtilities {
+
+    // class only supplies static methods
+    private IntlUtilities(){}
 
     /**
      * Parse a number.
      *
      * Use as a locale-aware replacement for Float.valueOf("1").floatValue() and
      * Float.parseFloat("1").floatValue().
-     *
+     * <p>
+     * White space, potentially included as a thousand separator is removed.
      * @param val the value to parse
      * @return a parsed number
      * @throws java.text.ParseException if val cannot be parsed as a number
      */
-    static public float floatValue(String val) throws java.text.ParseException {
-        return java.text.NumberFormat.getInstance().parse(val).floatValue();
+    public static float floatValue(@Nonnull String val) throws ParseException {
+        return NumberFormat.getInstance().parse(trimWhiteSpace(val)).floatValue();
     }
 
     /**
@@ -30,13 +40,33 @@ public class IntlUtilities {
      *
      * Use as a locale-aware replacement for Double.valueOf("1").doubleValue()
      * and Double.parseDouble("1").doubleValue().
-     *
+     * <p>
+     * White space, potentially included as a thousand separator is removed.
      * @param val the value to parse
      * @return a parsed number
      * @throws java.text.ParseException if val cannot be parsed as a number
      */
-    static public double doubleValue(String val) throws java.text.ParseException {
-        return java.text.NumberFormat.getInstance().parse(val).doubleValue();
+    public static double doubleValue(@Nonnull String val) throws ParseException {
+        return NumberFormat.getInstance().parse(trimWhiteSpace(val)).doubleValue();
+    }
+
+    /**
+     * Parse a number.
+     *
+     * Use as a locale-aware replacement for Integer.valueOf("1").intValue()
+     * and Integer.parseInt("1").intValue().
+     * <p>
+     * White space, potentially included as a thousand separator is removed.
+     * @param val the value to parse
+     * @return a parsed number
+     * @throws java.text.ParseException if val cannot be parsed as a number
+     */
+    public static int intValue(@Nonnull String val) throws ParseException {
+        return NumberFormat.getInstance().parse(trimWhiteSpace(val)).intValue();
+    }
+
+    private static String trimWhiteSpace(String val) {
+        return val.trim().replaceAll("\\s", "");
     }
 
     /**
@@ -47,8 +77,8 @@ public class IntlUtilities {
      * @param val the number
      * @return the text representation
      */
-    static public String valueOf(double val) {
-        return java.text.NumberFormat.getInstance().format(val);
+    public static String valueOf(double val) {
+        return NumberFormat.getInstance().format(val);
     }
 
     /**
@@ -59,10 +89,9 @@ public class IntlUtilities {
      * @param val the number
      * @return the text representation
      */
-    static public String valueOf(int val) {
-        return java.text.NumberFormat.getInstance().format(val);
+    public static String valueOf(int val) {
+        return NumberFormat.getInstance().format(val);
     }
 
-    // initialize logging
     //private final static Logger log = LoggerFactory.getLogger(IntlUtilities.class);
 }

--- a/java/test/jmri/util/IntlUtilitiesTest.java
+++ b/java/test/jmri/util/IntlUtilitiesTest.java
@@ -1,5 +1,6 @@
 package jmri.util;
 
+import java.text.ParseException;
 import java.util.Locale;
 
 import org.junit.Assert;
@@ -13,48 +14,80 @@ import org.junit.jupiter.api.*;
 public class IntlUtilitiesTest {
 
     @Test
-    public void testFloatInUSEnglish() throws java.text.ParseException {
+    public void testFloatInUSEnglish() throws ParseException {
         Locale startingLocale = Locale.getDefault();
         try {
             Locale.setDefault(Locale.US);
             Assert.assertEquals("1.0", 1.0f, IntlUtilities.floatValue("1.0"), 0.0);
             Assert.assertEquals("2.3", 2.3f, IntlUtilities.floatValue("2.3"), 0.0);
+            Assert.assertEquals("1234567.3", 1234567.3f, IntlUtilities.floatValue("1 234 567.3"), 0.0);
         } finally {
             Locale.setDefault(startingLocale);
         }
     }
 
     @Test
-    public void testFloatInItalyItalian() throws java.text.ParseException {
+    public void testFloatInItalyItalian() throws ParseException {
         Locale startingLocale = Locale.getDefault();
         try {
             Locale.setDefault(Locale.ITALY);
             Assert.assertEquals("1,0", 1.0f, IntlUtilities.floatValue("1,0"), 0.0);
             Assert.assertEquals("2,3", 2.3f, IntlUtilities.floatValue("2,3"), 0.0);
+            Assert.assertEquals("1234567,3", 1234567.3f, IntlUtilities.floatValue("1 234 567,3"), 0.0);
         } finally {
             Locale.setDefault(startingLocale);
         }
     }
 
     @Test
-    public void testDoubleInUSEnglish() throws java.text.ParseException {
+    public void testDoubleInUSEnglish() throws ParseException {
         Locale startingLocale = Locale.getDefault();
         try {
             Locale.setDefault(Locale.US);
             Assert.assertEquals("1.0", 1.0, IntlUtilities.doubleValue("1.0"), 0.0);
             Assert.assertEquals("2.3", 2.3, IntlUtilities.doubleValue("2.3"), 0.0);
+            Assert.assertEquals("1234567.3", 1234567.3, IntlUtilities.doubleValue("1 234 567.3"), 0.0);
         } finally {
             Locale.setDefault(startingLocale);
         }
     }
 
     @Test
-    public void testDoubleInItalyItalian() throws java.text.ParseException {
+    public void testDoubleInItalyItalian() throws ParseException {
         Locale startingLocale = Locale.getDefault();
         try {
             Locale.setDefault(Locale.ITALY);
             Assert.assertEquals("1,0", 1.0, IntlUtilities.doubleValue("1,0"), 0.0);
             Assert.assertEquals("2,3", 2.3, IntlUtilities.doubleValue("2,3"), 0.0);
+            Assert.assertEquals("1234567,3", 1234567.3, IntlUtilities.doubleValue("1 234 567,3"), 0.0);
+        } finally {
+            Locale.setDefault(startingLocale);
+        }
+    }
+
+    @Test
+    public void testIntInUKEnglish() throws ParseException {
+        Locale startingLocale = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.UK);
+            Assertions.assertEquals( 1111, IntlUtilities.intValue("1,111"));
+            Assertions.assertEquals( 1234567, IntlUtilities.intValue("1,234,567"));
+            Assertions.assertEquals( 1234568, IntlUtilities.intValue("1 234 568"));
+            Assertions.assertEquals( 1000, IntlUtilities.intValue("1000"));
+        } finally {
+            Locale.setDefault(startingLocale);
+        }
+    }
+
+    @Test
+    public void testIntInGerman() throws ParseException {
+        Locale startingLocale = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.GERMAN);
+            Assertions.assertEquals( 2023, IntlUtilities.intValue("2.023"));
+            Assertions.assertEquals( 1234567, IntlUtilities.intValue("1.234.567"));
+            Assertions.assertEquals( 1234568, IntlUtilities.intValue("1 234 568"));
+            Assertions.assertEquals( 2099, IntlUtilities.intValue("2099"));
         } finally {
             Locale.setDefault(startingLocale);
         }
@@ -105,6 +138,44 @@ public class IntlUtilitiesTest {
         } finally {
             Locale.setDefault(startingLocale);
         }
+    }
+
+    @Test
+    public void testExceptions(){
+
+        Exception ex = Assertions.assertThrows(ParseException.class, () ->
+            IntlUtilities.doubleValue(""));
+        Assertions.assertNotNull(ex);
+
+        ex = Assertions.assertThrows(ParseException.class, () ->
+            IntlUtilities.doubleValue("Not A Number !"));
+        Assertions.assertNotNull(ex);
+
+        ex = Assertions.assertThrows(ParseException.class, () ->
+            IntlUtilities.floatValue(""));
+        Assertions.assertNotNull(ex);
+
+        ex = Assertions.assertThrows(ParseException.class, () ->
+            IntlUtilities.floatValue("Not A Number !"));
+        Assertions.assertNotNull(ex);
+
+        ex = Assertions.assertThrows(ParseException.class, () ->
+            IntlUtilities.intValue(""));
+        Assertions.assertNotNull(ex);
+
+        ex = Assertions.assertThrows(ParseException.class, () ->
+            IntlUtilities.intValue("Not A Number !"));
+        Assertions.assertNotNull(ex);
+    }
+
+    @BeforeEach
+    public void setUp() {
+        JUnitUtil.setUp();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        JUnitUtil.tearDown();
     }
 
 }


### PR DESCRIPTION
**IntlUtilities**
Adds public static int intValue( String) to complement Float / Double methods.
Removes whitespace from Strings to enable processing of whitespace thousands separator.
Nonnull annotation.

**IntlUtilitiesTest**
Adds tests for intValue
Adds tests for exceptions.
Adds assertions for whitespace thousands separator.
Adds BeforeEach / AfterEach.

**I8N.shtml**
Add IntlUtilities.intValue