### PR TITLE
Roco Z21 test tweaks

### DIFF
--- a/java/test/jmri/jmrix/roco/z21/XNetInitializationManagerTest.java
+++ b/java/test/jmri/jmrix/roco/z21/XNetInitializationManagerTest.java
@@ -1,10 +1,12 @@
 package jmri.jmrix.roco.z21;
 
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
 import jmri.implementation.DccConsistManager;
 import jmri.jmrix.lenz.*;
 import jmri.util.JUnitUtil;
 
-import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -36,24 +38,20 @@ public class XNetInitializationManagerTest {
                 .consistManager(null)
                 .noCommandStation()
                 .init();
-        SoftAssertions softly = new SoftAssertions();
-        softly.assertThat(memo.getCommandStation()).isNull();
-        softly.assertThat(memo.getPowerManager()).isExactlyInstanceOf((XNetPowerManager.class));
-        softly.assertThat(memo.getThrottleManager()).isExactlyInstanceOf(Z21XNetThrottleManager.class);
-        softly.assertThat(memo.getProgrammerManager()).isExactlyInstanceOf(Z21XNetProgrammerManager.class);
-        softly.assertThat(memo.getProgrammerManager().getGlobalProgrammer().getConfigurator())
-                .isExactlyInstanceOf(XNetProgrammer.XNetConfigurator.class);
-        softly.assertThat(memo.getProgrammerManager().getAddressedProgrammer(false,42).getConfigurator())
-                .isExactlyInstanceOf(XNetOpsModeProgrammer.XNetOpsConfigurator.class);
-        softly.assertThat(memo.getTurnoutManager()).isExactlyInstanceOf(Z21XNetTurnoutManager.class);
-        softly.assertThat(memo.getSensorManager()).isExactlyInstanceOf(XNetSensorManager.class);
-        softly.assertThat(memo.getLightManager()).isExactlyInstanceOf(XNetLightManager.class);
-        softly.assertThat(memo.getConsistManager()).isExactlyInstanceOf(DccConsistManager.class);
-        softly.assertAll();
+        assertNull( memo.getCommandStation());
+        assertInstanceOf( XNetPowerManager.class, memo.getPowerManager());
+        assertInstanceOf( Z21XNetThrottleManager.class, memo.getThrottleManager());
+        assertInstanceOf( Z21XNetProgrammerManager.class, memo.getProgrammerManager());
+        assertInstanceOf( XNetProgrammer.XNetConfigurator.class, memo.getProgrammerManager().getGlobalProgrammer().getConfigurator());
+        assertInstanceOf( XNetOpsModeProgrammer.XNetOpsConfigurator.class, memo.getProgrammerManager().getAddressedProgrammer(false,42).getConfigurator());
+        assertInstanceOf( Z21XNetTurnoutManager.class, memo.getTurnoutManager());
+        assertInstanceOf( XNetSensorManager.class, memo.getSensorManager());
+        assertInstanceOf( XNetLightManager.class, memo.getLightManager());
+        assertInstanceOf( DccConsistManager.class, memo.getConsistManager());
     }
 
     @BeforeEach
