### PR TITLE
REGRESSION: Re-add shift modes to ESU function map

### DIFF
--- a/xml/decoderIndex.xml
+++ b/xml/decoderIndex.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet href="/xml/XSLT/DecoderID.xsl" type="text/xsl"?>
 <decoderIndex-config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
-  <!--Written by JMRI version 5.13.3plus+heiko+20250809T1511Z+R2db03cc518 on Sat Aug 09 17:14:14 CEST 2025-->
-  <decoderIndex version="655">
+  <!--Written by JMRI version 5.13.3plus+heiko+20250809T1538Z+Raea4524d0f on Sat Aug 09 17:39:07 CEST 2025-->
+  <decoderIndex version="657">
     <!--The manufacturer list is from the nmra_mfg_list.xml file-->
     <mfgList nmraListDate="2024-12-10" updated="2025-03-30" lastadd="171">
       <manufacturer mfg="NMRA" mfgID="999" />
@@ -7063,12 +7063,12 @@
           <output name="3,14" label="Sound fade" />
           <output name="3,15" label="Disable brake sound" />
           <output name="3,16" label="Volume &amp; Mute" />
-          <output name="3,17" label="Shift Mode 1" />
-          <output name="3,18" label="Shift Mode 2" />
-          <output name="3,19" label="Shift Mode 3" />
-          <output name="3,20" label="Shift Mode 4" />
-          <output name="3,21" label="Shift Mode 5" />
-          <output name="3,22" label="Shift Mode 6" />
+          <output name="3,17" label="|" />
+          <output name="3,18" label="|" />
+          <output name="3,19" label="|" />
+          <output name="3,20" label="|" />
+          <output name="3,21" label="|" />
+          <output name="3,22" label="|" />
           <output name="3,23" label="|" />
           <output name="3,24" label="|" />
           <output name="4,1" label="Virtual drive sound" />

--- a/xml/decoderIndex.xml
+++ b/xml/decoderIndex.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet href="/xml/XSLT/DecoderID.xsl" type="text/xsl"?>
 <decoderIndex-config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
-  <!--Written by JMRI version 5.13.2plus+jake+20250808T1025Z+R3ce3892a5b4 on Fri Aug 08 06:25:45 EDT 2025-->
-  <decoderIndex version="653">
+  <!--Written by JMRI version 5.13.3plus+heiko+20250809T1511Z+R2db03cc518 on Sat Aug 09 17:14:14 CEST 2025-->
+  <decoderIndex version="655">
     <!--The manufacturer list is from the nmra_mfg_list.xml file-->
     <mfgList nmraListDate="2024-12-10" updated="2025-03-30" lastadd="171">
       <manufacturer mfg="NMRA" mfgID="999" />
@@ -7063,12 +7063,12 @@
           <output name="3,14" label="Sound fade" />
           <output name="3,15" label="Disable brake sound" />
           <output name="3,16" label="Volume &amp; Mute" />
-          <output name="3,17" label="|" />
-          <output name="3,18" label="|" />
-          <output name="3,19" label="|" />
-          <output name="3,20" label="|" />
-          <output name="3,21" label="|" />
-          <output name="3,22" label="|" />
+          <output name="3,17" label="Shift Mode 1" />
+          <output name="3,18" label="Shift Mode 2" />
+          <output name="3,19" label="Shift Mode 3" />
+          <output name="3,20" label="Shift Mode 4" />
+          <output name="3,21" label="Shift Mode 5" />
+          <output name="3,22" label="Shift Mode 6" />
           <output name="3,23" label="|" />
           <output name="3,24" label="|" />
           <output name="4,1" label="Virtual drive sound" />
@@ -7532,12 +7532,12 @@
           <output name="3,14" label="Sound fade" />
           <output name="3,15" label="Disable brake sound" />
           <output name="3,16" label="Volume &amp; Mute" />
