### PR TITLE
LocoNetExpThrottle Test asserts to JUnit5

### DIFF
--- a/java/test/jmri/jmrix/loconet/LocoNetExpThrottleTest.java
+++ b/java/test/jmri/jmrix/loconet/LocoNetExpThrottleTest.java
@@ -1,17 +1,20 @@
 package jmri.jmrix.loconet;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import jmri.CommandStation;
 import jmri.util.JUnitUtil;
 import jmri.SpeedStepMode;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.*;
 
 public class LocoNetExpThrottleTest extends jmri.jmrix.AbstractThrottleTest {
 
     @Test
     public void testCTor() {
-        Assert.assertNotNull(instance);
+        assertNotNull(instance);
     }
 
     // test the speed setting code.
@@ -31,10 +34,10 @@ public class LocoNetExpThrottleTest extends jmri.jmrix.AbstractThrottleTest {
             }
         };
         LocoNetThrottle t1 = new LocoNetThrottle(memo, s1);
-        Assert.assertEquals(0.0f, t1.getSpeedSetting(), 0.0);
+        assertEquals(0.0f, t1.getSpeedSetting(), 0.0);
         t1.setSpeedSetting(0.5f);
         // the speed change SHOULD be changed.
-        Assert.assertEquals(0.5f, t1.getSpeedSetting(), 0.0);
+        assertEquals(0.5f, t1.getSpeedSetting(), 0.0);
 
         // Case 2: The locomotive is a consist top.
         LocoNetSlot s2 = new LocoNetSlot(1) {
@@ -49,10 +52,10 @@ public class LocoNetExpThrottleTest extends jmri.jmrix.AbstractThrottleTest {
             }
         };
         LocoNetThrottle t2 = new LocoNetThrottle(memo, s2);
-        Assert.assertEquals(0.0f, t2.getSpeedSetting(), 0.0);
+        assertEquals(0.0f, t2.getSpeedSetting(), 0.0);
         t2.setSpeedSetting(0.5f);
         // the speed change SHOULD be changed.
-        Assert.assertEquals(0.5f, t2.getSpeedSetting(), 0.0);
+        assertEquals(0.5f, t2.getSpeedSetting(), 0.0);
 
         // Case 3: The locomotive is a consist mid.
         LocoNetSlot s3 = new LocoNetSlot(2) {
@@ -67,10 +70,10 @@ public class LocoNetExpThrottleTest extends jmri.jmrix.AbstractThrottleTest {
             }
         };
         LocoNetThrottle t3 = new LocoNetThrottle(memo, s3);
-        Assert.assertEquals(0.0f, t3.getSpeedSetting(), 0.0);
+        assertEquals(0.0f, t3.getSpeedSetting(), 0.0);
         t3.setSpeedSetting(0.5f);
         // the speed change SHOULD NOT be changed.
-        Assert.assertEquals(0.0f, t3.getSpeedSetting(), 0.0);
+        assertEquals(0.0f, t3.getSpeedSetting(), 0.0);
 
         // Case 3: The locomotive is a consist mid.
         // make sure the speed does NOT change for a consist sub
@@ -86,10 +89,10 @@ public class LocoNetExpThrottleTest extends jmri.jmrix.AbstractThrottleTest {
             }
         };
         LocoNetThrottle t4 = new LocoNetThrottle(memo, s4);
-        Assert.assertEquals(0.0f, t4.getSpeedSetting(), 0.0);
+        assertEquals(0.0f, t4.getSpeedSetting(), 0.0);
         t4.setSpeedSetting(0.5f);
         // the speed change SHOULD be ignored.
-        Assert.assertEquals(0.0f, t4.getSpeedSetting(), 0.0);
+        assertEquals(0.0f, t4.getSpeedSetting(), 0.0);
     }
 
     /**
@@ -100,7 +103,7 @@ public class LocoNetExpThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     public void testGetIsForward() {
         boolean expResult = true;
         boolean result = instance.getIsForward();
-        Assert.assertEquals(expResult, result);
+        assertEquals(expResult, result);
     }
 
     /**
@@ -111,7 +114,7 @@ public class LocoNetExpThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     public void testGetSpeedStepMode() {
         SpeedStepMode expResult = SpeedStepMode.NMRA_DCC_28;
         SpeedStepMode result = instance.getSpeedStepMode();
-        Assert.assertEquals(expResult, result);
+        assertEquals(expResult, result);
     }
 
     /**
@@ -122,7 +125,7 @@ public class LocoNetExpThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     public void testGetSpeedIncrement() {
         float expResult = 1.0F/28.0F;
         float result = instance.getSpeedIncrement();
-        Assert.assertEquals(expResult, result, 0.0);
+        assertEquals(expResult, result, 0.0);
     }
 
     /**
@@ -146,18 +149,24 @@ public class LocoNetExpThrottleTest extends jmri.jmrix.AbstractThrottleTest {
         lnis.resetStatistics(); // and clears outbound message log
         boolean f0 = false;
         instance.setFunction(0,f0);
-        Assert.assertEquals(f0, instance.getFunction(0));
-        Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
-        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
-        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F0F6, lnis.outbound.get(0).getElement(1) & 0x78);
-        Assert.assertEquals("sent f0 in correct state", 0, lnis.outbound.get(0).getElement(4) & LnConstants.DIRF_F0);
+        assertEquals(f0, instance.getFunction(0));
+        assertEquals( 1, lnis.outbound.size(), "number of messages is 1");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR,
+            lnis.outbound.get(0).getOpCode(), "opcode is OPC_EXP");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F0F6,
+            lnis.outbound.get(0).getElement(1) & 0x78, "opcode is OPC_EXP2");
+        assertEquals( 0, lnis.outbound.get(0).getElement(4) & LnConstants.DIRF_F0,
+            "sent f0 in correct state");
         f0 = true;
         instance.setFunction(0,f0);
-        Assert.assertEquals(f0, instance.getFunction(0));
-        Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
-        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
-        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F0F6, lnis.outbound.get(1).getElement(1) & 0x78);
-        Assert.assertEquals("sent f0 in correct state", LnConstants.DIRF_F0, lnis.outbound.get(1).getElement(4) & LnConstants.DIRF_F0);
+        assertEquals(f0, instance.getFunction(0));
+        assertEquals( 2, lnis.outbound.size(), "number of messages is 2");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR,
+            lnis.outbound.get(1).getOpCode(), "opcode is OPC_EXP");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F0F6,
+            lnis.outbound.get(1).getElement(1) & 0x78, "opcode is OPC_EXP2");
+        assertEquals( LnConstants.DIRF_F0, lnis.outbound.get(1).getElement(4) & LnConstants.DIRF_F0,
+            "sent f0 in correct state");
     }
 
     /**
@@ -170,18 +179,24 @@ public class LocoNetExpThrottleTest extends jmri.jmrix.AbstractThrottleTest {
         lnis.resetStatistics(); // and clears outbound message log
         boolean f1 = false;
         instance.setFunction(1,f1);
-        Assert.assertEquals(f1, instance.getFunction(1));
-        Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
-        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
-        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F0F6, lnis.outbound.get(0).getElement(1) & 0x78);
-        Assert.assertEquals("sent f0 in correct state", 0, lnis.outbound.get(0).getElement(4) & LnConstants.DIRF_F1);
+        assertEquals(f1, instance.getFunction(1));
+        assertEquals( 1, lnis.outbound.size(), "number of messages is 1");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR,
+            lnis.outbound.get(0).getOpCode(), "opcode is OPC_EXP");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F0F6,
+            lnis.outbound.get(0).getElement(1) & 0x78, "opcode is OPC_EXP2");
+        assertEquals( 0, lnis.outbound.get(0).getElement(4) & LnConstants.DIRF_F1,
+            "sent f0 in correct state");
         f1 = true;
         instance.setFunction(1,f1);
-        Assert.assertEquals(f1, instance.getFunction(1));
-        Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
-        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
-        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F0F6, lnis.outbound.get(1).getElement(1) & 0x78);
-        Assert.assertEquals("sent f1 in correct state", LnConstants.DIRF_F1, lnis.outbound.get(1).getElement(4) & LnConstants.DIRF_F1);
+        assertEquals(f1, instance.getFunction(1));
+        assertEquals( 2, lnis.outbound.size(), "number of messages is 2");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR,
+            lnis.outbound.get(1).getOpCode(), "opcode is OPC_EXP");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F0F6,
+            lnis.outbound.get(1).getElement(1) & 0x78, "opcode is OPC_EXP2");
+        assertEquals( LnConstants.DIRF_F1,
+            lnis.outbound.get(1).getElement(4) & LnConstants.DIRF_F1, "sent f1 in correct state");
     }
 
     /**
@@ -194,18 +209,24 @@ public class LocoNetExpThrottleTest extends jmri.jmrix.AbstractThrottleTest {
         lnis.resetStatistics(); // and clears outbound message log
         boolean f2 = false;
         instance.setFunction(2,f2);
-        Assert.assertEquals(f2, instance.getFunction(2));
-        Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
-        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
-        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F0F6, lnis.outbound.get(0).getElement(1) & 0x78);
-        Assert.assertEquals("sent f2 in correct state", 0, lnis.outbound.get(0).getElement(4) & LnConstants.DIRF_F2);
+        assertEquals(f2, instance.getFunction(2));
+        assertEquals( 1, lnis.outbound.size(), "number of messages is 1");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR,
+            lnis.outbound.get(0).getOpCode(), "opcode is OPC_EXP");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F0F6,
+            lnis.outbound.get(0).getElement(1) & 0x78, "opcode is OPC_EXP2");
+        assertEquals( 0, lnis.outbound.get(0).getElement(4) & LnConstants.DIRF_F2,
+            "sent f2 in correct state");
         f2 = true;
         instance.setFunction(2,f2);
-        Assert.assertEquals(f2, instance.getFunction(2));
-        Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
-        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
-        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F0F6, lnis.outbound.get(1).getElement(1) & 0x78);
-        Assert.assertEquals("sent f2 in correct state", LnConstants.DIRF_F2, lnis.outbound.get(1).getElement(4) & LnConstants.DIRF_F2);
+        assertEquals(f2, instance.getFunction(2));
+        assertEquals( 2, lnis.outbound.size(), "number of messages is 2");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR,
+            lnis.outbound.get(1).getOpCode(), "opcode is OPC_EXP");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F0F6, 
+            lnis.outbound.get(1).getElement(1) & 0x78, "opcode is OPC_EXP2");
+        assertEquals( LnConstants.DIRF_F2,
+            lnis.outbound.get(1).getElement(4) & LnConstants.DIRF_F2, "sent f2 in correct state");
     }
 
     /**
@@ -218,18 +239,24 @@ public class LocoNetExpThrottleTest extends jmri.jmrix.AbstractThrottleTest {
         lnis.resetStatistics(); // and clears outbound message log
         boolean f3 = false;
         instance.setFunction(3,f3);
-        Assert.assertEquals(f3, instance.getFunction(3));
-        Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
-        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
-        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F0F6, lnis.outbound.get(0).getElement(1) & 0x78);
-        Assert.assertEquals("sent f3 in correct state", 0, lnis.outbound.get(0).getElement(4) & LnConstants.DIRF_F3);
+        assertEquals(f3, instance.getFunction(3));
+        assertEquals( 1, lnis.outbound.size(), "number of messages is 1");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR,
+            lnis.outbound.get(0).getOpCode(), "opcode is OPC_EXP");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F0F6,
+            lnis.outbound.get(0).getElement(1) & 0x78, "opcode is OPC_EXP2");
+        assertEquals( 0, lnis.outbound.get(0).getElement(4) & LnConstants.DIRF_F3,
+            "sent f3 in correct state");
         f3 = true;
         instance.setFunction(3,f3);
-        Assert.assertEquals(f3, instance.getFunction(3));
-        Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
-        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
-        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F0F6, lnis.outbound.get(1).getElement(1) & 0x78);
-        Assert.assertEquals("sent f3 in correct state", LnConstants.DIRF_F3, lnis.outbound.get(1).getElement(4) & LnConstants.DIRF_F3);
+        assertEquals(f3, instance.getFunction(3));
+        assertEquals( 2, lnis.outbound.size(), "number of messages is 2");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR,
+            lnis.outbound.get(1).getOpCode(), "opcode is OPC_EXP");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F0F6,
+            lnis.outbound.get(1).getElement(1) & 0x78, "opcode is OPC_EXP2");
+        assertEquals( LnConstants.DIRF_F3,
+            lnis.outbound.get(1).getElement(4) & LnConstants.DIRF_F3, "sent f3 in correct state");
     }
 
     /**
@@ -242,18 +269,24 @@ public class LocoNetExpThrottleTest extends jmri.jmrix.AbstractThrottleTest {
         lnis.resetStatistics(); // and clears outbound message log
         boolean f4 = false;
         instance.setFunction(4,f4);
-        Assert.assertEquals(f4, instance.getFunction(4));
-        Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
-        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
-        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F0F6, lnis.outbound.get(0).getElement(1) & 0x78);
-        Assert.assertEquals("sent f4 in correct state", 0, lnis.outbound.get(0).getElement(4) & LnConstants.DIRF_F4);
+        assertEquals(f4, instance.getFunction(4));
+        assertEquals( 1, lnis.outbound.size(), "number of messages is 1");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR,
+            lnis.outbound.get(0).getOpCode(), "opcode is OPC_EXP");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F0F6,
+            lnis.outbound.get(0).getElement(1) & 0x78, "opcode is OPC_EXP2");
+        assertEquals( 0, lnis.outbound.get(0).getElement(4) & LnConstants.DIRF_F4,
+            "sent f4 in correct state");
         f4 = true;
         instance.setFunction(4,f4);
-        Assert.assertEquals(f4, instance.getFunction(4));
-        Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
-        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
-        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F0F6, lnis.outbound.get(1).getElement(1) & 0x78);
-        Assert.assertEquals("sent f4 in correct state", LnConstants.DIRF_F4, lnis.outbound.get(1).getElement(4) & LnConstants.DIRF_F4);
+        assertEquals(f4, instance.getFunction(4));
+        assertEquals( 2, lnis.outbound.size(), "number of messages is 2");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR,
+            lnis.outbound.get(1).getOpCode(), "opcode is OPC_EXP");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F0F6,
+            lnis.outbound.get(1).getElement(1) & 0x78, "opcode is OPC_EXP2");
+        assertEquals( LnConstants.DIRF_F4,
+            lnis.outbound.get(1).getElement(4) & LnConstants.DIRF_F4, "sent f4 in correct state");
     }
 
     /**
@@ -266,18 +299,24 @@ public class LocoNetExpThrottleTest extends jmri.jmrix.AbstractThrottleTest {
         lnis.resetStatistics(); // and clears outbound message log
         boolean f5 = false;
         instance.setFunction(5,f5);
-        Assert.assertEquals(f5, instance.getFunction(5));
-        Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
-        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
-        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F0F6, lnis.outbound.get(0).getElement(1) & 0x78);
-        Assert.assertEquals("sent f5 in correct state", 0, lnis.outbound.get(0).getElement(4) & 0x20);
+        assertEquals(f5, instance.getFunction(5));
+        assertEquals( 1, lnis.outbound.size(), "number of messages is 1");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR,
+            lnis.outbound.get(0).getOpCode(), "opcode is OPC_EXP");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F0F6,
+            lnis.outbound.get(0).getElement(1) & 0x78, "opcode is OPC_EXP2");
+        assertEquals( 0, lnis.outbound.get(0).getElement(4) & 0x20,
+            "sent f5 in correct state");
         f5 = true;
         instance.setFunction(5,f5);
-        Assert.assertEquals(f5, instance.getFunction(5));
-        Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
-        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
-        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F0F6, lnis.outbound.get(1).getElement(1) & 0x78);
-        Assert.assertEquals("sent f5 in correct state", 0x20, lnis.outbound.get(1).getElement(4) & 0x20);
+        assertEquals(f5, instance.getFunction(5));
+        assertEquals( 2, lnis.outbound.size(), "number of messages is 2");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR,
+            lnis.outbound.get(1).getOpCode(), "opcode is OPC_EXP");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F0F6,
+            lnis.outbound.get(1).getElement(1) & 0x78, "opcode is OPC_EXP2");
+        assertEquals( 0x20, lnis.outbound.get(1).getElement(4) & 0x20,
+            "sent f5 in correct state");
     }
 
     /**
@@ -290,19 +329,26 @@ public class LocoNetExpThrottleTest extends jmri.jmrix.AbstractThrottleTest {
         lnis.resetStatistics(); // and clears outbound message log
         boolean f6 = false;
         instance.setFunction(6,f6);
-        Assert.assertEquals(f6, instance.getFunction(6));
-        Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
-        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
-        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F0F6, lnis.outbound.get(0).getElement(1) & 0x78);
-        Assert.assertEquals("sent f6 in correct state", 0, lnis.outbound.get(0).getElement(4) & 0x40);
+        assertEquals(f6, instance.getFunction(6));
+        assertEquals( 1, lnis.outbound.size(), "number of messages is 1");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR,
+            lnis.outbound.get(0).getOpCode(), "opcode is OPC_EXP");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F0F6,
+            lnis.outbound.get(0).getElement(1) & 0x78, "opcode is OPC_EXP2");
+        assertEquals( 0, lnis.outbound.get(0).getElement(4) & 0x40,
+            "sent f6 in correct state");
         f6 = true;
         instance.setFunction(6,f6);
-        Assert.assertEquals(f6, instance.getFunction(6));
-        Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
-        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
-        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F0F6, lnis.outbound.get(1).getElement(1) & 0x78);
-        Assert.assertEquals("sent f6 in correct state", 0x40, lnis.outbound.get(1).getElement(4) & 0x40);
+        assertEquals(f6, instance.getFunction(6));
+        assertEquals( 2, lnis.outbound.size(), "number of messages is 2");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR,
+            lnis.outbound.get(1).getOpCode(), "opcode is OPC_EXP");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F0F6,
+            lnis.outbound.get(1).getElement(1) & 0x78, "opcode is OPC_EXP2");
+        assertEquals( 0x40, lnis.outbound.get(1).getElement(4) & 0x40,
+            "sent f6 in correct state");
     }
+
     /**
      * Test of setF7 method, of class AbstractThrottle.
      */
