### PR TITLE
Create Lionel-TMCC 2-Legacy

### DIFF
--- a/xml/decoders/Lionel-TMCC2-Legacy
+++ b/xml/decoders/Lionel-TMCC2-Legacy
@@ -30,9 +30,9 @@
     </revision>
   </revhistory>
   <decoder>
-    <family name="TMCC Steam" mfg="Lionel"> <!-- Lionel has no NMRA id, but that's OK -->
+    <family name="TMCC 2 Legacy" mfg="Lionel"> <!-- Lionel has no NMRA id, but that's OK -->
       <xi:include href="http://jmri.org/xml/decoders/nmra/outputs1-4.xml"/>
-      <model model="TMCC Steam" maxFnNum="68" numOuts="1"/>
+      <model model="TMCC 2 Legacy" maxFnNum="68" numOuts="1"/>
     </family>
     <programming direct="yes" paged="yes" register="yes" ops="yes"/>
     <variables>


### PR DESCRIPTION
Adding generic TMCC2-Legacy decoder definition as the Lionel-TMCC-Steam decoder definition limits understanding that this decoder can support multiple motive types and not just steam.