-          <output name="3,17" label="|" />
-          <output name="3,18" label="|" />
-          <output name="3,19" label="|" />
-          <output name="3,20" label="|" />
-          <output name="3,21" label="|" />
-          <output name="3,22" label="|" />
+          <output name="3,17" label="Shift Mode 1" />
+          <output name="3,18" label="Shift Mode 2" />
+          <output name="3,19" label="Shift Mode 3" />
+          <output name="3,20" label="Shift Mode 4" />
+          <output name="3,21" label="Shift Mode 5" />
+          <output name="3,22" label="Shift Mode 6" />
           <output name="3,23" label="|" />
           <output name="3,24" label="|" />
         </outputs>

--- a/xml/decoders/esu/v5lpOutputLabels.xml
+++ b/xml/decoders/esu/v5lpOutputLabels.xml
@@ -111,37 +111,37 @@
 		<label xml:lang="de">Lautstärke</label>
         <label xml:lang="nl">Volume &amp; Mute</label>
     </output>
-    <output name="3,17" label="|">
+    <output name="3,17" label="Shift Mode 1">
         <label xml:lang="ca">Mode de Canvi 1</label>
         <label xml:lang="cs">Režim posunu 1</label>
         <label xml:lang="da">Shift Mode 1</label>
         <label xml:lang="nl">Shift Mode 1</label>
     </output>
-    <output name="3,18" label="|">
+    <output name="3,18" label="Shift Mode 2">
         <label xml:lang="ca">Mode de Canvi 2</label>
         <label xml:lang="cs">Režim posunu 2</label>
         <label xml:lang="da">Shift Mode 2</label>
         <label xml:lang="nl">Shift Mode 2</label>
     </output>
-    <output name="3,19" label="|">
+    <output name="3,19" label="Shift Mode 3">
         <label xml:lang="ca">Mode de Canvi 3</label>
         <label xml:lang="cs">Režim posunu 3</label>
         <label xml:lang="da">Shift Mode 3</label>
         <label xml:lang="nl">Shift Mode 3</label>
     </output>
-    <output name="3,20" label="|">
+    <output name="3,20" label="Shift Mode 4">
         <label xml:lang="ca">Mode de Canvi 4</label>
         <label xml:lang="cs">Režim posunu 4</label>
         <label xml:lang="da">Shift Mode 4</label>
         <label xml:lang="nl">Shift Mode 4</label>
     </output>
-    <output name="3,21" label="|">
+    <output name="3,21" label="Shift Mode 5">
         <label xml:lang="ca">Mode de Canvi 5</label>
         <label xml:lang="cs">Režim posunu 5</label>
         <label xml:lang="da">Shift Mode 5</label>
         <label xml:lang="nl">Shift Mode 5</label>
     </output>
-    <output name="3,22" label="|">
+    <output name="3,22" label="Shift Mode 6">
         <label xml:lang="ca">Mode de Canvi 6</label>
         <label xml:lang="cs">Režim posunu 6</label>
         <label xml:lang="da">Shift Mode 6</label>

--- a/xml/decoders/esu/v5lpOutputLabels.xml
+++ b/xml/decoders/esu/v5lpOutputLabels.xml
@@ -111,42 +111,12 @@
 		<label xml:lang="de">Lautstärke</label>
         <label xml:lang="nl">Volume &amp; Mute</label>
     </output>
