### PR TITLE
Use correct ThrottleManager on non-default ThrottleManager Dispose / release / dispatch

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -579,7 +579,7 @@
     <h3>Throttle</h3>
         <a id="throttle" name="throttle"></a>
         <ul>
-            <li></li>
+            <li>Uses correct connection for non-default Throttle release / dispatch requests.</li>
         </ul>
 
     <h3>Timetable</h3>

--- a/java/src/jmri/Throttle.java
+++ b/java/src/jmri/Throttle.java
@@ -34,20 +34,46 @@ public interface Throttle extends PropertyChangeProvider {
     /**
      * Constant used in getThrottleInfo.
      */
-    static final String SPEEDSTEPMODE = "SpeedStepsMode"; // speed steps NOI18N
+    String SPEEDSTEPMODE = "SpeedStepsMode"; // speed steps NOI18N
 
     /*
      * Properties strings sent to property change listeners
      */
 
     /**
-     * Constant sent by Throttle on Property Change.
+     * Constant sent by Throttle on Speed Steps Property Change.
      */
-    static final String SPEEDSTEPS = "SpeedSteps"; // speed steps NOI18N
+    String SPEEDSTEPS = "SpeedSteps";
 
-    static final String SPEEDSETTING = "SpeedSetting"; // speed setting NOI18N
-    static final String ISFORWARD = "IsForward"; // direction setting NOI18N
-    static final String SPEEDINCREMENT = "SpeedIncrement"; // direction setting NOI18N
+    /**
+     * Constant sent by Throttle on Speed Setting Property Change.
+     */
+    String SPEEDSETTING = "SpeedSetting";
+
+    /**
+     * Constant sent by Throttle on Direction Property Change.
+     */
+    String ISFORWARD = "IsForward";
+
+    /**
+     * Constant sent by Throttle on Speed Increment Property Change.
+     */
+    String SPEEDINCREMENT = "SpeedIncrement";
+
+    /**
+     * Constant sent by Throttle on Connected Property Change.
+     */
+    String CONNECTED = "ThrottleConnected";
+
+    /**
+     * Constant sent by Throttle on Dispatch Enabled Property Change.
+     */
+    String DISPATCH_ENABLED = "DispatchEnabled";
+
+    /**
+     * Constant sent by Throttle on Release Enabled Property Change.
+     */
+    String RELEASE_ENABLED = "ReleaseEnabled";
 
     /**
      * Constants to represent the functions F0 through F28.

--- a/java/src/jmri/jmrix/AbstractThrottle.java
+++ b/java/src/jmri/jmrix/AbstractThrottle.java
@@ -15,6 +15,7 @@ import jmri.InstanceManager;
 import jmri.SystemConnectionMemo;
 import jmri.Throttle;
 import jmri.ThrottleListener;
+import jmri.ThrottleManager;
 import jmri.beans.PropertyChangeSupport;
 
 import jmri.jmrit.roster.RosterEntry;
@@ -270,7 +271,7 @@ abstract public class AbstractThrottle extends PropertyChangeSupport implements 
      * normal release / dispose is not possible.
      */
     protected void notifyThrottleDisconnect() {
-        firePropertyChange("ThrottleConnected", true, false); // NOI18N
+        firePropertyChange(CONNECTED, true, false);
     }
 
     // set initial values purely for changelistener following
@@ -290,7 +291,7 @@ abstract public class AbstractThrottle extends PropertyChangeSupport implements 
      */
     @Override
     public void notifyThrottleDispatchEnabled(boolean newVal) {
-        firePropertyChange("DispatchEnabled", _dispatchEnabled, _dispatchEnabled = newVal); // NOI18N
+        firePropertyChange(DISPATCH_ENABLED, _dispatchEnabled, _dispatchEnabled = newVal); // NOI18N
     }
 
     /**
@@ -305,7 +306,7 @@ abstract public class AbstractThrottle extends PropertyChangeSupport implements 
      */
     @Override
     public void notifyThrottleReleaseEnabled(boolean newVal) {
-        firePropertyChange("ReleaseEnabled", _releaseEnabled, _releaseEnabled = newVal); // NOI18N
+        firePropertyChange(RELEASE_ENABLED, _releaseEnabled, _releaseEnabled = newVal); // NOI18N
     }
 
     /**
@@ -342,7 +343,7 @@ abstract public class AbstractThrottle extends PropertyChangeSupport implements 
         log.debug("removePropertyChangeListener(): throttle: {} listeners size is {}", getLocoAddress(), getPropertyChangeListeners().length);
         if (getPropertyChangeListeners().length == 0) {
             log.debug("No listeners so calling ThrottleManager.dispose with an empty ThrottleListener for {}",getLocoAddress());
-            InstanceManager.throttleManagerInstance().disposeThrottle(this, new ThrottleListener() {
+            getThrottleManager().disposeThrottle(this, new ThrottleListener() {
                 @Override
                 public void notifyFailedThrottleRequest(LocoAddress address, String reason) {
                 }
@@ -369,7 +370,7 @@ abstract public class AbstractThrottle extends PropertyChangeSupport implements 
         if (!active) {
             log.error("Dispose called when not active {}", this.getClass().getName());
         }
-        InstanceManager.throttleManagerInstance().disposeThrottle(this, l);
+        getThrottleManager().disposeThrottle(this, l);
     }
 
     /**
@@ -380,7 +381,7 @@ abstract public class AbstractThrottle extends PropertyChangeSupport implements 
         if (!active) {
             log.warn("dispatch called when not active {}", this.getClass().getName());
         }
-        InstanceManager.throttleManagerInstance().dispatchThrottle(this, l);
+        getThrottleManager().dispatchThrottle(this, l);
     }
 
     /**
@@ -391,7 +392,15 @@ abstract public class AbstractThrottle extends PropertyChangeSupport implements 
         if (!active) {
             log.warn("release called when not active {}",this.getClass().getName());
         }
-        InstanceManager.throttleManagerInstance().releaseThrottle(this, l);
+        getThrottleManager().releaseThrottle(this, l);
+    }
+
+    private ThrottleManager getThrottleManager(){
+        if (adapterMemo != null && adapterMemo.get(ThrottleManager.class) !=null) {
+            return adapterMemo.get(ThrottleManager.class);
+        }
+        log.warn("No {} Throttle Manager for {}", adapterMemo, this.getClass());
+        return InstanceManager.getDefault(ThrottleManager.class);
     }
 
     /**


### PR DESCRIPTION
For multi-connection setups, the default ThrottleManager may not be the actual ThrottleManager for a Throttle.
ThrottleManager is not a proxy manager.

On Throttle Dispose / release / dispatch, we now notify the ThrottleManager for the connection, not the Default.
This relies on a System connections being present so I'll be making further PRs around this.

This PR likely adds a number of log4j warnings to the CI tests, though this should be temporary.


Adds property change constant Strings to Throttle interface.