@@ -313,19 +359,26 @@ public class LocoNetExpThrottleTest extends jmri.jmrix.AbstractThrottleTest {
         lnis.resetStatistics(); // and clears outbound message log
         boolean f7 = false;
         int func = 7;
+        int bit = 0x01;
         instance.setFunction(func,f7);
-        Assert.assertEquals(f7, instance.getFunction(func));
-        Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
-        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
-        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F7F13, lnis.outbound.get(0).getElement(1) & 0x78);
-        Assert.assertEquals("sent " + func + " in correct state", 0, lnis.outbound.get(0).getElement(4) & 0x01);
+        assertEquals(f7, instance.getFunction(func));
+        assertEquals( 1, lnis.outbound.size(), "number of messages is 1");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR,
+            lnis.outbound.get(0).getOpCode(), "opcode is OPC_EXP");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F7F13,
+            lnis.outbound.get(0).getElement(1) & 0x78, "opcode is OPC_EXP2");
+        assertEquals( 0, lnis.outbound.get(0).getElement(4) & bit,
+            () -> "sent " + func + " in correct state");
         f7 = true;
         instance.setFunction(func,f7);
-        Assert.assertEquals(f7, instance.getFunction(func));
-        Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
-        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
-        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F7F13, lnis.outbound.get(1).getElement(1) & 0x78);
-        Assert.assertEquals("sent " + func + " in correct state", 0x01, lnis.outbound.get(1).getElement(4) & 0x01);
+        assertEquals(f7, instance.getFunction(func));
+        assertEquals( 2, lnis.outbound.size(), "number of messages is 2");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR,
+            lnis.outbound.get(1).getOpCode(), "opcode is OPC_EXP");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F7F13,
+            lnis.outbound.get(1).getElement(1) & 0x78, "opcode is OPC_EXP2");
+        assertEquals( bit, lnis.outbound.get(1).getElement(4) & bit,
+            () -> "sent " + func + " in correct state");
     }
 
     /**
@@ -340,18 +393,24 @@ public class LocoNetExpThrottleTest extends jmri.jmrix.AbstractThrottleTest {
         int func = 8;
         int bit = 0x02;
         instance.setFunction(func,f8);
-        Assert.assertEquals(f8, instance.getFunction(func));
-        Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
-        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
-        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F7F13, lnis.outbound.get(0).getElement(1) & 0x78);
-        Assert.assertEquals("sent " + func + " in correct state", 0, lnis.outbound.get(0).getElement(4) & bit);
+        assertEquals(f8, instance.getFunction(func));
+        assertEquals( 1, lnis.outbound.size(), "number of messages is 1");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR,
+            lnis.outbound.get(0).getOpCode(), "opcode is OPC_EXP");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F7F13,
+            lnis.outbound.get(0).getElement(1) & 0x78, "opcode is OPC_EXP2");
+        assertEquals( 0, lnis.outbound.get(0).getElement(4) & bit,
+            () -> "sent " + func + " in correct state");
         f8 = true;
         instance.setFunction(func,f8);
-        Assert.assertEquals(f8, instance.getFunction(func));
-        Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
-        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
-        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F7F13, lnis.outbound.get(1).getElement(1) & 0x78);
-        Assert.assertEquals("sent " + func + " in correct state", bit, lnis.outbound.get(1).getElement(4) & bit);
+        assertEquals(f8, instance.getFunction(func));
+        assertEquals( 2, lnis.outbound.size(), "number of messages is 2");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR,
+            lnis.outbound.get(1).getOpCode(), "opcode is OPC_EXP");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F7F13,
+            lnis.outbound.get(1).getElement(1) & 0x78, "opcode is OPC_EXP2");
+        assertEquals( bit, lnis.outbound.get(1).getElement(4) & bit,
+            () -> "sent " + func + " in correct state");
     }
 
     /**
@@ -366,18 +425,24 @@ public class LocoNetExpThrottleTest extends jmri.jmrix.AbstractThrottleTest {
         int func = 9;
         int bit = 0x04;
         instance.setFunction(func,f9);
-        Assert.assertEquals(f9, instance.getFunction(func));
-        Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
-        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
-        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F7F13, lnis.outbound.get(0).getElement(1) & 0x78);
-        Assert.assertEquals("sent " + func + " in correct state", 0, lnis.outbound.get(0).getElement(4) & bit);
+        assertEquals(f9, instance.getFunction(func));
+        assertEquals( 1, lnis.outbound.size(), "number of messages is 1");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR,
+            lnis.outbound.get(0).getOpCode(), "opcode is OPC_EXP");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F7F13,
+            lnis.outbound.get(0).getElement(1) & 0x78, "opcode is OPC_EXP2");
+        assertEquals( 0, lnis.outbound.get(0).getElement(4) & bit,
+            () -> "sent " + func + " in correct state");
         f9 = true;
         instance.setFunction(func,f9);
-        Assert.assertEquals(f9, instance.getFunction(func));
-        Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
-        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
-        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F7F13, lnis.outbound.get(1).getElement(1) & 0x78);
-        Assert.assertEquals("sent " + func + " in correct state", bit, lnis.outbound.get(1).getElement(4) & bit);
+        assertEquals(f9, instance.getFunction(func));
+        assertEquals( 2, lnis.outbound.size(), "number of messages is 2");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR,
+            lnis.outbound.get(1).getOpCode(), "opcode is OPC_EXP");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F7F13,
+            lnis.outbound.get(1).getElement(1) & 0x78, "opcode is OPC_EXP2");
+        assertEquals( bit, lnis.outbound.get(1).getElement(4) & bit,
+            () -> "sent " + func + " in correct state");
     }
 
     /**
@@ -392,18 +457,24 @@ public class LocoNetExpThrottleTest extends jmri.jmrix.AbstractThrottleTest {
         int func = 10;
         int bit = 0x08;
         instance.setFunction(func,f10);
-        Assert.assertEquals(f10, instance.getFunction(func));
-        Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
-        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
-        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F7F13, lnis.outbound.get(0).getElement(1) & 0x78);
-        Assert.assertEquals("sent " + func + " in correct state", 0, lnis.outbound.get(0).getElement(4) & bit);
+        assertEquals(f10, instance.getFunction(func));
+        assertEquals( 1, lnis.outbound.size(), "number of messages is 1");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR,
+            lnis.outbound.get(0).getOpCode(), "opcode is OPC_EXP");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F7F13,
+            lnis.outbound.get(0).getElement(1) & 0x78, "opcode is OPC_EXP2");
+        assertEquals( 0, lnis.outbound.get(0).getElement(4) & bit,
+            () -> "sent " + func + " in correct state");
         f10 = true;
         instance.setFunction(func,f10);
-        Assert.assertEquals(f10, instance.getFunction(func));
-        Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
-        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
-        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F7F13, lnis.outbound.get(1).getElement(1) & 0x78);
-        Assert.assertEquals("sent " + func + " in correct state", bit, lnis.outbound.get(1).getElement(4) & bit);
+        assertEquals(f10, instance.getFunction(func));
+        assertEquals( 2, lnis.outbound.size(), "number of messages is 2");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR,
+            lnis.outbound.get(1).getOpCode(), "opcode is OPC_EXP");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F7F13,
+            lnis.outbound.get(1).getElement(1) & 0x78, "opcode is OPC_EXP2");
+        assertEquals( bit, lnis.outbound.get(1).getElement(4) & bit,
+            () -> "sent " + func + " in correct state");
     }
 
     /**
@@ -418,18 +489,24 @@ public class LocoNetExpThrottleTest extends jmri.jmrix.AbstractThrottleTest {
         int func = 11;
         int bit = 0x10;
         instance.setFunction(func,f11);
-        Assert.assertEquals(f11, instance.getFunction(func));
-        Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
-        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
-        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F7F13, lnis.outbound.get(0).getElement(1) & 0x78);
-        Assert.assertEquals("sent " + func + " in correct state", 0, lnis.outbound.get(0).getElement(4) & bit);
+        assertEquals(f11, instance.getFunction(func));
+        assertEquals( 1, lnis.outbound.size(), "number of messages is 1");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR,
+            lnis.outbound.get(0).getOpCode(), "opcode is OPC_EXP");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F7F13,
+            lnis.outbound.get(0).getElement(1) & 0x78, "opcode is OPC_EXP2");
+        assertEquals( 0, lnis.outbound.get(0).getElement(4) & bit,
+            () -> "sent " + func + " in correct state");
         f11 = true;
         instance.setFunction(func,f11);
-        Assert.assertEquals(f11, instance.getFunction(func));
-        Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
-        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
-        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F7F13, lnis.outbound.get(1).getElement(1) & 0x78);
-        Assert.assertEquals("sent " + func + " in correct state", bit, lnis.outbound.get(1).getElement(4) & bit);
+        assertEquals(f11, instance.getFunction(func));
+        assertEquals( 2, lnis.outbound.size(), "number of messages is 2");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR,
+            lnis.outbound.get(1).getOpCode(), "opcode is OPC_EXP");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F7F13,
+            lnis.outbound.get(1).getElement(1) & 0x78, "opcode is OPC_EXP2");
+        assertEquals( bit, lnis.outbound.get(1).getElement(4) & bit,
+            () -> "sent " + func + " in correct state");
     }
 
     /**
@@ -444,18 +521,24 @@ public class LocoNetExpThrottleTest extends jmri.jmrix.AbstractThrottleTest {
         int func = 12;
         int bit = 0x20;
         instance.setFunction(func,f12);
-        Assert.assertEquals(f12, instance.getFunction(func));
-        Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
-        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
-        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F7F13, lnis.outbound.get(0).getElement(1) & 0x78);
-        Assert.assertEquals("sent " + func + " in correct state", 0, lnis.outbound.get(0).getElement(4) & bit);
+        assertEquals(f12, instance.getFunction(func));
+        assertEquals( 1, lnis.outbound.size(), "number of messages is 1");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR,
+            lnis.outbound.get(0).getOpCode(), "opcode is OPC_EXP");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F7F13,
+            lnis.outbound.get(0).getElement(1) & 0x78, "opcode is OPC_EXP2");
+        assertEquals( 0, lnis.outbound.get(0).getElement(4) & bit,
+            () -> "sent " + func + " in correct state");
         f12 = true;
         instance.setFunction(func,f12);
-        Assert.assertEquals(f12, instance.getFunction(func));
-        Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
-        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
-        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F7F13, lnis.outbound.get(1).getElement(1) & 0x78);
-        Assert.assertEquals("sent " + func + " in correct state", bit, lnis.outbound.get(1).getElement(4) & bit);
+        assertEquals(f12, instance.getFunction(func));
+        assertEquals( 2, lnis.outbound.size(), "number of messages is 2");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR,
+            lnis.outbound.get(1).getOpCode(), "opcode is OPC_EXP");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F7F13,
+            lnis.outbound.get(1).getElement(1) & 0x78, "opcode is OPC_EXP2");
+        assertEquals( bit, lnis.outbound.get(1).getElement(4) & bit,
+            () -> "sent " + func + " in correct state");
     }
 
     /**
@@ -470,18 +553,24 @@ public class LocoNetExpThrottleTest extends jmri.jmrix.AbstractThrottleTest {
         int func = 13;
         int bit = 0x40;
         instance.setFunction(func,f13);
-        Assert.assertEquals(f13, instance.getFunction(func));
-        Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
-        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
-        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F7F13, lnis.outbound.get(0).getElement(1) & 0x78);
-        Assert.assertEquals("sent " + func + " in correct state", 0, lnis.outbound.get(0).getElement(4) & bit);
+        assertEquals(f13, instance.getFunction(func));
+        assertEquals( 1, lnis.outbound.size(), "number of messages is 1");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR,
+            lnis.outbound.get(0).getOpCode(), "opcode is OPC_EXP");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F7F13,
+            lnis.outbound.get(0).getElement(1) & 0x78, "opcode is OPC_EXP2");
+        assertEquals( 0, lnis.outbound.get(0).getElement(4) & bit,
+            () -> "sent " + func + " in correct state");
         f13 = true;
         instance.setFunction(func,f13);
-        Assert.assertEquals(f13, instance.getFunction(func));
-        Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
-        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
-        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F7F13, lnis.outbound.get(1).getElement(1) & 0x78);
-        Assert.assertEquals("sent " + func + " in correct state", bit, lnis.outbound.get(1).getElement(4) & bit);
+        assertEquals(f13, instance.getFunction(func));
+        assertEquals( 2, lnis.outbound.size(), "number of messages is 2");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR,
+            lnis.outbound.get(1).getOpCode(), "opcode is OPC_EXP");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F7F13,
+            lnis.outbound.get(1).getElement(1) & 0x78, "opcode is OPC_EXP2");
+        assertEquals( bit, lnis.outbound.get(1).getElement(4) & bit,
+            () -> "sent " + func + " in correct state");
     }
 
     /**
@@ -496,18 +585,24 @@ public class LocoNetExpThrottleTest extends jmri.jmrix.AbstractThrottleTest {
         int func = 14;
         int bit = 0x01;
         instance.setFunction(func,f14);
-        Assert.assertEquals(f14, instance.getFunction(func));
-        Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
-        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
-        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F14F20, lnis.outbound.get(0).getElement(1) & 0x78);
-        Assert.assertEquals("sent " + func + " in correct state", 0, lnis.outbound.get(0).getElement(4) & bit);
+        assertEquals(f14, instance.getFunction(func));
+        assertEquals( 1, lnis.outbound.size(), "number of messages is 1");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR,
+            lnis.outbound.get(0).getOpCode(), "opcode is OPC_EXP");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F14F20,
+            lnis.outbound.get(0).getElement(1) & 0x78, "opcode is OPC_EXP2");
+        assertEquals( 0, lnis.outbound.get(0).getElement(4) & bit,
+            () -> "sent " + func + " in correct state");
         f14 = true;
         instance.setFunction(func,f14);
-        Assert.assertEquals(f14, instance.getFunction(func));
-        Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
-        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
-        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F14F20, lnis.outbound.get(1).getElement(1) & 0x78);
-        Assert.assertEquals("sent " + func + " in correct state", bit, lnis.outbound.get(1).getElement(4) & bit);
+        assertEquals(f14, instance.getFunction(func));
+        assertEquals( 2, lnis.outbound.size(), "number of messages is 2");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR,
+            lnis.outbound.get(1).getOpCode(), "opcode is OPC_EXP");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F14F20,
+            lnis.outbound.get(1).getElement(1) & 0x78, "opcode is OPC_EXP2");
+        assertEquals( bit, lnis.outbound.get(1).getElement(4) & bit,
+            () -> "sent " + func + " in correct state");
     }
 
     /**
@@ -522,18 +617,24 @@ public class LocoNetExpThrottleTest extends jmri.jmrix.AbstractThrottleTest {
         int func = 15;
         int bit = 0x02;
         instance.setFunction(func,f15);
-        Assert.assertEquals(f15, instance.getFunction(func));
-        Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
-        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
-        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F14F20, lnis.outbound.get(0).getElement(1) & 0x78);
-        Assert.assertEquals("sent " + func + " in correct state", 0, lnis.outbound.get(0).getElement(4) & bit);
+        assertEquals(f15, instance.getFunction(func));
+        assertEquals( 1, lnis.outbound.size(), "number of messages is 1");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR,
+            lnis.outbound.get(0).getOpCode(), "opcode is OPC_EXP");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F14F20,
+            lnis.outbound.get(0).getElement(1) & 0x78, "opcode is OPC_EXP2");
+        assertEquals( 0, lnis.outbound.get(0).getElement(4) & bit,
+            () -> "sent " + func + " in correct state");
         f15 = true;
         instance.setFunction(func,f15);
-        Assert.assertEquals(f15, instance.getFunction(func));
-        Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
-        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
-        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F14F20, lnis.outbound.get(1).getElement(1) & 0x78);
-        Assert.assertEquals("sent " + func + " in correct state", bit, lnis.outbound.get(1).getElement(4) & bit);
+        assertEquals(f15, instance.getFunction(func));
+        assertEquals( 2, lnis.outbound.size(), "number of messages is 2");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR,
+            lnis.outbound.get(1).getOpCode(), "opcode is OPC_EXP");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F14F20,
+            lnis.outbound.get(1).getElement(1) & 0x78, "opcode is OPC_EXP2");
+        assertEquals( bit, lnis.outbound.get(1).getElement(4) & bit,
+            () -> "sent " + func + " in correct state");
     }
 
     /**
@@ -548,18 +649,24 @@ public class LocoNetExpThrottleTest extends jmri.jmrix.AbstractThrottleTest {
         int func = 16;
         int bit = 0x04;
         instance.setFunction(func,f16);
-        Assert.assertEquals(f16, instance.getFunction(func));
-        Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
-        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
-        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F14F20, lnis.outbound.get(0).getElement(1) & 0x78);
-        Assert.assertEquals("sent " + func + " in correct state", 0, lnis.outbound.get(0).getElement(4) & bit);
+        assertEquals(f16, instance.getFunction(func));
+        assertEquals( 1, lnis.outbound.size(), "number of messages is 1");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR,
+            lnis.outbound.get(0).getOpCode(), "opcode is OPC_EXP");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F14F20,
+            lnis.outbound.get(0).getElement(1) & 0x78, "opcode is OPC_EXP2");
+        assertEquals( 0, lnis.outbound.get(0).getElement(4) & bit,
+            () -> "sent " + func + " in correct state");
         f16 = true;
         instance.setFunction(func,f16);
-        Assert.assertEquals(f16, instance.getFunction(func));
-        Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
-        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
-        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F14F20, lnis.outbound.get(1).getElement(1) & 0x78);
-        Assert.assertEquals("sent " + func + " in correct state", bit, lnis.outbound.get(1).getElement(4) & bit);
+        assertEquals(f16, instance.getFunction(func));
+        assertEquals( 2, lnis.outbound.size(), "number of messages is 2");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR,
+            lnis.outbound.get(1).getOpCode(), "opcode is OPC_EXP");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F14F20,
+            lnis.outbound.get(1).getElement(1) & 0x78, "opcode is OPC_EXP2");
+        assertEquals( bit, lnis.outbound.get(1).getElement(4) & bit,
+            () -> "sent " + func + " in correct state");
     }
 
     /**
@@ -574,18 +681,24 @@ public class LocoNetExpThrottleTest extends jmri.jmrix.AbstractThrottleTest {
         int func = 17;
         int bit = 0x08;
         instance.setFunction(func,f17);
-        Assert.assertEquals(f17, instance.getFunction(func));
-        Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
-        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
-        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F14F20, lnis.outbound.get(0).getElement(1) & 0x78);
-        Assert.assertEquals("sent " + func + " in correct state", 0, lnis.outbound.get(0).getElement(4) & bit);
+        assertEquals(f17, instance.getFunction(func));
+        assertEquals( 1, lnis.outbound.size(), "number of messages is 1");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR,
+            lnis.outbound.get(0).getOpCode(), "opcode is OPC_EXP");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F14F20,
+            lnis.outbound.get(0).getElement(1) & 0x78, "opcode is OPC_EXP2");
+        assertEquals( 0, lnis.outbound.get(0).getElement(4) & bit,
+            () -> "sent " + func + " in correct state");
         f17 = true;
         instance.setFunction(func,f17);
-        Assert.assertEquals(f17, instance.getFunction(func));
-        Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
-        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
-        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F14F20, lnis.outbound.get(1).getElement(1) & 0x78);
-        Assert.assertEquals("sent " + func + " in correct state", bit, lnis.outbound.get(1).getElement(4) & bit);
+        assertEquals(f17, instance.getFunction(func));
+        assertEquals( 2, lnis.outbound.size(), "number of messages is 2");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR,
+            lnis.outbound.get(1).getOpCode(), "opcode is OPC_EXP");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F14F20,
+            lnis.outbound.get(1).getElement(1) & 0x78, "opcode is OPC_EXP2");
+        assertEquals( bit, lnis.outbound.get(1).getElement(4) & bit,
+            () -> "sent " + func + " in correct state");
     }
 
     /**
@@ -600,18 +713,24 @@ public class LocoNetExpThrottleTest extends jmri.jmrix.AbstractThrottleTest {
         int func = 18;
         int bit = 0x10;
         instance.setFunction(func,f18);
-        Assert.assertEquals(f18, instance.getFunction(func));
-        Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
-        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
-        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F14F20, lnis.outbound.get(0).getElement(1) & 0x78);
-        Assert.assertEquals("sent " + func + " in correct state", 0, lnis.outbound.get(0).getElement(4) & bit);
+        assertEquals(f18, instance.getFunction(func));
+        assertEquals( 1, lnis.outbound.size(), "number of messages is 1");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR,
+            lnis.outbound.get(0).getOpCode(), "opcode is OPC_EXP");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F14F20,
+            lnis.outbound.get(0).getElement(1) & 0x78, "opcode is OPC_EXP2");
+        assertEquals( 0, lnis.outbound.get(0).getElement(4) & bit,
+            () -> "sent " + func + " in correct state");
         f18 = true;
         instance.setFunction(func,f18);
-        Assert.assertEquals(f18, instance.getFunction(func));
-        Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
-        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
-        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F14F20, lnis.outbound.get(1).getElement(1) & 0x78);
-        Assert.assertEquals("sent " + func + " in correct state", bit, lnis.outbound.get(1).getElement(4) & bit);
+        assertEquals(f18, instance.getFunction(func));
+        assertEquals( 2, lnis.outbound.size(), "number of messages is 2");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR,
+            lnis.outbound.get(1).getOpCode(), "opcode is OPC_EXP");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F14F20,
+            lnis.outbound.get(1).getElement(1) & 0x78, "opcode is OPC_EXP2");
+        assertEquals( bit, lnis.outbound.get(1).getElement(4) & bit,
+            () -> "sent " + func + " in correct state");
     }
 
     /**
@@ -626,18 +745,24 @@ public class LocoNetExpThrottleTest extends jmri.jmrix.AbstractThrottleTest {
         int func = 19;
         int bit = 0x20;
         instance.setFunction(func,f19);
-        Assert.assertEquals(f19, instance.getFunction(func));
-        Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
-        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
-        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F14F20, lnis.outbound.get(0).getElement(1) & 0x78);
-        Assert.assertEquals("sent " + func + " in correct state", 0, lnis.outbound.get(0).getElement(4) & bit);
+        assertEquals(f19, instance.getFunction(func));
+        assertEquals( 1, lnis.outbound.size(), "number of messages is 1");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR,
+            lnis.outbound.get(0).getOpCode(), "opcode is OPC_EXP");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F14F20,
+            lnis.outbound.get(0).getElement(1) & 0x78, "opcode is OPC_EXP2");
+        assertEquals( 0, lnis.outbound.get(0).getElement(4) & bit,
+            () -> "sent " + func + " in correct state");
         f19 = true;
         instance.setFunction(func,f19);
-        Assert.assertEquals(f19, instance.getFunction(func));
-        Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
-        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
-        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F14F20, lnis.outbound.get(1).getElement(1) & 0x78);
-        Assert.assertEquals("sent " + func + " in correct state", bit, lnis.outbound.get(1).getElement(4) & bit);
+        assertEquals(f19, instance.getFunction(func));
+        assertEquals( 2, lnis.outbound.size(), "number of messages is 2");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR,
+            lnis.outbound.get(1).getOpCode(), "opcode is OPC_EXP");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F14F20,
+            lnis.outbound.get(1).getElement(1) & 0x78, "opcode is OPC_EXP2");
+        assertEquals( bit, lnis.outbound.get(1).getElement(4) & bit,
+            () -> "sent " + func + " in correct state");
     }
 
     /**
@@ -652,18 +777,24 @@ public class LocoNetExpThrottleTest extends jmri.jmrix.AbstractThrottleTest {
         int func = 20;
         int bit = 0x40;
         instance.setFunction(func,f20);
-        Assert.assertEquals(f20, instance.getFunction(func));
-        Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
-        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
-        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F14F20, lnis.outbound.get(0).getElement(1) & 0x78);
-        Assert.assertEquals("sent " + func + " in correct state", 0, lnis.outbound.get(0).getElement(4) & bit);
+        assertEquals(f20, instance.getFunction(func));
+        assertEquals( 1, lnis.outbound.size(), "number of messages is 1");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR,
+            lnis.outbound.get(0).getOpCode(), "opcode is OPC_EXP");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F14F20,
+            lnis.outbound.get(0).getElement(1) & 0x78, "opcode is OPC_EXP2");
+        assertEquals( 0, lnis.outbound.get(0).getElement(4) & bit,
+            () -> "sent " + func + " in correct state");
         f20 = true;
         instance.setFunction(func,f20);
-        Assert.assertEquals(f20, instance.getFunction(func));
-        Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
-        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
-        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F14F20, lnis.outbound.get(1).getElement(1) & 0x78);
-        Assert.assertEquals("sent " + func + " in correct state", bit, lnis.outbound.get(1).getElement(4) & bit);
+        assertEquals(f20, instance.getFunction(func));
+        assertEquals( 2, lnis.outbound.size(), "number of messages is 2");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR,
+            lnis.outbound.get(1).getOpCode(), "opcode is OPC_EXP");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F14F20,
+            lnis.outbound.get(1).getElement(1) & 0x78, "opcode is OPC_EXP2");
+        assertEquals( bit, lnis.outbound.get(1).getElement(4) & bit,
+            () -> "sent " + func + " in correct state");
     }
 
     /**
@@ -678,18 +809,24 @@ public class LocoNetExpThrottleTest extends jmri.jmrix.AbstractThrottleTest {
         int func = 21;
         int bit = 0x01;
         instance.setFunction(func,f21);
-        Assert.assertEquals(f21, instance.getFunction(func));
-        Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
-        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
-        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F21F28_F28OFF, lnis.outbound.get(0).getElement(1) & 0x78);
-        Assert.assertEquals("sent " + func + " in correct state", 0, lnis.outbound.get(0).getElement(4) & bit);
+        assertEquals(f21, instance.getFunction(func));
+        assertEquals( 1, lnis.outbound.size(), "number of messages is 1");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR,
+            lnis.outbound.get(0).getOpCode(), "opcode is OPC_EXP");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F21F28_F28OFF,
+            lnis.outbound.get(0).getElement(1) & 0x78, "opcode is OPC_EXP2");
+        assertEquals( 0, lnis.outbound.get(0).getElement(4) & bit,
+            () -> "sent " + func + " in correct state");
         f21 = true;
         instance.setFunction(func,f21);
-        Assert.assertEquals(f21, instance.getFunction(func));
-        Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
-        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
-        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F21F28_F28OFF, lnis.outbound.get(1).getElement(1) & 0x78);
-        Assert.assertEquals("sent " + func + " in correct state", bit, lnis.outbound.get(1).getElement(4) & bit);
+        assertEquals(f21, instance.getFunction(func));
+        assertEquals( 2, lnis.outbound.size(), "number of messages is 2");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR,
+            lnis.outbound.get(1).getOpCode(), "opcode is OPC_EXP");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F21F28_F28OFF,
+            lnis.outbound.get(1).getElement(1) & 0x78, "opcode is OPC_EXP2");
+        assertEquals( bit, lnis.outbound.get(1).getElement(4) & bit,
+            () -> "sent " + func + " in correct state");
     }
 
     /**
@@ -704,18 +841,24 @@ public class LocoNetExpThrottleTest extends jmri.jmrix.AbstractThrottleTest {
         int func = 22;
         int bit = 0x02;
         instance.setFunction(func,f22);
-        Assert.assertEquals(f22, instance.getFunction(func));
-        Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
-        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
-        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F21F28_F28OFF, lnis.outbound.get(0).getElement(1) & 0x78);
-        Assert.assertEquals("sent " + func + " in correct state", 0, lnis.outbound.get(0).getElement(4) & bit);
+        assertEquals(f22, instance.getFunction(func));
+        assertEquals( 1, lnis.outbound.size(), "number of messages is 1");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR,
+            lnis.outbound.get(0).getOpCode(), "opcode is OPC_EXP");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F21F28_F28OFF,
+            lnis.outbound.get(0).getElement(1) & 0x78, "opcode is OPC_EXP2");
+        assertEquals( 0, lnis.outbound.get(0).getElement(4) & bit,
+            () -> "sent " + func + " in correct state");
         f22 = true;
         instance.setFunction(func,f22);
-        Assert.assertEquals(f22, instance.getFunction(func));
-        Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
-        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
-        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F21F28_F28OFF, lnis.outbound.get(1).getElement(1) & 0x78);
-        Assert.assertEquals("sent " + func + " in correct state", bit, lnis.outbound.get(1).getElement(4) & bit);
+        assertEquals(f22, instance.getFunction(func));
+        assertEquals( 2, lnis.outbound.size(), "number of messages is 2");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR,
+            lnis.outbound.get(1).getOpCode(), "opcode is OPC_EXP");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F21F28_F28OFF,
+            lnis.outbound.get(1).getElement(1) & 0x78, "opcode is OPC_EXP2");
+        assertEquals( bit, lnis.outbound.get(1).getElement(4) & bit,
+            () -> "sent " + func + " in correct state");
     }
 
     /**
@@ -730,18 +873,24 @@ public class LocoNetExpThrottleTest extends jmri.jmrix.AbstractThrottleTest {
         int func = 23;
         int bit = 0x04;
         instance.setFunction(func,f23);
-        Assert.assertEquals(f23, instance.getFunction(func));
-        Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
-        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
-        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F21F28_F28OFF, lnis.outbound.get(0).getElement(1) & 0x78);
-        Assert.assertEquals("sent " + func + " in correct state", 0, lnis.outbound.get(0).getElement(4) & bit);
+        assertEquals(f23, instance.getFunction(func));
+        assertEquals( 1, lnis.outbound.size(), "number of messages is 1");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR,
+            lnis.outbound.get(0).getOpCode(), "opcode is OPC_EXP");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F21F28_F28OFF,
+            lnis.outbound.get(0).getElement(1) & 0x78, "opcode is OPC_EXP2");
+        assertEquals( 0, lnis.outbound.get(0).getElement(4) & bit,
+            () -> "sent " + func + " in correct state");
         f23 = true;
         instance.setFunction(func,f23);
-        Assert.assertEquals(f23, instance.getFunction(func));
-        Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
-        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
-        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F21F28_F28OFF, lnis.outbound.get(1).getElement(1) & 0x78);
-        Assert.assertEquals("sent " + func + " in correct state", bit, lnis.outbound.get(1).getElement(4) & bit);
+        assertEquals(f23, instance.getFunction(func));
+        assertEquals( 2, lnis.outbound.size(), "number of messages is 2");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR,
+            lnis.outbound.get(1).getOpCode(), "opcode is OPC_EXP");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F21F28_F28OFF,
+            lnis.outbound.get(1).getElement(1) & 0x78, "opcode is OPC_EXP2");
+        assertEquals( bit, lnis.outbound.get(1).getElement(4) & bit,
+            () -> "sent " + func + " in correct state");
     }
 
     /**
@@ -756,18 +905,24 @@ public class LocoNetExpThrottleTest extends jmri.jmrix.AbstractThrottleTest {
         int func = 24;
         int bit = 0x08;
         instance.setFunction(func,f24);
-        Assert.assertEquals(f24, instance.getFunction(func));
-        Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
-        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
-        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F21F28_F28OFF, lnis.outbound.get(0).getElement(1) & 0x78);
-        Assert.assertEquals("sent " + func + " in correct state", 0, lnis.outbound.get(0).getElement(4) & bit);
+        assertEquals(f24, instance.getFunction(func));
+        assertEquals( 1, lnis.outbound.size(), "number of messages is 1");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR,
+            lnis.outbound.get(0).getOpCode(), "opcode is OPC_EXP");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F21F28_F28OFF,
+            lnis.outbound.get(0).getElement(1) & 0x78, "opcode is OPC_EXP2");
+        assertEquals( 0, lnis.outbound.get(0).getElement(4) & bit,
+            () -> "sent " + func + " in correct state");
         f24 = true;
         instance.setFunction(func,f24);
-        Assert.assertEquals(f24, instance.getFunction(func));
-        Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
-        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
-        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F21F28_F28OFF, lnis.outbound.get(1).getElement(1) & 0x78);
-        Assert.assertEquals("sent " + func + " in correct state", bit, lnis.outbound.get(1).getElement(4) & bit);
+        assertEquals(f24, instance.getFunction(func));
+        assertEquals( 2, lnis.outbound.size(), "number of messages is 2");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR,
+            lnis.outbound.get(1).getOpCode(), "opcode is OPC_EXP");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F21F28_F28OFF,
+            lnis.outbound.get(1).getElement(1) & 0x78, "opcode is OPC_EXP2");
+        assertEquals( bit, lnis.outbound.get(1).getElement(4) & bit,
+            () -> "sent " + func + " in correct state");
     }
 
     /**
@@ -782,18 +937,24 @@ public class LocoNetExpThrottleTest extends jmri.jmrix.AbstractThrottleTest {
         int func = 25;
         int bit = 0x10;
         instance.setFunction(func,f25);
-        Assert.assertEquals(f25, instance.getFunction(func));
-        Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
-        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
-        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F21F28_F28OFF, lnis.outbound.get(0).getElement(1) & 0x78);
-        Assert.assertEquals("sent " + func + " in correct state", 0, lnis.outbound.get(0).getElement(4) & bit);
+        assertEquals(f25, instance.getFunction(func));
+        assertEquals( 1, lnis.outbound.size(), "number of messages is 1");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR,
+            lnis.outbound.get(0).getOpCode(), "opcode is OPC_EXP");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F21F28_F28OFF,
+            lnis.outbound.get(0).getElement(1) & 0x78, "opcode is OPC_EXP2");
+        assertEquals( 0, lnis.outbound.get(0).getElement(4) & bit,
+            () -> "sent " + func + " in correct state");
         f25 = true;
         instance.setFunction(func,f25);
-        Assert.assertEquals(f25, instance.getFunction(func));
-        Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
-        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
-        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F21F28_F28OFF, lnis.outbound.get(1).getElement(1) & 0x78);
-        Assert.assertEquals("sent " + func + " in correct state", bit, lnis.outbound.get(1).getElement(4) & bit);
+        assertEquals(f25, instance.getFunction(func));
+        assertEquals( 2, lnis.outbound.size(), "number of messages is 2");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR,
+            lnis.outbound.get(1).getOpCode(), "opcode is OPC_EXP");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F21F28_F28OFF,
+            lnis.outbound.get(1).getElement(1) & 0x78, "opcode is OPC_EXP2");
+        assertEquals( bit, lnis.outbound.get(1).getElement(4) & bit,
+            () -> "sent " + func + " in correct state");
     }
 
     /**
@@ -808,18 +969,24 @@ public class LocoNetExpThrottleTest extends jmri.jmrix.AbstractThrottleTest {
         int func = 26;
         int bit = 0x20;
         instance.setFunction(func,f26);
-        Assert.assertEquals(f26, instance.getFunction(func));
-        Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
-        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
-        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F21F28_F28OFF, lnis.outbound.get(0).getElement(1) & 0x78);
-        Assert.assertEquals("sent " + func + " in correct state", 0, lnis.outbound.get(0).getElement(4) & bit);
+        assertEquals(f26, instance.getFunction(func));
+        assertEquals( 1, lnis.outbound.size(), "number of messages is 1");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR,
+            lnis.outbound.get(0).getOpCode(), "opcode is OPC_EXP");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F21F28_F28OFF,
+            lnis.outbound.get(0).getElement(1) & 0x78, "opcode is OPC_EXP2");
+        assertEquals( 0, lnis.outbound.get(0).getElement(4) & bit,
+            () -> "sent " + func + " in correct state");
         f26 = true;
         instance.setFunction(func,f26);
-        Assert.assertEquals(f26, instance.getFunction(func));
-        Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
-        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
-        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F21F28_F28OFF, lnis.outbound.get(1).getElement(1) & 0x78);
-        Assert.assertEquals("sent " + func + " in correct state", bit, lnis.outbound.get(1).getElement(4) & bit);
+        assertEquals(f26, instance.getFunction(func));
+        assertEquals( 2, lnis.outbound.size(), "number of messages is 2");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR,
+            lnis.outbound.get(1).getOpCode(), "opcode is OPC_EXP");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F21F28_F28OFF,
+            lnis.outbound.get(1).getElement(1) & 0x78, "opcode is OPC_EXP2");
+        assertEquals( bit, lnis.outbound.get(1).getElement(4) & bit,
+            () -> "sent " + func + " in correct state");
     }
 
     /**
@@ -834,18 +1001,24 @@ public class LocoNetExpThrottleTest extends jmri.jmrix.AbstractThrottleTest {
         int func = 27;
         int bit = 0x40;
         instance.setFunction(func,f27);
-        Assert.assertEquals(f27, instance.getFunction(func));
-        Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
-        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
-        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F21F28_F28OFF, lnis.outbound.get(0).getElement(1) & 0x78);
-        Assert.assertEquals("sent " + func + " in correct state", 0, lnis.outbound.get(0).getElement(4) & bit);
+        assertEquals(f27, instance.getFunction(func));
+        assertEquals( 1, lnis.outbound.size(), "number of messages is 1");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR,
+            lnis.outbound.get(0).getOpCode(), "opcode is OPC_EXP");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F21F28_F28OFF,
+            lnis.outbound.get(0).getElement(1) & 0x78, "opcode is OPC_EXP2");
+        assertEquals( 0, lnis.outbound.get(0).getElement(4) & bit,
+            () -> "sent " + func + " in correct state");
         f27 = true;
         instance.setFunction(func,f27);
-        Assert.assertEquals(f27, instance.getFunction(func));
-        Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
-        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
-        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F21F28_F28OFF, lnis.outbound.get(1).getElement(1) & 0x78);
-        Assert.assertEquals("sent " + func + " in correct state", bit, lnis.outbound.get(1).getElement(4) & bit);
+        assertEquals(f27, instance.getFunction(func));
+        assertEquals( 2, lnis.outbound.size(), "number of messages is 2");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR,
+            lnis.outbound.get(1).getOpCode(), "opcode is OPC_EXP");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F21F28_F28OFF,
+            lnis.outbound.get(1).getElement(1) & 0x78, "opcode is OPC_EXP2");
+        assertEquals( bit, lnis.outbound.get(1).getElement(4) & bit,
+            () -> "sent " + func + " in correct state");
     }
 
     /**
@@ -860,18 +1033,24 @@ public class LocoNetExpThrottleTest extends jmri.jmrix.AbstractThrottleTest {
         int func = 28;
         int bit = 0xFF;   // all off both ways
         instance.setFunction(func,f28);
-        Assert.assertEquals(f28, instance.getFunction(func));
-        Assert.assertEquals("number of messages is 1", 1, lnis.outbound.size());
-        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(0).getOpCode());
-        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F21F28_F28OFF, lnis.outbound.get(0).getElement(1) & 0x78);
-        Assert.assertEquals("sent " + func + " in correct state", 0, lnis.outbound.get(0).getElement(4) & bit);
+        assertEquals(f28, instance.getFunction(func));
+        assertEquals( 1, lnis.outbound.size(), "number of messages is 1");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR,
+            lnis.outbound.get(0).getOpCode(), "opcode is OPC_EXP");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F21F28_F28OFF,
+            lnis.outbound.get(0).getElement(1) & 0x78, "opcode is OPC_EXP2");
+        assertEquals( 0, lnis.outbound.get(0).getElement(4) & bit,
+            () -> "sent " + func + " in correct state");
         f28 = true;
         instance.setFunction(func,f28);
-        Assert.assertEquals(f28, instance.getFunction(func));
-        Assert.assertEquals("number of messages is 2", 2, lnis.outbound.size());
-        Assert.assertEquals("opcode is OPC_EXP", LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR, lnis.outbound.get(1).getOpCode());
-        Assert.assertEquals("opcode is OPC_EXP2", LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F21F28_F28ON, lnis.outbound.get(1).getElement(1) & 0x78);
-        Assert.assertEquals("sent " + func + " in correct state", 0, lnis.outbound.get(1).getElement(4) & bit);
+        assertEquals(f28, instance.getFunction(func));
+        assertEquals( 2, lnis.outbound.size(), "number of messages is 2");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_OR_SPEED_AND_DIR,
+            lnis.outbound.get(1).getOpCode(), "opcode is OPC_EXP");
+        assertEquals( LnConstants.OPC_EXP_SEND_FUNCTION_GROUP_F21F28_F28ON,
+            lnis.outbound.get(1).getElement(1) & 0x78, "opcode is OPC_EXP2");
+        assertEquals( 0, lnis.outbound.get(1).getElement(4) & bit,
+            () -> "sent " + func + " in correct state");
     }
 
     /**
@@ -884,17 +1063,17 @@ public class LocoNetExpThrottleTest extends jmri.jmrix.AbstractThrottleTest {
         int func = 29;
         LocoNetMessage funcOnMess = new LocoNetMessage(new int[] {0xED, 0x0B, 0x7f, 0x33, 0x02, 0x00, 0x58, 0x01, 0x00, 0x00, 0x00});
         LocoNetMessage funcOffMess = new LocoNetMessage(new int [] {0xED, 0x0B, 0x7F, 0x33, 0x02, 0x00, 0x58, 0x00, 0x00, 0x00, 0x00});
-        Assert.assertEquals("check send of function exp f" + func, 0, lnis.outbound.size());
+        assertEquals( 0, lnis.outbound.size(), () -> "check send of function exp f" + func);
         instance.setFunction(func,true);
-        Assert.assertEquals("check send of function" + func, 1, lnis.outbound.size());
-        Assert.assertTrue("check opcode",funcOnMess.equals(lnis.outbound.get(0)));
+        assertEquals( 1, lnis.outbound.size(), () -> "check send of function" + func);
+        assertTrue( funcOnMess.equals(lnis.outbound.get(0)), "check opcode");
         instance.setFunction(func,false);
-        Assert.assertEquals("check send OFF function" + func, 2, lnis.outbound.size());
-        Assert.assertTrue("check opcode",funcOffMess.equals(lnis.outbound.get(1)));
+        assertEquals( 2, lnis.outbound.size(), "check send OFF function" + func);
+        assertTrue( funcOffMess.equals(lnis.outbound.get(1)), "check opcode");
     }
 
     /**
-     * Test of sendFunction 69
+     * Test of sendFunction 68
      */
     @Test
     public void testSendExpFunctionF68() {
@@ -903,13 +1082,13 @@ public class LocoNetExpThrottleTest extends jmri.jmrix.AbstractThrottleTest {
         int func = 68;
         LocoNetMessage funcOnMess = new LocoNetMessage(new int[] {0xED, 0x0B, 0x7f, 0x33, 0x06, 0x00, 0x5C, 0x00, 0x00, 0x00, 0x00});
         LocoNetMessage funcOffMess = new LocoNetMessage(new int [] {0xED, 0x0B, 0x7F, 0x33, 0x02, 0x00, 0x5C, 0x00, 0x00, 0x00, 0x00});
-        Assert.assertEquals("check send of function exp f" + func, 0, lnis.outbound.size());
+        assertEquals( 0, lnis.outbound.size(), () -> "check send of function exp f" + func);
         instance.setFunction(func,true);
-        Assert.assertEquals("check send of function" + func, 1, lnis.outbound.size());
-        Assert.assertTrue("check opcode",funcOnMess.equals(lnis.outbound.get(0)));
+        assertEquals( 1, lnis.outbound.size(), () -> "check send of function" + func);
+        assertTrue( funcOnMess.equals(lnis.outbound.get(0)), "check opcode");
         instance.setFunction(func,false);
-        Assert.assertEquals("check send OFF function" + func, 2, lnis.outbound.size());
-        Assert.assertTrue("check opcode",funcOffMess.equals(lnis.outbound.get(1)));
+        assertEquals( 2, lnis.outbound.size(), () -> "check send OFF function" + func);
+        assertTrue( funcOffMess.equals(lnis.outbound.get(1)), "check opcode");
     }
 
     /**
@@ -920,27 +1099,27 @@ public class LocoNetExpThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     public void testSendFunctionGroup1() {
 
         lnis.resetStatistics(); // and clears outbound message log
-        instance.setF0(false);
-        instance.setF1(true);
-        instance.setF2(true);
-        instance.setF3(false);
+        instance.setFunction( 0, false);
+        instance.setFunction( 1, true);
+        instance.setFunction( 2, true);
+        instance.setFunction( 3, false);
         instance.setIsForward(true);
 
         lnis.resetStatistics();  // and clears outbound message log
-        Assert.assertEquals("check send of function group 1 (0)", 0, lnis.outbound.size());
+        assertEquals( 0, lnis.outbound.size(), "check send of function group 1 (0)");
         ((LocoNetThrottle)instance).sendFunctionGroup1();
-        Assert.assertEquals("check send of function group 1 (1)", 1, lnis.outbound.size());
-        Assert.assertEquals("check opcode",LnConstants.OPC_LOCO_DIRF, lnis.outbound.get(0).getOpCode());
-        Assert.assertEquals("check dirf byte", 0x03, lnis.outbound.get(0).getElement(2));
+        assertEquals( 1, lnis.outbound.size(), "check send of function group 1 (1)");
+        assertEquals( LnConstants.OPC_LOCO_DIRF, lnis.outbound.get(0).getOpCode(), "check opcode");
+        assertEquals( 0x03, lnis.outbound.get(0).getElement(2), "check dirf byte");
 
 
         lnis.resetStatistics(); // and clears outbound message log
         instance.setIsForward(false);
-        Assert.assertEquals("check send of function group 1 (2)", 1, lnis.outbound.size());
+        assertEquals( 1, lnis.outbound.size(), "check send of function group 1 (2)");
         ((LocoNetThrottle)instance).sendFunctionGroup1();
-        Assert.assertEquals("check send of function group 1 (3)", 2, lnis.outbound.size());
-        Assert.assertEquals("check opcode",LnConstants.OPC_LOCO_DIRF, lnis.outbound.get(1).getOpCode());
-        Assert.assertEquals("check dirf byte {4}", 0x023, lnis.outbound.get(1).getElement(2));
+        assertEquals( 2, lnis.outbound.size(), "check send of function group 1 (3)");
+        assertEquals( LnConstants.OPC_LOCO_DIRF, lnis.outbound.get(1).getOpCode(), "check opcode");
+        assertEquals( 0x023, lnis.outbound.get(1).getElement(2), "check dirf byte {4}");
 
     }
 
@@ -952,29 +1131,35 @@ public class LocoNetExpThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     public void testSendFunctionGroup2() {
 
         for (int i = 5; i <9; ++i ) {
-            instance.setF5(i==5);
-            instance.setF6(i==6);
-            instance.setF7(i==7);
-            instance.setF8(i==8);
+            instance.setFunction( 5, i==5);
+            instance.setFunction( 6, i==6);
+            instance.setFunction( 7, i==7);
+            instance.setFunction( 8, i==8);
 
             lnis.resetStatistics(); // and clears outbound message log
             ((LocoNetThrottle)instance).sendFunctionGroup2();
 
-            Assert.assertEquals("check send of function group 2 for F"+i+" (0)", 1, lnis.outbound.size());
-            Assert.assertEquals("check opcode is OPC_LOCO_SND for F"+i+"",LnConstants.OPC_LOCO_SND, lnis.outbound.get(0).getOpCode());
-            Assert.assertEquals("check byte 2 for F"+i+"{0}", 1<<(i-5), lnis.outbound.get(0).getElement(2));
+            assertEquals( 1, lnis.outbound.size(),
+                "check send of function group 2 for F"+i+" (0)");
+            assertEquals( LnConstants.OPC_LOCO_SND, lnis.outbound.get(0).getOpCode(),
+                "check opcode is OPC_LOCO_SND for F"+i+"");
+            assertEquals( 1<<(i-5), lnis.outbound.get(0).getElement(2),
+                "check byte 2 for F"+i+"{0}");
 
-            instance.setF5(!(i==5));
-            instance.setF6(!(i==6));
-            instance.setF7(!(i==7));
-            instance.setF8(!(i==8));
+            instance.setFunction( 5, !(i==5));
+            instance.setFunction( 6, !(i==6));
+            instance.setFunction( 7, !(i==7));
+            instance.setFunction( 8, !(i==8));
 
             lnis.resetStatistics(); // and clears outbound message log
             ((LocoNetThrottle)instance).sendFunctionGroup2();
 
-            Assert.assertEquals("check send of function group 2 for !F"+i+"(1)", 1, lnis.outbound.size());
-            Assert.assertEquals("check opcode is OPC_LOCO_SND for F"+i+"",LnConstants.OPC_LOCO_SND, lnis.outbound.get(0).getOpCode());
-            Assert.assertEquals("check byte 2 for !F"+i+"{1}", 0x0f - (1<<(i-5)), lnis.outbound.get(0).getElement(2));
+            assertEquals( 1, lnis.outbound.size(),
+                "check send of function group 2 for !F"+i+"(1)");
+            assertEquals( LnConstants.OPC_LOCO_SND, lnis.outbound.get(0).getOpCode(),
+                "check opcode is OPC_LOCO_SND for F"+i+"");
+            assertEquals( 0x0f - (1<<(i-5)), lnis.outbound.get(0).getElement(2),
+                "check byte 2 for !F"+i+"{1}");
         }
     }
 
@@ -986,45 +1171,47 @@ public class LocoNetExpThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     public void testSendFunctionGroup3() {
 
         for (int i = 9; i <13; ++i ) {
-            instance.setF9(i==9);
-            instance.setF10(i==10);
-            instance.setF11(i==11);
-            instance.setF12(i==12);
+            instance.setFunction(9, i==9);
+            instance.setFunction(10, i==10);
+            instance.setFunction(11, i==11);
+            instance.setFunction(12, i==12);
 
             lnis.resetStatistics(); // and clears outbound message log
             ((LocoNetThrottle)instance).sendFunctionGroup3();
 
-            Assert.assertEquals("check send of function group 3 for F"+i+" (0)", 1, lnis.outbound.size());
-            Assert.assertEquals("check opcode is OPC_IMM_PACKET for F"+i+"",LnConstants.OPC_IMM_PACKET, lnis.outbound.get(0).getOpCode());
-            Assert.assertEquals("check byte 1 for F"+i+"{0}", 0x0b, lnis.outbound.get(0).getElement(1));
-            Assert.assertEquals("check byte 2 for F"+i+"{0}", 0x7f, lnis.outbound.get(0).getElement(2));
-            Assert.assertEquals("check byte 3 for F"+i+"{0}", 0x23, lnis.outbound.get(0).getElement(3));
-            Assert.assertEquals("check byte 4 for F"+i+"{0}", 0x02, lnis.outbound.get(0).getElement(4));
-            Assert.assertEquals("check byte 5 for F"+i+"{0}", 0x00, lnis.outbound.get(0).getElement(5));
-            Assert.assertEquals("check byte 6 for F"+i+"{0}", 0x20+(1<<(i-9)), lnis.outbound.get(0).getElement(6));
-            Assert.assertEquals("check byte 7 for F"+i+"{0}", 0x00, lnis.outbound.get(0).getElement(7));
-            Assert.assertEquals("check byte 8 for F"+i+"{0}", 0x00, lnis.outbound.get(0).getElement(8));
-            Assert.assertEquals("check byte 9 for F"+i+"{0}", 0x00, lnis.outbound.get(0).getElement(9));
+            assertEquals( 1, lnis.outbound.size(), "check send of function group 3 for F"+i+" (0)");
+            assertEquals( LnConstants.OPC_IMM_PACKET, lnis.outbound.get(0).getOpCode(),
+                "check opcode is OPC_IMM_PACKET for F"+i+"");
+            assertEquals( 0x0b, lnis.outbound.get(0).getElement(1), "check byte 1 for F"+i+"{0}");
+            assertEquals( 0x7f, lnis.outbound.get(0).getElement(2), "check byte 2 for F"+i+"{0}");
+            assertEquals( 0x23, lnis.outbound.get(0).getElement(3), "check byte 3 for F"+i+"{0}");
+            assertEquals( 0x02, lnis.outbound.get(0).getElement(4), "check byte 4 for F"+i+"{0}");
+            assertEquals( 0x00, lnis.outbound.get(0).getElement(5), "check byte 5 for F"+i+"{0}");
+            assertEquals( 0x20+(1<<(i-9)), lnis.outbound.get(0).getElement(6), "check byte 6 for F"+i+"{0}");
+            assertEquals( 0x00, lnis.outbound.get(0).getElement(7), "check byte 7 for F"+i+"{0}");
+            assertEquals( 0x00, lnis.outbound.get(0).getElement(8), "check byte 8 for F"+i+"{0}");
+            assertEquals( 0x00, lnis.outbound.get(0).getElement(9), "check byte 9 for F"+i+"{0}");
 
-            instance.setF9(!(i==9));
-            instance.setF10(!(i==10));
-            instance.setF11(!(i==11));
-            instance.setF12(!(i==12));
+            instance.setFunction(9, !(i==9));
+            instance.setFunction(10, !(i==10));
+            instance.setFunction(11, !(i==11));
+            instance.setFunction(12, !(i==12));
 
             lnis.resetStatistics(); // and clears outbound message log
             ((LocoNetThrottle)instance).sendFunctionGroup3();
 
-            Assert.assertEquals("check send of function group 3 for !F"+i+"(1)", 1, lnis.outbound.size());
-            Assert.assertEquals("check opcode is OPC_IMM_PACKET for !F"+i+"{1}",LnConstants.OPC_IMM_PACKET, lnis.outbound.get(0).getOpCode());
-            Assert.assertEquals("check byte 1 for !F"+i+"{1}", 0x0b, lnis.outbound.get(0).getElement(1));
-            Assert.assertEquals("check byte 2 for !F"+i+"{1}", 0x7f, lnis.outbound.get(0).getElement(2));
-            Assert.assertEquals("check byte 3 for !F"+i+"{1}", 0x23, lnis.outbound.get(0).getElement(3));
-            Assert.assertEquals("check byte 4 for !F"+i+"{1}", 0x02, lnis.outbound.get(0).getElement(4));
-            Assert.assertEquals("check byte 5 for !F"+i+"{1}", 0x00, lnis.outbound.get(0).getElement(5));
-            Assert.assertEquals("check byte 6 for !F"+i+"{1}", 0x2F-(1<<(i-9)), lnis.outbound.get(0).getElement(6));
-            Assert.assertEquals("check byte 7 for !F"+i+"{1}", 0x00, lnis.outbound.get(0).getElement(7));
-            Assert.assertEquals("check byte 8 for !F"+i+"{1}", 0x00, lnis.outbound.get(0).getElement(8));
-            Assert.assertEquals("check byte 9 for 1F"+i+"{1}", 0x00, lnis.outbound.get(0).getElement(9));
+            assertEquals( 1, lnis.outbound.size(), "check send of function group 3 for !F"+i+"(1)");
+            assertEquals( LnConstants.OPC_IMM_PACKET, lnis.outbound.get(0).getOpCode(),
+                "check opcode is OPC_IMM_PACKET for !F"+i+"{1}");
+            assertEquals( 0x0b, lnis.outbound.get(0).getElement(1), "check byte 1 for !F"+i+"{1}");
+            assertEquals( 0x7f, lnis.outbound.get(0).getElement(2), "check byte 2 for !F"+i+"{1}");
+            assertEquals( 0x23, lnis.outbound.get(0).getElement(3), "check byte 3 for !F"+i+"{1}");
+            assertEquals( 0x02, lnis.outbound.get(0).getElement(4), "check byte 4 for !F"+i+"{1}");
+            assertEquals( 0x00, lnis.outbound.get(0).getElement(5), "check byte 5 for !F"+i+"{1}");
+            assertEquals( 0x2F-(1<<(i-9)), lnis.outbound.get(0).getElement(6), "check byte 6 for !F"+i+"{1}");
+            assertEquals( 0x00, lnis.outbound.get(0).getElement(7), "check byte 7 for !F"+i+"{1}");
+            assertEquals( 0x00, lnis.outbound.get(0).getElement(8), "check byte 8 for !F"+i+"{1}");
+            assertEquals( 0x00, lnis.outbound.get(0).getElement(9), "check byte 9 for 1F"+i+"{1}");
         }
     }
 
@@ -1035,53 +1222,55 @@ public class LocoNetExpThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     @Override
     public void testSendFunctionGroup4() {
         for (int i = 13; i <21; ++i ) {
-            instance.setF13(i==13);
-            instance.setF14(i==14);
-            instance.setF15(i==15);
-            instance.setF16(i==16);
-            instance.setF17(i==17);
-            instance.setF18(i==18);
-            instance.setF19(i==19);
-            instance.setF20(i==20);
+            instance.setFunction( 13, i==13);
+            instance.setFunction( 14, i==14);
+            instance.setFunction( 15, i==15);
+            instance.setFunction( 16, i==16);
+            instance.setFunction( 17, i==17);
+            instance.setFunction( 18, i==18);
+            instance.setFunction( 19, i==19);
+            instance.setFunction( 20, i==20);
 
             lnis.resetStatistics(); // and clears outbound message log
             ((LocoNetThrottle)instance).sendFunctionGroup4();
 
-            Assert.assertEquals("check send of function group 4 for F"+i+" (0)", 1, lnis.outbound.size());
-            Assert.assertEquals("check opcode is OPC_IMM_PACKET for F"+i+"",LnConstants.OPC_IMM_PACKET, lnis.outbound.get(0).getOpCode());
-            Assert.assertEquals("check byte 1 for F"+i+"{0}", 0x0b, lnis.outbound.get(0).getElement(1));
-            Assert.assertEquals("check byte 2 for F"+i+"{0}", 0x7f, lnis.outbound.get(0).getElement(2));
-            Assert.assertEquals("check byte 3 for F"+i+"{0}", 0x33, lnis.outbound.get(0).getElement(3));
-            Assert.assertEquals("check byte 4 for F"+i+"{0}", (i==20)?0x06:0x02, lnis.outbound.get(0).getElement(4));
-            Assert.assertEquals("check byte 5 for F"+i+"{0}", 0x00, lnis.outbound.get(0).getElement(5));
-            Assert.assertEquals("check byte 6 for F"+i+"{0}", 0x5e, lnis.outbound.get(0).getElement(6));
-            Assert.assertEquals("check byte 7 for F"+i+"{0}", (i < 20)?(1<<(i-13)):0, lnis.outbound.get(0).getElement(7));
-            Assert.assertEquals("check byte 8 for F"+i+"{0}", 0x00, lnis.outbound.get(0).getElement(8));
-            Assert.assertEquals("check byte 9 for F"+i+"{0}", 0x00, lnis.outbound.get(0).getElement(9));
+            assertEquals( 1, lnis.outbound.size(), "check send of function group 4 for F"+i+" (0)");
+            assertEquals( LnConstants.OPC_IMM_PACKET, lnis.outbound.get(0).getOpCode(),
+                "check opcode is OPC_IMM_PACKET for F"+i+"");
+            assertEquals( 0x0b, lnis.outbound.get(0).getElement(1), "check byte 1 for F"+i+"{0}");
+            assertEquals( 0x7f, lnis.outbound.get(0).getElement(2), "check byte 2 for F"+i+"{0}");
+            assertEquals( 0x33, lnis.outbound.get(0).getElement(3), "check byte 3 for F"+i+"{0}");
+            assertEquals( (i==20)?0x06:0x02, lnis.outbound.get(0).getElement(4), "check byte 4 for F"+i+"{0}");
+            assertEquals( 0x00, lnis.outbound.get(0).getElement(5), "check byte 5 for F"+i+"{0}");
+            assertEquals( 0x5e, lnis.outbound.get(0).getElement(6), "check byte 6 for F"+i+"{0}");
+            assertEquals( (i < 20)?(1<<(i-13)):0, lnis.outbound.get(0).getElement(7), "check byte 7 for F"+i+"{0}");
+            assertEquals( 0x00, lnis.outbound.get(0).getElement(8), "check byte 8 for F"+i+"{0}");
+            assertEquals( 0x00, lnis.outbound.get(0).getElement(9), "check byte 9 for F"+i+"{0}");
 
-            instance.setF13(!(i==13));
-            instance.setF14(!(i==14));
-            instance.setF15(!(i==15));
-            instance.setF16(!(i==16));
-            instance.setF17(!(i==17));
-            instance.setF18(!(i==18));
-            instance.setF19(!(i==19));
-            instance.setF20(!(i==20));
+            instance.setFunction( 13, !(i==13));
+            instance.setFunction( 14, !(i==14));
+            instance.setFunction( 15, !(i==15));
+            instance.setFunction( 16, !(i==16));
+            instance.setFunction( 17, !(i==17));
+            instance.setFunction( 18, !(i==18));
+            instance.setFunction( 19, !(i==19));
+            instance.setFunction( 20, !(i==20));
 
             lnis.resetStatistics(); // and clears outbound message log
             ((LocoNetThrottle)instance).sendFunctionGroup4();
 
-            Assert.assertEquals("check send of function group 4 for !F"+i+"(1)", 1, lnis.outbound.size());
-            Assert.assertEquals("check opcode is OPC_IMM_PACKET for !F"+i+"{1}",LnConstants.OPC_IMM_PACKET, lnis.outbound.get(0).getOpCode());
-            Assert.assertEquals("check byte 1 for !F"+i+"{1}", 0x0b, lnis.outbound.get(0).getElement(1));
-            Assert.assertEquals("check byte 2 for !F"+i+"{1}", 0x7f, lnis.outbound.get(0).getElement(2));
-            Assert.assertEquals("check byte 3 for !F"+i+"{1}", 0x33, lnis.outbound.get(0).getElement(3));
-            Assert.assertEquals("check byte 4 for !F"+i+"{1}", (i==20)?0x02:0x06, lnis.outbound.get(0).getElement(4));
-            Assert.assertEquals("check byte 5 for !F"+i+"{1}", 0x00, lnis.outbound.get(0).getElement(5));
-            Assert.assertEquals("check byte 6 for !F"+i+"{1}", 0x5e, lnis.outbound.get(0).getElement(6));
-            Assert.assertEquals("check byte 7 for !F"+i+"{1}", (i < 20)?(127-(1<<(i-13))):0x7f, lnis.outbound.get(0).getElement(7));
-            Assert.assertEquals("check byte 8 for !F"+i+"{1}", 0x00, lnis.outbound.get(0).getElement(8));
-            Assert.assertEquals("check byte 9 for 1F"+i+"{1}", 0x00, lnis.outbound.get(0).getElement(9));
+            assertEquals( 1, lnis.outbound.size(), "check send of function group 4 for !F"+i+"(1)");
+            assertEquals( LnConstants.OPC_IMM_PACKET, lnis.outbound.get(0).getOpCode(),
+                "check opcode is OPC_IMM_PACKET for !F"+i+"{1}");
+            assertEquals( 0x0b, lnis.outbound.get(0).getElement(1), "check byte 1 for !F"+i+"{1}");
+            assertEquals( 0x7f, lnis.outbound.get(0).getElement(2), "check byte 2 for !F"+i+"{1}");
+            assertEquals( 0x33, lnis.outbound.get(0).getElement(3), "check byte 3 for !F"+i+"{1}");
+            assertEquals( (i==20)?0x02:0x06, lnis.outbound.get(0).getElement(4), "check byte 4 for !F"+i+"{1}");
+            assertEquals( 0x00, lnis.outbound.get(0).getElement(5), "check byte 5 for !F"+i+"{1}");
+            assertEquals( 0x5e, lnis.outbound.get(0).getElement(6), "check byte 6 for !F"+i+"{1}");
+            assertEquals( (i < 20)?(127-(1<<(i-13))):0x7f, lnis.outbound.get(0).getElement(7), "check byte 7 for !F"+i+"{1}");
+            assertEquals( 0x00, lnis.outbound.get(0).getElement(8), "check byte 8 for !F"+i+"{1}");
+            assertEquals( 0x00, lnis.outbound.get(0).getElement(9), "check byte 9 for 1F"+i+"{1}");
         }
     }
 
@@ -1092,53 +1281,55 @@ public class LocoNetExpThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     @Override
     public void testSendFunctionGroup5() {
         for (int i = 21; i <29; ++i ) {
-            instance.setF21(i==21);
-            instance.setF22(i==22);
-            instance.setF23(i==23);
-            instance.setF24(i==24);
-            instance.setF25(i==25);
-            instance.setF26(i==26);
-            instance.setF27(i==27);
-            instance.setF28(i==28);
+            instance.setFunction( 21, i==21);
+            instance.setFunction( 22, i==22);
+            instance.setFunction( 23, i==23);
+            instance.setFunction( 24, i==24);
+            instance.setFunction( 25, i==25);
+            instance.setFunction( 26, i==26);
+            instance.setFunction( 27, i==27);
+            instance.setFunction( 28, i==28);
 
             lnis.resetStatistics(); // and clears outbound message log
             ((LocoNetThrottle)instance).sendFunctionGroup5();
 
-            Assert.assertEquals("check send of function group 5 for F"+i+" (0)", 1, lnis.outbound.size());
-            Assert.assertEquals("check opcode is OPC_IMM_PACKET for F"+i+"",LnConstants.OPC_IMM_PACKET, lnis.outbound.get(0).getOpCode());
-            Assert.assertEquals("check byte 1 for F"+i+"{0}", 0x0b, lnis.outbound.get(0).getElement(1));
-            Assert.assertEquals("check byte 2 for F"+i+"{0}", 0x7f, lnis.outbound.get(0).getElement(2));
-            Assert.assertEquals("check byte 3 for F"+i+"{0}", 0x33, lnis.outbound.get(0).getElement(3));
-            Assert.assertEquals("check byte 4 for F"+i+"{0}", (i==28)?0x06:0x02, lnis.outbound.get(0).getElement(4));
-            Assert.assertEquals("check byte 5 for F"+i+"{0}", 0x00, lnis.outbound.get(0).getElement(5));
-            Assert.assertEquals("check byte 6 for F"+i+"{0}", 0x5f, lnis.outbound.get(0).getElement(6));
-            Assert.assertEquals("check byte 7 for F"+i+"{0}", (i < 28)?(1<<(i-21)):0, lnis.outbound.get(0).getElement(7));
-            Assert.assertEquals("check byte 8 for F"+i+"{0}", 0x00, lnis.outbound.get(0).getElement(8));
-            Assert.assertEquals("check byte 9 for F"+i+"{0}", 0x00, lnis.outbound.get(0).getElement(9));
+            assertEquals( 1, lnis.outbound.size(), "check send of function group 5 for F"+i+" (0)");
+            assertEquals( LnConstants.OPC_IMM_PACKET, lnis.outbound.get(0).getOpCode(),
+                "check opcode is OPC_IMM_PACKET for F"+i+"");
+            assertEquals( 0x0b, lnis.outbound.get(0).getElement(1), "check byte 1 for F"+i+"{0}");
+            assertEquals( 0x7f, lnis.outbound.get(0).getElement(2), "check byte 2 for F"+i+"{0}");
+            assertEquals( 0x33, lnis.outbound.get(0).getElement(3), "check byte 3 for F"+i+"{0}");
+            assertEquals( (i==28)?0x06:0x02, lnis.outbound.get(0).getElement(4), "check byte 4 for F"+i+"{0}");
+            assertEquals( 0x00, lnis.outbound.get(0).getElement(5), "check byte 5 for F"+i+"{0}");
+            assertEquals( 0x5f, lnis.outbound.get(0).getElement(6), "check byte 6 for F"+i+"{0}");
+            assertEquals( (i < 28)?(1<<(i-21)):0, lnis.outbound.get(0).getElement(7), "check byte 7 for F"+i+"{0}");
+            assertEquals( 0x00, lnis.outbound.get(0).getElement(8), "check byte 8 for F"+i+"{0}");
+            assertEquals( 0x00, lnis.outbound.get(0).getElement(9), "check byte 9 for F"+i+"{0}");
 
-            instance.setF21(!(i==21));
-            instance.setF22(!(i==22));
-            instance.setF23(!(i==23));
-            instance.setF24(!(i==24));
-            instance.setF25(!(i==25));
-            instance.setF26(!(i==26));
-            instance.setF27(!(i==27));
-            instance.setF28(!(i==28));
+            instance.setFunction( 21, !(i==21));
+            instance.setFunction( 22, !(i==22));
+            instance.setFunction( 23, !(i==23));
+            instance.setFunction( 24, !(i==24));
+            instance.setFunction( 25, !(i==25));
+            instance.setFunction( 26, !(i==26));
+            instance.setFunction( 27, !(i==27));
+            instance.setFunction( 28, !(i==28));
 
             lnis.resetStatistics(); // and clears outbound message log
             ((LocoNetThrottle)instance).sendFunctionGroup5();
 
-            Assert.assertEquals("check send of function group 5 for !F"+i+"(1)", 1, lnis.outbound.size());
-            Assert.assertEquals("check opcode is OPC_IMM_PACKET for !F"+i+"{1}",LnConstants.OPC_IMM_PACKET, lnis.outbound.get(0).getOpCode());
-            Assert.assertEquals("check byte 1 for !F"+i+"{1}", 0x0b, lnis.outbound.get(0).getElement(1));
-            Assert.assertEquals("check byte 2 for !F"+i+"{1}", 0x7f, lnis.outbound.get(0).getElement(2));
-            Assert.assertEquals("check byte 3 for !F"+i+"{1}", 0x33, lnis.outbound.get(0).getElement(3));
-            Assert.assertEquals("check byte 4 for !F"+i+"{1}", (i==28)?0x02:0x06, lnis.outbound.get(0).getElement(4));
-            Assert.assertEquals("check byte 5 for !F"+i+"{1}", 0x00, lnis.outbound.get(0).getElement(5));
-            Assert.assertEquals("check byte 6 for !F"+i+"{1}", 0x5f, lnis.outbound.get(0).getElement(6));
-            Assert.assertEquals("check byte 7 for !F"+i+"{1}", (i < 28)?(127-(1<<(i-21))):0x7f, lnis.outbound.get(0).getElement(7));
-            Assert.assertEquals("check byte 8 for !F"+i+"{1}", 0x00, lnis.outbound.get(0).getElement(8));
-            Assert.assertEquals("check byte 9 for 1F"+i+"{1}", 0x00, lnis.outbound.get(0).getElement(9));
+            assertEquals( 1, lnis.outbound.size(), "check send of function group 5 for !F"+i+"(1)");
+            assertEquals( LnConstants.OPC_IMM_PACKET, lnis.outbound.get(0).getOpCode(),
+                "check opcode is OPC_IMM_PACKET for !F"+i+"{1}");
+            assertEquals( 0x0b, lnis.outbound.get(0).getElement(1), "check byte 1 for !F"+i+"{1}");
+            assertEquals( 0x7f, lnis.outbound.get(0).getElement(2), "check byte 2 for !F"+i+"{1}");
+            assertEquals( 0x33, lnis.outbound.get(0).getElement(3), "check byte 3 for !F"+i+"{1}");
+            assertEquals( (i==28)?0x02:0x06, lnis.outbound.get(0).getElement(4), "check byte 4 for !F"+i+"{1}");
+            assertEquals( 0x00, lnis.outbound.get(0).getElement(5), "check byte 5 for !F"+i+"{1}");
+            assertEquals( 0x5f, lnis.outbound.get(0).getElement(6), "check byte 6 for !F"+i+"{1}");
+            assertEquals( (i < 28)?(127-(1<<(i-21))):0x7f, lnis.outbound.get(0).getElement(7), "check byte 7 for !F"+i+"{1}");
+            assertEquals( 0x00, lnis.outbound.get(0).getElement(8), "check byte 8 for !F"+i+"{1}");
+            assertEquals( 0x00, lnis.outbound.get(0).getElement(9), "check byte 9 for 1F"+i+"{1}");
 
         }
     }
@@ -1150,13 +1341,13 @@ public class LocoNetExpThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     @Override
     public void testGetF2Momentary() {
         boolean expResult = true;
-        boolean result = instance.getF2Momentary();
-        Assert.assertEquals("Check F2 Momentary true", expResult, result);
+        boolean result = instance.getFunctionMomentary(2);
+        assertEquals( expResult, result, "Check F2 Momentary true");
 
         expResult = false;
-        instance.setF2Momentary(false);
-        result = instance.getF2Momentary();
-        Assert.assertEquals("Check F2 Momentary false", expResult, result);
+        instance.setFunctionMomentary( 2, false);
+        result = instance.getFunctionMomentary(2);
+        assertEquals( expResult, result, "Check F2 Momentary false");
 
     }
 


### PR DESCRIPTION
Updates from deprecated Function methods.
Asserts JU4 > JU5