### PR TITLE
DCC++ Test updates

### DIFF
--- a/java/test/jmri/jmrix/dccpp/DCCppProgrammerTest.java
+++ b/java/test/jmri/jmrix/dccpp/DCCppProgrammerTest.java
@@ -1,3 +1,17 @@
+package jmri.jmrix.dccpp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jmri.*;
+import jmri.util.JUnitUtil;
+
+import org.junit.jupiter.api.*;
+
 /**
  * DCCppProgrammerTest.java
  *
@@ -6,14 +20,6 @@
  * @author Bob Jacobsen
  * @author Mark Underwood (C) 2015
  */
-package jmri.jmrix.dccpp;
-
-import jmri.*;
-import jmri.util.JUnitUtil;
-
-import org.junit.Assert;
-import org.junit.jupiter.api.*;
-
 public class DCCppProgrammerTest extends jmri.jmrix.AbstractProgrammerTest {
 
     static final int RESTART_TIME = 20;
@@ -25,35 +31,36 @@ public class DCCppProgrammerTest extends jmri.jmrix.AbstractProgrammerTest {
     @Test
     @Override
     public void testDefault() {
-        Assert.assertEquals("Check Default", ProgrammingMode.DIRECTBYTEMODE,
-                programmer.getMode());
+        assertEquals( ProgrammingMode.DIRECTBYTEMODE, programmer.getMode(),
+            "Check Default");
     }
 
     @Override
     @Test
     public void testDefaultViaBestMode() {
-        Assert.assertEquals("Check Default", ProgrammingMode.DIRECTBYTEMODE,
-                ((DCCppProgrammer) programmer).getBestMode());
+        assertEquals( ProgrammingMode.DIRECTBYTEMODE,
+            ((DCCppProgrammer) programmer).getBestMode(), "Check Default");
     }
 
     @Test
     @Override
     public void testSetGetMode() {
-        Throwable throwable = Assert.assertThrows(IllegalArgumentException.class, () -> programmer.setMode(ProgrammingMode.REGISTERMODE));
-        Assertions.assertNotNull(throwable.getMessage());
+        Throwable throwable = assertThrows( IllegalArgumentException.class,
+            () -> programmer.setMode(ProgrammingMode.REGISTERMODE));
+        assertNotNull(throwable.getMessage());
     }
 
     @Override
     @Test
     public void testGetCanWriteAddress() {
-        Assert.assertFalse("can write address", programmer.getCanWrite("1234"));
+        assertFalse( programmer.getCanWrite("1234"), "can write address");
     }
 
     @Override
     @Test
     public void testGetWriteConfirmMode() {
-        Assert.assertEquals("Write Confirm Mode", Programmer.WriteConfirmMode.DecoderReply,
-                programmer.getWriteConfirmMode("1234"));
+        assertEquals( Programmer.WriteConfirmMode.DecoderReply,
+            programmer.getWriteConfirmMode("1234"), "Write Confirm Mode");
     }
 
     @Test
@@ -61,8 +68,9 @@ public class DCCppProgrammerTest extends jmri.jmrix.AbstractProgrammerTest {
         // and do the write
         p.writeCV("29", 34, l);
         // check "prog mode" message sent
-        Assert.assertEquals("mode message sent", 1, t.outbound.size());
-        Assert.assertEquals("write message contents", "W 29 34 0 87", t.outbound.elementAt(0).toString());
+        assertEquals( 1, t.outbound.size(), "mode message sent");
+        assertEquals( "W 29 34 0 87", t.outbound.elementAt(0).toString(),
+            "write message contents");
         // send reply
         DCCppReply mr1 = DCCppReply.parseDCCppReply("r 0|87|29 34");
         t.sendTestMessage(mr1);
@@ -73,10 +81,10 @@ public class DCCppProgrammerTest extends jmri.jmrix.AbstractProgrammerTest {
         // traffic controller to exit from service mode.  We just
         // need to wait a few seconds and see that the listener we
         // registered earlier received the values we expected.
-        JUnitUtil.waitFor(() -> { return !(l.getRcvdInvoked() == 0); });
+        JUnitUtil.waitFor(() -> !(l.getRcvdInvoked() == 0), "Rcvd not invoked");
         
-        Assert.assertFalse("Receive Called by Programmer", l.getRcvdInvoked() == 0);
-        Assert.assertEquals("Direct mode received value", 34, l.getRcvdValue());
+        assertNotEquals( 0, l.getRcvdInvoked(), "Receive Called by Programmer");
+        assertEquals( 34, l.getRcvdValue(), "Direct mode received value");
     }
 
     @Test
@@ -142,8 +150,8 @@ public class DCCppProgrammerTest extends jmri.jmrix.AbstractProgrammerTest {
         // and do the read
         p.readCV("29", l);
         // check "prog mode" message sent
-        Assert.assertEquals("mode message sent", 1, t.outbound.size());
-        Assert.assertEquals("read message contents", "R 29 0 82", t.outbound.elementAt(0).toString());
+        assertEquals( 1, t.outbound.size(), "mode message sent");
+        assertEquals( "R 29 0 82", t.outbound.elementAt(0).toString(), "read message contents");
 
         // send reply
         DCCppReply mr1 = DCCppReply.parseDCCppReply("r 0|82|29 12");
@@ -155,11 +163,10 @@ public class DCCppProgrammerTest extends jmri.jmrix.AbstractProgrammerTest {
         // traffic controller to exit from service mode.  We just
         // need to wait a few seconds and see that the listener we
         // registered earlier received the values we expected.
-        JUnitUtil.waitFor(() -> { return !(l.getRcvdInvoked() == 0); });
+        JUnitUtil.waitFor(() -> !(l.getRcvdInvoked() == 0), "Rcvd not invoked");
         
-        Assert.assertFalse("Receive Called by Programmer", l.getRcvdInvoked() == 0);
-
-        Assert.assertEquals("Register mode received value", 12, l.getRcvdValue());
+        assertNotEquals( 0, l.getRcvdInvoked(), "Receive Called by Programmer");
+        assertEquals( 12, l.getRcvdValue(), "Register mode received value");
     }
 
     @Test
@@ -174,7 +181,7 @@ public class DCCppProgrammerTest extends jmri.jmrix.AbstractProgrammerTest {
         // infrastructure objects
         DCCppCommandStation cs = new DCCppCommandStation();
         cs.setVersion("3.0.0"); //set the version to support startVal
-        Assert.assertTrue(cs.getVersion().equals("3.0.0"));
+        assertEquals( "3.0.0", cs.getVersion());
         t = new DCCppInterfaceScaffold(cs);
         l = new ProgListenerScaffold();
         p = new DCCppProgrammer(t) {
@@ -187,8 +194,8 @@ public class DCCppProgrammerTest extends jmri.jmrix.AbstractProgrammerTest {
         // and do the read, with 12 as startVal
         p.readCV("29", l, 12);
         // check "prog mode" message sent
-        Assert.assertEquals("mode message sent", 1, t.outbound.size());
-        Assert.assertEquals("read message contents", "V 29 12", t.outbound.elementAt(0).toString());
+        assertEquals( 1, t.outbound.size(), "mode message sent");
+        assertEquals( "V 29 12", t.outbound.elementAt(0).toString(), "read message contents");
 
         // send reply
         DCCppReply mr1 = DCCppReply.parseDCCppReply("v 29 12");
@@ -200,12 +207,12 @@ public class DCCppProgrammerTest extends jmri.jmrix.AbstractProgrammerTest {
         // traffic controller to exit from service mode.  We just
         // need to wait a few seconds and see that the listener we
         // registered earlier received the values we expected.
-        JUnitUtil.waitFor(() -> { return !(l.getRcvdInvoked() == 0); });
+        JUnitUtil.waitFor(() -> !(l.getRcvdInvoked() == 0), "Rcvd not invoked");
 
         //failure in this test occurs with the next line.
-        Assert.assertFalse("Receive Called by Programmer", l.getRcvdInvoked() == 0);
+        assertNotEquals( 0, l.getRcvdInvoked());
 
-        Assert.assertEquals("Register mode received value", 12, l.getRcvdValue());
+        assertEquals( 12, l.getRcvdValue(), "Register mode received value");
     }
 
     @Test
@@ -272,8 +279,8 @@ public class DCCppProgrammerTest extends jmri.jmrix.AbstractProgrammerTest {
         // and do the write
         p.writeCV("300", 34, l);
         // check "prog mode" message sent
-        Assert.assertEquals("mode message sent", 1, t.outbound.size());
-        Assert.assertEquals("write message contents", "W 300 34 0 87", t.outbound.elementAt(0).toString());
+        assertEquals( 1, t.outbound.size(), "mode message sent");
+        assertEquals( "W 300 34 0 87", t.outbound.elementAt(0).toString(), "write message contents");
         // send reply
         DCCppReply mr1 = DCCppReply.parseDCCppReply("r 0|87|300 34");
         t.sendTestMessage(mr1);
@@ -284,10 +291,10 @@ public class DCCppProgrammerTest extends jmri.jmrix.AbstractProgrammerTest {
         // traffic controller to exit from service mode.  We just
         // need to wait a few seconds and see that the listener we
         // registered earlier received the values we expected.
-        JUnitUtil.waitFor(() -> { return !(l.getRcvdInvoked() == 0); });
+        JUnitUtil.waitFor(() -> !(l.getRcvdInvoked() == 0), "Rcvd not invoked");
 
-        Assert.assertFalse("Receive Called by Programmer", l.getRcvdInvoked() == 0);
-        Assert.assertEquals("Direct mode received value", 34, l.getRcvdValue());
+        assertNotEquals( 0, l.getRcvdInvoked(), "Receive Called by Programmer");
+        assertEquals( 34, l.getRcvdValue(), "Direct mode received value");
     }
 
     // this test is the same as the testReadCvSequence test, but
@@ -299,8 +306,8 @@ public class DCCppProgrammerTest extends jmri.jmrix.AbstractProgrammerTest {
         // and do the read
         p.readCV("300", l);
         // check "prog mode" message sent
-        Assert.assertEquals("mode message sent", 1, t.outbound.size());
-        Assert.assertEquals("read message contents", "R 300 0 82", t.outbound.elementAt(0).toString());
+        assertEquals( 1, t.outbound.size(), "mode message sent");
+        assertEquals( "R 300 0 82", t.outbound.elementAt(0).toString(), "read message contents");
 
         // send reply
         DCCppReply mr1 = DCCppReply.parseDCCppReply("r 0|82|300 34");
@@ -312,11 +319,11 @@ public class DCCppProgrammerTest extends jmri.jmrix.AbstractProgrammerTest {
         // traffic controller to exit from service mode.  We just
         // need to wait a few seconds and see that the listener we
         // registered earlier received the values we expected.
-        JUnitUtil.waitFor(() -> { return !(l.getRcvdInvoked() == 0); });
+        JUnitUtil.waitFor(() -> !(l.getRcvdInvoked() == 0), "Rcvd not invoked");
 
-        Assert.assertFalse("Receive Called by Programmer", l.getRcvdInvoked() == 0);
+        assertNotEquals( 0, l.getRcvdInvoked(), "Receive Called by Programmer");
 
-        Assert.assertEquals("Direct mode received value", 34, l.getRcvdValue());
+        assertEquals( 34, l.getRcvdValue(), "Direct mode received value");
     }
 
     // Test to make sure the getCanWrite(int,string) function works correctly
@@ -329,7 +336,7 @@ public class DCCppProgrammerTest extends jmri.jmrix.AbstractProgrammerTest {
         //p.setMode(ProgrammingMode.PAGEMODE);
         //Assert.assertTrue("DCC++ Base Station Can Write CV3 in paged mode", p.getCanWrite("3"));
         p.setMode(ProgrammingMode.DIRECTBYTEMODE);
-        Assert.assertTrue("DCC++ Base Station Can Write CV3 in direct byte mode", p.getCanWrite("3"));
+        assertTrue( p.getCanWrite("3"), "DCC++ Base Station Can Write CV3 in direct byte mode");
 
 //        p.setMode(ProgrammingMode.DIRECTBITMODE);
 //        Assert.assertFalse("DCC++ Base Station Can Not Write CV3 in direct bit mode", p.getCanWrite("3"));
@@ -339,13 +346,13 @@ public class DCCppProgrammerTest extends jmri.jmrix.AbstractProgrammerTest {
         //p.setMode(ProgrammingMode.PAGEMODE);
         //Assert.assertFalse("DCC++ Base Station Can not Write CV300 in paged mode", p.getCanWrite("300"));
         p.setMode(ProgrammingMode.DIRECTBYTEMODE);
-        Assert.assertTrue("DCC++ Base Station Can Write CV300 in direct byte mode", p.getCanWrite("300"));
+        assertTrue( p.getCanWrite("300"), "DCC++ Base Station Can Write CV300 in direct byte mode");
 
 //        p.setMode(ProgrammingMode.DIRECTBITMODE);
 //        Assert.assertFalse("DCC++ Base Station Can Not Write CV300 in direct bit mode", p.getCanWrite("300"));
 
         p.setMode(ProgrammingMode.DIRECTBYTEMODE);
-        Assert.assertFalse("DCC++ Base Station Can Not Write CV3000 in direct byte mode", p.getCanWrite("3000"));
+        assertFalse( p.getCanWrite("3000"), "DCC++ Base Station Can Not Write CV3000 in direct byte mode");
 
 //        p.setMode(ProgrammingMode.DIRECTBITMODE);
 //        Assert.assertFalse("DCC++ Base Station Can Not  Write CV3000 in direct bit mode", p.getCanWrite("3000"));
@@ -363,7 +370,7 @@ public class DCCppProgrammerTest extends jmri.jmrix.AbstractProgrammerTest {
         //Assert.assertTrue("DCC++ Base Station Can Read CV3 in paged mode", p.getCanRead("3"));
 
         p.setMode(ProgrammingMode.DIRECTBYTEMODE);
-        Assert.assertTrue("DCC++ Base Station Can Read CV3 in direct byte mode", p.getCanRead("3"));
+        assertTrue( p.getCanRead("3"), "DCC++ Base Station Can Read CV3 in direct byte mode");
 
 //        p.setMode(ProgrammingMode.DIRECTBITMODE);
 //        Assert.assertFalse("DCC++ Base Station Can Not Read CV3 in direct bit mode", p.getCanRead("3"));
@@ -373,13 +380,13 @@ public class DCCppProgrammerTest extends jmri.jmrix.AbstractProgrammerTest {
         //p.setMode(ProgrammingMode.PAGEMODE);
         //Assert.assertFalse("DCC++ Base Station Can not Read CV300 in paged mode", p.getCanRead("300"));
         p.setMode(ProgrammingMode.DIRECTBYTEMODE);
-        Assert.assertTrue("DCC++ Base Station Can Read CV300 in direct byte mode", p.getCanRead("300"));
+        assertTrue( p.getCanRead("300"), "DCC++ Base Station Can Read CV300 in direct byte mode");
 
 //        p.setMode(ProgrammingMode.DIRECTBITMODE);
 //        Assert.assertFalse("DCC++ Base Station Can Not Read CV300 in direct bit mode", p.getCanRead("300"));
 
         p.setMode(ProgrammingMode.DIRECTBYTEMODE);
-        Assert.assertFalse("DCC++ Base Station Can not Read CV3000 in direct byte mode", p.getCanRead("3000"));
+        assertFalse( p.getCanRead("3000"), "DCC++ Base Station Can not Read CV3000 in direct byte mode");
 
 //        p.setMode(ProgrammingMode.DIRECTBITMODE);
 //        Assert.assertFalse("DCC++ Base Station Can not Read CV3000 in direct bit mode", p.getCanRead("3000"));

--- a/java/test/jmri/jmrix/dccpp/DCCppTurnoutTest.java
+++ b/java/test/jmri/jmrix/dccpp/DCCppTurnoutTest.java
@@ -1,9 +1,12 @@
 package jmri.jmrix.dccpp;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import jmri.Turnout;
 import jmri.util.JUnitUtil;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.*;
 
 /**
@@ -19,73 +22,75 @@ public class DCCppTurnoutTest extends jmri.implementation.AbstractTurnoutTestBas
         return dnis.numListeners();
     }
 
-    protected DCCppInterfaceScaffold dnis;
+    private DCCppInterfaceScaffold dnis;
 
     @Override
     public void checkClosedMsgSent() {
-        Assert.assertEquals("closed message", "a 11 1 0",
-                dnis.outbound.elementAt(dnis.outbound.size() - 1).toString());
+        assertEquals( "a 11 1 0",
+            dnis.outbound.elementAt(dnis.outbound.size() - 1).toString(),
+            "closed message");
     }
 
     @Override
     public void checkThrownMsgSent() {
-        Assert.assertEquals("thrown message", "a 11 1 1",
-                dnis.outbound.elementAt(dnis.outbound.size() - 1).toString());
+        assertEquals( "a 11 1 1",
+            dnis.outbound.elementAt(dnis.outbound.size() - 1).toString(),
+            "thrown message");
     }
 
     @Test
     public void testCtor() {
-        Assert.assertNotNull(t);
+        assertNotNull(t);
     }
 
     // Test the initialization sequence.
     @Test
-    public void testInitSequence() throws Exception {
+    public void testInitSequence() {
         int num = ((DCCppTurnout)t).getNumber();
-        Assert.assertEquals(42, num);
+        assertEquals(42, num);
         
         int[] vals = DCCppTurnout.getModeValues();
-        Assert.assertEquals(6, vals.length);
-        Assert.assertEquals(Turnout.MONITORING, vals[4]);
-        Assert.assertEquals(Turnout.EXACT, vals[5]);
+        assertEquals(6, vals.length);
+        assertEquals(Turnout.MONITORING, vals[4]);
+        assertEquals(Turnout.EXACT, vals[5]);
         
         String[] names = DCCppTurnout.getModeNames();
-        Assert.assertEquals(6, names.length);
-        Assert.assertEquals("BSTURNOUT", names[4]);
-        Assert.assertEquals("BSOUTPUT", names[5]);
+        assertEquals(6, names.length);
+        assertEquals("BSTURNOUT", names[4]);
+        assertEquals("BSOUTPUT", names[5]);
         // TODO: CHeck some othr stuff
         
         // Check a few basic things
-        Assert.assertTrue(t.canInvert());
+        assertTrue(t.canInvert());
         
     }
     
     @Test
-    public void testMonitoringMode() throws Exception {
+    public void testMonitoringMode() {
         // Set mode to Monitoring
         t.setFeedbackMode(Turnout.MONITORING);
-        Assert.assertEquals(Turnout.MONITORING, t.getFeedbackMode());
+        assertEquals(Turnout.MONITORING, t.getFeedbackMode());
         
         // Check that state changes appropriately
         t.setCommandedState(Turnout.THROWN);
         //Assert.assertEquals(t.getState(), Turnout.THROWN);
         DCCppMessage m = dnis.outbound.elementAt(0);
-        Assert.assertTrue(m.isTurnoutCmdMessage());
-        Assert.assertEquals(1, m.getTOStateInt());
-        Assert.assertEquals(Turnout.INCONSISTENT, t.getState());
+        assertTrue(m.isTurnoutCmdMessage());
+        assertEquals(1, m.getTOStateInt());
+        assertEquals(Turnout.INCONSISTENT, t.getState());
         DCCppReply r = DCCppReply.parseDCCppReply("H 42 1");
         ((DCCppTurnout) t).message(r);
-        Assert.assertEquals(Turnout.THROWN, t.getState());
+        assertEquals(Turnout.THROWN, t.getState());
         
         t.setCommandedState(Turnout.CLOSED);
         //Assert.assertEquals(t.getState(), Turnout.CLOSED);
         m = dnis.outbound.elementAt(1);
-        Assert.assertTrue(m.isTurnoutCmdMessage());
-        Assert.assertEquals(0, m.getTOStateInt());
-        Assert.assertEquals(Turnout.INCONSISTENT, t.getState());
+        assertTrue(m.isTurnoutCmdMessage());
+        assertEquals(0, m.getTOStateInt());
+        assertEquals(Turnout.INCONSISTENT, t.getState());
         r = DCCppReply.parseDCCppReply("H 42 0");
         ((DCCppTurnout) t).message(r);
-        Assert.assertEquals(Turnout.CLOSED, t.getState());
+        assertEquals(Turnout.CLOSED, t.getState());
 
         // Test Inverted Mode
         // Check that state changes appropriately
@@ -93,50 +98,50 @@ public class DCCppTurnoutTest extends jmri.implementation.AbstractTurnoutTestBas
         t.setCommandedState(Turnout.THROWN);
         //Assert.assertEquals(t.getState(), Turnout.THROWN);
         m = dnis.outbound.elementAt(2);
-        Assert.assertTrue(m.isTurnoutCmdMessage());
-        Assert.assertEquals(0, m.getTOStateInt());
-        Assert.assertEquals(Turnout.INCONSISTENT, t.getState());
+        assertTrue(m.isTurnoutCmdMessage());
+        assertEquals(0, m.getTOStateInt());
+        assertEquals(Turnout.INCONSISTENT, t.getState());
         r = DCCppReply.parseDCCppReply("H 42 0");
         ((DCCppTurnout) t).message(r);
-        Assert.assertEquals(Turnout.THROWN, t.getState());
+        assertEquals(Turnout.THROWN, t.getState());
         
         t.setCommandedState(Turnout.CLOSED);
         //Assert.assertEquals(t.getState(), Turnout.CLOSED);
         m = dnis.outbound.elementAt(3);
-        Assert.assertTrue(m.isTurnoutCmdMessage());
-        Assert.assertEquals(1, m.getTOStateInt());
-        Assert.assertEquals(Turnout.INCONSISTENT, t.getState());
+        assertTrue(m.isTurnoutCmdMessage());
+        assertEquals(1, m.getTOStateInt());
+        assertEquals(Turnout.INCONSISTENT, t.getState());
         r = DCCppReply.parseDCCppReply("H 42 1");
         ((DCCppTurnout) t).message(r);
-        Assert.assertEquals(Turnout.CLOSED, t.getState());
+        assertEquals(Turnout.CLOSED, t.getState());
     }
 
     @Test
-    public void testExactMode() throws Exception {
+    public void testExactMode() {
         // Set mode to Exact
         t.setFeedbackMode(Turnout.EXACT);
-        Assert.assertEquals(Turnout.EXACT, t.getFeedbackMode());
+        assertEquals(Turnout.EXACT, t.getFeedbackMode());
         
         // Check that state changes appropriately
         t.setCommandedState(Turnout.THROWN);
         //Assert.assertEquals(t.getState(), Turnout.THROWN);
         DCCppMessage m = dnis.outbound.elementAt(0);
-        Assert.assertTrue(m.isOutputCmdMessage());
-        Assert.assertEquals(0, m.getOutputStateInt());
-        Assert.assertEquals(Turnout.INCONSISTENT, t.getState());
+        assertTrue(m.isOutputCmdMessage());
+        assertEquals(0, m.getOutputStateInt());
+        assertEquals(Turnout.INCONSISTENT, t.getState());
         DCCppReply r = DCCppReply.parseDCCppReply("Y 42 0");
         ((DCCppTurnout) t).message(r);
-        Assert.assertEquals(Turnout.THROWN, t.getState());
+        assertEquals(Turnout.THROWN, t.getState());
 
         t.setCommandedState(Turnout.CLOSED);
         //Assert.assertEquals(t.getState(), Turnout.CLOSED);
         m = dnis.outbound.elementAt(1);
-        Assert.assertTrue(m.isOutputCmdMessage());
-        Assert.assertEquals(1, m.getOutputStateInt());
-        Assert.assertEquals(Turnout.INCONSISTENT, t.getState());
+        assertTrue(m.isOutputCmdMessage());
+        assertEquals(1, m.getOutputStateInt());
+        assertEquals(Turnout.INCONSISTENT, t.getState());
         r = DCCppReply.parseDCCppReply("Y 42 1");
         ((DCCppTurnout) t).message(r);
-        Assert.assertEquals(Turnout.CLOSED, t.getState());
+        assertEquals(Turnout.CLOSED, t.getState());
 
         // Test Inverted Mode
         // Check that state changes appropriately
@@ -144,42 +149,42 @@ public class DCCppTurnoutTest extends jmri.implementation.AbstractTurnoutTestBas
         t.setCommandedState(Turnout.THROWN);
         //Assert.assertEquals(t.getState(), Turnout.THROWN);
         m = dnis.outbound.elementAt(2);
-        Assert.assertTrue(m.isOutputCmdMessage());
-        Assert.assertEquals(1, m.getOutputStateInt());
-        Assert.assertEquals(Turnout.INCONSISTENT, t.getState());
+        assertTrue(m.isOutputCmdMessage());
+        assertEquals(1, m.getOutputStateInt());
+        assertEquals(Turnout.INCONSISTENT, t.getState());
         r = DCCppReply.parseDCCppReply("Y 42 1");
         ((DCCppTurnout) t).message(r);
-        Assert.assertEquals(Turnout.THROWN, t.getState());
+        assertEquals(Turnout.THROWN, t.getState());
 
         t.setCommandedState(Turnout.CLOSED);
         //Assert.assertEquals(t.getState(), Turnout.CLOSED);
         m = dnis.outbound.elementAt(3);
-        Assert.assertTrue(m.isOutputCmdMessage());
-        Assert.assertEquals(0, m.getOutputStateInt());
-        Assert.assertEquals(Turnout.INCONSISTENT, t.getState());
+        assertTrue(m.isOutputCmdMessage());
+        assertEquals(0, m.getOutputStateInt());
+        assertEquals(Turnout.INCONSISTENT, t.getState());
         r = DCCppReply.parseDCCppReply("Y 42 0");
         ((DCCppTurnout) t).message(r);
-        Assert.assertEquals(Turnout.CLOSED, t.getState());
+        assertEquals(Turnout.CLOSED, t.getState());
     }
 
     @Test
-    public void testDirectMode() throws Exception {
+    public void testDirectMode() {
         // Set mode to DIRECT
         t.setFeedbackMode(Turnout.DIRECT);
-        Assert.assertEquals(Turnout.DIRECT, t.getFeedbackMode());
+        assertEquals(Turnout.DIRECT, t.getFeedbackMode());
         
         // Check that state changes appropriately
         t.setCommandedState(Turnout.THROWN);
         DCCppMessage m = dnis.outbound.elementAt(0);
-        Assert.assertTrue(m.isAccessoryMessage());
-        Assert.assertEquals(1, m.getAccessoryStateInt());
-        Assert.assertEquals(Turnout.THROWN, t.getState());
+        assertTrue(m.isAccessoryMessage());
+        assertEquals(1, m.getAccessoryStateInt());
+        assertEquals(Turnout.THROWN, t.getState());
         
         t.setCommandedState(Turnout.CLOSED);
         m = dnis.outbound.elementAt(1);
-        Assert.assertTrue(m.isAccessoryMessage());
-        Assert.assertEquals(0, m.getAccessoryStateInt());
-        Assert.assertEquals(Turnout.CLOSED, t.getState());
+        assertTrue(m.isAccessoryMessage());
+        assertEquals(0, m.getAccessoryStateInt());
+        assertEquals(Turnout.CLOSED, t.getState());
     }
 
     @Test
@@ -189,7 +194,7 @@ public class DCCppTurnoutTest extends jmri.implementation.AbstractTurnoutTestBas
 
         //is deferred to after first use
         t.dispose();
-        Assert.assertEquals("controller listeners remaining", 1, numListeners());
+        assertEquals( 1, numListeners(), "controller listeners remaining");
     }
 
 
@@ -205,7 +210,8 @@ public class DCCppTurnoutTest extends jmri.implementation.AbstractTurnoutTestBas
     @Override
     @AfterEach
     public void tearDown() {
-        JUnitUtil.clearShutDownManager(); // put in place because AbstractMRTrafficController implementing subclass was not terminated properly
+        dnis.terminateThreads();
+        dnis = null;
         JUnitUtil.tearDown();
 
     }

--- a/java/test/jmri/jmrix/dccpp/swing/ConfigBaseStationActionTest.java
+++ b/java/test/jmri/jmrix/dccpp/swing/ConfigBaseStationActionTest.java
@@ -2,40 +2,54 @@ package jmri.jmrix.dccpp.swing;
 
 import jmri.jmrix.dccpp.DCCppSystemConnectionMemo;
 import jmri.util.JUnitUtil;
+import jmri.util.ThreadingUtil;
+import jmri.util.junit.annotations.DisabledIfHeadless;
 
-import java.awt.GraphicsEnvironment;
-
-import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.jupiter.api.*;
+import org.netbeans.jemmy.operators.JFrameOperator;
 
 /**
  *
  * @author Paul Bender Copyright (C) 2017
  */
+@DisabledIfHeadless
 public class ConfigBaseStationActionTest {
 
     private DCCppSystemConnectionMemo _memo;
 
     @Test
     public void testCTor() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        ConfigBaseStationFrame action = new ConfigBaseStationFrame(_memo);
-        Assert.assertNotNull("exists", action);
+        ConfigBaseStationAction action = new ConfigBaseStationAction(); // default memo and title
+        Assertions.assertNotNull( action, "exists");
+    }
+
+    @Test
+    public void testConfigBaseStationActionActionPerformed() {
+        ConfigBaseStationAction action = new ConfigBaseStationAction(_memo);
+        ThreadingUtil.runOnGUI(() -> action.actionPerformed(null));
+
+        JFrameOperator jfo = new JFrameOperator(Bundle.getMessage("FieldManageBaseStationFrameTitle"));
+        Assertions.assertNotNull(jfo);
+
+        JUnitUtil.dispose(jfo.getWindow());
+        jfo.waitClosed();
+
     }
 
     @BeforeEach
     public void setUp() {
         JUnitUtil.setUp();
         jmri.jmrix.dccpp.DCCppInterfaceScaffold t = new jmri.jmrix.dccpp.DCCppInterfaceScaffold(new jmri.jmrix.dccpp.DCCppCommandStation());
-        _memo = new jmri.jmrix.dccpp.DCCppSystemConnectionMemo(t);
-
-        jmri.InstanceManager.store(_memo, jmri.jmrix.dccpp.DCCppSystemConnectionMemo.class);
+        _memo = new DCCppSystemConnectionMemo(t);
+        jmri.InstanceManager.store(_memo, DCCppSystemConnectionMemo.class);
     }
 
     @AfterEach
     public void tearDown() {
-        JUnitUtil.clearShutDownManager(); // put in place because AbstractMRTrafficController implementing subclass was not terminated properly         
+        _memo.getDCCppTrafficController().terminateThreads();
+        _memo.dispose();
+        _memo = null;
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrix/dccpp/swing/ConfigBaseStationFrameTest.java
+++ b/java/test/jmri/jmrix/dccpp/swing/ConfigBaseStationFrameTest.java
@@ -1,11 +1,10 @@
 package jmri.jmrix.dccpp.swing;
 
-import java.awt.GraphicsEnvironment;
-
 import jmri.jmrix.dccpp.DCCppCommandStation;
 import jmri.jmrix.dccpp.DCCppInterfaceScaffold;
 import jmri.jmrix.dccpp.DCCppSystemConnectionMemo;
 import jmri.util.JUnitUtil;
+import jmri.util.junit.annotations.DisabledIfHeadless;
 
 import org.junit.jupiter.api.*;
 
@@ -13,7 +12,10 @@ import org.junit.jupiter.api.*;
  *
  * @author Paul Bender Copyright (C) 2017
  */
+@DisabledIfHeadless
 public class ConfigBaseStationFrameTest extends jmri.util.JmriJFrameTestBase {
+
+    private DCCppSystemConnectionMemo memo;
 
     @BeforeEach
     @Override
@@ -21,17 +23,18 @@ public class ConfigBaseStationFrameTest extends jmri.util.JmriJFrameTestBase {
         JUnitUtil.setUp();
         // infrastructure objects
         DCCppInterfaceScaffold tc = new DCCppInterfaceScaffold(new DCCppCommandStation());
-        DCCppSystemConnectionMemo memo = new DCCppSystemConnectionMemo(tc);
-        if (!GraphicsEnvironment.isHeadless()) {
-            frame = new ConfigBaseStationFrame(memo);
-        }
+        memo = new DCCppSystemConnectionMemo(tc);
+        frame = new ConfigBaseStationFrame(memo);
 
     }
 
     @AfterEach
     @Override
     public void tearDown() {
-        JUnitUtil.clearShutDownManager(); // put in place because AbstractMRTrafficController implementing subclass was not terminated properly
+        memo.getDCCppTrafficController().terminateThreads();
+        memo.dispose();
+        memo = null;
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         super.tearDown();
     }
 

--- a/java/test/jmri/jmrix/dccpp/swing/DCCppMenuTest.java
+++ b/java/test/jmri/jmrix/dccpp/swing/DCCppMenuTest.java
@@ -1,11 +1,12 @@
 package jmri.jmrix.dccpp.swing;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import jmri.jmrix.dccpp.DCCppCommandStation;
 import jmri.jmrix.dccpp.DCCppInterfaceScaffold;
 import jmri.jmrix.dccpp.DCCppSystemConnectionMemo;
 import jmri.util.JUnitUtil;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.*;
 
 /**
@@ -21,14 +22,14 @@ public class DCCppMenuTest {
     public void testCTor() {
         // infrastructure objects
         DCCppMenu t = new DCCppMenu(memo);
-        Assert.assertNotNull("exists",t);
+        assertNotNull( t, "exists");
     }
 
     @Test
-    public void test2ParamCTor() {
+    public void test2ParamDCCppMenuCTor() {
         // infrastructure objects
         DCCppMenu t = new DCCppMenu("DCc++ test",memo);
-        Assert.assertNotNull("exists",t);
+        assertNotNull( t, "exists");
     }
 
     @BeforeEach
@@ -40,7 +41,10 @@ public class DCCppMenuTest {
 
     @AfterEach
     public void tearDown() {
-        JUnitUtil.clearShutDownManager(); // put in place because AbstractMRTrafficController implementing subclass was not terminated properly
+        memo.getDCCppTrafficController().terminateThreads();
+        memo.dispose();
+        memo = null;
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
 
     }

--- a/java/test/jmri/jmrix/dccpp/swing/packetgen/PacketGenActionTest.java
+++ b/java/test/jmri/jmrix/dccpp/swing/packetgen/PacketGenActionTest.java
@@ -1,28 +1,39 @@
 package jmri.jmrix.dccpp.swing.packetgen;
 
-import java.awt.GraphicsEnvironment;
-
 import jmri.util.JUnitUtil;
+import jmri.util.ThreadingUtil;
+import jmri.util.junit.annotations.DisabledIfHeadless;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.*;
-import org.junit.Assume;
+import org.netbeans.jemmy.operators.JFrameOperator;
 
 /**
  * Test simple functioning of PacketGenAction
  *
  * @author Paul Bender Copyright (C) 2016
  */
+@DisabledIfHeadless
 public class PacketGenActionTest {
 
     
     private jmri.jmrix.dccpp.DCCppSystemConnectionMemo memo = null;
 
     @Test
-    public void testMemoCtor() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+    public void testDccPpPacketGenMemoCtor() {
         PacketGenAction action = new PacketGenAction(memo);
-        Assert.assertNotNull("exists", action);
+        Assertions.assertNotNull( action, "exists");
+    }
+
+    @Test
+    public void testPacketGenActionPerformed() {
+        PacketGenAction action = new PacketGenAction(); // default CTor
+        ThreadingUtil.runOnGUI(() -> action.actionPerformed(null));
+
+        JFrameOperator jfo = new JFrameOperator(Bundle.getMessage("PacketGenFrameTitle") + " (D)");
+        Assertions.assertNotNull(jfo);
+
+        JUnitUtil.dispose(jfo.getWindow());
+        jfo.waitClosed();
     }
 
     @BeforeEach
@@ -36,7 +47,10 @@ public class PacketGenActionTest {
     }
 
     @AfterEach
-    public void tearDown() {        JUnitUtil.clearShutDownManager(); // put in place because AbstractMRTrafficController implementing subclass was not terminated properly
+    public void tearDown() {
+        memo.getDCCppTrafficController().terminateThreads();
+        memo.dispose();
+        memo = null;
         JUnitUtil.tearDown();
     }
 }


### PR DESCRIPTION
**DCCppProgrammerTest** 
Add failure text to JUnitUtil.waitFor, return value currently unchecked.

**DCCppThrottleManagerTest** 
Removes logging to confirm condition.

**DCCppTurnoutTest**
Remove throws Exception from test classes.
This fixes Spotbug - Method lists Exception in its throws clause, but it could be more specific.

**ConfigBaseStationActionTest** / **PacketGenActionTest**
Adds new test for action performed.

Asserts JU4 > JU5

