### PR TITLE
New PR workflow

### DIFF
--- a/.github/workflows/new-pr.yml
+++ b/.github/workflows/new-pr.yml
@@ -5,7 +5,7 @@ permissions:
   pull-requests: write
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened, labeled, unlabeled, synchronize]
 
 jobs:


### PR DESCRIPTION
Adds a workflow which runs when a PR is updated.
If the PR is < 24hrs, makes sure the "New PR" label is added.
If the label is present, blocks merging.

Seemed OK in another repo, will need a bit of testing to ensure reliable.