### PR TITLE
Add decoder manufacturer and family columns to DP main display

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -426,7 +426,11 @@
     <h3>DecoderPro</h3>
         <a id="DecoderPro" name="DecoderPro"></a>
         <ul>
-            <li></li>
+            <li>There are two new columns in the DecoderPro main 
+                display:  "Decoder Manufacturer" and "Decoder Family".
+                These start out hidden.  To display them, 
+                right or control click in the header of any column, 
+                and then put a check next to the column name.</li>
         </ul>
 
    <h3>Dispatcher</h3>
@@ -515,7 +519,11 @@
     <h3>Roster</h3>
         <a id="Roster" name="Roster"></a>
         <ul>
-            <li></li>
+            <li>There are two new columns in the DecoderPro display of the 
+                roster:  "Decoder Manufacturer" and "Decoder Family".
+                These start out hidden.  To display them, 
+                right or control click in the header of any column, 
+                and then put a check next to the column name.</li>
         </ul>
 
     <h3>Routes</h3>

--- a/java/src/jmri/jmrit/roster/JmritRosterBundle.properties
+++ b/java/src/jmri/jmrit/roster/JmritRosterBundle.properties
@@ -32,6 +32,7 @@ FieldModel = Model
 FieldSpeedLimit = Throttle Speed Limit
 FieldDCCAddress = DCC Address
 FieldComment = Comment
+FieldDecoderMfg   = Decoder Manufacturer
 FieldDecoderFamily = Decoder Family
 FieldDecoderModel = Decoder Model
 FieldDecoderModes = Programming Mode(s)

--- a/java/src/jmri/jmrit/roster/swing/RosterTable.java
+++ b/java/src/jmri/jmrit/roster/swing/RosterTable.java
@@ -109,6 +109,10 @@ public class RosterTable extends JmriPanel implements RosterEntrySelector, Roste
         // format the last updated date time, last operated date time.
         dataTable.setDefaultRenderer(Date.class, new DateTimeCellRenderer());
 
+        // Start with two columns not visible
+        columnModel.setColumnVisible(columnModel.getColumnByModelIndex(RosterTableModel.DECODERMFGCOL), false);
+        columnModel.setColumnVisible(columnModel.getColumnByModelIndex(RosterTableModel.DECODERFAMILYCOL), false);
+
         TableColumn tc = columnModel.getColumnByModelIndex(RosterTableModel.PROTOCOL);
         columnModel.setColumnVisible(tc, false);
 

