### PR TITLE
Fix for Brake function key selection (F0-F28), including "no active" value. (Lokommander II decoders)

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -361,7 +361,7 @@
 
         <h4>Technologistic (train-O-matic)</h4>
             <ul>
-                <li></li>
+                <li>Fix for Brake function key selection (F0-F28), including "no active" value. (Lokommander II decoders)</li>
             </ul>
 
         <h4>Trix Modelleisenbahn</h4>

--- a/xml/decoders/tOm/brakeCVs.xml
+++ b/xml/decoders/tOm/brakeCVs.xml
@@ -20,17 +20,17 @@
 
 <!-- CV197,198,199 set brake functions -->
   <variable item="Brake1 Function" CV="197" default="255">
-    <xi:include href="http://jmri.org/xml/decoders/parts/enum-F1-F28.xml"/>
+    <xi:include href="http://jmri.org/xml/decoders/tOm/enum-tom-F0-F28.xml"/>
     <label>Brake 1 function</label>
   </variable>
 
   <variable item="Brake2 Function" CV="198" default="255">
-    <xi:include href="http://jmri.org/xml/decoders/parts/enum-F1-F28.xml"/>
+    <xi:include href="http://jmri.org/xml/decoders/tOm/enum-tom-F0-F28.xml"/>
     <label>Brake 2 function</label>
   </variable>
 
   <variable item="Brake3 Function" CV="199" default="255">
-    <xi:include href="http://jmri.org/xml/decoders/parts/enum-F1-F28.xml"/>
+    <xi:include href="http://jmri.org/xml/decoders/tOm/enum-tom-F0-F28.xml"/>
     <label>Brake 3 function</label>
   </variable>
 

--- a/xml/decoders/tOm/commonCVs.xml
+++ b/xml/decoders/tOm/commonCVs.xml
@@ -1118,7 +1118,7 @@
 
 <!-- CV213 -->
       <variable item="Special Function" CV="213" default="28">
-        <xi:include href="http://jmri.org/xml/decoders/parts/enum-F1-F28.xml"/>
+        <xi:include href="http://jmri.org/xml/decoders/tOm/enum-tom-F0-F28.xml"/>
         <label>Special saving function</label>
         <label xml:lang="cs">Funkce speciálních ukládání</label>
       </variable>

--- a/xml/decoders/tOm/cv114.116_v6.xml
+++ b/xml/decoders/tOm/cv114.116_v6.xml
@@ -20,21 +20,21 @@
     
 <!-- CV114 -->
       <variable item="Shunting Speed Active Function" CV="114" default="3">
-        <xi:include href="http://jmri.org/xml/decoders/parts/enum-F1-F28.xml"/>
+        <xi:include href="http://jmri.org/xml/decoders/tOm/enum-tom-F0-F28.xml"/>
         <label>Shunting Speed Active Function</label>
         <label xml:lang="cs">Posunvací rychlost aktivuje</label>
       </variable>
       
 <!-- CV115 -->
       <variable item="Switch Off Acceleration Deceleration Function" CV="115" default="4">
-        <xi:include href="http://jmri.org/xml/decoders/parts/enum-F1-F28.xml"/>
+        <xi:include href="http://jmri.org/xml/decoders/tOm/enum-tom-F0-F28.xml"/>
         <label>Switch Off Acceleration Deceleration Function</label>
         <label xml:lang="cs">Zrychlení zpomalení vypne</label>
       </variable>
       
 <!-- CV116 -->
       <variable item="Disable Constant Braking Distance Function" CV="116" default="5">
-        <xi:include href="http://jmri.org/xml/decoders/parts/enum-F1-F28.xml"/>
+        <xi:include href="http://jmri.org/xml/decoders/tOm/enum-tom-F0-F28.xml"/>
         <label>Disable Constant Braking Distance Function</label>
         <label xml:lang="cs">Konstantní brzdnou dráhu vypne</label>
       </variable>

