### PR TITLE
DecoderPro detachable window menu updates

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -36,7 +36,7 @@
 
         <h4>DCC++ and DCC-EX</h4>
             <ul>
-                <li>Change DCC-EX heartbeat from <s> to <#>, requested by DCC-EX team</li>
+                <li>Change DCC-EX heartbeat from &lt;s&gt; to &lt;#&gt;, requested by DCC-EX team</li>
             </ul>
 
         <h4>DCC4pc</h4>
@@ -430,6 +430,9 @@
                 as you configure the values in the other panes.
                 What you type there will appear in the comment field
                 on the Roster Entry pane and vice versa.</li>
+            <li>Detachable panes no longer appear in the Windows menu
+                <i>unless</i> they are actually detached.</li>
+            <li>Added Help and Windows menus to the detached panes.</li>
         </ul>
 
    <h3>Dispatcher</h3>

--- a/java/src/jmri/util/HelpUtil.java
+++ b/java/src/jmri/util/HelpUtil.java
@@ -53,7 +53,10 @@ public class HelpUtil {
 
     public static JMenu makeHelpMenu(String ref, boolean direct) {
         JMenu helpMenu = new JMenu(Bundle.getMessage("ButtonHelp"));
-        helpMenu.add(makeHelpMenuItem(ref));
+        var helpMenuItem = makeHelpMenuItem(ref);
+        if (helpMenuItem != null) {
+            helpMenu.add(helpMenuItem);
+        }
 
         if (direct) {
             ServiceLoader<MenuProvider> providers = ServiceLoader.load(MenuProvider.class);
@@ -69,6 +72,8 @@ public class HelpUtil {
     }
 
     public static JMenuItem makeHelpMenuItem(String ref) {
+        if (ref == null) return null;
+        
         JMenuItem menuItem = new JMenuItem(Bundle.getMessage("MenuItemWindowHelp"));
 
         menuItem.addActionListener((ignore) -> displayHelpRef(ref));

--- a/java/src/jmri/util/JmriJFrame.java
+++ b/java/src/jmri/util/JmriJFrame.java
@@ -183,6 +183,19 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
     }
 
     /**
+     * Add this window tp the Windows Menu by adding it from the list of
+     * active JmriJFrames.
+     */
+    public void makePublicWindow() {
+        JmriJFrameManager m = getJmriJFrameManager();
+        synchronized (m) {
+            if (! m.contains(this)) {
+                m.add(this);
+            }
+        }
+    }
+
+    /**
       * Reset frame location and size to stored preference value
       */
     public void setFrameLocation() {
@@ -496,7 +509,7 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
      *
      * Final because it defines the content of a standard help menu, not to be messed with individually
      *
-     * @param ref    JHelp reference for the desired window-specific help page
+     * @param ref    JHelp reference for the desired window-specific help page; null means no page
      * @param direct true if the help main-menu item goes directly to the help system,
      *               such as when there are no items in the help menu
      */

--- a/java/src/jmri/util/org/mitre/jawb/swing/DetachableTabbedPane.java
+++ b/java/src/jmri/util/org/mitre/jawb/swing/DetachableTabbedPane.java
@@ -500,7 +500,9 @@ public class DetachableTabbedPane extends JTabbedPane {
       this.index = index;
 
       /* frame to display component when detached. */
-      this.frame = new JmriJFrame ( (title!=null?title:comp.getName())+titleSuffix);
+      frame = new JmriJFrame ( (title!=null?title:comp.getName())+titleSuffix);
+      frame.makePrivateWindow();
+      frame.addHelpMenu(null,true);
       frame.addWindowListener (new WindowAdapter () {
           @Override
           public void windowClosing (WindowEvent e) {
@@ -563,6 +565,8 @@ public class DetachableTabbedPane extends JTabbedPane {
         component.setVisible (true);
         frame.getContentPane().add (component, BorderLayout.CENTER);
         
+        frame.makePublicWindow();
+        
         // some window managers like to reposition windows. Don't let 'em
         Rectangle bounds = frame.getBounds();
         
@@ -574,6 +578,7 @@ public class DetachableTabbedPane extends JTabbedPane {
       } else if (! detached && frame.isVisible()) {
         frame.setVisible (false);
         frame.getContentPane().removeAll ();
+        frame.makePrivateWindow();
       } 
     }
 


### PR DESCRIPTION
1) Detachable panes now don't show in Windows menu unless they're actually detected

2) Detached panes now have Windows and Help menus

3) Internal changes to support Help menus with no window-specific help; to allow a window to add itself to the Windows menu after being removed