### PR TITLE
build.xml - execute tests, junit-platform.properties location

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -612,7 +612,9 @@
             <fileset dir="${resourcedir}" includes="*.gif"/>
         </copy>
         <copy todir="${target}">
-            <fileset dir="${source}" includes="**/*.properties,**/*.js,**/*.png,**/*.json"/>
+            <fileset dir="${source}" includes="**/*.properties,**/*.js,**/*.png,**/*.json">
+                <exclude name="**/junit-platform.properties"/><!-- Only required for tests -->
+            </fileset>
         </copy>
     </target>
 


### PR DESCRIPTION
Adds the JUnit ConsoleLauncher execute command to start of command line for tasks executing the launcher from a Java process ( ie. tasks which don't use the built-in ant junitlauncher ).

Currently, junit-platform.properties is copied from the root directory to 2 classpath directories.
As this file is only required for tests, this PR removes it from non-test builds, i.e. `target/classes` , however is still present in test builds within `target/test-classes/` . 


Prevents
```
     [java] WARNING: Delegated to the 'execute' command.
     [java]          This behaviour has been deprecated and will be removed in a future release.
     [java]          Please use the 'execute' command directly.
```

and
```
     [java] WARNING: Discovered 2 'junit-platform.properties' configuration files on the classpath (see below); only the first (*) will be used.
     [java] - file:/C:/Users/Steve/Documents/GitHub/JMRI/target/classes/junit-platform.properties (*)
     [java] - file:/C:/Users/Steve/Documents/GitHub/JMRI/target/test-classes/junit-platform.properties
```