### PR TITLE
Have markers appear in a fixed, not random, location

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -404,7 +404,7 @@
     <h3>Control Panel Editor</h3>
         <a id="CPE" name="CPE"></a>
         <ul>
-            <li></li>
+            <li>Fixed a bug that would cause Markers to be created in random locations.</li>
         </ul>
         <h4>Circuit Builder</h4>
             <a id="CPE-CB" name="CPE-CB"></a>
@@ -454,7 +454,7 @@
     <h3>Layout Editor</h3>
         <a id="LE" name="LE"></a>
         <ul>
-            <li></li>
+            <li>Fixed a bug that would cause Markers to be created in random locations.</li>
         </ul>
 
         <h4>NX - Entry/Exit Tool</h4>
@@ -496,7 +496,7 @@
    <h3>Panel Editor</h3>
         <a id="PE" name="PE"></a>
         <ul>
-            <li></li>
+            <li>Fixed a bug that would cause Markers to be created in random locations.</li>
         </ul>
 
     <h3>Permissions</h3>

--- a/java/src/jmri/jmrit/display/Editor.java
+++ b/java/src/jmri/jmrit/display/Editor.java
@@ -1879,6 +1879,7 @@ abstract public class Editor extends JmriJFrameWithPermissions
         l.setHorizontalTextPosition(SwingConstants.CENTER);
         l.setSize(l.getPreferredSize().width, l.getPreferredSize().height);
         l.setEditable(isEditable());    // match popup mode to editor mode
+        l.setLocation(75, 75);  // fixed location 
         try {
             putItem(l);
         } catch (Positionable.DuplicateIdException e) {


### PR DESCRIPTION
Previously, when you requested a new marker on an Editor panel, it would appear in a random location somewhere on the panel.  This makes them appear at 75, 75 in the upper left, where you can find the darn things.