### PR TITLE
update LnThrottleManager Test, LnOpsModeProgrammer Test, StoreAndLoadTest Ln(LogixNG)

### DIFF
--- a/java/test/jmri/jmrix/loconet/LnOpsModeProgrammerTest.java
+++ b/java/test/jmri/jmrix/loconet/LnOpsModeProgrammerTest.java
@@ -2,39 +2,43 @@ package jmri.jmrix.loconet;
 
 import jmri.ProgListenerScaffold;
 import jmri.ProgrammerException;
-import jmri.util.JUnitUtil;
 import jmri.ProgrammingMode;
+import jmri.util.JUnitUtil;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class LnOpsModeProgrammerTest extends jmri.AddressedProgrammerTestBase{
 
-    LocoNetInterfaceScaffold lnis;
-    SlotManager sm;
-    LocoNetSystemConnectionMemo memo;
-    ProgListenerScaffold pl;
-    LnOpsModeProgrammer lnopsmodeprogrammer;
+    private LocoNetInterfaceScaffold lnis;
+    private SlotManager sm;
+    private LocoNetSystemConnectionMemo memo;
+    private ProgListenerScaffold pl;
+    private LnOpsModeProgrammer lnopsmodeprogrammer;
+
     @Override
     @Test
     public void testGetCanWriteAddress() {
-        Assert.assertFalse("can write address", programmer.getCanWrite("1234"));
+        assertFalse( programmer.getCanWrite("1234"), "can write address");
     }
 
     @Test
     public void testSetMode() {
-        try {
-            lnopsmodeprogrammer.setMode(ProgrammingMode.PAGEMODE);
-        } catch (IllegalArgumentException e) {
-            return;
-        }
-        Assert.fail("No IllegalArgumentException thrown");
+        IllegalArgumentException ex = assertThrows( IllegalArgumentException.class, () ->
+            lnopsmodeprogrammer.setMode(ProgrammingMode.PAGEMODE),
+        "No IllegalArgumentException thrown");
+        assertNotNull(ex);
     }
 
     @Test
     public void testGetMode() {
         ProgrammingMode intRet = lnopsmodeprogrammer.getMode();
-        Assert.assertEquals("OpsByteMode", ProgrammingMode.OPSBYTEMODE, intRet);
+        assertEquals( ProgrammingMode.OPSBYTEMODE, intRet, "OpsByteMode");
     }
 
     @Test
@@ -44,8 +48,7 @@ public class LnOpsModeProgrammerTest extends jmri.AddressedProgrammerTestBase{
 
         lnopsmodeprogrammer = new LnOpsModeProgrammer(memo, 1, true);
 
-        Assert.assertEquals("ops mode can read with transponding", true,
-                lnopsmodeprogrammer.getCanRead());
+        assertTrue( lnopsmodeprogrammer.getCanRead(), "ops mode can read with transponding");
     }
 
     @Test
@@ -54,11 +57,11 @@ public class LnOpsModeProgrammerTest extends jmri.AddressedProgrammerTestBase{
 
         // check data bytes
         lnopsmodeprogrammer.loadSV2MessageFormat(m, 0, 0, 0x12345678);
-        Assert.assertEquals(0x10, m.getElement(10));
-        Assert.assertEquals(0x78, m.getElement(11));
-        Assert.assertEquals(0x56, m.getElement(12));
-        Assert.assertEquals(0x34, m.getElement(13));
-        Assert.assertEquals(0x12, m.getElement(14));
+        assertEquals(0x10, m.getElement(10));
+        assertEquals(0x78, m.getElement(11));
+        assertEquals(0x56, m.getElement(12));
+        assertEquals(0x34, m.getElement(13));
+        assertEquals(0x12, m.getElement(14));
     }
 
     @Test
@@ -67,172 +70,172 @@ public class LnOpsModeProgrammerTest extends jmri.AddressedProgrammerTestBase{
 
         // check high bits
         lnopsmodeprogrammer.loadSV2MessageFormat(m, 0, 0, 0x01020384);
-        Assert.assertEquals(0x11, m.getElement(10));
-        Assert.assertEquals(0x04, m.getElement(11));
-        Assert.assertEquals(0x03, m.getElement(12));
-        Assert.assertEquals(0x02, m.getElement(13));
-        Assert.assertEquals(0x01, m.getElement(14));
+        assertEquals(0x11, m.getElement(10));
+        assertEquals(0x04, m.getElement(11));
+        assertEquals(0x03, m.getElement(12));
+        assertEquals(0x02, m.getElement(13));
+        assertEquals(0x01, m.getElement(14));
 
         lnopsmodeprogrammer.loadSV2MessageFormat(m, 0, 0, 0x01028304);
-        Assert.assertEquals(0x12, m.getElement(10));
-        Assert.assertEquals(0x04, m.getElement(11));
-        Assert.assertEquals(0x03, m.getElement(12));
-        Assert.assertEquals(0x02, m.getElement(13));
-        Assert.assertEquals(0x01, m.getElement(14));
+        assertEquals(0x12, m.getElement(10));
+        assertEquals(0x04, m.getElement(11));
+        assertEquals(0x03, m.getElement(12));
+        assertEquals(0x02, m.getElement(13));
+        assertEquals(0x01, m.getElement(14));
 
         lnopsmodeprogrammer.loadSV2MessageFormat(m, 0, 0, 0x01820304);
-        Assert.assertEquals(0x14, m.getElement(10));
-        Assert.assertEquals(0x04, m.getElement(11));
-        Assert.assertEquals(0x03, m.getElement(12));
-        Assert.assertEquals(0x02, m.getElement(13));
-        Assert.assertEquals(0x01, m.getElement(14));
+        assertEquals(0x14, m.getElement(10));
+        assertEquals(0x04, m.getElement(11));
+        assertEquals(0x03, m.getElement(12));
+        assertEquals(0x02, m.getElement(13));
+        assertEquals(0x01, m.getElement(14));
 
         lnopsmodeprogrammer.loadSV2MessageFormat(m, 0, 0, 0x81020304);
-        Assert.assertEquals(0x18, m.getElement(10));
-        Assert.assertEquals(0x04, m.getElement(11));
-        Assert.assertEquals(0x03, m.getElement(12));
-        Assert.assertEquals(0x02, m.getElement(13));
-        Assert.assertEquals(0x01, m.getElement(14));
+        assertEquals(0x18, m.getElement(10));
+        assertEquals(0x04, m.getElement(11));
+        assertEquals(0x03, m.getElement(12));
+        assertEquals(0x02, m.getElement(13));
+        assertEquals(0x01, m.getElement(14));
 
         lnopsmodeprogrammer.loadSV2MessageFormat(m, 0, 0, 0x81828384);
-        Assert.assertEquals(0x1F, m.getElement(10));
-        Assert.assertEquals(0x04, m.getElement(11));
-        Assert.assertEquals(0x03, m.getElement(12));
-        Assert.assertEquals(0x02, m.getElement(13));
-        Assert.assertEquals(0x01, m.getElement(14));
+        assertEquals(0x1F, m.getElement(10));
+        assertEquals(0x04, m.getElement(11));
+        assertEquals(0x03, m.getElement(12));
+        assertEquals(0x02, m.getElement(13));
+        assertEquals(0x01, m.getElement(14));
     }
 
     @Test
-     public void testSOps16001Read() throws ProgrammerException {
-        LnOpsModeProgrammer lnopsmodeprogrammer = new LnOpsModeProgrammer(memo, 16001, true);
+    public void testSOps16001Read() throws ProgrammerException {
+        lnopsmodeprogrammer = new LnOpsModeProgrammer(memo, 16001, true);
 
         lnopsmodeprogrammer.readCV("2",pl);
 
         // should have written and not returned
-        Assert.assertEquals("one message sent", 1, lnis.outbound.size());
-        Assert.assertEquals("No programming reply", 0, pl.getRcvdInvoked());
+        assertEquals( 1, lnis.outbound.size(), "one message sent");
+        assertEquals( 0, pl.getRcvdInvoked(), "No programming reply");
 
-        Assert.assertEquals("message", "[EF 0E 7C 2F 00 7D 01 00 00 01 00 7F 7F 00]", lnis.outbound.toString());
+        assertEquals( "[EF 0E 7C 2F 00 7D 01 00 00 01 00 7F 7F 00]", lnis.outbound.toString(), "message");
 
-     }
+    }
 
-     @Test
-     public void testSv1Write() throws ProgrammerException {
+    @Test
+    public void testSv1Write() throws ProgrammerException {
         int testVal = 120;
         lnopsmodeprogrammer.setMode(LnProgrammerManager.LOCONETSV1MODE);
         lnopsmodeprogrammer.writeCV("91",testVal,pl);
 
         // should have written and not returned
-        Assertions.assertEquals(1, lnis.outbound.size(), "one message sent");
-        Assertions.assertEquals(0, pl.getRcvdInvoked(), "No programming reply");
+        assertEquals(1, lnis.outbound.size(), "one message sent");
+        assertEquals(0, pl.getRcvdInvoked(), "No programming reply");
 
          // check echo of sent message has no effect
         LocoNetMessage m = lnis.outbound.get(0);
         lnopsmodeprogrammer.message(m);
-        Assertions.assertEquals(1, lnis.outbound.size(), "still one message sent");
-        Assertions.assertEquals(0, pl.getRcvdInvoked(), "No programming reply");
+        assertEquals(1, lnis.outbound.size(), "still one message sent");
+        assertEquals(0, pl.getRcvdInvoked(), "No programming reply");
 
         // Known-good message in reply
         m = new LocoNetMessage(new int[]{0xE5, 0x10, 0x53, 0x50, 0x01, 0x00, 0x01, 0x5B, 0x66, 0x7B, 0x00, 0x01, 0x00, 0x00, testVal, 0x36});
         lnopsmodeprogrammer.message(m);
 
-        Assertions.assertEquals(1, lnis.outbound.size(), "still one message sent");
-        Assertions.assertEquals(1, pl.getRcvdInvoked(), "Got programming reply");
-        Assertions.assertEquals(0, pl.getRcvdStatus(), "Reply status OK");
-        Assertions.assertEquals(testVal, pl.getRcvdValue(), "Reply value matches written");
+        assertEquals(1, lnis.outbound.size(), "still one message sent");
+        assertEquals(1, pl.getRcvdInvoked(), "Got programming reply");
+        assertEquals(0, pl.getRcvdStatus(), "Reply status OK");
+        assertEquals(testVal, pl.getRcvdValue(), "Reply value matches written");
 
-     }
+    }
 
-     @Test
-     public void testBoardRead0() throws ProgrammerException {
+    @Test
+    public void testBoardRead0() throws ProgrammerException {
         lnopsmodeprogrammer = new LnOpsModeProgrammer(memo, 4, true);
 
         lnopsmodeprogrammer.setMode(LnProgrammerManager.LOCONETBDOPSWMODE);
         lnopsmodeprogrammer.readCV("113.6",pl);
 
         // should have written and not returned
-        Assertions.assertEquals(1, lnis.outbound.size(), "one message sent");
-        Assertions.assertEquals(0, pl.getRcvdInvoked(), "No programming reply");
+        assertEquals(1, lnis.outbound.size(), "one message sent");
+        assertEquals(0, pl.getRcvdInvoked(), "No programming reply");
 
-        Assertions.assertEquals(0xD0, lnis.outbound.get(0).getElement(0) & 0xFF, "sent byte 0");
-        Assertions.assertEquals(0x62, lnis.outbound.get(0).getElement(1) & 0xFF, "sent byte 1");
-        Assertions.assertEquals(0x03, lnis.outbound.get(0).getElement(2) & 0xFF, "sent byte 2");
-        Assertions.assertEquals(113, lnis.outbound.get(0).getElement(3) & 0xFF, "sent byte 3");
-        Assertions.assertEquals(0x0A, lnis.outbound.get(0).getElement(4) & 0xFF, "sent byte 4");
+        assertEquals(0xD0, lnis.outbound.get(0).getElement(0) & 0xFF, "sent byte 0");
+        assertEquals(0x62, lnis.outbound.get(0).getElement(1) & 0xFF, "sent byte 1");
+        assertEquals(0x03, lnis.outbound.get(0).getElement(2) & 0xFF, "sent byte 2");
+        assertEquals(113, lnis.outbound.get(0).getElement(3) & 0xFF, "sent byte 3");
+        assertEquals(0x0A, lnis.outbound.get(0).getElement(4) & 0xFF, "sent byte 4");
 
         int testVal = 0;
 
         // check echo of sent message has no effect
         LocoNetMessage m = lnis.outbound.get(0);
         lnopsmodeprogrammer.message(m);
-        Assertions.assertEquals(1, lnis.outbound.size(), "still one message sent");
-        Assertions.assertEquals(0, pl.getRcvdInvoked(), "No programming reply");
+        assertEquals(1, lnis.outbound.size(), "still one message sent");
+        assertEquals(0, pl.getRcvdInvoked(), "No programming reply");
 
         // Known-good message in reply
         m = new LocoNetMessage(new int[]{0xB4, 0x50, 0x40, 0x00});
         lnopsmodeprogrammer.message(m);
-        Assertions.assertEquals(1, lnis.outbound.size(), "still one message sent");
-        Assertions.assertEquals(1, pl.getRcvdInvoked(), "Got programming reply");
-        Assertions.assertEquals(0, pl.getRcvdStatus(), "Reply status OK");
-        Assertions.assertEquals(testVal, pl.getRcvdValue(), "Reply value matches");
+        assertEquals(1, lnis.outbound.size(), "still one message sent");
+        assertEquals(1, pl.getRcvdInvoked(), "Got programming reply");
+        assertEquals(0, pl.getRcvdStatus(), "Reply status OK");
+        assertEquals(testVal, pl.getRcvdValue(), "Reply value matches");
 
-     }
+    }
 
-     @Test
-     public void testBoardRead1() throws ProgrammerException {
+    @Test
+    public void testBoardRead1() throws ProgrammerException {
         lnopsmodeprogrammer = new LnOpsModeProgrammer(memo, 4, true);
 
         lnopsmodeprogrammer.setMode(LnProgrammerManager.LOCONETBDOPSWMODE);
         lnopsmodeprogrammer.readCV("113.6",pl);
 
         // should have written and not returned
-        Assert.assertEquals("one message sent", 1, lnis.outbound.size());
-        Assert.assertEquals("No programming reply", 0, pl.getRcvdInvoked());
+        assertEquals( 1, lnis.outbound.size(), "one message sent");
+        assertEquals( 0, pl.getRcvdInvoked(), "No programming reply");
 
-        Assert.assertEquals("sent byte 0", 0xD0, lnis.outbound.get(0).getElement(0) & 0xFF);
-        Assert.assertEquals("sent byte 1", 0x62, lnis.outbound.get(0).getElement(1) & 0xFF);
-        Assert.assertEquals("sent byte 2", 0x03, lnis.outbound.get(0).getElement(2) & 0xFF);
-        Assert.assertEquals("sent byte 3", 113, lnis.outbound.get(0).getElement(3) & 0xFF);
-        Assert.assertEquals("sent byte 4", 0x0A, lnis.outbound.get(0).getElement(4) & 0xFF);
+        assertEquals( 0xD0, lnis.outbound.get(0).getElement(0) & 0xFF, "sent byte 0");
+        assertEquals( 0x62, lnis.outbound.get(0).getElement(1) & 0xFF, "sent byte 1");
+        assertEquals( 0x03, lnis.outbound.get(0).getElement(2) & 0xFF, "sent byte 2");
+        assertEquals( 113, lnis.outbound.get(0).getElement(3) & 0xFF, "sent byte 3");
+        assertEquals( 0x0A, lnis.outbound.get(0).getElement(4) & 0xFF, "sent byte 4");
 
         int testVal = 1;
 
         // check echo of sent message has no effect
         LocoNetMessage m = lnis.outbound.get(0);
         lnopsmodeprogrammer.message(m);
-        Assert.assertEquals("still one message sent", 1, lnis.outbound.size());
-        Assert.assertEquals("No programming reply", 0, pl.getRcvdInvoked());
+        assertEquals( 1, lnis.outbound.size(), "still one message sent");
+        assertEquals( 0, pl.getRcvdInvoked(), "No programming reply");
 
         // Known-good message in reply
         m = new LocoNetMessage(new int[]{0xB4, 0x50, 0x60, 0x00});
         lnopsmodeprogrammer.message(m);
-        Assert.assertEquals("still one message sent", 1, lnis.outbound.size());
-        Assert.assertEquals("Got programming reply", 1, pl.getRcvdInvoked());
-        Assert.assertEquals("Reply status OK", 0, pl.getRcvdStatus());
-        Assert.assertEquals("Reply value matches", testVal, pl.getRcvdValue());
+        assertEquals( 1, lnis.outbound.size(), "still one message sent");
+        assertEquals( 1, pl.getRcvdInvoked(), "Got programming reply");
+        assertEquals( 0, pl.getRcvdStatus(), "Reply status OK");
+        assertEquals( testVal, pl.getRcvdValue(), "Reply value matches");
 
-     }
+    }
 
-     @Test
-     public void testBoardReadTimeout() throws ProgrammerException {
+    @Test
+    public void testBoardReadTimeout() throws ProgrammerException {
         lnopsmodeprogrammer = new LnOpsModeProgrammer(memo, 4, true);
 
         lnopsmodeprogrammer.setMode(LnProgrammerManager.LOCONETBDOPSWMODE);
         lnopsmodeprogrammer.readCV("113.6",pl);
 
         // should have written and not returned
-        Assert.assertEquals("one message sent", 1, lnis.outbound.size());
-        Assert.assertEquals("No programming reply", 0, pl.getRcvdInvoked());
+        assertEquals( 1, lnis.outbound.size(), "one message sent");
+        assertEquals( 0, pl.getRcvdInvoked(), "No programming reply");
 
         // No reply message, wait for timeout
-        jmri.util.JUnitUtil.waitFor(()->{return pl.getRcvdInvoked() == 1;},"programming reply not received");
-        Assert.assertEquals("still one message sent", 1, lnis.outbound.size());
-        Assert.assertEquals("Reply status Not OK", jmri.ProgListener.FailedTimeout, pl.getRcvdStatus());
-        Assert.assertTrue("Correct thread", pl.wasRightThread());
-     }
+        JUnitUtil.waitFor(()->{return pl.getRcvdInvoked() == 1;},"programming reply not received");
+        assertEquals( 1, lnis.outbound.size(), "still one message sent");
+        assertEquals( jmri.ProgListener.FailedTimeout, pl.getRcvdStatus(), "Reply status Not OK");
+        assertTrue( pl.wasRightThread(), "Correct thread");
+    }
 
-     @Test
-     public void testBoardWrite() throws ProgrammerException {
+    @Test
+    public void testBoardWrite() throws ProgrammerException {
         lnopsmodeprogrammer = new LnOpsModeProgrammer(memo, 4, true);
 
         int testVal = 1;
@@ -241,33 +244,33 @@ public class LnOpsModeProgrammerTest extends jmri.AddressedProgrammerTestBase{
         lnopsmodeprogrammer.writeCV("113.6", testVal, pl);
 
         // should have written
-        Assert.assertEquals("one message sent", 1, lnis.outbound.size());
-        Assert.assertEquals("No programming reply", 0, pl.getRcvdInvoked());
+        assertEquals( 1, lnis.outbound.size(), "one message sent");
+        assertEquals( 0, pl.getRcvdInvoked(), "No programming reply");
 
-        Assert.assertEquals("sent byte 0", 0xD0, lnis.outbound.get(0).getElement(0) & 0xFF);
-        Assert.assertEquals("sent byte 1", 0x72, lnis.outbound.get(0).getElement(1) & 0xFF);
-        Assert.assertEquals("sent byte 2", 0x03, lnis.outbound.get(0).getElement(2) & 0xFF);
-        Assert.assertEquals("sent byte 3", 113, lnis.outbound.get(0).getElement(3) & 0xFF);
-        Assert.assertEquals("sent byte 4", 0x0B, lnis.outbound.get(0).getElement(4) & 0xFF);
+        assertEquals( 0xD0, lnis.outbound.get(0).getElement(0) & 0xFF, "sent byte 0");
+        assertEquals( 0x72, lnis.outbound.get(0).getElement(1) & 0xFF, "sent byte 1");
+        assertEquals( 0x03, lnis.outbound.get(0).getElement(2) & 0xFF, "sent byte 2");
+        assertEquals( 113, lnis.outbound.get(0).getElement(3) & 0xFF, "sent byte 3");
+        assertEquals( 0x0B, lnis.outbound.get(0).getElement(4) & 0xFF, "sent byte 4");
 
         // check echo of sent message has no effect
         LocoNetMessage m = lnis.outbound.get(0);
         lnopsmodeprogrammer.message(m);
-        Assert.assertEquals("still one message sent", 1, lnis.outbound.size());
-        Assert.assertEquals("No programming reply", 0, pl.getRcvdInvoked());
+        assertEquals( 1, lnis.outbound.size(), "still one message sent");
+        assertEquals( 0, pl.getRcvdInvoked(), "No programming reply");
 
         // Known-good message in reply
         m = new LocoNetMessage(new int[]{0xB4, 0x50, 0x60, 0x00});
         lnopsmodeprogrammer.message(m);
-        Assert.assertEquals("still one message sent", 1, lnis.outbound.size());
-        Assert.assertEquals("Got programming reply", 1, pl.getRcvdInvoked());
-        Assert.assertEquals("Reply status OK", 0, pl.getRcvdStatus());
-        Assert.assertEquals("Reply value matches", testVal, pl.getRcvdValue());
+        assertEquals( 1, lnis.outbound.size(), "still one message sent");
+        assertEquals( 1, pl.getRcvdInvoked(), "Got programming reply");
+        assertEquals( 0, pl.getRcvdStatus(), "Reply status OK");
+        assertEquals( testVal, pl.getRcvdValue(), "Reply value matches");
 
-     }
+    }
 
-     @Test
-     public void testBoardWriteTimeout() throws ProgrammerException {
+    @Test
+    public void testBoardWriteTimeout() throws ProgrammerException {
         lnopsmodeprogrammer = new LnOpsModeProgrammer(memo, 4, true);
 
         int testVal = 1;
@@ -276,58 +279,58 @@ public class LnOpsModeProgrammerTest extends jmri.AddressedProgrammerTestBase{
         lnopsmodeprogrammer.writeCV("113.6", testVal, pl);
 
         // should have written
-        Assert.assertEquals("one message sent", 1, lnis.outbound.size());
-        Assert.assertEquals("No programming reply", 0, pl.getRcvdInvoked());
+        assertEquals( 1, lnis.outbound.size(), "one message sent");
+        assertEquals( 0, pl.getRcvdInvoked(), "No programming reply");
 
         // No reply message, wait for timeout
-        jmri.util.JUnitUtil.waitFor(()->{return pl.getRcvdInvoked() == 1;},"programming reply not received");
-        Assert.assertEquals("still one message sent", 1, lnis.outbound.size());
-        Assert.assertEquals("Reply status Not OK", jmri.ProgListener.FailedTimeout, pl.getRcvdStatus());
-        Assert.assertTrue("Correct thread", pl.wasRightThread());
+        JUnitUtil.waitFor(()->{return pl.getRcvdInvoked() == 1;},"programming reply not received");
+        assertEquals( 1, lnis.outbound.size(), "still one message sent");
+        assertEquals( jmri.ProgListener.FailedTimeout, pl.getRcvdStatus(), "Reply status Not OK");
+        assertTrue( pl.wasRightThread(), "Correct thread");
      }
 
-     @Test
-     public void testSv1ARead() throws ProgrammerException {
+    @Test
+    public void testSv1ARead() throws ProgrammerException {
         lnopsmodeprogrammer = new LnOpsModeProgrammer(memo, 1, true);
 
         lnopsmodeprogrammer.setMode(LnProgrammerManager.LOCONETSV1MODE);
         lnopsmodeprogrammer.readCV("83", pl);
 
         // should have written and not returned
-        Assertions.assertEquals(1, lnis.outbound.size(), "one message sent");
-        Assertions.assertEquals(0, pl.getRcvdInvoked(), "No programming reply");
+        assertEquals(1, lnis.outbound.size(), "one message sent");
+        assertEquals(0, pl.getRcvdInvoked(), "No programming reply");
 
-        Assertions.assertEquals(0xE5, lnis.outbound.get(0).getElement(0) & 0xFF, "sent byte 0");
-        Assertions.assertEquals(0x50, lnis.outbound.get(0).getElement(2) & 0xFF, "sent byte 2");
+        assertEquals(0xE5, lnis.outbound.get(0).getElement(0) & 0xFF, "sent byte 0");
+        assertEquals(0x50, lnis.outbound.get(0).getElement(2) & 0xFF, "sent byte 2");
 
         int testVal = 132;
 
         // check echo of sent message has no effect
         LocoNetMessage m = lnis.outbound.get(0);
         lnopsmodeprogrammer.message(m);
-        Assertions.assertEquals(1, lnis.outbound.size(), "still one message sent");
-        Assertions.assertEquals(0, pl.getRcvdInvoked(), "No programming reply");
+        assertEquals(1, lnis.outbound.size(), "still one message sent");
+        assertEquals(0, pl.getRcvdInvoked(), "No programming reply");
 
         // Known-good message in reply
         m = new LocoNetMessage(new int[]{0xE5, 0x10, 0x53, 0x50, 0x01, 0x00, 0x02, 0x5B, 0x66, 0x7B, 0x02, 0x01, 0x04, 0x00, 0x00, 0x48});
         lnopsmodeprogrammer.message(m);
-        Assertions.assertEquals(1, lnis.outbound.size(), "still one message sent");
-        Assertions.assertEquals(1, pl.getRcvdInvoked(), "Got programming reply");
-        Assertions.assertEquals(0, pl.getRcvdStatus(), "Reply status OK");
-        Assertions.assertEquals(testVal, pl.getRcvdValue(), "Reply value matches");
-     }
+        assertEquals(1, lnis.outbound.size(), "still one message sent");
+        assertEquals(1, pl.getRcvdInvoked(), "Got programming reply");
+        assertEquals(0, pl.getRcvdStatus(), "Reply status OK");
+        assertEquals(testVal, pl.getRcvdValue(), "Reply value matches");
+    }
 
-     @Test
-     public void testSv1BRead() throws ProgrammerException {
+    @Test
+    public void testSv1BRead() throws ProgrammerException {
         lnopsmodeprogrammer.setMode(LnProgrammerManager.LOCONETSV1MODE);
         lnopsmodeprogrammer.readCV("83",pl);
 
         // should have written and not returned
-        Assertions.assertEquals(1, lnis.outbound.size(), "one message sent");
-        Assertions.assertEquals(0, pl.getRcvdInvoked(), "No programming reply");
+        assertEquals(1, lnis.outbound.size(), "one message sent");
+        assertEquals(0, pl.getRcvdInvoked(), "No programming reply");
 
-        Assertions.assertEquals(0xE5, lnis.outbound.get(0).getElement(0) & 0xFF, "sent byte 0");
-        Assertions.assertEquals(0x50, lnis.outbound.get(0).getElement(2) & 0xFF, "sent byte 2");
+        assertEquals(0xE5, lnis.outbound.get(0).getElement(0) & 0xFF, "sent byte 0");
+        assertEquals(0x50, lnis.outbound.get(0).getElement(2) & 0xFF, "sent byte 2");
 
         int testVal = 47; // 0x2F
 
@@ -336,52 +339,52 @@ public class LnOpsModeProgrammerTest extends jmri.AddressedProgrammerTestBase{
             = new LocoNetMessage(new int[]{0xE5, 0x10, 0x53, 0x50, 0x01, 0x00, 0x02, 0x03, 0x66, 0x7B, 0x00, 0x01, 0x2F, 0x78, 0x10, 0x52});
         lnopsmodeprogrammer.message(m);
 
-        Assertions.assertEquals(1, lnis.outbound.size(), "still one message sent");
-        Assertions.assertEquals(1, pl.getRcvdInvoked(), "Got programming reply");
-        Assertions.assertEquals(0, pl.getRcvdStatus(), "Reply status OK");
-        Assertions.assertEquals(testVal, pl.getRcvdValue(), "Reply value matches");
-     }
+        assertEquals(1, lnis.outbound.size(), "still one message sent");
+        assertEquals(1, pl.getRcvdInvoked(), "Got programming reply");
+        assertEquals(0, pl.getRcvdStatus(), "Reply status OK");
+        assertEquals(testVal, pl.getRcvdValue(), "Reply value matches");
+    }
 
-     @Test
-     public void testSv2Write() throws ProgrammerException {
+    @Test
+    public void testSv2Write() throws ProgrammerException {
         lnopsmodeprogrammer.setMode(LnProgrammerManager.LOCONETSV2MODE);
         lnopsmodeprogrammer.writeCV("22",33,pl);
 
         // should have written and not returned
-        Assertions.assertEquals(1, lnis.outbound.size(), "one message sent");
-        Assertions.assertEquals(0, pl.getRcvdInvoked(), "No programming reply");
+        assertEquals(1, lnis.outbound.size(), "one message sent");
+        assertEquals(0, pl.getRcvdInvoked(), "No programming reply");
 
         // check echo of sent message has no effect
         LocoNetMessage m = lnis.outbound.get(0);
         lnopsmodeprogrammer.message(m);
-        Assertions.assertEquals(1, lnis.outbound.size(), "still one message sent");
-        Assertions.assertEquals(0, pl.getRcvdInvoked(), "No programming reply");
+        assertEquals(1, lnis.outbound.size(), "still one message sent");
+        assertEquals(0, pl.getRcvdInvoked(), "No programming reply");
 
         // turn the message around as a reply
         m.setElement(3, m.getElement(3) | 0x40);
         lnopsmodeprogrammer.message(m);
 
-        Assertions.assertEquals(1, lnis.outbound.size(), "still one message sent");
-        Assertions.assertEquals(1, pl.getRcvdInvoked(), "Got programming reply");
-        Assertions.assertEquals(0, pl.getRcvdStatus(), "Reply status OK");
-     }
+        assertEquals(1, lnis.outbound.size(), "still one message sent");
+        assertEquals(1, pl.getRcvdInvoked(), "Got programming reply");
+        assertEquals(0, pl.getRcvdStatus(), "Reply status OK");
+    }
 
-     @Test
-     public void testSv2Read() throws ProgrammerException {
+    @Test
+    public void testSv2Read() throws ProgrammerException {
         lnopsmodeprogrammer.setMode(LnProgrammerManager.LOCONETSV2MODE);
         lnopsmodeprogrammer.readCV("22",pl);
 
         // should have written and not returned
-        Assertions.assertEquals(1, lnis.outbound.size(), "one message sent");
-        Assertions.assertEquals(0, pl.getRcvdInvoked(), "No programming reply");
+        assertEquals(1, lnis.outbound.size(), "one message sent");
+        assertEquals(0, pl.getRcvdInvoked(), "No programming reply");
 
         int testVal = 130;
 
         // check echo of sent message has no effect
         LocoNetMessage m = lnis.outbound.get(0);
         lnopsmodeprogrammer.message(m);
-        Assertions.assertEquals(1, lnis.outbound.size(), "still one message sent");
-        Assertions.assertEquals(0, pl.getRcvdInvoked(), "No programming reply");
+        assertEquals(1, lnis.outbound.size(), "still one message sent");
+        assertEquals(0, pl.getRcvdInvoked(), "No programming reply");
 
         // turn the message around as a reply
         m.setElement(3, m.getElement(3) | 0x40);
@@ -389,33 +392,33 @@ public class LnOpsModeProgrammerTest extends jmri.AddressedProgrammerTestBase{
         m.setElement(11, testVal & 0x7F);
         lnopsmodeprogrammer.message(m);
 
-        Assertions.assertEquals(1, lnis.outbound.size(), "still one message sent");
-        Assertions.assertEquals(1, pl.getRcvdInvoked(), "Got programming reply");
-        Assertions.assertEquals(0, pl.getRcvdStatus(), "Reply status OK");
-        Assertions.assertEquals(130, pl.getRcvdValue(), "Reply value matches");
-     }
+        assertEquals(1, lnis.outbound.size(), "still one message sent");
+        assertEquals(1, pl.getRcvdInvoked(), "Got programming reply");
+        assertEquals(0, pl.getRcvdStatus(), "Reply status OK");
+        assertEquals(130, pl.getRcvdValue(), "Reply value matches");
+    }
 
-     @Test
-     public void testOpsReadDecoderTransponding() throws ProgrammerException {
+    @Test
+    public void testOpsReadDecoderTransponding() throws ProgrammerException {
         // allow transponding
         sm.setTranspondingAvailable(true);
 
-        LnOpsModeProgrammer lnopsmodeprogrammer = new LnOpsModeProgrammer(memo, 4, true);
+        lnopsmodeprogrammer = new LnOpsModeProgrammer(memo, 4, true);
 
         lnopsmodeprogrammer.setMode(ProgrammingMode.OPSBYTEMODE);
         lnopsmodeprogrammer.readCV("12", pl);
 
         // should have written
-        Assert.assertEquals("one message sent", 1, lnis.outbound.size());
-        Assert.assertEquals("No programming reply", 0, pl.getRcvdInvoked());
+        assertEquals( 1, lnis.outbound.size(), "one message sent");
+        assertEquals( 0, pl.getRcvdInvoked(), "No programming reply");
 
-        Assert.assertEquals("sent", "EF 0E 7C 2F 00 00 04 00 00 0B 00 7F 7F 00", lnis.outbound.get(0).toString());
+        assertEquals( "EF 0E 7C 2F 00 00 04 00 00 0B 00 7F 7F 00", lnis.outbound.get(0).toString(), "sent");
 
         // check echo of sent message has no effect
         LocoNetMessage m = lnis.outbound.get(0);
         lnopsmodeprogrammer.message(m);
-        Assert.assertEquals("still one message sent", 1, lnis.outbound.size());
-        Assert.assertEquals("No programming reply", 0, pl.getRcvdInvoked());
+        assertEquals( 1, lnis.outbound.size(), "still one message sent");
+        assertEquals( 0, pl.getRcvdInvoked(), "No programming reply");
 
         // LACK followed by Known-good message in reply
         m = new LocoNetMessage(new int[]{0xB4, 0x6F, 0x01, 0x25});
@@ -425,31 +428,31 @@ public class LnOpsModeProgrammerTest extends jmri.AddressedProgrammerTestBase{
         lnopsmodeprogrammer.message(m);
         sm.message(m);
         JUnitUtil.waitFor(()->{return pl.getRcvdInvoked() == 1;},"getRcvdInvoked not set");
-        Assert.assertEquals("still one message sent", 1, lnis.outbound.size());
-        Assert.assertEquals("Reply status OK", 0, pl.getRcvdStatus());
-     }
+        assertEquals( 1, lnis.outbound.size(), "still one message sent");
+        assertEquals( 0, pl.getRcvdStatus(), "Reply status OK");
+    }
 
-     @Test
-     public void testOpsReadLocoNetMode() throws ProgrammerException {
+    @Test
+    public void testOpsReadLocoNetMode() throws ProgrammerException {
         // allow transponding
         sm.setTranspondingAvailable(false);
 
-        LnOpsModeProgrammer lnopsmodeprogrammer = new LnOpsModeProgrammer(memo, 4, true);
+        lnopsmodeprogrammer = new LnOpsModeProgrammer(memo, 4, true);
 
         lnopsmodeprogrammer.setMode(LnProgrammerManager.LOCONETOPSBOARD);
         lnopsmodeprogrammer.readCV("12", pl);
 
         // should have written
-        Assert.assertEquals("one message sent", 1, lnis.outbound.size());
-        Assert.assertEquals("No programming reply", 0, pl.getRcvdInvoked());
+        assertEquals( 1, lnis.outbound.size(), "one message sent");
+        assertEquals( 0, pl.getRcvdInvoked(), "No programming reply");
 
-        Assert.assertEquals("sent", "EF 0E 7C 2F 00 00 04 00 00 0B 00 7F 7F 00", lnis.outbound.get(0).toString());
+        assertEquals( "EF 0E 7C 2F 00 00 04 00 00 0B 00 7F 7F 00", lnis.outbound.get(0).toString(), "sent");
 
         // check echo of sent message has no effect
         LocoNetMessage m = lnis.outbound.get(0);
         lnopsmodeprogrammer.message(m);
-        Assert.assertEquals("still one message sent", 1, lnis.outbound.size());
-        Assert.assertEquals("No programming reply", 0, pl.getRcvdInvoked());
+        assertEquals( 1, lnis.outbound.size(), "still one message sent");
+        assertEquals( 0, pl.getRcvdInvoked(), "No programming reply");
 
         // LACK followed by Known-good message in reply
         m = new LocoNetMessage(new int[]{0xB4, 0x6F, 0x01, 0x25});
@@ -460,32 +463,32 @@ public class LnOpsModeProgrammerTest extends jmri.AddressedProgrammerTestBase{
         lnopsmodeprogrammer.message(m);
         sm.message(m);
         JUnitUtil.waitFor(()->{return pl.getRcvdInvoked() == 1;},"getRcvdInvoked not set");
-        Assert.assertEquals("still one message sent", 1, lnis.outbound.size());
-        Assert.assertEquals("Reply status OK", 0, pl.getRcvdStatus());
+        assertEquals( 1, lnis.outbound.size(), "still one message sent");
+        assertEquals( 0, pl.getRcvdStatus(), "Reply status OK");
 
-     }
+    }
 
-     @Test
-     public void testOpsReadLocoNetModeLACKRejected() throws ProgrammerException {
+    @Test
+    public void testOpsReadLocoNetModeLACKRejected() throws ProgrammerException {
         // allow transponding
         sm.setTranspondingAvailable(false);
 
-        LnOpsModeProgrammer lnopsmodeprogrammer = new LnOpsModeProgrammer(memo, 4, true);
+        lnopsmodeprogrammer = new LnOpsModeProgrammer(memo, 4, true);
 
         lnopsmodeprogrammer.setMode(LnProgrammerManager.LOCONETOPSBOARD);
         lnopsmodeprogrammer.readCV("12", pl);
 
         // should have written
-        Assert.assertEquals("one message sent", 1, lnis.outbound.size());
-        Assert.assertEquals("No programming reply", 0, pl.getRcvdInvoked());
+        assertEquals( 1, lnis.outbound.size(), "one message sent");
+        assertEquals( 0, pl.getRcvdInvoked(), "No programming reply");
 
-        Assert.assertEquals("sent", "EF 0E 7C 2F 00 00 04 00 00 0B 00 7F 7F 00", lnis.outbound.get(0).toString());
+        assertEquals( "EF 0E 7C 2F 00 00 04 00 00 0B 00 7F 7F 00", lnis.outbound.get(0).toString(), "sent");
 
         // check echo of sent message has no effect
         LocoNetMessage m = lnis.outbound.get(0);
         lnopsmodeprogrammer.message(m);
-        Assert.assertEquals("still one message sent", 1, lnis.outbound.size());
-        Assert.assertEquals("No programming reply", 0, pl.getRcvdInvoked());
+        assertEquals( 1, lnis.outbound.size(), "still one message sent");
+        assertEquals( 0, pl.getRcvdInvoked(), "No programming reply");
 
         // LACK "command rejected" followed by Known-good message in reply
         m = new LocoNetMessage(new int[]{0xB4, 0x6F, 0x00, 0x24});
@@ -496,32 +499,32 @@ public class LnOpsModeProgrammerTest extends jmri.AddressedProgrammerTestBase{
         lnopsmodeprogrammer.message(m);
         sm.message(m);
         JUnitUtil.waitFor(()->{return pl.getRcvdInvoked() == 1;},"getRcvdInvoked not set");
-        Assert.assertEquals("still one message sent", 1, lnis.outbound.size());
-        Assert.assertEquals("Reply status OK", 0, pl.getRcvdStatus());
+        assertEquals( 1, lnis.outbound.size(), "still one message sent");
+        assertEquals( 0, pl.getRcvdStatus(), "Reply status OK");
 
-     }
+    }
 
-     @Test
-     public void testOpsReadLocoNetModeLACKAcceptedBlind() throws ProgrammerException {
+    @Test
+    public void testOpsReadLocoNetModeLACKAcceptedBlind() throws ProgrammerException {
         // allow transponding
         sm.setTranspondingAvailable(false);
 
-        LnOpsModeProgrammer lnopsmodeprogrammer = new LnOpsModeProgrammer(memo, 4, true);
+        lnopsmodeprogrammer = new LnOpsModeProgrammer(memo, 4, true);
 
         lnopsmodeprogrammer.setMode(LnProgrammerManager.LOCONETOPSBOARD);
         lnopsmodeprogrammer.readCV("12", pl);
 
         // should have written
-        Assert.assertEquals("one message sent", 1, lnis.outbound.size());
-        Assert.assertEquals("No programming reply", 0, pl.getRcvdInvoked());
+        assertEquals( 1, lnis.outbound.size(), "one message sent");
+        assertEquals( 0, pl.getRcvdInvoked(), "No programming reply");
 
-        Assert.assertEquals("sent", "EF 0E 7C 2F 00 00 04 00 00 0B 00 7F 7F 00", lnis.outbound.get(0).toString());
+        assertEquals( "EF 0E 7C 2F 00 00 04 00 00 0B 00 7F 7F 00", lnis.outbound.get(0).toString(), "sent");
 
         // check echo of sent message has no effect
         LocoNetMessage m = lnis.outbound.get(0);
         lnopsmodeprogrammer.message(m);
-        Assert.assertEquals("still one message sent", 1, lnis.outbound.size());
-        Assert.assertEquals("No programming reply", 0, pl.getRcvdInvoked());
+        assertEquals( 1, lnis.outbound.size(), "still one message sent");
+        assertEquals( 0, pl.getRcvdInvoked(), "No programming reply");
 
         // LACK "accepted blind" followed by Known-good message in reply
         m = new LocoNetMessage(new int[]{0xB4, 0x6F, 0x40, 0x64});
@@ -532,40 +535,36 @@ public class LnOpsModeProgrammerTest extends jmri.AddressedProgrammerTestBase{
         lnopsmodeprogrammer.message(m);
         sm.message(m);
         JUnitUtil.waitFor(()->{return pl.getRcvdInvoked() == 1;},"getRcvdInvoked not set");
-        Assert.assertEquals("still one message sent", 1, lnis.outbound.size());
-        Assert.assertEquals("Reply status OK", 0, pl.getRcvdStatus());
+        assertEquals( 1, lnis.outbound.size(), "still one message sent");
+        assertEquals( 0, pl.getRcvdStatus(), "Reply status OK");
 
-     }
+    }
 
     @Test
-     public void testOneOps7genAccyCvReadAccess() throws ProgrammerException {
+    public void testOneOps7genAccyCvReadAccess() throws ProgrammerException {
         // disallow transponding
         sm.setTranspondingAvailable(false);
 
-        LnOpsModeProgrammer lnopsmodeprogrammer = new LnOpsModeProgrammer(memo, 4625, true);
+        lnopsmodeprogrammer = new LnOpsModeProgrammer(memo, 4625, true);
 
         lnopsmodeprogrammer.setMode(LnProgrammerManager.LOCONETBD7OPSWMODE);
         lnopsmodeprogrammer.readCV("12", pl);
 
         // should have written
-        Assert.assertEquals("one message sent", 1, lnis.outbound.size());
-        Assert.assertEquals("No programming reply", 0, pl.getRcvdInvoked());
+        assertEquals( 1, lnis.outbound.size(), "one message sent");
+        assertEquals( 0, pl.getRcvdInvoked(), "No programming reply");
 
-        Assert.assertEquals("sent", "ED 0B 7F 54 07 04 58 64 0B 00 00", lnis.outbound.get(0).toString());
+        assertEquals( "ED 0B 7F 54 07 04 58 64 0B 00 00", lnis.outbound.get(0).toString(), "sent");
 
         // check echo of sent message has no effect
         LocoNetMessage m = lnis.outbound.get(0);
 
         lnis.sendTestMessage(m); // (Device sends the message on LocoNet)
 
-        Assert.assertEquals("still one message sent", 1, lnis.outbound.size());
-        Assert.assertEquals("No programming reply", 0, pl.getRcvdInvoked());
+        assertEquals( 1, lnis.outbound.size(), "still one message sent");
+        assertEquals( 0, pl.getRcvdInvoked(), "No programming reply");
 
-        try {
-            Thread.sleep(1);
-        } catch (InterruptedException e) {
-
-        }
+        JUnitUtil.waitFor(1);
 
         // receive a LACK "accepted" from "command station"
         m = new LocoNetMessage(new int[]{0xB4, 0x6d, 0x7f, 0x64});
@@ -573,12 +572,7 @@ public class LnOpsModeProgrammerTest extends jmri.AddressedProgrammerTestBase{
         lnis.sendTestMessage(m); // (Device sends the message on LocoNet)
 
         // make sure the "accepted blind" was received.
-        try {
-            Thread.sleep(10);
-
-        } catch (InterruptedException e) {
-
-        }
+        JUnitUtil.waitFor(10);
 
         // Now "receive" the reply from the 7th-gen Accy device
         m = new LocoNetMessage(new int[]{0xB4, 0x6E, 0x12, 0x00});
@@ -587,22 +581,18 @@ public class LnOpsModeProgrammerTest extends jmri.AddressedProgrammerTestBase{
         lnis.sendTestMessage(m); // (Device sends the message on LocoNet)
 
         JUnitUtil.waitFor(()->{return pl.getRcvdInvoked() == 1;},"getRcvdInvoked not set");
-        Assert.assertEquals("still one message sent", 1, lnis.outbound.size());
-        Assert.assertEquals("Reply status OK", 0, pl.getRcvdStatus());
-        Assert.assertEquals("Got read of 18", 18, pl.getRcvdValue());
+        assertEquals( 1, lnis.outbound.size(), "still one message sent");
+        assertEquals( 0, pl.getRcvdStatus(), "Reply status OK");
+        assertEquals( 18, pl.getRcvdValue(), "Got read of 18");
 
-        try {
-            Thread.sleep(10);
-        } catch (InterruptedException e) {
-
-        }
+        JUnitUtil.waitFor(10);
         // end of first read!
 
         JUnitUtil.waitFor(()->{return pl.getRcvdInvoked() == 1;},"getRcvdInvoked not set");
-     }
+    }
 
-     @Test
-     public void testOps7genAccyAccesses() throws ProgrammerException {
+    @Test
+    public void testOps7genAccyAccesses() throws ProgrammerException {
         // disallow transponding
         sm.setTranspondingAvailable(false);
 
@@ -716,7 +706,7 @@ public class LnOpsModeProgrammerTest extends jmri.AddressedProgrammerTestBase{
 
     }
 
-     private void checkSome7thGenAccyReads(int address)  throws ProgrammerException {
+    private void checkSome7thGenAccyReads(int address)  throws ProgrammerException {
         int incoming = 1;
         int num;
         int i;
@@ -730,11 +720,10 @@ public class LnOpsModeProgrammerTest extends jmri.AddressedProgrammerTestBase{
             log.debug("checkSome7thGenAccyReads iteration {}", i);
 
             lnis.clearReceivedMessages();
-            Assert.assertEquals("Zero messages sent", 0, lnis.outbound.size());
+            assertEquals( 0, lnis.outbound.size(), "Zero messages sent");
             num = 1 << i;
             pl = new ProgListenerScaffold();
-            Assert.assertEquals("no programmingListener reply (yet)",
-                    0, pl.getRcvdInvoked());
+            assertEquals( 0, pl.getRcvdInvoked(), "no programmingListener reply (yet)");
             log.debug("At begin of loop {}, getRcvdInvolked = {}, Num {}",
                     i, pl.getRcvdInvoked(), num);
 
@@ -743,11 +732,11 @@ public class LnOpsModeProgrammerTest extends jmri.AddressedProgrammerTestBase{
             log.debug("   testcase continuing...  After the CV Read accesss started, getRcvdInvolked = {}",
                     pl.getRcvdInvoked());
             // should have sent the CV access to Addr 1 CV num (i)
-            Assert.assertEquals("outbound size (i="+Integer.toString(i)+") ",
-                    1, lnis.outbound.size());
+
+            assertEquals( 1, lnis.outbound.size(),
+                "outbound size (i="+Integer.toString(i)+") ");
             log.debug("  testcase checks lnis.outbound.size() as 1 and was ok.");
-            Assert.assertEquals("no programmingListener reply (yet)",
-                    0, pl.getRcvdInvoked());
+            assertEquals( 0, pl.getRcvdInvoked(), "no programmingListener reply (yet)");
 
             String snum = "0"+Integer.toHexString(num-1);
             if (snum.length() >= 3) {
@@ -767,8 +756,8 @@ public class LnOpsModeProgrammerTest extends jmri.AddressedProgrammerTestBase{
             if (sa2.length() != 2) {
                 sa2 = sa2.substring(sa2.length()-2);
             }
-            Assert.assertEquals("sent", "ED 0B 7F 54 07 " + sa2 + " " + sa1 +" 64 "+snum+" 00 00",
-                    lnis.outbound.get(0).toString());
+            assertEquals( "ED 0B 7F 54 07 " + sa2 + " " + sa1 +" 64 "+snum+" 00 00",
+                lnis.outbound.get(0).toString(), "sent");
             // check echo of sent message has no effect
             log.debug("   testcase got access request message from JMRI's LocoNet transmit");
             m = lnis.outbound.get(0);
@@ -776,33 +765,29 @@ public class LnOpsModeProgrammerTest extends jmri.AddressedProgrammerTestBase{
             lnis.sendTestMessage(m);  // (LocoNet echo of transmitted message!)
             log.debug("   testcase has echoed CV access request");
 
-            Assert.assertEquals("Still 1 message sent", 1, lnis.outbound.size());
-            Assert.assertEquals("Still 0 programming replies",
-                    0, pl.getRcvdInvoked());
+            assertEquals( 1, lnis.outbound.size(), "Still 1 message sent");
+            assertEquals( 0, pl.getRcvdInvoked(), "Still 0 programming replies");
             incoming++;
 
             // wait a little for command station response
-            try {
-                Thread.sleep(1);
-            } catch (InterruptedException e) {
-            }
+            JUnitUtil.waitFor(1);
 
-            Assert.assertEquals("saw 1 message sent", 1, lnis.outbound.size());
+            assertEquals( 1, lnis.outbound.size(), "saw 1 message sent");
             // receive a LACK "accepted" from "command station"
             m = new LocoNetMessage(new int[]{0xB4, 0x6d, 0x7f, 0x64});
 
             log.debug("   testcase is sending c.s.'s 'long_ack' as {}", m.toString());
             lnis.sendTestMessage(m);  // (Command station default response)
 
-            Assert.assertEquals("saw 1 message sent", 1, lnis.outbound.size());
+            assertEquals( 1, lnis.outbound.size(), "saw 1 message sent");
 
             // make sure the "accepted blind" was received.
-            Assert.assertNotNull("PL is not null",pl);
+            assertNotNull(pl, "PL is not null");
             final int j= incoming;
             log.debug("   testcase getRcvdInvolked = {}; j = incoming = {}.",
                     pl.getRcvdInvoked(), Integer.toString(j));
             JUnitUtil.waitFor(()->{return pl.getRcvdInvoked() == 0;},"getRcvdInvoked not set after CS long_ack");
-            Assert.assertEquals("Still Reply status not ready", -1, pl.getRcvdStatus());
+            assertEquals( -1, pl.getRcvdStatus(), "Still Reply status not ready");
 
             // Now "receive" the reply from the 7th-gen Accy device
 
@@ -810,10 +795,7 @@ public class LnOpsModeProgrammerTest extends jmri.AddressedProgrammerTestBase{
                     "; j = "+Integer.toString(j)+" before sent.");
 
             // wait a while for the device to reply
-            try {
-                Thread.sleep(1);
-            } catch (InterruptedException e) {
-            }
+            JUnitUtil.waitFor(1);
 
             m = getLnLongAckFromVal(num);
             lnis.sendTestMessage(m); // (Device sends the message on LocoNet)
@@ -822,20 +804,17 @@ public class LnOpsModeProgrammerTest extends jmri.AddressedProgrammerTestBase{
                     + " after send, pl.getRcvdInvoked() is {}  for j = {}, num= {}.",
                     Integer.toString(pl.getRcvdInvoked()), j, num);
             JUnitUtil.waitFor(()->{return pl.getRcvdInvoked() == 1;},"getRcvdInvoked not set (#2)");
-            Assert.assertEquals("saw 1 message sent", 1, lnis.outbound.size());
-            Assert.assertEquals("Still Reply status OK", 0, pl.getRcvdStatus());
-            Assert.assertEquals("Expected read of "+num, num, pl.getRcvdValue());
+            assertEquals( 1, lnis.outbound.size(), "saw 1 message sent");
+            assertEquals( 0, pl.getRcvdStatus(), "Still Reply status OK");
+            assertEquals( num, pl.getRcvdValue(), "Expected read of "+num);
             log.debug("Got readCV result of {} at {}.",pl.getRcvdValue(), java.time.LocalTime.now());
 
-            try {
-                Thread.sleep(1);
-            } catch (InterruptedException e) {
-            }
+            JUnitUtil.waitFor(1);
 
             log.debug("!! checkSome7thGenAccyReads: end of test !!");
         }
         log.debug("!!!!!! checkSome7thGenAccyReads: end of test loop !!!!!!");
-     }
+    }
 
     private void checkSome7thGenAccyWrites(int address)  throws ProgrammerException {
         int incoming = 1;
@@ -850,10 +829,9 @@ public class LnOpsModeProgrammerTest extends jmri.AddressedProgrammerTestBase{
             num = 1 << i;
             log.debug("checkSome7thGenAccyWrites iteration {}, num = {}", i, num);
             lnis.clearReceivedMessages();
-            Assert.assertEquals("Zero messages sent", 0, lnis.outbound.size());
+            assertEquals( 0, lnis.outbound.size(), "Zero messages sent");
             pl = new ProgListenerScaffold();
-            Assert.assertEquals("no programmingListener reply (yet)",
-                    0, pl.getRcvdInvoked());
+            assertEquals( 0, pl.getRcvdInvoked(), "no programmingListener reply (yet)");
             log.debug("At begin of loop {}, getRcvdInvolked = {}, Num {}",
                     i, pl.getRcvdInvoked(), num);
 
@@ -862,11 +840,9 @@ public class LnOpsModeProgrammerTest extends jmri.AddressedProgrammerTestBase{
             log.debug("   testcase continuing...  After the CV Read accesss started, getRcvdInvolked = {}",
                     pl.getRcvdInvoked());
             // should have sent the CV access to Addr 1 CV num (i)
-            Assert.assertEquals("outbound size (i="+Integer.toString(i)+") ",
-                    1, lnis.outbound.size());
+            assertEquals( 1, lnis.outbound.size(), "outbound size (i="+Integer.toString(i)+") ");
             log.debug("  testcase checks lnis.outbound.size() as 1 and was ok.");
-            Assert.assertEquals("no programmingListener reply (yet)",
-                    0, pl.getRcvdInvoked());
+            assertEquals( 0, pl.getRcvdInvoked(), "no programmingListener reply (yet)");
 
             String snum = "0"+Integer.toHexString(num-1);
             if (snum.length() >= 3) {
@@ -897,8 +873,8 @@ public class LnOpsModeProgrammerTest extends jmri.AddressedProgrammerTestBase{
                 evExtraBits = evExtraBits.substring(evExtraBits.length()-2);
             }
 
-            Assert.assertEquals("sent", "ED 0B 7F 54 "+evExtraBits+" " + sa2 + " " + sa1 +" 6C "+snum+" "+ expectVal+" 00",
-                    lnis.outbound.get(0).toString());
+            assertEquals( "ED 0B 7F 54 "+evExtraBits+" " + sa2 + " " + sa1 +" 6C "+snum+" "+ expectVal+" 00",
+                lnis.outbound.get(0).toString(), "sent");
             // check echo of sent message has no effect
             log.debug("   testcase got access request message from JMRI's LocoNet transmit");
             m = lnis.outbound.get(0);
@@ -906,33 +882,29 @@ public class LnOpsModeProgrammerTest extends jmri.AddressedProgrammerTestBase{
             lnis.sendTestMessage(m);  // (LocoNet echo of transmitted message!)
             log.debug("   testcase has echoed CV access request");
 
-            Assert.assertEquals("Still 1 message sent", 1, lnis.outbound.size());
-            Assert.assertEquals("Still 0 programming replies",
-                    0, pl.getRcvdInvoked());
+            assertEquals( 1, lnis.outbound.size(), "Still 1 message sent");
+            assertEquals( 0, pl.getRcvdInvoked(), "Still 0 programming replies");
             incoming++;
 
             // wait a little for command station response
-            try {
-                Thread.sleep(1);
-            } catch (InterruptedException e) {
-            }
+            JUnitUtil.waitFor(1);
 
-            Assert.assertEquals("saw 1 message sent", 1, lnis.outbound.size());
+            assertEquals( 1, lnis.outbound.size(), "saw 1 message sent");
             // receive a LACK "accepted" from "command station"
             m = new LocoNetMessage(new int[]{0xB4, 0x6d, 0x7f, 0x64});
 
             log.debug("   checkSome7thGenAccyWrites: testcase is sending c.s.'s 'long_ack' as {}", m.toString());
             lnis.sendTestMessage(m);  // (Command station default response)
 
-            Assert.assertEquals("saw 1 message sent", 1, lnis.outbound.size());
+            assertEquals( 1, lnis.outbound.size(), "saw 1 message sent");
 
             // make sure the "accepted blind" was received.
-            Assert.assertNotNull("PL is not null",pl);
+            assertNotNull( pl, "PL is not null");
             final int j= incoming;
             log.debug("   testcase getRcvdInvolked = {}; j = incoming = {}.",
                     pl.getRcvdInvoked(), Integer.toString(j));
             JUnitUtil.waitFor(()->{return pl.getRcvdInvoked() == 0;},"getRcvdInvoked not set after CS long_ack");
-            Assert.assertEquals("Still Reply status not ready", -1, pl.getRcvdStatus());
+            assertEquals( -1, pl.getRcvdStatus(), "Still Reply status not ready");
 
             // Now "receive" the reply from the 7th-gen Accy device
 
@@ -940,10 +912,7 @@ public class LnOpsModeProgrammerTest extends jmri.AddressedProgrammerTestBase{
                     "; j = "+Integer.toString(j)+" before sent.");
 
             // wait a while for the device to reply
-            try {
-                Thread.sleep(1);
-            } catch (InterruptedException e) {
-            }
+            JUnitUtil.waitFor(1);
 
             // send the reply from the device
             m = getLnLongAckFromVal(0x5A);
@@ -953,22 +922,19 @@ public class LnOpsModeProgrammerTest extends jmri.AddressedProgrammerTestBase{
             log.debug("   testcase: after send, pl.getRcvdInvoked() is {}  for j = {}, num= {}.",
                     Integer.toString(pl.getRcvdInvoked()), j, num);
             JUnitUtil.waitFor(()->{return pl.getRcvdInvoked() == 1;},"getRcvdInvoked not set (#2)");
-            Assert.assertEquals("saw 1 message sent", 1, lnis.outbound.size());
-            Assert.assertEquals("Still Reply status OK", 0, pl.getRcvdStatus());
+            assertEquals( 1, lnis.outbound.size(), "saw 1 message sent");
+            assertEquals( 0, pl.getRcvdStatus(), "Still Reply status OK");
             // figure result  expectationres
             int result = ((num & 1)==1)?0:1;
             log.debug("checkSome7thGenAccyWrites write value was {}, result expected is {}", num, result);
 
-            Assert.assertEquals("checkSome7thGenAccyWrites Expected result of "+Integer.toString(result), result, pl.getRcvdValue());
-            try {
-                Thread.sleep(1);
-            } catch (InterruptedException e) {
-            }
+            assertEquals( result, pl.getRcvdValue(), "checkSome7thGenAccyWrites Expected result of "+Integer.toString(result));
+            JUnitUtil.waitFor(1);
 
             log.debug("!! checkSome7thGenAccyWrites: end of test loop !!");
         }
         log.debug("end of checkSome7thGenAccyWrites");
-     }
+    }
 
     private LocoNetMessage getLnLongAckFromVal(int val) {
         int opc = LnConstants.OPC_LONG_ACK;
@@ -1011,11 +977,14 @@ public class LnOpsModeProgrammerTest extends jmri.AddressedProgrammerTestBase{
     @AfterEach
     @Override
     public void tearDown() {
+        lnopsmodeprogrammer.dispose();
         memo.dispose();
         lnis = null;
 
         programmer = lnopsmodeprogrammer = null;
         JUnitUtil.tearDown();
     }
-    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LnOpsModeProgrammerTest.class);
+
+    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LnOpsModeProgrammerTest.class);
+
 }

--- a/java/test/jmri/jmrix/loconet/LnThrottleManagerTest.java
+++ b/java/test/jmri/jmrix/loconet/LnThrottleManagerTest.java
@@ -251,7 +251,11 @@ public class LnThrottleManagerTest extends jmri.managers.AbstractThrottleManager
                 lnis.outbound.elementAt(lnis.outbound.size() - 1).toString(), "address request message");
         memo.getSlotManager().message(lnis.outbound.elementAt(lnis.outbound.size()-1));
 
-        assertEquals(1, lnis.outbound.size(), "count is correct");
+        // Throttle request messages may be missed on 1st send so we wait for
+        // the 2nd message sent ( in 5.13.5 it's 1000ms after the 1st)
+        JUnitUtil.waitFor( () -> lnis.outbound.size() == 2, "throttle request repeated");
+        assertEquals( lnis.outbound.get(0), lnis.outbound.get(1), "2nd request matches 1st" );
+
         LocoNetMessage cmdStationReply = new LocoNetMessage(new int[] {
                 0xe7, 0x0e, 0x60, 0x30, 0x55, 0x0, 0x0, 0x7, 0x0, 0x00, 0x0, 0x2, 0x70, 0x53});  // slot is in-use
         lnis.sendTestMessage(cmdStationReply);
@@ -270,7 +274,11 @@ public class LnThrottleManagerTest extends jmri.managers.AbstractThrottleManager
             lnis.outbound.elementAt(lnis.outbound.size() - 1).toString(), "address request message");
         memo.getSlotManager().message(lnis.outbound.elementAt(lnis.outbound.size()-1));
 
-        assertEquals( 1, lnis.outbound.size(), "count is correct");
+        // Throttle request messages may be missed on 1st send so we wait for
+        // the 2nd message sent ( in 5.13.5 it's 1000ms after the 1st)
+        JUnitUtil.waitFor( () -> lnis.outbound.size() == 2, "throttle request repeated");
+        assertEquals( lnis.outbound.get(0), lnis.outbound.get(1), "2nd request matches 1st" );
+
         LocoNetMessage cmdStationReply = new LocoNetMessage(new int[] {
                 0xe7, 0x0e, 0x8, 0x30, 0x00, 0x0, 0x0, 0x7, 0x0, 0x02, 0x00, 0x13, 0x01, 0x53});  // slot is in-use
         lnis.sendTestMessage(cmdStationReply);

--- a/java/test/jmri/jmrix/loconet/logixng/configurexml/StoreAndLoadTest.java
+++ b/java/test/jmri/jmrix/loconet/logixng/configurexml/StoreAndLoadTest.java
@@ -17,12 +17,14 @@ import jmri.jmrix.loconet.logixng.ActionClearSlots;
 import jmri.jmrix.loconet.logixng.ActionUpdateSlots;
 import jmri.jmrix.loconet.logixng.ExpressionSlotUsage;
 import jmri.util.*;
+import jmri.util.junit.annotations.DisabledIfHeadless;
 
 import org.apache.commons.lang3.mutable.MutableInt;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.*;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Creates a LogixNG with all actions and expressions to test store and load.
@@ -39,7 +41,7 @@ public class StoreAndLoadTest {
     private LocoNetSystemConnectionMemo memo1;
     private LocoNetSystemConnectionMemo memo2;
 
-    @DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
+    @DisabledIfHeadless
     @Test
     public void testLogixNGs() throws PropertyVetoException, Exception {
 
@@ -175,7 +177,8 @@ public class StoreAndLoadTest {
             log.debug(results ? "store was successful" : "store failed");
             if (!results) {
                 log.error("Failed to store panel");
-                throw new RuntimeException("Failed to store panel");
+                // throw new RuntimeException("Failed to store panel");
+                fail("Failed to store panel", new Exception());
             }
 
             // Add the header comment to the xml file
@@ -206,10 +209,10 @@ public class StoreAndLoadTest {
                 digitalExpressionManager.deleteDigitalExpression(aDigitalExpression);
             }
 
-            Assert.assertEquals(0, logixNG_Manager.getNamedBeanSet().size());
-            Assert.assertEquals(0, conditionalNGManager.getNamedBeanSet().size());
-            Assert.assertEquals(0, digitalActionManager.getNamedBeanSet().size());
-            Assert.assertEquals(0, digitalExpressionManager.getNamedBeanSet().size());
+            assertEquals(0, logixNG_Manager.getNamedBeanSet().size());
+            assertEquals(0, conditionalNGManager.getNamedBeanSet().size());
+            assertEquals(0, digitalActionManager.getNamedBeanSet().size());
+            assertEquals(0, digitalExpressionManager.getNamedBeanSet().size());
 
             LogixNG_Thread.stopAllLogixNGThreads();
             LogixNG_Thread.assertLogixNGThreadNotRunning();
@@ -263,11 +266,11 @@ public class StoreAndLoadTest {
 */
 //                    log.error(conditionalNGManager.getBySystemName(originalTree).getChild(0).getConnectedSocket().getSystemName());
 
-                    Assert.fail("tree has changed");
+                    fail("tree has changed");
 //                    throw new RuntimeException("tree has changed");
                 }
             } else {
-                Assert.fail("Failed to load panel");
+                fail("Failed to load panel");
 //                throw new RuntimeException("Failed to load panel");
             }
         }
@@ -341,12 +344,16 @@ public class StoreAndLoadTest {
     @AfterEach
     public void tearDown() {
         // JUnitAppender.clearBacklog();    // REMOVE THIS!!!
+        lnis1.dispose();
+        lnis2.dispose();
+        memo1.dispose();
+        memo2.dispose();
 
         JUnitUtil.removeMatchingThreads("LnPowerManager LnTrackStatusUpdateThread");
         JUnitUtil.removeMatchingThreads("LnSensorUpdateThread");
         JUnitUtil.removeMatchingThreads("LocoNetThrottledTransmitter");
 
-        jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }


### PR DESCRIPTION
**LnThrottleManagerTest**
Throttle request messages occasionally missed on 1st send so wait for the message to be repeated.

**StoreAndLoadTest** ( LogixNG )
Moves RuntimeException to test failure.
Disposes of memos and LocoNetInterfaceScaffolds

**LnOpsModeProgrammerTest**
Use existing lnopsmodeprogrammer field and dispose of it on tearDown.
Moves Thread.sleep instances to JUnitUtil.waitFor
Assertions JU4 > JU5