### PR TITLE
Add 'No Group' to the roster groups, and handle appropriately

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -424,7 +424,12 @@
     <h3>DecoderPro</h3>
         <a id="DecoderPro" name="DecoderPro"></a>
         <ul>
-            <li></li>
+            <li>DecoderPro now shows a "No Group" choice in the Roster Groups selector.
+                This contains all those roster entries that have not been 
+                assigned to a specific group.  You can delete roster entries
+                from the roster when displaying the "No Group" by selecting
+                the roster entry, then ctrl-clicking / right-clicking on it
+                and selecting "Delete from Roster".</li>
         </ul>
 
    <h3>Dispatcher</h3>

--- a/java/src/jmri/jmrit/roster/DeleteRosterItemAction.java
+++ b/java/src/jmri/jmrit/roster/DeleteRosterItemAction.java
@@ -21,7 +21,7 @@ import jmri.util.swing.WindowInterface;
  * posts a dialog box to select the loco to be deleted, and then posts an "are
  * you sure" dialog box before acting.
  *
- * @author Bob Jacobsen Copyright (C) 2001, 2002
+ * @author Bob Jacobsen Copyright (C) 2001, 2002, 2025
  * @see jmri.jmrit.XmlFile
  */
 public class DeleteRosterItemAction extends JmriAbstractAction {
@@ -88,7 +88,7 @@ public class DeleteRosterItemAction extends JmriAbstractAction {
 
             // prompt for one last chance
             log.debug("rosterGroup now {}", rosterGroup);
-            if (rosterGroup == null) {
+            if (rosterGroup == null || rosterGroup.equals(Roster.NOGROUP)) {
                 if (!userOK(re.titleString(), filename, fullFilename)) {
                     return;
                 }

--- a/java/src/jmri/jmrit/roster/JmritRosterBundle.properties
+++ b/java/src/jmri/jmrit/roster/JmritRosterBundle.properties
@@ -174,6 +174,7 @@ READMFGVER =  Read MFG version - CV 7
 LONG\ ADDRESS\ -\ READ\ CV\ 18 = Long address - read CV 18
 
 ALLENTRIES = All Entries
+NOGROUP    = No Group
 
 RosterEntryComboBoxNoSelection = Select Loco
 RosterGroupComboBoxNoGroups = No Groups

--- a/java/src/jmri/jmrit/roster/swing/CopyRosterGroupAction.java
+++ b/java/src/jmri/jmrit/roster/swing/CopyRosterGroupAction.java
@@ -72,7 +72,7 @@ public class CopyRosterGroupAction extends JmriAbstractAction {
         }
         // null might be valid output from getting the selectedRosterGroup,
         // so we have to check for null again.
-        if (group == null) {
+        if (group == null || group == Roster.NOGROUP) {
             group = (String) JmriJOptionPane.showInputDialog(_who,
                     Bundle.getMessage("DuplicateRosterGroupDialog"),
                     Bundle.getMessage("DuplicateRosterGroupTitle", ""),
@@ -81,8 +81,8 @@ public class CopyRosterGroupAction extends JmriAbstractAction {
                     Roster.getDefault().getRosterGroupList().toArray(),
                     null);
         }
-        // don't duplicate the null and ALLENTRIES groups (they are the entire roster)
-        if (group == null || group.equals(Roster.ALLENTRIES)) {
+        // don't duplicate the null, ALLENTRIES and NOGROUP groups (they are the entire roster)
+        if (group == null || group.equals(Roster.ALLENTRIES) || group.equals(Roster.NOGROUP)) {
             return;
         }
 
@@ -96,7 +96,7 @@ public class CopyRosterGroupAction extends JmriAbstractAction {
         if (entry != null) {
             entry = entry.trim(); // remove white space around name, also prevent "Space" as a Group name
         }
-        if (entry == null || entry.length() == 0 || entry.equals(Roster.ALLENTRIES)) {
+        if (entry == null || entry.length() == 0 || entry.equals(Roster.ALLENTRIES) || entry.equals(Roster.NOGROUP)) {
             return;
         } else if (Roster.getDefault().getRosterGroupList().contains(entry)) {
             JmriJOptionPane.showMessageDialog(_who,
@@ -105,7 +105,7 @@ public class CopyRosterGroupAction extends JmriAbstractAction {
                     JmriJOptionPane.ERROR_MESSAGE);
         }
 
-        // rename the roster grouping
+        // copy the roster grouping
         Roster.getDefault().copyRosterGroupList(group, entry);
         Roster.getDefault().writeRoster();
     }

--- a/java/src/jmri/jmrit/roster/swing/CreateRosterGroupAction.java
+++ b/java/src/jmri/jmrit/roster/swing/CreateRosterGroupAction.java
@@ -65,7 +65,7 @@ public class CreateRosterGroupAction extends JmriAbstractAction {
         if (entry != null) {
             entry = entry.trim(); // remove white space around name, also prevent "Space" as a Group name
         }
-        if (entry == null || entry.length() == 0 || entry.equals(Roster.ALLENTRIES)) {
+        if (entry == null || entry.length() == 0 || entry.equals(Roster.ALLENTRIES) || entry.equals(Roster.NOGROUP)) {
             return;
         }
         if (rosterEntries != null) {

--- a/java/src/jmri/jmrit/roster/swing/DeleteRosterGroupAction.java
+++ b/java/src/jmri/jmrit/roster/swing/DeleteRosterGroupAction.java
@@ -65,7 +65,7 @@ public class DeleteRosterGroupAction extends JmriAbstractAction {
         }
         // null might be valid output from getting the selectedRosterGroup,
         // so we have to check for null again.
-        if (group == null) {
+        if (group == null || group.equals(Roster.NOGROUP)) {
             group = (String) JmriJOptionPane.showInputDialog(_who,
                     Bundle.getMessage("DeleteRosterGroupDialog"),
                     Bundle.getMessage("DeleteRosterGroupTitle", ""),
@@ -74,8 +74,8 @@ public class DeleteRosterGroupAction extends JmriAbstractAction {
                     Roster.getDefault().getRosterGroupList().toArray(),
                     null);
         }
-        // can't delete the roster itself (ALLENTRIES and null represent the roster)
-        if (group == null || group.equals(Roster.ALLENTRIES)) {
+        // can't delete the roster itself (ALLENTRIES and null represent the roster) and NOGROUP
+        if (group == null || group.equals(Roster.ALLENTRIES) || group.equals(Roster.NOGROUP)) {
             return;
         }
         // prompt for one last chance

--- a/java/src/jmri/jmrit/roster/swing/RenameRosterGroupAction.java
+++ b/java/src/jmri/jmrit/roster/swing/RenameRosterGroupAction.java
@@ -68,7 +68,7 @@ public class RenameRosterGroupAction extends JmriAbstractAction {
         }
         // null might be valid output from getting the selectedRosterGroup,
         // so we have to check for null again.
-        if (group == null) {
+        if (group == null || group.equals(Roster.NOGROUP)) {
             group = (String) JmriJOptionPane.showInputDialog(_who,
                     Bundle.getMessage("RenameRosterGroupDialog"),
                     Bundle.getMessage("RenameRosterGroupTitle", ""),
@@ -78,7 +78,7 @@ public class RenameRosterGroupAction extends JmriAbstractAction {
                     null);
         }
         // can't rename the groups that represent the entire roster 
-        if (group == null || group.equals(Roster.ALLENTRIES)) {
+        if (group == null || group.equals(Roster.ALLENTRIES) || group.equals(Roster.NOGROUP)) {
             return;
         }
 

--- a/java/src/jmri/jmrit/roster/swing/RosterFrame.java
+++ b/java/src/jmri/jmrit/roster/swing/RosterFrame.java
@@ -1298,7 +1298,8 @@ public class RosterFrame extends TwoPaneTBWindow implements RosterEntrySelector,
             menuItem.setEnabled(false);
         }
         popupMenu.add(menuItem);
-        menuItem = new JMenuItem(this.getSelectedRosterGroup() != null ? Bundle.getMessage("DeleteFromGroup") : Bundle.getMessage("DeleteFromRoster")); // NOI18N
+        boolean deleteFromGroup = this.getSelectedRosterGroup() != null && !this.getSelectedRosterGroup().equals(Roster.NOGROUP);
+        menuItem = new JMenuItem(deleteFromGroup ? Bundle.getMessage("DeleteFromGroup") : Bundle.getMessage("DeleteFromRoster")); // NOI18N
         menuItem.addActionListener((ActionEvent e1) -> deleteLoco());
         popupMenu.add(menuItem);
         menuItem.setEnabled(this.getSelectedRosterEntries().length > 0);

--- a/java/src/jmri/jmrit/roster/swing/RosterGroupsPanel.java
+++ b/java/src/jmri/jmrit/roster/swing/RosterGroupsPanel.java
@@ -396,6 +396,7 @@ public class RosterGroupsPanel extends JPanel implements RosterGroupSelector {
         for (String g : Roster.getDefault().getRosterGroupList()) {
             root.add(new DefaultMutableTreeNode(g));
         }
+        root.add(new DefaultMutableTreeNode(Roster.NOGROUP));
     }
 
     // allow private classes to fire property change events as the RGP

--- a/java/src/jmri/jmrit/roster/swing/RosterTable.java
+++ b/java/src/jmri/jmrit/roster/swing/RosterTable.java
@@ -315,8 +315,16 @@ public class RosterTable extends JmriPanel implements RosterEntrySelector, Roste
                 re = entry;
                 int entries = dataTable.getRowCount();
                 for (int i = 0; i < entries; i++) {
-                    if (dataModel.getValueAt(sorter
-                        .convertRowIndexToModel(i), RosterTableModel.IDCOL).equals(re.getId())) {
+                                    
+                    // skip over entry being deleted from the group
+                    if (dataModel.getValueAt(sorter.convertRowIndexToModel(i), 
+                                                                RosterTableModel.IDCOL) == null) {
+                        continue;
+                    }
+
+                    if (dataModel.getValueAt(sorter.convertRowIndexToModel(i), 
+                                            RosterTableModel.IDCOL)
+                                    .equals(re.getId())) {
                         dataTable.addRowSelectionInterval(i, i);
                         foundIt = true;
                     }

--- a/java/test/jmri/server/json/roster/JsonRosterSocketServiceTest.java
+++ b/java/test/jmri/server/json/roster/JsonRosterSocketServiceTest.java
@@ -105,7 +105,7 @@ public class JsonRosterSocketServiceTest {
         // add a roster group and verify message sent by listener
         this.connection.sendMessage(null, 0);
         Roster.getDefault().addRosterGroup("NewRosterGroup");
-        Assert.assertEquals("Single message sent", 1, this.connection.getMessages().size());
+        Assert.assertEquals("Two replies sent", 2, this.connection.getMessages().size());
         message = this.connection.getMessage();
         Assert.assertNotNull("Message was sent", message);
         Assert.assertEquals("Three groups exist", 3, message.size());


### PR DESCRIPTION
DecoderPro will now show a "No Group" choice in the Roster Groups selector. 

This contains all those roster entries that have not been  assigned to a specific group.  You can delete roster entries from the roster when displaying the "No Group" by selecting the roster entry, then ctrl-clicking / right-clicking on it and selecting "Delete from Roster".