### PR TITLE
update LocoNet tests

### DIFF
--- a/java/test/jmri/jmrix/loconet/LnDeferProgrammerTest.java
+++ b/java/test/jmri/jmrix/loconet/LnDeferProgrammerTest.java
@@ -1,10 +1,14 @@
 package jmri.jmrix.loconet;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import jmri.ProgListener;
 import jmri.ProgrammingMode;
 import jmri.util.JUnitUtil;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.*;
 
 /**
@@ -16,11 +20,10 @@ public class LnDeferProgrammerTest {
 
     @Test
     public void testCTor() {
-        LnTrafficController lnis = new LocoNetInterfaceScaffold();
-        SlotManager slotmanager = new SlotManager(lnis);
+
         LocoNetSystemConnectionMemo memo = new LocoNetSystemConnectionMemo(lnis, slotmanager);
         LnDeferProgrammer t = new LnDeferProgrammer(memo);
-        Assert.assertNotNull("exists", t);
+        assertNotNull( t, "exists");
         memo.dispose();
     }
 
@@ -28,23 +31,21 @@ public class LnDeferProgrammerTest {
     @Test
     public void testReadCVPaged() throws jmri.ProgrammerException {
         String CV1 = "12";
-        ProgListener p2 = null;
         slotmanager.setMode(ProgrammingMode.PAGEMODE);
-        slotmanager.readCV(CV1, p2);
-        Assert.assertEquals("read message",
-                "EF 0E 7C 23 00 00 00 00 00 0B 00 7F 7F 00",
-                lnis.outbound.elementAt(lnis.outbound.size() - 1).toString());
+        slotmanager.readCV(CV1, null);
+        assertEquals( "EF 0E 7C 23 00 00 00 00 00 0B 00 7F 7F 00",
+            lnis.outbound.elementAt(lnis.outbound.size() - 1).toString(),
+            "read message");
     }
 
     @Test
     public void testReadCVRegister() throws jmri.ProgrammerException {
         String CV1 = "2";
-        ProgListener p2 = null;
         slotmanager.setMode(ProgrammingMode.REGISTERMODE);
-        slotmanager.readCV(CV1, p2);
-        Assert.assertEquals("read message",
-                "EF 0E 7C 13 00 00 00 00 00 01 00 7F 7F 00",
-                lnis.outbound.elementAt(lnis.outbound.size() - 1).toString());
+        slotmanager.readCV(CV1, null);
+        assertEquals( "EF 0E 7C 13 00 00 00 00 00 01 00 7F 7F 00",
+            lnis.outbound.elementAt(lnis.outbound.size() - 1).toString(),
+            "read message");
     }
 
     @Test
@@ -53,11 +54,11 @@ public class LnDeferProgrammerTest {
         String CV1 = "29";
         slotmanager.setMode(ProgrammingMode.DIRECTBYTEMODE);
         slotmanager.readCV(CV1, lstn);
-        Assert.assertEquals("read message",
-                "EF 0E 7C 2B 00 00 00 00 00 1C 00 7F 7F 00",
-                lnis.outbound.elementAt(lnis.outbound.size() - 1).toString());
-        Assert.assertEquals("one message sent", 1, lnis.outbound.size());
-        Assert.assertEquals("initial status", -999, status);
+        assertEquals( "EF 0E 7C 2B 00 00 00 00 00 1C 00 7F 7F 00",
+            lnis.outbound.elementAt(lnis.outbound.size() - 1).toString(),
+            "read message");
+        assertEquals( 1, lnis.outbound.size(), "one message sent");
+        assertEquals( -999, status, "initial status");
 
         // LACK received back (DCS240 sequence)
         log.debug("send LACK back");
@@ -66,9 +67,9 @@ public class LnDeferProgrammerTest {
 
         slotmanager.message(new LocoNetMessage(new int[]{0xB4, 0x6F, 0x01, 0x25}));
         JUnitUtil.waitFor(()->{return startedLongTimer;},"startedLongTimer not set");
-        Assert.assertEquals("post-LACK status", -999, status);
-        Assert.assertTrue("started long timer", startedLongTimer);
-        Assert.assertFalse("didn't start short timer", startedShortTimer);
+        assertEquals( -999, status, "post-LACK status");
+        assertTrue( startedLongTimer, "started long timer");
+        assertFalse( startedShortTimer, "didn't start short timer");
 
         // read received back (DCS240 sequence)
         value = 0;
@@ -76,8 +77,8 @@ public class LnDeferProgrammerTest {
         slotmanager.message(new LocoNetMessage(new int[]{0xE7, 0x0E, 0x7C, 0x2B, 0x00, 0x00, 0x02, 0x47, 0x00, 0x1C, 0x23, 0x7F, 0x7F, 0x3B}));
         JUnitUtil.waitFor(()->{return value == 35;},"value == 35 not set");
         log.debug("checking..");
-        Assert.assertEquals("reply status", 0, status);
-        Assert.assertEquals("reply value", 35, value);
+        assertEquals( 0, status, "reply status");
+        assertEquals( 35, value, "reply value");
 
         log.debug(".... end testReadCVDirect ...");
     }
@@ -85,69 +86,63 @@ public class LnDeferProgrammerTest {
     @Test
     public void testReadCVOpsModeLong() throws jmri.ProgrammerException {
         String CV1 = "12";
-        ProgListener p2 = null;
-        slotmanager.readCVOpsMode(CV1, p2, 4 * 128 + 0x23, true);
-        Assert.assertEquals("read message",
-                "EF 0E 7C 2F 00 04 23 00 00 0B 00 7F 7F 00",
-                lnis.outbound.elementAt(lnis.outbound.size() - 1).toString());
+        slotmanager.readCVOpsMode(CV1, null, 4 * 128 + 0x23, true);
+        assertEquals( "EF 0E 7C 2F 00 04 23 00 00 0B 00 7F 7F 00",
+            lnis.outbound.elementAt(lnis.outbound.size() - 1).toString(),
+            "read message");
     }
 
     @Test
     public void testReadCVOpsModeShort() throws jmri.ProgrammerException {
         String CV1 = "12";
-        ProgListener p2 = null;
-        slotmanager.readCVOpsMode(CV1, p2, 22, false);
-        Assert.assertEquals("read message",
-                "EF 0E 7C 2F 00 00 16 00 00 0B 00 7F 7F 00",
-                lnis.outbound.elementAt(lnis.outbound.size() - 1).toString());
+        slotmanager.readCVOpsMode(CV1, null, 22, false);
+        assertEquals( "EF 0E 7C 2F 00 00 16 00 00 0B 00 7F 7F 00",
+            lnis.outbound.elementAt(lnis.outbound.size() - 1).toString(),
+            "read message");
     }
 
     @Test
     public void testWriteCVPaged() throws jmri.ProgrammerException {
         String CV1 = "12";
         int val2 = 34;
-        ProgListener p3 = null;
         slotmanager.setMode(ProgrammingMode.PAGEMODE);
-        slotmanager.writeCV(CV1, val2, p3);
-        Assert.assertEquals("write message",
-                "EF 0E 7C 63 00 00 00 00 00 0B 22 7F 7F 00",
-                lnis.outbound.elementAt(lnis.outbound.size() - 1).toString());
+        slotmanager.writeCV(CV1, val2, null);
+        assertEquals( "EF 0E 7C 63 00 00 00 00 00 0B 22 7F 7F 00",
+            lnis.outbound.elementAt(lnis.outbound.size() - 1).toString(),
+            "write message");
     }
 
     @Test
     public void testWriteCVPagedString() throws jmri.ProgrammerException {
         String CV1 = "12";
         int val2 = 34;
-        ProgListener p3 = null;
         slotmanager.setMode(ProgrammingMode.PAGEMODE);
-        slotmanager.writeCV(CV1, val2, p3);
-        Assert.assertEquals("write message",
-                "EF 0E 7C 63 00 00 00 00 00 0B 22 7F 7F 00",
-                lnis.outbound.elementAt(lnis.outbound.size() - 1).toString());
+        slotmanager.writeCV(CV1, val2, null);
+        assertEquals( "EF 0E 7C 63 00 00 00 00 00 0B 22 7F 7F 00",
+            lnis.outbound.elementAt(lnis.outbound.size() - 1).toString(),
+            "write message");
     }
 
     @Test
     public void testWriteCVRegister() throws jmri.ProgrammerException {
         String CV1 = "2";
         int val2 = 34;
-        ProgListener p3 = null;
         slotmanager.setMode(ProgrammingMode.REGISTERMODE);
-        slotmanager.writeCV(CV1, val2, p3);
-        Assert.assertEquals("write message",
-                "EF 0E 7C 53 00 00 00 00 00 01 22 7F 7F 00",
-                lnis.outbound.elementAt(lnis.outbound.size() - 1).toString());
+        slotmanager.writeCV(CV1, val2, null);
+        assertEquals( "EF 0E 7C 53 00 00 00 00 00 01 22 7F 7F 00",
+            lnis.outbound.elementAt(lnis.outbound.size() - 1).toString(),
+            "write message");
     }
 
     @Test
     public void testWriteCVDirect() throws jmri.ProgrammerException {
         String CV1 = "12";
         int val2 = 34;
-        ProgListener p3 = null;
         slotmanager.setMode(ProgrammingMode.DIRECTBYTEMODE);
-        slotmanager.writeCV(CV1, val2, p3);
-        Assert.assertEquals("write message",
-                "EF 0E 7C 6B 00 00 00 00 00 0B 22 7F 7F 00",
-                lnis.outbound.elementAt(lnis.outbound.size() - 1).toString());
+        slotmanager.writeCV(CV1, val2, null);
+        assertEquals( "EF 0E 7C 6B 00 00 00 00 00 0B 22 7F 7F 00",
+            lnis.outbound.elementAt(lnis.outbound.size() - 1).toString(),
+            "write message");
     }
 
     @Test
@@ -157,13 +152,13 @@ public class LnDeferProgrammerTest {
         int val2 = 16;
         slotmanager.setMode(ProgrammingMode.DIRECTBYTEMODE);
         slotmanager.writeCV(CV1, val2, lstn);
-        Assert.assertEquals("one message sent", 1, lnis.outbound.size());
-        Assert.assertEquals("initial status", -999, status);
-        Assert.assertEquals("write message",
-                "EF 0E 7C 6B 00 00 00 00 00 1E 10 7F 7F 00",
-                lnis.outbound.elementAt(lnis.outbound.size() - 1).toString());
-        Assert.assertEquals("one message sent", 1, lnis.outbound.size());
-        Assert.assertEquals("initial status", -999, status);
+        assertEquals( 1, lnis.outbound.size(), "one message sent");
+        assertEquals( -999, status, "initial status");
+        assertEquals( "EF 0E 7C 6B 00 00 00 00 00 1E 10 7F 7F 00",
+            lnis.outbound.elementAt(lnis.outbound.size() - 1).toString(),
+            "write message");
+        assertEquals( 1, lnis.outbound.size(), "one message sent");
+        assertEquals( -999, status, "initial status");
 
         // LACK received back (DCS240 sequence)
         log.debug("send LACK back");
@@ -171,34 +166,35 @@ public class LnDeferProgrammerTest {
         startedLongTimer = false;
         slotmanager.message(new LocoNetMessage(new int[]{0xB4, 0x6F, 0x01, 0x25}));
         JUnitUtil.waitFor(()->{return startedShortTimer;},"startedShortTimer not set");
-        Assert.assertEquals("post-LACK status", -999, status);
-        Assert.assertTrue("started short timer", startedShortTimer);
-        Assert.assertFalse("didn't start long timer", startedLongTimer);
+        assertEquals( -999, status, "post-LACK status");
+        assertTrue( startedShortTimer, "started short timer");
+        assertFalse( startedLongTimer, "didn't start long timer");
 
         // read received back (DCS240 sequence)
         value = -15;
         log.debug("send E7 reply back");
         slotmanager.message(new LocoNetMessage(new int[]{0xE7, 0x0E, 0x7C, 0x6B, 0x00, 0x00, 0x02, 0x47, 0x00, 0x1E, 0x10, 0x7F, 0x7F, 0x4A}));
-        Assert.assertEquals("no immediate reply", -999, status);
+        assertEquals( -999, status, "no immediate reply");
         JUnitUtil.waitFor(()->{return value == -1;},"value == -1 not set");
         log.debug("checking..");
-        Assert.assertEquals("reply status", 0, status);
-        Assert.assertEquals("reply value", -1, value);
+        assertEquals( 0, status, "reply status");
+        assertEquals( -1, value, "reply value");
+        assertTrue(stoppedTimer);
 
         log.debug(".... end testWriteCVDirectStringDCS240 ...");
     }
 
 
-    LocoNetInterfaceScaffold lnis;
-    SlotManager slotmanager;
-    int status;
-    int value;
-    boolean startedShortTimer = false;
-    boolean startedLongTimer = false;
-    boolean stoppedTimer = false;
+    private LocoNetInterfaceScaffold lnis;
+    private SlotManager slotmanager;
+    private int status;
+    private int value;
+    private boolean startedShortTimer = false;
+    private boolean startedLongTimer = false;
+    private boolean stoppedTimer = false;
 
-    ProgListener lstn;
-    int releaseTestDelay = 150; // probably needs to be at least 150, see SlotManager.postProgDelay
+    private ProgListener lstn;
+    // private final int releaseTestDelay = 150; // probably needs to be at least 150, see SlotManager.postProgDelay
 
     @BeforeEach
     public void setUp() {
@@ -243,7 +239,10 @@ public class LnDeferProgrammerTest {
 
     @AfterEach
     public void tearDown() {
+        lnis.dispose();
         slotmanager.dispose();
+        lnis = null;
+        slotmanager = null;
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrix/loconet/LnSensorTest.java
+++ b/java/test/jmri/jmrix/loconet/LnSensorTest.java
@@ -1,11 +1,11 @@
 package jmri.jmrix.loconet;
 
-import jmri.util.JUnitUtil;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Assert;
+import jmri.util.JUnitUtil;
+import jmri.util.junit.annotations.NotApplicable;
+
 import org.junit.jupiter.api.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Tests for the jmri.jmrix.loconet.LnSensor class.
@@ -30,12 +30,13 @@ public class LnSensorTest extends jmri.implementation.AbstractSensorTestBase {
         // doesn't send a message right now, pending figuring out what
         // to send.
     }
-    
+
+    @Test
     @Override
+    @NotApplicable("status not currently updated when set UNKNOWN / INCONSISTENT")
     public void testSensorSetKnownState() {
-        // status not currently updated when set UNKNOWN / INCONSISTENT
     }
-    
+
     // LnSensor test for incoming status message
     @Test
     public void testLnSensorStatusMsg() {
@@ -50,7 +51,7 @@ public class LnSensorTest extends jmri.implementation.AbstractSensorTestBase {
         m.setElement(2, 0x60);     // Aux (low addr bit high), sensor low
         m.setElement(3, 0x38);
         s.messageFromManager(m);
-        Assert.assertEquals("Known state after inactivate ", jmri.Sensor.INACTIVE, s.getKnownState());
+        assertEquals( jmri.Sensor.INACTIVE, s.getKnownState(), "Known state after inactivate ");
 
         m = new LocoNetMessage(4);
         m.setOpCode(0xb2);         // OPC_INPUT_REP
@@ -58,7 +59,7 @@ public class LnSensorTest extends jmri.implementation.AbstractSensorTestBase {
         m.setElement(2, 0x70);     // Aux (low addr bit high), sensor high
         m.setElement(3, 0x78);
         s.messageFromManager(m);
-        Assert.assertEquals("Known state after activate ", jmri.Sensor.ACTIVE, s.getKnownState());
+        assertEquals( jmri.Sensor.ACTIVE, s.getKnownState(), "Known state after activate ");
     }
 
     @BeforeEach
@@ -70,9 +71,8 @@ public class LnSensorTest extends jmri.implementation.AbstractSensorTestBase {
         lnis = new LocoNetInterfaceScaffold() {
             @Override
             public void sendLocoNetMessage(LocoNetMessage m) {
-                log.debug("sendLocoNetMessage [{}]", m);
-                // save a copy
-                outbound.addElement(m);
+                // super logs to debug and saves a copy to outbound.
+                super.sendLocoNetMessage(m);
                 ((LnSensor)t).messageFromManager(m);
             }
         };
@@ -83,10 +83,11 @@ public class LnSensorTest extends jmri.implementation.AbstractSensorTestBase {
     @Override
     public void tearDown() {
         t.dispose();
+        t = null;
         lnis = null;
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(LnSensorTest.class);
+    // private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LnSensorTest.class);
     
 }

--- a/java/test/jmri/jmrix/loconet/LnTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/loconet/LnTurnoutManagerTest.java
@@ -1,15 +1,18 @@
 package jmri.jmrix.loconet;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.ArrayList;
 import java.util.List;
 
 import jmri.Turnout;
 import jmri.util.JUnitUtil;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Tests for the jmri.jmrix.loconet.LnTurnoutManager class.
@@ -27,8 +30,8 @@ public class LnTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTestBa
     @Override
     public void testMisses() {
         // try to get nonexistant turnouts
-        Assert.assertNull(l.getByUserName("foo"));
-        Assert.assertNull(l.getBySystemName("bar"));
+        assertNull(l.getByUserName("foo"));
+        assertNull(l.getBySystemName("bar"));
     }
 
     @Test
@@ -51,8 +54,8 @@ public class LnTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTestBa
         lnis.sendTestMessage(m2);
 
         // try to get turnouts to see if they exist
-        Assert.assertNotNull(l.getBySystemName("LT21"));
-        Assert.assertNotNull(l.getBySystemName("LT22"));
+        assertNotNull(l.getBySystemName("LT21"));
+        assertNotNull(l.getBySystemName("LT22"));
 
         // check the list
         List<String> testList = new ArrayList<>(2);
@@ -61,48 +64,48 @@ public class LnTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTestBa
 
         jmri.util.JUnitAppender.suppressWarnMessageStartsWith("getSystemNameList");
 
-        Assert.assertEquals("2 Turnouts in nambedbeanset",2,l.getNamedBeanSet().size());
-        Assert.assertTrue(l.getNamedBeanSet().contains(l.getBySystemName("LT21")));
-        Assert.assertTrue(l.getNamedBeanSet().contains(l.getBySystemName("LT22")));
+        assertEquals(2, l.getNamedBeanSet().size(), "2 Turnouts in nambedbeanset");
+        assertTrue(l.getNamedBeanSet().contains(l.getBySystemName("LT21")));
+        assertTrue(l.getNamedBeanSet().contains(l.getBySystemName("LT22")));
 
     }
 
     @Test
-    public void testCreateFromMessage1 () {
+    public void testCreateFromMessage1() {
         // Turnout LT61 () Switch input is Closed (input off).
         LocoNetMessage m = new LocoNetMessage(new int[]{0xb1, 0x3C, 0x70, 0x02});
         lnis.sendTestMessage(m);
-        Assert.assertNotNull(l.getBySystemName("LT61"));
-        Assert.assertEquals(Turnout.CLOSED, l.getBySystemName("LT61").getKnownState());
+        assertNotNull(l.getBySystemName("LT61"));
+        assertEquals(Turnout.CLOSED, l.getBySystemName("LT61").getKnownState());
     }
 
     @Test
-    public void testCreateFromMessage2 () {
+    public void testCreateFromMessage2() {
         // Turnout LT62 () Switch input is Thrown (input on).
         LocoNetMessage m = new LocoNetMessage(new int[]{0xb1, 0x3D, 0x60, 0x13});
         lnis.sendTestMessage(m);
-        Assert.assertNotNull(l.getBySystemName("LT62"));
-        Assert.assertEquals(Turnout.THROWN, l.getBySystemName("LT62").getKnownState());
+        assertNotNull(l.getBySystemName("LT62"));
+        assertEquals(Turnout.THROWN, l.getBySystemName("LT62").getKnownState());
     }
 
     @Test
-    public void testCreateFromMessage3 () {
+    public void testCreateFromMessage3() {
         // Turnout LT63 () Aux input is Thrown (input ).
         LocoNetMessage m = new LocoNetMessage(new int[]{0xb1, 0x3E, 0x40, 0x30});
         lnis.sendTestMessage(m);
-        Assert.assertNotNull(l.getBySystemName("LT63"));
-        Assert.assertEquals("EXACT", l.getBySystemName("LT63").getFeedbackModeName());
-        Assert.assertEquals(Turnout.INCONSISTENT, l.getBySystemName("LT63").getKnownState());
+        assertNotNull(l.getBySystemName("LT63"));
+        assertEquals("EXACT", l.getBySystemName("LT63").getFeedbackModeName());
+        assertEquals(Turnout.INCONSISTENT, l.getBySystemName("LT63").getKnownState());
     }
 
     @Test
-    public void testCreateFromMessage4 () {
+    public void testCreateFromMessage4() {
         // Turnout LT64 () Aux input is Closed (input off).
         LocoNetMessage m = new LocoNetMessage(new int[]{0xb1, 0x3F, 0x50, 0x21});
         lnis.sendTestMessage(m);
-        Assert.assertNotNull(l.getBySystemName("LT64"));
-        Assert.assertEquals("EXACT", l.getBySystemName("LT64").getFeedbackModeName());
-        Assert.assertEquals(Turnout.THROWN, l.getBySystemName("LT64").getKnownState());
+        assertNotNull(l.getBySystemName("LT64"));
+        assertEquals("EXACT", l.getBySystemName("LT64").getFeedbackModeName());
+        assertEquals(Turnout.THROWN, l.getBySystemName("LT64").getKnownState());
     }
 
     @Test
@@ -111,85 +114,81 @@ public class LnTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTestBa
         Turnout o = l.newTurnout("LT21", "my name");
 
         log.debug("received turnout value {}", o);
-        Assert.assertNotNull(o);
+        assertNotNull(o);
 
         // make sure loaded into tables
         if (log.isDebugEnabled()) {
             log.debug("by system name: {}", l.getBySystemName("LT21"));
-        }
-        if (log.isDebugEnabled()) {
             log.debug("by user name:   {}", l.getByUserName("my name"));
         }
 
-        Assert.assertNotNull(l.getBySystemName("LT21"));
-        Assert.assertNotNull(l.getByUserName("my name"));
+        assertNotNull(l.getBySystemName("LT21"));
+        assertNotNull(l.getByUserName("my name"));
     }
 
     @Test
     public void testOpcLongAck() {
-        Assert.assertEquals("Check no outbound messages", 0, lnis.outbound.size());
-        ((LnTurnoutManager)l).mTurnoutNoRetry=false;
+        assertEquals(0, lnis.outbound.size(), "Check no outbound messages");
+        ((LnTurnoutManager) l).mTurnoutNoRetry = false;
 
-        Turnout t = ((LnTurnoutManager)l).provideTurnout("LT1");   // createNewTurnout does not register it.
-        LocoNetMessage m = new LocoNetMessage(new int[] {0xb0, 0x00, 0x20, 0x6f});
+        Turnout t = ((LnTurnoutManager) l).provideTurnout("LT1");   // createNewTurnout does not register it.
+        LocoNetMessage m = new LocoNetMessage(new int[]{0xb0, 0x00, 0x20, 0x6f});
         lnis.sendTestMessage(m);
-        Assert.assertEquals("check now closed", Turnout.CLOSED, t.getKnownState());
-        Assert.assertEquals("Check no outbound messages", 0, lnis.outbound.size());
-        Assert.assertNotNull(((LnTurnoutManager)l).lastSWREQ);
-        Assert.assertEquals(LnConstants.OPC_SW_REQ, ((LnTurnoutManager)l).lastSWREQ.getOpCode());
-        Assert.assertEquals(0x00, ((LnTurnoutManager)l).lastSWREQ.getElement(1));
-        Assert.assertEquals(0x20, ((LnTurnoutManager)l).lastSWREQ.getElement(2));
+        assertEquals(Turnout.CLOSED, t.getKnownState(), "check now closed");
+        assertEquals(0, lnis.outbound.size(), "Check no outbound messages");
+        assertNotNull(((LnTurnoutManager) l).lastSWREQ);
+        assertEquals(LnConstants.OPC_SW_REQ, ((LnTurnoutManager) l).lastSWREQ.getOpCode());
+        assertEquals(0x00, ((LnTurnoutManager) l).lastSWREQ.getElement(1));
+        assertEquals(0x20, ((LnTurnoutManager) l).lastSWREQ.getElement(2));
 
-        Assert.assertEquals("Check no outbound messages", 0, lnis.outbound.size());
-        Assert.assertEquals("Check that the turnout message was saved as 'last'",
-                m, ((LnTurnoutManager)l).lastSWREQ);
+        assertEquals(0, lnis.outbound.size(), "Check no outbound messages");
+        assertEquals(m, ((LnTurnoutManager) l).lastSWREQ, "Check that the turnout message was saved as 'last'");
         lnis.sendTestMessage(m);    // command station rejection of turnout command
         m.setOpCode(0xB4);
         m.setElement(1, 0x30);
         m.setElement(2, 0x00);
         m.setElement(3, 0x7b);
-        Assert.assertEquals("check sent message opcode", 0xb4, m.getOpCode());
+        assertEquals(0xb4, m.getOpCode(), "check sent message opcode");
         lnis.sendTestMessage(m);    // command station rejection of turnout command
-        Assert.assertEquals("Check one outbound messages", 1, lnis.outbound.size());
-        Assert.assertEquals("check now closed (2)", Turnout.CLOSED, t.getKnownState());
+        assertEquals(1, lnis.outbound.size(), "Check one outbound messages");
+        assertEquals(Turnout.CLOSED, t.getKnownState(), "check now closed (2)");
 
-        Assert.assertFalse("check turnout manager retry mechanism setting", ((LnTurnoutManager)l).mTurnoutNoRetry);
+        assertFalse(((LnTurnoutManager) l).mTurnoutNoRetry, "check turnout manager retry mechanism setting");
 
-        jmri.util.JUnitUtil.fasterWaitFor(() -> {return 1 < lnis.outbound.size();});
-        Assert.assertEquals("Check an outbound message", 1, lnis.outbound.size());
+        JUnitUtil.fasterWaitFor(() -> !lnis.outbound.isEmpty(), "outbound sent");
+        assertEquals(1, lnis.outbound.size(), "Check an outbound message");
 
-        Assert.assertEquals("Check outbound message opcode", LnConstants.OPC_SW_REQ, lnis.outbound.get(0).getOpCode());
-        Assert.assertEquals("Check outbound message byte 1", 0x00, lnis.outbound.get(0).getElement(1));
-        Assert.assertEquals("Check outbound message byte 2", 0x20, lnis.outbound.get(0).getElement(2));
+        assertEquals(LnConstants.OPC_SW_REQ, lnis.outbound.get(0).getOpCode(), "Check outbound message opcode");
+        assertEquals(0x00, lnis.outbound.get(0).getElement(1), "Check outbound message byte 1");
+        assertEquals(0x20, lnis.outbound.get(0).getElement(2), "Check outbound message byte 2");
     }
 
     @Test
     public void testOpcLongAckToEnquiry() {
-        Assert.assertEquals("Check no outbound messages", 0, lnis.outbound.size());
-        ((LnTurnoutManager)l).mTurnoutNoRetry=false;
+        assertEquals(0, lnis.outbound.size(), "Check no outbound messages");
+        ((LnTurnoutManager) l).mTurnoutNoRetry = false;
 
-        ((LnTurnoutManager)l).provideTurnout("LT1018");   // This is effectively an enquiry command
-        LocoNetMessage m = new LocoNetMessage(new int[] {0xb0, 0x79, 0x37, 0x01});
+        ((LnTurnoutManager) l).provideTurnout("LT1018");   // This is effectively an enquiry command
+        LocoNetMessage m = new LocoNetMessage(new int[]{0xb0, 0x79, 0x37, 0x01});
         lnis.sendTestMessage(m);
-        Assert.assertEquals("Check no outbound messages", 0, lnis.outbound.size());
-        Assert.assertNotNull(((LnTurnoutManager)l).lastSWREQ);
-        Assert.assertEquals(LnConstants.OPC_SW_REQ, ((LnTurnoutManager)l).lastSWREQ.getOpCode());
-        Assert.assertEquals(0x79, ((LnTurnoutManager)l).lastSWREQ.getElement(1));
-        Assert.assertEquals(0x37, ((LnTurnoutManager)l).lastSWREQ.getElement(2));
+        assertEquals(0, lnis.outbound.size(), "Check no outbound messages");
+        assertNotNull(((LnTurnoutManager) l).lastSWREQ);
+        assertEquals(LnConstants.OPC_SW_REQ, ((LnTurnoutManager) l).lastSWREQ.getOpCode());
+        assertEquals(0x79, ((LnTurnoutManager) l).lastSWREQ.getElement(1));
+        assertEquals(0x37, ((LnTurnoutManager) l).lastSWREQ.getElement(2));
 
-        Assert.assertEquals("Check no outbound messages", 0, lnis.outbound.size());
-        Assert.assertEquals("Check that the turnout message was saved as 'last'",
-                m, ((LnTurnoutManager)l).lastSWREQ);
+        assertEquals(0, lnis.outbound.size(), "Check no outbound messages");
+        assertEquals(m, ((LnTurnoutManager) l).lastSWREQ, "Check that the turnout message was saved as 'last'");
         lnis.sendTestMessage(m);    // command station rejection of turnout command
         m.setOpCode(0xB4);
         m.setElement(1, 0x30);
         m.setElement(2, 0x00);
         m.setElement(3, 0x7b);
-        Assert.assertEquals("check sent message opcode", 0xb4, m.getOpCode());
+        assertEquals(0xb4, m.getOpCode(), "check sent message opcode");
         lnis.sendTestMessage(m);    // command station rejection of turnout command
-        Assert.assertEquals("Check no outbound messages", 0, lnis.outbound.size());
+        assertEquals(0, lnis.outbound.size(), "Check no outbound messages");
 
-        Assert.assertFalse("check turnout manager retry mechanism setting", ((LnTurnoutManager)l).mTurnoutNoRetry);
+        assertFalse(((LnTurnoutManager) l).mTurnoutNoRetry, "check turnout manager retry mechanism setting");
     }
 
     private LocoNetInterfaceScaffold lnis;
@@ -197,9 +196,9 @@ public class LnTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTestBa
 
     @Override
     @BeforeEach
-    public void setUp(){
-        jmri.util.JUnitUtil.setUp();
-        jmri.util.JUnitUtil.resetInstanceManager();
+    public void setUp() {
+        JUnitUtil.setUp();
+        JUnitUtil.resetInstanceManager();
         // prepare an interface, register
         memo = new LocoNetSystemConnectionMemo();
         lnis = new LocoNetInterfaceScaffold(memo);
@@ -217,6 +216,6 @@ public class LnTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTestBa
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(LnTurnoutManagerTest.class);
+    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LnTurnoutManagerTest.class);
 
 }

--- a/java/test/jmri/jmrix/loconet/LocoNetExpThrottleTest.java
+++ b/java/test/jmri/jmrix/loconet/LocoNetExpThrottleTest.java
@@ -1,1207 +1,1207 @@
-    package jmri.jmrix.loconet;
+package jmri.jmrix.loconet;
 
-    import jmri.CommandStation;
-    import jmri.util.JUnitUtil;
-    import jmri.SpeedStepMode;
+import jmri.CommandStation;
+import jmri.util.JUnitUtil;
+import jmri.SpeedStepMode;
 
-    import org.junit.Assert;
-    import org.junit.jupiter.api.*;
+import org.junit.Assert;
+import org.junit.jupiter.api.*;
 
-    public class LocoNetExpThrottleTest extends jmri.jmrix.AbstractThrottleTest {
+public class LocoNetExpThrottleTest extends jmri.jmrix.AbstractThrottleTest {
 
-        @Test
-        public void testCTor() {
-            Assert.assertNotNull(instance);
-        }
+    @Test
+    public void testCTor() {
+        Assert.assertNotNull(instance);
+    }
 
-        // test the speed setting code.
-        @Test
-        public void testSpeedSetting() {
-            // we have 4 cases to check
-            // Case 1: The locomotive is not consisted.
-            LocoNetSlot s1 = new LocoNetSlot(0) {
-                @Override
-                public int consistStatus() {
-                    return LnConstants.CONSIST_NO;
-                }
-
-                @Override
-                public int speed() {
-                    return 0;
-                }
-            };
-            LocoNetThrottle t1 = new LocoNetThrottle(memo, s1);
-            Assert.assertEquals(0.0f, t1.getSpeedSetting(), 0.0);
-            t1.setSpeedSetting(0.5f);
-            // the speed change SHOULD be changed.
-            Assert.assertEquals(0.5f, t1.getSpeedSetting(), 0.0);
-
-            // Case 2: The locomotive is a consist top.
-            LocoNetSlot s2 = new LocoNetSlot(1) {
-                @Override
-                public int consistStatus() {
-                    return LnConstants.CONSIST_TOP;
-                }
-
-                @Override
-                public int speed() {
-                    return 0;
-                }
-            };
-            LocoNetThrottle t2 = new LocoNetThrottle(memo, s2);
-            Assert.assertEquals(0.0f, t2.getSpeedSetting(), 0.0);
-            t2.setSpeedSetting(0.5f);
-            // the speed change SHOULD be changed.
-            Assert.assertEquals(0.5f, t2.getSpeedSetting(), 0.0);
-
-            // Case 3: The locomotive is a consist mid.
-            LocoNetSlot s3 = new LocoNetSlot(2) {
-                @Override
-                public int consistStatus() {
-                    return LnConstants.CONSIST_MID;
-                }
-
-                @Override
-                public int speed() {
-                    return 0;
-                }
-            };
-            LocoNetThrottle t3 = new LocoNetThrottle(memo, s3);
-            Assert.assertEquals(0.0f, t3.getSpeedSetting(), 0.0);
-            t3.setSpeedSetting(0.5f);
-            // the speed change SHOULD NOT be changed.
-            Assert.assertEquals(0.0f, t3.getSpeedSetting(), 0.0);
-
-            // Case 3: The locomotive is a consist mid.
-            // make sure the speed does NOT change for a consist sub
-            LocoNetSlot s4 = new LocoNetSlot(3) {
-                @Override
-                public int consistStatus() {
-                    return LnConstants.CONSIST_SUB;
-                }
-
-                @Override
-                public int speed() {
-                    return 0;
-                }
-            };
-            LocoNetThrottle t4 = new LocoNetThrottle(memo, s4);
-            Assert.assertEquals(0.0f, t4.getSpeedSetting(), 0.0);
-            t4.setSpeedSetting(0.5f);
-            // the speed change SHOULD be ignored.
-            Assert.assertEquals(0.0f, t4.getSpeedSetting(), 0.0);
-        }
-
-        /**
-         * Test of getIsForward method, of class AbstractThrottle.
-         */
-        @Test
-        @Override
-        public void testGetIsForward() {
-            boolean expResult = true;
-            boolean result = instance.getIsForward();
-            Assert.assertEquals(expResult, result);
-        }
-
-        /**
-         * Test of getSpeedStepMode method, of class AbstractThrottle.
-         */
-        @Test
-        @Override
-        public void testGetSpeedStepMode() {
-            SpeedStepMode expResult = SpeedStepMode.NMRA_DCC_28;
-            SpeedStepMode result = instance.getSpeedStepMode();
-            Assert.assertEquals(expResult, result);
-        }
-
-        /**
-         * Test of getSpeedIncrement method, of class AbstractThrottle.
-         */
-        @Test
-        @Override
-        public void testGetSpeedIncrement() {
-            float expResult = 1.0F/28.0F;
-            float result = instance.getSpeedIncrement();
-            Assert.assertEquals(expResult, result, 0.0);
-        }
-
-        /**
-         * Test of intSpeed method, of class AbstractThrottle.
-         */
-        @Test
-        @Override
-        public void testGetSpeed_float() {
-            // set speed step mode to 128.
-            instance.setSpeedStepMode(jmri.SpeedStepMode.NMRA_DCC_128);
-            super.testGetSpeed_float();
-        }
-
-        /**
-         * Test of setF0 method, of class AbstractThrottle.
-         */
-        @Test
-        @Override
-        public void testSetF0() {
-            lnis.outbound.clear();
-            lnis.resetStatistics();
-            boolean f0 = false;
-            instance.setFunction(0,f0);
-            Assert.assertEquals(f0, instance.getFunction(0));
-            Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
-            Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
-            Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F0F6, lnis.outbound.get(0).getElement(1) & 0x78);
-            Assert.assertEquals("sent f0 in correct state", 0, lnis.outbound.get(0).getElement(4) & LnConstants.DIRF_F0);
-            f0 = true;
-            instance.setFunction(0,f0);
-            Assert.assertEquals(f0, instance.getFunction(0));
-            Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
-            Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
-            Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F0F6, lnis.outbound.get(1).getElement(1) & 0x78);
-            Assert.assertEquals("sent f0 in correct state", LnConstants.DIRF_F0, lnis.outbound.get(1).getElement(4) & LnConstants.DIRF_F0);
-        }
-
-        /**
-         * Test of setF1 method, of class AbstractThrottle.
-         */
-        @Test
-        @Override
-        public void testSetF1() {
-            lnis.outbound.clear();
-            lnis.resetStatistics();
-            boolean f1 = false;
-            instance.setFunction(1,f1);
-            Assert.assertEquals(f1, instance.getFunction(1));
-            Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
-            Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
-            Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F0F6, lnis.outbound.get(0).getElement(1) & 0x78);
-            Assert.assertEquals("sent f0 in correct state", 0, lnis.outbound.get(0).getElement(4) & LnConstants.DIRF_F1);
-            f1 = true;
-            instance.setFunction(1,f1);
-            Assert.assertEquals(f1, instance.getFunction(1));
-            Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
-            Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
-            Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F0F6, lnis.outbound.get(1).getElement(1) & 0x78);
-            Assert.assertEquals("sent f1 in correct state", LnConstants.DIRF_F1, lnis.outbound.get(1).getElement(4) & LnConstants.DIRF_F1);
-        }
-
-        /**
-         * Test of setF2 method, of class AbstractThrottle.
-         */
-        @Test
-        @Override
-        public void testSetF2() {
-            lnis.outbound.clear();
-            lnis.resetStatistics();
-            boolean f2 = false;
-            instance.setFunction(2,f2);
-            Assert.assertEquals(f2, instance.getFunction(2));
-            Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
-            Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
-            Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F0F6, lnis.outbound.get(0).getElement(1) & 0x78);
-            Assert.assertEquals("sent f2 in correct state", 0, lnis.outbound.get(0).getElement(4) & LnConstants.DIRF_F2);
-            f2 = true;
-            instance.setFunction(2,f2);
-            Assert.assertEquals(f2, instance.getFunction(2));
-            Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
-            Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
-            Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F0F6, lnis.outbound.get(1).getElement(1) & 0x78);
-            Assert.assertEquals("sent f2 in correct state", LnConstants.DIRF_F2, lnis.outbound.get(1).getElement(4) & LnConstants.DIRF_F2);
-        }
-
-        /**
-         * Test of setF3 method, of class AbstractThrottle.
-         */
-        @Test
-        @Override
-        public void testSetF3() {
-            lnis.outbound.clear();
-            lnis.resetStatistics();
-            boolean f3 = false;
-            instance.setFunction(3,f3);
-            Assert.assertEquals(f3, instance.getFunction(3));
-            Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
-            Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
-            Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F0F6, lnis.outbound.get(0).getElement(1) & 0x78);
-            Assert.assertEquals("sent f3 in correct state", 0, lnis.outbound.get(0).getElement(4) & LnConstants.DIRF_F3);
-            f3 = true;
-            instance.setFunction(3,f3);
-            Assert.assertEquals(f3, instance.getFunction(3));
-            Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
-            Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
-            Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F0F6, lnis.outbound.get(1).getElement(1) & 0x78);
-            Assert.assertEquals("sent f3 in correct state", LnConstants.DIRF_F3, lnis.outbound.get(1).getElement(4) & LnConstants.DIRF_F3);
-        }
-
-        /**
-         * Test of setF4 method, of class AbstractThrottle.
-         */
-        @Test
-        @Override
-        public void testSetF4() {
-            lnis.outbound.clear();
-            lnis.resetStatistics();
-            boolean f4 = false;
-            instance.setFunction(4,f4);
-            Assert.assertEquals(f4, instance.getFunction(4));
-            Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
-            Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
-            Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F0F6, lnis.outbound.get(0).getElement(1) & 0x78);
-            Assert.assertEquals("sent f4 in correct state", 0, lnis.outbound.get(0).getElement(4) & LnConstants.DIRF_F4);
-            f4 = true;
-            instance.setFunction(4,f4);
-            Assert.assertEquals(f4, instance.getFunction(4));
-            Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
-            Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
-            Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F0F6, lnis.outbound.get(1).getElement(1) & 0x78);
-            Assert.assertEquals("sent f4 in correct state", LnConstants.DIRF_F4, lnis.outbound.get(1).getElement(4) & LnConstants.DIRF_F4);
-        }
-
-        /**
-         * Test of setF5 method, of class AbstractThrottle.
-         */
-        @Test
-        @Override
-        public void testSetF5() {
-            lnis.outbound.clear();
-            lnis.resetStatistics();
-            boolean f5 = false;
-            instance.setFunction(5,f5);
-            Assert.assertEquals(f5, instance.getFunction(5));
-            Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
-            Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
-            Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F0F6, lnis.outbound.get(0).getElement(1) & 0x78);
-            Assert.assertEquals("sent f5 in correct state", 0, lnis.outbound.get(0).getElement(4) & 0x20);
-            f5 = true;
-            instance.setFunction(5,f5);
-            Assert.assertEquals(f5, instance.getFunction(5));
-            Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
-            Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
-            Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F0F6, lnis.outbound.get(1).getElement(1) & 0x78);
-            Assert.assertEquals("sent f5 in correct state", 0x20, lnis.outbound.get(1).getElement(4) & 0x20);
-        }
-
-        /**
-         * Test of setF6 method, of class AbstractThrottle.
-         */
-        @Test
-        @Override
-        public void testSetF6() {
-            lnis.outbound.clear();
-            lnis.resetStatistics();
-            boolean f6 = false;
-            instance.setFunction(6,f6);
-            Assert.assertEquals(f6, instance.getFunction(6));
-            Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
-            Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
-            Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F0F6, lnis.outbound.get(0).getElement(1) & 0x78);
-            Assert.assertEquals("sent f6 in correct state", 0, lnis.outbound.get(0).getElement(4) & 0x40);
-            f6 = true;
-            instance.setFunction(6,f6);
-            Assert.assertEquals(f6, instance.getFunction(6));
-            Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
-            Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
-            Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F0F6, lnis.outbound.get(1).getElement(1) & 0x78);
-            Assert.assertEquals("sent f6 in correct state", 0x40, lnis.outbound.get(1).getElement(4) & 0x40);
-        }
-        /**
-         * Test of setF7 method, of class AbstractThrottle.
-         */
-        @Test
-        @Override
-        public void testSetF7() {
-            lnis.outbound.clear();
-            lnis.resetStatistics();
-            boolean f7 = false;
-            int func = 7;
-            instance.setFunction(func,f7);
-            Assert.assertEquals(f7, instance.getFunction(func));
-            Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
-            Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
-            Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F7F13, lnis.outbound.get(0).getElement(1) & 0x78);
-            Assert.assertEquals("sent " + func + " in correct state", 0, lnis.outbound.get(0).getElement(4) & 0x01);
-            f7 = true;
-            instance.setFunction(func,f7);
-            Assert.assertEquals(f7, instance.getFunction(func));
-            Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
-            Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
-            Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F7F13, lnis.outbound.get(1).getElement(1) & 0x78);
-            Assert.assertEquals("sent " + func + " in correct state", 0x01, lnis.outbound.get(1).getElement(4) & 0x01);
-        }
-
-        /**
-         * Test of setF8 method, of class AbstractThrottle.
-         */
-        @Test
-        @Override
-        public void testSetF8() {
-            lnis.outbound.clear();
-            lnis.resetStatistics();
-            boolean f8 = false;
-            int func = 8;
-            int bit = 0x02;
-            instance.setFunction(func,f8);
-            Assert.assertEquals(f8, instance.getFunction(func));
-            Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
-            Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
-            Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F7F13, lnis.outbound.get(0).getElement(1) & 0x78);
-            Assert.assertEquals("sent " + func + " in correct state", 0, lnis.outbound.get(0).getElement(4) & bit);
-            f8 = true;
-            instance.setFunction(func,f8);
-            Assert.assertEquals(f8, instance.getFunction(func));
-            Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
-            Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
-            Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F7F13, lnis.outbound.get(1).getElement(1) & 0x78);
-            Assert.assertEquals("sent " + func + " in correct state", bit, lnis.outbound.get(1).getElement(4) & bit);
-        }
-
-        /**
-         * Test of setF9 method, of class AbstractThrottle.
-         */
-        @Test
-        @Override
-        public void testSetF9() {
-            lnis.outbound.clear();
-            lnis.resetStatistics();
-            boolean f9 = false;
-            int func = 9;
-            int bit = 0x04;
-            instance.setFunction(func,f9);
-            Assert.assertEquals(f9, instance.getFunction(func));
-            Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
-            Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
-            Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F7F13, lnis.outbound.get(0).getElement(1) & 0x78);
-            Assert.assertEquals("sent " + func + " in correct state", 0, lnis.outbound.get(0).getElement(4) & bit);
-            f9 = true;
-            instance.setFunction(func,f9);
-            Assert.assertEquals(f9, instance.getFunction(func));
-            Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
-            Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
-            Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F7F13, lnis.outbound.get(1).getElement(1) & 0x78);
-            Assert.assertEquals("sent " + func + " in correct state", bit, lnis.outbound.get(1).getElement(4) & bit);
-        }
-
-        /**
-         * Test of setF10 method, of class AbstractThrottle.
-         */
-        @Test
-        @Override
-        public void testSetF10() {
-            lnis.outbound.clear();
-            lnis.resetStatistics();
-            boolean f10 = false;
-            int func = 10;
-            int bit = 0x08;
-            instance.setFunction(func,f10);
-            Assert.assertEquals(f10, instance.getFunction(func));
-            Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
-            Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
-            Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F7F13, lnis.outbound.get(0).getElement(1) & 0x78);
-            Assert.assertEquals("sent " + func + " in correct state", 0, lnis.outbound.get(0).getElement(4) & bit);
-            f10 = true;
-            instance.setFunction(func,f10);
-            Assert.assertEquals(f10, instance.getFunction(func));
-            Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
-            Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
-            Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F7F13, lnis.outbound.get(1).getElement(1) & 0x78);
-            Assert.assertEquals("sent " + func + " in correct state", bit, lnis.outbound.get(1).getElement(4) & bit);
-        }
-
-        /**
-         * Test of setF11 method, of class AbstractThrottle.
-         */
-        @Test
-        @Override
-        public void testSetF11() {
-            lnis.outbound.clear();
-            lnis.resetStatistics();
-            boolean f11 = false;
-            int func = 11;
-            int bit = 0x10;
-            instance.setFunction(func,f11);
-            Assert.assertEquals(f11, instance.getFunction(func));
-            Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
-            Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
-            Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F7F13, lnis.outbound.get(0).getElement(1) & 0x78);
-            Assert.assertEquals("sent " + func + " in correct state", 0, lnis.outbound.get(0).getElement(4) & bit);
-            f11 = true;
-            instance.setFunction(func,f11);
-            Assert.assertEquals(f11, instance.getFunction(func));
-            Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
-            Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
-            Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F7F13, lnis.outbound.get(1).getElement(1) & 0x78);
-            Assert.assertEquals("sent " + func + " in correct state", bit, lnis.outbound.get(1).getElement(4) & bit);
-        }
-
-        /**
-         * Test of setF12 method, of class AbstractThrottle.
-         */
-        @Test
-        @Override
-        public void testSetF12() {
-            lnis.outbound.clear();
-            lnis.resetStatistics();
-            boolean f12 = false;
-            int func = 12;
-            int bit = 0x20;
-            instance.setFunction(func,f12);
-            Assert.assertEquals(f12, instance.getFunction(func));
-            Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
-            Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
-            Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F7F13, lnis.outbound.get(0).getElement(1) & 0x78);
-            Assert.assertEquals("sent " + func + " in correct state", 0, lnis.outbound.get(0).getElement(4) & bit);
-            f12 = true;
-            instance.setFunction(func,f12);
-            Assert.assertEquals(f12, instance.getFunction(func));
-            Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
-            Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
-            Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F7F13, lnis.outbound.get(1).getElement(1) & 0x78);
-            Assert.assertEquals("sent " + func + " in correct state", bit, lnis.outbound.get(1).getElement(4) & bit);
-        }
-
-        /**
-         * Test of setF13 method, of class AbstractThrottle.
-         */
-        @Test
-        @Override
-        public void testSetF13() {
-            lnis.outbound.clear();
-            lnis.resetStatistics();
-            boolean f13 = false;
-            int func = 13;
-            int bit = 0x40;
-            instance.setFunction(func,f13);
-            Assert.assertEquals(f13, instance.getFunction(func));
-            Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
-            Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
-            Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F7F13, lnis.outbound.get(0).getElement(1) & 0x78);
-            Assert.assertEquals("sent " + func + " in correct state", 0, lnis.outbound.get(0).getElement(4) & bit);
-            f13 = true;
-            instance.setFunction(func,f13);
-            Assert.assertEquals(f13, instance.getFunction(func));
-            Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
-            Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
-            Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F7F13, lnis.outbound.get(1).getElement(1) & 0x78);
-            Assert.assertEquals("sent " + func + " in correct state", bit, lnis.outbound.get(1).getElement(4) & bit);
-        }
-
-        /**
-         * Test of setF14 method, of class AbstractThrottle.
-         */
-        @Test
-        @Override
-        public void testSetF14() {
-            lnis.outbound.clear();
-            lnis.resetStatistics();
-            boolean f14 = false;
-            int func = 14;
-            int bit = 0x01;
-            instance.setFunction(func,f14);
-            Assert.assertEquals(f14, instance.getFunction(func));
-            Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
-            Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
-            Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F14F20, lnis.outbound.get(0).getElement(1) & 0x78);
-            Assert.assertEquals("sent " + func + " in correct state", 0, lnis.outbound.get(0).getElement(4) & bit);
-            f14 = true;
-            instance.setFunction(func,f14);
-            Assert.assertEquals(f14, instance.getFunction(func));
-            Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
-            Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
-            Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F14F20, lnis.outbound.get(1).getElement(1) & 0x78);
-            Assert.assertEquals("sent " + func + " in correct state", bit, lnis.outbound.get(1).getElement(4) & bit);
-        }
-
-        /**
-         * Test of setF15 method, of class AbstractThrottle.
-         */
-        @Test
-        @Override
-        public void testSetF15() {
-            lnis.outbound.clear();
-            lnis.resetStatistics();
-            boolean f15 = false;
-            int func = 15;
-            int bit = 0x02;
-            instance.setFunction(func,f15);
-            Assert.assertEquals(f15, instance.getFunction(func));
-            Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
-            Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
-            Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F14F20, lnis.outbound.get(0).getElement(1) & 0x78);
-            Assert.assertEquals("sent " + func + " in correct state", 0, lnis.outbound.get(0).getElement(4) & bit);
-            f15 = true;
-            instance.setFunction(func,f15);
-            Assert.assertEquals(f15, instance.getFunction(func));
-            Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
-            Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
-            Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F14F20, lnis.outbound.get(1).getElement(1) & 0x78);
-            Assert.assertEquals("sent " + func + " in correct state", bit, lnis.outbound.get(1).getElement(4) & bit);
-        }
-
-        /**
-         * Test of setF16 method, of class AbstractThrottle.
-         */
-        @Test
-        @Override
-        public void testSetF16() {
-            lnis.outbound.clear();
-            lnis.resetStatistics();
-            boolean f16 = false;
-            int func = 16;
-            int bit = 0x04;
-            instance.setFunction(func,f16);
-            Assert.assertEquals(f16, instance.getFunction(func));
-            Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
-            Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
-            Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F14F20, lnis.outbound.get(0).getElement(1) & 0x78);
-            Assert.assertEquals("sent " + func + " in correct state", 0, lnis.outbound.get(0).getElement(4) & bit);
-            f16 = true;
-            instance.setFunction(func,f16);
-            Assert.assertEquals(f16, instance.getFunction(func));
-            Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
-            Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
-            Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F14F20, lnis.outbound.get(1).getElement(1) & 0x78);
-            Assert.assertEquals("sent " + func + " in correct state", bit, lnis.outbound.get(1).getElement(4) & bit);
-        }
-
-        /**
-         * Test of setF17 method, of class AbstractThrottle.
-         */
-        @Test
-        @Override
-        public void testSetF17() {
-            lnis.outbound.clear();
-            lnis.resetStatistics();
-            boolean f17 = false;
-            int func = 17;
-            int bit = 0x08;
-            instance.setFunction(func,f17);
-            Assert.assertEquals(f17, instance.getFunction(func));
-            Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
-            Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
-            Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F14F20, lnis.outbound.get(0).getElement(1) & 0x78);
-            Assert.assertEquals("sent " + func + " in correct state", 0, lnis.outbound.get(0).getElement(4) & bit);
-            f17 = true;
-            instance.setFunction(func,f17);
-            Assert.assertEquals(f17, instance.getFunction(func));
-            Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
-            Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
-            Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F14F20, lnis.outbound.get(1).getElement(1) & 0x78);
-            Assert.assertEquals("sent " + func + " in correct state", bit, lnis.outbound.get(1).getElement(4) & bit);
-        }
-
-        /**
-         * Test of setF18 method, of class AbstractThrottle.
-         */
-        @Test
-        @Override
-        public void testSetF18() {
-            lnis.outbound.clear();
-            lnis.resetStatistics();
-            boolean f18 = false;
-            int func = 18;
-            int bit = 0x10;
-            instance.setFunction(func,f18);
-            Assert.assertEquals(f18, instance.getFunction(func));
-            Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
-            Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
-            Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F14F20, lnis.outbound.get(0).getElement(1) & 0x78);
-            Assert.assertEquals("sent " + func + " in correct state", 0, lnis.outbound.get(0).getElement(4) & bit);
-            f18 = true;
-            instance.setFunction(func,f18);
-            Assert.assertEquals(f18, instance.getFunction(func));
-            Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
-            Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
-            Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F14F20, lnis.outbound.get(1).getElement(1) & 0x78);
-            Assert.assertEquals("sent " + func + " in correct state", bit, lnis.outbound.get(1).getElement(4) & bit);
-        }
-
-        /**
-         * Test of setF19 method, of class AbstractThrottle.
-         */
-        @Test
-        @Override
-        public void testSetF19() {
-            lnis.outbound.clear();
-            lnis.resetStatistics();
-            boolean f19 = false;
-            int func = 19;
-            int bit = 0x20;
-            instance.setFunction(func,f19);
-            Assert.assertEquals(f19, instance.getFunction(func));
-            Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
-            Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
-            Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F14F20, lnis.outbound.get(0).getElement(1) & 0x78);
-            Assert.assertEquals("sent " + func + " in correct state", 0, lnis.outbound.get(0).getElement(4) & bit);
-            f19 = true;
-            instance.setFunction(func,f19);
-            Assert.assertEquals(f19, instance.getFunction(func));
-            Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
-            Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
-            Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F14F20, lnis.outbound.get(1).getElement(1) & 0x78);
-            Assert.assertEquals("sent " + func + " in correct state", bit, lnis.outbound.get(1).getElement(4) & bit);
-        }
-
-        /**
-         * Test of setF20 method, of class AbstractThrottle.
-         */
-        @Test
-        @Override
-        public void testSetF20() {
-            lnis.outbound.clear();
-            lnis.resetStatistics();
-            boolean f20 = false;
-            int func = 20;
-            int bit = 0x40;
-            instance.setFunction(func,f20);
-            Assert.assertEquals(f20, instance.getFunction(func));
-            Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
-            Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
-            Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F14F20, lnis.outbound.get(0).getElement(1) & 0x78);
-            Assert.assertEquals("sent " + func + " in correct state", 0, lnis.outbound.get(0).getElement(4) & bit);
-            f20 = true;
-            instance.setFunction(func,f20);
-            Assert.assertEquals(f20, instance.getFunction(func));
-            Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
-            Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
-            Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F14F20, lnis.outbound.get(1).getElement(1) & 0x78);
-            Assert.assertEquals("sent " + func + " in correct state", bit, lnis.outbound.get(1).getElement(4) & bit);
-        }
-
-        /**
-         * Test of setF21 method, of class AbstractThrottle.
-         */
-        @Test
-        @Override
-        public void testSetF21() {
-            lnis.outbound.clear();
-            lnis.resetStatistics();
-            boolean f21 = false;
-            int func = 21;
-            int bit = 0x01;
-            instance.setFunction(func,f21);
-            Assert.assertEquals(f21, instance.getFunction(func));
-            Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
-            Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
-            Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F21F28_F28OFF, lnis.outbound.get(0).getElement(1) & 0x78);
-            Assert.assertEquals("sent " + func + " in correct state", 0, lnis.outbound.get(0).getElement(4) & bit);
-            f21 = true;
-            instance.setFunction(func,f21);
-            Assert.assertEquals(f21, instance.getFunction(func));
-            Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
-            Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
-            Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F21F28_F28OFF, lnis.outbound.get(1).getElement(1) & 0x78);
-            Assert.assertEquals("sent " + func + " in correct state", bit, lnis.outbound.get(1).getElement(4) & bit);
-        }
-
-        /**
-         * Test of setF22 method, of class AbstractThrottle.
-         */
-        @Test
-        @Override
-        public void testSetF22() {
-            lnis.outbound.clear();
-            lnis.resetStatistics();
-            boolean f22 = false;
-            int func = 22;
-            int bit = 0x02;
-            instance.setFunction(func,f22);
-            Assert.assertEquals(f22, instance.getFunction(func));
-            Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
-            Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
-            Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F21F28_F28OFF, lnis.outbound.get(0).getElement(1) & 0x78);
-            Assert.assertEquals("sent " + func + " in correct state", 0, lnis.outbound.get(0).getElement(4) & bit);
-            f22 = true;
-            instance.setFunction(func,f22);
-            Assert.assertEquals(f22, instance.getFunction(func));
-            Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
-            Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
-            Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F21F28_F28OFF, lnis.outbound.get(1).getElement(1) & 0x78);
-            Assert.assertEquals("sent " + func + " in correct state", bit, lnis.outbound.get(1).getElement(4) & bit);
-        }
-
-        /**
-         * Test of setF23 method, of class AbstractThrottle.
-         */
-        @Test
-        @Override
-        public void testSetF23() {
-            lnis.outbound.clear();
-            lnis.resetStatistics();
-            boolean f23 = false;
-            int func = 23;
-            int bit = 0x04;
-            instance.setFunction(func,f23);
-            Assert.assertEquals(f23, instance.getFunction(func));
-            Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
-            Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
-            Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F21F28_F28OFF, lnis.outbound.get(0).getElement(1) & 0x78);
-            Assert.assertEquals("sent " + func + " in correct state", 0, lnis.outbound.get(0).getElement(4) & bit);
-            f23 = true;
-            instance.setFunction(func,f23);
-            Assert.assertEquals(f23, instance.getFunction(func));
-            Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
-            Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
-            Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F21F28_F28OFF, lnis.outbound.get(1).getElement(1) & 0x78);
-            Assert.assertEquals("sent " + func + " in correct state", bit, lnis.outbound.get(1).getElement(4) & bit);
-        }
-
-        /**
-         * Test of setF24 method, of class AbstractThrottle.
-         */
-        @Test
-        @Override
-        public void testSetF24() {
-            lnis.outbound.clear();
-            lnis.resetStatistics();
-            boolean f24 = false;
-            int func = 24;
-            int bit = 0x08;
-            instance.setFunction(func,f24);
-            Assert.assertEquals(f24, instance.getFunction(func));
-            Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
-            Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
-            Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F21F28_F28OFF, lnis.outbound.get(0).getElement(1) & 0x78);
-            Assert.assertEquals("sent " + func + " in correct state", 0, lnis.outbound.get(0).getElement(4) & bit);
-            f24 = true;
-            instance.setFunction(func,f24);
-            Assert.assertEquals(f24, instance.getFunction(func));
-            Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
-            Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
-            Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F21F28_F28OFF, lnis.outbound.get(1).getElement(1) & 0x78);
-            Assert.assertEquals("sent " + func + " in correct state", bit, lnis.outbound.get(1).getElement(4) & bit);
-        }
-
-        /**
-         * Test of setF25 method, of class AbstractThrottle.
-         */
-        @Test
-        @Override
-        public void testSetF25() {
-            lnis.outbound.clear();
-            lnis.resetStatistics();
-            boolean f25 = false;
-            int func = 25;
-            int bit = 0x10;
-            instance.setFunction(func,f25);
-            Assert.assertEquals(f25, instance.getFunction(func));
-            Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
-            Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
-            Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F21F28_F28OFF, lnis.outbound.get(0).getElement(1) & 0x78);
-            Assert.assertEquals("sent " + func + " in correct state", 0, lnis.outbound.get(0).getElement(4) & bit);
-            f25 = true;
-            instance.setFunction(func,f25);
-            Assert.assertEquals(f25, instance.getFunction(func));
-            Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
-            Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
-            Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F21F28_F28OFF, lnis.outbound.get(1).getElement(1) & 0x78);
-            Assert.assertEquals("sent " + func + " in correct state", bit, lnis.outbound.get(1).getElement(4) & bit);
-        }
-
-        /**
-         * Test of setF26 method, of class AbstractThrottle.
-         */
-        @Test
-        @Override
-        public void testSetF26() {
-            lnis.outbound.clear();
-            lnis.resetStatistics();
-            boolean f26 = false;
-            int func = 26;
-            int bit = 0x20;
-            instance.setFunction(func,f26);
-            Assert.assertEquals(f26, instance.getFunction(func));
-            Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
-            Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
-            Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F21F28_F28OFF, lnis.outbound.get(0).getElement(1) & 0x78);
-            Assert.assertEquals("sent " + func + " in correct state", 0, lnis.outbound.get(0).getElement(4) & bit);
-            f26 = true;
-            instance.setFunction(func,f26);
-            Assert.assertEquals(f26, instance.getFunction(func));
-            Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
-            Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
-            Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F21F28_F28OFF, lnis.outbound.get(1).getElement(1) & 0x78);
-            Assert.assertEquals("sent " + func + " in correct state", bit, lnis.outbound.get(1).getElement(4) & bit);
-        }
-
-        /**
-         * Test of setF27 method, of class AbstractThrottle.
-         */
-        @Test
-        @Override
-        public void testSetF27() {
-            lnis.outbound.clear();
-            lnis.resetStatistics();
-            boolean f27 = false;
-            int func = 27;
-            int bit = 0x40;
-            instance.setFunction(func,f27);
-            Assert.assertEquals(f27, instance.getFunction(func));
-            Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
-            Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
-            Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F21F28_F28OFF, lnis.outbound.get(0).getElement(1) & 0x78);
-            Assert.assertEquals("sent " + func + " in correct state", 0, lnis.outbound.get(0).getElement(4) & bit);
-            f27 = true;
-            instance.setFunction(func,f27);
-            Assert.assertEquals(f27, instance.getFunction(func));
-            Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
-            Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
-            Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F21F28_F28OFF, lnis.outbound.get(1).getElement(1) & 0x78);
-            Assert.assertEquals("sent " + func + " in correct state", bit, lnis.outbound.get(1).getElement(4) & bit);
-        }
-
-        /**
-         * Test of setF28 method, of class AbstractThrottle.
-         */
-        @Test
-        @Override
-        public void testSetF28() {
-            lnis.outbound.clear();
-            lnis.resetStatistics();
-            boolean f28 = false;
-            int func = 28;
-            int bit = 0xFF;   // all off both ways
-            instance.setFunction(func,f28);
-            Assert.assertEquals(f28, instance.getFunction(func));
-            Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
-            Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
-            Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F21F28_F28OFF, lnis.outbound.get(0).getElement(1) & 0x78);
-            Assert.assertEquals("sent " + func + " in correct state", 0, lnis.outbound.get(0).getElement(4) & bit);
-            f28 = true;
-            instance.setFunction(func,f28);
-            Assert.assertEquals(f28, instance.getFunction(func));
-            Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
-            Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
-            Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F21F28_F28ON, lnis.outbound.get(1).getElement(1) & 0x78);
-            Assert.assertEquals("sent " + func + " in correct state", 0, lnis.outbound.get(1).getElement(4) & bit);
-        }
-
-        /**
-         * Test of sendFunction 29
-         */
-        @Test
-        public void testSendExpFunctionF29() {
-            lnis.outbound.clear();
-            lnis.resetStatistics();
-            int func = 29;
-            LocoNetMessage funcOnMess = new LocoNetMessage(new int[] {0xED, 0x0B, 0x7f, 0x33, 0x02, 0x00, 0x58, 0x01, 0x00, 0x00, 0x00});
-            LocoNetMessage funcOffMess = new LocoNetMessage(new int [] {0xED, 0x0B, 0x7F, 0x33, 0x02, 0x00, 0x58, 0x00, 0x00, 0x00, 0x00});
-            Assert.assertEquals("check send of function exp f" + func, 0, lnis.outbound.size());
-            instance.setFunction(func,true);
-            Assert.assertEquals("check send of function" + func, 1, lnis.outbound.size());
-            Assert.assertTrue("check opcode",funcOnMess.equals(lnis.outbound.get(0)));
-            instance.setFunction(func,false);
-            Assert.assertEquals("check send OFF function" + func, 2, lnis.outbound.size());
-            Assert.assertTrue("check opcode",funcOffMess.equals(lnis.outbound.get(1)));
-        }
-
-        /**
-         * Test of sendFunction 69
-         */
-        @Test
-        public void testSendExpFunctionF68() {
-            lnis.outbound.clear();
-            lnis.resetStatistics();
-            int func = 68;
-            LocoNetMessage funcOnMess = new LocoNetMessage(new int[] {0xED, 0x0B, 0x7f, 0x33, 0x06, 0x00, 0x5C, 0x00, 0x00, 0x00, 0x00});
-            LocoNetMessage funcOffMess = new LocoNetMessage(new int [] {0xED, 0x0B, 0x7F, 0x33, 0x02, 0x00, 0x5C, 0x00, 0x00, 0x00, 0x00});
-            Assert.assertEquals("check send of function exp f" + func, 0, lnis.outbound.size());
-            instance.setFunction(func,true);
-            Assert.assertEquals("check send of function" + func, 1, lnis.outbound.size());
-            Assert.assertTrue("check opcode",funcOnMess.equals(lnis.outbound.get(0)));
-            instance.setFunction(func,false);
-            Assert.assertEquals("check send OFF function" + func, 2, lnis.outbound.size());
-            Assert.assertTrue("check opcode",funcOffMess.equals(lnis.outbound.get(1)));
-        }
-
-        /**
-         * Test of sendFunctionGroup1 method, of class AbstractThrottle.
-         */
-        @Test
-        @Override
-        public void testSendFunctionGroup1() {
-            lnis.outbound.clear();
-            lnis.resetStatistics();
-            instance.setF0(false);
-            instance.setF1(true);
-            instance.setF2(true);
-            instance.setF3(false);
-            instance.setIsForward(true);
-            lnis.outbound.clear();
-            lnis.resetStatistics();
-            Assert.assertEquals("check send of function group 1 (0)", 0, lnis.outbound.size());
-            ((LocoNetThrottle)instance).sendFunctionGroup1();
-            Assert.assertEquals("check send of function group 1 (1)", 1, lnis.outbound.size());
-            Assert.assertEquals("check opcode",LnConstants.OPC_LOCO_DIRF, lnis.outbound.get(0).getOpCode());
-            Assert.assertEquals("check dirf byte", 0x03, lnis.outbound.get(0).getElement(2));
-
-            lnis.outbound.clear();
-            lnis.resetStatistics();
-            instance.setIsForward(false);
-            Assert.assertEquals("check send of function group 1 (2)", 1, lnis.outbound.size());
-            ((LocoNetThrottle)instance).sendFunctionGroup1();
-            Assert.assertEquals("check send of function group 1 (3)", 2, lnis.outbound.size());
-            Assert.assertEquals("check opcode",LnConstants.OPC_LOCO_DIRF, lnis.outbound.get(1).getOpCode());
-            Assert.assertEquals("check dirf byte {4}", 0x023, lnis.outbound.get(1).getElement(2));
-
-        }
-
-        /**
-         * Test of sendFunctionGroup2 method, of class AbstractThrottle.
-         */
-        @Test
-        @Override
-        public void testSendFunctionGroup2() {
-
-            for (int i = 5; i <9; ++i ) {
-                instance.setF5(i==5);
-                instance.setF6(i==6);
-                instance.setF7(i==7);
-                instance.setF8(i==8);
-                lnis.outbound.clear();
-                lnis.resetStatistics();
-                ((LocoNetThrottle)instance).sendFunctionGroup2();
-
-                Assert.assertEquals("check send of function group 2 for F"+i+" (0)", 1, lnis.outbound.size());
-                Assert.assertEquals("check opcode is OPC_LOCO_SND for F"+i+"",LnConstants.OPC_LOCO_SND, lnis.outbound.get(0).getOpCode());
-                Assert.assertEquals("check byte 2 for F"+i+"{0}", 1<<(i-5), lnis.outbound.get(0).getElement(2));
-
-                instance.setF5(!(i==5));
-                instance.setF6(!(i==6));
-                instance.setF7(!(i==7));
-                instance.setF8(!(i==8));
-                lnis.outbound.clear();
-                lnis.resetStatistics();
-                ((LocoNetThrottle)instance).sendFunctionGroup2();
-
-                Assert.assertEquals("check send of function group 2 for !F"+i+"(1)", 1, lnis.outbound.size());
-                Assert.assertEquals("check opcode is OPC_LOCO_SND for F"+i+"",LnConstants.OPC_LOCO_SND, lnis.outbound.get(0).getOpCode());
-                Assert.assertEquals("check byte 2 for !F"+i+"{1}", 0x0f - (1<<(i-5)), lnis.outbound.get(0).getElement(2));
+    // test the speed setting code.
+    @Test
+    public void testSpeedSetting() {
+        // we have 4 cases to check
+        // Case 1: The locomotive is not consisted.
+        LocoNetSlot s1 = new LocoNetSlot(0) {
+            @Override
+            public int consistStatus() {
+                return LnConstants.CONSIST_NO;
             }
-        }
 
-        /**
-         * Test of sendFunctionGroup3 method, of class AbstractThrottle.
-         */
-        @Test
-        @Override
-        public void testSendFunctionGroup3() {
-
-            for (int i = 9; i <13; ++i ) {
-                instance.setF9(i==9);
-                instance.setF10(i==10);
-                instance.setF11(i==11);
-                instance.setF12(i==12);
-                lnis.outbound.clear();
-                lnis.resetStatistics();
-                ((LocoNetThrottle)instance).sendFunctionGroup3();
-
-                Assert.assertEquals("check send of function group 3 for F"+i+" (0)", 1, lnis.outbound.size());
-                Assert.assertEquals("check opcode is OPC_IMM_PACKET for F"+i+"",LnConstants.OPC_IMM_PACKET, lnis.outbound.get(0).getOpCode());
-                Assert.assertEquals("check byte 1 for F"+i+"{0}", 0x0b, lnis.outbound.get(0).getElement(1));
-                Assert.assertEquals("check byte 2 for F"+i+"{0}", 0x7f, lnis.outbound.get(0).getElement(2));
-                Assert.assertEquals("check byte 3 for F"+i+"{0}", 0x23, lnis.outbound.get(0).getElement(3));
-                Assert.assertEquals("check byte 4 for F"+i+"{0}", 0x02, lnis.outbound.get(0).getElement(4));
-                Assert.assertEquals("check byte 5 for F"+i+"{0}", 0x00, lnis.outbound.get(0).getElement(5));
-                Assert.assertEquals("check byte 6 for F"+i+"{0}", 0x20+(1<<(i-9)), lnis.outbound.get(0).getElement(6));
-                Assert.assertEquals("check byte 7 for F"+i+"{0}", 0x00, lnis.outbound.get(0).getElement(7));
-                Assert.assertEquals("check byte 8 for F"+i+"{0}", 0x00, lnis.outbound.get(0).getElement(8));
-                Assert.assertEquals("check byte 9 for F"+i+"{0}", 0x00, lnis.outbound.get(0).getElement(9));
-
-                instance.setF9(!(i==9));
-                instance.setF10(!(i==10));
-                instance.setF11(!(i==11));
-                instance.setF12(!(i==12));
-                lnis.outbound.clear();
-                lnis.resetStatistics();
-                ((LocoNetThrottle)instance).sendFunctionGroup3();
-
-                Assert.assertEquals("check send of function group 3 for !F"+i+"(1)", 1, lnis.outbound.size());
-                Assert.assertEquals("check opcode is OPC_IMM_PACKET for !F"+i+"{1}",LnConstants.OPC_IMM_PACKET, lnis.outbound.get(0).getOpCode());
-                Assert.assertEquals("check byte 1 for !F"+i+"{1}", 0x0b, lnis.outbound.get(0).getElement(1));
-                Assert.assertEquals("check byte 2 for !F"+i+"{1}", 0x7f, lnis.outbound.get(0).getElement(2));
-                Assert.assertEquals("check byte 3 for !F"+i+"{1}", 0x23, lnis.outbound.get(0).getElement(3));
-                Assert.assertEquals("check byte 4 for !F"+i+"{1}", 0x02, lnis.outbound.get(0).getElement(4));
-                Assert.assertEquals("check byte 5 for !F"+i+"{1}", 0x00, lnis.outbound.get(0).getElement(5));
-                Assert.assertEquals("check byte 6 for !F"+i+"{1}", 0x2F-(1<<(i-9)), lnis.outbound.get(0).getElement(6));
-                Assert.assertEquals("check byte 7 for !F"+i+"{1}", 0x00, lnis.outbound.get(0).getElement(7));
-                Assert.assertEquals("check byte 8 for !F"+i+"{1}", 0x00, lnis.outbound.get(0).getElement(8));
-                Assert.assertEquals("check byte 9 for 1F"+i+"{1}", 0x00, lnis.outbound.get(0).getElement(9));
+            @Override
+            public int speed() {
+                return 0;
             }
-        }
+        };
+        LocoNetThrottle t1 = new LocoNetThrottle(memo, s1);
+        Assert.assertEquals(0.0f, t1.getSpeedSetting(), 0.0);
+        t1.setSpeedSetting(0.5f);
+        // the speed change SHOULD be changed.
+        Assert.assertEquals(0.5f, t1.getSpeedSetting(), 0.0);
 
-        /**
-         * Test of sendFunctionGroup4 method, of class AbstractThrottle.
-         */
-        @Test
-        @Override
-        public void testSendFunctionGroup4() {
-            for (int i = 13; i <21; ++i ) {
-                instance.setF13(i==13);
-                instance.setF14(i==14);
-                instance.setF15(i==15);
-                instance.setF16(i==16);
-                instance.setF17(i==17);
-                instance.setF18(i==18);
-                instance.setF19(i==19);
-                instance.setF20(i==20);
-                lnis.outbound.clear();
-                lnis.resetStatistics();
-                ((LocoNetThrottle)instance).sendFunctionGroup4();
-
-                Assert.assertEquals("check send of function group 4 for F"+i+" (0)", 1, lnis.outbound.size());
-                Assert.assertEquals("check opcode is OPC_IMM_PACKET for F"+i+"",LnConstants.OPC_IMM_PACKET, lnis.outbound.get(0).getOpCode());
-                Assert.assertEquals("check byte 1 for F"+i+"{0}", 0x0b, lnis.outbound.get(0).getElement(1));
-                Assert.assertEquals("check byte 2 for F"+i+"{0}", 0x7f, lnis.outbound.get(0).getElement(2));
-                Assert.assertEquals("check byte 3 for F"+i+"{0}", 0x33, lnis.outbound.get(0).getElement(3));
-                Assert.assertEquals("check byte 4 for F"+i+"{0}", (i==20)?0x06:0x02, lnis.outbound.get(0).getElement(4));
-                Assert.assertEquals("check byte 5 for F"+i+"{0}", 0x00, lnis.outbound.get(0).getElement(5));
-                Assert.assertEquals("check byte 6 for F"+i+"{0}", 0x5e, lnis.outbound.get(0).getElement(6));
-                Assert.assertEquals("check byte 7 for F"+i+"{0}", (i < 20)?(1<<(i-13)):0, lnis.outbound.get(0).getElement(7));
-                Assert.assertEquals("check byte 8 for F"+i+"{0}", 0x00, lnis.outbound.get(0).getElement(8));
-                Assert.assertEquals("check byte 9 for F"+i+"{0}", 0x00, lnis.outbound.get(0).getElement(9));
-
-                instance.setF13(!(i==13));
-                instance.setF14(!(i==14));
-                instance.setF15(!(i==15));
-                instance.setF16(!(i==16));
-                instance.setF17(!(i==17));
-                instance.setF18(!(i==18));
-                instance.setF19(!(i==19));
-                instance.setF20(!(i==20));
-                lnis.outbound.clear();
-                lnis.resetStatistics();
-                ((LocoNetThrottle)instance).sendFunctionGroup4();
-
-                Assert.assertEquals("check send of function group 4 for !F"+i+"(1)", 1, lnis.outbound.size());
-                Assert.assertEquals("check opcode is OPC_IMM_PACKET for !F"+i+"{1}",LnConstants.OPC_IMM_PACKET, lnis.outbound.get(0).getOpCode());
-                Assert.assertEquals("check byte 1 for !F"+i+"{1}", 0x0b, lnis.outbound.get(0).getElement(1));
-                Assert.assertEquals("check byte 2 for !F"+i+"{1}", 0x7f, lnis.outbound.get(0).getElement(2));
-                Assert.assertEquals("check byte 3 for !F"+i+"{1}", 0x33, lnis.outbound.get(0).getElement(3));
-                Assert.assertEquals("check byte 4 for !F"+i+"{1}", (i==20)?0x02:0x06, lnis.outbound.get(0).getElement(4));
-                Assert.assertEquals("check byte 5 for !F"+i+"{1}", 0x00, lnis.outbound.get(0).getElement(5));
-                Assert.assertEquals("check byte 6 for !F"+i+"{1}", 0x5e, lnis.outbound.get(0).getElement(6));
-                Assert.assertEquals("check byte 7 for !F"+i+"{1}", (i < 20)?(127-(1<<(i-13))):0x7f, lnis.outbound.get(0).getElement(7));
-                Assert.assertEquals("check byte 8 for !F"+i+"{1}", 0x00, lnis.outbound.get(0).getElement(8));
-                Assert.assertEquals("check byte 9 for 1F"+i+"{1}", 0x00, lnis.outbound.get(0).getElement(9));
+        // Case 2: The locomotive is a consist top.
+        LocoNetSlot s2 = new LocoNetSlot(1) {
+            @Override
+            public int consistStatus() {
+                return LnConstants.CONSIST_TOP;
             }
-        }
 
-        /**
-         * Test of sendFunctionGroup5 method, of class AbstractThrottle.
-         */
-        @Test
-        @Override
-        public void testSendFunctionGroup5() {
-            for (int i = 21; i <29; ++i ) {
-                instance.setF21(i==21);
-                instance.setF22(i==22);
-                instance.setF23(i==23);
-                instance.setF24(i==24);
-                instance.setF25(i==25);
-                instance.setF26(i==26);
-                instance.setF27(i==27);
-                instance.setF28(i==28);
-                lnis.outbound.clear();
-                lnis.resetStatistics();
-                ((LocoNetThrottle)instance).sendFunctionGroup5();
-
-                Assert.assertEquals("check send of function group 5 for F"+i+" (0)", 1, lnis.outbound.size());
-                Assert.assertEquals("check opcode is OPC_IMM_PACKET for F"+i+"",LnConstants.OPC_IMM_PACKET, lnis.outbound.get(0).getOpCode());
-                Assert.assertEquals("check byte 1 for F"+i+"{0}", 0x0b, lnis.outbound.get(0).getElement(1));
-                Assert.assertEquals("check byte 2 for F"+i+"{0}", 0x7f, lnis.outbound.get(0).getElement(2));
-                Assert.assertEquals("check byte 3 for F"+i+"{0}", 0x33, lnis.outbound.get(0).getElement(3));
-                Assert.assertEquals("check byte 4 for F"+i+"{0}", (i==28)?0x06:0x02, lnis.outbound.get(0).getElement(4));
-                Assert.assertEquals("check byte 5 for F"+i+"{0}", 0x00, lnis.outbound.get(0).getElement(5));
-                Assert.assertEquals("check byte 6 for F"+i+"{0}", 0x5f, lnis.outbound.get(0).getElement(6));
-                Assert.assertEquals("check byte 7 for F"+i+"{0}", (i < 28)?(1<<(i-21)):0, lnis.outbound.get(0).getElement(7));
-                Assert.assertEquals("check byte 8 for F"+i+"{0}", 0x00, lnis.outbound.get(0).getElement(8));
-                Assert.assertEquals("check byte 9 for F"+i+"{0}", 0x00, lnis.outbound.get(0).getElement(9));
-
-                instance.setF21(!(i==21));
-                instance.setF22(!(i==22));
-                instance.setF23(!(i==23));
-                instance.setF24(!(i==24));
-                instance.setF25(!(i==25));
-                instance.setF26(!(i==26));
-                instance.setF27(!(i==27));
-                instance.setF28(!(i==28));
-                lnis.outbound.clear();
-                lnis.resetStatistics();
-                ((LocoNetThrottle)instance).sendFunctionGroup5();
-
-                Assert.assertEquals("check send of function group 5 for !F"+i+"(1)", 1, lnis.outbound.size());
-                Assert.assertEquals("check opcode is OPC_IMM_PACKET for !F"+i+"{1}",LnConstants.OPC_IMM_PACKET, lnis.outbound.get(0).getOpCode());
-                Assert.assertEquals("check byte 1 for !F"+i+"{1}", 0x0b, lnis.outbound.get(0).getElement(1));
-                Assert.assertEquals("check byte 2 for !F"+i+"{1}", 0x7f, lnis.outbound.get(0).getElement(2));
-                Assert.assertEquals("check byte 3 for !F"+i+"{1}", 0x33, lnis.outbound.get(0).getElement(3));
-                Assert.assertEquals("check byte 4 for !F"+i+"{1}", (i==28)?0x02:0x06, lnis.outbound.get(0).getElement(4));
-                Assert.assertEquals("check byte 5 for !F"+i+"{1}", 0x00, lnis.outbound.get(0).getElement(5));
-                Assert.assertEquals("check byte 6 for !F"+i+"{1}", 0x5f, lnis.outbound.get(0).getElement(6));
-                Assert.assertEquals("check byte 7 for !F"+i+"{1}", (i < 28)?(127-(1<<(i-21))):0x7f, lnis.outbound.get(0).getElement(7));
-                Assert.assertEquals("check byte 8 for !F"+i+"{1}", 0x00, lnis.outbound.get(0).getElement(8));
-                Assert.assertEquals("check byte 9 for 1F"+i+"{1}", 0x00, lnis.outbound.get(0).getElement(9));
-
+            @Override
+            public int speed() {
+                return 0;
             }
-        }
+        };
+        LocoNetThrottle t2 = new LocoNetThrottle(memo, s2);
+        Assert.assertEquals(0.0f, t2.getSpeedSetting(), 0.0);
+        t2.setSpeedSetting(0.5f);
+        // the speed change SHOULD be changed.
+        Assert.assertEquals(0.5f, t2.getSpeedSetting(), 0.0);
 
-        /**
-         * Test of getF2Momentary method, of class AbstractThrottle.
-         */
-        @Test
-        @Override
-        public void testGetF2Momentary() {
-            boolean expResult = true;
-            boolean result = instance.getF2Momentary();
-            Assert.assertEquals("Check F2 Momentary true", expResult, result);
+        // Case 3: The locomotive is a consist mid.
+        LocoNetSlot s3 = new LocoNetSlot(2) {
+            @Override
+            public int consistStatus() {
+                return LnConstants.CONSIST_MID;
+            }
 
-            expResult = false;
-            instance.setF2Momentary(false);
-            result = instance.getF2Momentary();
-            Assert.assertEquals("Check F2 Momentary false", expResult, result);
+            @Override
+            public int speed() {
+                return 0;
+            }
+        };
+        LocoNetThrottle t3 = new LocoNetThrottle(memo, s3);
+        Assert.assertEquals(0.0f, t3.getSpeedSetting(), 0.0);
+        t3.setSpeedSetting(0.5f);
+        // the speed change SHOULD NOT be changed.
+        Assert.assertEquals(0.0f, t3.getSpeedSetting(), 0.0);
 
-        }
+        // Case 3: The locomotive is a consist mid.
+        // make sure the speed does NOT change for a consist sub
+        LocoNetSlot s4 = new LocoNetSlot(3) {
+            @Override
+            public int consistStatus() {
+                return LnConstants.CONSIST_SUB;
+            }
 
-        private LocoNetInterfaceScaffold lnis;
-        private SlotManager slotmanager;
-        private LocoNetSystemConnectionMemo memo = null;
+            @Override
+            public int speed() {
+                return 0;
+            }
+        };
+        LocoNetThrottle t4 = new LocoNetThrottle(memo, s4);
+        Assert.assertEquals(0.0f, t4.getSpeedSetting(), 0.0);
+        t4.setSpeedSetting(0.5f);
+        // the speed change SHOULD be ignored.
+        Assert.assertEquals(0.0f, t4.getSpeedSetting(), 0.0);
+    }
 
-        @BeforeEach
-        @Override
-        public void setUp() throws Exception {
-            JUnitUtil.setUp();
-            // prepare an interface
-            maxFns = 69;
+    /**
+     * Test of getIsForward method, of class AbstractThrottle.
+     */
+    @Test
+    @Override
+    public void testGetIsForward() {
+        boolean expResult = true;
+        boolean result = instance.getIsForward();
+        Assert.assertEquals(expResult, result);
+    }
 
-            lnis = new LocoNetInterfaceScaffold();
-            slotmanager = new SlotManager(lnis);
-            slotmanager.setLoconetProtocolAutoDetect(true);
+    /**
+     * Test of getSpeedStepMode method, of class AbstractThrottle.
+     */
+    @Test
+    @Override
+    public void testGetSpeedStepMode() {
+        SpeedStepMode expResult = SpeedStepMode.NMRA_DCC_28;
+        SpeedStepMode result = instance.getSpeedStepMode();
+        Assert.assertEquals(expResult, result);
+    }
 
-            // set slot 3 to address 3
-            LocoNetMessage m = new LocoNetMessage(21);
-            m.setOpCode(LnConstants.OPC_EXP_WR_SL_DATA);
-            m.setElement(1, 0x15);
-            m.setElement(3, 0x03);
-            m.setElement(4, 0x00);
-            m.setElement(7, 0x47);
-            slotmanager.slot(3).setSlot(m);
+    /**
+     * Test of getSpeedIncrement method, of class AbstractThrottle.
+     */
+    @Test
+    @Override
+    public void testGetSpeedIncrement() {
+        float expResult = 1.0F/28.0F;
+        float result = instance.getSpeedIncrement();
+        Assert.assertEquals(expResult, result, 0.0);
+    }
 
-            memo = new LocoNetSystemConnectionMemo(lnis, slotmanager);
-            memo.setThrottleManager(new LnThrottleManager(memo));
-            memo.store(slotmanager,CommandStation.class);
+    /**
+     * Test of intSpeed method, of class AbstractThrottle.
+     */
+    @Test
+    @Override
+    public void testGetSpeed_float() {
+        // set speed step mode to 128.
+        instance.setSpeedStepMode(jmri.SpeedStepMode.NMRA_DCC_128);
+        super.testGetSpeed_float();
+    }
 
-            jmri.InstanceManager.setDefault(jmri.ThrottleManager.class, memo.getThrottleManager());
-            // use slot 3
-            instance = new LocoNetThrottle(memo, slotmanager.slot(3)); // creates throttle in exp mode
+    /**
+     * Test of setF0 method, of class AbstractThrottle.
+     */
+    @Test
+    @Override
+    public void testSetF0() {
 
-        }
+        lnis.resetStatistics(); // and clears outbound message log
+        boolean f0 = false;
+        instance.setFunction(0,f0);
+        Assert.assertEquals(f0, instance.getFunction(0));
+        Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
+        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
+        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F0F6, lnis.outbound.get(0).getElement(1) & 0x78);
+        Assert.assertEquals("sent f0 in correct state", 0, lnis.outbound.get(0).getElement(4) & LnConstants.DIRF_F0);
+        f0 = true;
+        instance.setFunction(0,f0);
+        Assert.assertEquals(f0, instance.getFunction(0));
+        Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
+        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
+        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F0F6, lnis.outbound.get(1).getElement(1) & 0x78);
+        Assert.assertEquals("sent f0 in correct state", LnConstants.DIRF_F0, lnis.outbound.get(1).getElement(4) & LnConstants.DIRF_F0);
+    }
 
-        @AfterEach
-        @Override
-        public void tearDown() {
-            memo.getThrottleManager().dispose();
-            memo.dispose();
-            lnis = null;
-            JUnitUtil.tearDown();
-        }
+    /**
+     * Test of setF1 method, of class AbstractThrottle.
+     */
+    @Test
+    @Override
+    public void testSetF1() {
+
+        lnis.resetStatistics(); // and clears outbound message log
+        boolean f1 = false;
+        instance.setFunction(1,f1);
+        Assert.assertEquals(f1, instance.getFunction(1));
+        Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
+        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
+        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F0F6, lnis.outbound.get(0).getElement(1) & 0x78);
+        Assert.assertEquals("sent f0 in correct state", 0, lnis.outbound.get(0).getElement(4) & LnConstants.DIRF_F1);
+        f1 = true;
+        instance.setFunction(1,f1);
+        Assert.assertEquals(f1, instance.getFunction(1));
+        Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
+        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
+        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F0F6, lnis.outbound.get(1).getElement(1) & 0x78);
+        Assert.assertEquals("sent f1 in correct state", LnConstants.DIRF_F1, lnis.outbound.get(1).getElement(4) & LnConstants.DIRF_F1);
+    }
+
+    /**
+     * Test of setF2 method, of class AbstractThrottle.
+     */
+    @Test
+    @Override
+    public void testSetF2() {
+
+        lnis.resetStatistics(); // and clears outbound message log
+        boolean f2 = false;
+        instance.setFunction(2,f2);
+        Assert.assertEquals(f2, instance.getFunction(2));
+        Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
+        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
+        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F0F6, lnis.outbound.get(0).getElement(1) & 0x78);
+        Assert.assertEquals("sent f2 in correct state", 0, lnis.outbound.get(0).getElement(4) & LnConstants.DIRF_F2);
+        f2 = true;
+        instance.setFunction(2,f2);
+        Assert.assertEquals(f2, instance.getFunction(2));
+        Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
+        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
+        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F0F6, lnis.outbound.get(1).getElement(1) & 0x78);
+        Assert.assertEquals("sent f2 in correct state", LnConstants.DIRF_F2, lnis.outbound.get(1).getElement(4) & LnConstants.DIRF_F2);
+    }
+
+    /**
+     * Test of setF3 method, of class AbstractThrottle.
+     */
+    @Test
+    @Override
+    public void testSetF3() {
+
+        lnis.resetStatistics(); // and clears outbound message log
+        boolean f3 = false;
+        instance.setFunction(3,f3);
+        Assert.assertEquals(f3, instance.getFunction(3));
+        Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
+        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
+        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F0F6, lnis.outbound.get(0).getElement(1) & 0x78);
+        Assert.assertEquals("sent f3 in correct state", 0, lnis.outbound.get(0).getElement(4) & LnConstants.DIRF_F3);
+        f3 = true;
+        instance.setFunction(3,f3);
+        Assert.assertEquals(f3, instance.getFunction(3));
+        Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
+        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
+        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F0F6, lnis.outbound.get(1).getElement(1) & 0x78);
+        Assert.assertEquals("sent f3 in correct state", LnConstants.DIRF_F3, lnis.outbound.get(1).getElement(4) & LnConstants.DIRF_F3);
+    }
+
+    /**
+     * Test of setF4 method, of class AbstractThrottle.
+     */
+    @Test
+    @Override
+    public void testSetF4() {
+
+        lnis.resetStatistics(); // and clears outbound message log
+        boolean f4 = false;
+        instance.setFunction(4,f4);
+        Assert.assertEquals(f4, instance.getFunction(4));
+        Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
+        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
+        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F0F6, lnis.outbound.get(0).getElement(1) & 0x78);
+        Assert.assertEquals("sent f4 in correct state", 0, lnis.outbound.get(0).getElement(4) & LnConstants.DIRF_F4);
+        f4 = true;
+        instance.setFunction(4,f4);
+        Assert.assertEquals(f4, instance.getFunction(4));
+        Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
+        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
+        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F0F6, lnis.outbound.get(1).getElement(1) & 0x78);
+        Assert.assertEquals("sent f4 in correct state", LnConstants.DIRF_F4, lnis.outbound.get(1).getElement(4) & LnConstants.DIRF_F4);
+    }
+
+    /**
+     * Test of setF5 method, of class AbstractThrottle.
+     */
+    @Test
+    @Override
+    public void testSetF5() {
+
+        lnis.resetStatistics(); // and clears outbound message log
+        boolean f5 = false;
+        instance.setFunction(5,f5);
+        Assert.assertEquals(f5, instance.getFunction(5));
+        Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
+        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
+        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F0F6, lnis.outbound.get(0).getElement(1) & 0x78);
+        Assert.assertEquals("sent f5 in correct state", 0, lnis.outbound.get(0).getElement(4) & 0x20);
+        f5 = true;
+        instance.setFunction(5,f5);
+        Assert.assertEquals(f5, instance.getFunction(5));
+        Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
+        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
+        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F0F6, lnis.outbound.get(1).getElement(1) & 0x78);
+        Assert.assertEquals("sent f5 in correct state", 0x20, lnis.outbound.get(1).getElement(4) & 0x20);
+    }
+
+    /**
+     * Test of setF6 method, of class AbstractThrottle.
+     */
+    @Test
+    @Override
+    public void testSetF6() {
+
+        lnis.resetStatistics(); // and clears outbound message log
+        boolean f6 = false;
+        instance.setFunction(6,f6);
+        Assert.assertEquals(f6, instance.getFunction(6));
+        Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
+        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
+        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F0F6, lnis.outbound.get(0).getElement(1) & 0x78);
+        Assert.assertEquals("sent f6 in correct state", 0, lnis.outbound.get(0).getElement(4) & 0x40);
+        f6 = true;
+        instance.setFunction(6,f6);
+        Assert.assertEquals(f6, instance.getFunction(6));
+        Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
+        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
+        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F0F6, lnis.outbound.get(1).getElement(1) & 0x78);
+        Assert.assertEquals("sent f6 in correct state", 0x40, lnis.outbound.get(1).getElement(4) & 0x40);
+    }
+    /**
+     * Test of setF7 method, of class AbstractThrottle.
+     */
+    @Test
+    @Override
+    public void testSetF7() {
+
+        lnis.resetStatistics(); // and clears outbound message log
+        boolean f7 = false;
+        int func = 7;
+        instance.setFunction(func,f7);
+        Assert.assertEquals(f7, instance.getFunction(func));
+        Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
+        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
+        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F7F13, lnis.outbound.get(0).getElement(1) & 0x78);
+        Assert.assertEquals("sent " + func + " in correct state", 0, lnis.outbound.get(0).getElement(4) & 0x01);
+        f7 = true;
+        instance.setFunction(func,f7);
+        Assert.assertEquals(f7, instance.getFunction(func));
+        Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
+        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
+        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F7F13, lnis.outbound.get(1).getElement(1) & 0x78);
+        Assert.assertEquals("sent " + func + " in correct state", 0x01, lnis.outbound.get(1).getElement(4) & 0x01);
+    }
+
+    /**
+     * Test of setF8 method, of class AbstractThrottle.
+     */
+    @Test
+    @Override
+    public void testSetF8() {
+
+        lnis.resetStatistics(); // and clears outbound message log
+        boolean f8 = false;
+        int func = 8;
+        int bit = 0x02;
+        instance.setFunction(func,f8);
+        Assert.assertEquals(f8, instance.getFunction(func));
+        Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
+        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
+        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F7F13, lnis.outbound.get(0).getElement(1) & 0x78);
+        Assert.assertEquals("sent " + func + " in correct state", 0, lnis.outbound.get(0).getElement(4) & bit);
+        f8 = true;
+        instance.setFunction(func,f8);
+        Assert.assertEquals(f8, instance.getFunction(func));
+        Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
+        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
+        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F7F13, lnis.outbound.get(1).getElement(1) & 0x78);
+        Assert.assertEquals("sent " + func + " in correct state", bit, lnis.outbound.get(1).getElement(4) & bit);
+    }
+
+    /**
+     * Test of setF9 method, of class AbstractThrottle.
+     */
+    @Test
+    @Override
+    public void testSetF9() {
+
+        lnis.resetStatistics(); // and clears outbound message log
+        boolean f9 = false;
+        int func = 9;
+        int bit = 0x04;
+        instance.setFunction(func,f9);
+        Assert.assertEquals(f9, instance.getFunction(func));
+        Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
+        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
+        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F7F13, lnis.outbound.get(0).getElement(1) & 0x78);
+        Assert.assertEquals("sent " + func + " in correct state", 0, lnis.outbound.get(0).getElement(4) & bit);
+        f9 = true;
+        instance.setFunction(func,f9);
+        Assert.assertEquals(f9, instance.getFunction(func));
+        Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
+        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
+        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F7F13, lnis.outbound.get(1).getElement(1) & 0x78);
+        Assert.assertEquals("sent " + func + " in correct state", bit, lnis.outbound.get(1).getElement(4) & bit);
+    }
+
+    /**
+     * Test of setF10 method, of class AbstractThrottle.
+     */
+    @Test
+    @Override
+    public void testSetF10() {
+
+        lnis.resetStatistics(); // and clears outbound message log
+        boolean f10 = false;
+        int func = 10;
+        int bit = 0x08;
+        instance.setFunction(func,f10);
+        Assert.assertEquals(f10, instance.getFunction(func));
+        Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
+        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
+        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F7F13, lnis.outbound.get(0).getElement(1) & 0x78);
+        Assert.assertEquals("sent " + func + " in correct state", 0, lnis.outbound.get(0).getElement(4) & bit);
+        f10 = true;
+        instance.setFunction(func,f10);
+        Assert.assertEquals(f10, instance.getFunction(func));
+        Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
+        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
+        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F7F13, lnis.outbound.get(1).getElement(1) & 0x78);
+        Assert.assertEquals("sent " + func + " in correct state", bit, lnis.outbound.get(1).getElement(4) & bit);
+    }
+
+    /**
+     * Test of setF11 method, of class AbstractThrottle.
+     */
+    @Test
+    @Override
+    public void testSetF11() {
+
+        lnis.resetStatistics(); // and clears outbound message log
+        boolean f11 = false;
+        int func = 11;
+        int bit = 0x10;
+        instance.setFunction(func,f11);
+        Assert.assertEquals(f11, instance.getFunction(func));
+        Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
+        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
+        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F7F13, lnis.outbound.get(0).getElement(1) & 0x78);
+        Assert.assertEquals("sent " + func + " in correct state", 0, lnis.outbound.get(0).getElement(4) & bit);
+        f11 = true;
+        instance.setFunction(func,f11);
+        Assert.assertEquals(f11, instance.getFunction(func));
+        Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
+        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
+        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F7F13, lnis.outbound.get(1).getElement(1) & 0x78);
+        Assert.assertEquals("sent " + func + " in correct state", bit, lnis.outbound.get(1).getElement(4) & bit);
+    }
+
+    /**
+     * Test of setF12 method, of class AbstractThrottle.
+     */
+    @Test
+    @Override
+    public void testSetF12() {
+
+        lnis.resetStatistics(); // and clears outbound message log
+        boolean f12 = false;
+        int func = 12;
+        int bit = 0x20;
+        instance.setFunction(func,f12);
+        Assert.assertEquals(f12, instance.getFunction(func));
+        Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
+        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
+        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F7F13, lnis.outbound.get(0).getElement(1) & 0x78);
+        Assert.assertEquals("sent " + func + " in correct state", 0, lnis.outbound.get(0).getElement(4) & bit);
+        f12 = true;
+        instance.setFunction(func,f12);
+        Assert.assertEquals(f12, instance.getFunction(func));
+        Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
+        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
+        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F7F13, lnis.outbound.get(1).getElement(1) & 0x78);
+        Assert.assertEquals("sent " + func + " in correct state", bit, lnis.outbound.get(1).getElement(4) & bit);
+    }
+
+    /**
+     * Test of setF13 method, of class AbstractThrottle.
+     */
+    @Test
+    @Override
+    public void testSetF13() {
+
+        lnis.resetStatistics(); // and clears outbound message log
+        boolean f13 = false;
+        int func = 13;
+        int bit = 0x40;
+        instance.setFunction(func,f13);
+        Assert.assertEquals(f13, instance.getFunction(func));
+        Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
+        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
+        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F7F13, lnis.outbound.get(0).getElement(1) & 0x78);
+        Assert.assertEquals("sent " + func + " in correct state", 0, lnis.outbound.get(0).getElement(4) & bit);
+        f13 = true;
+        instance.setFunction(func,f13);
+        Assert.assertEquals(f13, instance.getFunction(func));
+        Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
+        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
+        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F7F13, lnis.outbound.get(1).getElement(1) & 0x78);
+        Assert.assertEquals("sent " + func + " in correct state", bit, lnis.outbound.get(1).getElement(4) & bit);
+    }
+
+    /**
+     * Test of setF14 method, of class AbstractThrottle.
+     */
+    @Test
+    @Override
+    public void testSetF14() {
+
+        lnis.resetStatistics(); // and clears outbound message log
+        boolean f14 = false;
+        int func = 14;
+        int bit = 0x01;
+        instance.setFunction(func,f14);
+        Assert.assertEquals(f14, instance.getFunction(func));
+        Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
+        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
+        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F14F20, lnis.outbound.get(0).getElement(1) & 0x78);
+        Assert.assertEquals("sent " + func + " in correct state", 0, lnis.outbound.get(0).getElement(4) & bit);
+        f14 = true;
+        instance.setFunction(func,f14);
+        Assert.assertEquals(f14, instance.getFunction(func));
+        Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
+        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
+        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F14F20, lnis.outbound.get(1).getElement(1) & 0x78);
+        Assert.assertEquals("sent " + func + " in correct state", bit, lnis.outbound.get(1).getElement(4) & bit);
+    }
+
+    /**
+     * Test of setF15 method, of class AbstractThrottle.
+     */
+    @Test
+    @Override
+    public void testSetF15() {
+
+        lnis.resetStatistics(); // and clears outbound message log
+        boolean f15 = false;
+        int func = 15;
+        int bit = 0x02;
+        instance.setFunction(func,f15);
+        Assert.assertEquals(f15, instance.getFunction(func));
+        Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
+        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
+        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F14F20, lnis.outbound.get(0).getElement(1) & 0x78);
+        Assert.assertEquals("sent " + func + " in correct state", 0, lnis.outbound.get(0).getElement(4) & bit);
+        f15 = true;
+        instance.setFunction(func,f15);
+        Assert.assertEquals(f15, instance.getFunction(func));
+        Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
+        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
+        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F14F20, lnis.outbound.get(1).getElement(1) & 0x78);
+        Assert.assertEquals("sent " + func + " in correct state", bit, lnis.outbound.get(1).getElement(4) & bit);
+    }
+
+    /**
+     * Test of setF16 method, of class AbstractThrottle.
+     */
+    @Test
+    @Override
+    public void testSetF16() {
+
+        lnis.resetStatistics(); // and clears outbound message log
+        boolean f16 = false;
+        int func = 16;
+        int bit = 0x04;
+        instance.setFunction(func,f16);
+        Assert.assertEquals(f16, instance.getFunction(func));
+        Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
+        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
+        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F14F20, lnis.outbound.get(0).getElement(1) & 0x78);
+        Assert.assertEquals("sent " + func + " in correct state", 0, lnis.outbound.get(0).getElement(4) & bit);
+        f16 = true;
+        instance.setFunction(func,f16);
+        Assert.assertEquals(f16, instance.getFunction(func));
+        Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
+        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
+        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F14F20, lnis.outbound.get(1).getElement(1) & 0x78);
+        Assert.assertEquals("sent " + func + " in correct state", bit, lnis.outbound.get(1).getElement(4) & bit);
+    }
+
+    /**
+     * Test of setF17 method, of class AbstractThrottle.
+     */
+    @Test
+    @Override
+    public void testSetF17() {
+
+        lnis.resetStatistics(); // and clears outbound message log
+        boolean f17 = false;
+        int func = 17;
+        int bit = 0x08;
+        instance.setFunction(func,f17);
+        Assert.assertEquals(f17, instance.getFunction(func));
+        Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
+        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
+        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F14F20, lnis.outbound.get(0).getElement(1) & 0x78);
+        Assert.assertEquals("sent " + func + " in correct state", 0, lnis.outbound.get(0).getElement(4) & bit);
+        f17 = true;
+        instance.setFunction(func,f17);
+        Assert.assertEquals(f17, instance.getFunction(func));
+        Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
+        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
+        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F14F20, lnis.outbound.get(1).getElement(1) & 0x78);
+        Assert.assertEquals("sent " + func + " in correct state", bit, lnis.outbound.get(1).getElement(4) & bit);
+    }
+
+    /**
+     * Test of setF18 method, of class AbstractThrottle.
+     */
+    @Test
+    @Override
+    public void testSetF18() {
+
+        lnis.resetStatistics(); // and clears outbound message log
+        boolean f18 = false;
+        int func = 18;
+        int bit = 0x10;
+        instance.setFunction(func,f18);
+        Assert.assertEquals(f18, instance.getFunction(func));
+        Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
+        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
+        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F14F20, lnis.outbound.get(0).getElement(1) & 0x78);
+        Assert.assertEquals("sent " + func + " in correct state", 0, lnis.outbound.get(0).getElement(4) & bit);
+        f18 = true;
+        instance.setFunction(func,f18);
+        Assert.assertEquals(f18, instance.getFunction(func));
+        Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
+        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
+        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F14F20, lnis.outbound.get(1).getElement(1) & 0x78);
+        Assert.assertEquals("sent " + func + " in correct state", bit, lnis.outbound.get(1).getElement(4) & bit);
+    }
+
+    /**
+     * Test of setF19 method, of class AbstractThrottle.
+     */
+    @Test
+    @Override
+    public void testSetF19() {
+
+        lnis.resetStatistics(); // and clears outbound message log
+        boolean f19 = false;
+        int func = 19;
+        int bit = 0x20;
+        instance.setFunction(func,f19);
+        Assert.assertEquals(f19, instance.getFunction(func));
+        Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
+        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
+        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F14F20, lnis.outbound.get(0).getElement(1) & 0x78);
+        Assert.assertEquals("sent " + func + " in correct state", 0, lnis.outbound.get(0).getElement(4) & bit);
+        f19 = true;
+        instance.setFunction(func,f19);
+        Assert.assertEquals(f19, instance.getFunction(func));
+        Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
+        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
+        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F14F20, lnis.outbound.get(1).getElement(1) & 0x78);
+        Assert.assertEquals("sent " + func + " in correct state", bit, lnis.outbound.get(1).getElement(4) & bit);
+    }
+
+    /**
+     * Test of setF20 method, of class AbstractThrottle.
+     */
+    @Test
+    @Override
+    public void testSetF20() {
+
+        lnis.resetStatistics(); // and clears outbound message log
+        boolean f20 = false;
+        int func = 20;
+        int bit = 0x40;
+        instance.setFunction(func,f20);
+        Assert.assertEquals(f20, instance.getFunction(func));
+        Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
+        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
+        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F14F20, lnis.outbound.get(0).getElement(1) & 0x78);
+        Assert.assertEquals("sent " + func + " in correct state", 0, lnis.outbound.get(0).getElement(4) & bit);
+        f20 = true;
+        instance.setFunction(func,f20);
+        Assert.assertEquals(f20, instance.getFunction(func));
+        Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
+        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
+        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F14F20, lnis.outbound.get(1).getElement(1) & 0x78);
+        Assert.assertEquals("sent " + func + " in correct state", bit, lnis.outbound.get(1).getElement(4) & bit);
+    }
+
+    /**
+     * Test of setF21 method, of class AbstractThrottle.
+     */
+    @Test
+    @Override
+    public void testSetF21() {
+
+        lnis.resetStatistics(); // and clears outbound message log
+        boolean f21 = false;
+        int func = 21;
+        int bit = 0x01;
+        instance.setFunction(func,f21);
+        Assert.assertEquals(f21, instance.getFunction(func));
+        Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
+        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
+        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F21F28_F28OFF, lnis.outbound.get(0).getElement(1) & 0x78);
+        Assert.assertEquals("sent " + func + " in correct state", 0, lnis.outbound.get(0).getElement(4) & bit);
+        f21 = true;
+        instance.setFunction(func,f21);
+        Assert.assertEquals(f21, instance.getFunction(func));
+        Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
+        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
+        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F21F28_F28OFF, lnis.outbound.get(1).getElement(1) & 0x78);
+        Assert.assertEquals("sent " + func + " in correct state", bit, lnis.outbound.get(1).getElement(4) & bit);
+    }
+
+    /**
+     * Test of setF22 method, of class AbstractThrottle.
+     */
+    @Test
+    @Override
+    public void testSetF22() {
+
+        lnis.resetStatistics(); // and clears outbound message log
+        boolean f22 = false;
+        int func = 22;
+        int bit = 0x02;
+        instance.setFunction(func,f22);
+        Assert.assertEquals(f22, instance.getFunction(func));
+        Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
+        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
+        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F21F28_F28OFF, lnis.outbound.get(0).getElement(1) & 0x78);
+        Assert.assertEquals("sent " + func + " in correct state", 0, lnis.outbound.get(0).getElement(4) & bit);
+        f22 = true;
+        instance.setFunction(func,f22);
+        Assert.assertEquals(f22, instance.getFunction(func));
+        Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
+        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
+        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F21F28_F28OFF, lnis.outbound.get(1).getElement(1) & 0x78);
+        Assert.assertEquals("sent " + func + " in correct state", bit, lnis.outbound.get(1).getElement(4) & bit);
+    }
+
+    /**
+     * Test of setF23 method, of class AbstractThrottle.
+     */
+    @Test
+    @Override
+    public void testSetF23() {
+
+        lnis.resetStatistics(); // and clears outbound message log
+        boolean f23 = false;
+        int func = 23;
+        int bit = 0x04;
+        instance.setFunction(func,f23);
+        Assert.assertEquals(f23, instance.getFunction(func));
+        Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
+        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
+        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F21F28_F28OFF, lnis.outbound.get(0).getElement(1) & 0x78);
+        Assert.assertEquals("sent " + func + " in correct state", 0, lnis.outbound.get(0).getElement(4) & bit);
+        f23 = true;
+        instance.setFunction(func,f23);
+        Assert.assertEquals(f23, instance.getFunction(func));
+        Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
+        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
+        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F21F28_F28OFF, lnis.outbound.get(1).getElement(1) & 0x78);
+        Assert.assertEquals("sent " + func + " in correct state", bit, lnis.outbound.get(1).getElement(4) & bit);
+    }
+
+    /**
+     * Test of setF24 method, of class AbstractThrottle.
+     */
+    @Test
+    @Override
+    public void testSetF24() {
+
+        lnis.resetStatistics(); // and clears outbound message log
+        boolean f24 = false;
+        int func = 24;
+        int bit = 0x08;
+        instance.setFunction(func,f24);
+        Assert.assertEquals(f24, instance.getFunction(func));
+        Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
+        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
+        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F21F28_F28OFF, lnis.outbound.get(0).getElement(1) & 0x78);
+        Assert.assertEquals("sent " + func + " in correct state", 0, lnis.outbound.get(0).getElement(4) & bit);
+        f24 = true;
+        instance.setFunction(func,f24);
+        Assert.assertEquals(f24, instance.getFunction(func));
+        Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
+        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
+        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F21F28_F28OFF, lnis.outbound.get(1).getElement(1) & 0x78);
+        Assert.assertEquals("sent " + func + " in correct state", bit, lnis.outbound.get(1).getElement(4) & bit);
+    }
+
+    /**
+     * Test of setF25 method, of class AbstractThrottle.
+     */
+    @Test
+    @Override
+    public void testSetF25() {
+
+        lnis.resetStatistics(); // and clears outbound message log
+        boolean f25 = false;
+        int func = 25;
+        int bit = 0x10;
+        instance.setFunction(func,f25);
+        Assert.assertEquals(f25, instance.getFunction(func));
+        Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
+        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
+        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F21F28_F28OFF, lnis.outbound.get(0).getElement(1) & 0x78);
+        Assert.assertEquals("sent " + func + " in correct state", 0, lnis.outbound.get(0).getElement(4) & bit);
+        f25 = true;
+        instance.setFunction(func,f25);
+        Assert.assertEquals(f25, instance.getFunction(func));
+        Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
+        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
+        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F21F28_F28OFF, lnis.outbound.get(1).getElement(1) & 0x78);
+        Assert.assertEquals("sent " + func + " in correct state", bit, lnis.outbound.get(1).getElement(4) & bit);
+    }
+
+    /**
+     * Test of setF26 method, of class AbstractThrottle.
+     */
+    @Test
+    @Override
+    public void testSetF26() {
+
+        lnis.resetStatistics(); // and clears outbound message log
+        boolean f26 = false;
+        int func = 26;
+        int bit = 0x20;
+        instance.setFunction(func,f26);
+        Assert.assertEquals(f26, instance.getFunction(func));
+        Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
+        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
+        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F21F28_F28OFF, lnis.outbound.get(0).getElement(1) & 0x78);
+        Assert.assertEquals("sent " + func + " in correct state", 0, lnis.outbound.get(0).getElement(4) & bit);
+        f26 = true;
+        instance.setFunction(func,f26);
+        Assert.assertEquals(f26, instance.getFunction(func));
+        Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
+        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
+        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F21F28_F28OFF, lnis.outbound.get(1).getElement(1) & 0x78);
+        Assert.assertEquals("sent " + func + " in correct state", bit, lnis.outbound.get(1).getElement(4) & bit);
+    }
+
+    /**
+     * Test of setF27 method, of class AbstractThrottle.
+     */
+    @Test
+    @Override
+    public void testSetF27() {
+
+        lnis.resetStatistics(); // and clears outbound message log
+        boolean f27 = false;
+        int func = 27;
+        int bit = 0x40;
+        instance.setFunction(func,f27);
+        Assert.assertEquals(f27, instance.getFunction(func));
+        Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
+        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
+        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F21F28_F28OFF, lnis.outbound.get(0).getElement(1) & 0x78);
+        Assert.assertEquals("sent " + func + " in correct state", 0, lnis.outbound.get(0).getElement(4) & bit);
+        f27 = true;
+        instance.setFunction(func,f27);
+        Assert.assertEquals(f27, instance.getFunction(func));
+        Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
+        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
+        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F21F28_F28OFF, lnis.outbound.get(1).getElement(1) & 0x78);
+        Assert.assertEquals("sent " + func + " in correct state", bit, lnis.outbound.get(1).getElement(4) & bit);
+    }
+
+    /**
+     * Test of setF28 method, of class AbstractThrottle.
+     */
+    @Test
+    @Override
+    public void testSetF28() {
+
+        lnis.resetStatistics(); // and clears outbound message log
+        boolean f28 = false;
+        int func = 28;
+        int bit = 0xFF;   // all off both ways
+        instance.setFunction(func,f28);
+        Assert.assertEquals(f28, instance.getFunction(func));
+        Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
+        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
+        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F21F28_F28OFF, lnis.outbound.get(0).getElement(1) & 0x78);
+        Assert.assertEquals("sent " + func + " in correct state", 0, lnis.outbound.get(0).getElement(4) & bit);
+        f28 = true;
+        instance.setFunction(func,f28);
+        Assert.assertEquals(f28, instance.getFunction(func));
+        Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
+        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
+        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F21F28_F28ON, lnis.outbound.get(1).getElement(1) & 0x78);
+        Assert.assertEquals("sent " + func + " in correct state", 0, lnis.outbound.get(1).getElement(4) & bit);
+    }
+
+    /**
+     * Test of sendFunction 29
+     */
+    @Test
+    public void testSendExpFunctionF29() {
+
+        lnis.resetStatistics(); // and clears outbound message log
+        int func = 29;
+        LocoNetMessage funcOnMess = new LocoNetMessage(new int[] {0xED, 0x0B, 0x7f, 0x33, 0x02, 0x00, 0x58, 0x01, 0x00, 0x00, 0x00});
+        LocoNetMessage funcOffMess = new LocoNetMessage(new int [] {0xED, 0x0B, 0x7F, 0x33, 0x02, 0x00, 0x58, 0x00, 0x00, 0x00, 0x00});
+        Assert.assertEquals("check send of function exp f" + func, 0, lnis.outbound.size());
+        instance.setFunction(func,true);
+        Assert.assertEquals("check send of function" + func, 1, lnis.outbound.size());
+        Assert.assertTrue("check opcode",funcOnMess.equals(lnis.outbound.get(0)));
+        instance.setFunction(func,false);
+        Assert.assertEquals("check send OFF function" + func, 2, lnis.outbound.size());
+        Assert.assertTrue("check opcode",funcOffMess.equals(lnis.outbound.get(1)));
+    }
+
+    /**
+     * Test of sendFunction 69
+     */
+    @Test
+    public void testSendExpFunctionF68() {
+
+        lnis.resetStatistics(); // and clears outbound message log
+        int func = 68;
+        LocoNetMessage funcOnMess = new LocoNetMessage(new int[] {0xED, 0x0B, 0x7f, 0x33, 0x06, 0x00, 0x5C, 0x00, 0x00, 0x00, 0x00});
+        LocoNetMessage funcOffMess = new LocoNetMessage(new int [] {0xED, 0x0B, 0x7F, 0x33, 0x02, 0x00, 0x5C, 0x00, 0x00, 0x00, 0x00});
+        Assert.assertEquals("check send of function exp f" + func, 0, lnis.outbound.size());
+        instance.setFunction(func,true);
+        Assert.assertEquals("check send of function" + func, 1, lnis.outbound.size());
+        Assert.assertTrue("check opcode",funcOnMess.equals(lnis.outbound.get(0)));
+        instance.setFunction(func,false);
+        Assert.assertEquals("check send OFF function" + func, 2, lnis.outbound.size());
+        Assert.assertTrue("check opcode",funcOffMess.equals(lnis.outbound.get(1)));
+    }
+
+    /**
+     * Test of sendFunctionGroup1 method, of class AbstractThrottle.
+     */
+    @Test
+    @Override
+    public void testSendFunctionGroup1() {
+
+        lnis.resetStatistics(); // and clears outbound message log
+        instance.setF0(false);
+        instance.setF1(true);
+        instance.setF2(true);
+        instance.setF3(false);
+        instance.setIsForward(true);
+
+        lnis.resetStatistics();  // and clears outbound message log
+        Assert.assertEquals("check send of function group 1 (0)", 0, lnis.outbound.size());
+        ((LocoNetThrottle)instance).sendFunctionGroup1();
+        Assert.assertEquals("check send of function group 1 (1)", 1, lnis.outbound.size());
+        Assert.assertEquals("check opcode",LnConstants.OPC_LOCO_DIRF, lnis.outbound.get(0).getOpCode());
+        Assert.assertEquals("check dirf byte", 0x03, lnis.outbound.get(0).getElement(2));
+
+
+        lnis.resetStatistics(); // and clears outbound message log
+        instance.setIsForward(false);
+        Assert.assertEquals("check send of function group 1 (2)", 1, lnis.outbound.size());
+        ((LocoNetThrottle)instance).sendFunctionGroup1();
+        Assert.assertEquals("check send of function group 1 (3)", 2, lnis.outbound.size());
+        Assert.assertEquals("check opcode",LnConstants.OPC_LOCO_DIRF, lnis.outbound.get(1).getOpCode());
+        Assert.assertEquals("check dirf byte {4}", 0x023, lnis.outbound.get(1).getElement(2));
 
     }
 
