### PR TITLE
Fix improper LocoNet message length interpretation

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -86,7 +86,8 @@
 
         <h4>LocoNet</h4>
             <ul>
-                <li></li>
+                <li>Resolved a Console log 'Error' message that could be seen when
+                    using the Slot Monitor's "Clear All Non-InUse Slots" button.</li>
             </ul>
 
         <h4>Maple</h4>
@@ -648,4 +649,3 @@
         <ul>
             <li></li>
         </ul>
-

--- a/java/src/jmri/jmrix/loconet/LocoNetSlot.java
+++ b/java/src/jmri/jmrix/loconet/LocoNetSlot.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Bob Jacobsen Copyright (C) 2001
  * @author Stephen Williams Copyright (C) 2008
- * @author B. Milhaupt, Copyright (C) 2018
+ * @author B. Milhaupt, Copyright (C) 2018, 2025
  * @author S. Gigiel, Copyright (C) 2018
  */
 public class LocoNetSlot {
@@ -85,7 +85,7 @@ public class LocoNetSlot {
     /**
      * Creates a slot object based on the contents of a LocoNet message.
      * The slot number is assumed to be found in byte 2 of the message if message is 0xE6 or bytes 2 and 3 for 0xE7
-     * 
+     *
      * @param l  a LocoNet message
      * @throws LocoNetException if the slot does not have an easily-found
      * slot number
@@ -884,12 +884,14 @@ public class LocoNetSlot {
                     if ((l.getElement(1) & 0b00001000) != 0) {
                         dirf = dirf | 0b00100000;
                     }
+                    lastUpdateTime = System.currentTimeMillis();
                 } else if ((l.getElement(1) & LnConstants.OPC_EXP_SEND_SUB_CODE_MASK_FUNCTION) == LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F0F6) {
                     // function grp 1
                     dirf = dirf & 0b11100000;
                     dirf = dirf | (l.getElement(4) & 0b00011111);
                     snd = snd & 0b11111100;
                     snd = snd | ((l.getElement(4) & 0b01100000) >> 5);
+                    lastUpdateTime = System.currentTimeMillis();
                 } else if ((l.getElement(1) & LnConstants.OPC_EXP_SEND_SUB_CODE_MASK_FUNCTION) == LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F7F13) {
                     // function grp 2
                     snd = snd & 0b11110011;
@@ -899,6 +901,7 @@ public class LocoNetSlot {
                     localF11 = ((l.getElement(4) & 0b00010000) != 0);
                     localF12 = ((l.getElement(4) & 0b00100000) != 0);
                     localF13 = ((l.getElement(4) & 0b01000000) != 0);
+                    lastUpdateTime = System.currentTimeMillis();
                 } else if ((l.getElement(1) & LnConstants.OPC_EXP_SEND_SUB_CODE_MASK_FUNCTION) == LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F14F20) {
                     localF14 = ((l.getElement(4) & 0b00000001) != 0);
                     localF15 = ((l.getElement(4) & 0b00000010) != 0);
@@ -907,6 +910,7 @@ public class LocoNetSlot {
                     localF18 = ((l.getElement(4) & 0b00010000) != 0);
                     localF19 = ((l.getElement(4) & 0b00100000) != 0);
                     localF20 = ((l.getElement(4) & 0b01000000) != 0);
+                    lastUpdateTime = System.currentTimeMillis();
                 } else if ((l.getElement(1) & LnConstants.OPC_EXP_SEND_SUB_CODE_MASK_FUNCTION) == LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F21F28_F28OFF
                         || (l.getElement(1) & LnConstants.OPC_EXP_SEND_SUB_CODE_MASK_FUNCTION) == LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F21F28_F28ON) {
                     localF21 = ((l.getElement(4) & 0b00000001) != 0);
@@ -917,6 +921,7 @@ public class LocoNetSlot {
                     localF26 = ((l.getElement(4) & 0b00100000) != 0);
                     localF27 = ((l.getElement(4) & 0b01000000) != 0);
                     localF28 = ((l.getElement(1) & 0b00010000) != 0);
+                    lastUpdateTime = System.currentTimeMillis();
                 }
                 notifySlotListeners();
                 break;
@@ -927,7 +932,7 @@ public class LocoNetSlot {
                 addr = l.getElement(5) + 128 * l.getElement(6);
                 spd = l.getElement(8);
                 if (loconetProtocol == LnConstants.LOCONETPROTOCOL_UNKNOWN) {
-                    // it has to be 2 
+                    // it has to be 2
                     loconetProtocol = LnConstants.LOCONETPROTOCOL_TWO;
                 }
                 dirf = l.getElement(10) & 0b00111111;

--- a/java/src/jmri/jmrix/loconet/SlotManager.java
+++ b/java/src/jmri/jmrix/loconet/SlotManager.java
@@ -42,7 +42,7 @@ import jmri.jmrix.loconet.SlotMapEntry.SlotType;
  * definitely can't.
  *
  * @author Bob Jacobsen Copyright (C) 2001, 2003, 2024
- * @author B. Milhaupt, Copyright (C) 2018
+ * @author B. Milhaupt, Copyright (C) 2018, 2024
  */
 public class SlotManager extends AbstractProgrammer implements LocoNetListener, CommandStation {
 
@@ -56,7 +56,7 @@ public class SlotManager extends AbstractProgrammer implements LocoNetListener, 
 
     public int serviceModeReplyDelay = 20;  // this is public to allow changes via script and tests. Adjusted by UsbDcs210PlusAdapter
 
-    public int opsModeReplyDelay = 100;  // this is public to allow changes via script and tests. 
+    public int opsModeReplyDelay = 100;  // this is public to allow changes via script and tests.
 
     public boolean pmManagerGotReply = false;  //this is public to allow changes via script and tests
 
@@ -524,6 +524,12 @@ public class SlotManager extends AbstractProgrammer implements LocoNetListener, 
             }
             return;
         }
+
+        if (m.getElement(1) != 0x15) {
+            // cannot check short slot messages.
+            return;
+        }
+
         switch (slot) {
             case 250:
                 // slot info if we have serial, the serial number in this slot

--- a/java/test/jmri/jmrix/loconet/SlotManagerTest.java
+++ b/java/test/jmri/jmrix/loconet/SlotManagerTest.java
@@ -588,9 +588,9 @@ public class SlotManagerTest {
                 lnis.outbound.elementAt(lnis.outbound.size() - 1).toString());
         Assert.assertEquals("reply status", -999, status);
         Assert.assertEquals("reply value", -999, value);
-        
+
         // provide LONG_ACK: Function not implemented, no reply will follow.
-        slotmanager.message(new LocoNetMessage(new int[]{0xB4, 0x6F, 0x7F}));             
+        slotmanager.message(new LocoNetMessage(new int[]{0xB4, 0x6F, 0x7F}));
         JUnitUtil.waitFor(releaseTestDelay);
         Assert.assertEquals("reply status", 0, status);
         Assert.assertEquals("reply value", -1, value);
@@ -609,11 +609,11 @@ public class SlotManagerTest {
                 lnis.outbound.elementAt(lnis.outbound.size() - 1).toString());
         Assert.assertEquals("reply status", -999, status);
         Assert.assertEquals("reply value", -999, value);
-        
+
         // provide LONG_ACK: Function not implemented, no reply will follow.
-        slotmanager.message(new LocoNetMessage(new int[]{0xB4, 0x6F, 0x7F}));             
+        slotmanager.message(new LocoNetMessage(new int[]{0xB4, 0x6F, 0x7F}));
         // LONG_ACK: The Slot Write command was accepted blind (no response will be sent).
-        slotmanager.message(new LocoNetMessage(new int[]{0xB4, 0x6F, 0x40}));             
+        slotmanager.message(new LocoNetMessage(new int[]{0xB4, 0x6F, 0x40}));
         JUnitUtil.waitFor(releaseTestDelay);
         Assert.assertEquals("reply status", 0, status);
         Assert.assertEquals("reply value", -1, value);
@@ -1491,6 +1491,15 @@ public class SlotManagerTest {
                 lnis.outbound.elementAt(0).toString());
     }
 
+    @Test
+    public void testClearAllNonZeroSlotsFail() {
+        // test fix of error when "clear All Non-zero slots" operation is executed.
+        slotmanager.message(new LocoNetMessage(new int[]{0xD4, 0x39, 0x7A, 0x60,
+            0x02, 0x0A}));
+        JUnitUtil.waitFor(200);
+        Assert.assertEquals("No Outbound Data", 0, lnis.outbound.size());
+    }
+
     private LocoNetInterfaceScaffold lnis;
     private SlotManager slotmanager;
     private int status;
@@ -1500,9 +1509,9 @@ public class SlotManagerTest {
     private boolean stoppedTimer = false;
 
     private ProgListener lstn;
-    
+
     private int releaseTestDelay;
-    
+
     @BeforeEach
     public void setUp() {
         JUnitUtil.setUp();
@@ -1536,8 +1545,8 @@ public class SlotManagerTest {
         value = -999;
         startedShortTimer = false;
         startedLongTimer = false;
-        
-        releaseTestDelay = Math.max(slotmanager.serviceModeReplyDelay, slotmanager.opsModeReplyDelay)+75; 
+
+        releaseTestDelay = Math.max(slotmanager.serviceModeReplyDelay, slotmanager.opsModeReplyDelay)+75;
 
         lstn = (int val, int stat) -> {
             log.debug("   reply val: {} status: {}", val, stat);


### PR DESCRIPTION
A 6-byte LocoNet message sent as part of the "Clear All Not-InUse Slots" operation is improperly interpreted as a 21-byte message.  Fix is to ignore that portion of the LocoNet message interpretation when the LocoNet message is short.

Also improves the JMRI's attempt at a "purge" timer to "track" newer style "speed/direction/functions" messages.

Fixes #14203 .