--- a/java/src/jmri/jmrit/roster/swing/RosterTableModel.java
+++ b/java/src/jmri/jmrit/roster/swing/RosterTableModel.java
@@ -33,17 +33,19 @@ import jmri.jmrit.roster.rostergroup.RosterGroupSelector;
  */
 public class RosterTableModel extends DefaultTableModel implements PropertyChangeListener {
 
-    public static final int IDCOL = 0;
-    static final int ADDRESSCOL = 1;
-    static final int ICONCOL = 2;
-    static final int DECODERCOL = 3;
-    static final int ROADNAMECOL = 4;
-    static final int ROADNUMBERCOL = 5;
-    static final int MFGCOL = 6;
-    static final int MODELCOL = 7;
-    static final int OWNERCOL = 8;
-    static final int DATEUPDATECOL = 9;
-    public static final int PROTOCOL = 10;
+    public static final int IDCOL       = 0;
+    static final int ADDRESSCOL         = 1;
+    static final int ICONCOL            = 2;
+    static final int DECODERMFGCOL      = 3;
+    static final int DECODERFAMILYCOL   = 4;
+    static final int DECODERMODELCOL    = 5;
+    static final int ROADNAMECOL        = 6;
+    static final int ROADNUMBERCOL      = 7;
+    static final int MFGCOL             = 8;
+    static final int MODELCOL           = 9;
+    static final int OWNERCOL           = 10;
+    static final int DATEUPDATECOL      = 11;
+    public static final int PROTOCOL    = 12;
     public static final int NUMCOL = PROTOCOL + 1;
     private String rosterGroup = null;
     boolean editable = false;
@@ -113,7 +115,11 @@ public class RosterTableModel extends DefaultTableModel implements PropertyChang
                 return Bundle.getMessage("FieldID");
             case ADDRESSCOL:
                 return Bundle.getMessage("FieldDCCAddress");
-            case DECODERCOL:
+            case DECODERMFGCOL:
+                return Bundle.getMessage("FieldDecoderMfg");
+            case DECODERFAMILYCOL:
+                return Bundle.getMessage("FieldDecoderFamily");
+            case DECODERMODELCOL:
                 return Bundle.getMessage("FieldDecoderModel");
             case MODELCOL:
                 return Bundle.getMessage("FieldModel");
@@ -196,7 +202,13 @@ public class RosterTableModel extends DefaultTableModel implements PropertyChang
         if (col == PROTOCOL) {
             return false;
         }
-        if (col == DECODERCOL) {
+        if (col == DECODERMFGCOL) {
+            return false;
+        }
+        if (col == DECODERFAMILYCOL) {
+            return false;
+        }
+        if (col == DECODERMODELCOL) {
             return false;
         }
         if (col == ICONCOL) {
@@ -243,7 +255,18 @@ public class RosterTableModel extends DefaultTableModel implements PropertyChang
                 return re.getId();
             case ADDRESSCOL:
                 return re.getDccLocoAddress().getNumber();
-            case DECODERCOL:
+            case DECODERMFGCOL:
+                var index = jmri.InstanceManager.getDefault(jmri.jmrit.decoderdefn.DecoderIndexFile.class);
+                var matches = index.matchingDecoderList(
+                        null, re.getDecoderFamily(),
+                        null, null, null,
+                        re.getDecoderModel()
+                        );
+                if (matches.size() == 0) return "";
+                return matches.get(0).getMfg();
+            case DECODERFAMILYCOL:
+                return re.getDecoderFamily();
+            case DECODERMODELCOL:
                 return re.getDecoderModel();
             case MODELCOL:
                 return re.getModel();

--- a/java/test/jmri/jmrit/roster/swing/RosterTableModelTest.java
+++ b/java/test/jmri/jmrit/roster/swing/RosterTableModelTest.java
@@ -28,14 +28,16 @@ public class RosterTableModelTest {
         RosterTableModel t = new RosterTableModel(true); // set Editable
 
         // hard-coded value is number of columns expected
-        // 11 normal columns + 4 attribute columns
-        Assert.assertEquals(15, t.getColumnCount());
+        // 13 normal columns + 4 attribute columns
+        Assert.assertEquals(17, t.getColumnCount());
         
         
         Assertions.assertTrue(t.isCellEditable(0, RosterTableModel.IDCOL));
         Assertions.assertFalse(t.isCellEditable(0, RosterTableModel.ADDRESSCOL));
         Assertions.assertFalse(t.isCellEditable(0, RosterTableModel.ICONCOL));
-        Assertions.assertFalse(t.isCellEditable(0, RosterTableModel.DECODERCOL));
+        Assertions.assertFalse(t.isCellEditable(0, RosterTableModel.DECODERMFGCOL));
+        Assertions.assertFalse(t.isCellEditable(0, RosterTableModel.DECODERFAMILYCOL));
+        Assertions.assertFalse(t.isCellEditable(0, RosterTableModel.DECODERMODELCOL));
         Assertions.assertTrue(t.isCellEditable(0, RosterTableModel.ROADNAMECOL));
         Assertions.assertTrue(t.isCellEditable(0, RosterTableModel.ROADNUMBERCOL));
         Assertions.assertTrue(t.isCellEditable(0, RosterTableModel.MFGCOL));
@@ -59,7 +61,7 @@ public class RosterTableModelTest {
         Assert.assertEquals(Bundle.getMessage("FieldID"), t.getColumnName( RosterTableModel.IDCOL));
         Assert.assertEquals(Bundle.getMessage("FieldDCCAddress"), t.getColumnName(RosterTableModel.ADDRESSCOL));
         Assert.assertEquals(Bundle.getMessage("FieldIcon"), t.getColumnName(RosterTableModel.ICONCOL));
-        Assert.assertEquals(Bundle.getMessage("FieldDecoderModel"), t.getColumnName(RosterTableModel.DECODERCOL));
+        Assert.assertEquals(Bundle.getMessage("FieldDecoderModel"), t.getColumnName(RosterTableModel.DECODERMODELCOL));
         Assert.assertEquals(Bundle.getMessage("FieldRoadName"), t.getColumnName(RosterTableModel.ROADNAMECOL));
         Assert.assertEquals(Bundle.getMessage("FieldRoadNumber"), t.getColumnName(RosterTableModel.ROADNUMBERCOL));
         Assert.assertEquals(Bundle.getMessage("FieldManufacturer"), t.getColumnName(RosterTableModel.MFGCOL));
@@ -85,15 +87,15 @@ public class RosterTableModelTest {
 
         Assert.assertEquals("id 1", t.getValueAt(0, RosterTableModel.IDCOL));
         Assert.assertEquals(12, (int)t.getValueAt(0, RosterTableModel.ADDRESSCOL));
-        Assert.assertEquals("33", t.getValueAt(0, RosterTableModel.DECODERCOL));
+        Assert.assertEquals("33", t.getValueAt(0, RosterTableModel.DECODERMODELCOL));
 
         Assert.assertEquals("id 2", t.getValueAt(1, RosterTableModel.IDCOL));
         Assert.assertEquals(13,(int) t.getValueAt(1, RosterTableModel.ADDRESSCOL));
-        Assert.assertEquals("34", t.getValueAt(1, RosterTableModel.DECODERCOL));
+        Assert.assertEquals("34", t.getValueAt(1, RosterTableModel.DECODERMODELCOL));
 
         Assert.assertEquals("id 3", t.getValueAt(2, RosterTableModel.IDCOL));
         Assert.assertEquals(14, (int)t.getValueAt(2, RosterTableModel.ADDRESSCOL));
-        Assert.assertEquals("35", t.getValueAt(2, RosterTableModel.DECODERCOL));
+        Assert.assertEquals("35", t.getValueAt(2, RosterTableModel.DECODERMODELCOL));
         
         Assert.assertEquals("DCC Long", t.getValueAt(2, RosterTableModel.PROTOCOL));
         
@@ -175,8 +177,8 @@ public class RosterTableModelTest {
         RosterTableModel t = new RosterTableModel(true); // set Editable
 
         // hard-coded value is number of columns expected
-        // 11 normal columns + 2 attribute columns
-        Assert.assertEquals(13, t.getColumnCount());
+        // 13 normal columns + 2 attribute columns
+        Assert.assertEquals(15, t.getColumnCount());
         Assert.assertTrue(java.util.Date.class == t.getColumnClass(RosterTableModel.NUMCOL));
 
         Assert.assertNotNull(t.getValueAt(0, RosterTableModel.NUMCOL));


### PR DESCRIPTION
This PR adds two new columns in the DecoderPro display of the  roster:  "Decoder Manufacturer" and "Decoder Family". These start out hidden.  To display them, right or control click in the header of any column, and then put a check next to the column name.

Resolves Issue #14290 