### PR TITLE
add keep-alive option to netBiDiB connection settings

### DIFF
--- a/help/en/html/hardware/bidib/index.shtml
+++ b/help/en/html/hardware/bidib/index.shtml
@@ -94,7 +94,7 @@
       
       <h4>netBiDiB</h4>
       
-      <p><a href="https://bidib.org/transport/bidib_net_e.html">netBiDiB</a> allows the transport of the BiDiB protocol over a network connection (TCP). The connection is authorized once through the pairing process, so that a device cannot simply be controlled by someone else. To simplify configuration, BiDiB devices should announce themself in the network (mDNS/Bonjour) and can be selected in a combo box field in the JMRI settings for BiDiB. If this discovery is not available, automatic configuration can be switched off and the IP address of the device entered manually. The standard port number is 62875.
+      <p><a href="https://bidib.org/transport/bidib_net_e.html">netBiDiB</a> allows the transport of the BiDiB protocol over a network connection (TCP). The connection is authorized once through the pairing process, so that a device cannot simply be controlled by someone else. To simplify configuration, BiDiB devices should announce themself in the network (mDNS/Bonjour) and can be selected in a combo box field in the JMRI settings for BiDiB. If this discovery is not available, automatic configuration can be switched off and the IP address of the device entered manually. The standard port number is 62875. JMRI supports a continuous keep-alive test (local ping) so that connection drops are quickly detected. Since not all BiDiB devices support this, it can be configured in the connection settings under "Keep-Alive."
       </p>
       
       <h4>BiDiB over TCP</h4>

--- a/help/en/html/hardware/bidib/index_de.shtml
+++ b/help/en/html/hardware/bidib/index_de.shtml
@@ -96,7 +96,7 @@
        
       <h4>netBiDiB</h4>
       
-      <p><a href="https://bidib.org/transport/bidib_net.html">netBiDiB</a> ermöglicht den Transport des BiDiB-Protokolls über eine Netzwerkverbindung (TCP). Die Verbindung wird einmal durch den Pairing-Vorgang authorisiert, sodass ein Gerät nicht einfach fremdgesteuert werden kann. Zur einfacheren Konfiguration sollen sich BiDiB-Geräte im Netz melden (mDNS/Bonjour) und können so in den JMRI Einstellungen für BiDiB in einem Auswahlfeld gewählt werden. Wenn dieses Discovery nicht verfügbar ist, kann die Automatische Konfiguration abgeschaltet werden und die IP-Adresse des Geräts manuell eingegeben werden. Die Standardportnummer ist 62875.
+      <p><a href="https://bidib.org/transport/bidib_net.html">netBiDiB</a> ermöglicht den Transport des BiDiB-Protokolls über eine Netzwerkverbindung (TCP). Die Verbindung wird einmal durch den Pairing-Vorgang authorisiert, sodass ein Gerät nicht einfach fremdgesteuert werden kann. Zur einfacheren Konfiguration sollen sich BiDiB-Geräte im Netz melden (mDNS/Bonjour) und können so in den JMRI Einstellungen für BiDiB in einem Auswahlfeld gewählt werden. Wenn dieses Discovery nicht verfügbar ist, kann die Automatische Konfiguration abgeschaltet werden und die IP-Adresse des Geräts manuell eingegeben werden. Die Standardportnummer ist 62875. JMRI unterstützt einen ständigen Keep-Alive Test (local ping), sodass Verbindungsabbrüche schnell bemerkt werden. Da nicht alle BiDiB-Geräte dies unterstützen, ist es in den Verbindungseinstellungen unter "Keep-Alive" einstellbar.
       </p>
       
       <h4>BiDiB über TCP</h4>

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -21,7 +21,7 @@
 
         <h4><a href="http://bidib.org/index_e.html">BiDiB</a></h4>
             <ul>
-                <li></li>
+                <li>Add "keep-alive" setting for netBiDiB connections.</li>
             </ul>
 
         <h4>CBUS</h4>

--- a/java/src/jmri/jmrix/bidib/BiDiBBundle.properties
+++ b/java/src/jmri/jmrix/bidib/BiDiBBundle.properties
@@ -1,5 +1,10 @@
 # BiDiBBundle.properties
 #
+# connection config
+KeepAlive = Keep-Alive
+KeepAliveLocalPing = Local Ping
+KeepAliveNone = -----
+
 # Serial connection config
 UniqueIDHex = Unique ID (hex)
 SerialConnectionUseAutoscan = Use Autoscan

