### PR TITLE
update LogixNG DefaultFemale Socket tests

### DIFF
--- a/java/test/jmri/jmrit/logixng/implementation/DefaultFemaleAnalogActionSocketTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/DefaultFemaleAnalogActionSocketTest.java
@@ -1,5 +1,10 @@
 package jmri.jmrit.logixng.implementation;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -13,11 +18,8 @@ import jmri.jmrit.logixng.actions.AnalogActionMemory;
 import jmri.util.JUnitUtil;
 
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.*;
 
 /**
  * Test ExpressionTimer
@@ -30,9 +32,6 @@ public class DefaultFemaleAnalogActionSocketTest extends FemaleSocketTestBase {
     private Memory _memory;
     private MyAnalogActionMemory _action;
 
-    @Rule
-    public final ExpectedException thrown = ExpectedException.none();
-
     @Override
     protected Manager<? extends NamedBean> getManager() {
         return InstanceManager.getDefault(AnalogActionManager.class);
@@ -40,20 +39,20 @@ public class DefaultFemaleAnalogActionSocketTest extends FemaleSocketTestBase {
 
     @Test
     public void testBundleClass() {
-        Assert.assertEquals("bundle is correct", "Test Bundle bb aa cc", Bundle.getMessage("TestBundle", "aa", "bb", "cc"));
-        Assert.assertEquals("bundle is correct", "Generic", Bundle.getMessage(Locale.US, "SocketTypeGeneric"));
-        Assert.assertEquals("bundle is correct", "Test Bundle bb aa cc", Bundle.getMessage(Locale.US, "TestBundle", "aa", "bb", "cc"));
+        assertEquals( "Test Bundle bb aa cc", Bundle.getMessage("TestBundle", "aa", "bb", "cc"), "bundle is correct");
+        assertEquals( "Generic", Bundle.getMessage(Locale.US, "SocketTypeGeneric"), "bundle is correct 2");
+        assertEquals( "Test Bundle bb aa cc", Bundle.getMessage(Locale.US, "TestBundle", "aa", "bb", "cc"), "bundle is correct 3");
     }
 
     @Test
     public void testGetName() {
-        Assert.assertTrue("String matches", "A1".equals(_femaleSocket.getName()));
+        assertTrue( "A1".equals(_femaleSocket.getName()), "String matches");
     }
 
     @Test
     public void testGetDescription() {
-        Assert.assertEquals("String matches", "!~", _femaleSocket.getShortDescription());
-        Assert.assertEquals("String matches", "!~ A1", _femaleSocket.getLongDescription());
+        assertEquals( "!~", _femaleSocket.getShortDescription(), "String matches");
+        assertEquals( "!~ A1", _femaleSocket.getLongDescription(), "String matches 2");
     }
 
     @Override
@@ -75,10 +74,10 @@ public class DefaultFemaleAnalogActionSocketTest extends FemaleSocketTestBase {
     }
 
     @Test
-    public void testSetValue() throws Exception {
+    public void testSetValue() throws JmriException {
         // Every test method should have an assertion
-        Assert.assertNotNull("femaleSocket is not null", _femaleSocket);
-        Assert.assertFalse("femaleSocket is not connected", _femaleSocket.isConnected());
+        assertNotNull( _femaleSocket, "femaleSocket is not null");
+        assertFalse( _femaleSocket.isConnected(), "femaleSocket is not connected");
         // Test setValue() when not connected
         ((DefaultFemaleAnalogActionSocket)_femaleSocket).setValue(0.0);
     }
@@ -99,8 +98,8 @@ public class DefaultFemaleAnalogActionSocketTest extends FemaleSocketTestBase {
         classes = new ArrayList<>();
         map.put(LogixNG_Category.OTHER, classes);
 
-        Assert.assertTrue("maps are equal",
-                isConnectionClassesEquals(map, _femaleSocket.getConnectableClasses()));
+        assertTrue( isConnectionClassesEquals(map, _femaleSocket.getConnectableClasses()),
+            "maps are equal");
     }
 /*
     @Test
@@ -123,6 +122,7 @@ public class DefaultFemaleAnalogActionSocketTest extends FemaleSocketTestBase {
 */
     // The minimal setup for log4J
     @Before
