### PR TITLE
Abstract Throttle tweaks

### DIFF
--- a/java/src/jmri/jmrix/AbstractThrottle.java
+++ b/java/src/jmri/jmrix/AbstractThrottle.java
@@ -86,11 +86,8 @@ abstract public class AbstractThrottle extends PropertyChangeSupport implements 
      * All function and momentary functions set to Off.
      * @param memo System Connection.
      */
-    public AbstractThrottle(SystemConnectionMemo memo) {
-        active = true;
-        adapterMemo = memo;
-        FUNCTION_BOOLEAN_ARRAY = new boolean[29];
-        FUNCTION_MOMENTARY_BOOLEAN_ARRAY = new boolean[29];
+    public AbstractThrottle(@Nonnull SystemConnectionMemo memo) {
+        this( memo, 29);
     }
 
     /**
@@ -100,7 +97,7 @@ abstract public class AbstractThrottle extends PropertyChangeSupport implements 
      * @param memo System Connection this throttle is on
      * @param totalFunctions total number of functions available, including 0
      */
-    public AbstractThrottle(SystemConnectionMemo memo, int totalFunctions) {
+    public AbstractThrottle(@Nonnull SystemConnectionMemo memo, int totalFunctions) {
         active = true;
         adapterMemo = memo;
         FUNCTION_BOOLEAN_ARRAY = new boolean[totalFunctions];
@@ -108,9 +105,15 @@ abstract public class AbstractThrottle extends PropertyChangeSupport implements 
     }
 
     /**
-     * System Connection this throttle is on
+     * Get the System Connection this throttle is on.
+     * @return non-null system connection.
      */
-    protected SystemConnectionMemo adapterMemo;
+    @Nonnull
+    protected SystemConnectionMemo getMemo() {
+        return adapterMemo;
+    }
+
+    protected final SystemConnectionMemo adapterMemo;
 
     /**
      * speed - expressed as a value {@literal 0.0 -> 1.0.} Negative means
@@ -399,7 +402,7 @@ abstract public class AbstractThrottle extends PropertyChangeSupport implements 
         if (adapterMemo != null && adapterMemo.get(ThrottleManager.class) !=null) {
             return adapterMemo.get(ThrottleManager.class);
         }
-        log.warn("No {} Throttle Manager for {}", adapterMemo, this.getClass());
+        log.error("No {} Throttle Manager for {}", adapterMemo, this.getClass());
         return InstanceManager.getDefault(ThrottleManager.class);
     }
 
@@ -936,6 +939,6 @@ abstract public class AbstractThrottle extends PropertyChangeSupport implements 
     }
 
     // initialize logging
-    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(AbstractThrottle.class);
+    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(AbstractThrottle.class);
 
 }

--- a/java/src/jmri/jmrix/sprog/SprogCSThrottle.java
+++ b/java/src/jmri/jmrix/sprog/SprogCSThrottle.java
@@ -1,12 +1,11 @@
 package jmri.jmrix.sprog;
 
+import javax.annotation.Nonnull;
+
 import jmri.DccLocoAddress;
 import jmri.LocoAddress;
 import jmri.SpeedStepMode;
 import jmri.jmrix.AbstractThrottle;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * An implementation of DccThrottle with code specific to a SPROG Command
@@ -23,7 +22,7 @@ public class SprogCSThrottle extends AbstractThrottle {
      * @param memo system connection.
      * @param address Loco Address.
      */
-    public SprogCSThrottle(SprogSystemConnectionMemo memo, LocoAddress address) {
+    public SprogCSThrottle(@Nonnull SprogSystemConnectionMemo memo, LocoAddress address) {
         super(memo, SprogConstants.MAX_FUNCTIONS);
 
         if (address instanceof DccLocoAddress) {
@@ -46,7 +45,7 @@ public class SprogCSThrottle extends AbstractThrottle {
         //should support other modes, but doesn't in practice.
         //@see AbstractThrottleManager.supportedSpeedModes()
         // Find our command station
-        if ((memo != null) && (memo.get(jmri.CommandStation.class) != null)) {
+        if ( memo.get(jmri.CommandStation.class) != null) {
             commandStation = (SprogCommandStation) memo.get(jmri.CommandStation.class);
         } else {
             commandStation = (SprogCommandStation) jmri.InstanceManager.getNullableDefault(jmri.CommandStation.class);
@@ -295,6 +294,6 @@ public class SprogCSThrottle extends AbstractThrottle {
         finishRecord();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(SprogCSThrottle.class);
+    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(SprogCSThrottle.class);
 
 }

--- a/java/test/jmri/jmrix/AbstractThrottleTest.java
+++ b/java/test/jmri/jmrix/AbstractThrottleTest.java
@@ -10,6 +10,7 @@ import jmri.InstanceManager;
 import jmri.LocoAddress;
 import jmri.SpeedStepMode;
 import jmri.jmrit.roster.RosterEntry;
+import jmri.jmrix.internal.InternalSystemConnectionMemo;
 import jmri.util.JUnitAppender;
 
 import org.slf4j.Logger;
@@ -29,11 +30,13 @@ public class AbstractThrottleTest {
 
     protected AbstractThrottle instance = null;
     protected int maxFns = 29;
+    private InternalSystemConnectionMemo memo;
 
     @BeforeEach
-    public void setUp() throws Exception {
+    public void setUp() {
         JUnitUtil.setUp();
-        InstanceManager.setThrottleManager(new AbstractThrottleManager() {
+        memo = InstanceManager.getDefault(InternalSystemConnectionMemo.class);
+        var tm = new AbstractThrottleManager(memo) {
 
             @Override
             public void requestThrottleSetup(LocoAddress a, boolean control) {
@@ -53,12 +56,17 @@ public class AbstractThrottleTest {
             public boolean addressTypeUnique() {
                 return true;
             }
-        });
-        instance = new AbstractThrottleImpl();
+        };
+        InstanceManager.setThrottleManager(tm);
+        memo.store(tm, jmri.ThrottleManager.class);
+        instance = new AbstractThrottleImpl(memo);
     }
 
     @AfterEach
-    public void tearDown() throws Exception {
+    public void tearDown() {
+        memo.dispose();
+        memo = null;
+        instance = null;
         JUnitUtil.tearDown();
     }
 
@@ -1648,12 +1656,12 @@ public class AbstractThrottleTest {
         Assertions.assertFalse(instance.getFunctionMomentaryNoWarn(999999));
     }
 
-    public static final class AbstractThrottleImpl extends AbstractThrottle {
+    private static final class AbstractThrottleImpl extends AbstractThrottle {
 
         private LocoAddress locoAddress;
 
-        public AbstractThrottleImpl() {
-            super(null);
+        AbstractThrottleImpl(InternalSystemConnectionMemo memo) {
+            super(memo);
             this.setLocoAddress(new DccLocoAddress(3, LocoAddress.Protocol.DCC_SHORT));
         }
 

--- a/java/test/jmri/jmrix/AbstractThrottleTest.java
+++ b/java/test/jmri/jmrix/AbstractThrottleTest.java
@@ -33,7 +33,7 @@ public class AbstractThrottleTest {
     private InternalSystemConnectionMemo memo;
 
     @BeforeEach
-    public void setUp() {
+    public void setUp() throws Exception {
         JUnitUtil.setUp();
         memo = InstanceManager.getDefault(InternalSystemConnectionMemo.class);
         var tm = new AbstractThrottleManager(memo) {
@@ -63,7 +63,7 @@ public class AbstractThrottleTest {
     }
 
     @AfterEach
-    public void tearDown() {
+    public void tearDown() throws Exception {
         memo.dispose();
         memo = null;
         instance = null;

--- a/java/test/jmri/jmrix/lenz/XNetThrottleTest.java
+++ b/java/test/jmri/jmrix/lenz/XNetThrottleTest.java
@@ -26,7 +26,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
 
     // Test the constructor with an address specified.
     @Test
-    public void testCtorWithArg() throws Exception {
+    public void testCtorWithArg() {
         XNetThrottle t = new XNetThrottle(memo, new jmri.DccLocoAddress(3, false), tc);
         Assert.assertNotNull(t);
         t.throttleDispose();
@@ -34,7 +34,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
 
     // Test the initialization sequence.
     @Test
-    public void testInitSequenceNormalUnitSpeedStep128() throws Exception {
+    public void testInitSequenceNormalUnitSpeedStep128() {
         int n = tc.outbound.size();
         // this test requires a new throttle.
         XNetThrottle t = new XNetThrottle(memo, new jmri.DccLocoAddress(3, false), tc);
@@ -110,7 +110,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     }
 
     @Test
-    public void initSequenceNormalUnitSpeedStep14() throws Exception {
+    public void initSequenceNormalUnitSpeedStep14() {
         tc.getCommandStation().setCommandStationSoftwareVersion(new XNetReply("63 21 36 00 74"));
         int n = tc.outbound.size();
         // this test requires a new throttle.
@@ -199,7 +199,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     }
 
     @Test
-    public void initSequenceMUAddress28SpeedStep() throws Exception {
+    public void initSequenceMUAddress28SpeedStep() {
         tc.getCommandStation().setCommandStationSoftwareVersion(new XNetReply("63 21 36 00 74"));
         int n = tc.outbound.size();
         // this test requires a new throttle.
@@ -272,7 +272,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     }
 
     @Test
-    public void initSequenceMuedUnitSpeedStep128() throws Exception {
+    public void initSequenceMuedUnitSpeedStep128() {
         tc.getCommandStation().setCommandStationSoftwareVersion(new XNetReply("63 21 36 00 74"));
         int n = tc.outbound.size();
         // this test requires a new throttle.
@@ -362,7 +362,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     }
 
     @Test
-    public void initSequenceDHUnitSpeedStep27() throws Exception {
+    public void initSequenceDHUnitSpeedStep27() {
         tc.getCommandStation().setCommandStationSoftwareVersion(new XNetReply("63 21 36 00 74"));
         int n = tc.outbound.size();
         // this test requires a new throttle.
@@ -453,7 +453,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     }
 
     @Test
-    public void testSendStatusInformationRequest() throws Exception {
+    public void testSendStatusInformationRequest() {
         int n = tc.outbound.size();
         XNetThrottle t = (XNetThrottle) instance;
         initThrottle(t, n);
@@ -545,7 +545,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     }
 
     @Test
-    public void testSendFunctionHighMomentaryStatusRequest() throws Exception {
+    public void testSendFunctionHighMomentaryStatusRequest() {
         int n = tc.outbound.size();
         XNetThrottle t = (XNetThrottle) instance;
         initThrottle(t, n);
@@ -745,7 +745,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     }
 
     @Test
-    public void testSendFunctionGroup5v35() throws Exception {
+    public void testSendFunctionGroup5v35() {
         int n = tc.outbound.size();
         XNetThrottle t = (XNetThrottle) instance;
         initThrottlev35(t, n);
@@ -941,7 +941,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     }
 
     @Test
-    public void setReverse() throws Exception {
+    public void setReverse() {
         int n = tc.outbound.size();
         XNetThrottle t = (XNetThrottle) instance;
         initThrottle(t, n);
@@ -973,7 +973,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     }
 
     @Test
-    public void setForward() throws Exception {
+    public void setForward() {
         int n = tc.outbound.size();
         XNetThrottle t = (XNetThrottle) instance;
         initThrottle(t, n);
@@ -1005,7 +1005,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     }
 
     @Test
-    public void sendEmergencyStop() throws Exception {
+    public void sendEmergencyStop() {
         int n = tc.outbound.size();
         XNetThrottle t = (XNetThrottle) instance;
         initThrottle(t, n);
@@ -1034,7 +1034,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     }
 
     @Test
-    public void setSpeedStep128() throws Exception {
+    public void setSpeedStep128() {
         int n = tc.outbound.size();
         XNetThrottle t = (XNetThrottle) instance;
         initThrottle(t, n);
@@ -1068,7 +1068,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     }
 
     @Test
-    public void setSpeedStep28() throws Exception {
+    public void setSpeedStep28() {
         int n = tc.outbound.size();
         XNetThrottle t = (XNetThrottle) instance;
         initThrottle(t, n);
@@ -1102,7 +1102,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     }
 
     @Test
-    public void setSpeedStep27() throws Exception {
+    public void setSpeedStep27() {
         int n = tc.outbound.size();
         XNetThrottle t = (XNetThrottle) instance;
         initThrottle(t, n);
@@ -1136,7 +1136,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     }
 
     @Test
-    public void setSpeedStep14() throws Exception {
+    public void setSpeedStep14() {
         int n = tc.outbound.size();
         XNetThrottle t = (XNetThrottle) instance;
         initThrottle(t, n);
@@ -1593,7 +1593,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
 
     @BeforeEach
     @Override
-    public void setUp() throws Exception {
+    public void setUp() {
         JUnitUtil.setUp();
         JUnitUtil.resetProfileManager();
 
@@ -1614,7 +1614,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
 
     @AfterEach
     @Override
-    public void tearDown() throws Exception {
+    public void tearDown() {
         try {
             ((XNetThrottle) instance).throttleDispose();
         }

--- a/java/test/jmri/jmrix/lenz/XNetThrottleTest.java
+++ b/java/test/jmri/jmrix/lenz/XNetThrottleTest.java
@@ -26,7 +26,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
 
     // Test the constructor with an address specified.
     @Test
-    public void testCtorWithArg() {
+    public void testCtorWithArg() throws Exception {
         XNetThrottle t = new XNetThrottle(memo, new jmri.DccLocoAddress(3, false), tc);
         Assert.assertNotNull(t);
         t.throttleDispose();
@@ -34,7 +34,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
 
     // Test the initialization sequence.
     @Test
-    public void testInitSequenceNormalUnitSpeedStep128() {
+    public void testInitSequenceNormalUnitSpeedStep128() throws Exception {
         int n = tc.outbound.size();
         // this test requires a new throttle.
         XNetThrottle t = new XNetThrottle(memo, new jmri.DccLocoAddress(3, false), tc);
@@ -110,7 +110,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     }
 
     @Test
-    public void initSequenceNormalUnitSpeedStep14() {
+    public void initSequenceNormalUnitSpeedStep14() throws Exception {
         tc.getCommandStation().setCommandStationSoftwareVersion(new XNetReply("63 21 36 00 74"));
         int n = tc.outbound.size();
         // this test requires a new throttle.
@@ -199,7 +199,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     }
 
     @Test
-    public void initSequenceMUAddress28SpeedStep() {
+    public void initSequenceMUAddress28SpeedStep() throws Exception {
         tc.getCommandStation().setCommandStationSoftwareVersion(new XNetReply("63 21 36 00 74"));
         int n = tc.outbound.size();
         // this test requires a new throttle.
@@ -272,7 +272,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     }
 
     @Test
-    public void initSequenceMuedUnitSpeedStep128() {
+    public void initSequenceMuedUnitSpeedStep128() throws Exception {
         tc.getCommandStation().setCommandStationSoftwareVersion(new XNetReply("63 21 36 00 74"));
         int n = tc.outbound.size();
         // this test requires a new throttle.
@@ -362,7 +362,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     }
 
     @Test
-    public void initSequenceDHUnitSpeedStep27() {
+    public void initSequenceDHUnitSpeedStep27() throws Exception {
         tc.getCommandStation().setCommandStationSoftwareVersion(new XNetReply("63 21 36 00 74"));
         int n = tc.outbound.size();
         // this test requires a new throttle.
@@ -453,7 +453,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     }
 
     @Test
-    public void testSendStatusInformationRequest() {
+    public void testSendStatusInformationRequest() throws Exception {
         int n = tc.outbound.size();
         XNetThrottle t = (XNetThrottle) instance;
         initThrottle(t, n);
@@ -545,7 +545,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     }
 
     @Test
-    public void testSendFunctionHighMomentaryStatusRequest() {
+    public void testSendFunctionHighMomentaryStatusRequest() throws Exception {
         int n = tc.outbound.size();
         XNetThrottle t = (XNetThrottle) instance;
         initThrottle(t, n);
@@ -745,7 +745,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     }
 
     @Test
-    public void testSendFunctionGroup5v35() {
+    public void testSendFunctionGroup5v35() throws Exception {
         int n = tc.outbound.size();
         XNetThrottle t = (XNetThrottle) instance;
         initThrottlev35(t, n);
@@ -941,7 +941,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     }
 
     @Test
-    public void setReverse() {
+    public void setReverse() throws Exception {
         int n = tc.outbound.size();
         XNetThrottle t = (XNetThrottle) instance;
         initThrottle(t, n);
@@ -973,7 +973,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     }
 
     @Test
-    public void setForward() {
+    public void setForward() throws Exception {
         int n = tc.outbound.size();
         XNetThrottle t = (XNetThrottle) instance;
         initThrottle(t, n);
@@ -1005,7 +1005,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     }
 
     @Test
-    public void sendEmergencyStop() {
+    public void sendEmergencyStop() throws Exception {
         int n = tc.outbound.size();
         XNetThrottle t = (XNetThrottle) instance;
         initThrottle(t, n);
@@ -1034,7 +1034,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     }
 
     @Test
-    public void setSpeedStep128() {
+    public void setSpeedStep128() throws Exception {
         int n = tc.outbound.size();
         XNetThrottle t = (XNetThrottle) instance;
         initThrottle(t, n);
@@ -1068,7 +1068,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     }
 
     @Test
-    public void setSpeedStep28() {
+    public void setSpeedStep28() throws Exception {
         int n = tc.outbound.size();
         XNetThrottle t = (XNetThrottle) instance;
         initThrottle(t, n);
@@ -1102,7 +1102,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     }
 
     @Test
-    public void setSpeedStep27() {
+    public void setSpeedStep27() throws Exception {
         int n = tc.outbound.size();
         XNetThrottle t = (XNetThrottle) instance;
         initThrottle(t, n);
@@ -1136,7 +1136,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     }
 
     @Test
-    public void setSpeedStep14() {
+    public void setSpeedStep14() throws Exception {
         int n = tc.outbound.size();
         XNetThrottle t = (XNetThrottle) instance;
         initThrottle(t, n);
@@ -1593,7 +1593,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
 
     @BeforeEach
     @Override
-    public void setUp() {
+    public void setUp() throws Exception {
         JUnitUtil.setUp();
         JUnitUtil.resetProfileManager();
 
@@ -1614,7 +1614,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
 
     @AfterEach
     @Override
-    public void tearDown() {
+    public void tearDown() throws Exception {
         try {
             ((XNetThrottle) instance).throttleDispose();
         }


### PR DESCRIPTION
**AbstractThrottle**
Adds NonNull annotation for system connection.
Logs ERROR ( up from WARN ) if disposing via default ThrottleManager.

**SprogCSThrottle**
Removes null memo check

**AbstractThrottle Test**
Passes memo to Throttle instance