### PR TITLE
Create Lionel-TMCC 1

### DIFF
--- a/xml/decoders/Lionel TMCC 1
+++ b/xml/decoders/Lionel TMCC 1
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet type="text/xsl" href="../XSLT/decoder.xsl"?>
+<!-- Copyright (C) JMRI 2001, 2005, 2007, 2-009, 2010 All rights reserved -->
+<!--                                                                        -->
+<!-- JMRI is free software; you can redistribute it and/or modify it under  -->
+<!-- the terms of version 2 of the GNU General Public License as published  -->
+<!-- by the Free Software Foundation. See the "COPYING" file for a copy     -->
+<!-- of this license.                                                       -->
+<!--                                                                        -->
+<!-- JMRI is distributed in the hope that it will be useful, but WITHOUT    -->
+<!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
+<!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
+<!-- for more details.                                                      -->
+<decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+  <copyright xmlns="http://docbook.org/ns/docbook">
+    <year>2000</year>
+    <year>2010</year>
+    <year>2019</year>
+    <holder>JMRI</holder>
+  </copyright>
+  <authorgroup xmlns="http://docbook.org/ns/docbook">
+    <author>
+      <personname><firstname>Timothy</firstname><surname>Jump</surname></personname>
+	  <!-- email: t1jump@gmail.com -->
+	  <!-- This decoder definition was built on the existing decoder definition -->
+	  <!-- mfg: Lionel; family name: TMCC Steam; version: 1.0; date: 2023-05-17 created by Bob Jacobsen -->
+    </author>
+  </authorgroup>
+  <revhistory xmlns="http://docbook.org/ns/docbook">
+    <revision>
+      <revnumber>1</revnumber><date>2023-05-17</date><authorinitials>BJ</authorinitials>
+      <revremark>Initial file creation</revremark>
+    </revision>
+  </revhistory>
+  <decoder>
+    <family name="TMCC 1" mfg="Lionel"> <!-- Lionel has no NMRA id, but that's OK -->
+      <xi:include href="http://jmri.org/xml/decoders/nmra/outputs1-4.xml"/>
+      <model model="TMCC 1" maxFnNum="28" numOuts="1"/>
+    </family>
+    <programming direct="yes" paged="yes" register="yes" ops="yes"/>
+    <variables>
+      <xi:include href="http://jmri.org/xml/decoders/nmra/shortAddressOnly.xml"/>
+    </variables>
+  </decoder>
+</decoder-config>


### PR DESCRIPTION
Adding a new decoder definition for Lionel TMCC 1 platforms (Lionel, ERR, K-Line, TAS).