### PR TITLE
drM SPC200R - basic Speedo support

### DIFF
--- a/default_lcf.xml
+++ b/default_lcf.xml
@@ -114,7 +114,6 @@
         <!-- <Logger name="jmri.jmrit.symbolicprog.DecVariableValue" level="DEBUG"/> -->
         <!-- <Logger name="jmri.jmrix" level="DEBUG"/> -->
         <!-- <Logger name="jmri.jmrix.nce.NceTrafficController" level="WARN"/> -->
-        <!-- <Logger name="jmri.jmrix.bachrus" level="DEBUG"/> -->
 
         <!-- <Logger name="jmri.jmrit.display.layoutEditor" level="DEBUG"/> -->
         <!-- <Logger name="jmri.jmrit.display.layoutEditor.LayoutBlock" level="DEBUG"/> -->

--- a/default_lcf.xml
+++ b/default_lcf.xml
@@ -114,6 +114,7 @@
         <!-- <Logger name="jmri.jmrit.symbolicprog.DecVariableValue" level="DEBUG"/> -->
         <!-- <Logger name="jmri.jmrix" level="DEBUG"/> -->
         <!-- <Logger name="jmri.jmrix.nce.NceTrafficController" level="WARN"/> -->
+        <Logger name="jmri.jmrix.bachrus" level="TRACE"/>
 
         <!-- <Logger name="jmri.jmrit.display.layoutEditor" level="DEBUG"/> -->
         <!-- <Logger name="jmri.jmrit.display.layoutEditor.LayoutBlock" level="DEBUG"/> -->

--- a/default_lcf.xml
+++ b/default_lcf.xml
@@ -114,7 +114,7 @@
         <!-- <Logger name="jmri.jmrit.symbolicprog.DecVariableValue" level="DEBUG"/> -->
         <!-- <Logger name="jmri.jmrix" level="DEBUG"/> -->
         <!-- <Logger name="jmri.jmrix.nce.NceTrafficController" level="WARN"/> -->
-        <Logger name="jmri.jmrix.bachrus" level="TRACE"/>
+        <!-- <Logger name="jmri.jmrix.bachrus" level="DEBUG"/> -->
 
         <!-- <Logger name="jmri.jmrit.display.layoutEditor" level="DEBUG"/> -->
         <!-- <Logger name="jmri.jmrit.display.layoutEditor.LayoutBlock" level="DEBUG"/> -->

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -49,6 +49,11 @@
                 <li></li>
             </ul>
 
+        <h4>drM</h4>
+            <ul>
+                <li>Added initial support for the SPC200R Speedo meter. Speed will correctly show. Further support pending.</li>
+            </ul>
+
         <h4>ESU</h4>
             <ul>
                 <li></li>

--- a/java/src/jmri/jmrix/bachrus/BachrusBundle.properties
+++ b/java/src/jmri/jmrix/bachrus/BachrusBundle.properties
@@ -85,6 +85,7 @@ Reader40 = 40 series reader
 Reader50 = 50 series reader
 Reader60 = 60 series reader
 Reader103 = KPF-Zeller reader
+Reader200 = drM SPC200R reader
 ReaderErr = Reader Error!
 
 StatTOn = Track power on

--- a/java/src/jmri/jmrix/bachrus/DRMConnectionTypeList.java
+++ b/java/src/jmri/jmrix/bachrus/DRMConnectionTypeList.java
@@ -1,0 +1,32 @@
+package jmri.jmrix.bachrus;
+
+import jmri.jmrix.ConnectionTypeList;
+import org.openide.util.lookup.ServiceProvider;
+
+/**
+ * Returns a list of valid drM Connection Types
+ *
+ * @author Bob Jacobsen Copyright (C) 2010, 2022
+ * @author Kevin Dickerson Copyright (C) 2010
+ * @author Andrew Crosland Copyright (C) 2010
+ * @author Lolke Bijlsma Copyright (C) 2025
+  *
+ */
+@ServiceProvider(service = ConnectionTypeList.class)
+public class DRMConnectionTypeList implements jmri.jmrix.ConnectionTypeList {
+
+    public static final String DRM = "drM";
+
+    @Override
+    public String[] getAvailableProtocolClasses() {
+        return new String[]{
+            "jmri.jmrix.bachrus.drmserialdriver.ConnectionConfig"
+        };
+    }
+
+    @Override
+    public String[] getManufacturers() {
+        return new String[]{DRM};
+    }
+
+}

