### PR TITLE
Add 'visible' to the decoder definition function labels schema

### DIFF
--- a/xml/schema/decoder-4-15-2.xsd
+++ b/xml/schema/decoder-4-15-2.xsd
@@ -687,6 +687,7 @@
             </xs:element>
           </xs:sequence>
           <xs:attribute name="num" type="xs:string"/>
+          <xs:attribute name="visible" type="xs:string"/>
           <xs:attribute name="lockable" type="xs:string"/>
         </xs:complexType>
       </xs:element>


### PR DESCRIPTION
Due to an oversight, the 'visible' attribute was omitted from the `functionlabel` element in the decoder definition schema.  This PR adds it back in.  The code to access it was already present, just not yet used.