### PR TITLE
LogixNG Tests - assert some log warnings

### DIFF
--- a/java/test/jmri/jmrit/logixng/actions/AbstractAnalogActionTestBase.java
+++ b/java/test/jmri/jmrit/logixng/actions/AbstractAnalogActionTestBase.java
@@ -5,6 +5,8 @@ import jmri.JmriException;
 import jmri.NamedBean;
 import jmri.jmrit.logixng.AbstractBaseTestBase;
 import jmri.jmrit.logixng.AnalogActionBean;
+import jmri.util.JUnitAppender;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -41,14 +43,17 @@ public abstract class AbstractAnalogActionTestBase extends AbstractBaseTestBase 
     public void testState() throws JmriException {
         AnalogActionBean _action = (AnalogActionBean)_base;
         _action.setState(AnalogIO.INCONSISTENT);
+        JUnitAppender.assertWarnMessage("Unexpected call to setState in AbstractAnalogAction.");
         Assert.assertTrue("State matches", AnalogIO.INCONSISTENT == _action.getState());
-        jmri.util.JUnitAppender.assertWarnMessage("Unexpected call to getState in AbstractAnalogAction.");
+        JUnitAppender.assertWarnMessage("Unexpected call to getState in AbstractAnalogAction.");
         _action.setState(AnalogIO.UNKNOWN);
+        JUnitAppender.assertWarnMessage("Unexpected call to setState in AbstractAnalogAction.");
         Assert.assertTrue("State matches", AnalogIO.UNKNOWN == _action.getState());
-        jmri.util.JUnitAppender.assertWarnMessage("Unexpected call to getState in AbstractAnalogAction.");
+        JUnitAppender.assertWarnMessage("Unexpected call to getState in AbstractAnalogAction.");
         _action.setState(AnalogIO.INCONSISTENT);
+        JUnitAppender.assertWarnMessage("Unexpected call to setState in AbstractAnalogAction.");
         Assert.assertTrue("State matches", AnalogIO.INCONSISTENT == _action.getState());
-        jmri.util.JUnitAppender.assertWarnMessage("Unexpected call to getState in AbstractAnalogAction.");
+        JUnitAppender.assertWarnMessage("Unexpected call to getState in AbstractAnalogAction.");
     }
     
 }

--- a/java/test/jmri/jmrit/logixng/actions/AbstractStringActionTestBase.java
+++ b/java/test/jmri/jmrit/logixng/actions/AbstractStringActionTestBase.java
@@ -5,6 +5,7 @@ import jmri.JmriException;
 import jmri.NamedBean;
 import jmri.jmrit.logixng.AbstractBaseTestBase;
 import jmri.jmrit.logixng.StringActionBean;
+import jmri.util.JUnitAppender;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -42,14 +43,17 @@ public abstract class AbstractStringActionTestBase extends AbstractBaseTestBase 
     public void testState() throws JmriException {
         StringActionBean _action = (StringActionBean)_base;
         _action.setState(StringIO.INCONSISTENT);
+        JUnitAppender.assertWarnMessage("Unexpected call to setState in AbstractStringAction.");
         Assert.assertTrue("State matches", StringIO.INCONSISTENT == _action.getState());
-        jmri.util.JUnitAppender.assertWarnMessage("Unexpected call to getState in AbstractStringAction.");
+        JUnitAppender.assertWarnMessage("Unexpected call to getState in AbstractStringAction.");
         _action.setState(StringIO.UNKNOWN);
+        JUnitAppender.assertWarnMessage("Unexpected call to setState in AbstractStringAction.");
         Assert.assertTrue("State matches", StringIO.UNKNOWN == _action.getState());
-        jmri.util.JUnitAppender.assertWarnMessage("Unexpected call to getState in AbstractStringAction.");
+        JUnitAppender.assertWarnMessage("Unexpected call to getState in AbstractStringAction.");
         _action.setState(StringIO.INCONSISTENT);
+        JUnitAppender.assertWarnMessage("Unexpected call to setState in AbstractStringAction.");
         Assert.assertTrue("State matches", StringIO.INCONSISTENT == _action.getState());
-        jmri.util.JUnitAppender.assertWarnMessage("Unexpected call to getState in AbstractStringAction.");
+        JUnitAppender.assertWarnMessage("Unexpected call to getState in AbstractStringAction.");
     }
     
 }

