### PR TITLE
Switchboard Editor - prevent duplicate UserName

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -585,7 +585,7 @@
    <h3>Switchboard Editor</h3>
         <a id="SW" name="SW"></a>
         <ul>
-            <li></li>
+            <li>Adds check to prevent a duplicate Turnout / Sensor / Light UserName being set.</li>
         </ul>
 
     <h3>Throttle</h3>

--- a/java/src/jmri/jmrit/display/switchboardEditor/BeanSwitch.java
+++ b/java/src/jmri/jmrit/display/switchboardEditor/BeanSwitch.java
@@ -922,7 +922,7 @@ public class BeanSwitch extends JPanel implements java.beans.PropertyChangeListe
         if (addFrame != null) {
             ThreadingUtil.runOnGUI( () -> addFrame.setVisible(false) );
             addFrame.dispose();
-           addFrame = null;
+            addFrame = null;
         }
     }
 

--- a/java/src/jmri/jmrit/display/switchboardEditor/BeanSwitch.java
+++ b/java/src/jmri/jmrit/display/switchboardEditor/BeanSwitch.java
@@ -18,13 +18,16 @@ import javax.swing.*;
 import jmri.InstanceManager;
 import jmri.JmriException;
 import jmri.Light;
+import jmri.LightManager;
+import jmri.Manager;
 import jmri.NamedBean;
 import jmri.NamedBeanHandle;
 import jmri.Sensor;
+import jmri.SensorManager;
 import jmri.Turnout;
+import jmri.TurnoutManager;
 import jmri.jmrit.beantable.AddNewDevicePanel;
