### PR TITLE
Add back Assume to make ant headless Cucumber tests pass

### DIFF
--- a/java/test/jmri/RunCucumberIT.java
+++ b/java/test/jmri/RunCucumberIT.java
@@ -39,6 +39,7 @@ public class RunCucumberIT {
 
     @BeforeClass
     public static void beforeTests() {
+        org.junit.Assume.assumeFalse(java.awt.GraphicsEnvironment.isHeadless());
         JUnitUtil.setUp();
         JUnitUtil.resetProfileManager();
         JUnitUtil.initZeroConfServiceManager();


### PR DESCRIPTION
`ant headlesstest` started failing when a 

```
org.junit.Assume.assumeFalse(java.awt.GraphicsEnvironment.isHeadless());
```

in the Cucumber test class was replaced by an

```
@DisabledIfHeadless
```

In theory these should be equivalent, with the 2nd preferred. But something about the structure of the Cucumber test process, which I don't understand at all, means that they're _not_ equivalent, and the 2nd one fails to suppress the tests.  Since they can't run headless, this causes them to fail, and hence `ant headlesstest` to fail.

This PR restores the earlier `assumeFalse` to get the `ant headlesstest` target to start passing again.  Unfortunately, I don't have a better solution that will work with just the `@DisabledIfHeadless`.