--- a/java/test/jmri/jmrit/logixng/expressions/AbstractAnalogExpressionTestBase.java
+++ b/java/test/jmri/jmrit/logixng/expressions/AbstractAnalogExpressionTestBase.java
@@ -6,6 +6,8 @@ import jmri.NamedBean;
 import jmri.jmrit.logixng.AnalogExpressionBean;
 import jmri.jmrit.logixng.AbstractBaseTestBase;
 import jmri.jmrit.logixng.implementation.DefaultMaleAnalogExpressionSocket.AnalogExpressionDebugConfig;
+import jmri.util.JUnitAppender;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -42,14 +44,17 @@ public abstract class AbstractAnalogExpressionTestBase extends AbstractBaseTestB
     public void testState() throws JmriException {
         AnalogExpressionBean _expression = (AnalogExpressionBean)_base;
         _expression.setState(AnalogIO.INCONSISTENT);
+        JUnitAppender.assertWarnMessage("Unexpected call to setState in AbstractAnalogExpression.");
         Assert.assertTrue("State matches", AnalogIO.INCONSISTENT == _expression.getState());
-        jmri.util.JUnitAppender.assertWarnMessage("Unexpected call to getState in AbstractAnalogExpression.");
+        JUnitAppender.assertWarnMessage("Unexpected call to getState in AbstractAnalogExpression.");
         _expression.setState(AnalogIO.UNKNOWN);
+        JUnitAppender.assertWarnMessage("Unexpected call to setState in AbstractAnalogExpression.");
         Assert.assertTrue("State matches", AnalogIO.UNKNOWN == _expression.getState());
-        jmri.util.JUnitAppender.assertWarnMessage("Unexpected call to getState in AbstractAnalogExpression.");
+        JUnitAppender.assertWarnMessage("Unexpected call to getState in AbstractAnalogExpression.");
         _expression.setState(AnalogIO.INCONSISTENT);
+        JUnitAppender.assertWarnMessage("Unexpected call to setState in AbstractAnalogExpression.");
         Assert.assertTrue("State matches", AnalogIO.INCONSISTENT == _expression.getState());
-        jmri.util.JUnitAppender.assertWarnMessage("Unexpected call to getState in AbstractAnalogExpression.");
+        JUnitAppender.assertWarnMessage("Unexpected call to getState in AbstractAnalogExpression.");
     }
     
     @Test

--- a/java/test/jmri/jmrit/logixng/expressions/AbstractStringExpressionTestBase.java
+++ b/java/test/jmri/jmrit/logixng/expressions/AbstractStringExpressionTestBase.java
@@ -6,6 +6,7 @@ import jmri.NamedBean;
 import jmri.jmrit.logixng.StringExpressionBean;
 import jmri.jmrit.logixng.AbstractBaseTestBase;
 import jmri.jmrit.logixng.implementation.DefaultMaleStringExpressionSocket.StringExpressionDebugConfig;
+import jmri.util.JUnitAppender;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -43,14 +44,17 @@ public abstract class AbstractStringExpressionTestBase extends AbstractBaseTestB
     public void testState() throws JmriException {
         StringExpressionBean _expression = (StringExpressionBean)_base;
         _expression.setState(StringIO.INCONSISTENT);
+        JUnitAppender.assertWarnMessage("Unexpected call to setState in AbstractStringExpression.");
         Assert.assertTrue("State matches", StringIO.INCONSISTENT == _expression.getState());
-        jmri.util.JUnitAppender.assertWarnMessage("Unexpected call to getState in AbstractStringExpression.");
+        JUnitAppender.assertWarnMessage("Unexpected call to getState in AbstractStringExpression.");
         _expression.setState(StringIO.UNKNOWN);
+        JUnitAppender.assertWarnMessage("Unexpected call to setState in AbstractStringExpression.");
         Assert.assertTrue("State matches", StringIO.UNKNOWN == _expression.getState());
-        jmri.util.JUnitAppender.assertWarnMessage("Unexpected call to getState in AbstractStringExpression.");
+        JUnitAppender.assertWarnMessage("Unexpected call to getState in AbstractStringExpression.");
         _expression.setState(StringIO.INCONSISTENT);
+        JUnitAppender.assertWarnMessage("Unexpected call to setState in AbstractStringExpression.");
         Assert.assertTrue("State matches", StringIO.INCONSISTENT == _expression.getState());
-        jmri.util.JUnitAppender.assertWarnMessage("Unexpected call to getState in AbstractStringExpression.");
+        JUnitAppender.assertWarnMessage("Unexpected call to getState in AbstractStringExpression.");
     }
     
     @Test


### PR DESCRIPTION
Adds more asserts for warn levels in logging.
JUnitAppender.assertWarnMessage() currently discards warnings / errors prior to the match.