### PR TITLE
Fix jogamp link

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1821,7 +1821,7 @@
         <repository>
             <id>jogamp-remote</id>
             <name>jogamp test mirror</name>
-            <url>https://www.jogamp.org/deployment/maven/</url>
+            <url>https://jogamp.org/deployment/maven/</url>
             <layout>default</layout>
         </repository>
         <!--


### PR DESCRIPTION
CI failed completely on my JMRI repository for some time. It seems that GitHub in some cases are unable to follow the redirection of the link. This PR fixes that problem.