--- a/xml/decoders/tOm/enum-tom-F0-F28.xml
+++ b/xml/decoders/tOm/enum-tom-F0-F28.xml
@@ -1,0 +1,185 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet type="text/xsl" href="../XSLT/decoder.xsl"?>
+<!-- Copyright (C) JMRI 2025 All rights reserved -->
+<enumVal xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+      <enumChoice choice="Controlled by F0 key">
+        <choice>Controlled by F0 key</choice>
+        <choice xml:lang="it">Controllato da F0</choice>
+        <choice xml:lang="cs">Řízeno klávesou F0</choice>
+        <choice xml:lang="de">gesteuert mit F0</choice>
+      </enumChoice>
+      <enumChoice choice="Controlled by F1 key">
+        <choice>Controlled by F1 key</choice>
+        <choice xml:lang="it">Controllato da F1</choice>
+        <choice xml:lang="cs">Řízeno klávesou F1</choice>
+        <choice xml:lang="de">gesteuert mit F1</choice>
+      </enumChoice>
+      <enumChoice choice="Controlled by F2 key">
+        <choice>Controlled by F2 key</choice>
+        <choice xml:lang="it">Controllato da F2</choice>
+        <choice xml:lang="cs">Řízeno klávesou F2</choice>
+        <choice xml:lang="de">gesteuert mit F2</choice>
+      </enumChoice>
+      <enumChoice choice="Controlled by F3 key">
+        <choice>Controlled by F3 key</choice>
+        <choice xml:lang="it">Controllato da F3</choice>
+        <choice xml:lang="cs">Řízeno klávesou F3</choice>
+        <choice xml:lang="de">gesteuert mit F3</choice>
+      </enumChoice>
+      <enumChoice choice="Controlled by F4 key">
+        <choice>Controlled by F4 key</choice>
+        <choice xml:lang="it">Controllato da F4</choice>
+        <choice xml:lang="cs">Řízeno klávesou F4</choice>
+        <choice xml:lang="de">gesteuert mit F4</choice>
+      </enumChoice>
+      <enumChoice choice="Controlled by F5 key">
+        <choice>Controlled by F5 key</choice>
+        <choice xml:lang="it">Controllato da F5</choice>
+        <choice xml:lang="cs">Řízeno klávesou F5</choice>
+        <choice xml:lang="de">gesteuert mit F5</choice>
+      </enumChoice>
+      <enumChoice choice="Controlled by F6 key">
+        <choice>Controlled by F6 key</choice>
+        <choice xml:lang="it">Controllato da F6</choice>
+        <choice xml:lang="cs">Řízeno klávesou F6</choice>
+        <choice xml:lang="de">gesteuert mit F6</choice>
+      </enumChoice>
+      <enumChoice choice="Controlled by F7 key">
+        <choice>Controlled by F7 key</choice>
+        <choice xml:lang="it">Controllato da F7</choice>
+        <choice xml:lang="cs">Řízeno klávesou F7</choice>
+        <choice xml:lang="de">gesteuert mit F7</choice>
+      </enumChoice>
+      <enumChoice choice="Controlled by F8 key">
+        <choice>Controlled by F8 key</choice>
+        <choice xml:lang="it">Controllato da F8</choice>
+        <choice xml:lang="cs">Řízeno klávesou F8</choice>
+        <choice xml:lang="de">gesteuert mit F8</choice>
+      </enumChoice>
+      <enumChoice choice="Controlled by F9 key">
+        <choice>Controlled by F9 key</choice>
+        <choice xml:lang="it">Controllato da F9</choice>
+        <choice xml:lang="cs">Řízeno klávesou F9</choice>
+        <choice xml:lang="de">gesteuert mit F9</choice>
+      </enumChoice>
+      <enumChoice choice="Controlled by F10 key">
+        <choice>Controlled by F10 key</choice>
+        <choice xml:lang="it">Controllato da F10</choice>
+        <choice xml:lang="cs">Řízeno klávesou F10</choice>
+        <choice xml:lang="de">gesteuert mit F10</choice>
+      </enumChoice>
+      <enumChoice choice="Controlled by F11 key">
+        <choice>Controlled by F11 key</choice>
+        <choice xml:lang="it">Controllato da F11</choice>
+        <choice xml:lang="cs">Řízeno klávesou F11</choice>
+        <choice xml:lang="de">gesteuert mit F11</choice>
+      </enumChoice>
+      <enumChoice choice="Controlled by F12 key">
+        <choice>Controlled by F12 key</choice>
+        <choice xml:lang="it">Controllato da F12</choice>
+        <choice xml:lang="cs">Řízeno klávesou F12</choice>
+        <choice xml:lang="de">gesteuert mit F12</choice>
+      </enumChoice>
+      <enumChoice choice="Controlled by F13 key">
+        <choice>Controlled by F13 key</choice>
+        <choice xml:lang="it">Controllato da F13</choice>
+        <choice xml:lang="cs">Řízeno klávesou F13</choice>
+        <choice xml:lang="de">gesteuert mit F13</choice>
+      </enumChoice>
+      <enumChoice choice="Controlled by F14 key">
+        <choice>Controlled by F14 key</choice>
+        <choice xml:lang="it">Controllato da F14</choice>
+        <choice xml:lang="cs">Řízeno klávesou F14</choice>
+        <choice xml:lang="de">gesteuert mit F14</choice>
+      </enumChoice>
+      <enumChoice choice="Controlled by F15 key">
+        <choice>Controlled by F15 key</choice>
+        <choice xml:lang="it">Controllato da F15</choice>
+        <choice xml:lang="cs">Řízeno klávesou F15</choice>
+        <choice xml:lang="de">gesteuert mit F15</choice>
+      </enumChoice>
+      <enumChoice choice="Controlled by F16 key">
+        <choice>Controlled by F16 key</choice>
+        <choice xml:lang="it">Controllato da F16</choice>
+        <choice xml:lang="cs">Řízeno klávesou F16</choice>
+        <choice xml:lang="de">gesteuert mit F16</choice>
+      </enumChoice>
+      <enumChoice choice="Controlled by F17 key">
+        <choice>Controlled by F17 key</choice>
+        <choice xml:lang="it">Controllato da F17</choice>
+        <choice xml:lang="cs">Řízeno klávesou F17</choice>
+        <choice xml:lang="de">gesteuert mit F17</choice>
+      </enumChoice>
+      <enumChoice choice="Controlled by F18 key">
+        <choice>Controlled by F18 key</choice>
+        <choice xml:lang="it">Controllato da F18</choice>
+        <choice xml:lang="cs">Řízeno klávesou F18</choice>
+        <choice xml:lang="de">gesteuert mit F18</choice>
+      </enumChoice>
+      <enumChoice choice="Controlled by F19 key">
+        <choice>Controlled by F19 key</choice>
+        <choice xml:lang="it">Controllato da F19</choice>
+        <choice xml:lang="cs">Řízeno klávesou F19</choice>
+        <choice xml:lang="de">gesteuert mit F19</choice>
+      </enumChoice>
+      <enumChoice choice="Controlled by F20 key">
+        <choice>Controlled by F20 key</choice>
+        <choice xml:lang="it">Controllato da F20</choice>
+        <choice xml:lang="cs">Řízeno klávesou F20</choice>
+        <choice xml:lang="de">gesteuert mit F20</choice>
+      </enumChoice>
+      <enumChoice choice="Controlled by F21 key">
+        <choice>Controlled by F21 key</choice>
+        <choice xml:lang="it">Controllato da F21</choice>
+        <choice xml:lang="cs">Řízeno klávesou F21</choice>
+        <choice xml:lang="de">gesteuert mit F21</choice>
+      </enumChoice>
+      <enumChoice choice="Controlled by F22 key">
+        <choice>Controlled by F22 key</choice>
+        <choice xml:lang="it">Controllato da F22</choice>
+        <choice xml:lang="cs">Řízeno klávesou F22</choice>
+        <choice xml:lang="de">gesteuert mit F22</choice>
+      </enumChoice>
+      <enumChoice choice="Controlled by F23 key">
+        <choice>Controlled by F23 key</choice>
+        <choice xml:lang="it">Controllato da F23</choice>
+        <choice xml:lang="cs">Řízeno klávesou F23</choice>
+        <choice xml:lang="de">gesteuert mit F23</choice>
+      </enumChoice>
+      <enumChoice choice="Controlled by F24 key">
+        <choice>Controlled by F24 key</choice>
+        <choice xml:lang="it">Controllato da F24</choice>
+        <choice xml:lang="cs">Řízeno klávesou F24</choice>
+        <choice xml:lang="de">gesteuert mit F24</choice>
+      </enumChoice>
+      <enumChoice choice="Controlled by F25 key">
+        <choice>Controlled by F25 key</choice>
+        <choice xml:lang="it">Controllato da F25</choice>
+        <choice xml:lang="cs">Řízeno klávesou F25</choice>
+        <choice xml:lang="de">gesteuert mit F25</choice>
+      </enumChoice>
+      <enumChoice choice="Controlled by F26 key">
+        <choice>Controlled by F26 key</choice>
+        <choice xml:lang="it">Controllato da F26</choice>
+        <choice xml:lang="cs">Řízeno klávesou F26</choice>
+        <choice xml:lang="de">gesteuert mit F26</choice>
+      </enumChoice>
+      <enumChoice choice="Controlled by F27 key">
+        <choice>Controlled by F27 key</choice>
+        <choice xml:lang="it">Controllato da F27</choice>
+        <choice xml:lang="cs">Řízeno klávesou F27</choice>
+        <choice xml:lang="de">gesteuert mit F27</choice>
+      </enumChoice>
+      <enumChoice choice="Controlled by F28 key">
+        <choice>Controlled by F28 key</choice>
+        <choice xml:lang="it">Controllato da F28</choice>
+        <choice xml:lang="cs">Řízeno klávesou F28</choice>
+        <choice xml:lang="de">gesteuert mit F28</choice>
+      </enumChoice>
+      <enumChoice choice="Not active" value="255">
+        <choice>Not active</choice>
+        <choice xml:lang="it">Non Attivo</choice>
+        <choice xml:lang="cs">Neaktivní</choice>
+        <choice xml:lang="de">nicht aktiv</choice>
+      </enumChoice>
+</enumVal>

