### PR TITLE
Improve LCC/OpenLCB Send Frame window,

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -126,7 +126,14 @@
 
         <h4><a href="http://openlcb.org">OpenLCB</a> / LCC</h4>
             <ul>
-                <li></li>
+                <li>The Send Frame tool has 
+                    <ul>
+                        <li>some button labels updated,</li>
+                        <li>a new Send Global Identify Events button,</li>
+                        <li>more reliable control of the Open CDI Editor button state and</li>
+                        <li>some clean-up of the window layout.
+                    </ul>
+                </li>
             </ul>
 
         <h4>Powerline</h4>
@@ -405,7 +412,7 @@
 
         <h4>ZIMO</h4>
             <ul>
-                <li></li>
+                <li>See above.</li>
             </ul>
 
         <h4>Miscellaneous</h4>

--- a/java/src/jmri/jmrix/openlcb/swing/send/OpenLcbCanSendPane.java
+++ b/java/src/jmri/jmrix/openlcb/swing/send/OpenLcbCanSendPane.java
@@ -115,6 +115,9 @@ public class OpenLcbCanSendPane extends jmri.jmrix.can.swing.CanPanel implements
             @Override
             public void actionPerformed(ActionEvent e) {
                 setCdiButton();
+                jmri.util.ThreadingUtil.runOnGUIDelayed( ()->{ 
+                    setCdiButton(); 
+                }, 500);
             }
         });
 
@@ -188,20 +191,26 @@ public class OpenLcbCanSendPane extends jmri.jmrix.can.swing.CanPanel implements
         pane2 = new JPanel();
         pane2.setLayout(new WrapLayout());
         add(pane2);
-        b = new JButton("Send Request Consumers");
+        b = new JButton("Send Global Identify Events");
+        b.addActionListener(this::sendGlobalIdentifyEvents);
+        pane2.add(b);
+        b = new JButton("Send Event Produced");
+        b.addActionListener(this::sendEventPerformed);
+        pane2.add(b);
+        pane2 = new JPanel();
+        pane2.setLayout(new WrapLayout());
+        add(pane2);
+        b = new JButton("Send Identify Consumers");
         b.addActionListener(this::sendReqConsumers);
         pane2.add(b);
         b = new JButton("Send Consumer Identified");
         b.addActionListener(this::sendConsumerID);
         pane2.add(b);
-        b = new JButton("Send Request Producers");
+        b = new JButton("Send Identify Producers");
         b.addActionListener(this::sendReqProducers);
         pane2.add(b);
         b = new JButton("Send Producer Identified");
         b.addActionListener(this::sendProducerID);
-        pane2.add(b);
-        b = new JButton("Send Event Produced");
-        b.addActionListener(this::sendEventPerformed);
         pane2.add(b);
 
         // addressed messages
@@ -210,7 +219,7 @@ public class OpenLcbCanSendPane extends jmri.jmrix.can.swing.CanPanel implements
         pane2 = new JPanel();
         pane2.setLayout(new WrapLayout());
         add(pane2);
-        b = new JButton("Send Request Events");
+        b = new JButton("Send Addressed Identify Events");
         b.addActionListener(this::sendRequestEvents);
         pane2.add(b);
         b = new JButton("Send PIP Request");
@@ -231,7 +240,7 @@ public class OpenLcbCanSendPane extends jmri.jmrix.can.swing.CanPanel implements
         pane2.add(new JLabel("Contents: "));
         datagramContentsField.setColumns(45);
         pane2.add(datagramContentsField);
-        b = new JButton("Send Datagram Reply");
+        b = new JButton("Send Positive Datagram Reply");
         b.addActionListener(this::sendDatagramReply);
         pane2.add(b);
 
@@ -303,16 +312,20 @@ public class OpenLcbCanSendPane extends jmri.jmrix.can.swing.CanPanel implements
         var nodeID = nodeSelector.getSelectedNodeID();
         if (nodeID == null) { 
             cdiButton.setEnabled(false);
+            log.debug("null nodeID disables cdiButton");
             return;
         }
         var pip = store.getProtocolIdentification(nodeID);
         if (pip == null || pip.getProtocols() == null) { 
             cdiButton.setEnabled(false);
+            log.debug("null pip info disables cdiButton");
             return;
         }
-        cdiButton.setEnabled(
+        boolean setValue = 
             pip.getProtocols()
-                .contains(org.openlcb.ProtocolIdentification.Protocol.ConfigurationDescription));
+                .contains(org.openlcb.ProtocolIdentification.Protocol.ConfigurationDescription);
+        cdiButton.setEnabled(setValue);
+        log.debug("cdiButton set {} from PIP info", setValue);
     }
     
     private JPanel getSendSinglePacketJPanel() {
@@ -429,6 +442,11 @@ public class OpenLcbCanSendPane extends jmri.jmrix.can.swing.CanPanel implements
 
     public void sendRequestSnip(java.awt.event.ActionEvent e) {
         Message m = new SimpleNodeIdentInfoRequestMessage(srcNodeID, destNodeID());
+        connection.put(m, null);
+    }
+
+    public void sendGlobalIdentifyEvents(java.awt.event.ActionEvent e) {
+        Message m = new IdentifyEventsGlobalMessage(srcNodeID);
         connection.put(m, null);
     }
 


### PR DESCRIPTION
On the LCC/OpenLCB Send Frame window:
 - some button labels updated,
 - a new Send Global Identify Events button,
 - more reliable control of the Open CDI Editor button state and
 - some clean-up of the window layout.

Closes Issue #14583
