### PR TITLE
update About Dialog

### DIFF
--- a/java/src/apps/swing/AboutAction.java
+++ b/java/src/apps/swing/AboutAction.java
@@ -3,6 +3,7 @@ package apps.swing;
 import java.awt.event.ActionEvent;
 
 import javax.swing.Icon;
+import javax.swing.JFrame;
 
 import jmri.util.swing.*;
 
@@ -26,7 +27,14 @@ public class AboutAction extends JmriAbstractAction {
 
     @Override
     public void actionPerformed(ActionEvent e) {
-        new AboutDialog(null, true).setVisible(true);
+        JFrame tmp = null;
+        if ( e != null ) {
+            var x = jmri.util.swing.JmriJOptionPane.findWindowForObject(e.getSource());
+            if ( x instanceof JFrame ) {
+                tmp = (JFrame)x;
+            }
+        }
+        new AboutDialog(tmp, true).setVisible(true);
     }
 
     // never invoked, because we overrode actionPerformed above

--- a/java/src/apps/swing/AboutDialog.java
+++ b/java/src/apps/swing/AboutDialog.java
@@ -10,35 +10,49 @@ import jmri.jmrix.ConnectionConfig;
 import jmri.jmrix.ConnectionConfigManager;
 import jmri.swing.ConnectionLabel;
 import jmri.util.FileUtil;
+import jmri.util.swing.JmriJOptionPane;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * About dialog.
  *
  * @author Randall Wood Copyright (C) 2012
  */
-public final class AboutDialog extends JDialog {
+public final class AboutDialog {
 
-    // this should probably be changed to a JmriAbstractAction that opens a JmriJOptionPane with the contents and an OK button instead.
-    public AboutDialog(JFrame frame, boolean modal) {
+    private final JFrame frame;
+    private final boolean modal;
 
-        super(frame, modal);
+    // this should probably be changed to a JmriAbstractAction.
+    public AboutDialog(JFrame jframe, boolean isModal) {
+        frame = jframe;
+        modal = isModal;
+        
+    }
 
+    public void setVisible(boolean visible) {
+        if ( !visible ) {
+            return;
+        }
         log.debug("Start UI");
+        if (modal) {
+            JmriJOptionPane.showMessageDialog(frame, getMainPanel(),
+                Bundle.getMessage("TitleAbout", Application.getApplicationName()),
+                JmriJOptionPane.PLAIN_MESSAGE);
+        } else {
+            JmriJOptionPane.showMessageDialogNonModal(frame, getMainPanel(),
+                Bundle.getMessage("TitleAbout", Application.getApplicationName()),
+                JmriJOptionPane.PLAIN_MESSAGE, null);
+        }
+    }
 
+    private JPanel getMainPanel(){
         JPanel pane = new JPanel();
         pane.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
         pane.setLayout(new BoxLayout(pane, BoxLayout.Y_AXIS));
         pane.add(namePane());
         pane.add(infoPane());
-        this.add(pane);
-        this.pack();
-        this.setResizable(false);
-        this.setLocationRelativeTo(null); // center on screen
-        this.setTitle(Bundle.getMessage("TitleAbout", Application.getApplicationName()));
-        log.debug("End constructor");
+        return pane;
     }
 
     protected JPanel namePane() {
@@ -48,22 +62,26 @@ public final class AboutDialog extends JDialog {
         if (log.isDebugEnabled()) {
             log.debug("Fetch main logo: {} ({})", logo, FileUtil.findURL(logo, FileUtil.Location.INSTALLED));
         }
-        addCenteredComponent(new JLabel(new ImageIcon(getToolkit().getImage(FileUtil.findURL(logo, FileUtil.Location.INSTALLED)), "JMRI logo"), JLabel.CENTER), pane);
+        addCenteredComponent(new JLabel(new ImageIcon(
+            pane.getToolkit().getImage(FileUtil.findURL(logo, FileUtil.Location.INSTALLED)),
+            "JMRI logo"), SwingConstants.CENTER), pane);
         pane.add(Box.createRigidArea(new Dimension(0, 15)));
         String name = Application.getApplicationName();
-        name = checkCopyright(name);
-        JLabel appName = new JLabel(name, JLabel.CENTER);
+        name = checkRegisteredTmInString(name);
+        JLabel appName = new JLabel(name, SwingConstants.CENTER);
         appName.setFont(pane.getFont().deriveFont(Font.BOLD, pane.getFont().getSize() * 1.2f));
         addCenteredComponent(appName, pane);
-        addCenteredComponent(new JLabel(Application.getURL(), JLabel.CENTER), pane);
+        addCenteredComponent(new JLabel(Application.getURL(), SwingConstants.CENTER), pane);
         pane.add(Box.createRigidArea(new Dimension(0, 15)));
         pane.setAlignmentX(Component.CENTER_ALIGNMENT);
         return pane;
     }
 
-    protected String checkCopyright(String name) {
-        if (name.toUpperCase().equals("DECODERPRO")) {
-            name = name + "\u00ae";
+    private static final String REGISTERED_TM_SYMBOL = "\u00ae";
+
+    protected static String checkRegisteredTmInString(String name) {
+        if ( !name.contains(REGISTERED_TM_SYMBOL) ) {
+            return name + " " + REGISTERED_TM_SYMBOL;
         }
         return name;
     }
@@ -91,10 +109,10 @@ public final class AboutDialog extends JDialog {
         return pane1;
     }
 
-    protected void addCenteredComponent(JComponent c, JPanel p) {
+    protected static void addCenteredComponent(JComponent c, JPanel p) {
         c.setAlignmentX(Component.CENTER_ALIGNMENT); // doesn't work
         p.add(c);
     }
 
-    private static final Logger log = LoggerFactory.getLogger(AboutDialog.class);
+    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(AboutDialog.class);
 }

--- a/java/test/apps/swing/AboutDialogTest.java
+++ b/java/test/apps/swing/AboutDialogTest.java
@@ -5,9 +5,9 @@ import javax.swing.JFrame;
 import jmri.util.JUnitUtil;
 import jmri.util.ThreadingUtil;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.*;
 
+import org.netbeans.jemmy.operators.JButtonOperator;
 import org.netbeans.jemmy.operators.JDialogOperator;
 
 /**
@@ -24,8 +24,7 @@ public class AboutDialogTest {
         // remove the SwingUtilities$SharedOwnerFrame instance
         JFrame frame = new JFrame();
         AboutDialog dialog = new AboutDialog(frame, true);
-        Assert.assertNotNull(dialog);
-        JUnitUtil.dispose(dialog);
+        Assertions.assertNotNull(dialog);
         JUnitUtil.dispose(frame);
     }
 
@@ -37,18 +36,16 @@ public class AboutDialogTest {
         Thread t = new Thread(() -> {
             // constructor for jdo will wait until the dialog is visible
             JDialogOperator jdo = new JDialogOperator(Bundle.getMessage("TitleAbout", jmri.Application.getApplicationName()));
-            jdo.requestClose();
+            JButtonOperator jbo = new JButtonOperator(jdo, "OK");
+            jbo.doClick();
             jdo.waitClosed();
         });
         t.setName("About Dialog Close Thread");
         t.start();
-        ThreadingUtil.runOnGUI(() -> {
-            dialog.setVisible(true);
-        });
+        ThreadingUtil.runOnGUI(() -> dialog.setVisible(true));
         JUnitUtil.waitFor(() -> {
             return !t.isAlive();
         }, "About dialog did not close");
-        JUnitUtil.dispose(dialog);
         JUnitUtil.dispose(frame);
     }
 
@@ -60,9 +57,6 @@ public class AboutDialogTest {
 
     @AfterEach
     public void tearDown() {
-        JUnitUtil.resetWindows(false, false); // don't display the list of windows,
-        // it will display only show the ones
-        // from the current test.
         JUnitUtil.tearDown();
     }
 }


### PR DESCRIPTION
**AboutDialog**
Uses JmriJOptionPane, triggered from setVisible method.
No longer extends from JDialog.
Dialog includes OK button.
Renames Copyright method to checkRegisteredTmInString, adding TradeMark symbol to App names.
Moves 2 methods to static.

**AboutAction**
Uses ActionEvent source JFrame for About Dialog.
The JmriJOptionPane will now be document modal, see https://groups.io/g/jmriusers/message/241509

**AboutDialogTest**
Clicks OK to close Dialog.