### PR TITLE
LE ToolBarPanel tweak dispose

### DIFF
--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorToolBarPanel.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorToolBarPanel.java
@@ -836,6 +836,14 @@ public class LayoutEditorToolBarPanel extends JPanel implements Disposable {
             iconFrame.dispose();
             iconFrame = null;
         }
+        if (logixngFrame != null) {
+            logixngFrame.dispose();
+            logixngFrame = null;
+        }
+        if (audioFrame != null) {
+            audioFrame.dispose();
+            audioFrame = null;
+        }
     }
 
     private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LayoutEditorToolBarPanel.class);


### PR DESCRIPTION
On dispose, also disposes the LogixNG / Audio background Frames.