-    <output name="3,17" label="Shift Mode 1">
-        <label xml:lang="ca">Mode de Canvi 1</label>
-        <label xml:lang="cs">Režim posunu 1</label>
-        <label xml:lang="da">Shift Mode 1</label>
-        <label xml:lang="nl">Shift Mode 1</label>
-    </output>
-    <output name="3,18" label="Shift Mode 2">
-        <label xml:lang="ca">Mode de Canvi 2</label>
-        <label xml:lang="cs">Režim posunu 2</label>
-        <label xml:lang="da">Shift Mode 2</label>
-        <label xml:lang="nl">Shift Mode 2</label>
-    </output>
-    <output name="3,19" label="Shift Mode 3">
-        <label xml:lang="ca">Mode de Canvi 3</label>
-        <label xml:lang="cs">Režim posunu 3</label>
-        <label xml:lang="da">Shift Mode 3</label>
-        <label xml:lang="nl">Shift Mode 3</label>
-    </output>
-    <output name="3,20" label="Shift Mode 4">
-        <label xml:lang="ca">Mode de Canvi 4</label>
-        <label xml:lang="cs">Režim posunu 4</label>
-        <label xml:lang="da">Shift Mode 4</label>
-        <label xml:lang="nl">Shift Mode 4</label>
-    </output>
-    <output name="3,21" label="Shift Mode 5">
-        <label xml:lang="ca">Mode de Canvi 5</label>
-        <label xml:lang="cs">Režim posunu 5</label>
-        <label xml:lang="da">Shift Mode 5</label>
-        <label xml:lang="nl">Shift Mode 5</label>
-    </output>
-    <output name="3,22" label="Shift Mode 6">
-        <label xml:lang="ca">Mode de Canvi 6</label>
-        <label xml:lang="cs">Režim posunu 6</label>
-        <label xml:lang="da">Shift Mode 6</label>
-        <label xml:lang="nl">Shift Mode 6</label>
-    </output>
+    <output name="3,17" label="|" />
+    <output name="3,18" label="|" />
+    <output name="3,19" label="|" />
+    <output name="3,20" label="|" />
+    <output name="3,21" label="|" />
+    <output name="3,22" label="|" />
     <output name="3,23" label="|" />
     <output name="3,24" label="|" />
     <output name="4,1" label="Virtual drive sound"/>

--- a/xml/decoders/esu/v5lsOutputLabels.xml
+++ b/xml/decoders/esu/v5lsOutputLabels.xml
@@ -111,37 +111,37 @@
 		<label xml:lang="de">Lautstärke</label>
         <label xml:lang="nl">Volume &amp; Mute</label>
     </output>
-    <output name="3,17" label="|">
+    <output name="3,17" label="Shift Mode 1">
         <label xml:lang="ca">Mode de Canvi 1</label>
         <label xml:lang="cs">Režim posunu 1</label>
         <label xml:lang="da">Shift Mode 1</label>
         <label xml:lang="nl">Shift Mode 1</label>
     </output>
-    <output name="3,18" label="|">
+    <output name="3,18" label="Shift Mode 2">
         <label xml:lang="ca">Mode de Canvi 2</label>
         <label xml:lang="cs">Režim posunu 2</label>
         <label xml:lang="da">Shift Mode 2</label>
         <label xml:lang="nl">Shift Mode 2</label>
     </output>
-    <output name="3,19" label="|">
+    <output name="3,19" label="Shift Mode 3">
         <label xml:lang="ca">Mode de Canvi 3</label>
         <label xml:lang="cs">Režim posunu 3</label>
         <label xml:lang="da">Shift Mode 3</label>
         <label xml:lang="nl">Shift Mode 3</label>
     </output>
-    <output name="3,20" label="|">
+    <output name="3,20" label="Shift Mode 4">
         <label xml:lang="ca">Mode de Canvi 4</label>
         <label xml:lang="cs">Režim posunu 4</label>
         <label xml:lang="da">Shift Mode 4</label>
         <label xml:lang="nl">Shift Mode 4</label>
     </output>
-    <output name="3,21" label="|">
+    <output name="3,21" label="Shift Mode 5">
         <label xml:lang="ca">Mode de Canvi 5</label>
         <label xml:lang="cs">Režim posunu 5</label>
         <label xml:lang="da">Shift Mode 5</label>
         <label xml:lang="nl">Shift Mode 5</label>
     </output>
-    <output name="3,22" label="|">
+    <output name="3,22" label="Shift Mode 6">
         <label xml:lang="ca">Mode de Canvi 6</label>
         <label xml:lang="cs">Režim posunu 6</label>
         <label xml:lang="da">Shift Mode 6</label>


### PR DESCRIPTION
They got lost in 25a29ad5365c9aa355261b3a2ca8c96a74bc9ce8 about half a year ago and I never noticed before...

I don't recall the custom around the decoderIndex - I have included its update in this PR, but if that's untypical, I can remove it.

Heiko