### PR TITLE
restore macOS Maven caching

### DIFF
--- a/.github/workflows/run-separate-LinkedWarrantTest.yml
+++ b/.github/workflows/run-separate-LinkedWarrantTest.yml
@@ -22,10 +22,6 @@ jobs:
         distribution: 'zulu'
         java-version: 11
     - name: Cache Maven packages
-      # TODO: remove next line after working again
-      #  temporarily work around https://github.com/actions/runner-images/issues/13341
-      #  by disabling caching for macOS
-      if: ${{ runner.os != 'macOS' }}
       uses: actions/cache@v4
       with:
         path: ~/.m2

--- a/.github/workflows/run-separate.yml
+++ b/.github/workflows/run-separate.yml
@@ -22,10 +22,6 @@ jobs:
         distribution: 'zulu'
         java-version: 11
     - name: Cache Maven packages
-      # TODO: remove next line after working again
-      #  temporarily work around https://github.com/actions/runner-images/issues/13341
-      #  by disabling caching for macOS
-      if: ${{ runner.os != 'macOS' }}
       uses: actions/cache@v4
       with:
         path: ~/.m2


### PR DESCRIPTION
We had turned off Maven download caching for CI running during a recent GitHub outage.  This PR turns that back on to make those CI jobs run faster and more reliably.