### PR TITLE
Allow CAN-based connections to be specified at startup

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -101,7 +101,9 @@
 
         <h4>MERG</h4>
             <ul>
-                <li></li>
+                <li>If you have multiple CAN-based connections defined
+                    (MERG, LCC, OpenLCB),
+                    you can now specify which one for a start-up action to use.</li>
             </ul>
 
         <h4>MQTT</h4>
@@ -126,7 +128,9 @@
 
         <h4><a href="http://openlcb.org">OpenLCB</a> / LCC</h4>
             <ul>
-                <li></li>
+                <li>If you have multiple CAN-based connections defined
+                    (LCC, OpenLCB, MERG),
+                    you can now specify which one for a start-up action to use.</li>
             </ul>
 
         <h4>Powerline</h4>

--- a/java/src/jmri/jmrix/can/swing/CanNamedPaneAction.java
+++ b/java/src/jmri/jmrix/can/swing/CanNamedPaneAction.java
@@ -1,8 +1,14 @@
 package jmri.jmrix.can.swing;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
 import javax.swing.Icon;
+import jmri.SystemConnectionMemo;
 import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.util.swing.JmriPanel;
+import jmri.jmrix.swing.SystemConnectionAction;
 import jmri.util.swing.WindowInterface;
 
 /**
@@ -10,7 +16,8 @@ import jmri.util.swing.WindowInterface;
  *
  * @author Bob Jacobsen Copyright (C) 2012
  */
-public class CanNamedPaneAction extends jmri.util.swing.JmriNamedPaneAction {
+public class CanNamedPaneAction extends jmri.util.swing.JmriNamedPaneAction 
+    implements SystemConnectionAction<CanSystemConnectionMemo> {
 
     /**
      * Enhanced constructor for placing the pane in various GUIs.
@@ -58,6 +65,25 @@ public class CanNamedPaneAction extends jmri.util.swing.JmriNamedPaneAction {
         }
 
         return p;
+    }
+
+    @Override
+    public CanSystemConnectionMemo getSystemConnectionMemo() {
+        return this.memo;
+    }
+
+    @Override
+    public void setSystemConnectionMemo(CanSystemConnectionMemo memo) throws IllegalArgumentException {
+        if (CanSystemConnectionMemo.class.isAssignableFrom(memo.getClass())) {
+            this.memo = memo;
+        } else {
+            throw new IllegalArgumentException();
+        }
+    }
+
+    @Override
+    public Set<Class<? extends SystemConnectionMemo>> getSystemConnectionMemoClasses() {
+        return new HashSet<>(Arrays.asList(CanSystemConnectionMemo.class));
     }
 
     private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(CanNamedPaneAction.class);


### PR DESCRIPTION
Allows users with multiple CAN-based connections (MERG, OpenLCB, LCC) to specify the connection a start-up action should use.

This resolves (closes) Issue #14069 and replaces (closes) PR #14071