--- a/java/src/jmri/jmrix/bidib/BiDiBBundle_cs.properties
+++ b/java/src/jmri/jmrix/bidib/BiDiBBundle_cs.properties
@@ -1,5 +1,10 @@
 # BiDiBBundle_cs.properties
 # Translation:  Petr Sidlo
+
+# connection config
+#KeepAlive = Keep-Alive
+#KeepAliveLocalPing = Local Ping
+
 # Serial connection config
 UniqueIDHex = Jedine\u010dn\u00e9 ID (hex)
 SerialConnectionUseAutoscan = Pou\u017e\u00edt automatick\u00e9 skenov\u00e1n\u00ed

--- a/java/src/jmri/jmrix/bidib/BiDiBBundle_de.properties
+++ b/java/src/jmri/jmrix/bidib/BiDiBBundle_de.properties
@@ -1,5 +1,9 @@
 # BiDiBBundle_de.properties
 
+# connection config
+#KeepAlive = Keep-Alive
+#KeepAliveLocalPing = Local Ping
+
 # Serial connection config
 UniqueIDHex = Unique ID (hex)
 SerialConnectionUseAutoscan = Verwende Autoscan

--- a/java/src/jmri/jmrix/bidib/BiDiBProgrammer.java
+++ b/java/src/jmri/jmrix/bidib/BiDiBProgrammer.java
@@ -25,7 +25,7 @@ import org.bidib.jbidibc.messages.utils.NodeUtils;
  * from programming mode are now handled in the TrafficController code.
  *
  * @author Bob Jacobsen Copyright (C) 2001, 2016
- * @author Eckart Meyer Copyright (C) 2019-2023
+ * @author Eckart Meyer Copyright (C) 2019-2025
  */
 public class BiDiBProgrammer extends AbstractProgrammer {
 
@@ -161,17 +161,20 @@ public class BiDiBProgrammer extends AbstractProgrammer {
     private void sendBiDiBMessage(BidibCommandMessage message) {
         progNode = tc.getCurrentGlobalProgrammerNode(); //the global programmer progNode may have changed TODO: make the progNode user selectable!
         if (progNode != null) {
+            log.debug(" using programmer node {}, isBoosterOn = {}", progNode, isBoosterOn);
             if (isBoosterOn) {
                 startLongTimer();
                 tc.sendBiDiBMessage(message, progNode);
             }
             else {
                 // if the booster of OFF, return immediately without waiting for the timeout.
+                log.warn("BiDiB Booster is switched off!");
                 progState = NOTPROGRAMMING;
                 notifyProgListenerEnd(_val, jmri.ProgListener.NoAck);
             }
         }
         else {
+            log.warn("no prog node available!");
             progState = NOTPROGRAMMING;
             notifyProgListenerEnd(_val, jmri.ProgListener.NotImplemented);
         }

--- a/java/src/jmri/jmrix/bidib/netbidib/NetBiDiBAdapter.java
+++ b/java/src/jmri/jmrix/bidib/netbidib/NetBiDiBAdapter.java
@@ -55,7 +55,7 @@ import org.slf4j.LoggerFactory;
  * Implements BiDiBPortController for the netBiDiB system network
  * connection.
  *
- * @author Eckart Meyer Copyright (C) 2024
+ * @author Eckart Meyer Copyright (C) 2024-2025
  *
  * mDNS code based on LIUSBEthernetAdapter.
  */
@@ -195,6 +195,9 @@ public class NetBiDiBAdapter extends BiDiBNetworkPortController {
             log.warn("pairing store file is invalid: {}", ex.getMessage());
         }
         //deviceListAddFromPairingStore();
+        
+        options.put("ConnectionKeepAlive", new Option(Bundle.getMessage("KeepAlive"),
+                new String[]{Bundle.getMessage("KeepAliveLocalPing"),Bundle.getMessage("KeepAliveNone")} )); // NOI18N
     }
     
     public void deviceListAddFromPairingStore() {
@@ -324,6 +327,7 @@ public class NetBiDiBAdapter extends BiDiBNetworkPortController {
         
         ctx.register(BiDiBTrafficController.ASYNCCONNECTIONINIT, true); //netBiDiB uses asynchroneous initialization
         ctx.register(BiDiBTrafficController.ISNETBIDIB, true);
+        ctx.register(BiDiBTrafficController.USELOCALPING, getOptionState("ConnectionKeepAlive").equals(Bundle.getMessage("KeepAliveLocalPing")));
 
         log.debug("Context: {}", ctx);
         


### PR DESCRIPTION
A combo box has been added to the netBiDiB connection additional settings, so that the local ping keep-alive can be disabled for devices that do not support local ping.

Some other debug logging has been added.