### PR TITLE
Better 'notes' in Digitrax BDL716 roster entry

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -86,7 +86,7 @@
 
         <h4>LocoNet</h4>
             <ul>
-                <li></li>
+                <li>updated the "Notes" page for the BDL716's "Roster Entry".</li>
             </ul>
 
         <h4>Maple</h4>
@@ -662,4 +662,3 @@
                 has been updated to the current 1.2025.2 version.</li>
             <li>Fixed a bug where Dark Mode would fail due to a missing library.</li>
         </ul>
-

--- a/xml/decoders/Digitrax_BDL716.xml
+++ b/xml/decoders/Digitrax_BDL716.xml
@@ -156,33 +156,88 @@
         <name>Notes</name>
         <column>
             <label>
-                <text>&lt;html&gt;&lt;h2&gt;Notes:</text>
-            </label>
+                <text>&lt;html&gt;&lt;h2&gt;Notes:&lt;/h2&gt;
+                  &lt;ul&gt;
+                  &lt;li&gt;The BDL716 device implements features that "use" various
+                  types of addresses in&lt;br&gt;
+                  several types of "Address Spaces".  It is important that the
+                  device &lt;em&gt;only&lt;/em&gt; uses those&lt;br&gt;
+                  addresses that are &lt;em&gt;not&lt;/em&gt; used by any other device,
+                  whether on LocoNet or connected&lt;br&gt;
+                  to the "DCC Track" signal. &lt;/li&gt;
+                  &lt;li&gt;The BDL716 is believed to use the addresses as described below:&lt;br&gt;
+                  &lt;table border="3"&gt;
+                    &lt;tr&gt;&lt;th&gt;Address Type&lt;/th&gt;
+                    &lt;th&gt;Range of Addresses&lt;/th&gt;
+                    &lt;th&gt;Comments&lt;/th&gt;&lt;/tr&gt;
 
