### PR TITLE
update LogixNG ActionListenOnBeans Test

### DIFF
--- a/java/test/jmri/jmrit/logixng/actions/ActionListenOnBeansTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ActionListenOnBeansTest.java
@@ -1,7 +1,6 @@
 package jmri.jmrit.logixng.actions;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;


### PR DESCRIPTION
Updates annotation to JU5.
Retains JU4 Before / After annotation for JU4 tests in super classes.
Removes assert ( ln 153 ) to remove thread race for the textarea text, preventing occasional test failure
```
org.junit.ComparisonFailure: expected:<[]> but was:<[IS1, KnownState, 2
]>
	at org.junit.Assert.assertEquals(Assert.java:117)
	at org.junit.Assert.assertEquals(Assert.java:146)
	at jmri.jmrit.logixng.actions.ActionListenOnBeansTest.testExecute(ActionListenOnBeansTest.java:150)
```