### PR TITLE
ZeroConfService Mgr whitespace hostname

### DIFF
--- a/java/src/jmri/util/zeroconf/ZeroConfServiceManager.java
+++ b/java/src/jmri/util/zeroconf/ZeroConfServiceManager.java
@@ -480,7 +480,7 @@ public class ZeroConfServiceManager implements InstanceManagerAutoDefault, Dispo
         String puny = null;
         String name = string.toLowerCase(Locale.ROOT);
         name = name.replaceFirst("^[_\\.\\s]+", "");
-        if (string.isEmpty()) {
+        if (string.isBlank()) {
             name = NodeIdentity.networkIdentity();
         }
         if (name.length() > 63) {

--- a/java/test/jmri/util/zeroconf/ZeroConfServiceManagerTest.java
+++ b/java/test/jmri/util/zeroconf/ZeroConfServiceManagerTest.java
@@ -7,11 +7,12 @@ import jmri.util.JUnitUtil;
 import jmri.util.node.NodeIdentity;
 import jmri.web.server.WebServerPreferences;
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.Assert;
 import org.junit.jupiter.api.*;
-import org.junit.Assume;
-import org.junit.jupiter.api.BeforeAll;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests for the ZeroConfService class
@@ -24,16 +25,8 @@ public class ZeroConfServiceManagerTest {
     private static final String HTTP = "_http._tcp.local.";
     private ZeroConfServiceManager manager;
 
-    @BeforeAll
-    public static void setUpClass() throws Exception {
-    }
-
-    @AfterAll
-    public static void tearDownClass() throws Exception {
-    }
-
     @BeforeEach
-    public void setUp() throws Exception {
+    public void setUp() {
         JUnitUtil.setUp();
         JUnitUtil.resetZeroConfServiceManager();
         JUnitUtil.resetProfileManager();
@@ -43,7 +36,7 @@ public class ZeroConfServiceManagerTest {
     }
 
     @AfterEach
-    public void tearDown() throws Exception {
+    public void tearDown() {
         JUnitUtil.resetZeroConfServiceManager();
         manager = null;
         
@@ -70,8 +63,8 @@ public class ZeroConfServiceManagerTest {
     @Test
     public void testCreate_String_int() {
         ZeroConfService result = manager.create(HTTP, 9999);
-        Assert.assertNotNull(result);
-        Assert.assertEquals(InstanceManager.getDefault(WebServerPreferences.class).getRailroadName(), result.getName());
+        assertNotNull(result);
+        assertEquals(InstanceManager.getDefault(WebServerPreferences.class).getRailroadName(), result.getName());
     }
 
     /**
@@ -81,8 +74,8 @@ public class ZeroConfServiceManagerTest {
     public void testCreate_3args() {
         HashMap<String, String> properties = new HashMap<>();
         ZeroConfService result = manager.create(HTTP, 9999, properties);
-        Assert.assertNotNull(result);
-        Assert.assertEquals(InstanceManager.getDefault(WebServerPreferences.class).getRailroadName(), result.getName());
+        assertNotNull(result);
+        assertEquals(InstanceManager.getDefault(WebServerPreferences.class).getRailroadName(), result.getName());
     }
 
     /**
@@ -93,8 +86,8 @@ public class ZeroConfServiceManagerTest {
         String name = "my name"; // NOI18N
         HashMap<String, String> properties = new HashMap<>();
         ZeroConfService result = manager.create(HTTP, name, 9999, 1, 1, properties);
-        Assert.assertNotNull(result);
-        Assert.assertEquals(name, result.getName());
+        assertNotNull(result);
+        assertEquals(name, result.getName());
     }
 
     /**
@@ -102,7 +95,7 @@ public class ZeroConfServiceManagerTest {
      */
     @Test
     public void testKey_String_String() {
-        Assert.assertEquals("this.that", manager.key("THAT", "THIS"));
+        assertEquals("this.that", manager.key("THAT", "THIS"));
     }
 
     /**
@@ -111,7 +104,7 @@ public class ZeroConfServiceManagerTest {
     @Test
     public void testIsPublished() {
         ZeroConfService instance = manager.create(HTTP, 9999);
-        Assert.assertFalse(manager.isPublished(instance));
+        assertFalse(manager.isPublished(instance));
     }
 
     /**
@@ -120,14 +113,14 @@ public class ZeroConfServiceManagerTest {
     @Test
     public void testPublish() {
         ZeroConfService instance = manager.create(HTTP, 9999);
-        Assert.assertFalse(instance.isPublished());
-        Assert.assertFalse(manager.isPublished(instance));
+        assertFalse(instance.isPublished());
+        assertFalse(manager.isPublished(instance));
         // can fail if platform does not release earlier stopped service within 15 seconds
         manager.publish(instance);
-        Assume.assumeTrue("Timed out publishing ZeroConf Service", JUnitUtil.waitFor(() -> {
+        Assumptions.assumeTrue( JUnitUtil.waitFor(() -> {
             return manager.isPublished(instance) == true;
-        }));
-        Assert.assertTrue(manager.isPublished(instance));
+        }), "Timed out publishing ZeroConf Service");
+        assertTrue(manager.isPublished(instance));
     }
 
     /**
@@ -136,18 +129,18 @@ public class ZeroConfServiceManagerTest {
     @Test
     public void testStop() {
         ZeroConfService instance = manager.create(HTTP, 9999);
-        Assert.assertFalse(manager.isPublished(instance));
+        assertFalse(manager.isPublished(instance));
         // can fail if platform does not release earlier stopped service within 15 seconds
         manager.publish(instance);
-        Assume.assumeTrue("Timed out publishing ZeroConf Service", JUnitUtil.waitFor(() -> {
+        Assumptions.assumeTrue( JUnitUtil.waitFor(() -> {
             return manager.isPublished(instance) == true;
-        }));
-        Assert.assertTrue(manager.isPublished(instance));
+        }), "Timed out publishing ZeroConf Service");
+        assertTrue(manager.isPublished(instance));
         manager.stop(instance);
         JUnitUtil.waitFor(() -> {
             return manager.isPublished(instance) == false;
         }, "Stopping ZeroConf Service");
-        Assert.assertFalse(manager.isPublished(instance));
+        assertFalse(manager.isPublished(instance));
     }
 
     /**
@@ -156,18 +149,18 @@ public class ZeroConfServiceManagerTest {
     @Test
     public void testStopAll() {
         ZeroConfService instance = manager.create(HTTP, 9999);
-        Assert.assertFalse(manager.isPublished(instance));
+        assertFalse(manager.isPublished(instance));
         // can fail if platform does not release earlier stopped service within 15 seconds
         manager.publish(instance);
-        Assume.assumeTrue("Timed out publishing ZeroConf Service", JUnitUtil.waitFor(() -> {
+        Assumptions.assumeTrue( JUnitUtil.waitFor(() -> {
             return manager.isPublished(instance) == true;
-        }));
-        Assert.assertTrue(manager.isPublished(instance));
+        }), "Timed out publishing ZeroConf Service");
+        assertTrue(manager.isPublished(instance));
         manager.stopAll();
         JUnitUtil.waitFor(() -> {
             return manager.isPublished(instance) == false;
         }, "Stopping ZeroConf Service");
-        Assert.assertFalse(manager.isPublished(instance));
+        assertFalse(manager.isPublished(instance));
     }
 
     /**
@@ -175,35 +168,39 @@ public class ZeroConfServiceManagerTest {
      */
     @Test
     public void testAllServices() {
-        Assert.assertEquals(0, manager.allServices().size());
+        assertEquals(0, manager.allServices().size());
         ZeroConfService instance = manager.create(HTTP, 9999);
-        Assert.assertEquals(InstanceManager.getDefault(WebServerPreferences.class).getDefaultRailroadName(), instance.getName());
-        Assert.assertEquals(0, manager.allServices().size());
+        assertEquals(InstanceManager.getDefault(WebServerPreferences.class).getDefaultRailroadName(), instance.getName());
+        assertEquals(0, manager.allServices().size());
         // can fail if platform does not release earlier stopped service within 15 seconds
         manager.publish(instance);
-        Assume.assumeTrue("Timed out publishing ZeroConf Service", JUnitUtil.waitFor(() -> {
+        Assumptions.assumeTrue( JUnitUtil.waitFor(() -> {
             return manager.isPublished(instance) == true;
-        }));
-        Assert.assertEquals(1, manager.allServices().size());
+        }), "Timed out publishing ZeroConf Service");
+        assertEquals(1, manager.allServices().size());
     }
 
     @Test
     public void testHostNameString() {
-        Assert.assertEquals("Empty string to punycode", NodeIdentity.networkIdentity(), ZeroConfServiceManager.hostName(""));
-        Assert.assertEquals("Whitespace to punycode", NodeIdentity.networkIdentity(), ZeroConfServiceManager.hostName(""));
-        Assert.assertEquals("a b", "a-b", ZeroConfServiceManager.hostName("a b"));
-        Assert.assertEquals(".a.b", "a-b", ZeroConfServiceManager.hostName(".a.b"));
-        Assert.assertEquals("_a_b", "a-b", ZeroConfServiceManager.hostName("_a_b"));
-        Assert.assertEquals("My JMRI Railroad", "my-jmri-railroad", ZeroConfServiceManager.hostName("My JMRI Railroad"));
-        Assert.assertEquals("Very long name",
+        assertEquals( NodeIdentity.networkIdentity(), ZeroConfServiceManager.hostName(""),
+            "Empty string to punycode");
+        assertEquals( NodeIdentity.networkIdentity(), ZeroConfServiceManager.hostName(" "),
+            "Whitespace to punycode");
+        assertEquals( "a-b", ZeroConfServiceManager.hostName("a b"), "a b");
+        assertEquals( "a-b", ZeroConfServiceManager.hostName(".a.b"), ".a.b");
+        assertEquals( "a-b", ZeroConfServiceManager.hostName("_a_b"), "_a_b");
+        assertEquals( "my-jmri-railroad", ZeroConfServiceManager.hostName("My JMRI Railroad"), "My JMRI Railroad");
+        assertEquals(
                 "my-jmri-railroad-my-jmri-railroad-my-jmri-railroad-my-jmri-rail",
-                ZeroConfServiceManager.hostName("My JMRI Railroad My JMRI Railroad My JMRI Railroad My JMRI Railroad My JMRI Railroad My JMRI Railroad"));
-        Assert.assertEquals("Single emojii is name", "xn--w68h", ZeroConfServiceManager.hostName("🚞"));
-        Assert.assertEquals("Single emojii in name", "xn--my--railroad-je87k", ZeroConfServiceManager.hostName("My 🚞 Railroad"));
-        Assert.assertEquals("Multiple emojii in name", "xn--my--railroad-4277khl", ZeroConfServiceManager.hostName("My 🚂🚞 Railroad"));
-        Assert.assertEquals("Lots of emojii", "xn--358haaaa8nbbbb", ZeroConfServiceManager.hostName("🚂🚞🚂🚞🚂🚞🚂🚞🚂🚞"));
-        Assert.assertEquals("Very long name with emojii",
+                ZeroConfServiceManager.hostName("My JMRI Railroad My JMRI Railroad My JMRI Railroad My JMRI Railroad My JMRI Railroad My JMRI Railroad"),
+                "Very long name");
+        assertEquals( "xn--w68h", ZeroConfServiceManager.hostName("🚞"), "Single emojii is name");
+        assertEquals( "xn--my--railroad-je87k", ZeroConfServiceManager.hostName("My 🚞 Railroad"), "Single emojii in name");
+        assertEquals( "xn--my--railroad-4277khl", ZeroConfServiceManager.hostName("My 🚂🚞 Railroad"), "Multiple emojii in name");
+        assertEquals( "xn--358haaaa8nbbbb", ZeroConfServiceManager.hostName("🚂🚞🚂🚞🚂🚞🚂🚞🚂🚞"), "Lots of emojii");
+        assertEquals(
                 "xn--my--railroad-my--railroad-my--railroad-my-5g025bnan64joao",
-                ZeroConfServiceManager.hostName("My 🚂🚞 Railroad My 🚂🚞 Railroad My 🚂🚞 Railroad My 🚂🚞 Railroad My 🚂🚞 Railroad My 🚂🚞 Railroad"));
+                ZeroConfServiceManager.hostName("My 🚂🚞 Railroad My 🚂🚞 Railroad My 🚂🚞 Railroad My 🚂🚞 Railroad My 🚂🚞 Railroad My 🚂🚞 Railroad"),
+                "Very long name with emojii");
     }
 }


### PR DESCRIPTION
Use the network Identity if the host name is passed as a whitespace String. This now matches the JavaDoc for the hostName method, i.e. removing leading whitespace.

This now also matches the unit test comment, see amended test line 187 which was previously a duplicate of the test above, i.e. Whitespace to punycode, not just Empty strings to punycode.

Updates test asserts JU4  > JU5