### PR TITLE
Layout Editor turnouts get an option to better indicate UNKNOWN state

### DIFF
--- a/help/en/package/jmri/jmrit/display/LayoutEditor.shtml
+++ b/help/en/package/jmri/jmrit/display/LayoutEditor.shtml
@@ -1158,7 +1158,12 @@
       <p>Turnout drawings in a track diagram are drawn using solid lines for both continuing and
       diverging legs until the turnout drawings are linked to turnouts in the Turnout Table. Once
       linked to actual turnouts, turnout drawings show the "known states" of the turnouts they
-      represent. After linking, you can toggle each turnout on your layout by clicking on the
+      represent. When the turnout's state is UNKNOWN, both legs of the turnout are drawn.
+      You can change this to drawing a "?" character instead using the contextual
+      menu on the turnout.
+      </p>
+      
+      <p>After linking, you can toggle each turnout on your layout by clicking on the
       center point of its drawing (provided <strong>Disabled</strong> is not checked in the Options
       menu, and your system supports computer control of turnouts). The ability to toggle by
       clicking can be turned off by checking <strong>Disabled</strong> in the turnout's popup menu.

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -448,7 +448,11 @@
     <h3>Layout Editor</h3>
         <a id="LE" name="LE"></a>
         <ul>
-            <li></li>
+            <li>Normally, Layout Editor turnouts in UNKNOWN state are indicated
+                by drawing both legs of the turnout, instead of showing just one
+                as for CLOSED and THROWN.  There's a new option 'Show ? When Unknown'
+                in the turnout's contextual menu that will make the UNKNOWN state
+                more visible.</li>
         </ul>
 
         <h4>NX - Entry/Exit Tool</h4>

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorBundle.properties
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorBundle.properties
@@ -323,6 +323,7 @@ Mainline = Mainline Track
 NotMainline = Side Track
 Hidden = Hidden
 NotHidden = Not Hidden
+ShowUnknown = Show ? When Unknown
 DisabledWhenOccupied = Disable When Occupied
 Momentary = Momentary
 Tooltip = Tooltip

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutTurnoutView.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutTurnoutView.java
@@ -259,6 +259,8 @@ public class LayoutTurnoutView extends LayoutTrackView {
     public Point2D pointC = new Point2D.Double(60, 20);
     public Point2D pointD = new Point2D.Double(20, 20);
 
+    public boolean showUnknown = false; // if true, show "?" when state is UNKNOWN
+    
     private int version = 1;
 
     private final boolean useBlockSpeed = false;
@@ -462,6 +464,14 @@ public class LayoutTurnoutView extends LayoutTrackView {
         turnout.removeBeanReference(nb);
     }
 
+    public void setShowUnknown(boolean show) {
+        showUnknown = show;
+    }
+    
+    public boolean getShowUnknown() {
+        return showUnknown;
+    }
+    
     /**
      * {@inheritDoc}
      */
@@ -1695,6 +1705,14 @@ public class LayoutTurnoutView extends LayoutTrackView {
                 setHidden(o.isSelected());
             });
 
+            JCheckBoxMenuItem showUnknownCheckBoxMenuItem = new JCheckBoxMenuItem(Bundle.getMessage("ShowUnknown"));
+            hiddenCheckBoxMenuItem.setSelected(getShowUnknown());
+            popup.add(showUnknownCheckBoxMenuItem);
+            showUnknownCheckBoxMenuItem.addActionListener( e1 -> {
+                JCheckBoxMenuItem o = (JCheckBoxMenuItem) e1.getSource();
+                setShowUnknown(o.isSelected());
+            });
+            
             JCheckBoxMenuItem cbmi = new JCheckBoxMenuItem(Bundle.getMessage("Disabled"));
             cbmi.setSelected(isDisabled());
             popup.add(cbmi);
@@ -2035,6 +2053,13 @@ public class LayoutTurnoutView extends LayoutTrackView {
         }
 
         TurnoutType type = getTurnoutType();
+
+        // Just "?" if UNKNOWN and showUnknown requesting
+        if (showUnknown && state == UNKNOWN) {
+            g2.drawString("?", (float) pM.getX(), (float) pM.getY());
+            return;
+        }    
+
         if (type == TurnoutType.DOUBLE_XOVER) {
             if (state != Turnout.THROWN && state != INCONSISTENT) { // unknown or continuing path - not crossed over
                 if (isMain == mainlineA) {
@@ -2272,6 +2297,7 @@ public class LayoutTurnoutView extends LayoutTrackView {
         } else if (isTurnoutTypeSlip()) {
             log.error("{}.draw1(...); slips should be being drawn by LayoutSlip sub-class", getName());
         } else {    // LH, RH, or WYE Turnouts
+                            
             // draw A<===>center
             if (isMain == mainlineA) {
                 g2.setColor(colorA);

--- a/java/src/jmri/jmrit/display/layoutEditor/configurexml/LayoutTurnoutViewXml.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/configurexml/LayoutTurnoutViewXml.java
@@ -50,6 +50,11 @@ public class LayoutTurnoutViewXml extends LayoutTrackViewXml {
         element.setAttribute("disabled", "" + (p.isDisabled() ? "yes" : "no"));
         element.setAttribute("disableWhenOccupied", "" + (p.isDisabledWhenOccupied() ? "yes" : "no"));
 
+        if (pv.getShowUnknown()) {
+            // only write if set for background compatibility
+            element.setAttribute("showunknown", "yes");
+        }
+        
         if (p.showToolTip()) {
             element.setAttribute("showtooltip", "yes");
         }
@@ -405,6 +410,14 @@ public class LayoutTurnoutViewXml extends LayoutTrackViewXml {
             }
         }
 
+        lv.setShowUnknown(false);
+        a = element.getAttribute("showunknown");
+        if (a != null) {
+            if ("yes".equals(a.getValue())) {
+                lv.setShowUnknown(true);
+            }
+        }
+        
         if (version == 2) {
             try {
                 x = element.getAttribute("xa").getFloatValue();

--- a/xml/schema/types/editors.xsd
+++ b/xml/schema/types/editors.xsd
@@ -1429,6 +1429,7 @@
       <xs:attribute name="ver" type="xs:integer"></xs:attribute>
 
       <xs:attribute name="hidden" type="yesNoType"></xs:attribute>
+      <xs:attribute name="showunknown" type="yesNoType"></xs:attribute>
       <xs:attribute name="disabled" type="yesNoType"></xs:attribute>
       <xs:attribute name="disableWhenOccupied" type="yesNoType"></xs:attribute>
       <xs:attribute name="showtooltip" type="yesNoType"></xs:attribute>


### PR DESCRIPTION
Now, a Layout Editor turnout in UNKNOWN state is indicated by drawing both normal and diverging legs of the turnout/crossover.  This can be hard to notice.

This PR adds an option to the contextual menu of a layout turnout:  "Show ? When Unknown", along with associated store and load in the panel file.  When set true, this option replaces the drawing of both legs with a "?" character.  This is similar to what the default turnout icons do in Panel Editor.

Note that this does not change the appearance of existing LE panels:  You have to deliberately change this option via the contextual menu for it to have any effect.
