### PR TITLE
LE - Dispose of previous toolbar

### DIFF
--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
@@ -572,6 +572,9 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
 
         Dimension screenDim = Toolkit.getDefaultToolkit().getScreenSize();
         boolean toolBarIsVertical = (toolBarSide.equals(ToolBarSide.eRIGHT) || toolBarSide.equals(ToolBarSide.eLEFT));
+        if ( leToolBarPanel != null ) {
+            leToolBarPanel.dispose();
+        }
         if (toolBarIsVertical) {
             leToolBarPanel = new LayoutEditorVerticalToolBarPanel(this);
             editToolBarScrollPane = new JScrollPane(leToolBarPanel);

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorTest.java
@@ -8,10 +8,11 @@ import jmri.*;
 import jmri.jmrit.display.*;
 import jmri.util.*;
 import jmri.util.swing.JemmyUtil;
+import jmri.util.ThreadingUtil;
 
 import org.junit.Assert;
 import org.junit.jupiter.api.*;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
 import org.netbeans.jemmy.EventTool;
 import org.netbeans.jemmy.QueueTool;
 import org.netbeans.jemmy.operators.JMenuOperator;
@@ -24,7 +25,7 @@ import org.netbeans.jemmy.operators.JMenuOperator;
  * @author Bob Jacobsen Copyright (C) 2020
  */
 @Timeout(10)
-@DisabledIfSystemProperty(named = "java.awt.headless", matches = "true")
+@jmri.util.junit.annotations.DisabledIfHeadless
 public class LayoutEditorTest extends AbstractEditorTestBase<LayoutEditor> {
 
     private EditorFrameOperator jfo = null;
@@ -38,7 +39,7 @@ public class LayoutEditorTest extends AbstractEditorTestBase<LayoutEditor> {
         JUnitUtil.initLayoutBlockManager();
 
         e = new LayoutEditor("Layout Editor Test Layout");
-        e.setVisible(true);
+        ThreadingUtil.runOnGUI( () -> e.setVisible(true));
         jfo = new EditorFrameOperator(e);
 
     }

--- a/java/test/jmri/jmrit/logixng/util/parser/ExpressionNodeMethodTest.java
+++ b/java/test/jmri/jmrit/logixng/util/parser/ExpressionNodeMethodTest.java
@@ -1,5 +1,6 @@
 package jmri.jmrit.logixng.util.parser;
 
+import java.awt.geom.Point2D;
 import java.io.*;
 import java.util.*;
 
@@ -9,9 +10,9 @@ import jmri.jmrit.logixng.SymbolTable;
 import jmri.jmrit.logixng.implementation.DefaultConditionalNG;
 import jmri.jmrit.logixng.implementation.DefaultSymbolTable;
 import jmri.util.JUnitUtil;
+import jmri.util.junit.annotations.DisabledIfHeadless;
 
 import org.junit.jupiter.api.*;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 /**
  * Test ExpressionNodeMethod.
@@ -56,19 +57,35 @@ public class ExpressionNodeMethodTest {
     }
 
     @Test
-    @DisabledIfSystemProperty(named = "java.awt.headless", matches = "true")
+    @DisabledIfHeadless
     public void testMethodWithBooleanParameter() throws JmriException {
         var editor = new jmri.jmrit.display.layoutEditor.LayoutEditor("My layout");
-        var trackSegment = new TrackSegment("Id", "A", HitPointType.TRACK, "B", HitPointType.TRACK, false, editor);
+
+        // code retained for any future debug
+        // jmri.util.ThreadingUtil.runOnGUI( () -> editor.setVisible(true));
+        // jmri.jmrit.display.EditorFrameOperator efo = new jmri.jmrit.display.EditorFrameOperator("My layout");
+        // Assertions.assertNotNull(efo);
+
+        PositionablePoint p1 = new PositionablePoint("A", PositionablePoint.PointType.ANCHOR, editor);
+        PositionablePointView p1v = new PositionablePointView(p1, new Point2D.Double(210.0, 220.0), editor);
+        editor.addLayoutTrack(p1, p1v);
+
+        PositionablePoint p2 = new PositionablePoint("B", PositionablePoint.PointType.ANCHOR, editor);
+        PositionablePointView p2v = new PositionablePointView(p2, new Point2D.Double(220.0, 233.0), editor);
+        editor.addLayoutTrack(p2, p2v);
+
+        var trackSegment = new TrackSegment("Id", p1, HitPointType.POS_POINT, p2, HitPointType.POS_POINT, false, editor);
         var trackSegmentView = new TrackSegmentView(trackSegment, editor);
         editor.addLayoutTrack(trackSegment, trackSegmentView);
+
         var segments = editor.getTrackSegmentViews();
         var segment = segments.get(0);
         segment.setHidden(false);
         Assertions.assertFalse(segment.isHidden());
         testCall(segment, "setHidden", null, new Object[]{true});
         Assertions.assertTrue(segment.isHidden());
-        editor.dispose();
+
+        JUnitUtil.dispose(editor);
     }
 
     /**
@@ -239,7 +256,6 @@ public class ExpressionNodeMethodTest {
     @AfterEach
     public void tearDown() {
         JUnitUtil.deregisterBlockManagerShutdownTask();
-        JUnitUtil.resetWindows(false, false);
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/util/JUnitUtil.java
+++ b/java/test/jmri/util/JUnitUtil.java
@@ -137,8 +137,7 @@ public class JUnitUtil {
      * <p>
      * Set from the jmri.util.JUnitUtil.printSetUpTearDownNames environment variable.
      */
-    static boolean printSetUpTearDownNames = true;
-           // Boolean.getBoolean("jmri.util.JUnitUtil.printSetUpTearDownNames"); // false unless set true
+    static boolean printSetUpTearDownNames = Boolean.getBoolean("jmri.util.JUnitUtil.printSetUpTearDownNames"); // false unless set true
 
     /**
      * When true, checks that calls to setUp and tearDown properly alterante, printing an
@@ -161,6 +160,7 @@ public class JUnitUtil {
      * <p>
      * Set from the jmri.util.JUnitUtil.checkRemnantThreads environment variable.
      */
+//    static boolean checkRemnantThreads =    true;
     static boolean checkRemnantThreads =    Boolean.getBoolean("jmri.util.JUnitUtil.checkRemnantThreads"); // false unless set true
 
     /**
@@ -168,6 +168,7 @@ public class JUnitUtil {
      * <p>
      * Set from the jmri.util.JUnitUtil.failRemnantThreads environment variable.
      */
+//    static boolean failRemnantThreads =  true;
     static boolean failRemnantThreads =  Boolean.getBoolean("jmri.util.JUnitUtil.failRemnantThreads"); // false unless set true
 
     /**

--- a/java/test/jmri/util/JUnitUtil.java
+++ b/java/test/jmri/util/JUnitUtil.java
@@ -137,7 +137,8 @@ public class JUnitUtil {
      * <p>
      * Set from the jmri.util.JUnitUtil.printSetUpTearDownNames environment variable.
      */
-    static boolean printSetUpTearDownNames = Boolean.getBoolean("jmri.util.JUnitUtil.printSetUpTearDownNames"); // false unless set true
+    static boolean printSetUpTearDownNames = true;
+           // Boolean.getBoolean("jmri.util.JUnitUtil.printSetUpTearDownNames"); // false unless set true
 
     /**
      * When true, checks that calls to setUp and tearDown properly alterante, printing an
@@ -160,7 +161,6 @@ public class JUnitUtil {
      * <p>
      * Set from the jmri.util.JUnitUtil.checkRemnantThreads environment variable.
      */
-//    static boolean checkRemnantThreads =    true;
     static boolean checkRemnantThreads =    Boolean.getBoolean("jmri.util.JUnitUtil.checkRemnantThreads"); // false unless set true
 
     /**
@@ -168,7 +168,6 @@ public class JUnitUtil {
      * <p>
      * Set from the jmri.util.JUnitUtil.failRemnantThreads environment variable.
      */
-//    static boolean failRemnantThreads =  true;
     static boolean failRemnantThreads =  Boolean.getBoolean("jmri.util.JUnitUtil.failRemnantThreads"); // false unless set true
 
     /**


### PR DESCRIPTION
**LayoutEditor**
Disposes of any previous Toolbar prior to creating a new one.

**LayoutEditor Test**
Calls setVisible from GUI Thread.

**logixng/util/parser/ExpressionNodeMethod Test**
Was timing out on Win CI following the change.
With the LE visible, was throwing exception, resolved by adding PositionalPoints to the LayoutTrack in the test setup.

```
 >> Starting test in jmri.jmrit.logixng.util.parser.ExpressionNodeMethodTest
     [java] Exception in thread "AWT-EventQueue-0" java.lang.NullPointerException
     [java]     at java.base/java.util.Objects.requireNonNull(Objects.java:209)
     [java]     at jmri.jmrit.display.layoutEditor.LayoutEditor.getCoords(LayoutEditor.java:3519)
     [java]     at jmri.jmrit.display.layoutEditor.TrackSegmentView.draw1(TrackSegmentView.java:2163)
     [java]     at jmri.jmrit.display.layoutEditor.LayoutEditorComponent.draw1(LayoutEditorComponent.java:442)
     [java]     at jmri.jmrit.display.layoutEditor.LayoutEditorComponent.drawLayoutTracksHidden(LayoutEditorComponent.java:176)
     [java]     at jmri.jmrit.display.layoutEditor.LayoutEditorComponent.paint(LayoutEditorComponent.java:66)
     [java]     at java.desktop/javax.swing.JComponent.paintChildren(JComponent.java:952)
     [java]     at java.desktop/javax.swing.JComponent.paint(JComponent.java:1128)
```

