### PR TITLE
Add LogixNG action SendCbusEvent

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -471,6 +471,9 @@
     <h3>LogixNG</h3>
         <a id="LogixNG" name="LogixNG"></a>
         <ul>
+          <li>The LogixNG action <strong>Send CBUS event</strong> has
+              been added. It's available in the category <strong>CBUS</strong>
+              if there is a CBUS connection.</li>
           <li></li>
         </ul>
 

--- a/java/src/jmri/jmrix/can/cbus/logixng/ActionFactory.java
+++ b/java/src/jmri/jmrix/can/cbus/logixng/ActionFactory.java
@@ -1,0 +1,37 @@
+package jmri.jmrix.can.cbus.logixng;
+
+import java.util.AbstractMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import jmri.jmrit.logixng.Category;
+import jmri.jmrit.logixng.DigitalActionFactory;
+import jmri.jmrit.logixng.DigitalActionBean;
+
+import org.openide.util.lookup.ServiceProvider;
+
+/**
+ * The factory for LogixNG LocoNet classes.
+ */
+@ServiceProvider(service = DigitalActionFactory.class)
+public class ActionFactory implements DigitalActionFactory {
+
+    @Override
+    public void init() {
+        CategoryCbus.registerCategory();
+    }
+
+    @Override
+    public Set<Map.Entry<Category, Class<? extends DigitalActionBean>>> getActionClasses() {
+        Set<Map.Entry<Category, Class<? extends DigitalActionBean>>> actionClasses = new HashSet<>();
+
+        // We don't want to add these classes if we don't have a CBUS connection
+        if (CategoryCbus.hasCbus()) {
+            actionClasses.add(new AbstractMap.SimpleEntry<>(CategoryCbus.CBUS, SendCbusEvent.class));
+        }
+
+        return actionClasses;
+    }
+
+}