--- a/java/src/jmri/jmrix/bachrus/SpeedoConsoleFrame.java
+++ b/java/src/jmri/jmrix/bachrus/SpeedoConsoleFrame.java
@@ -1152,7 +1152,7 @@ public class SpeedoConsoleFrame extends JmriJFrame implements SpeedoListener,
      */
     @Override
     public synchronized void reply(SpeedoReply l) {  // receive a reply message and log it
-        //log.debug("Speedo reply " + l.toString());
+        log.debug("Speedo reply " + l.toString());
         count = l.getCount();
         series = l.getSeries();
         if (count > 0) {
@@ -1172,6 +1172,10 @@ public class SpeedoConsoleFrame extends JmriJFrame implements SpeedoListener,
                 case 103:
                     circ = (float) ((5.95 + 0.9) * Math.PI);
                     readerLabel.setText(Bundle.getMessage("Reader103"));
+                    break;
+                case 200:
+                    circ = 12.5664F;
+                    readerLabel.setText(Bundle.getMessage("Reader200"));
                     break;
                 default:
                     speedTextField.setText(Bundle.getMessage("ReaderErr"));
@@ -1207,6 +1211,12 @@ public class SpeedoConsoleFrame extends JmriJFrame implements SpeedoListener,
             avSpeed = sampleSpeed;
             log.debug("New KPF-Zeller sample: {} Average: {}", sampleSpeed, avSpeed);
 
+        } else if (series == 200) {
+            // SPC200R
+            sampleSpeed = count / 10.0f;
+            avSpeed = sampleSpeed;
+            log.debug("New SPC200R sample: {} Average: {}", sampleSpeed, avSpeed);
+            
         } else if (series > 0 && series <= 6) {
             // Bachrus
             // Scale the data and calculate kph

--- a/java/src/jmri/jmrix/bachrus/SpeedoConsoleFrame.java
+++ b/java/src/jmri/jmrix/bachrus/SpeedoConsoleFrame.java
@@ -1152,7 +1152,7 @@ public class SpeedoConsoleFrame extends JmriJFrame implements SpeedoListener,
      */
     @Override
     public synchronized void reply(SpeedoReply l) {  // receive a reply message and log it
-        log.debug("Speedo reply " + l.toString());
+        //log.debug("Speedo reply " + l.toString());
         count = l.getCount();
         series = l.getSeries();
         if (count > 0) {

--- a/java/src/jmri/jmrix/bachrus/SpeedoReply.java
+++ b/java/src/jmri/jmrix/bachrus/SpeedoReply.java
@@ -58,6 +58,29 @@ public class SpeedoReply extends jmri.jmrix.AbstractMRReply {
                 return 0;
             }
         }
+        // drM SPC200R
+        if (_nDataChars == 7) {
+            // Check for invalid speed flag (0x2D = 45)
+            for (int i = 3; i <= 6; i++) {
+                if (_dataChars[i] == 0x2D) {
+                    return -1;
+                }
+            }      
+            int hundreds = _dataChars[3];
+            int tens = _dataChars[4];
+            int units = _dataChars[5];
+            int tenths = _dataChars[6];
+
+            // Basic range check (optional)
+            if (hundreds > 9 || tens > 9 || units > 9 || tenths > 9) {
+                return -1;
+            }
+
+            Float speed = hundreds * 100 + tens * 10 + units + tenths / 10.0f;
+            int scaled = Math.round(speed * 10); // e.g. 123.4 -> 1234
+            log.trace("Speed float {} int {}", speed, scaled);
+            return scaled; 
+        }
         // bachrus formatting
         // don't return 0 as it will cause an exception
         if (_nDataChars < 9) {
@@ -78,6 +101,7 @@ public class SpeedoReply extends jmri.jmrix.AbstractMRReply {
      * <dt>5</dt><dd>Reader 50</dd>
      * <dt>6</dt><dd>Reader 60</dd>
      * <dt>103</dt><dd>KPR-Zeller</dd>
+     * <dt>200</dt><dd>drM SPC200R</dd>
      * </dl>
      * @return type code for specific reply content
      */
@@ -86,6 +110,10 @@ public class SpeedoReply extends jmri.jmrix.AbstractMRReply {
         // KPF-Zeller formatting
         if (_nDataChars == 13) {
             return 103;
+        }
+        // drM SPC200R formatting
+        if (_nDataChars == 7) {
+            return 200;
         }
         // bachrus formatting
         if (_nDataChars < 7) {

--- a/java/src/jmri/jmrix/bachrus/SpeedoReply.java
+++ b/java/src/jmri/jmrix/bachrus/SpeedoReply.java
@@ -59,7 +59,8 @@ public class SpeedoReply extends jmri.jmrix.AbstractMRReply {
             }
         }
         // drM SPC200R
-        if (_nDataChars == 7) {
+        if (_nDataChars == 7 &&
+               (_dataChars[0] == 0x50 || _dataChars[0] == 0x51 || _dataChars[0] == 0x52 || _dataChars[0] == 0x53) ) {
             // Check for invalid speed flag (0x2D = 45)
             for (int i = 3; i <= 6; i++) {
                 if (_dataChars[i] == 0x2D) {

--- a/java/src/jmri/jmrix/bachrus/SpeedoTrafficController.java
+++ b/java/src/jmri/jmrix/bachrus/SpeedoTrafficController.java
@@ -131,11 +131,19 @@ public class SpeedoTrafficController implements SpeedoInterface, SerialPortEvent
     boolean endReply(SpeedoReply msg) {
         // Detect that the reply buffer ends with ";"
         int num = msg.getNumDataElements();
-        // ptr is offset of last element in SpeedoReply
-        int ptr = num - 1;
-        if (msg.getElement(ptr) != ';') {
-            return false;
+        
+        //quick hack - TODO - support different buffer ends
+        // SPC200R has a 7 byte buffer, so assume that if a 7 byte buffer was read it is the SPC200R
+        // if not then check for ; as the Bachrus and KPF-Zeller use ; as termination
+        if (num != 7) {
+            
+            // ptr is offset of last element in SpeedoReply
+            int ptr = num - 1;
+            if (msg.getElement(ptr) != ';') {
+                return false;
+            }
         }
+
         unsolicited = true;
         return true;
     }
@@ -163,7 +171,9 @@ public class SpeedoTrafficController implements SpeedoInterface, SerialPortEvent
             case SerialPortEvent.DATA_AVAILABLE:
                 // we get here if data has been received
                 //fill the current reply with any data received
+                log.debug("SerialPortEvent: DATA_AVAILABLE");
                 int replyCurrentSize = this.reply.getNumDataElements();
+                log.debug("number of data elements {}", replyCurrentSize);
                 int i;
                 for (i = replyCurrentSize; i < SpeedoReply.maxSize - replyCurrentSize; i++) {
                     try {

--- a/java/src/jmri/jmrix/bachrus/SpeedoTrafficController.java
+++ b/java/src/jmri/jmrix/bachrus/SpeedoTrafficController.java
@@ -132,17 +132,24 @@ public class SpeedoTrafficController implements SpeedoInterface, SerialPortEvent
         // Detect that the reply buffer ends with ";"
         int num = msg.getNumDataElements();
         
-        //quick hack - TODO - support different buffer ends
-        // SPC200R has a 7 byte buffer, so assume that if a 7 byte buffer was read it is the SPC200R
-        // if not then check for ; as the Bachrus and KPF-Zeller use ; as termination
-        if (num != 7) {
+        // Check for the SPC200R, the first byte is always 0x50, 0x51, 0x52 or 0x53
+        int value = msg.getElement(0);
+        if (value == 0x50 || value == 0x51 || value == 0x52 || value == 0x53) {
+            // SPC200R has a 7 byte output
+            if (num != 7) {
+                return false;
+            }
+        }
+        else
+        {
+            // Check for ';' as Bachrus and KPF-Zeller use ; as termination
             
             // ptr is offset of last element in SpeedoReply
             int ptr = num - 1;
             if (msg.getElement(ptr) != ';') {
                 return false;
             }
-        }
+      }
 
         unsolicited = true;
         return true;
@@ -171,9 +178,8 @@ public class SpeedoTrafficController implements SpeedoInterface, SerialPortEvent
             case SerialPortEvent.DATA_AVAILABLE:
                 // we get here if data has been received
                 //fill the current reply with any data received
-                log.debug("SerialPortEvent: DATA_AVAILABLE");
                 int replyCurrentSize = this.reply.getNumDataElements();
-                log.debug("number of data elements {}", replyCurrentSize);
+                //log.debug("SerialPortEvent: DATA_AVAILABEL, number of data elements {}", replyCurrentSize);
                 int i;
                 for (i = replyCurrentSize; i < SpeedoReply.maxSize - replyCurrentSize; i++) {
                     try {

--- a/java/src/jmri/jmrix/bachrus/drmserialdriver/Bundle.java
+++ b/java/src/jmri/jmrix/bachrus/drmserialdriver/Bundle.java
@@ -1,0 +1,98 @@
+package jmri.jmrix.bachrus.drmserialdriver;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.Locale;
+import javax.annotation.CheckReturnValue;
+import javax.annotation.CheckForNull;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
+@CheckReturnValue
+@SuppressFBWarnings(value = "NM_SAME_SIMPLE_NAME_AS_SUPERCLASS", justification = "Desired pattern is repeated class names with package-level access to members")
+
+@javax.annotation.concurrent.Immutable
+
+/**
+ * Provides standard access for resource bundles in a package.
+ *
+ * Convention is to provide a subclass of this name in each package, working off
+ * the local resource bundle name.
+ *
+ * @author Bob Jacobsen Copyright (C) 2012
+ * @since 3.3.1
+ */
+public class Bundle extends jmri.jmrix.bachrus.Bundle {
+
+    @CheckForNull
+    private static final String name = null; // No local resources
+
+    //
+    // below here is boilerplate to be copied exactly
+    //
+    /**
+     * Provides a translated string for a given key from the package resource
+     * bundle or parent.
+     * <p>
+     * Note that this is intentionally package-local access.
+     *
+     * @param key Bundle key to be translated
+     * @return Internationalized text
+     */
+    static String getMessage(String key) {
+        return getBundle().handleGetMessage(key);
+    }
+
+    /**
+     * Merges user data with a translated string for a given key from the
+     * package resource bundle or parent.
+     * <p>
+     * Uses the transformation conventions of the Java MessageFormat utility.
+     * <p>
+     * Note that this is intentionally package-local access.
+     *
+     * @see java.text.MessageFormat
+     * @param key  Bundle key to be translated
+     * @param subs One or more objects to be inserted into the message
+     * @return Internationalized text
+     */
+    static String getMessage(String key, Object... subs) {
+        return getBundle().handleGetMessage(key, subs);
+    }
+
+    /**
+     * Merges user data with a translated string for a given key in a given
+     * locale from the package resource bundle or parent.
+     * <p>
+     * Uses the transformation conventions of the Java MessageFormat utility.
+     * <p>
+     * Note that this is intentionally package-local access.
+     *
+     * @see java.text.MessageFormat
+     * @param locale The locale to be used
+     * @param key    Bundle key to be translated
+     * @param subs   One or more objects to be inserted into the message
+     * @return Internationalized text
+     */
+    static String getMessage(Locale locale, String key, Object... subs) {
+        return getBundle().handleGetMessage(locale, key, subs);
+    }
+
+
+    private final static Bundle b = new Bundle();
+
+    @Override
+    @CheckForNull
+    protected String bundleName() {
+        return name;
+    }
+
+    protected static jmri.Bundle getBundle() {
+        return b;
+    }
+
+    @Override
+    protected String retry(Locale locale, String key) {
+        return super.getBundle().handleGetMessage(locale,key);
+    }
+
+}

--- a/java/src/jmri/jmrix/bachrus/drmserialdriver/COPYING
+++ b/java/src/jmri/jmrix/bachrus/drmserialdriver/COPYING
@@ -1,0 +1,372 @@
+JMRI is free software; you can redistribute it and/or modify it 
+under the terms of version 2 of the GNU General Public License as 
+published by the Free Software Foundation.
+
+JMRI is distributed in the hope that it will be useful, but 
+WITHOUT ANY WARRANTY; without even the implied warranty of 
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+GNU General Public License for more details.
+
+A copy of version 2 of the GNU General Public License is 
+appended below. For more information, see 
+<http://www.gnu.org/licenses/>.
+
+Linking JMRI or its parts statically or dynamically with other 
+modules is making a combined work based on this library. Thus, the 
+terms and conditions of the GNU General Public License 2.0 cover 
+the whole combination.
+
+As a special exception, the copyright holders of JMRI give you 
+permission to link JMRI with independent modules to produce an 
+executable, regardless of the license terms of these independent 
+modules, and to copy and distribute the resulting executable under 
+terms of your choice, provided that you also meet, for each linked 
+independent module, the terms and conditions of the license of that 
+module. An independent module is a module which is not derived from 
+or based on JMRI. If you modify JMRI, you may extend this exception 
+to your version of JMRI, but you are not obligated to do so. If you do 
+not wish to do so, delete this exception statement from your version.
+
+
+-------------------------------------------------------------------
+
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.
+

--- a/java/src/jmri/jmrix/bachrus/drmserialdriver/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/bachrus/drmserialdriver/ConnectionConfig.java
@@ -1,0 +1,57 @@
+package jmri.jmrix.bachrus.drmserialdriver;
+
+import jmri.util.SystemType;
+
+/**
+ * Definition of objects to handle configuring a connection via a Bachrus
+ * SerialDriverAdapter object.
+ *
+ * @author Bob Jacobsen Copyright (C) 2001, 2003
+ * @author Andrew Crosland Copyright (C) 2010
+ * @author Lolke Bijlsma Copyright (C) 2025
+ */
+public class ConnectionConfig extends jmri.jmrix.AbstractSerialConnectionConfig {
+
+    /**
+     * Create a connection configuration with a preexisting adapter. This is
+     * used principally when loading a configuration that defines this
+     * connection.
+     *
+     * @param p the adapter to create a connection configuration for
+     */
+    public ConnectionConfig(jmri.jmrix.SerialPortAdapter p) {
+        super(p);
+    }
+
+    /**
+     * Ctor for a connection configuration with no preexisting adapter.
+     * {@link #setInstance()} will fill the adapter member.
+     */
+    public ConnectionConfig() {
+        super();
+    }
+
+    @Override
+    public String name() {
+        return "Speedo"; // NOI18N
+    }
+
+    @Override
+    protected String[] getPortFriendlyNames() {
+        if (SystemType.isWindows()) {
+            return new String[]{"Bachrus Speedo", "Bachrus"};
+        }
+        return new String[]{};
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void setInstance() {
+        if (adapter == null) {
+            adapter = new SerialDriverAdapter();
+        }
+    }
+
+}

--- a/java/src/jmri/jmrix/bachrus/drmserialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/bachrus/drmserialdriver/SerialDriverAdapter.java
@@ -1,0 +1,192 @@
+package jmri.jmrix.bachrus.drmserialdriver;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.TooManyListenersException;
+
+import jmri.jmrix.bachrus.DRMConnectionTypeList;
+import jmri.jmrix.bachrus.SpeedoPortController;
+import jmri.jmrix.bachrus.SpeedoSystemConnectionMemo;
+import jmri.jmrix.bachrus.SpeedoTrafficController;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import jmri.jmrix.purejavacomm.CommPortIdentifier;
+import jmri.jmrix.purejavacomm.NoSuchPortException;
+import jmri.jmrix.purejavacomm.PortInUseException;
+import jmri.jmrix.purejavacomm.UnsupportedCommOperationException;
+
+/**
+ * Implements SerialPortAdapter for the drM SPC200R speedo.
+ * <p>
+ * This connects a drM speedo reader interface via a serial com port.
+ * Normally controlled by the SerialDriverFrame class.
+ * <p>
+ * The current implementation only handles the 115,200 baud rate, and does not use
+ * any other options at configuration time.
+ *
+ * Updated January 2010 for gnu io (RXTX) - Andrew Berridge. Comments tagged
+ * with "AJB" indicate changes or observations by me
+ *
+ * @author Bob Jacobsen Copyright (C) 2001, 2002
+ * @author Andrew Crosland Copyright (C) 2010
+ * @author Lolke Bijlsma Copyright (C) 2025
+ */
+public class SerialDriverAdapter extends SpeedoPortController {
+
+    public SerialDriverAdapter() {
+        super(new SpeedoSystemConnectionMemo());
+        setManufacturer(DRMConnectionTypeList.DRM);
+        this.getSystemConnectionMemo().setSpeedoTrafficController(new SpeedoTrafficController(this.getSystemConnectionMemo()));
+    }
+
+    jmri.jmrix.purejavacomm.SerialPort activeSerialPort = null;
+
+    @Override
+    public String openPort(String portName, String appName) {
+        // open the port, check ability to set moderators
+        try {
+            // get and open the primary port
+            CommPortIdentifier portID = CommPortIdentifier.getPortIdentifier(portName);
+            try {
+                activeSerialPort = portID.open(appName, 2000);  // name of program, msec to wait
+            } catch (PortInUseException p) {
+                return handlePortBusy(p, portName, log);
+            }
+
+            // try to set it for communication via SerialDriver
+            try {
+                activeSerialPort.setSerialPortParams(115200,
+                        jmri.jmrix.purejavacomm.SerialPort.DATABITS_8,
+                        jmri.jmrix.purejavacomm.SerialPort.STOPBITS_1,
+                        jmri.jmrix.purejavacomm.SerialPort.PARITY_NONE);
+            } catch (UnsupportedCommOperationException e) {
+                log.error("Cannot set serial parameters on port {}: {}", portName, e.getMessage());
+                return "Cannot set serial parameters on port " + portName + ": " + e.getMessage();
+            }
+
+            // set RTS high, DTR high
+            // disable flow control; hardware lines used for signaling, XON/XOFF might appear in data
+            //AJB: Removed Jan 2010 -
+            //Setting flow control mode to zero kills comms - SPROG doesn't send data
+            //Concern is that will disabling this affect other SPROGs? Serial ones?
+            configureLeadsAndFlowControl(activeSerialPort, 0);
+
+            // set timeout
+            // activeSerialPort.enableReceiveTimeout(1000);
+            log.debug("Serial timeout was observed as: {} {}", activeSerialPort.getReceiveTimeout(), activeSerialPort.isReceiveTimeoutEnabled());
+
+            // get and save stream
+            serialStream = activeSerialPort.getInputStream();
+
+            // purge contents, if any
+            purgeStream(serialStream);
+
+            // report status?
+            if (log.isInfoEnabled()) {
+                log.info("{} port opened at {} baud, sees  DTR: {} RTS: {} DSR: {} CTS: {}  CD: {}", portName, activeSerialPort.getBaudRate(), activeSerialPort.isDTR(), activeSerialPort.isRTS(), activeSerialPort.isDSR(), activeSerialPort.isCTS(), activeSerialPort.isCD());
+            }
+
+            //AJB - add Sprog Traffic Controller as event listener
+            try {
+                activeSerialPort.addEventListener(this.getSystemConnectionMemo().getTrafficController());
+            } catch (TooManyListenersException e) {
+            }
+            setManufacturer(DRMConnectionTypeList.DRM);
+
+            // AJB - activate the DATA_AVAILABLE notifier
+            activeSerialPort.notifyOnDataAvailable(true);
+
+            opened = true;
+
+        } catch (NoSuchPortException p) {
+            return handlePortNotFound(p, portName, log);
+        } catch (IOException ex) {
+            log.error("Unexpected exception while opening port {}", portName, ex);
+            return "Unexpected error while opening port " + portName + ": " + ex;
+        }
+
+        return null; // indicates OK return
+
+    }
+
+    public void setHandshake(int mode) {
+        try {
+            activeSerialPort.setFlowControlMode(mode);
+        } catch (UnsupportedCommOperationException ex) {
+            log.error("Unexpected exception while setting COM port handshake mode", ex);
+        }
+
+    }
+
+    /**
+     * set up all of the other objects to operate with an Sprog command station
+     * connected to this port
+     */
+    @Override
+    public void configure() {
+        // connect to the traffic controller
+        this.getSystemConnectionMemo().getTrafficController().connectPort(this);
+
+        this.getSystemConnectionMemo().configureManagers();
+    }
+
+    // base class methods for the SprogPortController interface
+    @Override
+    public DataInputStream getInputStream() {
+        if (!opened) {
+            log.error("getInputStream called before load(), stream not available");
+            return null;
+        }
+        return new DataInputStream(serialStream);
+    }
+
+    @Override
+    public DataOutputStream getOutputStream() {
+        if (!opened) {
+            log.error("getOutputStream called before load(), stream not available");
+        }
+        try {
+            return new DataOutputStream(activeSerialPort.getOutputStream());
+        } catch (java.io.IOException e) {
+            log.error("getOutputStream exception", e);
+        }
+        return null;
+    }
+
+    @Override
+    public boolean status() {
+        return opened;
+    }
+
+    /**
+     * {@inheritDoc}
+     * Currently only 115,200 bps
+     */
+    @Override
+    public String[] validBaudRates() {
+        return new String[]{"115,200 bps"};
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int[] validBaudNumbers() {
+        return new int[]{115200};
+    }
+
+    @Override
+    public int defaultBaudIndex() {
+        return 0;
+    }
+
+    private boolean opened = false;
+    InputStream serialStream = null;
+
+    private final static Logger log = LoggerFactory.getLogger(SerialDriverAdapter.class);
+
+}

--- a/java/src/jmri/jmrix/bachrus/drmserialdriver/configurexml/COPYING
+++ b/java/src/jmri/jmrix/bachrus/drmserialdriver/configurexml/COPYING
@@ -1,0 +1,372 @@
+JMRI is free software; you can redistribute it and/or modify it 
+under the terms of version 2 of the GNU General Public License as 
+published by the Free Software Foundation.
+
+JMRI is distributed in the hope that it will be useful, but 
+WITHOUT ANY WARRANTY; without even the implied warranty of 
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+GNU General Public License for more details.
+
+A copy of version 2 of the GNU General Public License is 
+appended below. For more information, see 
+<http://www.gnu.org/licenses/>.
+
+Linking JMRI or its parts statically or dynamically with other 
+modules is making a combined work based on this library. Thus, the 
+terms and conditions of the GNU General Public License 2.0 cover 
+the whole combination.
+
+As a special exception, the copyright holders of JMRI give you 
+permission to link JMRI with independent modules to produce an 
+executable, regardless of the license terms of these independent 
+modules, and to copy and distribute the resulting executable under 
+terms of your choice, provided that you also meet, for each linked 
+independent module, the terms and conditions of the license of that 
+module. An independent module is a module which is not derived from 
+or based on JMRI. If you modify JMRI, you may extend this exception 
+to your version of JMRI, but you are not obligated to do so. If you do 
+not wish to do so, delete this exception statement from your version.
+
+
+-------------------------------------------------------------------
+
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.
+

--- a/java/src/jmri/jmrix/bachrus/drmserialdriver/configurexml/ConnectionConfigXml.java
+++ b/java/src/jmri/jmrix/bachrus/drmserialdriver/configurexml/ConnectionConfigXml.java
@@ -1,0 +1,43 @@
+package jmri.jmrix.bachrus.drmserialdriver.configurexml;
+
+import jmri.jmrix.bachrus.drmserialdriver.ConnectionConfig;
+import jmri.jmrix.bachrus.drmserialdriver.SerialDriverAdapter;
+import jmri.jmrix.configurexml.AbstractSerialConnectionConfigXml;
+
+/**
+ * Handle XML persistance of layout connections by persisting the
+ * SerialDriverAdapter (and connections). Note this is named as the XML version
+ * of a ConnectionConfig object, but it's actually persisting the
+ * SerialDriverAdapter.
+ * <p>
+ * This class is invoked from jmrix.JmrixConfigPaneXml on write, as that class
+ * is the one actually registered. Reads are brought here directly via the class
+ * attribute in the XML.
+ *
+ * @author Bob Jacobsen Copyright: Copyright (c) 2003
+ */
+public class ConnectionConfigXml extends AbstractSerialConnectionConfigXml {
+
+    public ConnectionConfigXml() {
+        super();
+    }
+
+    @Override
+    protected void getInstance() {
+        if (adapter == null) {
+            adapter = new SerialDriverAdapter();
+        }
+    }
+
+    @Override
+    protected void getInstance(Object object) {
+        adapter = ((ConnectionConfig) object).getAdapter();
+    }
+
+
+    @Override
+    protected void register() {
+        this.register(new ConnectionConfig(adapter));
+    }
+
+}

--- a/java/src/jmri/jmrix/bachrus/drmserialdriver/package-info.java
+++ b/java/src/jmri/jmrix/bachrus/drmserialdriver/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Defines classes for interfacing to a drM
+ * speedo reader via an RS232 serial line, or a virtual COM port.
+ */
+// include empty DefaultAnnotation to avoid excessive recompilation
+@edu.umd.cs.findbugs.annotations.DefaultAnnotation(value={})
+package jmri.jmrix.bachrus.drmserialdriver;

--- a/java/test/jmri/jmrix/bachrus/SpeedoReplyTest.java
+++ b/java/test/jmri/jmrix/bachrus/SpeedoReplyTest.java
@@ -48,6 +48,13 @@ public class SpeedoReplyTest extends jmri.jmrix.AbstractMessageTestBase {
         Assert.assertEquals("getCount",2222, m.getCount());
     }
 
+    @Test
+    public void spc200rTest300() {
+        SpeedoReply m  = new SpeedoReply("\u0051\u0010\u0031\u0000\u0003\u0000\u0000");
+        Assert.assertEquals("getSeries",200, m.getSeries());
+        Assert.assertEquals("getCount",300, m.getCount());
+    }
+
     @Override
     @AfterEach
     public void tearDown() {


### PR DESCRIPTION
This adds basic Speedo meter support for the drM SPC200R. 
The basic functionality means that the Speedo dial shows the measured speed.

The SPC200R also has controls about speed unit (KPH/MPH) and scale but that is ignored not included at this moment. This is for future revisions.