+    /**
+     * Test of sendFunctionGroup2 method, of class AbstractThrottle.
+     */
+    @Test
+    @Override
+    public void testSendFunctionGroup2() {
+
+        for (int i = 5; i <9; ++i ) {
+            instance.setF5(i==5);
+            instance.setF6(i==6);
+            instance.setF7(i==7);
+            instance.setF8(i==8);
+
+            lnis.resetStatistics(); // and clears outbound message log
+            ((LocoNetThrottle)instance).sendFunctionGroup2();
+
+            Assert.assertEquals("check send of function group 2 for F"+i+" (0)", 1, lnis.outbound.size());
+            Assert.assertEquals("check opcode is OPC_LOCO_SND for F"+i+"",LnConstants.OPC_LOCO_SND, lnis.outbound.get(0).getOpCode());
+            Assert.assertEquals("check byte 2 for F"+i+"{0}", 1<<(i-5), lnis.outbound.get(0).getElement(2));
+
+            instance.setF5(!(i==5));
+            instance.setF6(!(i==6));
+            instance.setF7(!(i==7));
+            instance.setF8(!(i==8));
+
+            lnis.resetStatistics(); // and clears outbound message log
+            ((LocoNetThrottle)instance).sendFunctionGroup2();
+
+            Assert.assertEquals("check send of function group 2 for !F"+i+"(1)", 1, lnis.outbound.size());
+            Assert.assertEquals("check opcode is OPC_LOCO_SND for F"+i+"",LnConstants.OPC_LOCO_SND, lnis.outbound.get(0).getOpCode());
+            Assert.assertEquals("check byte 2 for !F"+i+"{1}", 0x0f - (1<<(i-5)), lnis.outbound.get(0).getElement(2));
+        }
+    }
+
+    /**
+     * Test of sendFunctionGroup3 method, of class AbstractThrottle.
+     */
+    @Test
+    @Override
+    public void testSendFunctionGroup3() {
+
+        for (int i = 9; i <13; ++i ) {
+            instance.setF9(i==9);
+            instance.setF10(i==10);
+            instance.setF11(i==11);
+            instance.setF12(i==12);
+
+            lnis.resetStatistics(); // and clears outbound message log
+            ((LocoNetThrottle)instance).sendFunctionGroup3();
+
+            Assert.assertEquals("check send of function group 3 for F"+i+" (0)", 1, lnis.outbound.size());
+            Assert.assertEquals("check opcode is OPC_IMM_PACKET for F"+i+"",LnConstants.OPC_IMM_PACKET, lnis.outbound.get(0).getOpCode());
+            Assert.assertEquals("check byte 1 for F"+i+"{0}", 0x0b, lnis.outbound.get(0).getElement(1));
+            Assert.assertEquals("check byte 2 for F"+i+"{0}", 0x7f, lnis.outbound.get(0).getElement(2));
+            Assert.assertEquals("check byte 3 for F"+i+"{0}", 0x23, lnis.outbound.get(0).getElement(3));
+            Assert.assertEquals("check byte 4 for F"+i+"{0}", 0x02, lnis.outbound.get(0).getElement(4));
+            Assert.assertEquals("check byte 5 for F"+i+"{0}", 0x00, lnis.outbound.get(0).getElement(5));
+            Assert.assertEquals("check byte 6 for F"+i+"{0}", 0x20+(1<<(i-9)), lnis.outbound.get(0).getElement(6));
+            Assert.assertEquals("check byte 7 for F"+i+"{0}", 0x00, lnis.outbound.get(0).getElement(7));
+            Assert.assertEquals("check byte 8 for F"+i+"{0}", 0x00, lnis.outbound.get(0).getElement(8));
+            Assert.assertEquals("check byte 9 for F"+i+"{0}", 0x00, lnis.outbound.get(0).getElement(9));
+
+            instance.setF9(!(i==9));
+            instance.setF10(!(i==10));
+            instance.setF11(!(i==11));
+            instance.setF12(!(i==12));
+
+            lnis.resetStatistics(); // and clears outbound message log
+            ((LocoNetThrottle)instance).sendFunctionGroup3();
+
+            Assert.assertEquals("check send of function group 3 for !F"+i+"(1)", 1, lnis.outbound.size());
+            Assert.assertEquals("check opcode is OPC_IMM_PACKET for !F"+i+"{1}",LnConstants.OPC_IMM_PACKET, lnis.outbound.get(0).getOpCode());
+            Assert.assertEquals("check byte 1 for !F"+i+"{1}", 0x0b, lnis.outbound.get(0).getElement(1));
+            Assert.assertEquals("check byte 2 for !F"+i+"{1}", 0x7f, lnis.outbound.get(0).getElement(2));
+            Assert.assertEquals("check byte 3 for !F"+i+"{1}", 0x23, lnis.outbound.get(0).getElement(3));
+            Assert.assertEquals("check byte 4 for !F"+i+"{1}", 0x02, lnis.outbound.get(0).getElement(4));
+            Assert.assertEquals("check byte 5 for !F"+i+"{1}", 0x00, lnis.outbound.get(0).getElement(5));
+            Assert.assertEquals("check byte 6 for !F"+i+"{1}", 0x2F-(1<<(i-9)), lnis.outbound.get(0).getElement(6));
+            Assert.assertEquals("check byte 7 for !F"+i+"{1}", 0x00, lnis.outbound.get(0).getElement(7));
+            Assert.assertEquals("check byte 8 for !F"+i+"{1}", 0x00, lnis.outbound.get(0).getElement(8));
+            Assert.assertEquals("check byte 9 for 1F"+i+"{1}", 0x00, lnis.outbound.get(0).getElement(9));
+        }
+    }
+
+    /**
+     * Test of sendFunctionGroup4 method, of class AbstractThrottle.
+     */
+    @Test
+    @Override
+    public void testSendFunctionGroup4() {
+        for (int i = 13; i <21; ++i ) {
+            instance.setF13(i==13);
+            instance.setF14(i==14);
+            instance.setF15(i==15);
+            instance.setF16(i==16);
+            instance.setF17(i==17);
+            instance.setF18(i==18);
+            instance.setF19(i==19);
+            instance.setF20(i==20);
+
+            lnis.resetStatistics(); // and clears outbound message log
+            ((LocoNetThrottle)instance).sendFunctionGroup4();
+
+            Assert.assertEquals("check send of function group 4 for F"+i+" (0)", 1, lnis.outbound.size());
+            Assert.assertEquals("check opcode is OPC_IMM_PACKET for F"+i+"",LnConstants.OPC_IMM_PACKET, lnis.outbound.get(0).getOpCode());
+            Assert.assertEquals("check byte 1 for F"+i+"{0}", 0x0b, lnis.outbound.get(0).getElement(1));
+            Assert.assertEquals("check byte 2 for F"+i+"{0}", 0x7f, lnis.outbound.get(0).getElement(2));
+            Assert.assertEquals("check byte 3 for F"+i+"{0}", 0x33, lnis.outbound.get(0).getElement(3));
+            Assert.assertEquals("check byte 4 for F"+i+"{0}", (i==20)?0x06:0x02, lnis.outbound.get(0).getElement(4));
+            Assert.assertEquals("check byte 5 for F"+i+"{0}", 0x00, lnis.outbound.get(0).getElement(5));
+            Assert.assertEquals("check byte 6 for F"+i+"{0}", 0x5e, lnis.outbound.get(0).getElement(6));
+            Assert.assertEquals("check byte 7 for F"+i+"{0}", (i < 20)?(1<<(i-13)):0, lnis.outbound.get(0).getElement(7));
+            Assert.assertEquals("check byte 8 for F"+i+"{0}", 0x00, lnis.outbound.get(0).getElement(8));
+            Assert.assertEquals("check byte 9 for F"+i+"{0}", 0x00, lnis.outbound.get(0).getElement(9));
+
+            instance.setF13(!(i==13));
+            instance.setF14(!(i==14));
+            instance.setF15(!(i==15));
+            instance.setF16(!(i==16));
+            instance.setF17(!(i==17));
+            instance.setF18(!(i==18));
+            instance.setF19(!(i==19));
+            instance.setF20(!(i==20));
+
+            lnis.resetStatistics(); // and clears outbound message log
+            ((LocoNetThrottle)instance).sendFunctionGroup4();
+
+            Assert.assertEquals("check send of function group 4 for !F"+i+"(1)", 1, lnis.outbound.size());
+            Assert.assertEquals("check opcode is OPC_IMM_PACKET for !F"+i+"{1}",LnConstants.OPC_IMM_PACKET, lnis.outbound.get(0).getOpCode());
+            Assert.assertEquals("check byte 1 for !F"+i+"{1}", 0x0b, lnis.outbound.get(0).getElement(1));
+            Assert.assertEquals("check byte 2 for !F"+i+"{1}", 0x7f, lnis.outbound.get(0).getElement(2));
+            Assert.assertEquals("check byte 3 for !F"+i+"{1}", 0x33, lnis.outbound.get(0).getElement(3));
+            Assert.assertEquals("check byte 4 for !F"+i+"{1}", (i==20)?0x02:0x06, lnis.outbound.get(0).getElement(4));
+            Assert.assertEquals("check byte 5 for !F"+i+"{1}", 0x00, lnis.outbound.get(0).getElement(5));
+            Assert.assertEquals("check byte 6 for !F"+i+"{1}", 0x5e, lnis.outbound.get(0).getElement(6));
+            Assert.assertEquals("check byte 7 for !F"+i+"{1}", (i < 20)?(127-(1<<(i-13))):0x7f, lnis.outbound.get(0).getElement(7));
+            Assert.assertEquals("check byte 8 for !F"+i+"{1}", 0x00, lnis.outbound.get(0).getElement(8));
+            Assert.assertEquals("check byte 9 for 1F"+i+"{1}", 0x00, lnis.outbound.get(0).getElement(9));
+        }
+    }
+
+    /**
+     * Test of sendFunctionGroup5 method, of class AbstractThrottle.
+     */
+    @Test
+    @Override
+    public void testSendFunctionGroup5() {
+        for (int i = 21; i <29; ++i ) {
+            instance.setF21(i==21);
+            instance.setF22(i==22);
+            instance.setF23(i==23);
+            instance.setF24(i==24);
+            instance.setF25(i==25);
+            instance.setF26(i==26);
+            instance.setF27(i==27);
+            instance.setF28(i==28);
+
+            lnis.resetStatistics(); // and clears outbound message log
+            ((LocoNetThrottle)instance).sendFunctionGroup5();
+
+            Assert.assertEquals("check send of function group 5 for F"+i+" (0)", 1, lnis.outbound.size());
+            Assert.assertEquals("check opcode is OPC_IMM_PACKET for F"+i+"",LnConstants.OPC_IMM_PACKET, lnis.outbound.get(0).getOpCode());
+            Assert.assertEquals("check byte 1 for F"+i+"{0}", 0x0b, lnis.outbound.get(0).getElement(1));
+            Assert.assertEquals("check byte 2 for F"+i+"{0}", 0x7f, lnis.outbound.get(0).getElement(2));
+            Assert.assertEquals("check byte 3 for F"+i+"{0}", 0x33, lnis.outbound.get(0).getElement(3));
+            Assert.assertEquals("check byte 4 for F"+i+"{0}", (i==28)?0x06:0x02, lnis.outbound.get(0).getElement(4));
+            Assert.assertEquals("check byte 5 for F"+i+"{0}", 0x00, lnis.outbound.get(0).getElement(5));
+            Assert.assertEquals("check byte 6 for F"+i+"{0}", 0x5f, lnis.outbound.get(0).getElement(6));
+            Assert.assertEquals("check byte 7 for F"+i+"{0}", (i < 28)?(1<<(i-21)):0, lnis.outbound.get(0).getElement(7));
+            Assert.assertEquals("check byte 8 for F"+i+"{0}", 0x00, lnis.outbound.get(0).getElement(8));
+            Assert.assertEquals("check byte 9 for F"+i+"{0}", 0x00, lnis.outbound.get(0).getElement(9));
+
+            instance.setF21(!(i==21));
+            instance.setF22(!(i==22));
+            instance.setF23(!(i==23));
+            instance.setF24(!(i==24));
+            instance.setF25(!(i==25));
+            instance.setF26(!(i==26));
+            instance.setF27(!(i==27));
+            instance.setF28(!(i==28));
+
+            lnis.resetStatistics(); // and clears outbound message log
+            ((LocoNetThrottle)instance).sendFunctionGroup5();
+
+            Assert.assertEquals("check send of function group 5 for !F"+i+"(1)", 1, lnis.outbound.size());
+            Assert.assertEquals("check opcode is OPC_IMM_PACKET for !F"+i+"{1}",LnConstants.OPC_IMM_PACKET, lnis.outbound.get(0).getOpCode());
+            Assert.assertEquals("check byte 1 for !F"+i+"{1}", 0x0b, lnis.outbound.get(0).getElement(1));
+            Assert.assertEquals("check byte 2 for !F"+i+"{1}", 0x7f, lnis.outbound.get(0).getElement(2));
+            Assert.assertEquals("check byte 3 for !F"+i+"{1}", 0x33, lnis.outbound.get(0).getElement(3));
+            Assert.assertEquals("check byte 4 for !F"+i+"{1}", (i==28)?0x02:0x06, lnis.outbound.get(0).getElement(4));
+            Assert.assertEquals("check byte 5 for !F"+i+"{1}", 0x00, lnis.outbound.get(0).getElement(5));
+            Assert.assertEquals("check byte 6 for !F"+i+"{1}", 0x5f, lnis.outbound.get(0).getElement(6));
+            Assert.assertEquals("check byte 7 for !F"+i+"{1}", (i < 28)?(127-(1<<(i-21))):0x7f, lnis.outbound.get(0).getElement(7));
+            Assert.assertEquals("check byte 8 for !F"+i+"{1}", 0x00, lnis.outbound.get(0).getElement(8));
+            Assert.assertEquals("check byte 9 for 1F"+i+"{1}", 0x00, lnis.outbound.get(0).getElement(9));
+
+        }
+    }
+
+    /**
+     * Test of getF2Momentary method, of class AbstractThrottle.
+     */
+    @Test
+    @Override
+    public void testGetF2Momentary() {
+        boolean expResult = true;
+        boolean result = instance.getF2Momentary();
+        Assert.assertEquals("Check F2 Momentary true", expResult, result);
+
+        expResult = false;
+        instance.setF2Momentary(false);
+        result = instance.getF2Momentary();
+        Assert.assertEquals("Check F2 Momentary false", expResult, result);
+
+    }
+
+    private LocoNetInterfaceScaffold lnis;
+    private SlotManager slotmanager;
+    private LocoNetSystemConnectionMemo memo = null;
+
+    @BeforeEach
+    @Override
+    public void setUp() throws Exception {
+        JUnitUtil.setUp();
+        // prepare an interface
+        maxFns = 69;
+
+        lnis = new LocoNetInterfaceScaffold();
+        slotmanager = new SlotManager(lnis);
+        slotmanager.setLoconetProtocolAutoDetect(true);
+
+        // set slot 3 to address 3
+        LocoNetMessage m = new LocoNetMessage(21);
+        m.setOpCode(LnConstants.OPC_EXP_WR_SL_DATA);
+        m.setElement(1, 0x15);
+        m.setElement(3, 0x03);
+        m.setElement(4, 0x00);
+        m.setElement(7, 0x47);
+        slotmanager.slot(3).setSlot(m);
+
+        memo = new LocoNetSystemConnectionMemo(lnis, slotmanager);
+        memo.setThrottleManager(new LnThrottleManager(memo));
+        memo.store(slotmanager,CommandStation.class);
+
+        jmri.InstanceManager.setDefault(jmri.ThrottleManager.class, memo.getThrottleManager());
+        // use slot 3
+        instance = new LocoNetThrottle(memo, slotmanager.slot(3)); // creates throttle in exp mode
+
+    }
+
+    @AfterEach
+    @Override
+    public void tearDown() {
+        memo.getThrottleManager().dispose();
+        memo.dispose();
+        memo = null;
+        lnis = null;
+        JUnitUtil.tearDown();
+    }
+
+}