+    @BeforeEach
     public void setUp() {
         JUnitUtil.setUp();
         JUnitUtil.resetInstanceManager();
@@ -161,6 +161,7 @@ public class DefaultFemaleAnalogActionSocketTest extends FemaleSocketTestBase {
     }
 
     @After
+    @AfterEach
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.deregisterBlockManagerShutdownTask();
@@ -169,11 +170,11 @@ public class DefaultFemaleAnalogActionSocketTest extends FemaleSocketTestBase {
 
 
 
-    private class MyAnalogActionMemory extends AnalogActionMemory {
+    private static class MyAnalogActionMemory extends AnalogActionMemory {
 
-        private boolean _hasBeenSetup = false;
+        boolean _hasBeenSetup = false;
 
-        public MyAnalogActionMemory(String systemName) {
+        MyAnalogActionMemory(String systemName) {
             super(systemName, null);
         }
 

--- a/java/test/jmri/jmrit/logixng/implementation/DefaultFemaleAnalogExpressionSocketTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/DefaultFemaleAnalogExpressionSocketTest.java
@@ -1,5 +1,10 @@
 package jmri.jmrit.logixng.implementation;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -12,11 +17,8 @@ import jmri.jmrit.logixng.expressions.AnalogExpressionMemory;
 import jmri.util.JUnitUtil;
 
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.*;
 
 /**
  * Test DefaultFemaleAnalogExpressionSocket
@@ -30,9 +32,6 @@ public class DefaultFemaleAnalogExpressionSocketTest extends FemaleSocketTestBas
     private Memory _memory;
     private MyAnalogExpressionMemory _expression;
 
-    @Rule
-    public final ExpectedException thrown = ExpectedException.none();
-
     @Override
     protected Manager<? extends NamedBean> getManager() {
         return InstanceManager.getDefault(AnalogExpressionManager.class);
@@ -40,13 +39,13 @@ public class DefaultFemaleAnalogExpressionSocketTest extends FemaleSocketTestBas
 
     @Test
     public void testGetName() {
-        Assert.assertTrue("String matches", "E1".equals(_femaleSocket.getName()));
+        assertTrue( "E1".equals(_femaleSocket.getName()), "String matches");
     }
 
     @Test
     public void testGetDescription() {
-        Assert.assertTrue("String matches", "?~".equals(_femaleSocket.getShortDescription()));
-        Assert.assertTrue("String matches", "?~ E1".equals(_femaleSocket.getLongDescription()));
+        assertTrue( "?~".equals(_femaleSocket.getShortDescription()), "String matches");
+        assertTrue( "?~ E1".equals(_femaleSocket.getLongDescription()), "String matches 2");
     }
 
     @Override
@@ -68,18 +67,21 @@ public class DefaultFemaleAnalogExpressionSocketTest extends FemaleSocketTestBas
     }
 
     @Test
-    public void testSetValue() throws Exception {
+    public void testSetValue() throws JmriException {
         // Every test method should have an assertion
-        Assert.assertNotNull("femaleSocket is not null", _femaleSocket);
-        Assert.assertFalse("femaleSocket is not connected", _femaleSocket.isConnected());
+        assertNotNull( _femaleSocket, "femaleSocket is not null");
+        assertFalse( _femaleSocket.isConnected(), "femaleSocket is not connected");
         // Test evaluate() when not connected
-        Assert.assertTrue("values are equals", 0.0 == ((DefaultFemaleAnalogExpressionSocket)_femaleSocket).evaluate());
+        assertEquals( 0.0,  ((DefaultFemaleAnalogExpressionSocket)_femaleSocket).evaluate(),
+            "values are equals");
         // Test evaluate() when connected
         _femaleSocket.connect(maleSocket);
         _memory.setValue(0.0);
-        Assert.assertTrue("values are equals", 0.0 == ((DefaultFemaleAnalogExpressionSocket)_femaleSocket).evaluate());
+        assertEquals( 0.0, ((DefaultFemaleAnalogExpressionSocket)_femaleSocket).evaluate(),
+            "values are equals");
         _memory.setValue(1.2);
-        Assert.assertTrue("values are equals", 1.2 == ((DefaultFemaleAnalogExpressionSocket)_femaleSocket).evaluate());
+        assertEquals( 1.2, ((DefaultFemaleAnalogExpressionSocket)_femaleSocket).evaluate(),
+            "values are equals");
     }
 
     @Test
@@ -101,12 +103,13 @@ public class DefaultFemaleAnalogExpressionSocketTest extends FemaleSocketTestBas
         classes = new ArrayList<>();
         map.put(LogixNG_Category.OTHER, classes);
 
-        Assert.assertTrue("maps are equal",
-                isConnectionClassesEquals(map, _femaleSocket.getConnectableClasses()));
+        assertTrue( isConnectionClassesEquals(map, _femaleSocket.getConnectableClasses()),
+            "maps are equal");
     }
 
     // The minimal setup for log4J
     @Before
+    @BeforeEach
     public void setUp() {
         JUnitUtil.setUp();
         JUnitUtil.resetInstanceManager();
@@ -141,6 +144,7 @@ public class DefaultFemaleAnalogExpressionSocketTest extends FemaleSocketTestBas
     }
 
     @After
+    @AfterEach
     public void tearDown() {
 //        JUnitAppender.clearBacklog();   // REMOVE THIS!!!!
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
@@ -150,11 +154,11 @@ public class DefaultFemaleAnalogExpressionSocketTest extends FemaleSocketTestBas
 
 
 
-    private class MyAnalogExpressionMemory extends AnalogExpressionMemory {
+    private static class MyAnalogExpressionMemory extends AnalogExpressionMemory {
 
-        private boolean _hasBeenSetup = false;
+        boolean _hasBeenSetup = false;
 
-        public MyAnalogExpressionMemory(String systemName) {
+        MyAnalogExpressionMemory(String systemName) {
             super(systemName, null);
         }
 

--- a/java/test/jmri/jmrit/logixng/implementation/DefaultFemaleDigitalActionSocketTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/DefaultFemaleDigitalActionSocketTest.java
@@ -1,5 +1,10 @@
 package jmri.jmrit.logixng.implementation;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -15,11 +20,8 @@ import jmri.jmrit.operations.logixng.CategoryOperations;
 import jmri.util.JUnitUtil;
 
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.*;
 
 /**
  * Test ExpressionTimer
@@ -30,9 +32,6 @@ public class DefaultFemaleDigitalActionSocketTest extends FemaleSocketTestBase {
 
     private MyActionTurnout _action;
 
-    @Rule
-    public final ExpectedException thrown = ExpectedException.none();
-
     @Override
     protected Manager<? extends NamedBean> getManager() {
         return InstanceManager.getDefault(DigitalActionManager.class);
@@ -40,20 +39,20 @@ public class DefaultFemaleDigitalActionSocketTest extends FemaleSocketTestBase {
 
     @Test
     public void testBundleClass() {
-        Assert.assertEquals("bundle is correct", "Test Bundle bb aa cc", Bundle.getMessage("TestBundle", "aa", "bb", "cc"));
-        Assert.assertEquals("bundle is correct", "Generic", Bundle.getMessage(Locale.US, "SocketTypeGeneric"));
-        Assert.assertEquals("bundle is correct", "Test Bundle bb aa cc", Bundle.getMessage(Locale.US, "TestBundle", "aa", "bb", "cc"));
+        assertEquals( "Test Bundle bb aa cc", Bundle.getMessage("TestBundle", "aa", "bb", "cc"), "bundle is correct");
+        assertEquals( "Generic", Bundle.getMessage(Locale.US, "SocketTypeGeneric"), "bundle is correct 2");
+        assertEquals( "Test Bundle bb aa cc", Bundle.getMessage(Locale.US, "TestBundle", "aa", "bb", "cc"), "bundle is correct 3");
     }
 
     @Test
     public void testGetName() {
-        Assert.assertTrue("String matches", "A1".equals(_femaleSocket.getName()));
+        assertTrue( "A1".equals(_femaleSocket.getName()), "String matches");
     }
 
     @Test
     public void testGetDescription() {
-        Assert.assertTrue("String matches", "!".equals(_femaleSocket.getShortDescription()));
-        Assert.assertTrue("String matches", "! A1".equals(_femaleSocket.getLongDescription()));
+        assertTrue( "!".equals(_femaleSocket.getShortDescription()), "String matches");
+        assertTrue( "! A1".equals(_femaleSocket.getLongDescription()), "String matches 2");
     }
 
     @Override
@@ -75,10 +74,10 @@ public class DefaultFemaleDigitalActionSocketTest extends FemaleSocketTestBase {
     }
 
     @Test
-    public void testSetValue() throws Exception {
+    public void testSetValue() throws JmriException {
         // Every test method should have an assertion
-        Assert.assertNotNull("femaleSocket is not null", _femaleSocket);
-        Assert.assertFalse("femaleSocket is not connected", _femaleSocket.isConnected());
+        assertNotNull( _femaleSocket, "femaleSocket is not null");
+        assertFalse( _femaleSocket.isConnected(), "femaleSocket is not connected");
         // Test execute() when not connected
         ((DefaultFemaleDigitalActionSocket)_femaleSocket).execute();
     }
@@ -180,12 +179,13 @@ public class DefaultFemaleDigitalActionSocketTest extends FemaleSocketTestBase {
         classes.add(jmri.jmrit.logixng.actions.WebRequest.class);
         map.put(LogixNG_Category.OTHER, classes);
 
-        Assert.assertTrue("maps are equal",
-                isConnectionClassesEquals(map, _femaleSocket.getConnectableClasses()));
+        assertTrue( isConnectionClassesEquals(map, _femaleSocket.getConnectableClasses()),
+            "maps are equal");
     }
 
     // The minimal setup for log4J
     @Before
+    @BeforeEach
     public void setUp() {
         JUnitUtil.setUp();
         JUnitUtil.resetInstanceManager();
@@ -222,6 +222,7 @@ public class DefaultFemaleDigitalActionSocketTest extends FemaleSocketTestBase {
     }
 
     @After
+    @AfterEach
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.deregisterBlockManagerShutdownTask();
@@ -230,11 +231,11 @@ public class DefaultFemaleDigitalActionSocketTest extends FemaleSocketTestBase {
 
 
 
-    private class MyActionTurnout extends ActionTurnout {
+    private static class MyActionTurnout extends ActionTurnout {
 
-        private boolean _hasBeenSetup = false;
+        boolean _hasBeenSetup = false;
 
-        public MyActionTurnout(String systemName) {
+        MyActionTurnout(String systemName) {
             super(systemName, null);
         }
 

--- a/java/test/jmri/jmrit/logixng/implementation/DefaultFemaleDigitalBooleanActionSocketTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/DefaultFemaleDigitalBooleanActionSocketTest.java
@@ -1,5 +1,10 @@
 package jmri.jmrit.logixng.implementation;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -13,11 +18,8 @@ import jmri.jmrit.logixng.actions.DigitalBooleanLogixAction;
 import jmri.util.JUnitUtil;
 
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.*;
 
 /**
  * Test ExpressionTimer
@@ -28,9 +30,6 @@ public class DefaultFemaleDigitalBooleanActionSocketTest extends FemaleSocketTes
 
     private MyOnChangeAction _action;
 
-    @Rule
-    public final ExpectedException thrown = ExpectedException.none();
-
     @Override
     protected Manager<? extends NamedBean> getManager() {
         return InstanceManager.getDefault(DigitalBooleanActionManager.class);
@@ -38,20 +37,20 @@ public class DefaultFemaleDigitalBooleanActionSocketTest extends FemaleSocketTes
 
     @Test
     public void testBundleClass() {
-        Assert.assertEquals("bundle is correct", "Test Bundle bb aa cc", Bundle.getMessage("TestBundle", "aa", "bb", "cc"));
-        Assert.assertEquals("bundle is correct", "Generic", Bundle.getMessage(Locale.US, "SocketTypeGeneric"));
-        Assert.assertEquals("bundle is correct", "Test Bundle bb aa cc", Bundle.getMessage(Locale.US, "TestBundle", "aa", "bb", "cc"));
+        assertEquals( "Test Bundle bb aa cc", Bundle.getMessage("TestBundle", "aa", "bb", "cc"), "bundle is correct");
+        assertEquals( "Generic", Bundle.getMessage(Locale.US, "SocketTypeGeneric"), "bundle is correct");
+        assertEquals( "Test Bundle bb aa cc", Bundle.getMessage(Locale.US, "TestBundle", "aa", "bb", "cc"), "bundle is correct");
     }
 
     @Test
     public void testGetName() {
-        Assert.assertTrue("String matches", "A1".equals(_femaleSocket.getName()));
+        assertTrue( "A1".equals(_femaleSocket.getName()), "String matches");
     }
 
     @Test
     public void testGetDescription() {
-        Assert.assertTrue("String matches", "!b".equals(_femaleSocket.getShortDescription()));
-        Assert.assertTrue("String matches", "!b A1".equals(_femaleSocket.getLongDescription()));
+        assertTrue( "!b".equals(_femaleSocket.getShortDescription()), "String matches");
+        assertTrue( "!b A1".equals(_femaleSocket.getLongDescription()), "String matches");
     }
 
     @Override
@@ -73,10 +72,10 @@ public class DefaultFemaleDigitalBooleanActionSocketTest extends FemaleSocketTes
     }
 
     @Test
-    public void testSetValue() throws Exception {
+    public void testSetValue() throws JmriException {
         // Every test method should have an assertion
-        Assert.assertNotNull("femaleSocket is not null", _femaleSocket);
-        Assert.assertFalse("femaleSocket is not connected", _femaleSocket.isConnected());
+        assertNotNull( _femaleSocket, "femaleSocket is not null");
+        assertFalse( _femaleSocket.isConnected(), "femaleSocket is not connected");
         // Test execute() when not connected
         ((DefaultFemaleDigitalBooleanActionSocket)_femaleSocket).execute(false);
     }
@@ -98,12 +97,13 @@ public class DefaultFemaleDigitalBooleanActionSocketTest extends FemaleSocketTes
 //        classes.add(jmri.jmrit.logixng.actions.ShutdownComputer.class);
         map.put(LogixNG_Category.OTHER, classes);
 
-        Assert.assertTrue("maps are equal",
-                isConnectionClassesEquals(map, _femaleSocket.getConnectableClasses()));
+        assertTrue( isConnectionClassesEquals(map, _femaleSocket.getConnectableClasses()),
+            "maps are equal");
     }
 
     // The minimal setup for log4J
     @Before
+    @BeforeEach
     public void setUp() {
         JUnitUtil.setUp();
         JUnitUtil.resetInstanceManager();
@@ -139,6 +139,7 @@ public class DefaultFemaleDigitalBooleanActionSocketTest extends FemaleSocketTes
     }
 
     @After
+    @AfterEach
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.deregisterBlockManagerShutdownTask();
@@ -147,11 +148,11 @@ public class DefaultFemaleDigitalBooleanActionSocketTest extends FemaleSocketTes
 
 
 
-    private class MyOnChangeAction extends DigitalBooleanLogixAction {
+    private static class MyOnChangeAction extends DigitalBooleanLogixAction {
 
-        private boolean _hasBeenSetup = false;
+        boolean _hasBeenSetup = false;
 
-        public MyOnChangeAction(String systemName) {
+        MyOnChangeAction(String systemName) {
             super(systemName, null, DigitalBooleanLogixAction.When.Either);
         }
 

--- a/java/test/jmri/jmrit/logixng/implementation/DefaultFemaleDigitalExpressionSocketTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/DefaultFemaleDigitalExpressionSocketTest.java
@@ -1,5 +1,9 @@
 package jmri.jmrit.logixng.implementation;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -12,11 +16,8 @@ import jmri.jmrit.logixng.expressions.ExpressionTurnout;
 import jmri.util.JUnitUtil;
 
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.*;
 
 /**
  * Test DefaultFemaleDigitalExpressionSocket
@@ -28,9 +29,6 @@ public class DefaultFemaleDigitalExpressionSocketTest extends FemaleSocketTestBa
     private ConditionalNG _conditionalNG;
     private MyExpressionTurnout _expression;
 
-    @Rule
-    public final ExpectedException thrown = ExpectedException.none();
-
     @Override
     protected Manager<? extends NamedBean> getManager() {
         return InstanceManager.getDefault(DigitalExpressionManager.class);
@@ -38,13 +36,13 @@ public class DefaultFemaleDigitalExpressionSocketTest extends FemaleSocketTestBa
 
     @Test
     public void testGetName() {
-        Assert.assertTrue("String matches", "E1".equals(_femaleSocket.getName()));
+        assertTrue( "E1".equals(_femaleSocket.getName()), "String matches");
     }
 
     @Test
     public void testGetDescription() {
-        Assert.assertTrue("String matches", "?".equals(_femaleSocket.getShortDescription()));
-        Assert.assertTrue("String matches", "? E1".equals(_femaleSocket.getLongDescription()));
+        assertTrue( "?".equals(_femaleSocket.getShortDescription()), "String matches");
+        assertTrue( "? E1".equals(_femaleSocket.getLongDescription()), "String matches");
     }
 
     @Override
@@ -66,22 +64,22 @@ public class DefaultFemaleDigitalExpressionSocketTest extends FemaleSocketTestBa
     }
 
     @Test
-    public void testSetValue() throws Exception {
+    public void testSetValue() throws JmriException {
         // Every test method should have an assertion
-        Assert.assertNotNull("femaleSocket is not null", _femaleSocket);
-        Assert.assertFalse("femaleSocket is not connected", _femaleSocket.isConnected());
+        assertNotNull( _femaleSocket, "femaleSocket is not null");
+        assertFalse( _femaleSocket.isConnected(), "femaleSocket is not connected");
         // Test evaluate() when not connected
-        Assert.assertFalse("result is false", ((DefaultFemaleDigitalExpressionSocket)_femaleSocket).evaluate());
+        assertFalse( ((DefaultFemaleDigitalExpressionSocket)_femaleSocket).evaluate(), "result is false");
         // Test evaluate() when connected
         _femaleSocket.connect(maleSocket);
-        if (! _conditionalNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
+        assertTrue( _conditionalNG.setParentForAllChildren(new ArrayList<>()));
         Turnout t = InstanceManager.getDefault(TurnoutManager.class).provideTurnout("IT1");
         _expression.getSelectNamedBean().setNamedBean(t);
         _expression.setBeanState(ExpressionTurnout.TurnoutState.Thrown);
         t.setState(Turnout.CLOSED);
-        Assert.assertFalse("turnout is not thrown", ((DefaultFemaleDigitalExpressionSocket)_femaleSocket).evaluate());
+        assertFalse( ((DefaultFemaleDigitalExpressionSocket)_femaleSocket).evaluate(), "turnout is not thrown");
         t.setState(Turnout.THROWN);
-        Assert.assertTrue("turnout is thrown", ((DefaultFemaleDigitalExpressionSocket)_femaleSocket).evaluate());
+        assertTrue( ((DefaultFemaleDigitalExpressionSocket)_femaleSocket).evaluate(), "turnout is thrown");
     }
 
     @Test
@@ -143,12 +141,13 @@ public class DefaultFemaleDigitalExpressionSocketTest extends FemaleSocketTestBa
             map.put(LogixNG_Category.LINUX, classes);
         }
 
-        Assert.assertTrue("maps are equal",
-                isConnectionClassesEquals(map, _femaleSocket.getConnectableClasses()));
+        assertTrue( isConnectionClassesEquals(map, _femaleSocket.getConnectableClasses()),
+            "maps are equal");
     }
 
     // The minimal setup for log4J
     @Before
+    @BeforeEach
     public void setUp() {
         JUnitUtil.setUp();
         JUnitUtil.resetInstanceManager();
@@ -180,6 +179,7 @@ public class DefaultFemaleDigitalExpressionSocketTest extends FemaleSocketTestBa
     }
 
     @After
+    @AfterEach
     public void tearDown() {
 //        JUnitAppender.clearBacklog();   // REMOVE THIS!!!
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
@@ -189,11 +189,11 @@ public class DefaultFemaleDigitalExpressionSocketTest extends FemaleSocketTestBa
 
 
 
-    private class MyExpressionTurnout extends ExpressionTurnout {
+    private static class MyExpressionTurnout extends ExpressionTurnout {
 
-        private boolean _hasBeenSetup = false;
+        boolean _hasBeenSetup = false;
 
-        public MyExpressionTurnout(String systemName) {
+        MyExpressionTurnout(String systemName) {
             super(systemName, null);
         }
 

--- a/java/test/jmri/jmrit/logixng/implementation/DefaultFemaleStringActionSocketTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/DefaultFemaleStringActionSocketTest.java
@@ -1,5 +1,10 @@
 package jmri.jmrit.logixng.implementation;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -13,11 +18,8 @@ import jmri.jmrit.logixng.actions.StringActionMemory;
 import jmri.util.JUnitUtil;
 
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.*;
 
 /**
  * Test ExpressionTimer
@@ -30,9 +32,6 @@ public class DefaultFemaleStringActionSocketTest extends FemaleSocketTestBase {
     private Memory _memory;
     private MyStringActionMemory _action;
 
-    @Rule
-    public final ExpectedException thrown = ExpectedException.none();
-
     @Override
     protected Manager<? extends NamedBean> getManager() {
         return InstanceManager.getDefault(StringActionManager.class);
@@ -40,20 +39,20 @@ public class DefaultFemaleStringActionSocketTest extends FemaleSocketTestBase {
 
     @Test
     public void testBundleClass() {
-        Assert.assertEquals("bundle is correct", "Test Bundle bb aa cc", Bundle.getMessage("TestBundle", "aa", "bb", "cc"));
-        Assert.assertEquals("bundle is correct", "Generic", Bundle.getMessage(Locale.US, "SocketTypeGeneric"));
-        Assert.assertEquals("bundle is correct", "Test Bundle bb aa cc", Bundle.getMessage(Locale.US, "TestBundle", "aa", "bb", "cc"));
+        assertEquals( "Test Bundle bb aa cc", Bundle.getMessage("TestBundle", "aa", "bb", "cc"), "bundle is correct");
+        assertEquals( "Generic", Bundle.getMessage(Locale.US, "SocketTypeGeneric"), "bundle is correct 2");
+        assertEquals( "Test Bundle bb aa cc", Bundle.getMessage(Locale.US, "TestBundle", "aa", "bb", "cc"), "bundle is correct 3");
     }
 
     @Test
     public void testGetName() {
-        Assert.assertTrue("String matches", "A1".equals(_femaleSocket.getName()));
+        assertTrue( "A1".equals(_femaleSocket.getName()), "String matches");
     }
 
     @Test
     public void testGetDescription() {
-        Assert.assertTrue("String matches", "!s".equals(_femaleSocket.getShortDescription()));
-        Assert.assertTrue("String matches", "!s A1".equals(_femaleSocket.getLongDescription()));
+        assertTrue( "!s".equals(_femaleSocket.getShortDescription()), "String matches");
+        assertTrue( "!s A1".equals(_femaleSocket.getLongDescription()), "String matches 2");
     }
 
     @Override
@@ -75,10 +74,10 @@ public class DefaultFemaleStringActionSocketTest extends FemaleSocketTestBase {
     }
 
     @Test
-    public void testSetValue() throws Exception {
+    public void testSetValue() throws JmriException {
         // Every test method should have an assertion
-        Assert.assertNotNull("femaleSocket is not null", _femaleSocket);
-        Assert.assertFalse("femaleSocket is not connected", _femaleSocket.isConnected());
+        assertNotNull( _femaleSocket, "femaleSocket is not null");
+        assertFalse( _femaleSocket.isConnected(), "femaleSocket is not connected");
         // Test setValue() when not connected
         ((DefaultFemaleStringActionSocket)_femaleSocket).setValue("");
     }
@@ -99,12 +98,13 @@ public class DefaultFemaleStringActionSocketTest extends FemaleSocketTestBase {
         classes = new ArrayList<>();
         map.put(LogixNG_Category.OTHER, classes);
 
-        Assert.assertTrue("maps are equal",
-                isConnectionClassesEquals(map, _femaleSocket.getConnectableClasses()));
+        assertTrue( isConnectionClassesEquals(map, _femaleSocket.getConnectableClasses()),
+            "maps are equal");
     }
 
     // The minimal setup for log4J
     @Before
+    @BeforeEach
     public void setUp() {
         JUnitUtil.setUp();
         JUnitUtil.resetInstanceManager();
@@ -143,6 +143,7 @@ public class DefaultFemaleStringActionSocketTest extends FemaleSocketTestBase {
     }
 
     @After
+    @AfterEach
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.deregisterBlockManagerShutdownTask();
@@ -151,11 +152,11 @@ public class DefaultFemaleStringActionSocketTest extends FemaleSocketTestBase {
 
 
 
-    private class MyStringActionMemory extends StringActionMemory {
+    private static class MyStringActionMemory extends StringActionMemory {
 
-        private boolean _hasBeenSetup = false;
+        boolean _hasBeenSetup = false;
 
-        public MyStringActionMemory(String systemName) {
+        MyStringActionMemory(String systemName) {
             super(systemName, null);
         }
 

--- a/java/test/jmri/jmrit/logixng/implementation/DefaultFemaleStringExpressionSocketTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/DefaultFemaleStringExpressionSocketTest.java
@@ -1,5 +1,10 @@
 package jmri.jmrit.logixng.implementation;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -12,11 +17,8 @@ import jmri.jmrit.logixng.expressions.StringExpressionMemory;
 import jmri.util.JUnitUtil;
 
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.*;
 
 /**
  * Test DefaultFemaleStringExpressionSocket
@@ -30,9 +32,6 @@ public class DefaultFemaleStringExpressionSocketTest extends FemaleSocketTestBas
     private Memory _memory;
     private MyStringExpressionMemory _expression;
 
-    @Rule
-    public final ExpectedException thrown = ExpectedException.none();
-
     @Override
     protected Manager<? extends NamedBean> getManager() {
         return InstanceManager.getDefault(StringExpressionManager.class);
@@ -40,13 +39,13 @@ public class DefaultFemaleStringExpressionSocketTest extends FemaleSocketTestBas
 
     @Test
     public void testGetName() {
-        Assert.assertTrue("String matches", "E1".equals(_femaleSocket.getName()));
+        assertTrue( "E1".equals(_femaleSocket.getName()), "String matches");
     }
 
     @Test
     public void testGetDescription() {
-        Assert.assertTrue("String matches", "?s".equals(_femaleSocket.getShortDescription()));
-        Assert.assertTrue("String matches", "?s E1".equals(_femaleSocket.getLongDescription()));
+        assertTrue( "?s".equals(_femaleSocket.getShortDescription()), "String matches");
+        assertTrue( "?s E1".equals(_femaleSocket.getLongDescription()), "String matches 2");
     }
 
     @Override
@@ -68,18 +67,18 @@ public class DefaultFemaleStringExpressionSocketTest extends FemaleSocketTestBas
     }
 
     @Test
-    public void testSetValue() throws Exception {
+    public void testSetValue() throws JmriException {
         // Every test method should have an assertion
-        Assert.assertNotNull("femaleSocket is not null", _femaleSocket);
-        Assert.assertFalse("femaleSocket is not connected", _femaleSocket.isConnected());
+        assertNotNull( _femaleSocket, "femaleSocket is not null");
+        assertFalse( _femaleSocket.isConnected(), "femaleSocket is not connected");
         // Test evaluate() when not connected
-        Assert.assertEquals("strings are equals", "", ((DefaultFemaleStringExpressionSocket)_femaleSocket).evaluate());
+        assertEquals( "", ((DefaultFemaleStringExpressionSocket)_femaleSocket).evaluate(), "strings are equals");
         // Test evaluate() when connected
         _femaleSocket.connect(maleSocket);
         _memory.setValue("");
-        Assert.assertEquals("strings are equals", "", ((DefaultFemaleStringExpressionSocket)_femaleSocket).evaluate());
+        assertEquals( "", ((DefaultFemaleStringExpressionSocket)_femaleSocket).evaluate(), "strings are equals 2");
         _memory.setValue("Test");
-        Assert.assertEquals("strings are equals", "Test", ((DefaultFemaleStringExpressionSocket)_femaleSocket).evaluate());
+        assertEquals( "Test", ((DefaultFemaleStringExpressionSocket)_femaleSocket).evaluate(), "strings are equals 3");
     }
 
     @Test
@@ -99,12 +98,13 @@ public class DefaultFemaleStringExpressionSocketTest extends FemaleSocketTestBas
         classes = new ArrayList<>();
         map.put(LogixNG_Category.OTHER, classes);
 
-        Assert.assertTrue("maps are equal",
-                isConnectionClassesEquals(map, _femaleSocket.getConnectableClasses()));
+        assertTrue( isConnectionClassesEquals(map, _femaleSocket.getConnectableClasses()),
+            "maps are equal");
     }
 
     // The minimal setup for log4J
     @Before
+    @BeforeEach
     public void setUp() {
         JUnitUtil.setUp();
         JUnitUtil.resetInstanceManager();
@@ -139,6 +139,7 @@ public class DefaultFemaleStringExpressionSocketTest extends FemaleSocketTestBas
     }
 
     @After
+    @AfterEach
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.deregisterBlockManagerShutdownTask();
@@ -147,11 +148,11 @@ public class DefaultFemaleStringExpressionSocketTest extends FemaleSocketTestBas
 
 
 
-    private class MyStringExpressionMemory extends StringExpressionMemory {
+    private static class MyStringExpressionMemory extends StringExpressionMemory {
 
-        private boolean _hasBeenSetup = false;
+        boolean _hasBeenSetup = false;
 
-        public MyStringExpressionMemory(String systemName) {
+        MyStringExpressionMemory(String systemName) {
             super(systemName, null);
         }
 


### PR DESCRIPTION
Removes deprecated JUnit4 ExpectedException rule.
Inner classes can be static.
Tests and Asserts JU4 > JU5