### PR TITLE
ZeroConfServiceManager close thread name

### DIFF
--- a/java/src/jmri/util/zeroconf/ZeroConfServiceManager.java
+++ b/java/src/jmri/util/zeroconf/ZeroConfServiceManager.java
@@ -317,7 +317,7 @@ public class ZeroConfServiceManager implements InstanceManagerAutoDefault, Dispo
                 }
                 nsLatch.countDown();
             });
-            t.setName(DNS_CLOSE_THREAD_NAME + ":" + dns.getHostName());
+            t.setName(DNS_CLOSE_THREAD_NAME + ":" + dns.toString());
             t.start();
         });
         try {

--- a/java/src/jmri/util/zeroconf/ZeroConfServiceManager.java
+++ b/java/src/jmri/util/zeroconf/ZeroConfServiceManager.java
@@ -317,7 +317,7 @@ public class ZeroConfServiceManager implements InstanceManagerAutoDefault, Dispo
                 }
                 nsLatch.countDown();
             });
-            t.setName(DNS_CLOSE_THREAD_NAME);
+            t.setName(DNS_CLOSE_THREAD_NAME + ":" + dns.getHostName());
             t.start();
         });
         try {

--- a/java/test/jmri/RunCucumberIT.java
+++ b/java/test/jmri/RunCucumberIT.java
@@ -2,13 +2,16 @@ package jmri;
 
 import cucumber.api.CucumberOptions;
 import cucumber.api.junit.Cucumber;
+
 import jmri.util.JUnitUtil;
+import jmri.util.junit.annotations.DisabledIfHeadless;
 import jmri.util.web.BrowserFactory;
 
 import org.junit.runner.RunWith;
-import org.junit.Assume;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Trigger file for Cucumber tests.
@@ -26,17 +29,16 @@ import org.junit.BeforeClass;
  *
  * @author Paul Bender Copyright 2017
  */
-
 @RunWith(Cucumber.class)
 @CucumberOptions(plugin = {"junit:cucumber-results.xml", "progress", "json:cucumber-results.json"},
         features = "java/acceptancetest/features/web",
         tags = {"not @webtest", "not @Disabled", "not @Ignore", "not @ignore"},
         glue = {"apps"})
+@DisabledIfHeadless
 public class RunCucumberIT {
 
     @BeforeClass
     public static void beforeTests() {
-        Assume.assumeFalse(java.awt.GraphicsEnvironment.isHeadless());
         JUnitUtil.setUp();
         JUnitUtil.resetProfileManager();
         JUnitUtil.initZeroConfServiceManager();
@@ -45,7 +47,7 @@ public class RunCucumberIT {
     @AfterClass
     public static void afterTests() {
         BrowserFactory.closeAllDrivers();
-        JUnitUtil.resetZeroConfServiceManager();
+        assertTrue(JUnitUtil.resetZeroConfServiceManager());
         JUnitUtil.clearShutDownManager();
         JUnitUtil.tearDown();
     }

--- a/java/test/jmri/util/MultipartMessageTest.java
+++ b/java/test/jmri/util/MultipartMessageTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.*;
 import jmri.web.server.WebServer;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
@@ -62,7 +63,7 @@ public class MultipartMessageTest {
             log.debug("NPE shutting down web server", npe2);
             //Assert.fail("Null Pointer Exception occured during teardown:" + npe2);
         }
-        JUnitUtil.resetZeroConfServiceManager();
+        assertTrue(JUnitUtil.resetZeroConfServiceManager());
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/util/zeroconf/ZeroConfServiceEventTest.java
+++ b/java/test/jmri/util/zeroconf/ZeroConfServiceEventTest.java
@@ -8,6 +8,7 @@ import jmri.util.JUnitUtil;
 import org.junit.jupiter.api.*;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  *
@@ -35,7 +36,7 @@ public class ZeroConfServiceEventTest {
 
     @AfterEach
     public void tearDown() {
-        JUnitUtil.resetZeroConfServiceManager();
+        assertTrue(JUnitUtil.resetZeroConfServiceManager());
         
         // wait for dns threads to end
         Thread.getAllStackTraces().keySet().forEach((t) -> 

--- a/java/test/jmri/util/zeroconf/ZeroConfServiceManagerTest.java
+++ b/java/test/jmri/util/zeroconf/ZeroConfServiceManagerTest.java
@@ -28,7 +28,7 @@ public class ZeroConfServiceManagerTest {
     @BeforeEach
     public void setUp() {
         JUnitUtil.setUp();
-        JUnitUtil.resetZeroConfServiceManager();
+        assertTrue(JUnitUtil.resetZeroConfServiceManager());
         JUnitUtil.resetProfileManager();
         // ensure the manager used for tests is also the default manager should
         // some other element involved invoke the default manager
@@ -37,7 +37,7 @@ public class ZeroConfServiceManagerTest {
 
     @AfterEach
     public void tearDown() {
-        JUnitUtil.resetZeroConfServiceManager();
+        assertTrue(JUnitUtil.resetZeroConfServiceManager());
         manager = null;
         
         // wait for dns threads to end

--- a/java/test/jmri/util/zeroconf/ZeroConfServiceTest.java
+++ b/java/test/jmri/util/zeroconf/ZeroConfServiceTest.java
@@ -36,7 +36,7 @@ public class ZeroConfServiceTest {
 
     @AfterEach
     public void tearDown() throws Exception {
-        JUnitUtil.resetZeroConfServiceManager();
+        assertTrue(JUnitUtil.resetZeroConfServiceManager());
         
         // wait for dns threads to end
         Thread.getAllStackTraces().keySet().forEach((t) -> 

--- a/java/test/jmri/web/server/WebServerTest.java
+++ b/java/test/jmri/web/server/WebServerTest.java
@@ -66,7 +66,7 @@ public class WebServerTest {
 
     @AfterEach
     public void tearDown() {
-        JUnitUtil.resetZeroConfServiceManager();
+        assertTrue(JUnitUtil.resetZeroConfServiceManager());
         JUnitUtil.tearDown();
     }
 }


### PR DESCRIPTION
**ZeroConfServiceManager**
Uses a unique name for close DNS thread, there could be multiple threads.

**JUnitUtil** resetZeroConfServiceManager
Adds Checks return value annotation to ensure threads have completed.

Return value assert added to tests where not currently present.