### PR TITLE
update MERG CBUS NodeConstants

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -102,7 +102,7 @@
 
         <h4>MERG</h4>
             <ul>
-                <li></li>
+                <li>Improved Node Manager CANCMDB support.</li>
             </ul>
 
         <h4>MQTT</h4>

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -26,7 +26,7 @@
 
         <h4>CBUS</h4>
             <ul>
-                <li></li>
+                <li>Improved Node Manager CANCMDB support.</li>
             </ul>
 
         <h4>C/MRI</h4>
@@ -102,7 +102,7 @@
 
         <h4>MERG</h4>
             <ul>
-                <li>Improved Node Manager CANCMDB support.</li>
+                <li></li>
             </ul>
 
         <h4>MQTT</h4>

--- a/java/src/jmri/jmrix/can/cbus/node/CbusNodeConstants.java
+++ b/java/src/jmri/jmrix/can/cbus/node/CbusNodeConstants.java
@@ -86,6 +86,7 @@ public class CbusNodeConstants {
                 case 10 : // CANCMD
                 case 55 : // or CANCSB 
                 case 12 : // or CANBC
+                case 83 : // or CANCMDB
                     if ( node.getNodeParamManager().getParameter(MAJOR_VER_IDX) == 4 ) { // v4 Firmware
                         node.getNodeEventManager().resetNodeEventsToZero(); // sets num events to 0 as does not respond to RQEVN
                         node.setStatResponseFlagsAccurate(false);
@@ -318,7 +319,15 @@ public class CbusNodeConstants {
         result.put(78, "CANSBIP");
         result.put(79, "CANBUFFER");
         result.put(80, "CANLEVER");
-        
+        result.put(81, "CANSHIELD");
+        result.put(82, "CAN4IN4OUT");
+        result.put(83, "CANCMDB");
+        result.put(84, "CANPIXEL");
+        result.put(85, "CANCABPE");
+        result.put(86, "CANSMARTTD");
+        result.put(87, "CANARGB");
+
+        result.put(252, "VLCB");
         result.put(253, "CANUSB"); // NOI18N
         result.put(254, "EMPTY"); // NOI18N
         result.put(255, "CAN_SW"); // NOI18N
@@ -497,7 +506,15 @@ public class CbusNodeConstants {
         result.put(78, "Q series PIC BIP module");
         result.put(79, "Message buffer");
         result.put(80, "Lever frame module");
-        
+        result.put(81, "Kit 110 Arduino shield test firmware");
+        result.put(82, "4 inputs 4 outputs (Arduino module)");
+        result.put(83, "CANCMD with built in booster");
+        result.put(84, "neopixel driver");
+        result.put(85, "Cab2 with pot or encoder");
+        result.put(86, "Smart train detector");
+        result.put(87, "Addressable LEDs");
+
+        result.put(252, "All VLCB modules have the same ID");
         result.put(253, "USB interface");
         result.put(254, "Empty module, bootloader only");
         result.put(255, "Software nodes");
@@ -667,7 +684,15 @@ public class CbusNodeConstants {
         // result.put(78, "CANSBIP");
         // result.put(79, "CANBUFFER");
         // result.put(80, "CANLEVER");
+        // result.put(81, "CANSHIELD");
+        // result.put(82, "CAN4IN4OUT");
+        result.put(83, "https://www.merg.org.uk/merg_wiki/doku.php?id=cbus:cancmdb");
+        // result.put(84, "CANPIXEL");
+        // result.put(85, "CANCABPE");
+        // result.put(86, "CANSMARTTD");
+        // result.put(87, "CANARGB");
 
+        // result.put(252, "VLCB");
         // result.put(253, "CANUSB"); // NOI18N
         // result.put(254, "EMPTY"); // NOI18N
         // result.put(255, "CAN_SW"); // NOI18N        


### PR DESCRIPTION
Updates MERG CBUS Module types as per
https://github.com/MERG-DEV/cbusdefs/blob/master/java/uk/org/merg/cbus/CbusMergModuleTypes.java

Adds node constant types 81-87 + VLCB Node 252
Adds CANCMDB to CANCMD derived firmware