### PR TITLE
[Security] Fix Zip Slip vulnerability in unzip function

### DIFF
--- a/java/src/jmri/util/UnzipFileClass.java
+++ b/java/src/jmri/util/UnzipFileClass.java
@@ -58,6 +58,12 @@ public class UnzipFileClass {
                 String entryName = entry.getName();
                 File file = new File(destinationFolder + File.separator + entryName);
 
+                // Security check: Validate that the resolved path is within the target directory
+                if (!file.toPath().normalize().startsWith(directory.toPath().normalize())) {
+                    throw new IOException("Zip Slip vulnerability detected: " + entryName + 
+                                        " would extract outside target directory");
+                }
+
                 log.info("Unzip file {} to {}", entryName, file.getAbsolutePath());
 
                 // create the directories of the zip directory


### PR DESCRIPTION
## Description
 potential Zip Slip vulnerability (CWE-22: Path Traversal) in the cloned function unzipFunction() in unzip_cloned.java was identified. This vulnerability allows malicious ZIP files to extract entries outside the intended destination directory, potentially leading to arbitrary file overwrite, code execution, or privilege escalation.

**Vulnerability Details**
The original vulnerable code directly constructed file paths without validation:
This approach is susceptible to directory traversal attacks where malicious ZIP entries with names like ../../../etc/passwd can escape the destination directory and write files to arbitrary locations on the filesystem.

**Fix Applied**
This PR implements proper path validation to prevent Zip Slip attacks:

**How the fix works:**

- Path Normalization: file.toPath().normalize() resolves any .. or . sequences in the path
- Boundary Validation: startsWith(directory.toPath().normalize()) ensures the final path is within the intended destination directory

This vulnerability was also found in  dylwedma11748/JTegraNX@dd5c2e1 and fixed, but the fix is not applied here.

**References:**
1. https://cwe.mitre.org/data/definitions/22.html
2. dylwedma11748/JTegraNX@dd5c2e1