--- a/xml/decoders/tOm/enum-tom-F0-F28.xml
+++ b/xml/decoders/tOm/enum-tom-F0-F28.xml
@@ -2,184 +2,184 @@
 <?xml-stylesheet type="text/xsl" href="../XSLT/decoder.xsl"?>
 <!-- Copyright (C) JMRI 2025 All rights reserved -->
 <enumVal xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
-      <enumChoice choice="Controlled by F0 key">
-        <choice>Controlled by F0 key</choice>
-        <choice xml:lang="it">Controllato da F0</choice>
-        <choice xml:lang="cs">Řízeno klávesou F0</choice>
-        <choice xml:lang="de">gesteuert mit F0</choice>
-      </enumChoice>
-      <enumChoice choice="Controlled by F1 key">
-        <choice>Controlled by F1 key</choice>
-        <choice xml:lang="it">Controllato da F1</choice>
-        <choice xml:lang="cs">Řízeno klávesou F1</choice>
-        <choice xml:lang="de">gesteuert mit F1</choice>
-      </enumChoice>
-      <enumChoice choice="Controlled by F2 key">
-        <choice>Controlled by F2 key</choice>
-        <choice xml:lang="it">Controllato da F2</choice>
-        <choice xml:lang="cs">Řízeno klávesou F2</choice>
-        <choice xml:lang="de">gesteuert mit F2</choice>
-      </enumChoice>
-      <enumChoice choice="Controlled by F3 key">
-        <choice>Controlled by F3 key</choice>
-        <choice xml:lang="it">Controllato da F3</choice>
-        <choice xml:lang="cs">Řízeno klávesou F3</choice>
-        <choice xml:lang="de">gesteuert mit F3</choice>
-      </enumChoice>
-      <enumChoice choice="Controlled by F4 key">
-        <choice>Controlled by F4 key</choice>
-        <choice xml:lang="it">Controllato da F4</choice>
-        <choice xml:lang="cs">Řízeno klávesou F4</choice>
-        <choice xml:lang="de">gesteuert mit F4</choice>
-      </enumChoice>
-      <enumChoice choice="Controlled by F5 key">
-        <choice>Controlled by F5 key</choice>
-        <choice xml:lang="it">Controllato da F5</choice>
-        <choice xml:lang="cs">Řízeno klávesou F5</choice>
-        <choice xml:lang="de">gesteuert mit F5</choice>
-      </enumChoice>
-      <enumChoice choice="Controlled by F6 key">
-        <choice>Controlled by F6 key</choice>
-        <choice xml:lang="it">Controllato da F6</choice>
-        <choice xml:lang="cs">Řízeno klávesou F6</choice>
-        <choice xml:lang="de">gesteuert mit F6</choice>
-      </enumChoice>
-      <enumChoice choice="Controlled by F7 key">
-        <choice>Controlled by F7 key</choice>
-        <choice xml:lang="it">Controllato da F7</choice>
-        <choice xml:lang="cs">Řízeno klávesou F7</choice>
-        <choice xml:lang="de">gesteuert mit F7</choice>
-      </enumChoice>
-      <enumChoice choice="Controlled by F8 key">
-        <choice>Controlled by F8 key</choice>
-        <choice xml:lang="it">Controllato da F8</choice>
-        <choice xml:lang="cs">Řízeno klávesou F8</choice>
-        <choice xml:lang="de">gesteuert mit F8</choice>
-      </enumChoice>
-      <enumChoice choice="Controlled by F9 key">
-        <choice>Controlled by F9 key</choice>
-        <choice xml:lang="it">Controllato da F9</choice>
-        <choice xml:lang="cs">Řízeno klávesou F9</choice>
-        <choice xml:lang="de">gesteuert mit F9</choice>
-      </enumChoice>
-      <enumChoice choice="Controlled by F10 key">
-        <choice>Controlled by F10 key</choice>
-        <choice xml:lang="it">Controllato da F10</choice>
-        <choice xml:lang="cs">Řízeno klávesou F10</choice>
-        <choice xml:lang="de">gesteuert mit F10</choice>
-      </enumChoice>
-      <enumChoice choice="Controlled by F11 key">
-        <choice>Controlled by F11 key</choice>
-        <choice xml:lang="it">Controllato da F11</choice>
-        <choice xml:lang="cs">Řízeno klávesou F11</choice>
-        <choice xml:lang="de">gesteuert mit F11</choice>
-      </enumChoice>
-      <enumChoice choice="Controlled by F12 key">
-        <choice>Controlled by F12 key</choice>
-        <choice xml:lang="it">Controllato da F12</choice>
-        <choice xml:lang="cs">Řízeno klávesou F12</choice>
-        <choice xml:lang="de">gesteuert mit F12</choice>
-      </enumChoice>
-      <enumChoice choice="Controlled by F13 key">
-        <choice>Controlled by F13 key</choice>
-        <choice xml:lang="it">Controllato da F13</choice>
-        <choice xml:lang="cs">Řízeno klávesou F13</choice>
-        <choice xml:lang="de">gesteuert mit F13</choice>
-      </enumChoice>
-      <enumChoice choice="Controlled by F14 key">
-        <choice>Controlled by F14 key</choice>
-        <choice xml:lang="it">Controllato da F14</choice>
-        <choice xml:lang="cs">Řízeno klávesou F14</choice>
-        <choice xml:lang="de">gesteuert mit F14</choice>
-      </enumChoice>
-      <enumChoice choice="Controlled by F15 key">
-        <choice>Controlled by F15 key</choice>
-        <choice xml:lang="it">Controllato da F15</choice>
-        <choice xml:lang="cs">Řízeno klávesou F15</choice>
-        <choice xml:lang="de">gesteuert mit F15</choice>
-      </enumChoice>
-      <enumChoice choice="Controlled by F16 key">
-        <choice>Controlled by F16 key</choice>
-        <choice xml:lang="it">Controllato da F16</choice>
-        <choice xml:lang="cs">Řízeno klávesou F16</choice>
-        <choice xml:lang="de">gesteuert mit F16</choice>
-      </enumChoice>
-      <enumChoice choice="Controlled by F17 key">
-        <choice>Controlled by F17 key</choice>
-        <choice xml:lang="it">Controllato da F17</choice>
-        <choice xml:lang="cs">Řízeno klávesou F17</choice>
-        <choice xml:lang="de">gesteuert mit F17</choice>
-      </enumChoice>
-      <enumChoice choice="Controlled by F18 key">
-        <choice>Controlled by F18 key</choice>
-        <choice xml:lang="it">Controllato da F18</choice>
-        <choice xml:lang="cs">Řízeno klávesou F18</choice>
-        <choice xml:lang="de">gesteuert mit F18</choice>
-      </enumChoice>
-      <enumChoice choice="Controlled by F19 key">
-        <choice>Controlled by F19 key</choice>
-        <choice xml:lang="it">Controllato da F19</choice>
-        <choice xml:lang="cs">Řízeno klávesou F19</choice>
-        <choice xml:lang="de">gesteuert mit F19</choice>
-      </enumChoice>
-      <enumChoice choice="Controlled by F20 key">
-        <choice>Controlled by F20 key</choice>
-        <choice xml:lang="it">Controllato da F20</choice>
-        <choice xml:lang="cs">Řízeno klávesou F20</choice>
-        <choice xml:lang="de">gesteuert mit F20</choice>
-      </enumChoice>
-      <enumChoice choice="Controlled by F21 key">
-        <choice>Controlled by F21 key</choice>
-        <choice xml:lang="it">Controllato da F21</choice>
-        <choice xml:lang="cs">Řízeno klávesou F21</choice>
-        <choice xml:lang="de">gesteuert mit F21</choice>
-      </enumChoice>
-      <enumChoice choice="Controlled by F22 key">
-        <choice>Controlled by F22 key</choice>
-        <choice xml:lang="it">Controllato da F22</choice>
-        <choice xml:lang="cs">Řízeno klávesou F22</choice>
-        <choice xml:lang="de">gesteuert mit F22</choice>
-      </enumChoice>
-      <enumChoice choice="Controlled by F23 key">
-        <choice>Controlled by F23 key</choice>
-        <choice xml:lang="it">Controllato da F23</choice>
-        <choice xml:lang="cs">Řízeno klávesou F23</choice>
-        <choice xml:lang="de">gesteuert mit F23</choice>
-      </enumChoice>
-      <enumChoice choice="Controlled by F24 key">
-        <choice>Controlled by F24 key</choice>
-        <choice xml:lang="it">Controllato da F24</choice>
-        <choice xml:lang="cs">Řízeno klávesou F24</choice>
-        <choice xml:lang="de">gesteuert mit F24</choice>
-      </enumChoice>
-      <enumChoice choice="Controlled by F25 key">
-        <choice>Controlled by F25 key</choice>
-        <choice xml:lang="it">Controllato da F25</choice>
-        <choice xml:lang="cs">Řízeno klávesou F25</choice>
-        <choice xml:lang="de">gesteuert mit F25</choice>
-      </enumChoice>
-      <enumChoice choice="Controlled by F26 key">
-        <choice>Controlled by F26 key</choice>
-        <choice xml:lang="it">Controllato da F26</choice>
-        <choice xml:lang="cs">Řízeno klávesou F26</choice>
-        <choice xml:lang="de">gesteuert mit F26</choice>
-      </enumChoice>
-      <enumChoice choice="Controlled by F27 key">
-        <choice>Controlled by F27 key</choice>
-        <choice xml:lang="it">Controllato da F27</choice>
-        <choice xml:lang="cs">Řízeno klávesou F27</choice>
-        <choice xml:lang="de">gesteuert mit F27</choice>
-      </enumChoice>
-      <enumChoice choice="Controlled by F28 key">
-        <choice>Controlled by F28 key</choice>
-        <choice xml:lang="it">Controllato da F28</choice>
-        <choice xml:lang="cs">Řízeno klávesou F28</choice>
-        <choice xml:lang="de">gesteuert mit F28</choice>
-      </enumChoice>
       <enumChoice choice="Not active" value="255">
         <choice>Not active</choice>
         <choice xml:lang="it">Non Attivo</choice>
         <choice xml:lang="cs">Neaktivní</choice>
         <choice xml:lang="de">nicht aktiv</choice>