--- a/java/src/jmri/jmrix/can/cbus/logixng/ActionFactory.java
+++ b/java/src/jmri/jmrix/can/cbus/logixng/ActionFactory.java
@@ -12,7 +12,7 @@ import jmri.jmrit.logixng.DigitalActionBean;
 import org.openide.util.lookup.ServiceProvider;
 
 /**
- * The factory for LogixNG LocoNet classes.
+ * The factory for LogixNG Cbus classes.
  */
 @ServiceProvider(service = DigitalActionFactory.class)
 public class ActionFactory implements DigitalActionFactory {

--- a/java/src/jmri/jmrix/can/cbus/logixng/Bundle.java
+++ b/java/src/jmri/jmrix/can/cbus/logixng/Bundle.java
@@ -1,0 +1,100 @@
+package jmri.jmrix.can.cbus.logixng;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+import java.util.Locale;
+
+import javax.annotation.CheckReturnValue;
+import javax.annotation.CheckForNull;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
+@CheckReturnValue
+@SuppressFBWarnings(value = "NM_SAME_SIMPLE_NAME_AS_SUPERCLASS", justification = "Desired pattern is repeated class names with package-level access to members")
+
+@javax.annotation.concurrent.Immutable
+
+/**
+ * Provides standard access for resource bundles in a package.
+ *
+ * Convention is to provide a subclass of this name in each package, working off
+ * the local resource bundle name.
+ *
+ * @author Bob Jacobsen Copyright (C) 2012
+ * @since 3.3.1
+ */
+public class Bundle extends jmri.jmrix.can.cbus.Bundle {
+
+    @CheckForNull
+    private static final String name = "jmri.jmrix.can.cbus.logixng.LogixNGCbusBundle"; // NOI18N
+
+    //
+    // below here is boilerplate to be copied exactly
+    //
+    /**
+     * Provides a translated string for a given key from the package resource
+     * bundle or parent.
+     * <p>
+     * Note that this is intentionally package-local access.
+     *
+     * @param key Bundle key to be translated
+     * @return Internationalized text
+     */
+    static String getMessage(String key) {
+        return getBundle().handleGetMessage(key);
+    }
+
+    /**
+     * Merges user data with a translated string for a given key from the
+     * package resource bundle or parent.
+     * <p>
+     * Uses the transformation conventions of the Java MessageFormat utility.
+     * <p>
+     * Note that this is intentionally package-local access.
+     *
+     * @see java.text.MessageFormat
+     * @param key  Bundle key to be translated
+     * @param subs One or more objects to be inserted into the message
+     * @return Internationalized text
+     */
+    static String getMessage(String key, Object... subs) {
+        return getBundle().handleGetMessage(key, subs);
+    }
+
+    /**
+     * Merges user data with a translated string for a given key in a given
+     * locale from the package resource bundle or parent.
+     * <p>
+     * Uses the transformation conventions of the Java MessageFormat utility.
+     * <p>
+     * Note that this is intentionally package-local access.
+     *
+     * @see java.text.MessageFormat
+     * @param locale The locale to be used
+     * @param key    Bundle key to be translated
+     * @param subs   One or more objects to be inserted into the message
+     * @return Internationalized text
+     */
+    static String getMessage(Locale locale, String key, Object... subs) {
+        return getBundle().handleGetMessage(locale, key, subs);
+    }
+
+
+    private final static Bundle b = new Bundle();
+
+    @Override
+    @CheckForNull
+    protected String bundleName() {
+        return name;
+    }
+
+    protected static jmri.Bundle getBundle() {
+        return b;
+    }
+
+    @Override
+    protected String retry(Locale locale, String key) {
+        return super.getBundle().handleGetMessage(locale,key);
+    }
+
+}

--- a/java/src/jmri/jmrix/can/cbus/logixng/CategoryCbus.java
+++ b/java/src/jmri/jmrix/can/cbus/logixng/CategoryCbus.java
@@ -6,9 +6,9 @@ import jmri.jmrit.logixng.Category;
 import jmri.jmrix.can.CanSystemConnectionMemo;
 
 /**
- * Defines the category LocoNet
+ * Defines the category Cbus
  *
- * @author Daniel Bergqvist Copyright 2020
+ * @author Daniel Bergqvist Copyright 2025
  */
 public final class CategoryCbus extends Category {
 

--- a/java/src/jmri/jmrix/can/cbus/logixng/CategoryCbus.java
+++ b/java/src/jmri/jmrix/can/cbus/logixng/CategoryCbus.java
@@ -1,0 +1,43 @@
+package jmri.jmrix.can.cbus.logixng;
+
+import java.util.List;
+
+import jmri.jmrit.logixng.Category;
+import jmri.jmrix.can.CanSystemConnectionMemo;
+
+/**
+ * Defines the category LocoNet
+ *
+ * @author Daniel Bergqvist Copyright 2020
+ */
+public final class CategoryCbus extends Category {
+
+    /**
+     * A item on the layout, for example turnout, sensor and signal mast.
+     */
+    public static final CategoryCbus CBUS = new CategoryCbus();
+
+
+    public CategoryCbus() {
+        super("CBUS", Bundle.getMessage("MenuCbus"), 300);
+    }
+
+    public static void registerCategory() {
+        // We don't want to add these classes if we don't have a Cbus connection
+        if (hasCbus() && !Category.values().contains(CBUS)) {
+            Category.registerCategory(CBUS);
+        }
+    }
+
+    /**
+     * Do we have a Cbus connection?
+     * @return true if we have Cbus, false otherwise
+     */
+    public static boolean hasCbus() {
+        List<CanSystemConnectionMemo> list = jmri.InstanceManager.getList(CanSystemConnectionMemo.class);
+
+        // We have at least one Cbus connection if the list is not empty
+        return !list.isEmpty();
+    }
+
+}

--- a/java/src/jmri/jmrix/can/cbus/logixng/LogixNGCbusBundle.properties
+++ b/java/src/jmri/jmrix/can/cbus/logixng/LogixNGCbusBundle.properties
@@ -1,0 +1,15 @@
+# LogixNGCbusBundle.properties
+#
+# Default properties for the jmri.jmrix.can.cbus.logixng package
+
+MemoNotSet          = connection not set
+
+MenuCbus            = CBUS
+
+
+SendCbusEvent_Short = Send CBUS event
+SendCbusEvent_Long  = Send CBUS event {0} of type {1} to node {2} for connection {3}
+
+SendCbusEvent_EventType_Off         = Off
+SendCbusEvent_EventType_On          = On
+SendCbusEvent_EventType_Request     = Request

--- a/java/src/jmri/jmrix/can/cbus/logixng/SendCbusEvent.java
+++ b/java/src/jmri/jmrix/can/cbus/logixng/SendCbusEvent.java
@@ -1,0 +1,185 @@
+package jmri.jmrix.can.cbus.logixng;
+
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.util.Locale;
+import java.util.Map;
+
+import jmri.*;
+import jmri.jmrit.logixng.*;
+import jmri.jmrit.logixng.actions.AbstractDigitalAction;
+import jmri.jmrit.logixng.util.LogixNG_SelectEnum;
+import jmri.jmrit.logixng.util.LogixNG_SelectInteger;
+import jmri.jmrit.logixng.util.parser.ParserException;
+import jmri.jmrix.can.CanSystemConnectionMemo;
+import jmri.jmrix.can.cbus.CbusEvent;
+import jmri.util.ThreadingUtil;
+
+/**
+ * This action sets the state of a light.
+ *
+ * @author Daniel Bergqvist Copyright 2018
+ */
+public class SendCbusEvent extends AbstractDigitalAction
+        implements PropertyChangeListener {
+
+    private final LogixNG_SelectInteger _selectNodeNumber =
+            new LogixNG_SelectInteger(
+                    this, this);
+
+    private final LogixNG_SelectInteger _selectEventNumber =
+            new LogixNG_SelectInteger(
+                    this, this);
+
+    private final LogixNG_SelectEnum<CbusEventType> _selectEventType =
+            new LogixNG_SelectEnum<>(this, CbusEventType.values(), CbusEventType.Off, this);
+
+    private CanSystemConnectionMemo _memo;
+
+
+    public SendCbusEvent(String sys, String user, CanSystemConnectionMemo memo)
+            throws BadUserNameException, BadSystemNameException {
+        super(sys, user);
+        _memo = memo;
+    }
+
+    @Override
+    public Base getDeepCopy(Map<String, String> systemNames, Map<String, String> userNames) throws ParserException {
+        DigitalActionManager manager = InstanceManager.getDefault(DigitalActionManager.class);
+        String sysName = systemNames.get(getSystemName());
+        String userName = userNames.get(getSystemName());
+        if (sysName == null) sysName = manager.getAutoSystemName();
+        SendCbusEvent copy = new SendCbusEvent(sysName, userName, _memo);
+        copy.setComment(getComment());
+        _selectNodeNumber.copy(copy._selectNodeNumber);
+        _selectEventNumber.copy(copy._selectEventNumber);
+        _selectEventType.copy(copy._selectEventType);
+
+        return manager.registerAction(copy);
+    }
+
+    public void setMemo(CanSystemConnectionMemo memo) {
+        assertListenersAreNotRegistered(log, "setMemo");
+        _memo = memo;
+    }
+
+    public CanSystemConnectionMemo getMemo() {
+        return _memo;
+    }
+
+    public LogixNG_SelectInteger getSelectNodeNumber() {
+        return _selectNodeNumber;
+    }
+
+    public LogixNG_SelectInteger getSelectEventNumber() {
+        return _selectEventNumber;
+    }
+
+    public LogixNG_SelectEnum<CbusEventType> getSelectEventType() {
+        return _selectEventType;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Category getCategory() {
+        return CategoryCbus.CBUS;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void execute() throws JmriException {
+        ConditionalNG conditionalNG = getConditionalNG();
+        int nodeNumber = _selectNodeNumber.evaluateValue(conditionalNG);
+        int eventNumber = _selectEventNumber.evaluateValue(conditionalNG);
+        CbusEventType state = _selectEventType.evaluateEnum(getConditionalNG());
+
+        ThreadingUtil.runOnLayoutWithJmriException(() -> {
+            CbusEvent event = new CbusEvent(_memo,nodeNumber,eventNumber);
+            state._command.action(event);
+        });
+    }
+
+    @Override
+    public FemaleSocket getChild(int index) throws IllegalArgumentException, UnsupportedOperationException {
+        throw new UnsupportedOperationException("Not supported.");
+    }
+
+    @Override
+    public int getChildCount() {
+        return 0;
+    }
+
+    @Override
+    public String getShortDescription(Locale locale) {
+        return Bundle.getMessage(locale, "SendCbusEvent_Short");
+    }
+
+    @Override
+    public String getLongDescription(Locale locale) {
+        String nodeNumber = _selectNodeNumber.getDescription(locale);
+        String eventNumber = _selectEventNumber.getDescription(locale);
+        String eventType = _selectEventType.getDescription(locale);
+
+        return Bundle.getMessage(locale, "SendCbusEvent_Long", eventNumber, eventType, nodeNumber,
+                _memo != null ? _memo.getUserName() : Bundle.getMessage("MemoNotSet"));
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void setup() {
+        // Do nothing
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void registerListenersForThisClass() {
+        _selectNodeNumber.registerListeners();
+        _selectEventType.registerListeners();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void unregisterListenersForThisClass() {
+        _selectNodeNumber.unregisterListeners();
+        _selectEventType.unregisterListeners();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void propertyChange(PropertyChangeEvent evt) {
+        getConditionalNG().execute();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void disposeMe() {
+    }
+
+
+    public enum CbusEventType {
+        Off((e)-> {e.sendOff();}, Bundle.getMessage("SendCbusEvent_EventType_Off")),
+        On((e)-> {e.sendOn();}, Bundle.getMessage("SendCbusEvent_EventType_On")),
+        Request((e)-> {e.sendRequest();}, Bundle.getMessage("SendCbusEvent_EventType_Request"));
+
+        private interface EventCommand {
+            void action(CbusEvent event);
+        }
+
+        private final EventCommand _command;
+        private final String _text;
+
+        private CbusEventType(EventCommand command, String text) {
+            this._command = command;
+            this._text = text;
+        }
+
+        @Override
+        public String toString() {
+            return _text;
+        }
+
+    }
+
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(SendCbusEvent.class);
+
+}

--- a/java/src/jmri/jmrix/can/cbus/logixng/SendCbusEvent.java
+++ b/java/src/jmri/jmrix/can/cbus/logixng/SendCbusEvent.java
@@ -16,9 +16,9 @@ import jmri.jmrix.can.cbus.CbusEvent;
 import jmri.util.ThreadingUtil;
 
 /**
- * This action sets the state of a light.
+ * This action sends a Cbus event.
  *
- * @author Daniel Bergqvist Copyright 2018
+ * @author Daniel Bergqvist Copyright 2025
  */
 public class SendCbusEvent extends AbstractDigitalAction
         implements PropertyChangeListener {

--- a/java/src/jmri/jmrix/can/cbus/logixng/configurexml/SendCbusEventXml.java
+++ b/java/src/jmri/jmrix/can/cbus/logixng/configurexml/SendCbusEventXml.java
@@ -16,8 +16,7 @@ import org.jdom2.Element;
  * Handle XML configuration for SendCbusEvent objects.
  *
  * @author Bob Jacobsen Copyright: Copyright (c) 2004, 2008, 2010
- * @author Daniel Bergqvist Copyright (C) 2021
- * @author Dave Sand Copyright (C) 2021
+ * @author Daniel Bergqvist Copyright (C) 2025
  */
 public class SendCbusEventXml extends jmri.managers.configurexml.AbstractNamedBeanManagerConfigXML {
 

--- a/java/src/jmri/jmrix/can/cbus/logixng/configurexml/SendCbusEventXml.java
+++ b/java/src/jmri/jmrix/can/cbus/logixng/configurexml/SendCbusEventXml.java
@@ -1,0 +1,92 @@
+package jmri.jmrix.can.cbus.logixng.configurexml;
+
+import java.util.List;
+
+import jmri.*;
+import jmri.configurexml.JmriConfigureXmlException;
+import jmri.jmrit.logixng.DigitalActionManager;
+import jmri.jmrit.logixng.util.configurexml.LogixNG_SelectEnumXml;
+import jmri.jmrit.logixng.util.configurexml.LogixNG_SelectIntegerXml;
+import jmri.jmrix.can.CanSystemConnectionMemo;
+import jmri.jmrix.can.cbus.logixng.SendCbusEvent;
+
+import org.jdom2.Element;
+
+/**
+ * Handle XML configuration for SendCbusEvent objects.
+ *
+ * @author Bob Jacobsen Copyright: Copyright (c) 2004, 2008, 2010
+ * @author Daniel Bergqvist Copyright (C) 2021
+ * @author Dave Sand Copyright (C) 2021
+ */
+public class SendCbusEventXml extends jmri.managers.configurexml.AbstractNamedBeanManagerConfigXML {
+
+    public SendCbusEventXml() {
+    }
+
+    /**
+     * Default implementation for storing the contents of a clock action.
+     *
+     * @param o Object to store, of type SendCbusEvent
+     * @return Element containing the complete info
+     */
+    @Override
+    public Element store(Object o) {
+        SendCbusEvent p = (SendCbusEvent) o;
+
+        var selectEnumXml = new LogixNG_SelectEnumXml<SendCbusEvent.CbusEventType>();
+        var selectIntegerXml = new LogixNG_SelectIntegerXml();
+
+        Element element = new Element("SendCbusEvent");
+        element.setAttribute("class", this.getClass().getName());
+        element.addContent(new Element("systemName").addContent(p.getSystemName()));
+
+        storeCommon(p, element);
+
+        if (p.getMemo() != null) {
+            element.addContent(new Element("systemConnection")
+                    .addContent(p.getMemo().getSystemPrefix()));
+        }
+
+        element.addContent(selectIntegerXml.store(p.getSelectNodeNumber(), "nodeNumber"));
+        element.addContent(selectIntegerXml.store(p.getSelectEventNumber(), "eventNumber"));
+        element.addContent(selectEnumXml.store(p.getSelectEventType(), "eventType"));
+
+        return element;
+    }
+
+    @Override
+    public boolean load(Element shared, Element perNode) throws JmriConfigureXmlException {
+        String sys = getSystemName(shared);
+        String uname = getUserName(shared);
+        SendCbusEvent h = new SendCbusEvent(sys, uname, null);
+
+        var selectEnumXml = new LogixNG_SelectEnumXml<SendCbusEvent.CbusEventType>();
+        var selectRateXml = new LogixNG_SelectIntegerXml();
+
+        loadCommon(h, shared);
+
+        Element systemConnection = shared.getChild("systemConnection");
+        if (systemConnection != null) {
+            String systemConnectionName = systemConnection.getTextTrim();
+            List<CanSystemConnectionMemo> systemConnections =
+                    jmri.InstanceManager.getList(CanSystemConnectionMemo.class);
+
+            for (CanSystemConnectionMemo memo : systemConnections) {
+                if (memo.getSystemPrefix().equals(systemConnectionName)) {
+                    h.setMemo(memo);
+                    break;
+                }
+            }
+        }
+
+        selectRateXml.load(shared.getChild("nodeNumber"), h.getSelectNodeNumber());
+        selectRateXml.load(shared.getChild("eventNumber"), h.getSelectEventNumber());
+        selectEnumXml.load(shared.getChild("eventType"), h.getSelectEventType());
+
+        InstanceManager.getDefault(DigitalActionManager.class).registerAction(h);
+        return true;
+    }
+
+//    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(SendCbusEventXml.class);
+}

--- a/java/src/jmri/jmrix/can/cbus/logixng/configurexml/package-info.java
+++ b/java/src/jmri/jmrix/can/cbus/logixng/configurexml/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Provides classes for interacting with CBUS Nodes using LogixNG.
+ */
+
+//@annotations for the entire package go here
+// include empty DefaultAnnotation to avoid excessive recompilation
+@edu.umd.cs.findbugs.annotations.DefaultAnnotation(value={})
+package jmri.jmrix.can.cbus.logixng.configurexml;

--- a/java/src/jmri/jmrix/can/cbus/logixng/package-info.java
+++ b/java/src/jmri/jmrix/can/cbus/logixng/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Provides classes for interacting with CBUS Nodes using LogixNG.
+ */
+
+//@annotations for the entire package go here
+// include empty DefaultAnnotation to avoid excessive recompilation
+@edu.umd.cs.findbugs.annotations.DefaultAnnotation(value={})
+package jmri.jmrix.can.cbus.logixng;

--- a/java/src/jmri/jmrix/can/cbus/logixng/swing/Bundle.java
+++ b/java/src/jmri/jmrix/can/cbus/logixng/swing/Bundle.java
@@ -1,0 +1,100 @@
+package jmri.jmrix.can.cbus.logixng.swing;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+import java.util.Locale;
+
+import javax.annotation.CheckReturnValue;
+import javax.annotation.CheckForNull;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
+@CheckReturnValue
+@SuppressFBWarnings(value = "NM_SAME_SIMPLE_NAME_AS_SUPERCLASS", justification = "Desired pattern is repeated class names with package-level access to members")
+
+@javax.annotation.concurrent.Immutable
+
+/**
+ * Provides standard access for resource bundles in a package.
+ *
+ * Convention is to provide a subclass of this name in each package, working off
+ * the local resource bundle name.
+ *
+ * @author Bob Jacobsen Copyright (C) 2012
+ * @since 3.3.1
+ */
+public class Bundle extends jmri.jmrix.can.cbus.logixng.Bundle {
+
+    @CheckForNull
+    private static final String name = "jmri.jmrix.can.cbus.logixng.swing.LogixNGCbusSwingBundle"; // NOI18N
+
+    //
+    // below here is boilerplate to be copied exactly
+    //
+    /**
+     * Provides a translated string for a given key from the package resource
+     * bundle or parent.
+     * <p>
+     * Note that this is intentionally package-local access.
+     *
+     * @param key Bundle key to be translated
+     * @return Internationalized text
+     */
+    static String getMessage(String key) {
+        return getBundle().handleGetMessage(key);
+    }
+
+    /**
+     * Merges user data with a translated string for a given key from the
+     * package resource bundle or parent.
+     * <p>
+     * Uses the transformation conventions of the Java MessageFormat utility.
+     * <p>
+     * Note that this is intentionally package-local access.
+     *
+     * @see java.text.MessageFormat
+     * @param key  Bundle key to be translated
+     * @param subs One or more objects to be inserted into the message
+     * @return Internationalized text
+     */
+    static String getMessage(String key, Object... subs) {
+        return getBundle().handleGetMessage(key, subs);
+    }
+
+    /**
+     * Merges user data with a translated string for a given key in a given
+     * locale from the package resource bundle or parent.
+     * <p>
+     * Uses the transformation conventions of the Java MessageFormat utility.
+     * <p>
+     * Note that this is intentionally package-local access.
+     *
+     * @see java.text.MessageFormat
+     * @param locale The locale to be used
+     * @param key    Bundle key to be translated
+     * @param subs   One or more objects to be inserted into the message
+     * @return Internationalized text
+     */
+    static String getMessage(Locale locale, String key, Object... subs) {
+        return getBundle().handleGetMessage(locale, key, subs);
+    }
+
+
+    private final static Bundle b = new Bundle();
+
+    @Override
+    @CheckForNull
+    protected String bundleName() {
+        return name;
+    }
+
+    protected static jmri.Bundle getBundle() {
+        return b;
+    }
+
+    @Override
+    protected String retry(Locale locale, String key) {
+        return super.getBundle().handleGetMessage(locale,key);
+    }
+
+}

--- a/java/src/jmri/jmrix/can/cbus/logixng/swing/LogixNGCbusSwingBundle.properties
+++ b/java/src/jmri/jmrix/can/cbus/logixng/swing/LogixNGCbusSwingBundle.properties
@@ -1,0 +1,8 @@
+# LogixNGCbusSwingBundle.properties
+#
+# Default properties for the jmri.jmrix.can.cbus.logixng.swing package
+
+SendCbusEventSwing_NodeNumber   = Node number
+SendCbusEventSwing_EventNumber  = Event number
+SendCbusEventSwing_EventType    = Node type
+SendCbusEventSwing_Memo         = Connection

--- a/java/src/jmri/jmrix/can/cbus/logixng/swing/LogixNGCbusSwingBundle.properties
+++ b/java/src/jmri/jmrix/can/cbus/logixng/swing/LogixNGCbusSwingBundle.properties
@@ -4,5 +4,5 @@
 
 SendCbusEventSwing_NodeNumber   = Node number
 SendCbusEventSwing_EventNumber  = Event number
-SendCbusEventSwing_EventType    = Node type
+SendCbusEventSwing_EventType    = Event type
 SendCbusEventSwing_Memo         = Connection

--- a/java/src/jmri/jmrix/can/cbus/logixng/swing/SendCbusEventSwing.java
+++ b/java/src/jmri/jmrix/can/cbus/logixng/swing/SendCbusEventSwing.java
@@ -19,8 +19,7 @@ import jmri.jmrix.can.CanSystemConnectionMemo;
 /**
  * Configures an SendCbusEvent object with a Swing JPanel.
  *
- * @author Daniel Bergqvist Copyright 2021
- * @author Dave Sand Copyright 2021
+ * @author Daniel Bergqvist Copyright 2025
  */
 public class SendCbusEventSwing extends AbstractDigitalActionSwing {
 

--- a/java/src/jmri/jmrix/can/cbus/logixng/swing/SendCbusEventSwing.java
+++ b/java/src/jmri/jmrix/can/cbus/logixng/swing/SendCbusEventSwing.java
@@ -1,0 +1,170 @@
+package jmri.jmrix.can.cbus.logixng.swing;
+
+import jmri.jmrit.logixng.actions.swing.*;
+
+import java.util.List;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import javax.swing.*;
+
+import jmri.InstanceManager;
+import jmri.jmrit.logixng.*;
+import jmri.jmrix.can.cbus.logixng.SendCbusEvent;
+import jmri.jmrix.can.cbus.logixng.SendCbusEvent.CbusEventType;
+import jmri.jmrit.logixng.util.swing.LogixNG_SelectEnumSwing;
+import jmri.jmrit.logixng.util.swing.LogixNG_SelectIntegerSwing;
+import jmri.jmrix.can.CanSystemConnectionMemo;
+
+/**
+ * Configures an SendCbusEvent object with a Swing JPanel.
+ *
+ * @author Daniel Bergqvist Copyright 2021
+ * @author Dave Sand Copyright 2021
+ */
+public class SendCbusEventSwing extends AbstractDigitalActionSwing {
+
+    private LogixNG_SelectIntegerSwing _selectNodeNumberSwing;
+    private LogixNG_SelectIntegerSwing _selectEventNumberSwing;
+    private LogixNG_SelectEnumSwing<CbusEventType> _selectEventTypeSwing;
+    private JComboBox<CbusConnection> _cbusConnection;
+
+
+    public SendCbusEventSwing() {
+    }
+
+    public SendCbusEventSwing(JDialog dialog) {
+        super.setJDialog(dialog);
+    }
+
+    @Override
+    protected void createPanel(@CheckForNull Base object, @Nonnull JPanel buttonPanel) {
+        SendCbusEvent action = (SendCbusEvent) object;
+        if (action == null) {
+            // Create a temporary action
+            action = new SendCbusEvent("IQDA1", null, null);
+        }
+
+        _selectNodeNumberSwing = new LogixNG_SelectIntegerSwing(getJDialog(), this);
+        _selectEventNumberSwing = new LogixNG_SelectIntegerSwing(getJDialog(), this);
+        _selectEventTypeSwing = new LogixNG_SelectEnumSwing<>(getJDialog(), this);
+
+        panel = new JPanel(new java.awt.GridBagLayout());
+        JPanel tabbedPaneNodeNumber;
+        JPanel tabbedPaneEventNumber;
+        JPanel tabbedPaneCbusEventType;
+
+        tabbedPaneNodeNumber = _selectNodeNumberSwing.createPanel(action.getSelectNodeNumber());
+        tabbedPaneEventNumber = _selectEventNumberSwing.createPanel(action.getSelectEventNumber());
+        tabbedPaneCbusEventType = _selectEventTypeSwing.createPanel(action.getSelectEventType(), CbusEventType.values());
+
+
+        _cbusConnection = new JComboBox<>();
+        List<CanSystemConnectionMemo> systemConnections =
+                jmri.InstanceManager.getList(CanSystemConnectionMemo.class);
+        for (CanSystemConnectionMemo connection : systemConnections) {
+            CbusConnection c = new CbusConnection(connection);
+            _cbusConnection.addItem(c);
+            if (action.getMemo() == connection) {
+                _cbusConnection.setSelectedItem(c);
+            }
+        }
+
+
+        java.awt.GridBagConstraints constraints = new java.awt.GridBagConstraints();
+        constraints.gridwidth = 1;
+        constraints.gridheight = 1;
+        constraints.gridx = 0;
+        constraints.gridy = 0;
+        constraints.anchor = java.awt.GridBagConstraints.EAST;
+        panel.add(new JLabel(Bundle.getMessage("SendCbusEventSwing_NodeNumber")), constraints);
+        constraints.gridy = 1;
+        panel.add(new JLabel(Bundle.getMessage("SendCbusEventSwing_EventNumber")), constraints);
+        constraints.gridy = 2;
+        panel.add(new JLabel(Bundle.getMessage("SendCbusEventSwing_EventType")), constraints);
+        constraints.gridy = 3;
+        panel.add(new JLabel(Bundle.getMessage("SendCbusEventSwing_Memo")), constraints);
+        constraints.gridx = 1;
+        constraints.gridy = 0;
+        constraints.anchor = java.awt.GridBagConstraints.WEST;
+        panel.add(tabbedPaneNodeNumber, constraints);
+        constraints.gridy = 1;
+        panel.add(tabbedPaneEventNumber, constraints);
+        constraints.gridy = 2;
+        panel.add(tabbedPaneCbusEventType, constraints);
+        constraints.gridy = 3;
+        panel.add(_cbusConnection, constraints);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean validate(@Nonnull List<String> errorMessages) {
+        // Create a temporary action to test formula
+        SendCbusEvent action = new SendCbusEvent("IQDA1", null, null);
+
+        _selectNodeNumberSwing.validate(action.getSelectNodeNumber(), errorMessages);
+        _selectEventNumberSwing.validate(action.getSelectEventNumber(), errorMessages);
+        _selectEventTypeSwing.validate(action.getSelectEventType(), errorMessages);
+
+        return errorMessages.isEmpty();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getAutoSystemName() {
+        return InstanceManager.getDefault(DigitalActionManager.class).getAutoSystemName();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public MaleSocket createNewObject(@Nonnull String systemName, @CheckForNull String userName) {
+        SendCbusEvent action = new SendCbusEvent(systemName, userName, null);
+        updateObject(action);
+        return InstanceManager.getDefault(DigitalActionManager.class).registerAction(action);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void updateObject(@Nonnull Base object) {
+        if (! (object instanceof SendCbusEvent)) {
+            throw new IllegalArgumentException("object must be an SendCbusEvent but is a: "+object.getClass().getName());
+        }
+        SendCbusEvent action = (SendCbusEvent) object;
+
+        _selectNodeNumberSwing.updateObject(action.getSelectNodeNumber());
+        _selectEventNumberSwing.updateObject(action.getSelectEventNumber());
+        _selectEventTypeSwing.updateObject(action.getSelectEventType());
+
+        action.setMemo(_cbusConnection.getItemAt(_cbusConnection.getSelectedIndex())._memo);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String toString() {
+        return Bundle.getMessage("SendCbusEvent_Short");
+    }
+
+    @Override
+    public void dispose() {
+        _selectEventTypeSwing.dispose();
+        _selectNodeNumberSwing.dispose();
+    }
+
+
+    private static class CbusConnection {
+
+        private CanSystemConnectionMemo _memo;
+
+        public CbusConnection(CanSystemConnectionMemo memo) {
+            _memo = memo;
+        }
+
+        @Override
+        public String toString() {
+            return _memo.getUserName();
+        }
+    }
+
+//    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(SendCbusEventSwing.class);
+
+}

--- a/java/src/jmri/jmrix/can/cbus/logixng/swing/package-info.java
+++ b/java/src/jmri/jmrix/can/cbus/logixng/swing/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Provides classes for interacting with CBUS Nodes using LogixNG.
+ */
+
+//@annotations for the entire package go here
+// include empty DefaultAnnotation to avoid excessive recompilation
+@edu.umd.cs.findbugs.annotations.DefaultAnnotation(value={})
+package jmri.jmrix.can.cbus.logixng.swing;

--- a/java/test/jmri/jmrit/logixng/CreateLogixNGTreeScaffold.java
+++ b/java/test/jmri/jmrit/logixng/CreateLogixNGTreeScaffold.java
@@ -18,6 +18,9 @@ import jmri.jmrit.logixng.actions.ActionListenOnBeans.NamedBeanReference;
 import jmri.jmrit.logixng.expressions.*;
 import jmri.jmrit.logixng.util.*;
 import jmri.jmrit.logixng.util.parser.ParserException;
+import jmri.jmrix.can.CanSystemConnectionMemo;
+import jmri.jmrix.can.TrafficControllerScaffold;
+import jmri.jmrix.can.cbus.logixng.SendCbusEvent;
 import jmri.jmrix.loconet.*;
 import jmri.jmrix.mqtt.MqttSystemConnectionMemo;
 import jmri.script.ScriptEngineSelector;
@@ -40,6 +43,8 @@ public class CreateLogixNGTreeScaffold {
         setupHasBeenCalled = newVal;
     }
 
+    private CanSystemConnectionMemo _cbusMemo;
+    private TrafficControllerScaffold _cbusTrafficController;
     private LocoNetSystemConnectionMemo _locoNetMemo;
     private MqttSystemConnectionMemo _mqttMemo;
 
@@ -2884,6 +2889,37 @@ public class CreateLogixNGTreeScaffold {
                 new jmri.jmrit.display.logixng.ActionAudioIcon(digitalActionManager.getAutoSystemName(), null);
         actionAudioIcon.setOperation(jmri.jmrit.display.logixng.ActionAudioIcon.Operation.Stop);
         maleSocket = digitalActionManager.registerAction(actionAudioIcon);
+        maleSocket.setEnabled(false);
+        actionManySocket.getChild(indexAction++).connect(maleSocket);
+
+
+        jmri.jmrix.can.cbus.logixng.SendCbusEvent sendCbusEvent =
+                new jmri.jmrix.can.cbus.logixng.SendCbusEvent(digitalActionManager.getAutoSystemName(), null, _cbusMemo);
+        maleSocket = digitalActionManager.registerAction(sendCbusEvent);
+        maleSocket.setEnabled(false);
+        actionManySocket.getChild(indexAction++).connect(maleSocket);
+
+        sendCbusEvent = new jmri.jmrix.can.cbus.logixng.SendCbusEvent(digitalActionManager.getAutoSystemName(), null, _cbusMemo);
+        sendCbusEvent.getSelectNodeNumber().setValue(10);
+        sendCbusEvent.getSelectEventNumber().setValue(20);
+        sendCbusEvent.getSelectEventType().setEnum(SendCbusEvent.CbusEventType.On);
+        maleSocket = digitalActionManager.registerAction(sendCbusEvent);
+        maleSocket.setEnabled(false);
+        actionManySocket.getChild(indexAction++).connect(maleSocket);
+
+        sendCbusEvent = new jmri.jmrix.can.cbus.logixng.SendCbusEvent(digitalActionManager.getAutoSystemName(), null, _cbusMemo);
+        sendCbusEvent.getSelectNodeNumber().setValue(3);
+        sendCbusEvent.getSelectEventNumber().setValue(30);
+        sendCbusEvent.getSelectEventType().setEnum(SendCbusEvent.CbusEventType.Off);
+        maleSocket = digitalActionManager.registerAction(sendCbusEvent);
+        maleSocket.setEnabled(false);
+        actionManySocket.getChild(indexAction++).connect(maleSocket);
+
+        sendCbusEvent = new jmri.jmrix.can.cbus.logixng.SendCbusEvent(digitalActionManager.getAutoSystemName(), null, _cbusMemo);
+        sendCbusEvent.getSelectNodeNumber().setValue(10);
+        sendCbusEvent.getSelectEventNumber().setValue(20);
+        sendCbusEvent.getSelectEventType().setEnum(SendCbusEvent.CbusEventType.Request);
+        maleSocket = digitalActionManager.registerAction(sendCbusEvent);
         maleSocket.setEnabled(false);
         actionManySocket.getChild(indexAction++).connect(maleSocket);
 
@@ -6222,6 +6258,11 @@ public class CreateLogixNGTreeScaffold {
         JUnitUtil.initSectionManager();
         JUnitUtil.initWarrantManager();
 
+        _cbusMemo = new CanSystemConnectionMemo();
+        _cbusTrafficController = new TrafficControllerScaffold();
+        _cbusMemo.setTrafficController(_cbusTrafficController);
+        _cbusMemo.configureManagers();
+
         LocoNetInterfaceScaffold lnis = new LocoNetInterfaceScaffold();
         SlotManager sm = new SlotManager(lnis);
         _locoNetMemo = new LocoNetSystemConnectionMemo(lnis, sm);
@@ -6245,6 +6286,8 @@ public class CreateLogixNGTreeScaffold {
     public void tearDown() {
         CreateLogixNGTreeScaffold.setUpCalled(false);     // Reset for the next test
 
+        _cbusTrafficController.terminateThreads();
+        _cbusMemo = null;
         _locoNetMemo = null;
         _mqttMemo = null;
 

--- a/xml/schema/logixng/digital-actions/digital-actions-4.23.1.xsd
+++ b/xml/schema/logixng/digital-actions/digital-actions-4.23.1.xsd
@@ -89,6 +89,7 @@
   <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/digital-actions/program-on-main-5.7.3.xsd"/>
   <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/digital-actions/return-5.1.3.xsd"/>
   <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/digital-actions/run-once-5.3.1.xsd"/>
+  <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/digital-actions/send-cbus-event-5.11.7.xsd"/>
   <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/digital-actions/sequence-4.23.1.xsd"/>
   <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/digital-actions/show-dialog-4.25.7.xsd"/>
   <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/digital-actions/shutdown-computer-4.23.1.xsd"/>
@@ -184,6 +185,7 @@
             <xs:element name="ProgramOnMain"     type="LogixNG_DigitalAction_ProgramOnMainType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="Return"            type="LogixNG_DigitalAction_ReturnType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="RunOnce"           type="LogixNG_DigitalAction_RunOnceType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="SendCbusEvent"     type="LogixNG_DigitalAction_SendCbusEventType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="Sequence"          type="LogixNG_DigitalAction_SequenceType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="ShowDialog"        type="LogixNG_DigitalAction_ShowDialogType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="ShutdownComputer"  type="LogixNG_DigitalAction_ShutdownComputerType" minOccurs="0" maxOccurs="unbounded" />

--- a/xml/schema/logixng/digital-actions/send-cbus-event-5.11.7.xsd
+++ b/xml/schema/logixng/digital-actions/send-cbus-event-5.11.7.xsd
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="../schema2xhtml.xsl" type="text/xsl"?>
+
+<!-- This schema is part of JMRI. Copyright 2018.                           -->
+<!--                                                                        -->
+<!-- JMRI is free software; you can redistribute it and/or modify it under  -->
+<!-- the terms of version 2 of the GNU General Public License as published  -->
+<!-- by the Free Software Foundation. See the "COPYING" file for a copy     -->
+<!-- of this license.                                                       -->
+<!--                                                                        -->
+<!-- JMRI is distributed in the hope that it will be useful, but WITHOUT    -->
+<!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
+<!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
+<!-- for more details.                                                      -->
+
+<!-- This file contains definitions for LogixNG                             -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:xsi ="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:docbook="http://docbook.org/ns/docbook"
+           xmlns:jmri="http://jmri.org/xml/schema/JMRIschema"
+           xsi:schemaLocation="
+                http://jmri.org/xml/schema/JMRIschema http://jmri.org/xml/schema/JMRIschema.xsd
+                http://docbook.org/ns/docbook http://jmri.org/xml/schema/docbook/docbook.xsd
+            "
+        >
+
+    <xs:complexType name="LogixNG_DigitalAction_SendCbusEventType">
+      <xs:annotation>
+        <xs:documentation>
+          Define the XML stucture for storing the contents of a SendCbusEventXml class.
+        </xs:documentation>
+        <xs:appinfo>
+            <jmri:usingclass configurexml="true">jmri.jmrit.logixng.digital.actions.configurexml.SendCbusEventXml</jmri:usingclass>
+        </xs:appinfo>
+      </xs:annotation>
+
+            <xs:sequence>
+
+              <xs:element name="systemName" type="systemNameType" minOccurs="1" maxOccurs="1"/>
+              <xs:element name="userName" type="userNameType" minOccurs="0" maxOccurs="1"/>
+              <xs:element name="comment" type="commentType" minOccurs="0" maxOccurs="unbounded"/>
+
+              <xs:element name="systemConnection" type="xs:string" minOccurs="0" maxOccurs="1"/>
+              
+              <xs:element name="nodeNumber" type="LogixNG_SelectIntegerType" minOccurs="1" maxOccurs="1" />
+              <xs:element name="eventNumber" type="LogixNG_SelectIntegerType" minOccurs="1" maxOccurs="1" />
+              <xs:element name="eventType" type="LogixNG_SelectEnumType" minOccurs="1" maxOccurs="1" />
+
+              <xs:element name="MaleSocket" type="LogixNG_MaleSocket_Type" minOccurs="0" maxOccurs="1"/>
+
+            </xs:sequence>
+
+            <xs:attribute name="class" type="classType" use="required"/>
+
+    </xs:complexType>
+
+</xs:schema>


### PR DESCRIPTION
This PR adds the LogixNG action `Send CBUS event`. It's in the category `CBUS`, which is available if there is a CBUS connection. It supports event types Off, On, Request.

See: https://groups.io/g/jmriusers/message/241957

![Skärmbild_2025-05-10_18-44-08](https://github.com/user-attachments/assets/5189c494-4401-4d84-b373-dcd986424dbd)