-import jmri.util.JmriJFrame;
-import jmri.util.SystemType;
+import jmri.util.*;
 import jmri.util.swing.JmriJOptionPane;
 
 /**
@@ -574,18 +577,18 @@ public class BeanSwitch extends JPanel implements java.beans.PropertyChangeListe
         if (log.isDebugEnabled()) {
             log.debug("property change: {} {} is now: {}", _switchSysName, e.getPropertyName(), e.getNewValue());
         }
-        if (e.getPropertyName().equals("KnownState")) {
+        if ( NamedBean.PROPERTY_KNOWN_STATE.equals(e.getPropertyName())) {
             int now = ((Integer) e.getNewValue());
             displayState(now);
             log.debug("Item state changed");
         }
-        if (e.getPropertyName().equals("UserName")) {
+        if ( NamedBean.PROPERTY_USERNAME.equals(e.getPropertyName())) {
             // update tooltip
             String newUserName;
             if (showToolTip) {
                 newUserName = ((String) e.getNewValue());
                 _uLabel = (newUserName == null ? "" : newUserName); // store for display on icon
-                if (newUserName == null || newUserName.equals("")) {
+                if (newUserName == null || newUserName.isEmpty()) {
                     newUserName = Bundle.getMessage("NoUserName"); // longer for tooltip
                 }
                 setToolTipText(_switchSysName + " (" + newUserName + ")");
@@ -908,23 +911,25 @@ public class BeanSwitch extends JPanel implements java.beans.PropertyChangeListe
             switchConnect.setOK(); // activate OK button on Add new device pane
             addFrame.add(switchConnect);
         }
-        addFrame.pack();
-        addFrame.setLocationRelativeTo(this);
-        addFrame.setVisible(true);
+        ThreadingUtil.runOnGUI( () -> {
+            addFrame.pack();
+            addFrame.setLocationRelativeTo(this);
+            addFrame.setVisible(true);
+        });
     }
 
     protected void cancelAddPressed(ActionEvent e) {
         if (addFrame != null) {
-            addFrame.setVisible(false);
+            ThreadingUtil.runOnGUI( () -> addFrame.setVisible(false) );
             addFrame.dispose();
-            addFrame = null;
+           addFrame = null;
         }
     }
 
     protected void okAddPressed(ActionEvent e) {
         NamedBean nb;
         String user = userName.getText();
-        if (user.trim().equals("")) {
+        if (user.isBlank()) {
             user = null;
         }
         // systemName can't be changed, fixed
@@ -935,6 +940,9 @@ public class BeanSwitch extends JPanel implements java.beans.PropertyChangeListe
         }
         switch (_switchSysName.charAt(manuPrefix.length())) {
             case 'T':
+                if ( existingUserName(InstanceManager.getDefault(TurnoutManager.class), user, e)) {
+                    return;
+                }
                 Turnout t;
                 try {
                     // add turnout to JMRI (w/appropriate manager)
@@ -942,12 +950,15 @@ public class BeanSwitch extends JPanel implements java.beans.PropertyChangeListe
                     t.setUserName(user);
                 } catch (IllegalArgumentException ex) {
                     // user input no good
-                    handleCreateException(_switchSysName);
+                    handleCreateException(_switchSysName, ex);
                     return; // without creating
                 }
                 nb = jmri.InstanceManager.turnoutManagerInstance().getTurnout(_switchSysName);
                 break;
             case 'S':
+                if ( existingUserName(InstanceManager.getDefault(SensorManager.class), user, e)) {
+                    return;
+                }
                 Sensor s;
                 try {
                     // add Sensor to JMRI (w/appropriate manager)
@@ -955,12 +966,15 @@ public class BeanSwitch extends JPanel implements java.beans.PropertyChangeListe
                     s.setUserName(user);
                 } catch (IllegalArgumentException ex) {
                     // user input no good
-                    handleCreateException(_switchSysName);
+                    handleCreateException(_switchSysName, ex);
                     return; // without creating
                 }
                 nb = jmri.InstanceManager.sensorManagerInstance().getSensor(_switchSysName);
                 break;
             case 'L':
+                if ( existingUserName(InstanceManager.getDefault(LightManager.class), user, e)) {
+                    return;
+                }
                 Light l;
                 try {
                     // add Light to JMRI (w/appropriate manager)
@@ -968,7 +982,7 @@ public class BeanSwitch extends JPanel implements java.beans.PropertyChangeListe
                     l.setUserName(user);
                 } catch (IllegalArgumentException ex) {
                     // user input no good
-                    handleCreateException(_switchSysName);
+                    handleCreateException(_switchSysName, ex);
                     return; // without creating
                 }
                 nb = jmri.InstanceManager.lightManagerInstance().getLight(_switchSysName);
@@ -989,10 +1003,21 @@ public class BeanSwitch extends JPanel implements java.beans.PropertyChangeListe
                     _editor.updatePressed();
                 }
             } catch (NullPointerException npe) {
-                handleCreateException(_switchSysName);
+                handleCreateException(_switchSysName, npe);
                 // exit without updating
             }
         }
+    }
+
+    private boolean existingUserName(Manager<?> mgr, String userName, Object e){
+        NamedBean nb = mgr.getByUserName(userName == null ? "" : userName);
+        if ( nb != null ) {
+            JmriJOptionPane.showMessageDialog( JmriJOptionPane.findWindowForObject(e),
+                Bundle.getMessage("InvalidUserNameAlreadyExists",nb.getBeanType(),userName),
+                Bundle.getMessage("WarningUserName", userName), JmriJOptionPane.ERROR_MESSAGE);
+            return true;
+        }
+        return false;
     }
 
     /**
@@ -1019,12 +1044,11 @@ public class BeanSwitch extends JPanel implements java.beans.PropertyChangeListe
         }
     }
 
-    void handleCreateException(String sysName) {
+    void handleCreateException(String sysName, Exception ex) {
         JmriJOptionPane.showMessageDialog(addFrame,
-                java.text.MessageFormat.format(
-                        Bundle.getMessage("ErrorSwitchAddFailed"), sysName),
-                Bundle.getMessage("ErrorTitle"),
-                JmriJOptionPane.ERROR_MESSAGE);
+            "<html>" + Bundle.getMessage("ErrorSwitchAddFailed") + "<br>" + ex.getLocalizedMessage()+"</html>",
+            Bundle.getMessage("ErrorTitle") + " : " + sysName,
+            JmriJOptionPane.ERROR_MESSAGE);
     }
 
     String rootPath = "resources/icons/misc/switchboard/";

--- a/java/src/jmri/jmrit/display/switchboardEditor/SwitchboardEditor.java
+++ b/java/src/jmri/jmrit/display/switchboardEditor/SwitchboardEditor.java
@@ -18,6 +18,7 @@ import jmri.jmrix.SystemConnectionMemoManager;
 import jmri.swing.ManagerComboBox;
 import jmri.util.ColorUtil;
 import jmri.util.JmriJFrame;
+import jmri.util.ThreadingUtil;
 import jmri.util.swing.JmriColorChooser;
 import jmri.util.swing.JmriJOptionPane;
 import jmri.util.swing.JmriMouseEvent;
@@ -191,7 +192,7 @@ public class SwitchboardEditor extends Editor {
         // always available (?) and supports all types, not required now, will be set by listener
 
         Container contentPane = getContentPane(); // the actual Editor configuration pane
-        setVisible(false);      // start with Editor window hidden
+        ThreadingUtil.runOnGUI( () -> setVisible(false)); // start with Editor window hidden
         setUseGlobalFlag(true); // always true for a Switchboard
         // handle Editor close box clicked without deleting the Switchboard panel
         super.setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
@@ -200,7 +201,7 @@ public class SwitchboardEditor extends Editor {
             public void windowClosing(java.awt.event.WindowEvent e) {
                 log.debug("switchboardEditor close box selected");
                 setAllEditable(false);
-                setVisible(false); // hide Editor window
+                ThreadingUtil.runOnGUI( () -> setVisible(false)); // hide Editor window
             }
         });
         // make menus
@@ -462,6 +463,10 @@ public class SwitchboardEditor extends Editor {
      * Switchboard JPanel WindowResize() event is handled by resizeInFrame()
      */
     public void updatePressed() {
+        ThreadingUtil.runOnGUI(this::updatePressedOnGui);
+    }
+
+    private void updatePressedOnGui() {
         log.debug("updatePressed START _tileSize = {}", _tileSize);
 
         if (_autoItemRange && !autoItemRange.isSelected()) {
@@ -1543,15 +1548,6 @@ public class SwitchboardEditor extends Editor {
         return _showUserName;
     }
 
-    /**
-     * Initial, simple boolean label option
-     * @param on true to show both system and user name on the switch label
-     */
-    @Deprecated
-    public void setShowUserName(Boolean on) {
-        setShowUserName(on ? SwitchBoardLabelDisplays.BOTH_NAMES : SwitchBoardLabelDisplays.SYSTEM_NAME);
-    }
-
     public void setShowUserName(SwitchBoardLabelDisplays label) {
         _showUserName = label;
         switch (label) {
@@ -1730,7 +1726,7 @@ public class SwitchboardEditor extends Editor {
      */
     public JmriJFrame makeFrame(String name) {
         JmriJFrame targetFrame = new JmriJFrame(name);
-        targetFrame.setVisible(true);
+        ThreadingUtil.runOnGUI( () -> targetFrame.setVisible(true) );
 
         JMenuBar menuBar = new JMenuBar();
         JMenu editMenu = new JMenu(Bundle.getMessage("MenuEdit"));

--- a/java/test/jmri/jmrit/display/switchboardEditor/BeanSwitchTest.java
+++ b/java/test/jmri/jmrit/display/switchboardEditor/BeanSwitchTest.java
@@ -3,74 +3,75 @@ package jmri.jmrit.display.switchboardEditor;
 import java.awt.event.MouseEvent;
 
 import jmri.*;
-import jmri.util.JUnitAppender;
-import jmri.util.JUnitUtil;
+import jmri.util.*;
 
 import org.junit.jupiter.api.*;
 
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.netbeans.jemmy.operators.JButtonOperator;
 import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JFrameOperator;
+import org.netbeans.jemmy.operators.JTextFieldOperator;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * Test functioning of switchboardeditor/BeanSwitch.
- * For now a lot of items turned off to find Travis CI problem.
+ * Test functioning of BeanSwitch.
  *
  * @author Egbert Broerse Copyright (C) 2017, 2021
  */
-@DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
+@jmri.util.junit.annotations.DisabledIfHeadless
 public class BeanSwitchTest {
 
     @Test
     public void testCTor() {
         BeanSwitch t = new BeanSwitch(1,null,"IT1",0, null);
-        Assertions.assertNotNull(t, "exists");
+        assertNotNull(t, "exists");
     }
 
     @Test
     public void testTurnoutSwitch() {
         NamedBean nb = jmri.InstanceManager.getDefault(TurnoutManager.class).provideTurnout("IT4");
         BeanSwitch t = new BeanSwitch(4, nb, "IT5", SwitchboardEditor.KEY, null);
-        Assertions.assertNotNull(t, "exists");
-        Assertions.assertNotNull(t.getIconLabel());
-        Assertions.assertEquals("IT5: ?", t.getIconLabel(), "Initial label -");
+        assertNotNull(t, "exists");
+        assertNotNull(t.getIconLabel());
+        assertEquals("IT5: ?", t.getIconLabel(), "Initial label -");
         t.displayState(Turnout.CLOSED);
-        Assertions.assertEquals("IT5: C", t.getIconLabel(), "On label +");
+        assertEquals("IT5: C", t.getIconLabel(), "On label +");
         t.displayState(Turnout.THROWN);
-        Assertions.assertEquals("IT5: T", t.getIconLabel(), "Off label -");
+        assertEquals("IT5: T", t.getIconLabel(), "Off label -");
         t.displayState(Turnout.UNKNOWN);
-        Assertions.assertEquals("IT5: ?", t.getIconLabel(), "Off label ?");
+        assertEquals("IT5: ?", t.getIconLabel(), "Off label ?");
         t.displayState(Turnout.INCONSISTENT);
-        Assertions.assertEquals("IT5: X", t.getIconLabel(), "Off label X");
+        assertEquals("IT5: X", t.getIconLabel(), "Off label X");
 
         t = new BeanSwitch(4, nb, "IT58", SwitchboardEditor.SLIDER, null);
-        Assertions.assertEquals("IT58: ?", t.getIconLabel(), "Initial label -");
+        assertEquals("IT58: ?", t.getIconLabel(), "Initial label -");
         t.displayState(Turnout.CLOSED);
-        Assertions.assertEquals("IT58: C", t.getIconLabel(), "On label +");
+        assertEquals("IT58: C", t.getIconLabel(), "On label +");
         t.displayState(Turnout.THROWN);
-        Assertions.assertEquals("IT58: T", t.getIconLabel(), "Off label -");
+        assertEquals("IT58: T", t.getIconLabel(), "Off label -");
         t.displayState(Turnout.UNKNOWN);
-        Assertions.assertEquals("IT58: ?", t.getIconLabel(), "Off label ?");
+        assertEquals("IT58: ?", t.getIconLabel(), "Off label ?");
         t.displayState(Turnout.INCONSISTENT);
-        Assertions.assertEquals("IT58: X", t.getIconLabel(), "Off label X");
+        assertEquals("IT58: X", t.getIconLabel(), "Off label X");
 
         t = new BeanSwitch(4, nb, "IT58", SwitchboardEditor.BUTTON, null);
-        Assertions.assertEquals("IT58: ?", t.getIconLabel(), "Initial label -");
+        assertEquals("IT58: ?", t.getIconLabel(), "Initial label -");
         t.displayState(Turnout.CLOSED);
-        Assertions.assertEquals("IT58: C", t.getIconLabel(), "On label +");
+        assertEquals("IT58: C", t.getIconLabel(), "On label +");
         t.displayState(Turnout.THROWN);
-        Assertions.assertEquals("IT58: T", t.getIconLabel(), "Off label -");
+        assertEquals("IT58: T", t.getIconLabel(), "Off label -");
         t.displayState(Turnout.UNKNOWN);
-        Assertions.assertEquals("IT58: ?", t.getIconLabel(), "Off label ?");
+        assertEquals("IT58: ?", t.getIconLabel(), "Off label ?");
         t.displayState(Turnout.INCONSISTENT);
-        Assertions.assertEquals("IT58: X", t.getIconLabel(), "Off label X");
+        assertEquals("IT58: X", t.getIconLabel(), "Off label X");
 
         t = new BeanSwitch(4, nb, "IT1", SwitchboardEditor.ICONS, null);
-        Assertions.assertEquals("IT1: ?", t.getIconLabel(), "Initial label -");
+        assertEquals("IT1: ?", t.getIconLabel(), "Initial label -");
         t.displayState(Turnout.CLOSED);
-        Assertions.assertEquals("IT1: C", t.getIconLabel(), "On label +");
+        assertEquals("IT1: C", t.getIconLabel(), "On label +");
         t.displayState(Turnout.THROWN);
-        Assertions.assertEquals("IT1: T", t.getIconLabel(), "Off label -");
+        assertEquals("IT1: T", t.getIconLabel(), "Off label -");
         t.setInverted(true); // test inverted display, C = T
         try {
             nb.setState(Turnout.THROWN);
@@ -78,11 +79,11 @@ public class BeanSwitchTest {
         }
         t.operate(new MouseEvent(t, 1, 0, 0, 0, 0, 1, false), "NAME");
 
-        Assertions.assertEquals("IT1: C", t.getIconLabel(), "On label +");
+        assertEquals("IT1: C", t.getIconLabel(), "On label +");
         t.displayState(Turnout.UNKNOWN);
-        Assertions.assertEquals("IT1: ?", t.getIconLabel(), "Off label ?");
+        assertEquals("IT1: ?", t.getIconLabel(), "Off label ?");
         t.displayState(Turnout.INCONSISTENT);
-        Assertions.assertEquals("IT1: X", t.getIconLabel(), "Off label X");
+        assertEquals("IT1: X", t.getIconLabel(), "Off label X");
 
         t.cleanup(); // make sure no exception is thrown
     }
@@ -91,50 +92,50 @@ public class BeanSwitchTest {
     public void testLightSwitch() {
         NamedBean nb = jmri.InstanceManager.getDefault(LightManager.class).provideLight("IL4");
         BeanSwitch t = new BeanSwitch(4, nb, "IL4", SwitchboardEditor.KEY, null);
-        Assertions.assertNotNull(t, "exists");
-        Assertions.assertNotNull(t.getIconLabel());
-        Assertions.assertEquals("IL4: -", t.getIconLabel(), "Initial label -");
+        assertNotNull(t, "exists");
+        assertNotNull(t.getIconLabel());
+        assertEquals("IL4: -", t.getIconLabel(), "Initial label -");
         t.displayState(Light.ON);
-        Assertions.assertEquals("IL4: +", t.getIconLabel(), "On label +");
+        assertEquals("IL4: +", t.getIconLabel(), "On label +");
         t.displayState(Light.OFF);
-        Assertions.assertEquals("IL4: -", t.getIconLabel(), "Off label -");
+        assertEquals("IL4: -", t.getIconLabel(), "Off label -");
         t.displayState(Light.UNKNOWN);
-        Assertions.assertEquals("IL4: ?", t.getIconLabel(), "Off label ?");
+        assertEquals("IL4: ?", t.getIconLabel(), "Off label ?");
         t.displayState(Light.INCONSISTENT);
-        Assertions.assertEquals("IL4: X", t.getIconLabel(), "Off label X");
+        assertEquals("IL4: X", t.getIconLabel(), "Off label X");
 
         t = new BeanSwitch(4, nb, "IL4", SwitchboardEditor.SLIDER, null);
-        Assertions.assertEquals("IL4: -", t.getIconLabel(), "Initial label -");
+        assertEquals("IL4: -", t.getIconLabel(), "Initial label -");
         t.displayState(Light.ON);
-        Assertions.assertEquals("IL4: +", t.getIconLabel(), "On label +");
+        assertEquals("IL4: +", t.getIconLabel(), "On label +");
         t.displayState(Light.OFF);
-        Assertions.assertEquals("IL4: -", t.getIconLabel(), "Off label -");
+        assertEquals("IL4: -", t.getIconLabel(), "Off label -");
         t.displayState(Light.UNKNOWN);
-        Assertions.assertEquals("IL4: ?", t.getIconLabel(), "Off label ?");
+        assertEquals("IL4: ?", t.getIconLabel(), "Off label ?");
         t.displayState(Light.INCONSISTENT);
-        Assertions.assertEquals("IL4: X", t.getIconLabel(), "Off label X");
+        assertEquals("IL4: X", t.getIconLabel(), "Off label X");
 
         t = new BeanSwitch(4, nb, "IL4", SwitchboardEditor.BUTTON, null);
-        Assertions.assertEquals("IL4: -", t.getIconLabel(), "Initial label -");
+        assertEquals("IL4: -", t.getIconLabel(), "Initial label -");
         t.displayState(Light.ON);
-        Assertions.assertEquals("IL4: +", t.getIconLabel(), "On label +");
+        assertEquals("IL4: +", t.getIconLabel(), "On label +");
         t.displayState(Light.OFF);
-        Assertions.assertEquals("IL4: -", t.getIconLabel(), "Off label -");
+        assertEquals("IL4: -", t.getIconLabel(), "Off label -");
         t.displayState(Light.UNKNOWN);
-        Assertions.assertEquals("IL4: ?", t.getIconLabel(), "Off label ?");
+        assertEquals("IL4: ?", t.getIconLabel(), "Off label ?");
         t.displayState(Light.INCONSISTENT);
-        Assertions.assertEquals("IL4: X", t.getIconLabel(), "Off label X");
+        assertEquals("IL4: X", t.getIconLabel(), "Off label X");
 
         t = new BeanSwitch(4, nb, "IL4", SwitchboardEditor.ICONS, null);
-        Assertions.assertEquals("IL4: -", t.getIconLabel(), "Initial label -");
+        assertEquals("IL4: -", t.getIconLabel(), "Initial label -");
         t.displayState(Light.ON);
-        Assertions.assertEquals("IL4: +", t.getIconLabel(), "On label +");
+        assertEquals("IL4: +", t.getIconLabel(), "On label +");
         t.displayState(Light.OFF);
-        Assertions.assertEquals("IL4: -", t.getIconLabel(), "Off label -");
+        assertEquals("IL4: -", t.getIconLabel(), "Off label -");
         t.displayState(Light.UNKNOWN);
-        Assertions.assertEquals("IL4: ?", t.getIconLabel(), "Off label ?");
+        assertEquals("IL4: ?", t.getIconLabel(), "Off label ?");
         t.displayState(Light.INCONSISTENT);
-        Assertions.assertEquals("IL4: X", t.getIconLabel(), "Off label X");
+        assertEquals("IL4: X", t.getIconLabel(), "Off label X");
 
         t.cleanup(); // make sure no exception is thrown
     }
@@ -150,59 +151,132 @@ public class BeanSwitchTest {
         dialog_thread1.start();
 
         BeanSwitch t = new BeanSwitch(3, null, "IP3", SwitchboardEditor.KEY, null);
+        assertNotNull(t);
         JUnitUtil.waitFor(() -> !(dialog_thread1.isAlive()), "Error dialog");
         JUnitAppender.assertErrorMessage("invalid char in Switchboard Button \"IP3\". Check connection name.");
 
         NamedBean nb = jmri.InstanceManager.getDefault(SensorManager.class).provideSensor("IS3");
         t = new BeanSwitch(3, nb, "IS3", SwitchboardEditor.KEY, null);
-        Assertions.assertNotNull(t, "exists");
-        Assertions.assertNotNull(t.getIconLabel());
-        Assertions.assertEquals("IS3: ?", t.getIconLabel(), "Initial label -");
+        assertNotNull(t, "exists");
+        assertNotNull(t.getIconLabel());
+        assertEquals("IS3: ?", t.getIconLabel(), "Initial label -");
         t.displayState(Sensor.ACTIVE);
-        Assertions.assertEquals("IS3: +", t.getIconLabel(), "On label +");
+        assertEquals("IS3: +", t.getIconLabel(), "On label +");
         t.displayState(Sensor.INACTIVE);
-        Assertions.assertEquals("IS3: -", t.getIconLabel(), "Off label -");
+        assertEquals("IS3: -", t.getIconLabel(), "Off label -");
         t.displayState(Sensor.UNKNOWN);
-        Assertions.assertEquals("IS3: ?", t.getIconLabel(), "Off label ?");
+        assertEquals("IS3: ?", t.getIconLabel(), "Off label ?");
         t.displayState(Sensor.INCONSISTENT);
-        Assertions.assertEquals("IS3: X", t.getIconLabel(), "Off label X");
+        assertEquals("IS3: X", t.getIconLabel(), "Off label X");
 
         t = new BeanSwitch(4, nb, "IS33", SwitchboardEditor.SLIDER, null);
-        Assertions.assertEquals("IS33: ?", t.getIconLabel(), "Initial label -");
+        assertEquals("IS33: ?", t.getIconLabel(), "Initial label -");
         t.displayState(Sensor.ACTIVE);
-        Assertions.assertEquals("IS33: +", t.getIconLabel(), "On label +");
+        assertEquals("IS33: +", t.getIconLabel(), "On label +");
         t.displayState(Sensor.INACTIVE);
-        Assertions.assertEquals("IS33: -", t.getIconLabel(), "Off label -");
+        assertEquals("IS33: -", t.getIconLabel(), "Off label -");
         t.displayState(Sensor.UNKNOWN);
-        Assertions.assertEquals("IS33: ?", t.getIconLabel(), "Off label ?");
+        assertEquals("IS33: ?", t.getIconLabel(), "Off label ?");
         t.displayState(Sensor.INCONSISTENT);
-        Assertions.assertEquals("IS33: X", t.getIconLabel(), "Off label X");
+        assertEquals("IS33: X", t.getIconLabel(), "Off label X");
 
         t = new BeanSwitch(4, nb, "IS23", SwitchboardEditor.BUTTON, null);
-        Assertions.assertEquals("IS23: ?", t.getIconLabel(), "Initial label -");
+        assertEquals("IS23: ?", t.getIconLabel(), "Initial label -");
         t.displayState(Sensor.ACTIVE);
-        Assertions.assertEquals("IS23: +", t.getIconLabel(), "On label +");
+        assertEquals("IS23: +", t.getIconLabel(), "On label +");
         t.displayState(Sensor.INACTIVE);
-        Assertions.assertEquals("IS23: -", t.getIconLabel(), "Off label -");
+        assertEquals("IS23: -", t.getIconLabel(), "Off label -");
         t.displayState(Sensor.UNKNOWN);
-        Assertions.assertEquals("IS23: ?", t.getIconLabel(), "Off label ?");
+        assertEquals("IS23: ?", t.getIconLabel(), "Off label ?");
         t.displayState(Sensor.INCONSISTENT);
-        Assertions.assertEquals("IS23: X", t.getIconLabel(), "Off label X");
+        assertEquals("IS23: X", t.getIconLabel(), "Off label X");
 
         t = new BeanSwitch(4, nb, "IS3", SwitchboardEditor.ICONS, null);
-        Assertions.assertEquals("IS3: ?", t.getIconLabel(), "Initial label -");
+        assertEquals("IS3: ?", t.getIconLabel(), "Initial label -");
         t.displayState(Sensor.ACTIVE);
-        Assertions.assertEquals("IS3: +", t.getIconLabel(), "On label +");
+        assertEquals("IS3: +", t.getIconLabel(), "On label +");
         t.displayState(Sensor.INACTIVE);
-        Assertions.assertEquals("IS3: -", t.getIconLabel(), "Off label -");
+        assertEquals("IS3: -", t.getIconLabel(), "Off label -");
         t.displayState(Sensor.UNKNOWN);
-        Assertions.assertEquals("IS3: ?", t.getIconLabel(), "Off label ?");
+        assertEquals("IS3: ?", t.getIconLabel(), "Off label ?");
         t.displayState(Sensor.INCONSISTENT);
-        Assertions.assertEquals("IS3: X", t.getIconLabel(), "Off label X");
+        assertEquals("IS3: X", t.getIconLabel(), "Off label X");
 
         t.cleanup(); // make sure no exception is thrown
     }
 
+    @Test
+    public void testSetTurnoutUserName() {
+        testSetUserName(InstanceManager.getDefault(TurnoutManager.class));
+    }
+
+    @Test
+    public void testSetSensorUserName() {
+        testSetUserName(InstanceManager.getDefault(SensorManager.class));
+    }
+
+    @Test
+    public void testSetLightUserName() {
+        testSetUserName(InstanceManager.getDefault(LightManager.class));
+    }
+
+    private static final String NEW_UNAME = "New UserName";
+    private static final String EXISTING_UNAME = "Existing UserName";
+
+    private void testSetUserName( ProvidingManager<?> mgr ) {
+
+        NamedBean nbA = mgr.provide(mgr.getSystemNamePrefix()+11);
+        NamedBean nbB = mgr.provide(mgr.getSystemNamePrefix()+12);
+        nbB.setUserName(EXISTING_UNAME);
+
+        var editor = new SwitchboardEditor("BeanSwitch TestSetUserName " + nbA.getBeanType());
+        editor.setSwitchType(String.valueOf(mgr.typeLetter()));
+        // editor.setTitle();
+        ThreadingUtil.runOnGUI( () -> editor.setVisible(true));
+
+        BeanSwitch t = new BeanSwitch(4, nbA, nbA.getSystemName(), SwitchboardEditor.BUTTON, editor);
+        // BeanSwitch tB = new BeanSwitch(5, nbB, nbB.getSystemName(), SwitchboardEditor.BUTTON, editor);
+        ThreadingUtil.runOnGUI( () -> t.connectNew() );
+
+        JFrameOperator jfo = new JFrameOperator(Bundle.getMessage("ConnectNewMenu", ""));
+        assertNotNull(jfo);
+
+        JTextFieldOperator jtfo = new JTextFieldOperator(jfo,1); // index 0 is SystemName
+        assertNotNull(jtfo);
+        jtfo.setText(NEW_UNAME);
+
+        JButtonOperator jbo = new JButtonOperator(jfo, Bundle.getMessage("ButtonOK"));
+        jbo.doClick();
+        jbo.getQueueTool().waitEmpty();
+
+        assertEquals(NEW_UNAME, nbA.getUserName());
+        assertEquals(EXISTING_UNAME, nbB.getUserName());
+
+        ThreadingUtil.runOnGUI( () -> t.connectNew() );
+
+        jfo = new JFrameOperator(Bundle.getMessage("ConnectNewMenu", ""));
+        assertNotNull(jfo);
+
+        jtfo = new JTextFieldOperator(jfo,1); // index 0 is SystemName
+        assertNotNull(jtfo);
+        jtfo.setText(EXISTING_UNAME);
+
+        Thread closeDialog = jmri.util.swing.JemmyUtil.createModalDialogOperatorThread(
+            Bundle.getMessage("WarningUserName", EXISTING_UNAME), Bundle.getMessage("ButtonOK"));
+
+        jbo = new JButtonOperator(jfo, Bundle.getMessage("ButtonOK"));
+        jbo.doClick();
+        jbo.getQueueTool().waitEmpty();
+
+        JUnitUtil.waitThreadTerminated(closeDialog);
+
+        assertEquals(NEW_UNAME, nbA.getUserName());
+        assertEquals(EXISTING_UNAME, nbB.getUserName());
+
+        JUnitUtil.dispose(editor.getTargetFrame());
+        JUnitUtil.dispose(editor);
+
+    }
 
     @BeforeEach
     public void setUp() {

--- a/java/test/jmri/jmrit/display/switchboardEditor/BeanSwitchTest.java
+++ b/java/test/jmri/jmrit/display/switchboardEditor/BeanSwitchTest.java
@@ -4,6 +4,7 @@ import java.awt.event.MouseEvent;
 
 import jmri.*;
 import jmri.util.*;
+import jmri.util.swing.JemmyUtil;
 
 import org.junit.jupiter.api.*;
 
@@ -231,11 +232,9 @@ public class BeanSwitchTest {
 
         var editor = new SwitchboardEditor("BeanSwitch TestSetUserName " + nbA.getBeanType());
         editor.setSwitchType(String.valueOf(mgr.typeLetter()));
-        // editor.setTitle();
         ThreadingUtil.runOnGUI( () -> editor.setVisible(true));
 
         BeanSwitch t = new BeanSwitch(4, nbA, nbA.getSystemName(), SwitchboardEditor.BUTTON, editor);
-        // BeanSwitch tB = new BeanSwitch(5, nbB, nbB.getSystemName(), SwitchboardEditor.BUTTON, editor);
         ThreadingUtil.runOnGUI( () -> t.connectNew() );
 
         JFrameOperator jfo = new JFrameOperator(Bundle.getMessage("ConnectNewMenu", ""));
@@ -261,7 +260,7 @@ public class BeanSwitchTest {
         assertNotNull(jtfo);
         jtfo.setText(EXISTING_UNAME);
 
-        Thread closeDialog = jmri.util.swing.JemmyUtil.createModalDialogOperatorThread(
+        Thread closeDialog = JemmyUtil.createModalDialogOperatorThread(
             Bundle.getMessage("WarningUserName", EXISTING_UNAME), Bundle.getMessage("ButtonOK"));
 
         jbo = new JButtonOperator(jfo, Bundle.getMessage("ButtonOK"));

--- a/java/test/jmri/jmrit/display/switchboardEditor/SwitchboardEditorTest.java
+++ b/java/test/jmri/jmrit/display/switchboardEditor/SwitchboardEditorTest.java
@@ -12,9 +12,13 @@ import org.netbeans.jemmy.operators.*;
 import jmri.*;
 import jmri.jmrit.display.AbstractEditorTestBase;
 import jmri.jmrit.display.EditorFrameOperator;
+
 import jmri.util.ColorUtil;
 import jmri.util.JUnitUtil;
+import jmri.util.ThreadingUtil;
 import jmri.util.swing.JemmyUtil;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Test functioning of SwitchboardEditor.
@@ -35,30 +39,24 @@ public class SwitchboardEditorTest extends AbstractEditorTestBase<SwitchboardEdi
     }
 
     @Test
-    public void testDefaultCtor() {
-        e = new SwitchboardEditor();
-        Assertions.assertNotNull(e, "exists");
-    }
-
-    @Test
-    public void testStringCtor() {
-        Assertions.assertNotNull(e, "exists");
+    public void testSwitchboardEditorCtor() {
+        assertNotNull(e, "exists");
     }
 
     @Test
     public void checkOptionsMenuExists() {
         JMenuOperator jmo = new JMenuOperator(jfo, Bundle.getMessage("MenuOptions"));
-        Assertions.assertNotNull(jmo, "Options Menu Exists");
-        Assertions.assertEquals(10, jmo.getItemCount(), "Menu Item Count");
+        assertNotNull(jmo, "Options Menu Exists");
+        assertEquals(10, jmo.getItemCount(), "Menu Item Count");
     }
 
     @Test
     public void checkSetEditable() {
         e.setAllEditable(true);
         JMenuBarOperator jmbo = new JMenuBarOperator(jfo);
-        Assertions.assertEquals(4, jmbo.getMenuCount(), "Editable Menu Count: 4");
+        assertEquals(4, jmbo.getMenuCount(), "Editable Menu Count: 4");
         e.setAllEditable(false);
-        Assertions.assertEquals(3, jmbo.getMenuCount(), "Non-editable Menu Count: 3");
+        assertEquals(3, jmbo.getMenuCount(), "Non-editable Menu Count: 3");
         e.setAllEditable(true); // reset to be able to get to the menuBar to delete e
     }
 
@@ -68,12 +66,12 @@ public class SwitchboardEditorTest extends AbstractEditorTestBase<SwitchboardEdi
         e.setSwitchManu("I");
         e.setSwitchType("T");
         // initially selected connection should be Internal
-        Assertions.assertEquals("I", e.getSwitchManu(), "Internal connection default at startup");
-        Assertions.assertEquals(1, e.getPanelMenuRangeMin(), "MinSpinner=1 default at startup");
-        Assertions.assertEquals(24, e.getPanelMenuRangeMax(), "MaxSpinner=24 default at startup");
-        Assertions.assertEquals("Turnouts", e.getSwitchTypeName(), "Type=Turnout default at startup");
+        assertEquals("I", e.getSwitchManu(), "Internal connection default at startup");
+        assertEquals(1, e.getPanelMenuRangeMin(), "MinSpinner=1 default at startup");
+        assertEquals(24, e.getPanelMenuRangeMax(), "MaxSpinner=24 default at startup");
+        assertEquals("Turnouts", e.getSwitchTypeName(), "Type=Turnout default at startup");
         BeanSwitch sw = e.getSwitch("IT1");
-        Assertions.assertNotNull(sw, "Found BeanSwitch IT1");
+        assertNotNull(sw, "Found BeanSwitch IT1");
 
         Thread popup_thread1 = new Thread(() -> {
             JPopupMenuOperator jpmo = new JPopupMenuOperator();
@@ -90,21 +88,21 @@ public class SwitchboardEditorTest extends AbstractEditorTestBase<SwitchboardEdi
     @Test
     public void testStartsNotDirty() {
         // defaults to false.
-        Assertions.assertFalse(e.isDirty(), "isDirty starts as false");
+        assertFalse(e.isDirty(), "isDirty starts as false");
     }
 
     @Test
     public void testSetDirty() {
         // defaults to false, setDirty() sets it to true.
         e.setDirty();
-        Assertions.assertTrue(e.isDirty(), "isDirty after set");
+        assertTrue(e.isDirty(), "isDirty after set");
     }
 
     @Test
     public void testSetDirtyWithParameter() {
         // defaults to false, so set it to true.
         e.setDirty(true);
-        Assertions.assertTrue(e.isDirty(), "isDirty after set");
+        assertTrue(e.isDirty(), "isDirty after set");
     }
 
     @Test
@@ -113,36 +111,36 @@ public class SwitchboardEditorTest extends AbstractEditorTestBase<SwitchboardEdi
         e.setDirty(true);
         // then call resetDirty, which sets it back to false.
         e.resetDirty();
-        Assertions.assertFalse(e.isDirty(), "isDirty after reset");
+        assertFalse(e.isDirty(), "isDirty after reset");
     }
 
     @Test
     public void testGetSetDefaultTextColor() {
-        Assertions.assertEquals(ColorUtil.ColorBlack, e.getDefaultTextColor(), "Default Text Color");
+        assertEquals(ColorUtil.ColorBlack, e.getDefaultTextColor(), "Default Text Color");
         e.setDefaultTextColor(Color.PINK);
-        Assertions.assertEquals(ColorUtil.ColorPink, e.getDefaultTextColor(), "Default Text Color after Set");
+        assertEquals(ColorUtil.ColorPink, e.getDefaultTextColor(), "Default Text Color after Set");
     }
 
     @Test
     public void testSwitchRangeTurnouts() {
         e.setSwitchType("T");
         e.setSwitchManu("I"); // set explicitly
-        Assertions.assertEquals("T", e.getSwitchType(), "Default Switch Type is Turnouts");
-        Assertions.assertEquals("button", e.getSwitchShape(), "Default Switch Shape Button");
-        Assertions.assertEquals(0, e.getRows(), "Default Rows 0"); // autoRows on
+        assertEquals("T", e.getSwitchType(), "Default Switch Type is Turnouts");
+        assertEquals("button", e.getSwitchShape(), "Default Switch Shape Button");
+        assertEquals(0, e.getRows(), "Default Rows 0"); // autoRows on
         e.setRows(10); // will turn off autoRows checkboxmenu
-        Assertions.assertEquals(10, e.getRows(), "Rows should now be be 10");
+        assertEquals(10, e.getRows(), "Rows should now be be 10");
         e.setShowUserName(SwitchBoardLabelDisplays.SYSTEM_NAME);
-        Assertions.assertEquals("no", e.showUserName(), "Show User Name is No");
+        assertEquals("no", e.showUserName(), "Show User Name is No");
         e.setSwitchShape("symbol");
-        Assertions.assertEquals("symbol", e.getSwitchShape(), "Switch shape set to 'symbol'");
+        assertEquals("symbol", e.getSwitchShape(), "Switch shape set to 'symbol'");
         ((TurnoutManager) e.getManager('T')).provideTurnout("IT9"); // will connect to item 1
 
         e.getSwitch("IT8").okAddPressed(new ActionEvent(e, ActionEvent.ACTION_PERFORMED, "test")); // and to item 2
 
         e.setHideUnconnected(true); // speed up redraw
         e.updatePressed(); // rebuild for new Turnouts + symbol shape
-        Assertions.assertEquals(2, e.getTotal(), "1 connected switch shown");
+        assertEquals(2, e.getTotal(), "1 connected switch shown");
     }
 
     @Test
@@ -153,22 +151,22 @@ public class SwitchboardEditorTest extends AbstractEditorTestBase<SwitchboardEdi
         e.updatePressed();    // rebuild for Sensors
         SensorManager sm = ((SensorManager) e.getManager('S'));
         Sensor sensor20 = sm.provideSensor("IS20");
-        Assertions.assertNotNull(sm.getSensor("IS20"));
+        assertNotNull(sm.getSensor("IS20"));
         Objects.requireNonNull(sm.getSensor("IS20")).setUserName("twenty"); // make it harder to fetch label
         e.updatePressed(); // recreate to connect switch "IS20" to Sensor sensor20
-        Assertions.assertEquals(24, e.getSwitches().size(), "24 (connected) items displayed");
-        Assertions.assertEquals(Sensor.UNKNOWN, sensor20.getState(), "sensor20 state is Unknown");
-        Assertions.assertNotNull(e.getSwitch("IS20"));
-        Assertions.assertEquals("IS20: ?", e.getSwitch("IS20").getIconLabel(), "IS20 displays Unknown");
+        assertEquals(24, e.getSwitches().size(), "24 (connected) items displayed");
+        assertEquals(Sensor.UNKNOWN, sensor20.getState(), "sensor20 state is Unknown");
+        assertNotNull(e.getSwitch("IS20"));
+        assertEquals("IS20: ?", e.getSwitch("IS20").getIconLabel(), "IS20 displays Unknown");
         sensor20.setCommandedState(Sensor.ACTIVE);
         // should follow state
-        Assertions.assertEquals("IS20: +", e.getSwitch("IS20").getIconLabel(), "IS20 displays Active");
+        assertEquals("IS20: +", e.getSwitch("IS20").getIconLabel(), "IS20 displays Active");
         e.getSwitch("IS20").doMouseClicked(new MouseEvent(e, 1, 0, 0, 0, 0, 1, false));
-        Assertions.assertEquals(Sensor.INACTIVE, sensor20.getState(), "sensor20 state is Inactive");
-        Assertions.assertEquals("IS20: -", e.getSwitch("IS20").getIconLabel(), "IS20 displays Inactive");
+        assertEquals(Sensor.INACTIVE, sensor20.getState(), "sensor20 state is Inactive");
+        assertEquals("IS20: -", e.getSwitch("IS20").getIconLabel(), "IS20 displays Inactive");
         e.getSwitch("IS20").setBeanInverted(true);
-        Assertions.assertEquals(Sensor.ACTIVE, sensor20.getState(), "sensor20 state is Active");
-        Assertions.assertEquals("IS20: +", e.getSwitch("IS20").getIconLabel(), "IS20 displays Active");
+        assertEquals(Sensor.ACTIVE, sensor20.getState(), "sensor20 state is Active");
+        assertEquals("IS20: +", e.getSwitch("IS20").getIconLabel(), "IS20 displays Active");
     }
 
     @Test
@@ -176,11 +174,11 @@ public class SwitchboardEditorTest extends AbstractEditorTestBase<SwitchboardEdi
         // initially selected connection should be Internal but is not 100% predictable (after type is changed?)
         e.setSwitchType("T");
         e.setSwitchManu("I"); // so set explicitly
-        Assertions.assertTrue(e.getManager() instanceof TurnoutManager, "manager is a TurnoutManager");
+        assertTrue(e.getManager() instanceof TurnoutManager, "manager is a TurnoutManager");
         ((TurnoutManager) e.getManager()).provideTurnout("IT24"); // active manager should be a TurnoutManager, connect to item 1
         e.setHideUnconnected(true);
         e.updatePressed(); // setHideUnconnected will not invoke updatePressed
-        Assertions.assertEquals(1, e.getTotal(), "1 connected switch shown");
+        assertEquals(1, e.getTotal(), "1 connected switch shown");
     }
 
     @Test
@@ -189,23 +187,23 @@ public class SwitchboardEditorTest extends AbstractEditorTestBase<SwitchboardEdi
         e.setSwitchManu("I"); // so set explicitly as LightManager
         e.updatePressed(); // rebuild for Lights
         e.getSwitch("IL1").doMouseClicked(null); // no result, so nothing to test
-        Assertions.assertNull(e.getSwitch("IL1").getLight(), "Click on unconnected switch");
+        assertNull(e.getSwitch("IL1").getLight(), "Click on unconnected switch");
         Light light1 = ((LightManager) e.getManager('L')).provideLight("IL1");
-        Assertions.assertNotNull(InstanceManager.lightManagerInstance().getLight("IL1"));
+        assertNotNull(InstanceManager.lightManagerInstance().getLight("IL1"));
         e.updatePressed(); // connect switch IL1 to Light IL1
-        Assertions.assertEquals(Light.OFF, light1.getState(), "IL1 is Off");
+        assertEquals(Light.OFF, light1.getState(), "IL1 is Off");
 
-        Assertions.assertNotNull(e.getSwitch("IL1"));
+        assertNotNull(e.getSwitch("IL1"));
         e.getSwitch("IL1").doMouseClicked(new MouseEvent(e, 1, 0, 0, 0, 0, 1, false));
-        Assertions.assertEquals(Light.ON, light1.getState(), "IL1 is On");
+        assertEquals(Light.ON, light1.getState(), "IL1 is On");
 
         e.switchAllLights(Light.OFF);
-        Assertions.assertEquals(Light.OFF, light1.getState(), "IL1 is Off via All");
+        assertEquals(Light.OFF, light1.getState(), "IL1 is Off via All");
 
-        Assertions.assertEquals(24, e.getTotal(), "Default 4x6 switches shown");
+        assertEquals(24, e.getTotal(), "Default 4x6 switches shown");
         e.setHideUnconnected(true);
         e.updatePressed(); // rebuild to hide unconnected
-        Assertions.assertEquals(1, e.getTotal(), "1 connected switch shown");
+        assertEquals(1, e.getTotal(), "1 connected switch shown");
     }
 
     @Test
@@ -213,7 +211,7 @@ public class SwitchboardEditorTest extends AbstractEditorTestBase<SwitchboardEdi
         e.setMinSpinner(8);
         e.setMaxSpinner(17);
         e.updatePressed();
-        Assertions.assertEquals(10, e.getSwitches().size(), "Get array containing all items");
+        assertEquals(10, e.getSwitches().size(), "Get array containing all items");
     }
 
     // from here down is testing infrastructure
@@ -229,7 +227,7 @@ public class SwitchboardEditorTest extends AbstractEditorTestBase<SwitchboardEdi
         JUnitUtil.initInternalLightManager();
 
         e = new SwitchboardEditor("Switchboard Editor Test");
-        e.setVisible(true);
+        ThreadingUtil.runOnGUI( () -> e.setVisible(true));
         JemmyUtil.waitFor(e);
         jfo = new EditorFrameOperator(e);
     }


### PR DESCRIPTION
**SwitchboardEditor**
Removes method deprecated 4.99.3 #10684
Ensure setVisisble actions on GUI Thread.

**BeanSwitch**
Checks for an existing userName on Connect to new Item.
Adds exception message to create exception dialog.

**SwitchboardEditorTest**
setVisible on GUI Thread
Removes duplicate cTor test

**BeanSwitchTest**
static import of assertions for readability.
Adds testing for setting STL UserName.
