### PR TITLE
Add separate comment pane to DP

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -424,7 +424,12 @@
     <h3>DecoderPro</h3>
         <a id="DecoderPro" name="DecoderPro"></a>
         <ul>
-            <li></li>
+            <li>When working with a single roster entry, there's a 
+                new "Comments" page. You can pop that off (using the 
+                page icon in the tab) and enter your comments there 
+                as you configure the values in the other panes.
+                What you type there will appear in the comment field
+                on the Roster Entry pane and vice versa.</li>
         </ul>
 
    <h3>Dispatcher</h3>

--- a/java/src/jmri/jmrit/roster/RosterEntryPane.java
+++ b/java/src/jmri/jmrit/roster/RosterEntryPane.java
@@ -9,6 +9,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import javax.swing.*;
+import javax.swing.text.*;
 
 import jmri.DccLocoAddress;
 import jmri.InstanceManager;
@@ -43,7 +44,8 @@ public class RosterEntryPane extends javax.swing.JPanel {
     JTextArea comment = new JTextArea(3, 50);
     public String getComment() {return comment.getText();}
     public void setComment(String text) {comment.setText(text);}
-
+    public Document getCommentDocument() {return comment.getDocument();}
+    
     // JScrollPanes are defined with scroll bars on always to avoid undesirable resizing behavior
     // Without this the field will shrink to minimum size any time the scroll bars become needed and
     // the scroll bars are inside, not outside the field area, obscuring their contents.

--- a/java/src/jmri/jmrit/symbolicprog/SymbolicProgBundle.properties
+++ b/java/src/jmri/jmrit/symbolicprog/SymbolicProgBundle.properties
@@ -195,6 +195,7 @@ VALUE\ IS\: = Value is:
 ROSTER\ ENTRY = Roster Entry
 FUNCTION\ LABELS = Function Labels
 ROSTER\ MEDIA = Roster Media
+COMMENT\ PANE = Comments
 Hexadecimal = Hexadecimal
 Decimal = Decimal
 CantReadThisMode = can't read in this Mode

--- a/java/src/jmri/jmrit/symbolicprog/tabbedframe/PaneProgFrame.java
+++ b/java/src/jmri/jmrit/symbolicprog/tabbedframe/PaneProgFrame.java
@@ -1194,6 +1194,14 @@ abstract public class PaneProgFrame extends JmriJFrame
             makeMediaPane(r);
         }
 
+        // add the comment tab
+        JPanel commentTab = new JPanel();
+        var comment = new JTextArea(_rPane.getCommentDocument());
+        JScrollPane commentScroller = new JScrollPane(comment, JScrollPane.VERTICAL_SCROLLBAR_ALWAYS, JScrollPane.HORIZONTAL_SCROLLBAR_ALWAYS);
+        commentTab.add(commentScroller);
+        commentTab.setLayout(new BoxLayout(commentTab, BoxLayout.Y_AXIS));
+        tabPane.addTab(Bundle.getMessage("COMMENT PANE"), commentTab);
+
         // for all "pane" elements in the programmer
         List<Element> progPaneList = base.getChildren("pane");
         if (log.isDebugEnabled()) {


### PR DESCRIPTION
As requested at the recent JMRI community meeting, this adds a new Comments pane to the DecoderPro tabbed panel that allows you to see and enter larger comments.  

What you enter there is synched to the smaller (with scroll bars) comment field on the Roster Entry pane.