-          <label>
-              <text> </text>
-          </label>
-          <label>
-              <text>&lt;html&gt;&lt;ul&gt;
-              &lt;li&gt;When accessing CVs for the BDL716 device, its CVs are
-                  implemented as if they are in &lt;br;&gt;the LocoNet "switch" address
-                  space, even though the BDL716 &lt;em&gt;does not&lt;/em&gt;
-                  implement &lt;br&gt;any "switches".&lt;/li&gt;
-              &lt;li&gt;The BDL716 might be accessible at &lt;em&gt;any of the
-                  "Switch" numbers&lt;/em&gt; that &lt;br;&gt;correspond to the BDL716's 
-                  "Sensor" addresses.&lt;/li&gt;
-              &lt;li&gt;The BDL716's CVs can (mistakenly!) be mapped to a "Base 
-                  Address" that "overlaps" &lt;br;&gt;another device on this 
-                  LocoNet connection, or via a DCC Track-connected device.  &lt;br;&gt;When 
-                  programming with this roster entry, it might cause other 
-                  devices to be &lt;br;&gt;mistakenly configured.&lt;/li&gt;
+                    &lt;tr&gt;&lt;td&gt;Sensors&lt;/td&gt;
+                    &lt;td&gt;Base Address to&lt;br&gt;(Base Address + 15)&lt;/td&gt;
+                    &lt;td&gt;The BDL716 implements 16 "Detection&lt;br&gt;
+                              Sensors" in the LocoNet sensor address&lt;br&gt;
+                              range.&lt;/td&gt;
+                    &lt;/tr&gt;
+
+                    &lt;tr&gt;&lt;td&gt;Switches&lt;/td&gt;
+                    &lt;td&gt;(None)&lt;/td&gt;
+                    &lt;td&gt;The BDL716 does not implement any&lt;br&gt;
+                              "Turnout"s in either the LocoNet or&lt;br&gt;
+                              the "NMRA Accessory" address range.&lt;/td&gt;
+                    &lt;/tr&gt;
+
+                    &lt;tr&gt;&lt;td&gt;NMRA "Extended&lt;br&gt;Accessories"
+                    &lt;br&gt;(Signal Aspect&lt;br&gt;Accessories)&lt;/td&gt;
+                    &lt;td&gt;Base Address to&lt;br&gt;(Base Address + 3)&lt;/td&gt;
+                    &lt;td&gt;The BDL716 uses NMRA "Extended&lt;br&gt;
+                              Accessory" ("Signal Aspect") &lt;br&gt;
+                              addresses for accessing Device&lt;br&gt;
+                              "CV" settings, but does not otherwise&lt;br&gt;
+                              implement any "Extended Accessory"&lt;br&gt;
+                              addresses.&lt;/td&gt;
+                    &lt;/tr&gt;
+
+                    &lt;tr&gt;&lt;td&gt;Transponding&lt;br&gt;"Zones"&lt;/td&gt;
+                    &lt;td&gt;(None)&lt;/td&gt;
+                    &lt;td&gt;The BDL716 does not implement any&lt;br&gt;
+                              "Transponding" addresses in the&lt;br&gt;
+                              LocoNet Transponding address range.&lt;/td&gt;
+                    &lt;/tr&gt;
+
+                    &lt;tr&gt;&lt;td&gt;"Power/Track&lt;br&gt;Status"&lt;/td&gt;
+                    &lt;td&gt;(None)&lt;/td&gt;
+                    &lt;td&gt;The BDL716 does not implement any&lt;br&gt;
+                              addresses in the LocoNet "Power/&lt;br&gt;
+                              Track Status" address range.&lt;/td&gt;
+                    &lt;/tr&gt;
+                  &lt;/table&gt;
+
+              &lt;li&gt;The BDL716's CVs can be mapped to a "Base Address" that
+                        "overlaps" another&lt;br;&gt;
+                        device on this LocoNet connection, or otherwise
+                        conflicts with an NMRA&lt;br;&gt;
+                        Extended Accessory decoder.&lt;br;&gt;
+                        &lt;em&gt;When programming with this roster entry, such a conflict
+                        can cause the conflicting&lt;br;&gt;
+                        device to be mistakenly configured.&lt;/em&gt;&lt;/li&gt;
+              &lt;li&gt;Because the DT602 or other mechanisms (like this roster entry!)
+                  can access this&lt;br;&gt;
+                  BDL716 device's CVs by any of a number of "device addresses"
+                  (See 'NMRA&lt;br&gt;
+                  "Extended Accessories" in the table above), this roster entry's
+                  "Board Address"&lt;br;&gt;
+                  should be configured to the actual device's Base Address. This
+                  will reduce the&lt;br;&gt;
+                  likelihood of mis-configuring this BDL716 or any other device
+                  that may be&lt;br;&gt;
+                  configured by this type of configuration method, whether a
+                  LocoNet peripheral or&lt;/li&gt;
+                  some other kind of device.&lt;/li&gt;
               &lt;li&gt;Because of the notes above, &lt;/em&gt;it is recommended&lt;/em&gt;
-                  that this BDL716 roster entry &lt;br;&gt;should be set to the 
-                  BDL716's "Base Address" setting, and the Base Address &lt;br;&gt;
-                  setting should not conflict with other BDL716 addresses.
-              &lt;li&gt;The BDL716 device's "Sensor" addresses are from the "Base 
-                  Address" to the &lt;br;&gt;"Base Address" + 15.&lt;/li&gt;
-              &lt;/ul&gt;&lt;/html&gt;</text>
+                  that this BDL716 roster entry &lt;br;&gt;
+                  should be set to the BDL716's "Base Address" setting, and that
+                  care must be taken&lt;br;&gt;
+                  to avoid other devices from using addresses that this BDL716
+                  will use.&lt;/ul&gt;&lt;/html&gt;</text>
           </label>
           <label>
               <text> </text>


### PR DESCRIPTION
provides a better "notes" page for the BDL716 roster entry.