### PR TITLE
Change <..> in Javadoc to use HTML entities so Javadoc compiles

### DIFF
--- a/java/src/jmri/jmrix/dccpp/DCCppCommandStation.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppCommandStation.java
@@ -176,7 +176,7 @@ public class DCCppCommandStation implements jmri.CommandStation {
     }
 
     /**
-     * Does this command station support the latest Current commands <JG>, <JI>, etc.?
+     * Does this command station support the latest Current commands &lt;JG&gt;, &lt;JI&gt;, etc.?
      * @return true if supported, false if not
      */
     public boolean isCurrentListSupported() {


### PR DESCRIPTION
The Javadoc job on Jenkins has been failing because of the presence of `<JG>` and `<JI>` in comments.  This changes those to use HTML entities so that the Javadoc will compile cleanly.