### PR TITLE
NX fix erroneous "can't create multipoint route" messages.

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -456,7 +456,8 @@
 
         <h4>NX - Entry/Exit Tool</h4>
             <ul>
-                <li></li>
+                <li>Fixed a bug which could sometimes cause extraneous messages
+                about failure to create a multipoint route even though one was available.</li>
             </ul>
 
     <h3>LccPro</h3>

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutBlockConnectivityTools.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutBlockConnectivityTools.java
@@ -83,7 +83,7 @@ final public class LayoutBlockConnectivityTools {
      */
     public boolean checkValidDest(NamedBean sourceBean, NamedBean destBean, Routing pathMethod) throws jmri.JmriException {
         if (log.isDebugEnabled()) {
-            log.debug("check valid des with source/dest bean {} {}", sourceBean.getDisplayName(), destBean.getDisplayName());
+            log.debug("checkValidDest with source/dest bean {} {}", sourceBean.getDisplayName(), destBean.getDisplayName());
         }
         LayoutBlock facingBlock = null;
         LayoutBlock protectingBlock = null;
@@ -114,6 +114,7 @@ final public class LayoutBlockConnectivityTools {
                 try {
                     return checkValidDest(facingBlock, protectingBlock, destFacingBlock, destProtectBlock, pathMethod);
                 } catch (JmriException e) {
+                    log.debug("Rethrowing exception from checkValidDest(..)");
                     throw e;
                 }
             } else {
@@ -172,6 +173,7 @@ final public class LayoutBlockConnectivityTools {
                 try {
                     return getLayoutBlocks(facingBlock, destFacingBlock, protectingBlock, validateOnly, pathMethod);
                 } catch (JmriException e) {
+                    log.debug("Rethrowing exception from getLayoutBlocks()");
                     throw e;
                 }
             } else {
@@ -646,11 +648,13 @@ final public class LayoutBlockConnectivityTools {
                 // Basically looking for the connected block, which there should only be one of!
                 log.debug("At get ConnectedBlockRoute");
                 result = currentLBlock.getConnectedBlockRouteIndex(destBlock, direction);
+                log.trace("getConnectedBlockRouteIndex returns result {} with destBlock {}, direction {}", result, destBlock, direction);
             } else {
                 if (log.isDebugEnabled()) {
                     log.debug("Off Set {}", offSet);
                 }
                 result = currentLBlock.getNextBestBlock(preBlock, destBlock, offSet, Metric.METRIC);
+                log.trace("getNextBestBlock returns result {} with preBlock {}, destBlock {}", result, preBlock, destBlock);
             }
             if (result != -1) {
                 block = currentLBlock.getRouteNextBlockAtIndex(result);
@@ -675,6 +679,7 @@ final public class LayoutBlockConnectivityTools {
                     /* We change the logging level to fatal in the layout block manager as we are testing to make sure that no signalhead/mast exists
                      this would generate an error message that is expected.*/
                     MDC.put("loggingDisabled", LayoutBlockManager.class.getName());
+                    log.trace(" current pathMethod is {}", pathMethod, new Exception("traceback"));
                     switch (pathMethod) {
                         case MASTTOMAST:
                             foundBean = InstanceManager.getDefault(LayoutBlockManager.class).getFacingSignalMast(currentBlock, blocktoCheck);

--- a/java/src/jmri/jmrit/entryexit/EntryExitPairs.java
+++ b/java/src/jmri/jmrit/entryexit/EntryExitPairs.java
@@ -493,9 +493,12 @@ public class EntryExitPairs extends VetoableChangeSupport implements Manager<Des
                 if (!toPd.getProtecting().isEmpty()) {
                     toProt = toPd.getProtecting().get(0);
                 }
+                log.trace("Calling checkValidDest");
                 boolean result = lbm.getLayoutBlockConnectivityTools().checkValidDest(
                     fromPd.getFacing(), pro, toPd.getFacing(), toProt,
-                        LayoutBlockConnectivityTools.Routing.SENSORTOSENSOR);
+                        LayoutBlockConnectivityTools.Routing.NONE); // Was SENSORTOSENSOR, needs to be consistent with three lines below
+                                                                    // See also around line 353 in LayoutBlockConnectivityTools
+                log.trace("         checkValidDest returned {}", result);
                 if (result) {
                     List<LayoutBlock> blkList = lbm.getLayoutBlockConnectivityTools().getLayoutBlocks(fromPd.getFacing(), toPd.getFacing(), pro, cleardown, LayoutBlockConnectivityTools.Routing.NONE);
                     if (!blkList.isEmpty()) {
@@ -537,6 +540,7 @@ public class EntryExitPairs extends VetoableChangeSupport implements Manager<Des
                     }
                 }
             } catch (jmri.JmriException e) {
+                log.trace("setMultiPointRoute catches exception", e);
                 // Can be considered normal if route is blocked
                 JmriJOptionPane.showMessageDialog(null,
                         Bundle.getMessage("MultiPointBlocked"),  // NOI18N


### PR DESCRIPTION
Fixed an issue with internal consistency that could, under certain uncommon circumstances, create a "can't create multipoint route"  error dialog.

In the process, added a lot of trace and debug output.