-    public void setUp() throws Exception {
+    public void setUp() {
         JUnitUtil.setUp();
         JUnitUtil.initConnectionConfigManager();
         tc = Mockito.mock(XNetTrafficController.class);
@@ -64,7 +62,9 @@ public class XNetInitializationManagerTest {
     }
 
     @AfterEach
-    public void tearDown() throws Exception {
+    public void tearDown() {
+        memo.dispose();
+        memo = null;
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrix/roco/z21/Z21LocoNetTunnelTest.java
+++ b/java/test/jmri/jmrix/roco/z21/Z21LocoNetTunnelTest.java
@@ -1,9 +1,10 @@
 package jmri.jmrix.roco.z21;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import jmri.util.JUnitAppender;
 import jmri.util.JUnitUtil;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.*;
 
 /**
@@ -19,7 +20,7 @@ public class Z21LocoNetTunnelTest {
 
     @Test
     public void testCtor() {
-        Assert.assertNotNull(tunnel);
+        assertNotNull(tunnel);
     }
 
     @BeforeEach
@@ -41,11 +42,9 @@ public class Z21LocoNetTunnelTest {
 
     @AfterEach
     public void tearDown() {
-        jmri.jmrix.loconet.streamport.LnStreamPortController lnspc = tunnel.getStreamPortController();
-        Assert.assertNotNull(lnspc);
+
         tunnel.dispose();
         memo.getTrafficController().terminateThreads();
-        JUnitUtil.waitFor(() -> {  return !lnspc.status(); });
         JUnitAppender.suppressWarnMessage("sendLocoNetMessage: IOException: java.io.IOException: Read end dead");
         tunnel = null;
         tc = null;

--- a/java/test/jmri/jmrix/roco/z21/Z21RMBusAddressTest.java
+++ b/java/test/jmri/jmrix/roco/z21/Z21RMBusAddressTest.java
@@ -1,16 +1,18 @@
 package jmri.jmrix.roco.z21;
 
-import jmri.Manager;
-import jmri.NamedBean;
-import jmri.util.JUnitAppender;
-
-import org.assertj.core.api.SoftAssertions;
-import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Locale;
 
-import static org.assertj.core.api.ThrowableAssert.catchThrowable;
-import static org.assertj.core.api.Assertions.assertThat;
+import jmri.Manager;
+import jmri.NamedBean;
+import jmri.util.JUnitAppender;
+import jmri.util.JUnitUtil;
+
+import org.junit.jupiter.api.*;
+
 /**
  *
  * @author Paul Bender Copyright (C) 2019
@@ -19,12 +21,11 @@ public class Z21RMBusAddressTest {
 
     @Test
     public void testGetBitFromAddress() {
-        SoftAssertions softly = new SoftAssertions();
-        softly.assertThat(Z21RMBusAddress.getBitFromSystemName("ZS150","Z")).isEqualTo(150);
-        softly.assertThat(Z21RMBusAddress.getBitFromSystemName("ZS999","Z")).isEqualTo(-1);
-        softly.assertAll();
+        assertEquals( 150, Z21RMBusAddress.getBitFromSystemName("ZS150","Z"));
+        assertEquals( -1, Z21RMBusAddress.getBitFromSystemName("ZS999","Z"));
         JUnitAppender.assertWarnMessage("Z21 RM Bus hardware address out of range in system name ZS999");
     }
+
     @Test
     public void testValidateSystemNameFormat() {
         Z21TrafficController znis = new Z21InterfaceScaffold();
@@ -32,22 +33,22 @@ public class Z21RMBusAddressTest {
         memo.setTrafficController(znis);
         memo.setRocoZ21CommandStation(new RocoZ21CommandStation());
         Z21SensorManager sm = new Z21SensorManager(memo);
-        SoftAssertions softly = new SoftAssertions();
-        softly.assertThat(Z21RMBusAddress.validateSystemNameFormat("ZS1", sm, Locale.ENGLISH)).isEqualTo("ZS1");
-        softly.assertThat(Z21RMBusAddress.validateSystemNameFormat("ZS75", sm, Locale.ENGLISH)).isEqualTo("ZS75");
-        softly.assertThat(Z21RMBusAddress.validateSystemNameFormat("ZS128", sm, Locale.ENGLISH)).isEqualTo("ZS128");
-        softly.assertAll();
 
-        Throwable thrown = catchThrowable(() -> {
+        assertEquals( "ZS1", Z21RMBusAddress.validateSystemNameFormat("ZS1", sm, Locale.ENGLISH));
+        assertEquals( "ZS75", Z21RMBusAddress.validateSystemNameFormat("ZS75", sm, Locale.ENGLISH));
+        assertEquals( "ZS128", Z21RMBusAddress.validateSystemNameFormat("ZS128", sm, Locale.ENGLISH));
+
+
+        Throwable thrown = assertThrows(NamedBean.BadSystemNameException.class, () -> {
             Z21RMBusAddress.validateSystemNameFormat("ZS0a:b", sm, Locale.ENGLISH);
         });
-        assertThat(thrown).isInstanceOf(NamedBean.BadSystemNameException.class);
+        assertNotNull(thrown);
         JUnitAppender.suppressWarnMessage("invalid character in number field of system name: ZS0b:a");
 
-        thrown = catchThrowable(() -> {
+        thrown = assertThrows( NamedBean.BadSystemNameException.class, () -> {
             Z21RMBusAddress.validateSystemNameFormat("ZS999", sm, Locale.ENGLISH);
         });
-        assertThat(thrown).isInstanceOf(NamedBean.BadSystemNameException.class);
+        assertNotNull(thrown);
         JUnitAppender.suppressWarnMessage("Z21 RM Bus hardware address out of range in system name ZS999");
         sm.dispose();
         znis.terminateThreads();
@@ -55,26 +56,25 @@ public class Z21RMBusAddressTest {
 
     @Test
     public void testValidSystemNameFormat() {
-        SoftAssertions softly = new SoftAssertions();
-        softly.assertThat(Z21RMBusAddress.validSystemNameFormat("ZS1",'S',"Z")).isEqualTo(Manager.NameValidity.VALID);
-        softly.assertThat(Z21RMBusAddress.validSystemNameFormat("ZS75",'S',"Z")).isEqualTo(Manager.NameValidity.VALID);
-        softly.assertThat(Z21RMBusAddress.validSystemNameFormat("ZS128",'S',"Z")).isEqualTo(Manager.NameValidity.VALID);
-        softly.assertThat(Z21RMBusAddress.validSystemNameFormat("ZS0b:a",'S',"Z")).isEqualTo(Manager.NameValidity.INVALID);
-        softly.assertThat(Z21RMBusAddress.validSystemNameFormat("ZS999",'S',"Z")).isEqualTo(Manager.NameValidity.INVALID);
-        softly.assertAll();
+
+        assertEquals(Manager.NameValidity.VALID, Z21RMBusAddress.validSystemNameFormat("ZS1",'S',"Z"));
+        assertEquals(Manager.NameValidity.VALID, Z21RMBusAddress.validSystemNameFormat("ZS75",'S',"Z"));
+        assertEquals(Manager.NameValidity.VALID, Z21RMBusAddress.validSystemNameFormat("ZS128",'S',"Z"));
+
+        assertEquals(Manager.NameValidity.INVALID, Z21RMBusAddress.validSystemNameFormat("ZS0b:a",'S',"Z"));
+        JUnitAppender.assertWarnMessage("invalid character in number field of system name: ZS0b:a");
+        assertEquals(Manager.NameValidity.INVALID, Z21RMBusAddress.validSystemNameFormat("ZS999",'S',"Z"));
         JUnitAppender.assertWarnMessage("Z21 RM Bus hardware address out of range in system name ZS999");
     }
 
     @BeforeEach
     public void setUp() {
-        jmri.util.JUnitUtil.setUp();
+        JUnitUtil.setUp();
     }
 
     @AfterEach
     public void tearDown() {
-        jmri.util.JUnitUtil.clearShutDownManager(); // put in place because AbstractMRTrafficController implementing subclass was not terminated properly
-        jmri.util.JUnitUtil.tearDown();
-
+        JUnitUtil.tearDown();
     }
 
 }

--- a/java/test/jmri/jmrix/roco/z21/Z21XPressNetTunnelTest.java
+++ b/java/test/jmri/jmrix/roco/z21/Z21XPressNetTunnelTest.java
@@ -1,8 +1,9 @@
 package jmri.jmrix.roco.z21;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import jmri.util.JUnitUtil;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.*;
 
 /**
@@ -18,21 +19,21 @@ public class Z21XPressNetTunnelTest {
 
     @Test
     public void testCtor() {
-        Assert.assertNotNull(tunnel);
+        assertNotNull(tunnel);
     }
 
     @Test
     public void testGetStreamPortController() {
-        Assert.assertNotNull(tunnel.getStreamPortController());
+        assertNotNull(tunnel.getStreamPortController());
     }
 
-    jmri.jmrix.lenz.XNetTrafficController packets;
+    private jmri.jmrix.lenz.XNetTrafficController packets;
 
     @BeforeEach
     public void setUp() {
         JUnitUtil.setUp();
-        jmri.util.JUnitUtil.resetProfileManager();
-        jmri.util.JUnitUtil.initConfigureManager();
+        JUnitUtil.resetProfileManager();
+        JUnitUtil.initConfigureManager();
 
         memo = new Z21SystemConnectionMemo();
         tc = new Z21InterfaceScaffold() {
@@ -60,7 +61,10 @@ public class Z21XPressNetTunnelTest {
 
     @AfterEach
     public void tearDown() {
-        packets.terminateThreads();
+        if ( packets != null ) {
+            packets.terminateThreads();
+        }
+        packets = null;
         tunnel.dispose();
         tunnel = null;
         tc.terminateThreads();

--- a/java/test/jmri/jmrix/roco/z21/simulator/Z21SimulatorAdapterTest.java
+++ b/java/test/jmri/jmrix/roco/z21/simulator/Z21SimulatorAdapterTest.java
@@ -112,6 +112,7 @@ public class Z21SimulatorAdapterTest {
             method = a.getClass().getDeclaredMethod(methodName);
         } catch ( NoSuchMethodException nsm) {
             fail("Could not find method " + methodName + "in Z21SimulatorAdapter class");
+            return;
         }
 
         // override the default permissions.

--- a/java/test/jmri/jmrix/roco/z21/simulator/Z21SimulatorAdapterTest.java
+++ b/java/test/jmri/jmrix/roco/z21/simulator/Z21SimulatorAdapterTest.java
@@ -1,15 +1,20 @@
 package jmri.jmrix.roco.z21.simulator;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.net.DatagramPacket;
 import java.net.DatagramSocket;
 import jmri.jmrix.roco.z21.Z21Reply;
 import jmri.util.JUnitAppender;
 import jmri.util.JUnitUtil;
-import org.junit.Assert;
+
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
-
-import static org.assertj.core.api.Assertions.*;
 
 /**
  * Z21SimulatorAdapterTest.java
@@ -22,12 +27,12 @@ import static org.assertj.core.api.Assertions.*;
 public class Z21SimulatorAdapterTest {
 
     private java.net.InetAddress host;
-    private int port = 21105; // default port for Z21 connections.
+    private final static int PORT = 21105; // default port for Z21 connections.
     private Z21SimulatorAdapter a = null;
 
     @Test
     public void testCtor() {
-        assertThat(a).isNotNull();
+        assertNotNull(a);
     }
 
     /*
@@ -38,10 +43,8 @@ public class Z21SimulatorAdapterTest {
     @DisabledIfSystemProperty(named ="jmri.skipTestsRequiringSeparateRunning", matches ="true")
     public void testConnection() {
         // connect the port
-        assertThatCode( () ->
-            a.connect())
-                .withFailMessage("Exception configuring server port")
-                .doesNotThrowAnyException();
+        assertDoesNotThrow( () ->
+            a.connect() ,"Exception configuring server port");
 
         // and configure/start the simulator.
         a.configure();
@@ -51,16 +54,15 @@ public class Z21SimulatorAdapterTest {
             // create a datagram with the data from a valid message.
             // this is a request to get the serial number.
             byte data[] = {0x04, 0x00, 0x10, 0x00};
-            DatagramPacket sendPacket = new DatagramPacket(data, 4, host, port);
+            DatagramPacket sendPacket = new DatagramPacket(data, 4, host, PORT);
             // and send it.
 
-            assertThatCode( () -> a.getSocket().send(sendPacket))
-                    .withFailMessage("IOException writing to network port")
-                    .doesNotThrowAnyException();
+            assertDoesNotThrow( () ->
+                a.getSocket().send(sendPacket),"IOException writing to network port");
 
-            assertThatCode( () -> {
+            assertDoesNotThrow( () -> {
                 byte buffer[] = new byte[100];
-                DatagramPacket p = new DatagramPacket(buffer, 100, host, port);
+                DatagramPacket p = new DatagramPacket(buffer, 100, host, PORT);
                 // set the timeout on the socket.
                 try {
                     a.getSocket().setSoTimeout(5000); // 5 second timeout.
@@ -69,31 +71,31 @@ public class Z21SimulatorAdapterTest {
                     // an optimization in case something went wrong.
                 }
                 a.getSocket().receive(p);
-                assertThat(p.getLength()).withFailMessage("received data from simulator").isGreaterThan(0);
-            }).withFailMessage("Exception reading from network port")
-                    .doesNotThrowAnyException();
+                assertTrue( p.getLength() > 0, "received data from simulator");
+            }, "Exception reading from network port");
+
         } catch (java.net.SocketException se) {
-            assertThat(se).withFailMessage("Failure Creating Socket").isNull();
+            assertNull(se, "Failure Creating Socket");
         }
     }
 
     @Test
-    public void RailComDataChangedReply() {
+    public void railComDataChangedReply() {
         cannedMessageCheck("getZ21RailComDataChangedReply", "04 00 88 00");
     }
 
     @Test
-    public void HardwareVersionReply() {
+    public void hardwareVersionReply() {
         cannedMessageCheck("getHardwareVersionReply", "0C 00 1A 00 00 02 00 00 20 01 00 00");
     }
 
     @Test
-    public void XPressNetUnknownCommandReply() {
+    public void xPressNetUnknownCommandReply() {
         cannedMessageCheck("getXPressNetUnknownCommandReply", "07 00 40 00 61 82 E3");
     }
 
     @Test
-    public void Z21SerialNumberReply() {
+    public void z21SerialNumberReply() {
         cannedMessageCheck("getZ21SerialNumberReply", "08 00 10 00 00 00 00 00");
     }
 
@@ -108,53 +110,51 @@ public class Z21SimulatorAdapterTest {
         java.lang.reflect.Method method = null;
         try {
             method = a.getClass().getDeclaredMethod(methodName);
-        } catch (java.lang.NoSuchMethodException nsm) {
-            Assert.fail("Could not find method " + methodName + "in Z21SimulatorAdapter class");
+        } catch ( NoSuchMethodException nsm) {
+            fail("Could not find method " + methodName + "in Z21SimulatorAdapter class");
         }
 
         // override the default permissions.
-        Assert.assertNotNull(method);
+        assertNotNull(method);
         method.setAccessible(true);
 
         try {
             Z21Reply z = (Z21Reply) method.invoke(a);
-            Assert.assertEquals(methodName + " return value", expectedReply, z.toString());
-        } catch (java.lang.IllegalAccessException iae) {
-            Assert.fail("Could not access method " + methodName + " in Z21SimulatorAdapter class");
+            assertNotNull(z);
+            assertEquals( expectedReply, z.toString(), methodName + " return value");
+        } catch ( IllegalAccessException iae) {
+            fail("Could not access method " + methodName + " in Z21SimulatorAdapter class", iae);
         } catch (java.lang.reflect.InvocationTargetException ite) {
             Throwable cause = ite.getCause();
-            Assert.fail(methodName + " executon failed reason: " + cause.getMessage());
+            fail(methodName + " executon failed reason: ", cause != null ? cause : ite);
         }
     }
 
     @Test
     public void testAddressedProgrammerManager() {
         // connect the port
-        assertThatCode( () ->
-                a.connect())
-                .withFailMessage("Exception configuring server port")
-                .doesNotThrowAnyException();
+        assertDoesNotThrow( () ->
+            a.connect(), "Exception configuring server port");
+
         // and configure/start the simulator.
         a.configure();
-        assertThat(a.getSystemConnectionMemo().provides(jmri.AddressedProgrammerManager.class)).isTrue();
+        assertTrue(a.getSystemConnectionMemo().provides(jmri.AddressedProgrammerManager.class));
     }
 
     // verify there is a Reporter manager
     @Test
     public void testReporterManager() {
-        assertThat(a.getSystemConnectionMemo().provides(jmri.ReporterManager.class)).isTrue();
+        assertTrue(a.getSystemConnectionMemo().provides(jmri.ReporterManager.class));
     }
 
     @BeforeEach
     public void setUp() {
         JUnitUtil.setUp();
-        jmri.util.JUnitUtil.resetProfileManager();
+        JUnitUtil.resetProfileManager();
         JUnitUtil.initConfigureManager();
 
-        assertThatCode( () ->
-            host = java.net.InetAddress.getLocalHost())
-               .withFailMessage("Unable to create host localhost")
-                .doesNotThrowAnyException();
+        assertDoesNotThrow( () ->
+            host = java.net.InetAddress.getLocalHost(), "Unable to create host localhost");
         // create a new simulator.
         a = new Z21SimulatorAdapter();
     }

--- a/java/test/jmri/jmrix/roco/z21/swing/Z21ComponentFactoryTest.java
+++ b/java/test/jmri/jmrix/roco/z21/swing/Z21ComponentFactoryTest.java
@@ -1,10 +1,12 @@
 package jmri.jmrix.roco.z21.swing;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
 import jmri.jmrix.roco.z21.Z21InterfaceScaffold;
 import jmri.jmrix.roco.z21.Z21SystemConnectionMemo;
 import jmri.util.JUnitUtil;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.*;
 
 /**
@@ -12,46 +14,45 @@ import org.junit.jupiter.api.*;
  *
  * @author Paul Bender Copyright (C) 2016
  **/
-
 public class Z21ComponentFactoryTest {
-        
-   private Z21SystemConnectionMemo memo = null;
-   private Z21InterfaceScaffold tc = null; 
 
-   @Test
-   public void MemoConstructorTest(){
-      Assert.assertNotNull("Z21ComponentFactory constructor",new Z21ComponentFactory(memo));
-   }
+    private Z21SystemConnectionMemo memo = null;
+    private Z21InterfaceScaffold tc = null;
 
-   @Test
-   public void getMenu(){
-      Z21ComponentFactory zcf = new Z21ComponentFactory(memo);
-      Assert.assertNotNull("Component Factory getMenu method",zcf.getMenu());
-   }
+    @Test
+    public void memoConstructorZ21ComponentFactoryTest(){
+        assertNotNull( new Z21ComponentFactory(memo), "Z21ComponentFactory constructor");
+    }
 
-   @Test
-   public void getMenuDisabled(){
-      memo.setDisabled(true);
-      Z21ComponentFactory zcf = new Z21ComponentFactory(memo);
-      Assert.assertNull("Disabled Component Factory getMenu method",zcf.getMenu());
-   }
+    @Test
+    public void getMenu(){
+        Z21ComponentFactory zcf = new Z21ComponentFactory(memo);
+        assertNotNull( zcf.getMenu(), "Component Factory getMenu method");
+    }
 
-   @BeforeEach
-   public void setUp() {
+    @Test
+    public void getMenuDisabled(){
+        memo.setDisabled(true);
+        Z21ComponentFactory zcf = new Z21ComponentFactory(memo);
+        assertNull( zcf.getMenu(), "Disabled Component Factory getMenu method");
+    }
+
+    @BeforeEach
+    public void setUp() {
         JUnitUtil.setUp();
 
-        jmri.util.JUnitUtil.initDefaultUserMessagePreferences();
+        JUnitUtil.initDefaultUserMessagePreferences();
         memo = new Z21SystemConnectionMemo();
         tc = new Z21InterfaceScaffold();
         memo.setTrafficController(tc);
-   }
+    }
 
-   @AfterEach
-   public void tearDown(){
+    @AfterEach
+    public void tearDown(){
         memo=null;
         tc.terminateThreads();
         tc=null;
         JUnitUtil.tearDown();
-   }
+    }
 
 }

--- a/java/test/jmri/jmrix/roco/z21/swing/Z21MenuTest.java
+++ b/java/test/jmri/jmrix/roco/z21/swing/Z21MenuTest.java
@@ -1,10 +1,11 @@
 package jmri.jmrix.roco.z21.swing;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import jmri.jmrix.roco.z21.Z21InterfaceScaffold;
 import jmri.jmrix.roco.z21.Z21SystemConnectionMemo;
 import jmri.util.JUnitUtil;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.*;
 
 /**
@@ -14,36 +15,36 @@ import org.junit.jupiter.api.*;
  **/
 
 public class Z21MenuTest {
-        
-   private Z21SystemConnectionMemo memo = null;
-   private Z21InterfaceScaffold tc = null; 
 
-   @Test
-   public void ConstructorTest(){
-      Assert.assertNotNull("Z21Menu constructor",new Z21Menu("Z21",memo));
-   }
+    private Z21SystemConnectionMemo memo = null;
+    private Z21InterfaceScaffold tc = null;
 
-   @Test
-   public void MemoConstructorTest(){
-      Assert.assertNotNull("Z21Menu constructor",new Z21Menu(memo));
-   }
+    @Test
+    public void constructorZ21MenuTestTest(){
+        assertNotNull( new Z21Menu("Z21",memo), "Z21Menu constructor");
+    }
 
-   @BeforeEach
-   public void setUp() {
+    @Test
+    public void memoConstructorZ21MenuTestTest(){
+        assertNotNull( new Z21Menu(memo), "Z21Menu constructor");
+    }
+
+    @BeforeEach
+    public void setUp() {
         JUnitUtil.setUp();
 
-        jmri.util.JUnitUtil.initDefaultUserMessagePreferences();
+        JUnitUtil.initDefaultUserMessagePreferences();
         memo = new Z21SystemConnectionMemo();
         tc = new Z21InterfaceScaffold();
         memo.setTrafficController(tc);
-   }
+    }
 
-   @AfterEach
-   public void tearDown(){
+    @AfterEach
+    public void tearDown(){
         memo=null;
         tc.terminateThreads();
         tc=null;
         JUnitUtil.tearDown();
-   }
+    }
 
 }

--- a/java/test/jmri/jmrix/roco/z21/swing/configtool/Z21ConfigActionTest.java
+++ b/java/test/jmri/jmrix/roco/z21/swing/configtool/Z21ConfigActionTest.java
@@ -1,10 +1,11 @@
 package jmri.jmrix.roco.z21.swing.configtool;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import jmri.jmrix.roco.z21.Z21InterfaceScaffold;
 import jmri.jmrix.roco.z21.Z21SystemConnectionMemo;
 import jmri.util.JUnitUtil;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.*;
 
 /**
@@ -12,38 +13,37 @@ import org.junit.jupiter.api.*;
  *
  * @author Paul Bender Copyright (C) 2016
  **/
-
 public class Z21ConfigActionTest {
-        
-   private Z21SystemConnectionMemo memo = null;
-   private Z21InterfaceScaffold tc = null; 
 
-   @Test
-   public void ConstructorTest(){
-      Assert.assertNotNull("Z21ConfigAction constructor",new Z21ConfigAction("Z21",memo));
-   }
+    private Z21SystemConnectionMemo memo = null;
+    private Z21InterfaceScaffold tc = null;
 
-   @Test
-   public void MemoConstructorTest(){
-      Assert.assertNotNull("Z21ConfigAction constructor",new Z21ConfigAction(memo));
-   }
+    @Test
+    public void constructorZ21ConfigActionTest(){
+        assertNotNull( new Z21ConfigAction("Z21",memo), "Z21ConfigAction constructor");
+    }
 
-   @BeforeEach
-   public void setUp() {
+    @Test
+    public void memoConstructorZ21ConfigActionTest(){
+        assertNotNull( new Z21ConfigAction(memo), "Z21ConfigAction constructor");
+    }
+
+    @BeforeEach
+    public void setUp() {
         JUnitUtil.setUp();
 
-        jmri.util.JUnitUtil.initDefaultUserMessagePreferences();
+        JUnitUtil.initDefaultUserMessagePreferences();
         memo = new Z21SystemConnectionMemo();
         tc = new Z21InterfaceScaffold();
         memo.setTrafficController(tc);
-   }
+    }
 
-   @AfterEach
-   public void tearDown(){
+    @AfterEach
+    public void tearDown(){
         memo=null;
         tc.terminateThreads();
         tc=null;
         JUnitUtil.tearDown();
-   }
+    }
 
 }

--- a/java/test/jmri/jmrix/roco/z21/swing/packetgen/PacketGenActionTest.java
+++ b/java/test/jmri/jmrix/roco/z21/swing/packetgen/PacketGenActionTest.java
@@ -1,10 +1,11 @@
 package jmri.jmrix.roco.z21.swing.packetgen;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import jmri.jmrix.roco.z21.Z21InterfaceScaffold;
 import jmri.jmrix.roco.z21.Z21SystemConnectionMemo;
 import jmri.util.JUnitUtil;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.*;
 
 /**
@@ -12,38 +13,37 @@ import org.junit.jupiter.api.*;
  *
  * @author Paul Bender Copyright (C) 2016
  **/
-
 public class PacketGenActionTest {
-        
-   private Z21SystemConnectionMemo memo = null;
-   private Z21InterfaceScaffold tc = null; 
 
-   @Test
-   public void ConstructorTest(){
-      Assert.assertNotNull("PacketGenAction constructor",new PacketGenAction("Z21",memo));
-   }
+    private Z21SystemConnectionMemo memo = null;
+    private Z21InterfaceScaffold tc = null;
 
-   @Test
-   public void MemoConstructorTest(){
-      Assert.assertNotNull("PacketGenAction constructor",new PacketGenAction(memo));
-   }
+    @Test
+    public void constructorPacketGenActionTest(){
+        assertNotNull( new PacketGenAction("Z21",memo), "PacketGenAction constructor");
+    }
 
-   @BeforeEach
-   public void setUp() {
+    @Test
+    public void memoConstructorPacketGenActionTest(){
+        assertNotNull( new PacketGenAction(memo), "PacketGenAction constructor");
+    }
+
+    @BeforeEach
+    public void setUp() {
         JUnitUtil.setUp();
 
-        jmri.util.JUnitUtil.initDefaultUserMessagePreferences();
+        JUnitUtil.initDefaultUserMessagePreferences();
         memo = new Z21SystemConnectionMemo();
         tc = new Z21InterfaceScaffold();
         memo.setTrafficController(tc);
-   }
+    }
 
-   @AfterEach
-   public void tearDown(){
+    @AfterEach
+    public void tearDown(){
         memo=null;
         tc.terminateThreads();
         tc=null;
         JUnitUtil.tearDown();
-   }
+    }
 
 }

--- a/java/test/jmri/jmrix/roco/z21/swing/packetgen/PacketGenFrameTest.java
+++ b/java/test/jmri/jmrix/roco/z21/swing/packetgen/PacketGenFrameTest.java
@@ -1,51 +1,48 @@
 package jmri.jmrix.roco.z21.swing.packetgen;
 
-import java.awt.GraphicsEnvironment;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import jmri.jmrix.roco.z21.RocoZ21CommandStation;
 import jmri.jmrix.roco.z21.Z21InterfaceScaffold;
 import jmri.jmrix.roco.z21.Z21SystemConnectionMemo;
 import jmri.util.JUnitUtil;
+import jmri.util.junit.annotations.DisabledIfHeadless;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.*;
-import org.junit.Assume;
 
 /**
  * Tests for PacketGenFrame class.
  *
  * @author Paul Bender Copyright (C) 2016
  **/
-
 public class PacketGenFrameTest {
-        
-   // not needed now, but once we test connect, it will be. 
-   private Z21SystemConnectionMemo memo = null;
-   private Z21InterfaceScaffold tc = null; 
 
-   @Test
-   public void MemoConstructorTest(){
-      Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-      Assert.assertNotNull("PacketGenFrame constructor",new PacketGenFrame());
-   }
+    private Z21SystemConnectionMemo memo = null;
+    private Z21InterfaceScaffold tc = null;
 
-   @BeforeEach
-   public void setUp() {
+    @Test
+    @DisabledIfHeadless
+    public void memoConstructorPacketGenFrameTest(){
+        assertNotNull( new PacketGenFrame(), "PacketGenFrame constructor");
+    }
+
+    @BeforeEach
+    public void setUp() {
         JUnitUtil.setUp();
 
-        jmri.util.JUnitUtil.initDefaultUserMessagePreferences();
+        JUnitUtil.initDefaultUserMessagePreferences();
         memo = new Z21SystemConnectionMemo();
         tc = new Z21InterfaceScaffold();
         memo.setTrafficController(tc);
         memo.setRocoZ21CommandStation(new RocoZ21CommandStation());
-   }
+    }
 
-   @AfterEach
-   public void tearDown(){
+    @AfterEach
+    public void tearDown(){
         memo=null;
         tc.terminateThreads();
         tc=null;
         JUnitUtil.tearDown();
-   }
+    }
 
 }


### PR DESCRIPTION
Method names to start lowercase.
Prevent NPE in test failure string
Indentation
Asserts JU4 > JU5

**Z21LocoNetTunnelTest**
In tearDown, remove waitFor lnspc status false,
this always returns true in LnStreamPortController

**Z21RMBusAddressTest**
Adds extra assert WarnMessage for invalid system name: ZS0b:a