### PR TITLE
Allow Disp. to clear locked route

### DIFF
--- a/java/src/jmri/jmrit/ctc/CodeButtonHandler.java
+++ b/java/src/jmri/jmrit/ctc/CodeButtonHandler.java
@@ -173,6 +173,15 @@ public class CodeButtonHandler {
 
     private void codeButtonStateChange(PropertyChangeEvent e) {
         if (e.getPropertyName().equals("KnownState") && (int)e.getNewValue() == Sensor.ACTIVE) {
+            
+//  NO MATTER what else happens, IF the dispatcher has Signals Indicator Normal lit, Signal Direction Lever Normal,
+//  and has press the Code Button, we DELETE any active routes FIRST, ALWAYS without question!
+//    private final SignalDirectionIndicatorsInterface _mSignalDirectionIndicators;
+//    private final SignalDirectionLever _mSignalDirectionLever;
+    if (_mSignalDirectionIndicators.signalsNormal() && getCurrentSignalDirectionLever(false) == CTCConstants.SIGNALSNORMAL) {
+      cancelLockedRoute();
+    }
+            
 //  NOTE: If the primary O.S. section is occupied, you CANT DO ANYTHING via a CTC machine, except:
 //  Preconditioning: IF the O.S. section is occupied, then it is a pre-conditioning request:
             if (isPrimaryOSSectionOccupied()) {

--- a/java/src/jmri/jmrit/ctc/CodeButtonHandler.java
+++ b/java/src/jmri/jmrit/ctc/CodeButtonHandler.java
@@ -173,15 +173,6 @@ public class CodeButtonHandler {
 
     private void codeButtonStateChange(PropertyChangeEvent e) {
         if (e.getPropertyName().equals("KnownState") && (int)e.getNewValue() == Sensor.ACTIVE) {
-            
-//  NO MATTER what else happens, IF the dispatcher has Signals Indicator Normal lit, Signal Direction Lever Normal,
-//  and has press the Code Button, we DELETE any active routes FIRST, ALWAYS without question!
-//    private final SignalDirectionIndicatorsInterface _mSignalDirectionIndicators;
-//    private final SignalDirectionLever _mSignalDirectionLever;
-    if (_mSignalDirectionIndicators.signalsNormal() && getCurrentSignalDirectionLever(false) == CTCConstants.SIGNALSNORMAL) {
-      cancelLockedRoute();
-    }
-            
 //  NOTE: If the primary O.S. section is occupied, you CANT DO ANYTHING via a CTC machine, except:
 //  Preconditioning: IF the O.S. section is occupied, then it is a pre-conditioning request:
             if (isPrimaryOSSectionOccupied()) {

--- a/nbactions.xml
+++ b/nbactions.xml
@@ -10,7 +10,7 @@
                 <goal>org.codehaus.mojo:exec-maven-plugin:1.5.0:exec</goal>
             </goals>
             <properties>
-                <exec.args>-classpath %classpath ${packageClassName}</exec.args>
+                <exec.args>-classpath %classpath apps.PanelPro.PanelPro</exec.args>
                 <exec.executable>java</exec.executable>
             </properties>
         </action>

--- a/nbactions.xml
+++ b/nbactions.xml
@@ -24,7 +24,7 @@
                 <goal>org.codehaus.mojo:exec-maven-plugin:1.5.0:exec</goal>
             </goals>
             <properties>
-                <exec.args>-agentlib:jdwp=transport=dt_socket,server=n,address=${jpda.address} -classpath %classpath apps.PanelPro.PanelPro</exec.args>
+                <exec.args>-agentlib:jdwp=transport=dt_socket,server=n,address=${jpda.address} -classpath %classpath ${packageClassName}</exec.args>
                 <exec.executable>java</exec.executable>
                 <jpda.listen>true</jpda.listen>
             </properties>

--- a/nbactions.xml
+++ b/nbactions.xml
@@ -24,7 +24,7 @@
                 <goal>org.codehaus.mojo:exec-maven-plugin:1.5.0:exec</goal>
             </goals>
             <properties>
-                <exec.args>-agentlib:jdwp=transport=dt_socket,server=n,address=${jpda.address} -classpath %classpath ${packageClassName}</exec.args>
+                <exec.args>-agentlib:jdwp=transport=dt_socket,server=n,address=${jpda.address} -classpath %classpath apps.PanelPro.PanelPro</exec.args>
                 <exec.executable>java</exec.executable>
                 <jpda.listen>true</jpda.listen>
             </properties>


### PR DESCRIPTION
Hardware problems, bad engineers etc. can cause CTC software to prematurely clear blocks, which could prevent the dispatcher from clearing further routes in the interlocking.  By setting the Signal Direction Lever to signals normal, having signal direction indicator to signals normal, and pressing the code button does the software cancel the locked route for this code button.