### PR TITLE
Turnout javaDoc tweak

### DIFF
--- a/java/src/jmri/Turnout.java
+++ b/java/src/jmri/Turnout.java
@@ -661,7 +661,7 @@ public interface Turnout extends DigitalIO, VariableControlSpanBean {
      * Used to insert a delay before calling {@link #setCommandedState(int)} to spread out a series of
      * output commands, as in {@link jmri.implementation.MatrixSignalMast#updateOutputs(char[])} and
      * {@link jmri.implementation.DefaultRoute} class SetRouteThread#run().
-     * Interval value is kept in the Memo per hardware connection, default = 0
+     * Interval value is kept in the Memo per hardware connection.
      *
      * @param s turnout state to forward
      */


### PR DESCRIPTION
Removes incorrect default value from javadoc, is a connection property.