--- a/java/test/jmri/jmrix/loconet/LocoNetInterfaceScaffold.java
+++ b/java/test/jmri/jmrix/loconet/LocoNetInterfaceScaffold.java
@@ -81,6 +81,16 @@ public class LocoNetInterfaceScaffold extends LnTrafficController {
         return listeners;
     }
 
+    /**
+     * Resets the outbound message log.
+     * {@inheritDoc }
+     */
+    @Override
+    public void resetStatistics() {
+        outbound.clear();
+        super.resetStatistics();
+    }
+
     private final static Logger log = LoggerFactory.getLogger(LocoNetInterfaceScaffold.class);
 
 }

--- a/java/test/jmri/jmrix/loconet/duplexgroup/swing/LnDplxGrpInfoImplTest.java
+++ b/java/test/jmri/jmrix/loconet/duplexgroup/swing/LnDplxGrpInfoImplTest.java
@@ -45,7 +45,7 @@ public class LnDplxGrpInfoImplTest {
                 dpxGrpInfoImpl.getFetchedDuplexGroupId());
 
         lnis.notify(new LocoNetMessage(new int[] {0x81, 0x00}));
-        jmri.util.JUnitUtil.fasterWaitFor(()->{
+        JUnitUtil.fasterWaitFor(()->{
             return dpxGrpInfoImpl.getMessagesHandled() >= 1;},
                 "LocoNetListener is registered");
         Assert.assertFalse("IPL Query timer is not running", dpxGrpInfoImpl.isIplQueryTimerRunning());
@@ -1189,7 +1189,7 @@ public class LnDplxGrpInfoImplTest {
         m.setElement(15, m.getElement(15)^1);
 
         dpxGrpInfoImpl.message(m);  // transmit the reply
-        jmri.util.JUnitUtil.fasterWaitFor(()->{return propChangeFlag == true;},"message received");
+        JUnitUtil.fasterWaitFor(()->{return propChangeFlag == true;},"message received");
         Assert.assertEquals("Expected exactly 3 prop change event", 3, propChangeCount);
 
         propChangeCount = 0;
@@ -1588,7 +1588,7 @@ public class LnDplxGrpInfoImplTest {
 
         dpxGrpInfoImpl.message(lnis.outbound.elementAt(1));  // return the LocoNet echo to the class
         Assert.assertEquals("expect propChangeCount of 1", 1, propChangeCount);
-        jmri.util.JUnitUtil.waitFor(()->{return dpxGrpInfoImpl.getNumUr92s() > 0;}, "UR92 IPL reply not received");
+        JUnitUtil.waitFor(()->{return dpxGrpInfoImpl.getNumUr92s() > 0;}, "UR92 IPL reply not received");
         Assert.assertEquals("got 1 UR92 IPL report", 1, dpxGrpInfoImpl.getNumUr92s());
 
         Assert.assertFalse("LDGII is no longer waiting for second UR92 IPL report (3)", dpxGrpInfoImpl.isWaitingForFirstUr92IPLReport());
@@ -1616,39 +1616,42 @@ public class LnDplxGrpInfoImplTest {
         Assert.assertEquals("got the UR92 reply info", 1,  dpxGrpInfoImpl.getNumUr92s() );
 
         lnis.sendTestMessage(m);
-        JUnitUtil.fasterWaitFor(()->{return dpxGrpInfoImpl.getNumUr92s() == 2;}); // 2022 June - does not get to 2
+        // JUnitUtil.fasterWaitFor(()->{return dpxGrpInfoImpl.getNumUr92s() == 2;},
+        //    "2022 June - does not get to 2, was " + dpxGrpInfoImpl.getNumUr92s());
+
+        JUnitUtil.waitFor( () -> propChangeCount > 26, "wait for 27");
         Assert.assertEquals("expect propChangeCount of 27", 27, propChangeCount);
 
         lnis.sendTestMessage(m);
-        JUnitUtil.fasterWaitFor(()->{return dpxGrpInfoImpl.getNumUr92s() == 3;});
+        // JUnitUtil.fasterWaitFor(()->{return dpxGrpInfoImpl.getNumUr92s() == 3;}, "Does not get to 3");
 
         m = LnDplxGrpInfoImpl.createUr92GroupNameReportPacket("Dcgitrax", "1234", 12, 65);
         lnis.sendTestMessage(m);
-        JUnitUtil.fasterWaitFor(()->{return dpxGrpInfoImpl.getNumUr92s() == 4;});
+        // JUnitUtil.fasterWaitFor(()->{return dpxGrpInfoImpl.getNumUr92s() == 4;}, "Does not get to 4");
         Assert.assertEquals("expect propChangeCount of 32", 32, propChangeCount);
 
         m = LnDplxGrpInfoImpl.createUr92GroupNameReportPacket("Digitrax", "1034", 12, 65);
 
         lnis.sendTestMessage(m);
-        JUnitUtil.fasterWaitFor(()->{return dpxGrpInfoImpl.getNumUr92s() == 5;});
+        // JUnitUtil.fasterWaitFor(()->{return dpxGrpInfoImpl.getNumUr92s() == 5;}, "Does not get to 5");
         Assert.assertEquals("expect propChangeCount of 35", 35, propChangeCount);
 
         m = LnDplxGrpInfoImpl.createUr92GroupNameReportPacket("Digitrax", "1234", 13, 65);
 
         lnis.sendTestMessage(m);
-        JUnitUtil.fasterWaitFor(()->{return dpxGrpInfoImpl.getNumUr92s() == 6;});
+        // JUnitUtil.fasterWaitFor(()->{return dpxGrpInfoImpl.getNumUr92s() == 6;}, "Does not get  to 6");
         Assert.assertEquals("expect propChangeCount of 38", 38, propChangeCount);
 
         m = LnDplxGrpInfoImpl.createUr92GroupNameReportPacket("Digitrax", "1234", 12, 7);
 
         lnis.sendTestMessage(m);
-        JUnitUtil.fasterWaitFor(()->{return dpxGrpInfoImpl.getNumUr92s() == 7;});
+        // JUnitUtil.fasterWaitFor(()->{return dpxGrpInfoImpl.getNumUr92s() == 7;}, "Does not get to 7");
         Assert.assertEquals("expect propChangeCount of 41", 41, propChangeCount);
 
         m = LnDplxGrpInfoImpl.createUr92GroupNameReportPacket("Digitrax", "1234", 12, 65);
 
         lnis.sendTestMessage(m);
-        JUnitUtil.fasterWaitFor(()->{return dpxGrpInfoImpl.getNumUr92s() == 8;});
+        // JUnitUtil.fasterWaitFor(()->{return dpxGrpInfoImpl.getNumUr92s() == 8;}, "Does not get to 8");
 
         Assert.assertEquals("expect propChangeCount of 43", 43, propChangeCount);
 

--- a/java/test/jmri/jmrix/loconet/duplexgroup/swing/LnIPLImplementationTest.java
+++ b/java/test/jmri/jmrix/loconet/duplexgroup/swing/LnIPLImplementationTest.java
@@ -3,10 +3,10 @@ package jmri.jmrix.loconet.duplexgroup.swing;
 import jmri.jmrix.loconet.LocoNetInterfaceScaffold;
 import jmri.jmrix.loconet.LocoNetMessage;
 import jmri.util.JUnitUtil;
+import jmri.util.junit.annotations.ToDo;
 
 import org.junit.Assert;
 import org.junit.jupiter.api.*;
-import org.junit.Assume;
 
 /**
  * Test simple functioning of LnIPLImplementation
@@ -1566,6 +1566,7 @@ public class LnIPLImplementationTest {
     }
 
     @Test
+    @ToDo("Further test development for 3rd and 4th property changes")
     public void testConnectMethod() {
         java.beans.PropertyChangeListener l = (java.beans.PropertyChangeEvent e) -> {
             if ((e.getPropertyName().equals("IplDeviceTypeQuery"))) {
@@ -1587,7 +1588,7 @@ public class LnIPLImplementationTest {
         m2 = new LocoNetMessage(v2);
         Assert.assertFalse("did not see property change flag yet", propChangeFlag);
         iplImplementation.message(m2);
-        jmri.util.JUnitUtil.fasterWaitFor(()->{return propChangeFlag == true;},"message received");
+        JUnitUtil.fasterWaitFor(()->{return propChangeFlag == true;},"message received");
         Assert.assertTrue("saw first property change IPL Report", propChangeReportFlag);
         Assert.assertFalse("didn't see first property change IPL Query", propChangeQueryFlag);
         propChangeFlag = false;
@@ -1598,7 +1599,7 @@ public class LnIPLImplementationTest {
         m2 = new LocoNetMessage(v2);
         Assert.assertFalse("did not see property change flag yet", propChangeFlag);
         iplImplementation.message(m2);
-        jmri.util.JUnitUtil.fasterWaitFor(()->{return propChangeFlag == true;},"message received");
+        JUnitUtil.fasterWaitFor(()->{return propChangeFlag == true;},"message received");
         Assert.assertFalse("didn't see second property change IPL Report", propChangeReportFlag);
         Assert.assertTrue("saw second property change IPL Query", propChangeQueryFlag);
         propChangeFlag = false;
@@ -1610,34 +1611,35 @@ public class LnIPLImplementationTest {
         Assert.assertFalse("did not see property change flag yet", propChangeFlag);
         iplImplementation.message(m2);
 
-        Assume.assumeTrue("reply not received",
-                jmri.util.JUnitUtil.fasterWaitFor(()->{return propChangeFlag == true;}));
-        Assert.assertFalse("didn't see third property change IPL Report", propChangeReportFlag);
-        Assert.assertFalse("didn't see third property change IPL Query", propChangeQueryFlag);
-        propChangeFlag = false;
-        propChangeReportFlag = false;
-        propChangeQueryFlag = false;
+        // below failing in 5.13.4+
 
-        m = new LocoNetMessage(2);
-        m.setElement(0, 0x81); m.setElement(1, 0);
-        iplImplementation.message(m);
-        Assume.assumeTrue("reply2 not received",
-                jmri.util.JUnitUtil.fasterWaitFor(()->{return propChangeFlag == true;}));
-        Assert.assertFalse("didn't see fourth property change IPL Report", propChangeReportFlag);
-        Assert.assertFalse("didn't see fourth property change IPL Query", propChangeQueryFlag);
-        propChangeFlag = false;
-        propChangeReportFlag = false;
-        propChangeQueryFlag = false;
-        Assert.assertNull("extracting slave device from GPON message", LnIPLImplementation.extractInterpretedIplSlaveDevice(m));
+        // JUnitUtil.waitFor(()->{return propChangeFlag == true;}, "reply not received");
+        // Assert.assertFalse("didn't see third property change IPL Report", propChangeReportFlag);
+        // Assert.assertFalse("didn't see third property change IPL Query", propChangeQueryFlag);
+        // propChangeFlag = false;
+        // propChangeReportFlag = false;
+        // propChangeQueryFlag = false;
+
+        // m = new LocoNetMessage(2);
+        // m.setElement(0, 0x81); m.setElement(1, 0);
+        // iplImplementation.message(m);
+        // JUnitUtil.fasterWaitFor(()->{return propChangeFlag == true;}, "reply2 not received");
+        // Assert.assertFalse("didn't see fourth property change IPL Report", propChangeReportFlag);
+        // Assert.assertFalse("didn't see fourth property change IPL Query", propChangeQueryFlag);
+        // propChangeFlag = false;
+        // propChangeReportFlag = false;
+        // propChangeQueryFlag = false;
+        // Assert.assertNull("extracting slave device from GPON message", LnIPLImplementation.extractInterpretedIplSlaveDevice(m));
 
         iplImplementation.removePropertyChangeListener(l);
     }
 
-    boolean propChangeQueryFlag;
-    boolean propChangeReportFlag;
-    boolean propChangeFlag;
+    private boolean propChangeQueryFlag;
+    private boolean propChangeReportFlag;
+    private boolean propChangeFlag;
 
     @Test
+    @Disabled("First waitFor fails in 5.13.4+")
     public void checkDispose() {
         propChangeFlag = false;
         Assert.assertFalse("did not see property change flag yet", propChangeFlag);
@@ -1647,16 +1649,14 @@ public class LnIPLImplementationTest {
                 1,0,0,0,0,
                 0,0,0,0,0});
         memo.getLnTrafficController().notify(m);
-        Assume.assumeTrue("reply received",
-                jmri.util.JUnitUtil.fasterWaitFor(()->{return propChangeFlag == true;}));
+        JUnitUtil.fasterWaitFor(()->{return propChangeFlag == true;}, "reply received");
         Assert.assertTrue("saw property change flag yet", propChangeFlag);
         propChangeFlag = false;
         Assert.assertTrue("isIplQueryTimerRunning is true", iplImplementation.isIplQueryTimerRunning());
         iplImplementation.dispose();
         Assert.assertFalse("did not see property change flag yet", propChangeFlag);
         memo.getLnTrafficController().notify(m);
-        Assume.assumeTrue("reply not received",
-                jmri.util.JUnitUtil.fasterWaitFor(()->{return propChangeFlag == true;}));
+        JUnitUtil.fasterWaitFor(()->{return propChangeFlag == true;}, "reply not received");
         Assert.assertFalse("did not seee property change flag after dispose", propChangeFlag);
         Assert.assertFalse("isIplQueryTimerRunning is false", iplImplementation.isIplQueryTimerRunning());
         iplImplementation = new LnIPLImplementation(memo);


### PR DESCRIPTION
**LocoNetInterfaceScaffold**
On call to resetStatistics, also clear the outbound log.

**LocoNetExpThrottleTest**
Indentation.
Remove calls to clear the outbound log, covered by resetStatistics.
Adds JUnitUtil waitFor failure text

**LnDplxGrpInfoImplTest**
Comment out failing JUnitUtil waitFors with unchecked return values.

**LnIPLImplementationTest**
False assumption currently fails halfway through test as reply not received.
Code commented following removing the assumption.

**LnDeferProgrammerTest**
Use existing lnis and slotManager to save creating 2 instances.

**LnSensorTest**
Adds Test / NotApplicable
Use scaffold for logging / outbound

**LnTurnoutManagerTest**
Adds failure message for JUnitUtil waitFor

Asserts JU4 > JU5