### PR TITLE
Stopping/Ramping using RosterSpeedProfile

### DIFF
--- a/java/src/jmri/jmrit/roster/RosterSpeedProfile.java
+++ b/java/src/jmri/jmrit/roster/RosterSpeedProfile.java
@@ -932,7 +932,8 @@ public class RosterSpeedProfile {
                 calculatedDistance = 0;
             }
             if (calculatedDistance <= 0 && !calculated) {
-                log.warn("distance remaining is now 0, but we have not reached desired speed setting {} v {}", desiredSpeedStep, calculatingStep);
+                //removed as overflows logs on the big test
+                //log.warn("distance remaining is now 0, but we have not reached desired speed setting {} v {}", desiredSpeedStep, calculatingStep);
                 ss = new SpeedSetting(desiredSpeedStep, 10, andStop);
                 synchronized (this) {
                     stepQueue.addLast(ss);

--- a/java/test/jmri/jmrit/roster/RosterSpeedProfileTest.java
+++ b/java/test/jmri/jmrit/roster/RosterSpeedProfileTest.java
@@ -6,12 +6,12 @@ import jmri.util.JUnitUtil;
 import jmri.DccThrottle;
 import jmri.InstanceManager;
 import jmri.LocoAddress;
+import jmri.SpeedStepMode;
 import jmri.ThrottleListener;
 import jmri.ThrottleManager;
 import jmri.implementation.SignalSpeedMap;
 import jmri.jmrit.roster.RosterSpeedProfile.SpeedSetting;
 import jmri.util.JUnitAppender;
-
 import org.junit.Assert;
 import org.junit.jupiter.api.*;
 
@@ -23,6 +23,8 @@ public class RosterSpeedProfileTest {
 
     private boolean throttleResult;
     private DccThrottle throttle;
+
+    private float globalTotalDistanceTolerance = 2.0f;
 
     private class ThrottleListen implements ThrottleListener {
 
@@ -81,147 +83,190 @@ public class RosterSpeedProfileTest {
             );
     }
 
-    @Test
-    public void testSpeedProfileStopFromFiftyPercent() {
+    private ReturnValues testScene(RosterEntry rF1, float currentSpeed,
+            float newSpeed, float testDistance,
+            float minSpeed, float maxSpeed, SpeedStepMode speedStepMode,
+            DccThrottle inThrottle ) {
+        inThrottle.setSpeedStepMode(speedStepMode);
+        inThrottle.setIsForward(true);
+        inThrottle.setSpeedSetting(currentSpeed);
+        RosterSpeedProfile sp = rF1.getSpeedProfile();
+        float mmFactor = sp.getForwardSpeed(1.0f);
+        sp.setTestMode(true);
+        sp.setExtraInitialDelay(0f);
+        sp.setMinMaxLimits(minSpeed, maxSpeed);
+        sp.changeLocoSpeed(throttle, testDistance, newSpeed);
+        ReturnValues returnValues = new ReturnValues();
+        returnValues.totalDistance = 0.0f;
+        returnValues.numberOfElements = sp.getSpeedStepTrace().size();
+        for (SpeedSetting ss : sp.getSpeedStepTrace()) {
+            returnValues.totalDistance += (ss.getDuration() / 1000.0f) * (ss.getSpeedStep() * mmFactor);
+            returnValues.finalSpeed = ss.getSpeedStep();
+        }
+        returnValues.throttleSpeedSetting = throttle.getSpeedSetting();
+        sp.cancelSpeedChange();
+
+        return returnValues;
+    }
+
+    public ReturnValuesFromAct testSpeedStep(SpeedStepMode stm,
+            long fromDistanceMm, long toDistanceMm, long byDistanceMm,
+            float fromSpeedStep, float bySpeedStep,    // limit for speed step is max throttle step
+            float fromSpeed, float toSpeed, float bySpeed,
+            float fromMin, float toMin, float byMin,
+            float fromMax_IsMinPlus, float toMax, float byMax,
+            org.jdom2.Element speedCurve) {
+        ReturnValuesFromAct resultSummary = new ReturnValuesFromAct();
+        long stmLimit = 0;
         // statics for test objects
-        org.jdom2.Element f1 = getLocoElement100();
-        RosterEntry rF1 = new RosterEntry(f1) {
+        RosterEntry rF1 = new RosterEntry(speedCurve) {
             @Override
             protected void warnShortLong(String s) {
             }
         };
+
         ThrottleListener throtListen = new ThrottleListen();
         ThrottleManager tm = InstanceManager.getDefault(ThrottleManager.class);
-        boolean OK = tm.requestThrottle(rF1, throtListen, throttleResult);
-        Assert.assertTrue("Throttle request denied",OK);
-        JUnitUtil.waitFor(()-> (throttleResult), "Got No throttle");
-        throttle.setIsForward(true);
-        throttle.setSpeedSetting(0.5f);
-        RosterSpeedProfile sp = rF1.getSpeedProfile();
-        sp.setTestMode(true);
-        sp.changeLocoSpeed(throttle, 50.0f, 0.0f);
-        // Allow speed step table to be constructed
-        //JUnitUtil.waitFor(5000);
-        // Note it must be a perfect 0.0
-        //Assert.assertEquals("Speed didnt get to a perfect zero", 0.0f, throttle.getSpeedSetting(), 0.0f);
-        JUnitUtil.waitFor(()->(throttle.getSpeedSetting() == 0.00f),"Failed to reach requested speed");
-        float maxDelta = 1.0f/126.0f/2.0f;  //half step
-        Assert.assertEquals("SpeedStep Table has incorrect number of entries.", 7, sp.getSpeedStepTrace().size() ) ;
-        int[] correctDuration = {750, 750, 750, 750, 750, 519, 0} ;
-        int[] durations = new int[sp.getSpeedStepTrace().size()];
-        int ix = 0;
-        for (SpeedSetting ss: sp.getSpeedStepTrace()) {
-            durations[ix]= ss.getDuration();
-            ix++;
+        if ( ! tm.requestThrottle(rF1, throtListen, throttleResult) ) {
+            return null;
         }
-        Assert.assertArrayEquals("Durations are wrong",correctDuration, durations);
-
-        float[] correctSpeed = {0.30798f, 0.17571f, 0.09067f, 0.04558f, 0.02260f, 0.01466f, 0.0f} ;
-        float[] speed = new float[sp.getSpeedStepTrace().size()];
-        ix=0;
-        for (SpeedSetting ss: sp.getSpeedStepTrace()) {
-            speed[ix]= ss.getSpeedStep();
-            ix++;
+        stmLimit = stm.numSteps;
+        resultSummary.testTotalCount = 0;
+        for (float testDistance = fromDistanceMm; testDistance <= toDistanceMm; testDistance += byDistanceMm) {
+            //Runtime.getRuntime().gc();
+            for (float currentSpeedStep = fromSpeedStep; currentSpeedStep >= 0 &&
+                    currentSpeedStep <= stmLimit; currentSpeedStep += bySpeedStep) {
+                for (float newPercentSpeed = fromSpeed; newPercentSpeed <= toSpeed; newPercentSpeed += bySpeed) {
+                    for (float minPercentSpeed = 0.00f; minPercentSpeed <= 1.0f ; minPercentSpeed+= 0.1f)  {
+                        for (float maxPercentSpeed = minPercentSpeed + fromMax_IsMinPlus;
+                                maxPercentSpeed <= toMax; maxPercentSpeed += byMax) {
+                            ReturnValues returnValues = testScene(rF1, //profile
+                                    currentSpeedStep / stmLimit, //current speed
+                                    newPercentSpeed, // new speed
+                                    testDistance, // distance
+                                    minPercentSpeed, // minSpeed
+                                    maxPercentSpeed, // max speed
+                                    stm,
+                                    throttle// stepmode
+                            );
+                            resultSummary.testTotalCount++;
+                            long ix = Math.round(
+                                    (Math.abs(testDistance - returnValues.totalDistance) / testDistance) *
+                                            100.0f);
+                            if (ix > 100) {
+                                ix = 101;
+                            }
+                            float expectedSpeed = newPercentSpeed;
+                            if (expectedSpeed > 0.0f &&
+                                    minPercentSpeed > 0.0f &&
+                                    minPercentSpeed > expectedSpeed) {
+                                expectedSpeed = minPercentSpeed;
+                            }
+                            if (maxPercentSpeed < expectedSpeed) {
+                                expectedSpeed = maxPercentSpeed;
+                            }
+                            if (Math.abs(expectedSpeed - returnValues.finalSpeed) > (1.0f / stmLimit)) {
+                                resultSummary.failedTestEndSpeed += 1;
+                            }
+                            if (returnValues.totalDistance == 0.0f &&
+                                    Math.abs(expectedSpeed - (currentSpeedStep / stmLimit)) < (1.0f /
+                                            stmLimit)) {
+                                // no speed change expected so no distance
+                                resultSummary.zeroTests++;
+                                resultSummary.lengthError[0] += 1;
+                            } else if ((Math.abs(testDistance - returnValues.totalDistance) /
+                                    testDistance) < globalTotalDistanceTolerance) {
+                                // within tolerance
+                                resultSummary.passedTests++;
+                                resultSummary.lengthError[(int) ix] += 1;
+                            } else {
+                                resultSummary.failedTests++;
+                                // use this to debug individual entries
+//                                    log.info("Failed {} CS {} NS {} D {} MIN {} MAX {} ACTD {} AS {} FTS {}",
+//                                            stm.name(),
+//                                            currentSpeedStep / stmLimit, //current speed
+//                                            newPercentSpeed, // new speed
+//                                            testDistance, // distance
+//                                            minPercentSpeed, // minSpeed
+//                                            maxPercentSpeed, returnValues.totalDistance, returnValues.finalSpeed,
+//                                            returnValues.throttleSpeedSetting);
+                                resultSummary.lengthError[(int) ix] += 1;
+                            }
+                            returnValues = null;
+                        }
+                    }
+                }
+            }
         }
-        Assert.assertArrayEquals("Speeds are wrong", correctSpeed, speed, maxDelta);
-        sp.cancelSpeedChange();
-
-        Assertions.assertEquals(10.0f, sp.mmsToScaleSpeed(10, false), 0.0001);
+        return resultSummary;
     }
 
     @Test
-    public void testSpeedProfileStopFromFiftyPercentWithMinimumSpeed() {
-        // statics for test objects
-        org.jdom2.Element f1 = getLocoElement100();
-        RosterEntry rF1 = new RosterEntry(f1) {
-            @Override
-            protected void warnShortLong(String s) {
-            }
-        };
-        ThrottleListener throtListen = new ThrottleListen();
-        ThrottleManager tm = InstanceManager.getDefault(ThrottleManager.class);
-        boolean OK = tm.requestThrottle(rF1, throtListen, throttleResult);
-        Assert.assertTrue("Throttle request denied",OK);
-        JUnitUtil.waitFor(()-> (throttleResult), "Got No throttle");
-        throttle.setIsForward(true);
-        throttle.setSpeedSetting(0.5f);
-        RosterSpeedProfile sp = rF1.getSpeedProfile();
-        sp.setTestMode(true);
-        sp.setMinMaxLimits(0.1f, 1.0f);
-        sp.changeLocoSpeed(throttle, 50.0f, 0.0f);
-        // Allow speed step table to be constructed
-        //JUnitUtil.waitFor(5000);
-        // Note it must be a perfect 0.0
-        //Assert.assertEquals("Speed didnt get to a perfect zero", 0.0f, throttle.getSpeedSetting(), 0.0f);
-        JUnitUtil.waitFor(()->(throttle.getSpeedSetting() == 0.00f),"Failed to reach requested speed");
-        float maxDelta = 1.0f/126.0f/2.0f;  //half step
-        //Assert.assertEquals("SpeedStep Table has incorrect number of entries.", 5, sp.getSpeedStepTrace().size() ) ;
-        int[] correctDuration = {750, 750, 750, 750, 0} ;
-        int[] durations = new int[sp.getSpeedStepTrace().size()];
-        int ix = 0;
-        for (SpeedSetting ss: sp.getSpeedStepTrace()) {
-            durations[ix]= ss.getDuration();
-            ix++;
-        }
-        Assert.assertArrayEquals("Durations are wrong",correctDuration, durations);
-
-        float[] correctSpeed = {0.31962f, 0.18434f, 0.10993f, 0.1f, 0.0f} ;
-        float[] speed = new float[sp.getSpeedStepTrace().size()];
-        ix=0;
-        for (SpeedSetting ss: sp.getSpeedStepTrace()) {
-            speed[ix]= ss.getSpeedStep();
-            ix++;
-        }
-        Assert.assertArrayEquals("Speeds are wrong", correctSpeed, speed, maxDelta);
-        sp.cancelSpeedChange();
-
-        Assertions.assertEquals(10.0f, sp.mmsToScaleSpeed(10, false), 0.0001);
+    public void testSpeedProfile_28() {
+        SpeedStepMode stm = SpeedStepMode.NMRA_DCC_28;
+        ReturnValuesFromAct resultSummary = testSpeedStep(stm,
+                100L, 2000L, 100L, //distance steps
+                1.0f, 1.0f, //from speed
+                0.0f, 1.0f, 0.1f, //   to speeds
+                0.0f, 0.3f, 0.6f, // min speeds
+                0.10f, 1.0f, 0.10f,
+                getLocoElement100());
+        String msg = stm.name + " Tests [" + resultSummary.testTotalCount
+                + "] run. Length Failed [" + resultSummary.failedTests
+                + "] Final Speed errors [" + + resultSummary.failedTestEndSpeed + "]";
+        Assertions.assertEquals(0, resultSummary.failedTests, msg);
+        Assertions.assertEquals(0, resultSummary.failedTestEndSpeed,msg);
     }
+
     @Test
-    public void testSpeedProfileFromFiftyPercentToTwenty() {
-        // statics for test objects
-        org.jdom2.Element f1 = getLocoElement200();
-        RosterEntry rF1 = new RosterEntry(f1) {
-            @Override
-            protected void warnShortLong(String s) {
-            }
-        };
-        ThrottleListener throtListen = new ThrottleListen();
-        ThrottleManager tm = InstanceManager.getDefault(ThrottleManager.class);
-        boolean OK = tm.requestThrottle(rF1, throtListen, throttleResult);
-        Assert.assertTrue("Throttle request denied",OK);
+    public void testSpeedProfile_128() {
+        SpeedStepMode stm = SpeedStepMode.NMRA_DCC_128;
+        ReturnValuesFromAct resultSummary = testSpeedStep(stm,
+                100L, 2000L, 100L,  //distance steps
+                1.0f,1.0f,         //from speed
+                0.0f, 1.0f, 0.1f, //   to speeds
+                0.0f, 0.3f, 0.6f, // min speeds
+                0.10f, 1.0f, 0.10f,
+                getLocoElement100());
+        String msg = stm.name + " Tests [" + resultSummary.testTotalCount
+                + "] run. Length Failed [" + resultSummary.failedTests
+                + "] Final Speed errors [" + + resultSummary.failedTestEndSpeed + "]";
+        Assertions.assertEquals(0, resultSummary.failedTests, msg);
+        Assertions.assertEquals(0, resultSummary.failedTestEndSpeed,msg);
+    }
 
-        JUnitUtil.waitFor(()-> (throttleResult), "Got No throttle");
-        throttle.setIsForward(true);
-        throttle.setSpeedSetting(0.6f);
-        RosterSpeedProfile sp = rF1.getSpeedProfile();
-        sp.setTestMode(true);
-        sp.changeLocoSpeed(throttle, 150.0f, 0.20f);
-        // Allow speed step table to be constructed
-        //JUnitUtil.waitFor(5000);
-        // Note it must be a perfect 0.20
-        JUnitUtil.waitFor(()->(throttle.getSpeedSetting() == 0.20f),"Failed to reach requested speed");
-        //Assert.assertEquals("Speed didnt get to a perfect 20", 0.20f, throttle.getSpeedSetting(), 0.00f);
-        float maxDelta = 1.0f/126.0f/2.0f;  //half step
-        //Assert.assertEquals("SpeedStep Table has lincorrect number of entries.", 4, sp.getSpeedStepTrace().size() ) ;
-        int[] correctDuration = {750, 750, 750, 540} ;
-        int[] durations = new int[sp.getSpeedStepTrace().size()];
-        int ix = 0;
-        for (SpeedSetting ss: sp.getSpeedStepTrace()) {
-            durations[ix]= ss.getDuration();
-            ix++;
-        }
-        Assert.assertArrayEquals("Durations are wrong",correctDuration, durations);
+    @Test
+    public void testSpeedProfile_14() {
+        SpeedStepMode stm = SpeedStepMode.NMRA_DCC_14;
+        ReturnValuesFromAct resultSummary = testSpeedStep(stm,
+                100L, 2000L, 100L,  //distance steps
+                1.0f,1.0f,         //from speed
+                0.0f, 1.0f, 0.1f, //   to speeds
+                0.0f, 0.3f, 0.6f, // min speeds
+                0.10f, 1.0f, 0.10f,
+                getLocoElement100());
+        String msg = stm.name + " Tests [" + resultSummary.testTotalCount
+                + "] run. Length Failed [" + resultSummary.failedTests
+                + "] Final Speed errors [" + + resultSummary.failedTestEndSpeed + "]";
+        Assertions.assertEquals(0, resultSummary.failedTests, msg);
+        Assertions.assertEquals(0, resultSummary.failedTestEndSpeed,msg);
+    }
 
-        float[] correctSpeed = {0.43912f, 0.30069f, 0.20311f, 0.2f} ;
-        float[] speed = new float[sp.getSpeedStepTrace().size()];
-        ix=0;
-        for (SpeedSetting ss: sp.getSpeedStepTrace()) {
-            speed[ix]= ss.getSpeedStep();
-            ix++;
-        }
-        Assert.assertArrayEquals("Speeds are wrong", correctSpeed, speed, maxDelta);
-        sp.cancelSpeedChange();
+    @Test
+    public void testSpeedProfile_100() {
+        SpeedStepMode stm = SpeedStepMode.TMCC1_100;
+        ReturnValuesFromAct resultSummary = testSpeedStep(stm,
+                100L, 2000L, 100L, //distance steps
+                1.0f, 1.0f, //from speed
+                0.0f, 1.0f, 0.1f, //   to speeds
+                0.0f, 0.3f, 0.6f, // min speeds
+                0.10f, 1.0f, 0.10f,
+                getLocoElement100());
+        String msg = stm.name + " Tests [" + resultSummary.testTotalCount
+                + "] run. Length Failed [" + resultSummary.failedTests
+                + "] Final Speed errors [" + + resultSummary.failedTestEndSpeed + "]";
+        Assertions.assertEquals(0, resultSummary.failedTests, msg);
+        Assertions.assertEquals(0, resultSummary.failedTestEndSpeed,msg);
     }
 
     private static org.jdom2.Element getLocoElement200() {
@@ -255,7 +300,7 @@ public class RosterSpeedProfileTest {
     }
 
     @Test
-    public void testSpeedProfileFromFiftyPercentToTwentyShortBlock() {
+    public void testSpeedProfileFromFiftyPercentToTwentyShortBlock() throws Exception {
         // statics for test objects
         org.jdom2.Element f1 = getLocoElement400();
         RosterEntry rF1 = new RosterEntry(f1) {
@@ -280,11 +325,14 @@ public class RosterSpeedProfileTest {
         JUnitUtil.waitFor(()->(throttle.getSpeedSetting() == 0.20f),"Failed to reach requested speed");
 
         JUnitAppender.assertWarnMessageStartsWith("distance remaining is now 0, but we have not reached desired speed setting 0.2 v 0.3");
-
+        //JUnitAppender.assertWarnMessageStartsWith("There is insufficient distance");
         // as the calc goes wrong we immediatly set speed to final speed. The entries are rubbish so dont bother checking
-        Assert.assertEquals("SpeedStep Table has lincorrect number of entries.", 1, sp.getSpeedStepTrace().size() ) ;
+        Assert.assertEquals("SpeedStep Table has incorrect number of entries.", 1, sp.getSpeedStepTrace().size() ) ;
+        //Assert.assertEquals("SpeedStep Table has incorrect number of entries.", 0, sp.getSpeedStepTrace().size() ) ;
+
         sp.cancelSpeedChange();
     }
+
 
     private static org.jdom2.Element getLocoElement400 () {
         return new org.jdom2.Element("locomotive")
@@ -395,6 +443,43 @@ public class RosterSpeedProfileTest {
     @AfterEach
     public void tearDown() {
         JUnitUtil.tearDown();
+    }
+
+    class ReturnValues {
+        // return values from an individual scene
+        public float totalDistance;
+        public float finalSpeed;
+        public int numberOfElements;
+        public float throttleSpeedSetting;
+        ReturnValues() {
+            totalDistance = 0.0f;
+            finalSpeed = 0.0f;
+            numberOfElements = 0;
+            throttleSpeedSetting = 0.0f;
+        }
+        ReturnValues(float totalDistance, float finalSpeed, int numberOfElements) {
+            this.totalDistance = totalDistance;
+            this.finalSpeed = finalSpeed;
+            this.numberOfElements = numberOfElements;
+        }
+        @Override
+        public String toString() {
+            return Float.toString(totalDistance)
+               +  "," + Float.toString(finalSpeed)
+               +  "," + Integer.toString(numberOfElements)
+               +  "," + Float.toString(throttleSpeedSetting);
+        }
+    }
+
+    class ReturnValuesFromAct {
+        // return values from a collection of scenes
+        public long passedTests;
+        public long failedTests;
+        public long zeroTests;
+        public float finalSpeed;
+        public long[] lengthError = new long[102];
+        public long failedTestEndSpeed;
+        public long testTotalCount;
     }
 
 }

--- a/java/test/jmri/jmrit/roster/RosterSpeedProfileTest.java
+++ b/java/test/jmri/jmrit/roster/RosterSpeedProfileTest.java
@@ -269,36 +269,6 @@ public class RosterSpeedProfileTest {
         Assertions.assertEquals(0, resultSummary.failedTestEndSpeed,msg);
     }
 
-    private static org.jdom2.Element getLocoElement200() {
-        return new org.jdom2.Element("locomotive")
-            .setAttribute("id", "id info")
-            .setAttribute("fileName", "file here")
-            .setAttribute("roadNumber", "431")
-            .setAttribute("roadName", "SP")
-            .setAttribute("mfg", "Athearn")
-            .setAttribute("dccAddress", "1234")
-            .addContent(new org.jdom2.Element("decoder")
-                .setAttribute("family", "91")
-                .setAttribute("model", "33")
-            )
-            .addContent(new org.jdom2.Element("locoaddress")
-                .addContent(new org.jdom2.Element("number").addContent("1234"))
-                //As there is no throttle manager available all protocols default to dcc short
-                .addContent(new org.jdom2.Element("protocol").addContent("dcc_short"))
-            )
-            .addContent(new org.jdom2.Element("speedprofile")
-                .addContent(new org.jdom2.Element("overRunTimeForward").addContent("0.0"))
-                .addContent(new org.jdom2.Element("overRunTimeReverse").addContent("0.0"))
-                .addContent(new org.jdom2.Element("speeds")
-                    .addContent(new org.jdom2.Element("speed")
-                        .addContent(new org.jdom2.Element("step").addContent("1000"))
-                        .addContent(new org.jdom2.Element("forward").addContent("200.00"))
-                        .addContent(new org.jdom2.Element("reverse").addContent("200.00"))
-                    )
-                )
-            );
-    }
-
     @Test
     public void testSpeedProfileFromFiftyPercentToTwentyShortBlock() throws Exception {
         // statics for test objects


### PR DESCRIPTION
Stopping/Ramping by speed profile.
    This first part updates the tests to iterate over each speed step, with a new speed of 0.0 to 1.0F throttle. And testing Min and Maxs.
    It shows the rough size of the errors.

Error:    RosterSpeedProfileTest.testSpeedProfileFromFiftyPercentToTwentyShortBlock:297 No WARN message present: distance remaining is now 0, but we have not reached desired speed setting 0.2 v 0.3
Error:    RosterSpeedProfileTest.testSpeedProfile_100:268 tmcc1_100 Tests [900000] run. Length Failed [394980] Final Speed errors [7067] ==> expected: <0> but was: <394980>
Error:    RosterSpeedProfileTest.testSpeedProfile_128:234 128 Tests [1134000] run. Length Failed [169520] Final Speed errors [1452] ==> expected: <0> but was: <169520>
Error:    RosterSpeedProfileTest.testSpeedProfile_14:251 14 Tests [126000] run. Length Failed [21772] Final Speed errors [1100] ==> expected: <0> but was: <21772>
Error:    RosterSpeedProfileTest.testSpeedProfile_28:217 28 Tests [252000] run. Length Failed [54348] Final Speed errors [1106] ==> expected: <0> but was: <54348>

The next push will, hopefully improve these figures.