### PR TITLE
update JsonThrottleSocketService Test

### DIFF
--- a/java/test/jmri/server/json/throttle/JsonThrottleSocketServiceTest.java
+++ b/java/test/jmri/server/json/throttle/JsonThrottleSocketServiceTest.java
@@ -1,5 +1,8 @@
 package jmri.server.json.throttle;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.Locale;
@@ -18,11 +21,13 @@ import jmri.server.json.roster.JsonRoster;
 import jmri.util.JUnitAppender;
 import jmri.util.JUnitUtil;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.*;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  *
@@ -36,13 +41,12 @@ public class JsonThrottleSocketServiceTest {
     public void testOnList() {
         JsonMockConnection connection = new JsonMockConnection((DataOutputStream) null);
         JsonThrottleSocketService service = new JsonThrottleSocketService(connection);
-        try {
-            service.onList(JsonThrottle.THROTTLE, connection.getObjectMapper().createObjectNode(), new JsonRequest(locale, JSON.V5, JSON.GET, 42));
-            Assert.fail("Expected exception not thrown");
-        } catch (JsonException ex) {
-            Assert.assertEquals("Error code is HTTP Bad Request", 400, ex.getCode());
-            Assert.assertEquals("Error message", "throttle cannot be listed.", ex.getMessage());
-        }
+        JsonException ex = assertThrows( JsonException.class, () ->
+            service.onList(JsonThrottle.THROTTLE, connection.getObjectMapper().createObjectNode(),
+                new JsonRequest(locale, JSON.V5, JSON.GET, 42))
+            ,"Expected exception not thrown");
+        assertEquals( 400, ex.getCode(), "Error code is HTTP Bad Request");
+        assertEquals( "throttle cannot be listed.", ex.getMessage(), "Error message");
     }
 
     /**
@@ -58,86 +62,86 @@ public class JsonThrottleSocketServiceTest {
         JsonMockConnection connection = new JsonMockConnection((DataOutputStream) null);
         JsonThrottleSocketService service = new JsonThrottleSocketService(connection);
         JsonThrottleManager manager = InstanceManager.getDefault(JsonThrottleManager.class);
-        Assert.assertEquals("No throttles", 0, manager.getThrottles().size());
+        assertEquals( 0, manager.getThrottles().size(), "No throttles");
         ObjectNode data = connection.getObjectMapper().createObjectNode();
         // get the throttle
         data.put(JSON.NAME, "42").put(JSON.ADDRESS, 42);
         service.onMessage(JsonThrottle.THROTTLE, data, new JsonRequest(locale, JSON.V5, JSON.POST, 42));
-        Assert.assertEquals("One throttle", 1, manager.getThrottles().size());
+        assertEquals( 1, manager.getThrottles().size(), "One throttle");
         JsonNode message = connection.getMessage();
-        Assert.assertNotNull(message);
-        Assert.assertEquals("Address", 42, message.path(JSON.DATA).path(JSON.ADDRESS).asInt());
-        Assert.assertEquals("Speed", 0.0, message.path(JSON.DATA).path(JSON.SPEED).asDouble(), 0.0);
-        Assert.assertTrue("Forward", message.path(JSON.DATA).path(JSON.FORWARD).asBoolean());
-        Assert.assertEquals("Speed Steps", 126, message.path(JSON.DATA).path(JsonThrottle.SPEED_STEPS).asInt());
-        Assert.assertEquals("Clients", 1, message.path(JSON.DATA).path(JsonThrottle.CLIENTS).asInt());
-        Assert.assertEquals("Throttle", "42", message.path(JSON.DATA).path(JSON.NAME).asText());
-        Assert.assertEquals("Throttle", "42", message.path(JSON.DATA).path(JsonThrottle.THROTTLE).asText());
-        Assert.assertEquals("Throttle status has 36 data elements", 36, message.findPath(JSON.DATA).size());
+        assertNotNull(message);
+        assertEquals( 42, message.path(JSON.DATA).path(JSON.ADDRESS).asInt(), "Address");
+        assertEquals( 0.0, message.path(JSON.DATA).path(JSON.SPEED).asDouble(), 0.0, "Speed");
+        assertTrue( message.path(JSON.DATA).path(JSON.FORWARD).asBoolean(), "Forward");
+        assertEquals( 126, message.path(JSON.DATA).path(JsonThrottle.SPEED_STEPS).asInt(), "Speed Steps");
+        assertEquals( 1, message.path(JSON.DATA).path(JsonThrottle.CLIENTS).asInt(), "Clients");
+        assertEquals( "42", message.path(JSON.DATA).path(JSON.NAME).asText(), "Throttle");
+        assertEquals( "42", message.path(JSON.DATA).path(JsonThrottle.THROTTLE).asText(), "Throttle");
+        assertEquals( 36, message.findPath(JSON.DATA).size(), "Throttle status has 36 data elements");
         connection.sendMessage(null, 42); // clear messages
         // set a speed of 50% in reverse
         data = connection.getObjectMapper().createObjectNode().put(JSON.NAME, "42");
         data.put(JSON.SPEED, 0.5);
         data.put(JSON.FORWARD, false);
-        Assert.assertTrue("No address", data.path(JSON.ADDRESS).isMissingNode());
+        assertTrue( data.path(JSON.ADDRESS).isMissingNode(), "No address");
         service.onMessage(JsonThrottle.THROTTLE, data, new JsonRequest(locale, JSON.V5, JSON.POST, 42));
         message = connection.getMessages(); // should be two messages, first speed change, then direction change
-        Assert.assertNotNull(message);
-        Assert.assertTrue(message.isArray());
-        Assert.assertEquals("Two messages", 2, message.size());
-        Assert.assertEquals("Speed", 0.5, message.path(0).path(JSON.DATA).path(JSON.SPEED).asDouble(), 0.0);
-        Assert.assertEquals("Throttle", "42", message.path(0).path(JSON.DATA).path(JsonThrottle.THROTTLE).asText());
-        Assert.assertEquals("Throttle change has two elements", 2, message.path(0).size());
-        Assert.assertFalse("Forward", message.path(1).path(JSON.DATA).path(JSON.FORWARD).asBoolean());
-        Assert.assertEquals("Throttle", "42", message.path(1).path(JSON.DATA).path(JSON.NAME).asText());
-        Assert.assertEquals("Throttle", "42", message.path(1).path(JSON.DATA).path(JsonThrottle.THROTTLE).asText());
-        Assert.assertEquals("Throttle change has two elements", 2, message.path(1).size());
+        assertNotNull(message);
+        assertTrue(message.isArray());
+        assertEquals( 2, message.size(), "Two messages");
+        assertEquals( 0.5, message.path(0).path(JSON.DATA).path(JSON.SPEED).asDouble(), 0.0, "Speed");
+        assertEquals( "42", message.path(0).path(JSON.DATA).path(JsonThrottle.THROTTLE).asText(), "Throttle");
+        assertEquals( 2, message.path(0).size(), "Throttle change has two elements");
+        assertFalse( message.path(1).path(JSON.DATA).path(JSON.FORWARD).asBoolean(), "Forward");
+        assertEquals( "42", message.path(1).path(JSON.DATA).path(JSON.NAME).asText(), "Throttle");
+        assertEquals( "42", message.path(1).path(JSON.DATA).path(JsonThrottle.THROTTLE).asText(), "Throttle");
+        assertEquals( 2, message.path(1).size(), "Throttle change has two elements");
         // request status
         data = connection.getObjectMapper().createObjectNode().put(JSON.NAME, "42");
         data.putNull(JSON.STATUS);
         service.onMessage(JsonThrottle.THROTTLE, data, new JsonRequest(locale, JSON.V5, JSON.POST, 42));
         message = connection.getMessage();
-        Assert.assertNotNull(message);
-        Assert.assertEquals("Address", 42, message.path(JSON.DATA).path(JSON.ADDRESS).asInt());
-        Assert.assertEquals("Speed", 0.5, message.path(JSON.DATA).path(JSON.SPEED).asDouble(), 0.0);
-        Assert.assertFalse("Forward", message.path(JSON.DATA).path(JSON.FORWARD).asBoolean());
-        Assert.assertEquals("Speed Steps", 126, message.path(JSON.DATA).path(JsonThrottle.SPEED_STEPS).asInt());
-        Assert.assertEquals("Clients", 1, message.path(JSON.DATA).path(JsonThrottle.CLIENTS).asInt());
-        Assert.assertEquals("Throttle", "42", message.path(JSON.DATA).path(JSON.NAME).asText());
-        Assert.assertEquals("Throttle", "42", message.path(JSON.DATA).path(JsonThrottle.THROTTLE).asText());
-        Assert.assertEquals("Throttle status has 36 data elements", 36, message.findPath(JSON.DATA).size());
+        assertNotNull(message);
+        assertEquals( 42, message.path(JSON.DATA).path(JSON.ADDRESS).asInt(), "Address");
+        assertEquals( 0.5, message.path(JSON.DATA).path(JSON.SPEED).asDouble(), 0.0, "Speed");
+        assertFalse( message.path(JSON.DATA).path(JSON.FORWARD).asBoolean(), "Forward");
+        assertEquals( 126, message.path(JSON.DATA).path(JsonThrottle.SPEED_STEPS).asInt(), "Speed Steps");
+        assertEquals( 1, message.path(JSON.DATA).path(JsonThrottle.CLIENTS).asInt(), "Clients");
+        assertEquals( "42", message.path(JSON.DATA).path(JSON.NAME).asText(), "Throttle");
+        assertEquals( "42", message.path(JSON.DATA).path(JsonThrottle.THROTTLE).asText(), "Throttle");
+        assertEquals( 36, message.findPath(JSON.DATA).size(), "Throttle status has 36 data elements");
         // Emergency Stop
         data = connection.getObjectMapper().createObjectNode().put(JSON.NAME, "42");
         data.putNull(JsonThrottle.ESTOP);
         service.onMessage(JsonThrottle.THROTTLE, data, new JsonRequest(locale, JSON.V5, JSON.POST, 42));
         message = connection.getMessage();
-        Assert.assertNotNull(message);
-        Assert.assertEquals("Speed", -1.0, message.path(JSON.DATA).path(JSON.SPEED).asDouble(), 0.0);
-        Assert.assertEquals("Throttle", "42", message.path(JSON.DATA).path(JSON.NAME).asText());
-        Assert.assertEquals("Throttle", "42", message.path(JSON.DATA).path(JsonThrottle.THROTTLE).asText());
-        Assert.assertEquals("Throttle change has two elements", 2, message.size());
+        assertNotNull(message);
+        assertEquals( -1.0, message.path(JSON.DATA).path(JSON.SPEED).asDouble(), 0.0, "Speed");
+        assertEquals( "42", message.path(JSON.DATA).path(JSON.NAME).asText(), "Throttle");
+        assertEquals( "42", message.path(JSON.DATA).path(JsonThrottle.THROTTLE).asText(), "Throttle");
+        assertEquals( 2, message.size(), "Throttle change has two elements");
         // Idle
         data = connection.getObjectMapper().createObjectNode().put(JSON.NAME, "42");
         data.putNull(JsonThrottle.IDLE);
         service.onMessage(JsonThrottle.THROTTLE, data, new JsonRequest(locale, JSON.V5, JSON.POST, 42));
         message = connection.getMessage();
-        Assert.assertNotNull(message);
-        Assert.assertEquals("Speed", 0.0, message.path(JSON.DATA).path(JSON.SPEED).asDouble(), 0.0);
-        Assert.assertEquals("Throttle", "42", message.path(JSON.DATA).path(JSON.NAME).asText());
-        Assert.assertEquals("Throttle", "42", message.path(JSON.DATA).path(JsonThrottle.THROTTLE).asText());
-        Assert.assertEquals("Throttle change has two elements", 2, message.size());
+        assertNotNull(message);
+        assertEquals( 0.0, message.path(JSON.DATA).path(JSON.SPEED).asDouble(), 0.0, "Speed");
+        assertEquals( "42", message.path(JSON.DATA).path(JSON.NAME).asText(), "Throttle");
+        assertEquals( "42", message.path(JSON.DATA).path(JsonThrottle.THROTTLE).asText(), "Throttle");
+        assertEquals( 2, message.size(), "Throttle change has two elements");
         // release
         data = connection.getObjectMapper().createObjectNode().put(JSON.NAME, "42");
         data.putNull(JsonThrottle.RELEASE);
         service.onMessage(JsonThrottle.THROTTLE, data, new JsonRequest(locale, JSON.V5, JSON.POST, 42));
         message = connection.getMessage();
-        Assert.assertNotNull(message);
-        Assert.assertTrue("Release", message.path(JSON.DATA).path(JsonThrottle.RELEASE).isNull());
-        Assert.assertEquals("Throttle", "42", message.path(JSON.DATA).path(JSON.NAME).asText());
-        Assert.assertEquals("Throttle", "42", message.path(JSON.DATA).path(JsonThrottle.THROTTLE).asText());
-        Assert.assertEquals("Throttle change has two elements", 2, message.size());
+        assertNotNull(message);
+        assertTrue( message.path(JSON.DATA).path(JsonThrottle.RELEASE).isNull(), "Release");
+        assertEquals( "42", message.path(JSON.DATA).path(JSON.NAME).asText(), "Throttle");
+        assertEquals( "42", message.path(JSON.DATA).path(JsonThrottle.THROTTLE).asText(), "Throttle");
+        assertEquals( 2, message.size(), "Throttle change has two elements");
         service.onClose();
-        Assert.assertEquals("No throttles", 0, manager.getThrottles().size());
+        assertEquals( 0, manager.getThrottles().size(), "No throttles");
     }
 
     /**
@@ -155,7 +159,7 @@ public class JsonThrottleSocketServiceTest {
         JsonMockConnection connection = new JsonMockConnection((DataOutputStream) null);
         JsonThrottleSocketService service = new JsonThrottleSocketService(connection);
         JsonThrottleManager manager = InstanceManager.getDefault(JsonThrottleManager.class);
-        Assert.assertEquals("No throttles", 0, manager.getThrottles().size());
+        assertEquals( 0, manager.getThrottles().size(), "No throttles");
         ObjectNode data = connection.getObjectMapper().createObjectNode();
         RosterEntry re = new RosterEntry();
         re.setOpen(true); // prevent writes when the AbstractThrottle gets released
@@ -165,67 +169,67 @@ public class JsonThrottleSocketServiceTest {
         re.setFunctionLockable(0, true);
         re.setFunctionLockable(1, false);
         Roster.getDefault().addEntry(re);
-        // get the throttle
-        data.put(JsonThrottle.THROTTLE, "42").put(JsonRoster.ROSTER_ENTRY, 42);
+        // get the throttle by JSON.NAME
+        data.put(JSON.NAME, "42").put(JsonRoster.ROSTER_ENTRY, 42);
         service.onMessage(JsonThrottle.THROTTLE, data, new JsonRequest(locale, JSON.V5, JSON.POST, 42));
-        Assert.assertEquals("One throttle", 1, manager.getThrottles().size());
+        assertEquals( 1, manager.getThrottles().size(), "One throttle");
         Throttle throttle = manager.get(new DccLocoAddress(3, false)).getThrottle();
-        throttle.setF0Momentary(!re.getFunctionLockable(0));
-        throttle.setF1Momentary(!re.getFunctionLockable(1));
-        Assert.assertFalse("F0 is not momentary", throttle.getFunctionMomentary(0));
-        Assert.assertTrue("F1 is momentary", throttle.getFunctionMomentary(1));
+        throttle.setFunctionMomentary( 0, !re.getFunctionLockable(0));
+        throttle.setFunctionMomentary( 1, !re.getFunctionLockable(1));
+        assertFalse( throttle.getFunctionMomentary(0), "F0 is not momentary");
+        assertTrue( throttle.getFunctionMomentary(1), "F1 is momentary");
         JsonNode message = connection.getMessage();
-        Assert.assertNotNull(message);
-        Assert.assertEquals("Address", 3, message.path(JSON.DATA).path(JSON.ADDRESS).asInt());
-        Assert.assertEquals("Speed", 0.0, message.path(JSON.DATA).path(JSON.SPEED).asDouble(), 0.0);
-        Assert.assertTrue("Forward", message.path(JSON.DATA).path(JSON.FORWARD).asBoolean());
-        Assert.assertEquals("Speed Steps", 126, message.path(JSON.DATA).path(JsonThrottle.SPEED_STEPS).asInt());
-        Assert.assertEquals("Clients", 1, message.path(JSON.DATA).path(JsonThrottle.CLIENTS).asInt());
-        Assert.assertFalse(F0, message.path(JSON.DATA).path(F0).asBoolean());
-        Assert.assertFalse(F1, message.path(JSON.DATA).path(F1).asBoolean());
-        Assert.assertEquals("Throttle", "42", message.path(JSON.DATA).path(JSON.NAME).asText());
-        Assert.assertEquals("Throttle", "42", message.path(JSON.DATA).path(JsonThrottle.THROTTLE).asText());
-        Assert.assertEquals("Throttle status has 37 data elements", 37, message.findPath(JSON.DATA).size());
+        assertNotNull(message);
+        assertEquals( 3, message.path(JSON.DATA).path(JSON.ADDRESS).asInt(), "Address");
+        assertEquals( 0.0, message.path(JSON.DATA).path(JSON.SPEED).asDouble(), 0.0, "Speed");
+        assertTrue( message.path(JSON.DATA).path(JSON.FORWARD).asBoolean(), "Forward");
+        assertEquals( 126, message.path(JSON.DATA).path(JsonThrottle.SPEED_STEPS).asInt(), "Speed Steps");
+        assertEquals( 1, message.path(JSON.DATA).path(JsonThrottle.CLIENTS).asInt(), "Clients");
+        assertFalse( message.path(JSON.DATA).path(F0).asBoolean(), F0);
+        assertFalse( message.path(JSON.DATA).path(F1).asBoolean(), F1);
+        assertEquals( "42", message.path(JSON.DATA).path(JSON.NAME).asText(), "Throttle");
+        assertEquals( "42", message.path(JSON.DATA).path(JsonThrottle.THROTTLE).asText(), "Throttle");
+        assertEquals( 37, message.findPath(JSON.DATA).size(), "Throttle status has 37 data elements");
         connection.sendMessage(null, 42); // clear messages
         // press F1 and F2
         data = connection.getObjectMapper().createObjectNode().put(JSON.NAME, "42");
         data.put(F0, true);
         data.put(F1, true);
-        Assert.assertTrue("No address", data.path(JSON.ADDRESS).isMissingNode());
+        assertTrue( data.path(JSON.ADDRESS).isMissingNode(), "No address");
         service.onMessage(JsonThrottle.THROTTLE, data, new JsonRequest(locale, JSON.V5, JSON.POST, 42));
         message = connection.getMessages(); // should be two messages, first speed change, then direction change
-        Assert.assertNotNull(message);
-        Assert.assertTrue(message.isArray());
-        Assert.assertEquals("Two messages", 2, message.size());
-        Assert.assertFalse("F0 exists", message.path(0).path(JSON.DATA).path(F0).isMissingNode());
-        Assert.assertTrue("F0 becomes true", message.path(0).path(JSON.DATA).path(F0).asBoolean());
-        Assert.assertEquals("Throttle", "42", message.path(0).path(JSON.DATA).path(JSON.NAME).asText());
-        Assert.assertEquals("Throttle", "42", message.path(0).path(JSON.DATA).path(JsonThrottle.THROTTLE).asText());
-        Assert.assertEquals("Throttle change has two elements", 2, message.path(0).size());
-        Assert.assertFalse("F1 exists", message.path(1).path(JSON.DATA).path(F1).isMissingNode());
-        Assert.assertTrue("F1 becomes true", message.path(1).path(JSON.DATA).path(F1).asBoolean());
-        Assert.assertEquals("Throttle", "42", message.path(1).path(JSON.DATA).path(JSON.NAME).asText());
-        Assert.assertEquals("Throttle", "42", message.path(1).path(JSON.DATA).path(JsonThrottle.THROTTLE).asText());
-        Assert.assertEquals("Throttle change has two elements", 2, message.path(1).size());
+        assertNotNull(message);
+        assertTrue(message.isArray());
+        assertEquals( 2, message.size(), "Two messages");
+        assertFalse( message.path(0).path(JSON.DATA).path(F0).isMissingNode(), "F0 exists");
+        assertTrue( message.path(0).path(JSON.DATA).path(F0).asBoolean(), "F0 becomes true");
+        assertEquals( "42", message.path(0).path(JSON.DATA).path(JSON.NAME).asText(), "Throttle");
+        assertEquals( "42", message.path(0).path(JSON.DATA).path(JsonThrottle.THROTTLE).asText(), "Throttle");
+        assertEquals( 2, message.path(0).size(), "Throttle change has two elements");
+        assertFalse( message.path(1).path(JSON.DATA).path(F1).isMissingNode(), "F1 exists");
+        assertTrue( message.path(1).path(JSON.DATA).path(F1).asBoolean(), "F1 becomes true");
+        assertEquals( "42", message.path(1).path(JSON.DATA).path(JSON.NAME).asText(), "Throttle");
+        assertEquals( "42", message.path(1).path(JSON.DATA).path(JsonThrottle.THROTTLE).asText(), "Throttle");
+        assertEquals( 2, message.path(1).size(), "Throttle change has two elements");
         // request status
         data = connection.getObjectMapper().createObjectNode().put(JSON.NAME, "42");
         data.putNull(JSON.STATUS);
         service.onMessage(JsonThrottle.THROTTLE, data, new JsonRequest(locale, JSON.V5, JSON.POST, 42));
         message = connection.getMessage();
-        Assert.assertNotNull(message);
-        Assert.assertEquals("Address", 3, message.path(JSON.DATA).path(JSON.ADDRESS).asInt());
-        Assert.assertEquals("Speed", 0.0, message.path(JSON.DATA).path(JSON.SPEED).asDouble(), 0.0);
-        Assert.assertTrue("Forward", message.path(JSON.DATA).path(JSON.FORWARD).asBoolean());
-        Assert.assertEquals("Speed Steps", 126, message.path(JSON.DATA).path(JsonThrottle.SPEED_STEPS).asInt());
-        Assert.assertEquals("Clients", 1, message.path(JSON.DATA).path(JsonThrottle.CLIENTS).asInt());
-        Assert.assertTrue(F0, message.path(JSON.DATA).path(F0).asBoolean());
-        Assert.assertTrue(F1, message.path(JSON.DATA).path(F1).asBoolean());
-        Assert.assertEquals("Throttle", "42", message.path(JSON.DATA).path(JSON.NAME).asText());
-        Assert.assertEquals("Throttle", "42", message.path(JSON.DATA).path(JsonThrottle.THROTTLE).asText());
-        Assert.assertEquals("Throttle status has 37 data elements", 37, message.findPath(JSON.DATA).size());
+        assertNotNull(message);
+        assertEquals( 3, message.path(JSON.DATA).path(JSON.ADDRESS).asInt(), "Address");
+        assertEquals( 0.0, message.path(JSON.DATA).path(JSON.SPEED).asDouble(), 0.0, "Speed");
+        assertTrue( message.path(JSON.DATA).path(JSON.FORWARD).asBoolean(), "Forward");
+        assertEquals( 126, message.path(JSON.DATA).path(JsonThrottle.SPEED_STEPS).asInt(), "Speed Steps");
+        assertEquals( 1, message.path(JSON.DATA).path(JsonThrottle.CLIENTS).asInt(), "Clients");
+        assertTrue( message.path(JSON.DATA).path(F0).asBoolean(), F0);
+        assertTrue( message.path(JSON.DATA).path(F1).asBoolean(), F1);
+        assertEquals( "42", message.path(JSON.DATA).path(JSON.NAME).asText(), "Throttle");
+        assertEquals( "42", message.path(JSON.DATA).path(JsonThrottle.THROTTLE).asText(), "Throttle");
+        assertEquals( 37, message.findPath(JSON.DATA).size(), "Throttle status has 37 data elements");
         // Close without release
         service.onClose();
-        Assert.assertEquals("No throttles", 0, manager.getThrottles().size());
+        assertEquals( 0, manager.getThrottles().size(), "No throttles");
         JUnitAppender.assertWarnMessage("Roster Entry 42 running time not saved as entry is already open for editing");
     }
 
@@ -246,51 +250,59 @@ public class JsonThrottleSocketServiceTest {
         JsonMockConnection connection2 = new JsonMockConnection((DataOutputStream) null);
         JsonThrottleSocketService service2 = new JsonThrottleSocketService(connection2);
         JsonThrottleManager manager = InstanceManager.getDefault(JsonThrottleManager.class);
-        Assert.assertEquals("No throttles", 0, manager.getThrottles().size());
+        assertEquals( 0, manager.getThrottles().size(), "No throttles");
         ObjectNode data1 = connection1.getObjectMapper().createObjectNode().put(JsonThrottle.THROTTLE, "client1");
         ObjectNode data2 = connection2.getObjectMapper().createObjectNode().put(JsonThrottle.THROTTLE, "client2");
+        // get the throttle by JsonThrottle.THROTTLE produces WARN client1
         service1.onMessage(JsonThrottle.THROTTLE, data1.put(JSON.ADDRESS, 3), new JsonRequest(locale, JSON.V5, JSON.POST, 42));
+        JUnitAppender.assertWarnMessage("JSON throttle \"client1\" requested using \"throttle\" instead of \"name\"");
         JsonNode message1 = connection1.getMessage();
-        Assert.assertNotNull(message1);
-        Assert.assertEquals("One client", 1, message1.path(JSON.DATA).path(JsonThrottle.CLIENTS).asInt());
+        assertNotNull(message1);
+        assertEquals( 1, message1.path(JSON.DATA).path(JsonThrottle.CLIENTS).asInt(), "One client");
         service2.onMessage(JsonThrottle.THROTTLE, data2.put(JSON.ADDRESS, 3), new JsonRequest(locale, JSON.V5, JSON.POST, 42));
-        Assert.assertEquals("One throttle", 1, manager.getThrottles().size());
-        Assert.assertEquals("Two services", 2, manager.getServers(manager.get(new DccLocoAddress(3, false))).size());
+        // get the throttle by JsonThrottle.THROTTLE produces WARN client2
+        JUnitAppender.assertWarnMessage("JSON throttle \"client2\" requested using \"throttle\" instead of \"name\"");
+        assertEquals( 1, manager.getThrottles().size(), "One throttle");
+        assertEquals( 2, manager.getServers(manager.get(new DccLocoAddress(3, false))).size(), "Two services");
         message1 = connection1.getMessage();
-        Assert.assertNotNull(message1);
-        Assert.assertEquals("Two clients", 2, message1.path(JSON.DATA).path(JsonThrottle.CLIENTS).asInt());
-        Assert.assertEquals("Client 1", "client1", message1.path(JSON.DATA).path(JsonThrottle.THROTTLE).asText());
+        assertNotNull(message1);
+        assertEquals( 2, message1.path(JSON.DATA).path(JsonThrottle.CLIENTS).asInt(), "Two clients");
+        assertEquals( "client1", message1.path(JSON.DATA).path(JsonThrottle.THROTTLE).asText(), "Client 1");
         JsonNode message2 = connection2.getMessage();
-        Assert.assertNotNull(message2);
-        Assert.assertEquals("Two clients", 2, message2.path(JSON.DATA).path(JsonThrottle.CLIENTS).asInt());
-        Assert.assertEquals("Client 2", "client2", message2.path(JSON.DATA).path(JsonThrottle.THROTTLE).asText());
+        assertNotNull(message2);
+        assertEquals( 2, message2.path(JSON.DATA).path(JsonThrottle.CLIENTS).asInt(), "Two clients");
+        assertEquals( "client2", message2.path(JSON.DATA).path(JsonThrottle.THROTTLE).asText(), "Client 2");
         data1 = connection1.getObjectMapper().createObjectNode().put(JsonThrottle.THROTTLE, "client1");
         service1.onMessage(JsonThrottle.THROTTLE, data1.put(JSON.SPEED, 0.5), new JsonRequest(locale, JSON.V5, JSON.POST, 42));
+        JUnitAppender.assertWarnMessage("JSON throttle \"client1\" requested using \"throttle\" instead of \"name\"");
         message1 = connection1.getMessage();
-        Assert.assertNotNull(message1);
-        Assert.assertEquals("50% Speed", 0.5, message1.path(JSON.DATA).path(JSON.SPEED).asDouble(), 0.0);
-        Assert.assertEquals("Client 1", "client1", message1.path(JSON.DATA).path(JsonThrottle.THROTTLE).asText());
+        assertNotNull(message1);
+        assertEquals( 0.5, message1.path(JSON.DATA).path(JSON.SPEED).asDouble(), 0.0, "50% Speed");
+        assertEquals( "client1", message1.path(JSON.DATA).path(JsonThrottle.THROTTLE).asText(), "Client 1");
         message2 = connection2.getMessage();
-        Assert.assertNotNull(message2);
-        Assert.assertEquals("50% Speed", 0.5, message2.path(JSON.DATA).path(JSON.SPEED).asDouble(), 0.0);
-        Assert.assertEquals("Client 2", "client2", message2.path(JSON.DATA).path(JsonThrottle.THROTTLE).asText());
+        assertNotNull(message2);
+        assertEquals( 0.5, message2.path(JSON.DATA).path(JSON.SPEED).asDouble(), 0.0, "50% Speed");
+        assertEquals( "client2", message2.path(JSON.DATA).path(JsonThrottle.THROTTLE).asText(), "Client 2");
         connection1.setThrowIOException(true);
         connection2.sendMessage(null, 42);
         data2 = connection2.getObjectMapper().createObjectNode().put(JsonThrottle.THROTTLE, "client2");
         service2.onMessage(JsonThrottle.THROTTLE, data2.putNull(JsonThrottle.ESTOP), new JsonRequest(locale, JSON.V5, JSON.POST, 42));
+        JUnitAppender.assertWarnMessage("JSON throttle \"client2\" requested using \"throttle\" instead of \"name\"");
         message2 = connection2.getMessages();
-        Assert.assertNotNull(message2);
-        Assert.assertTrue(message2.isArray());
-        Assert.assertEquals("Two messages expected", 2, message2.size());
+        assertNotNull(message2);
+        assertTrue(message2.isArray());
+        assertEquals( 2, message2.size(), "Two messages expected");
         // order is dropped client followed by ESTOP because first client errors sending ESTOP and notification that
         // client was dropped is sent before loop to send ESTOP to second client iterates
-        Assert.assertEquals("One client", 1, message2.path(0).path(JSON.DATA).path(JsonThrottle.CLIENTS).asInt());
-        Assert.assertEquals("Client 2", "client2",
-                message2.path(0).path(JSON.DATA).path(JsonThrottle.THROTTLE).asText());
-        Assert.assertEquals("Emergency Stop", -1.0,
-                message2.path(1).path(JSON.DATA).path(JSON.SPEED).asDouble(), 0.0);
-        Assert.assertEquals("Client 2", "client2",
-                message2.path(1).path(JSON.DATA).path(JsonThrottle.THROTTLE).asText());
+        assertEquals( 1, message2.path(0).path(JSON.DATA).path(JsonThrottle.CLIENTS).asInt(), "One client");
+        assertEquals( "client2",
+            message2.path(0).path(JSON.DATA).path(JsonThrottle.THROTTLE).asText(),
+            "Client 2");
+        assertEquals( -1.0, message2.path(1).path(JSON.DATA).path(JSON.SPEED).asDouble(), 0.0,
+            "Emergency Stop");
+        assertEquals( "client2",
+            message2.path(1).path(JSON.DATA).path(JsonThrottle.THROTTLE).asText(),
+            "Client 2");
         JUnitAppender.assertWarnMessage("Unable to send message, closing connection: null");
     }
 
@@ -300,13 +312,12 @@ public class JsonThrottleSocketServiceTest {
         JsonThrottleSocketService service = new JsonThrottleSocketService(connection);
         ObjectNode data = connection.getObjectMapper().createObjectNode();
         data.put(JSON.NAME, "42");
-        try {
-            service.onMessage(JsonThrottle.THROTTLE, data, new JsonRequest(locale, JSON.V5, JSON.POST, 42));
-            Assert.fail("Expected exception not thrown");
-        } catch (JsonException ex) {
-            Assert.assertEquals("Error code is HTTP Bad Request", 400, ex.getCode());
-            Assert.assertEquals("Error message", "Throttles must be requested with an address.", ex.getMessage());
-        }
+        JsonException ex = assertThrows(JsonException.class, () ->
+            service.onMessage(JsonThrottle.THROTTLE, data,
+                new JsonRequest(locale, JSON.V5, JSON.POST, 42))
+            ,"Expected exception not thrown");
+        assertEquals( 400, ex.getCode(), "Error code is HTTP Bad Request");
+        assertEquals( "Throttles must be requested with an address.", ex.getMessage(), "Error message");
         JUnitAppender.assertWarnMessage("No address specified");
     }
 
@@ -316,22 +327,22 @@ public class JsonThrottleSocketServiceTest {
         JsonThrottleSocketService service = new JsonThrottleSocketService(connection);
         ObjectNode data = connection.getObjectMapper().createObjectNode();
         data.put(JsonThrottle.THROTTLE, ""); // empty string
-        try {
-            service.onMessage(JsonThrottle.THROTTLE, data, new JsonRequest(locale, JSON.V5, JSON.POST, 42));
-            Assert.fail("Expected exception not thrown");
-        } catch (JsonException ex) {
-            Assert.assertEquals("Error code is HTTP Bad Request", 400, ex.getCode());
-            Assert.assertEquals("Error message", "Throttles must be assigned a client ID.", ex.getMessage());
-        }
+
+        JsonException ex = assertThrows(JsonException.class, () ->
+            service.onMessage(JsonThrottle.THROTTLE, data,
+                new JsonRequest(locale, JSON.V5, JSON.POST, 42)),
+            "Expected exception not thrown");
+        assertEquals( 400, ex.getCode(), "Error code is HTTP Bad Request");
+        assertEquals( "Throttles must be assigned a client ID.", ex.getMessage(), "Error message");
         JUnitAppender.assertWarnMessage("JSON throttle \"\" requested using \"throttle\" instead of \"name\"");
+
         data.put(JSON.NAME, ""); // empty string
-        try {
-            service.onMessage(JsonThrottle.THROTTLE, data, new JsonRequest(locale, JSON.V5, JSON.POST, 42));
-            Assert.fail("Expected exception not thrown");
-        } catch (JsonException ex) {
-            Assert.assertEquals("Error code is HTTP Bad Request", 400, ex.getCode());
-            Assert.assertEquals("Error message", "Throttles must be assigned a client ID.", ex.getMessage());
-        }
+        ex = assertThrows( JsonException.class, () ->
+            service.onMessage(JsonThrottle.THROTTLE, data,
+                new JsonRequest(locale, JSON.V5, JSON.POST, 42)),
+            "Expected exception not thrown");
+        assertEquals( 400, ex.getCode(), "Error code is HTTP Bad Request");
+        assertEquals( "Throttles must be assigned a client ID.", ex.getMessage(), "Error message");
         JUnitAppender.assertWarnMessage("JSON throttle \"\" requested using \"throttle\" instead of \"name\"");
     }
 


### PR DESCRIPTION
Asserts further warning messages produced prior to existing JUnitAppender.assertWarnMessage
Around ln 73 updates a request to use name instead of throttle, testing both formats.
Updates asserts JU4 > JU5