+      </enumChoice>
+      <enumChoice choice="Controlled by F0 key" value="0">
+        <choice>Controlled by F0 key</choice>
+        <choice xml:lang="it">Controllato da F0</choice>
+        <choice xml:lang="cs">Řízeno klávesou F0</choice>
+        <choice xml:lang="de">gesteuert mit F0</choice>
+      </enumChoice>
+      <enumChoice choice="Controlled by F1 key" value="1">
+        <choice>Controlled by F1 key</choice>
+        <choice xml:lang="it">Controllato da F1</choice>
+        <choice xml:lang="cs">Řízeno klávesou F1</choice>
+        <choice xml:lang="de">gesteuert mit F1</choice>
+      </enumChoice>
+      <enumChoice choice="Controlled by F2 key" value="2">
+        <choice>Controlled by F2 key</choice>
+        <choice xml:lang="it">Controllato da F2</choice>
+        <choice xml:lang="cs">Řízeno klávesou F2</choice>
+        <choice xml:lang="de">gesteuert mit F2</choice>
+      </enumChoice>
+      <enumChoice choice="Controlled by F3 key" value="3">
+        <choice>Controlled by F3 key</choice>
+        <choice xml:lang="it">Controllato da F3</choice>
+        <choice xml:lang="cs">Řízeno klávesou F3</choice>
+        <choice xml:lang="de">gesteuert mit F3</choice>
+      </enumChoice>
+      <enumChoice choice="Controlled by F4 key" value="4">
+        <choice>Controlled by F4 key</choice>
+        <choice xml:lang="it">Controllato da F4</choice>
+        <choice xml:lang="cs">Řízeno klávesou F4</choice>
+        <choice xml:lang="de">gesteuert mit F4</choice>
+      </enumChoice>
+      <enumChoice choice="Controlled by F5 key" value="5">
+        <choice>Controlled by F5 key</choice>
+        <choice xml:lang="it">Controllato da F5</choice>
+        <choice xml:lang="cs">Řízeno klávesou F5</choice>
+        <choice xml:lang="de">gesteuert mit F5</choice>
+      </enumChoice>
+      <enumChoice choice="Controlled by F6 key" value="6">
+        <choice>Controlled by F6 key</choice>
+        <choice xml:lang="it">Controllato da F6</choice>
+        <choice xml:lang="cs">Řízeno klávesou F6</choice>
+        <choice xml:lang="de">gesteuert mit F6</choice>
+      </enumChoice>
+      <enumChoice choice="Controlled by F7 key" value="7">
+        <choice>Controlled by F7 key</choice>
+        <choice xml:lang="it">Controllato da F7</choice>
+        <choice xml:lang="cs">Řízeno klávesou F7</choice>
+        <choice xml:lang="de">gesteuert mit F7</choice>
+      </enumChoice>
+      <enumChoice choice="Controlled by F8 key" value="8">
+        <choice>Controlled by F8 key</choice>
+        <choice xml:lang="it">Controllato da F8</choice>
+        <choice xml:lang="cs">Řízeno klávesou F8</choice>
+        <choice xml:lang="de">gesteuert mit F8</choice>
+      </enumChoice>
+      <enumChoice choice="Controlled by F9 key" value="9">
+        <choice>Controlled by F9 key</choice>
+        <choice xml:lang="it">Controllato da F9</choice>
+        <choice xml:lang="cs">Řízeno klávesou F9</choice>
+        <choice xml:lang="de">gesteuert mit F9</choice>
+      </enumChoice>
+      <enumChoice choice="Controlled by F10 key" value="10">
+        <choice>Controlled by F10 key</choice>
+        <choice xml:lang="it">Controllato da F10</choice>
+        <choice xml:lang="cs">Řízeno klávesou F10</choice>
+        <choice xml:lang="de">gesteuert mit F10</choice>
+      </enumChoice>
+      <enumChoice choice="Controlled by F11 key" value="11">
+        <choice>Controlled by F11 key</choice>
+        <choice xml:lang="it">Controllato da F11</choice>
+        <choice xml:lang="cs">Řízeno klávesou F11</choice>
+        <choice xml:lang="de">gesteuert mit F11</choice>
+      </enumChoice>
+      <enumChoice choice="Controlled by F12 key" value="12">
+        <choice>Controlled by F12 key</choice>
+        <choice xml:lang="it">Controllato da F12</choice>
+        <choice xml:lang="cs">Řízeno klávesou F12</choice>
+        <choice xml:lang="de">gesteuert mit F12</choice>
+      </enumChoice>
+      <enumChoice choice="Controlled by F13 key" value="13">
+        <choice>Controlled by F13 key</choice>
+        <choice xml:lang="it">Controllato da F13</choice>
+        <choice xml:lang="cs">Řízeno klávesou F13</choice>
+        <choice xml:lang="de">gesteuert mit F13</choice>
+      </enumChoice>
+      <enumChoice choice="Controlled by F14 key" value="14">
+        <choice>Controlled by F14 key</choice>
+        <choice xml:lang="it">Controllato da F14</choice>
+        <choice xml:lang="cs">Řízeno klávesou F14</choice>
+        <choice xml:lang="de">gesteuert mit F14</choice>
+      </enumChoice>
+      <enumChoice choice="Controlled by F15 key" value="15">
+        <choice>Controlled by F15 key</choice>
+        <choice xml:lang="it">Controllato da F15</choice>
+        <choice xml:lang="cs">Řízeno klávesou F15</choice>
+        <choice xml:lang="de">gesteuert mit F15</choice>
+      </enumChoice>
+      <enumChoice choice="Controlled by F16 key" value="16">
+        <choice>Controlled by F16 key</choice>
+        <choice xml:lang="it">Controllato da F16</choice>
+        <choice xml:lang="cs">Řízeno klávesou F16</choice>
+        <choice xml:lang="de">gesteuert mit F16</choice>
+      </enumChoice>
+      <enumChoice choice="Controlled by F17 key" value="17">
+        <choice>Controlled by F17 key</choice>
+        <choice xml:lang="it">Controllato da F17</choice>
+        <choice xml:lang="cs">Řízeno klávesou F17</choice>
+        <choice xml:lang="de">gesteuert mit F17</choice>
+      </enumChoice>
+      <enumChoice choice="Controlled by F18 key" value="18">
+        <choice>Controlled by F18 key</choice>
+        <choice xml:lang="it">Controllato da F18</choice>
+        <choice xml:lang="cs">Řízeno klávesou F18</choice>
+        <choice xml:lang="de">gesteuert mit F18</choice>
+      </enumChoice>
+      <enumChoice choice="Controlled by F19 key" value="19">
+        <choice>Controlled by F19 key</choice>
+        <choice xml:lang="it">Controllato da F19</choice>
+        <choice xml:lang="cs">Řízeno klávesou F19</choice>
+        <choice xml:lang="de">gesteuert mit F19</choice>
+      </enumChoice>
+      <enumChoice choice="Controlled by F20 key" value="20">
+        <choice>Controlled by F20 key</choice>
+        <choice xml:lang="it">Controllato da F20</choice>
+        <choice xml:lang="cs">Řízeno klávesou F20</choice>
+        <choice xml:lang="de">gesteuert mit F20</choice>
+      </enumChoice>
+      <enumChoice choice="Controlled by F21 key" value="21">
+        <choice>Controlled by F21 key</choice>
+        <choice xml:lang="it">Controllato da F21</choice>
+        <choice xml:lang="cs">Řízeno klávesou F21</choice>
+        <choice xml:lang="de">gesteuert mit F21</choice>
+      </enumChoice>
+      <enumChoice choice="Controlled by F22 key" value="22">
+        <choice>Controlled by F22 key</choice>
+        <choice xml:lang="it">Controllato da F22</choice>
+        <choice xml:lang="cs">Řízeno klávesou F22</choice>
+        <choice xml:lang="de">gesteuert mit F22</choice>
+      </enumChoice>
+      <enumChoice choice="Controlled by F23 key" value="23">
+        <choice>Controlled by F23 key</choice>
+        <choice xml:lang="it">Controllato da F23</choice>
+        <choice xml:lang="cs">Řízeno klávesou F23</choice>
+        <choice xml:lang="de">gesteuert mit F23</choice>
+      </enumChoice>
+      <enumChoice choice="Controlled by F24 key" value="24">
+        <choice>Controlled by F24 key</choice>
+        <choice xml:lang="it">Controllato da F24</choice>
+        <choice xml:lang="cs">Řízeno klávesou F24</choice>
+        <choice xml:lang="de">gesteuert mit F24</choice>
+      </enumChoice>
+      <enumChoice choice="Controlled by F25 key" value="25">
+        <choice>Controlled by F25 key</choice>
+        <choice xml:lang="it">Controllato da F25</choice>
+        <choice xml:lang="cs">Řízeno klávesou F25</choice>
+        <choice xml:lang="de">gesteuert mit F25</choice>
+      </enumChoice>
+      <enumChoice choice="Controlled by F26 key" value="26">
+        <choice>Controlled by F26 key</choice>
+        <choice xml:lang="it">Controllato da F26</choice>
+        <choice xml:lang="cs">Řízeno klávesou F26</choice>
+        <choice xml:lang="de">gesteuert mit F26</choice>
+      </enumChoice>
+      <enumChoice choice="Controlled by F27 key" value="27">
+        <choice>Controlled by F27 key</choice>
+        <choice xml:lang="it">Controllato da F27</choice>
+        <choice xml:lang="cs">Řízeno klávesou F27</choice>
+        <choice xml:lang="de">gesteuert mit F27</choice>
+      </enumChoice>
+      <enumChoice choice="Controlled by F28 key" value="28">
+        <choice>Controlled by F28 key</choice>
+        <choice xml:lang="it">Controllato da F28</choice>
+        <choice xml:lang="cs">Řízeno klávesou F28</choice>
+        <choice xml:lang="de">gesteuert mit F28</choice>
       </enumChoice>
 </enumVal>


### PR DESCRIPTION
The Train-O-Matic decoder definitions used the standard NMRA F1-F28 for F0-F28 selection and that is incorrect. New enum file created that has the correct values, including 255 which means it is not active.

Thanks for Nigel Cliffe for reporting this issue.
