### PR TITLE
Validate LogxNG actions and expressions

### DIFF
--- a/java/src/jmri/jmrit/logixng/actions/swing/ActionSoundSwing.java
+++ b/java/src/jmri/jmrit/logixng/actions/swing/ActionSoundSwing.java
@@ -180,7 +180,7 @@ public class ActionSoundSwing extends AbstractDigitalActionSwing {
         } catch (ParserException e) {
             errorMessages.add("Cannot parse formula: " + e.getMessage());
         }
-        return true;
+        return errorMessages.isEmpty();
     }
 
     /** {@inheritDoc} */

--- a/java/src/jmri/jmrit/logixng/expressions/swing/ExpressionScriptSwing.java
+++ b/java/src/jmri/jmrit/logixng/expressions/swing/ExpressionScriptSwing.java
@@ -283,7 +283,8 @@ public class ExpressionScriptSwing extends AbstractDigitalExpressionSwing {
         } catch (ParserException e) {
             errorMessages.add("Cannot parse formula: " + e.getMessage());
         }
-        return true;
+
+        return errorMessages.isEmpty();
     }
 
     /** {@inheritDoc} */

--- a/java/src/jmri/jmrit/logixng/expressions/swing/LogDataSwing.java
+++ b/java/src/jmri/jmrit/logixng/expressions/swing/LogDataSwing.java
@@ -148,7 +148,7 @@ public class LogDataSwing extends AbstractDigitalExpressionSwing {
                 }
             }
         }
-        return true;
+        return errorMessages.isEmpty();
     }
 
     /** {@inheritDoc} */


### PR DESCRIPTION
When editing a LogixNG action/expression, the method `validate()` is called when the user clicks OK. In some cases, that method returned true despite an error.