### PR TITLE
Olcb test tweaks

### DIFF
--- a/java/test/jmri/jmrix/openlcb/LinkNodeInventoryTest.java
+++ b/java/test/jmri/jmrix/openlcb/LinkNodeInventoryTest.java
@@ -2,7 +2,6 @@ package jmri.jmrix.openlcb;
 
 import jmri.util.JUnitUtil;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.*;
 
 /**
@@ -14,7 +13,7 @@ public class LinkNodeInventoryTest {
     @Test
     public void testCTor() {
         LinkNodeInventory t = new LinkNodeInventory();
-        Assert.assertNotNull("exists",t);
+        Assertions.assertNotNull( t, "exists");
     }
 
     @BeforeEach

--- a/java/test/jmri/jmrix/openlcb/OlcbAddressTest.java
+++ b/java/test/jmri/jmrix/openlcb/OlcbAddressTest.java
@@ -8,7 +8,7 @@ import jmri.util.JUnitUtil;
 
 import org.junit.jupiter.api.*;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests for the jmri.jmrix.openlcb.OlcbAddress class.

--- a/java/test/jmri/jmrix/openlcb/OlcbClockControlTest.java
+++ b/java/test/jmri/jmrix/openlcb/OlcbClockControlTest.java
@@ -24,7 +24,7 @@ import static jmri.Timebase.ClockInitialRunState.DO_NOTHING;
 import static jmri.Timebase.ClockInitialRunState.DO_START;
 import static jmri.Timebase.ClockInitialRunState.DO_STOP;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import static jmri.jmrix.openlcb.OlcbConfigurationManager.*;
 
@@ -36,8 +36,8 @@ import static org.mockito.Mockito.mock;
  * Created by bracz on 11/27/18.
  */
 public class OlcbClockControlTest {
-    OlcbTestInterface iface = null;
-    ClockControl clock;
+    private OlcbTestInterface iface = null;
+    private ClockControl clock;
 
     interface MockInterface {
         void onChange(String property, Object newValue);

--- a/java/test/jmri/jmrix/openlcb/OlcbConnectionTypeListTest.java
+++ b/java/test/jmri/jmrix/openlcb/OlcbConnectionTypeListTest.java
@@ -2,7 +2,6 @@ package jmri.jmrix.openlcb;
 
 import jmri.util.JUnitUtil;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.*;
 
 /**
@@ -14,7 +13,7 @@ public class OlcbConnectionTypeListTest {
     @Test
     public void testCTor() {
         OlcbConnectionTypeList t = new OlcbConnectionTypeList();
-        Assert.assertNotNull("exists",t);
+        Assertions.assertNotNull( t, "exists");
     }
 
     @BeforeEach

--- a/java/test/jmri/jmrix/openlcb/OlcbTestHelper.java
+++ b/java/test/jmri/jmrix/openlcb/OlcbTestHelper.java
@@ -50,7 +50,7 @@ public class OlcbTestHelper {
      * mock connection passed in at construction time.
      * Supports printing the messages for debugging.
      */
-    public class FakeConnection extends AbstractConnection {
+    public static class FakeConnection extends AbstractConnection {
         private final Connection mock;
         public boolean debugMessages = false;
 
@@ -105,7 +105,7 @@ public class OlcbTestHelper {
      * Helper class for the single-threaded operation. This class gets plugged into the OlcbInterface as the callback
      * for executing outgoing message send operations.
      */
-    class FakeExecutionThread implements OlcbInterface.SyncExecutor, Runnable {
+    static class FakeExecutionThread implements OlcbInterface.SyncExecutor, Runnable {
         private final BlockingQueue<QEntry> outputQueue = new LinkedBlockingQueue<>();
 
         /**
@@ -131,7 +131,7 @@ public class OlcbTestHelper {
         @Override
         public void run() {
             while (!Thread.currentThread().isInterrupted()) {
-                QEntry m = null;
+                QEntry m;
                 try {
                     m = outputQueue.take();
                     m.callback.run();
@@ -142,7 +142,7 @@ public class OlcbTestHelper {
             }
         }
 
-        private class QEntry {
+        private static class QEntry {
             QEntry(Runnable r) {
                 callback = r;
             }

--- a/java/test/jmri/jmrix/openlcb/configurexml/OlcbReporterManagerXmlTest.java
+++ b/java/test/jmri/jmrix/openlcb/configurexml/OlcbReporterManagerXmlTest.java
@@ -1,18 +1,22 @@
 package jmri.jmrix.openlcb.configurexml;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+
 import jmri.InstanceManager;
 import jmri.Reporter;
 import jmri.jmrix.openlcb.OlcbReporterManager;
 import jmri.jmrix.openlcb.OlcbTestInterface;
 import jmri.util.JUnitUtil;
+
 import org.jdom2.Element;
-import org.junit.Assert;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * OlcbReporterManagerXmlTest.java
@@ -25,7 +29,7 @@ import org.slf4j.LoggerFactory;
 public class OlcbReporterManagerXmlTest {
 
     @Test
-    public void testSaveAndRestore() throws Exception {
+    public void testSaveAndRestore() {
         log.debug("FIRST START");
         t = new OlcbTestInterface(new OlcbTestInterface.CreateConfigurationManager());
         OlcbReporterManager mgr = t.configurationManager.getReporterManager();
@@ -37,7 +41,7 @@ public class OlcbReporterManagerXmlTest {
         t.assertNoSentMessages();
 
         Element stored = xmlmgr.store(mgr);
-        Assert.assertNotNull(stored);
+        assertNotNull(stored);
 
         t.dispose();
         InstanceManager.getDefault().clearAll();
@@ -50,8 +54,8 @@ public class OlcbReporterManagerXmlTest {
         xmlmgr.load(stored, null);
 
         Reporter r2 = mgr.getBySystemName("MR1.2.3.4.5.6.0.0");
-        Assert.assertNotNull(r2);
-        Assert.assertEquals("rep1", r2.getUserName());
+        assertNotNull(r2);
+        assertEquals("rep1", r2.getUserName());
         t.flush();
         t.assertSentMessage(":X194a4c4cN010203040506ffff;");
         t.assertNoSentMessages();
@@ -59,13 +63,13 @@ public class OlcbReporterManagerXmlTest {
         t.dispose();
     }
 
-    OlcbTestInterface t;
-    private final static Logger log = LoggerFactory.getLogger(OlcbReporterManagerXmlTest.class);
+    private OlcbTestInterface t;
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(OlcbReporterManagerXmlTest.class);
 
     @BeforeAll
-    static public void checkSeparate() {
-       // this test is run separately because it leaves a lot of threads behind
-        org.junit.Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
+    public static void checkSeparate() {
+        // this test is run separately because it leaves a lot of threads behind
+        assumeFalse( Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"), "Ignoring intermittent test");
     }
 
     @BeforeEach

--- a/java/test/jmri/jmrix/openlcb/configurexml/OlcbSensorManagerXmlTest.java
+++ b/java/test/jmri/jmrix/openlcb/configurexml/OlcbSensorManagerXmlTest.java
@@ -1,7 +1,14 @@
 package jmri.jmrix.openlcb.configurexml;
 
-import jmri.InstanceManager;
-import jmri.Sensor;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+
+import jmri.*;
+import jmri.configurexml.JmriConfigureXmlException;
 import jmri.jmrix.can.CanMessage;
 import jmri.jmrix.openlcb.OlcbSensor;
 import jmri.jmrix.openlcb.OlcbSensorManager;
@@ -10,10 +17,8 @@ import jmri.jmrix.openlcb.OlcbUtils;
 import jmri.util.JUnitUtil;
 
 import org.jdom2.Element;
-import org.junit.Assert;
+
 import org.junit.jupiter.api.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * OlcbSensorManagerXmlTest.java
@@ -26,7 +31,7 @@ import org.slf4j.LoggerFactory;
 public class OlcbSensorManagerXmlTest {
 
     @Test
-    public void testSaveAndRestoreWithProperties() throws Exception {
+    public void testSaveAndRestoreWithProperties() throws JmriConfigureXmlException, JmriException {
         log.debug("FIRST START");
         t = new OlcbTestInterface(new OlcbTestInterface.CreateConfigurationManager());
         OlcbSensorManager mgr = t.configurationManager.getSensorManager();
@@ -36,7 +41,7 @@ public class OlcbSensorManagerXmlTest {
         t.flush();
         CanMessage expected = new CanMessage(new byte[]{1,2,3,4,5,6,7,8}, 0x198F4C4C);
         expected.setExtended(true);
-        Assert.assertEquals(expected, t.tc.rcvMessage);
+        assertEquals(expected, t.tc.rcvMessage);
         t.tc.rcvMessage = null;
 
         // Send a state query command
@@ -49,15 +54,15 @@ public class OlcbSensorManagerXmlTest {
         t.flush();
         expected = new CanMessage(new byte[]{1,2,3,4,5,6,7,8}, 0x194C4C4C);
         expected.setExtended(true);
-        Assert.assertEquals(expected, t.tc.rcvMessage);
+        assertEquals(expected, t.tc.rcvMessage);
         t.tc.rcvMessage = null;
 
         s.setProperty(OlcbUtils.PROPERTY_QUERY_AT_STARTUP, false);
         s.setAuthoritative(false);
-        Assert.assertEquals(1, mgr.getNamedBeanSet().size());
+        assertEquals(1, mgr.getNamedBeanSet().size());
 
         Element stored = xmlmgr.store(mgr);
-        Assert.assertNotNull(stored);
+        assertNotNull(stored);
         InstanceManager.getDefault().clearAll();
 
         log.debug("SECOND START");
@@ -68,9 +73,9 @@ public class OlcbSensorManagerXmlTest {
         xmlmgr.load(stored, null);
 
         Sensor s2 = mgr.getBySystemName("MS1.2.3.4.5.6.7.8;1.2.3.4.5.6.7.9");
-        Assert.assertNotNull(s2);
-        Assert.assertEquals(false, s2.getProperty(OlcbUtils.PROPERTY_QUERY_AT_STARTUP));
-        Assert.assertNull(s2.getProperty(OlcbUtils.PROPERTY_IS_CONSUMER));
+        assertNotNull(s2);
+        assertFalse( (Boolean)s2.getProperty(OlcbUtils.PROPERTY_QUERY_AT_STARTUP));
+        assertNull(s2.getProperty(OlcbUtils.PROPERTY_IS_CONSUMER));
 
         t.flush();
 
@@ -78,7 +83,7 @@ public class OlcbSensorManagerXmlTest {
         // init is disabled.
         expected = new CanMessage(new byte[]{1,2,3,4,5,6,7,9}, 0x194C7C4C);
         expected.setExtended(true);
-        Assert.assertEquals(expected, t.tc.rcvMessage);
+        assertEquals(expected, t.tc.rcvMessage);
         t.tc.rcvMessage = null;
 
         log.debug("SET STATE");
@@ -86,7 +91,7 @@ public class OlcbSensorManagerXmlTest {
         t.flush();
         expected = new CanMessage(new byte[]{1,2,3,4,5,6,7,8}, 0x195B4C4C);
         expected.setExtended(true);
-        Assert.assertEquals(expected, t.tc.rcvMessage);
+        assertEquals(expected, t.tc.rcvMessage);
         t.tc.rcvMessage = null;
 
         // Another query will get back unknown state due to the property loaded.
@@ -94,17 +99,17 @@ public class OlcbSensorManagerXmlTest {
         t.flush();
         expected = new CanMessage(new byte[]{1,2,3,4,5,6,7,8}, 0x194C7C4C);
         expected.setExtended(true);
-        Assert.assertEquals(expected, t.tc.rcvMessage);
+        assertEquals(expected, t.tc.rcvMessage);
         t.dispose();
     }
 
-    OlcbTestInterface t;
-    private final static Logger log = LoggerFactory.getLogger(OlcbSensorManagerXmlTest.class);
+    private OlcbTestInterface t;
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(OlcbSensorManagerXmlTest.class);
 
     @BeforeAll
     static public void checkSeparate() {
        // this test is run separately because it leaves a lot of threads behind
-        org.junit.Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
+        assumeFalse( Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"), "Ignoring intermittent test");
     }
 
     @BeforeEach

--- a/java/test/jmri/jmrix/openlcb/configurexml/ProtocolOptionsPersistenceTest.java
+++ b/java/test/jmri/jmrix/openlcb/configurexml/ProtocolOptionsPersistenceTest.java
@@ -1,6 +1,7 @@
 package jmri.jmrix.openlcb.configurexml;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 import org.junit.jupiter.api.*;
 
@@ -16,13 +17,13 @@ import jmri.jmrix.ConnectionConfigManager;
 import jmri.jmrix.PortAdapter;
 import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.profile.Profile;
+import jmri.util.JUnitAppender;
 import jmri.util.JUnitUtil;
 import jmri.util.prefs.HasConnectionButUnableToConnectException;
 
 /**
  * @author Balazs Racz, (C) 2018.
  */
-
 public class ProtocolOptionsPersistenceTest {
 
     private Path workspace = null;
@@ -35,7 +36,7 @@ public class ProtocolOptionsPersistenceTest {
     @BeforeAll
     static public void checkSeparate() {
        // this test is run separately because it leaves a lot of threads behind
-        org.junit.Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
+        assumeFalse( Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"), "Ignoring intermittent test");
     }
 
     @BeforeEach
@@ -54,6 +55,7 @@ public class ProtocolOptionsPersistenceTest {
         JUnitUtil.resetProfileManager();
         JUnitUtil.resetFileUtilSupport();
         //FileUtil.delete(this.workspace.toFile());
+        JUnitAppender.suppressWarnMessage("Can't get IP address to make NodeID. You should set a NodeID in the Connection preferences.");
         JUnitUtil.tearDown();
     }
 
@@ -98,7 +100,7 @@ public class ProtocolOptionsPersistenceTest {
 
         JUnitUtil.initConnectionConfigManager();
         connectionConfigManager = InstanceManager.getDefault(ConnectionConfigManager.class);
-        Assertions.assertNotNull(this.workspace);
+        assertNotNull(this.workspace);
         profile = new Profile(new File(this.workspace.toFile(), profileId));
         connectionConfigManager.initialize(profile);
 
@@ -160,21 +162,30 @@ public class ProtocolOptionsPersistenceTest {
         saveAndRestart();
         assertEquals("Hello, World", canSystemConnectionMemo.getProtocolOption("Ident", "UserName"));
 
-        assertTrue("getProtocolsWithOptions has Ident", canSystemConnectionMemo.getProtocolsWithOptions().contains("Ident"));
-        assertTrue("getProtocolsWithOptions has Throttles", canSystemConnectionMemo.getProtocolsWithOptions().contains("Throttles"));
-        assertTrue("getProtocolsWithOptions has Single", canSystemConnectionMemo.getProtocolsWithOptions().contains("Single"));
+        assertTrue( canSystemConnectionMemo.getProtocolsWithOptions().contains("Ident"),
+            "getProtocolsWithOptions has Ident");
+        assertTrue( canSystemConnectionMemo.getProtocolsWithOptions().contains("Throttles"),
+            "getProtocolsWithOptions has Throttles");
+        assertTrue( canSystemConnectionMemo.getProtocolsWithOptions().contains("Single"),
+            "getProtocolsWithOptions has Single");
         assertEquals(3, canSystemConnectionMemo.getProtocolsWithOptions().size());
 
-        assertTrue("Ident has UserName", canSystemConnectionMemo.getProtocolAllOptions("Ident").keySet().contains("UserName"));
-        assertTrue("Ident has Description",canSystemConnectionMemo.getProtocolAllOptions("Ident").keySet().contains("Description"));
+        assertTrue( canSystemConnectionMemo.getProtocolAllOptions("Ident").keySet().contains("UserName"),
+            "Ident has UserName");
+        assertTrue( canSystemConnectionMemo.getProtocolAllOptions("Ident").keySet().contains("Description"),
+            "Ident has Description");
         assertEquals(2, canSystemConnectionMemo.getProtocolAllOptions("Ident").size());
 
-        assertTrue("Throttles has Used", canSystemConnectionMemo.getProtocolAllOptions("Throttles").keySet().contains("Used"));
-        assertTrue("Throttles has Steal", canSystemConnectionMemo.getProtocolAllOptions("Throttles").keySet().contains("Steal"));
-        assertTrue("Throttles has MaxFn", canSystemConnectionMemo.getProtocolAllOptions("Throttles").keySet().contains("MaxFn"));
+        assertTrue( canSystemConnectionMemo.getProtocolAllOptions("Throttles").keySet().contains("Used"),
+            "Throttles has Used");
+        assertTrue( canSystemConnectionMemo.getProtocolAllOptions("Throttles").keySet().contains("Steal"),
+            "Throttles has Steal");
+        assertTrue( canSystemConnectionMemo.getProtocolAllOptions("Throttles").keySet().contains("MaxFn"),
+            "Throttles has MaxFn");
         assertEquals(3, canSystemConnectionMemo.getProtocolAllOptions("Throttles").size());
 
-        assertTrue("Single has Foo", canSystemConnectionMemo.getProtocolAllOptions("Single").keySet().contains("Foo"));
+        assertTrue( canSystemConnectionMemo.getProtocolAllOptions("Single").keySet().contains("Foo"),
+            "Single has Foo");
         assertEquals(1, canSystemConnectionMemo.getProtocolAllOptions("Single").size());
 
         expectOptionValue("Ident", "UserName", "Hello, World");

--- a/java/test/jmri/jmrix/openlcb/swing/OlcbSignalMastAddPaneTest.java
+++ b/java/test/jmri/jmrix/openlcb/swing/OlcbSignalMastAddPaneTest.java
@@ -1,17 +1,21 @@
 package jmri.jmrix.openlcb.swing;
 
-import jmri.jmrix.openlcb.OlcbSystemConnectionMemoScaffold;
-import jmri.*;
-import jmri.jmrit.beantable.signalmast.*;
-import jmri.jmrix.openlcb.*;
-import jmri.implementation.*;
-import jmri.util.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.*;
 
 import javax.swing.*;
 
-import org.junit.Assert;
+import jmri.*;
+import jmri.implementation.*;
+import jmri.jmrit.beantable.signalmast.*;
+import jmri.jmrix.openlcb.*;
+import jmri.jmrix.openlcb.OlcbSystemConnectionMemoScaffold;
+import jmri.util.*;
+
 import org.junit.jupiter.api.*;
 
 import org.openlcb.*;
@@ -42,17 +46,17 @@ public class OlcbSignalMastAddPaneTest extends AbstractSignalMastAddPaneTestBase
 
         OlcbSignalMastAddPane vp = new OlcbSignalMastAddPane();
 
-        Assert.assertTrue(vp.canHandleMast(s1));
-        Assert.assertTrue(vp.canHandleMast(s2));
-        Assert.assertTrue(vp.canHandleMast(s3));
-        Assert.assertFalse(vp.canHandleMast(m1));
+        assertTrue(vp.canHandleMast(s1));
+        assertTrue(vp.canHandleMast(s2));
+        assertTrue(vp.canHandleMast(s3));
+        assertFalse(vp.canHandleMast(m1));
 
         vp.setMast(null);
 
         SignalSystemManager ssm = InstanceManager.getDefault(SignalSystemManager.class);
-        Assert.assertNotNull(ssm);
+        assertNotNull(ssm);
         SignalSystem ss = ssm.getSystem("basic");
-        Assert.assertNotNull(ss);
+        assertNotNull(ss);
 
         vp.setAspectNames(s1.getAppearanceMap(), ss );
         vp.setMast(s1);
@@ -73,9 +77,9 @@ public class OlcbSignalMastAddPaneTest extends AbstractSignalMastAddPaneTestBase
         SignalMast mast = new OlcbSignalMast("MF$olm:basic:one-searchlight($1)", "no user name"){
             { setLastRef(4); } // reset references
         };
-        Assert.assertTrue(vp.canHandleMast(mast));
+        assertTrue(vp.canHandleMast(mast));
 
-        Assert.assertFalse(vp.canHandleMast(new jmri.implementation.VirtualSignalMast("IF$vsm:basic:one-searchlight($0001)")));
+        assertFalse(vp.canHandleMast(new jmri.implementation.VirtualSignalMast("IF$vsm:basic:one-searchlight($0001)")));
 
     }
 
@@ -89,11 +93,11 @@ public class OlcbSignalMastAddPaneTest extends AbstractSignalMastAddPaneTestBase
         vp.createMast("AAR-1946", "appearance-PL-2-high.xml", "user name");
 
         SignalMastManager smm = InstanceManager.getDefault(SignalMastManager.class);
-        Assert.assertNotNull(smm );
+        assertNotNull(smm );
         SignalMast sm = smm.getByUserName("user name");
-        Assert.assertNotNull(sm );
-        Assert.assertEquals("PL-2-high", sm.getMastType());
-        Assert.assertNotNull(smm.getBySystemName("MF$olm:AAR-1946:PL-2-high($0005)"));
+        assertNotNull(sm );
+        assertEquals("PL-2-high", sm.getMastType());
+        assertNotNull(smm.getBySystemName("MF$olm:AAR-1946:PL-2-high($0005)"));
 
     }
 
@@ -101,14 +105,16 @@ public class OlcbSignalMastAddPaneTest extends AbstractSignalMastAddPaneTestBase
     public void testCreateAndDisableViaGui() throws java.beans.PropertyVetoException {
 
         SignalMastManager mgr = InstanceManager.getDefault(SignalMastManager.class);
-        for (SignalMast m : mgr.getNamedBeanSet()) mgr.deleteBean(m, "DoDelete");
-        Assert.assertEquals(0, InstanceManager.getDefault(SignalMastManager.class).getObjectCount());
+        for (SignalMast m : mgr.getNamedBeanSet()) {
+            mgr.deleteBean(m, "DoDelete");
+        }
+        assertEquals(0, InstanceManager.getDefault(SignalMastManager.class).getObjectCount());
 
         OlcbSignalMastAddPane vp = new OlcbSignalMastAddPane();
         SignalSystemManager ssm = InstanceManager.getDefault(SignalSystemManager.class);
-        Assert.assertNotNull(ssm);
+        assertNotNull(ssm);
         SignalSystem ss = ssm.getSystem("basic");
-        Assert.assertNotNull(ss);
+        assertNotNull(ss);
 
         vp.setAspectNames(
             new jmri.implementation.DefaultSignalAppearanceMap("IM123") {
@@ -127,20 +133,20 @@ public class OlcbSignalMastAddPaneTest extends AbstractSignalMastAddPaneTestBase
         frame.setVisible(true);
 
         // check load
-        Assert.assertEquals("00.00.00.00.00.00.00.00", vp.litEventID.getText());
-        Assert.assertEquals("00.00.00.00.00.00.00.00", vp.notLitEventID.getText());
-        Assert.assertEquals("00.00.00.00.00.00.00.00", vp.heldEventID.getText());
-        Assert.assertEquals("00.00.00.00.00.00.00.00", vp.notHeldEventID.getText());
+        assertEquals("00.00.00.00.00.00.00.00", vp.litEventID.getText());
+        assertEquals("00.00.00.00.00.00.00.00", vp.notLitEventID.getText());
+        assertEquals("00.00.00.00.00.00.00.00", vp.heldEventID.getText());
+        assertEquals("00.00.00.00.00.00.00.00", vp.notHeldEventID.getText());
 
         // disable Approach Medim, change some of the event IDs
         // then build the mast, all on Swing thread
         ThreadingUtil.runOnGUI(() -> {
             var approachMed = vp.allAspectsCheckBoxes.get("Approach Medium");
-            Assert.assertNotNull(approachMed);
+            assertNotNull(approachMed);
             approachMed.setSelected(true);
 
             var clear = vp.aspectEventIDs.get("Clear");
-            Assert.assertNotNull(clear);
+            assertNotNull(clear);
             clear.setText("01.02.03.04.05.06.07.08");
 
             vp.litEventID.setText(    "03.02.01.01.01.01.01.01");
@@ -152,23 +158,23 @@ public class OlcbSignalMastAddPaneTest extends AbstractSignalMastAddPaneTestBase
         });
 
         // check list of SignalMasts
-        Assert.assertEquals(1, mgr.getObjectCount());
+        assertEquals(1, mgr.getObjectCount());
         SignalMast sm1 = mgr.getByUserName("user name 1");
-        Assert.assertNotNull(sm1);
+        assertNotNull(sm1);
         // system name not checked, depends on history of how many SignalMast objects have been created
 
         // check aspect disabled
-        Assert.assertTrue(sm1.isAspectDisabled("Approach Medium"));
-        Assert.assertFalse(sm1.isAspectDisabled("Clear"));
+        assertTrue(sm1.isAspectDisabled("Approach Medium"));
+        assertFalse(sm1.isAspectDisabled("Clear"));
 
         // check correct eventid present
         OlcbSignalMast foundMast = (OlcbSignalMast)sm1;
-        Assert.assertEquals(new OlcbAddress("01.02.03.04.05.06.07.08", null), new OlcbAddress(foundMast.getOutputForAppearance("Clear"), null));
+        assertEquals(new OlcbAddress("01.02.03.04.05.06.07.08", null), new OlcbAddress(foundMast.getOutputForAppearance("Clear"), null));
 
-        Assert.assertEquals(new OlcbAddress("03.02.01.01.01.01.01.01", null), new OlcbAddress(foundMast.getLitEventId(), null));
-        Assert.assertEquals(new OlcbAddress("04.02.01.01.01.01.01.01", null), new OlcbAddress(foundMast.getNotLitEventId(), null));
-        Assert.assertEquals(new OlcbAddress("05.02.01.01.01.01.01.01", null), new OlcbAddress(foundMast.getHeldEventId(), null));
-        Assert.assertEquals(new OlcbAddress("06.02.01.01.01.01.01.01", null), new OlcbAddress(foundMast.getNotHeldEventId(), null));
+        assertEquals(new OlcbAddress("03.02.01.01.01.01.01.01", null), new OlcbAddress(foundMast.getLitEventId(), null));
+        assertEquals(new OlcbAddress("04.02.01.01.01.01.01.01", null), new OlcbAddress(foundMast.getNotLitEventId(), null));
+        assertEquals(new OlcbAddress("05.02.01.01.01.01.01.01", null), new OlcbAddress(foundMast.getHeldEventId(), null));
+        assertEquals(new OlcbAddress("06.02.01.01.01.01.01.01", null), new OlcbAddress(foundMast.getNotHeldEventId(), null));
 
         ThreadingUtil.runOnGUI(frame::dispose);
     }
@@ -176,7 +182,7 @@ public class OlcbSignalMastAddPaneTest extends AbstractSignalMastAddPaneTestBase
     @Test
     public void testEditAndDisableViaGui() {
 
-        Assert.assertEquals(0, InstanceManager.getDefault(SignalMastManager.class).getObjectCount());
+        assertEquals(0, InstanceManager.getDefault(SignalMastManager.class).getObjectCount());
         OlcbSignalMast mast = new OlcbSignalMast("MF$olm:basic:one-searchlight($0001)", "user name 2");
         mast.setOutputForAppearance("Approach", "01.01.01.01.01.01.01.01");
         mast.setLitEventId("03.01.01.01.01.01.01.01");
@@ -187,16 +193,16 @@ public class OlcbSignalMastAddPaneTest extends AbstractSignalMastAddPaneTestBase
         SignalMastManager smm = InstanceManager.getDefault(SignalMastManager.class);
         smm.register(mast);
 
-        Assert.assertEquals(1, InstanceManager.getDefault(SignalMastManager.class).getObjectCount());
+        assertEquals(1, InstanceManager.getDefault(SignalMastManager.class).getObjectCount());
         mast.setAspectDisabled("Stop");
         mast.setAspectDisabled("Unlit"); // we will renable this below
 
         OlcbSignalMastAddPane vp = new OlcbSignalMastAddPane();
 
         SignalSystemManager ssm = InstanceManager.getDefault(SignalSystemManager.class);
-        Assert.assertNotNull(ssm);
+        assertNotNull(ssm);
         SignalSystem ss = ssm.getSystem("basic");
-        Assert.assertNotNull(ss);
+        assertNotNull(ss);
 
         vp.setAspectNames(
             new jmri.implementation.DefaultSignalAppearanceMap("IM123") {
@@ -212,51 +218,51 @@ public class OlcbSignalMastAddPaneTest extends AbstractSignalMastAddPaneTestBase
         frame.setVisible(true);
 
         // check load
-        Assert.assertEquals(new OlcbAddress("03.01.01.01.01.01.01.01", null), new OlcbAddress(vp.litEventID.getText(), null));
-        Assert.assertEquals(new OlcbAddress("04.01.01.01.01.01.01.01", null), new OlcbAddress(vp.notLitEventID.getText(), null));
-        Assert.assertEquals(new OlcbAddress("05.01.01.01.01.01.01.01", null), new OlcbAddress(vp.heldEventID.getText(), null));
-        Assert.assertEquals(new OlcbAddress("06.01.01.01.01.01.01.01", null), new OlcbAddress(vp.notHeldEventID.getText(), null));
+        assertEquals(new OlcbAddress("03.01.01.01.01.01.01.01", null), new OlcbAddress(vp.litEventID.getText(), null));
+        assertEquals(new OlcbAddress("04.01.01.01.01.01.01.01", null), new OlcbAddress(vp.notLitEventID.getText(), null));
+        assertEquals(new OlcbAddress("05.01.01.01.01.01.01.01", null), new OlcbAddress(vp.heldEventID.getText(), null));
+        assertEquals(new OlcbAddress("06.01.01.01.01.01.01.01", null), new OlcbAddress(vp.notHeldEventID.getText(), null));
 
         // disable Approach, change some of the event IDs
         // then build the mast, all on Swing thread
         ThreadingUtil.runOnGUI(() -> {
             var approach = vp.allAspectsCheckBoxes.get("Approach");
-            Assert.assertNotNull(approach);
+            assertNotNull(approach);
             approach.setSelected(true);
             
             var unlit = vp.allAspectsCheckBoxes.get("Unlit");
-            Assert.assertNotNull(unlit);
+            assertNotNull(unlit);
             unlit.setSelected(false);
 
             var clear = vp.aspectEventIDs.get("Clear");
-            Assert.assertNotNull(clear);
+            assertNotNull(clear);
             clear.setText("01.02.03.04.05.06.07.08");
 
             vp.createMast("basic", "appearance-one-searchlight.xml", "user name 1");
         });
 
         // check list of SignalMasts
-        Assert.assertEquals(1, smm.getObjectCount());
+        assertEquals(1, smm.getObjectCount());
         SignalMast sm2 = smm.getByUserName("user name 2");
-        Assert.assertNotNull(sm2);
+        assertNotNull(sm2);
         // system name not checked, depends on history of how many SignalMast objects have been created
 
         // check correct aspects disabled
-        Assert.assertFalse(sm2.isAspectDisabled("Clear"));
-        Assert.assertTrue(sm2.isAspectDisabled("Approach"));
-        Assert.assertTrue(sm2.isAspectDisabled("Stop"));
-        Assert.assertFalse(sm2.isAspectDisabled("Unlit"));
+        assertFalse(sm2.isAspectDisabled("Clear"));
+        assertTrue(sm2.isAspectDisabled("Approach"));
+        assertTrue(sm2.isAspectDisabled("Stop"));
+        assertFalse(sm2.isAspectDisabled("Unlit"));
 
         // check correct eventid present
         OlcbSignalMast foundMast = (OlcbSignalMast)sm2;
-        Assert.assertEquals(new OlcbAddress("00.00.00.00.00.00.00.00", null), new OlcbAddress(foundMast.getOutputForAppearance("Stop"), null));
-        Assert.assertEquals(new OlcbAddress("01.02.03.04.05.06.07.08", null), new OlcbAddress(foundMast.getOutputForAppearance("Clear"), null));
-        Assert.assertEquals(new OlcbAddress("01.01.01.01.01.01.01.01", null), new OlcbAddress(foundMast.getOutputForAppearance("Approach"), null));
+        assertEquals(new OlcbAddress("00.00.00.00.00.00.00.00", null), new OlcbAddress(foundMast.getOutputForAppearance("Stop"), null));
+        assertEquals(new OlcbAddress("01.02.03.04.05.06.07.08", null), new OlcbAddress(foundMast.getOutputForAppearance("Clear"), null));
+        assertEquals(new OlcbAddress("01.01.01.01.01.01.01.01", null), new OlcbAddress(foundMast.getOutputForAppearance("Approach"), null));
 
-        Assert.assertEquals(new OlcbAddress("03.01.01.01.01.01.01.01", null), new OlcbAddress(foundMast.getLitEventId(), null));
-        Assert.assertEquals(new OlcbAddress("04.01.01.01.01.01.01.01", null), new OlcbAddress(foundMast.getNotLitEventId(), null));
-        Assert.assertEquals(new OlcbAddress("05.01.01.01.01.01.01.01", null), new OlcbAddress(foundMast.getHeldEventId(), null));
-        Assert.assertEquals(new OlcbAddress("06.01.01.01.01.01.01.01", null), new OlcbAddress(foundMast.getNotHeldEventId(), null));
+        assertEquals(new OlcbAddress("03.01.01.01.01.01.01.01", null), new OlcbAddress(foundMast.getLitEventId(), null));
+        assertEquals(new OlcbAddress("04.01.01.01.01.01.01.01", null), new OlcbAddress(foundMast.getNotLitEventId(), null));
+        assertEquals(new OlcbAddress("05.01.01.01.01.01.01.01", null), new OlcbAddress(foundMast.getHeldEventId(), null));
+        assertEquals(new OlcbAddress("06.01.01.01.01.01.01.01", null), new OlcbAddress(foundMast.getNotHeldEventId(), null));
 
         ThreadingUtil.runOnGUI(frame::dispose);
     }
@@ -264,14 +270,14 @@ public class OlcbSignalMastAddPaneTest extends AbstractSignalMastAddPaneTestBase
     // TODO: GUI test of icons in Add/Edit pane
 
     // from here down is testing infrastructure
-    private static OlcbSystemConnectionMemoScaffold memo;
-    private static OlcbSystemConnectionMemoScaffold memo1;
+    private static volatile OlcbSystemConnectionMemoScaffold memo;
+    private static volatile OlcbSystemConnectionMemoScaffold memo1;
     private static OlcbSystemConnectionMemoScaffold memo2;
-    static Connection connection;
-    static NodeID nodeID = new NodeID(new byte[]{1, 0, 0, 0, 0, 0});
-    static NodeID nodeID1 = new NodeID(new byte[]{2, 0, 0, 0, 0, 0});
-    static NodeID nodeID2 = new NodeID(new byte[]{3, 0, 0, 0, 0, 0});
-    static java.util.ArrayList<Message> messages;
+    private static Connection connection;
+    private static NodeID nodeID = new NodeID(new byte[]{1, 0, 0, 0, 0, 0});
+    private static NodeID nodeID1 = new NodeID(new byte[]{2, 0, 0, 0, 0, 0});
+    private static NodeID nodeID2 = new NodeID(new byte[]{3, 0, 0, 0, 0, 0});
+    private static java.util.ArrayList<Message> messages;
 
     private static void resetMessages(){
         messages = new java.util.ArrayList<>();

--- a/java/test/jmri/jmrix/openlcb/swing/send/OpenLcbCanSendPaneTest.java
+++ b/java/test/jmri/jmrix/openlcb/swing/send/OpenLcbCanSendPaneTest.java
@@ -1,12 +1,15 @@
 package jmri.jmrix.openlcb.swing.send;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+
 import jmri.InstanceManager;
 import jmri.IdTagManager;
 import jmri.jmrix.openlcb.OlcbEventNameStore;
+import jmri.util.JUnitAppender;
 import jmri.util.JUnitUtil;
 
-import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.jupiter.api.*;
 
 import org.openlcb.EventID;
@@ -18,42 +21,42 @@ import org.openlcb.EventID;
 @jmri.util.junit.annotations.DisabledIfHeadless
 public class OpenLcbCanSendPaneTest extends jmri.util.swing.JmriPanelTest {
 
-    jmri.jmrix.can.CanSystemConnectionMemo memo;
-    jmri.jmrix.can.TrafficController tc;
+    private jmri.jmrix.can.CanSystemConnectionMemo memo;
+    private jmri.jmrix.can.TrafficController tc;
 
     @Test
     @Override
     public void testInitComponents() {
-        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
+        assumeFalse( Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"), "Ignoring intermittent test");
         // for now, just makes ure there isn't an exception.
         ((OpenLcbCanSendPane)panel).initComponents(memo);
     }
 
     @Test
     public void testInitContext() {
-        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
+        assumeFalse( Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"), "Ignoring intermittent test");
         // for now, just makes ure there isn't an exception.
         panel.initContext(memo);
     }
 
     @Test
     public void testEventId() {
-        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
+        assumeFalse( Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"), "Ignoring intermittent test");
         OpenLcbCanSendPane p = (OpenLcbCanSendPane) panel;
 
         p.sendEventField.setText("05.01.01.01.14.FF.01.02");
         EventID expected = new EventID(new byte[]{0x05, 0x01, 0x01, 0x01, 0x14, (byte) 0xff, 0x01, 0x02});
-        Assert.assertEquals(expected, p.eventID());
+        assertEquals(expected, p.eventID());
     }
 
     @Test
     public void testEventIdDotted() {
-        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
+        assumeFalse( Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"), "Ignoring intermittent test");
         OpenLcbCanSendPane p = (OpenLcbCanSendPane) panel;
 
         p.sendEventField.setText("05.01.01.01.14.FF.01.02");
         EventID expected = new EventID(new byte[]{0x05, 0x01, 0x01, 0x01, 0x14, (byte) 0xff, 0x01, 0x02});
-        Assert.assertEquals(expected, p.eventID());
+        assertEquals(expected, p.eventID());
     }
 
 
@@ -62,7 +65,7 @@ public class OpenLcbCanSendPaneTest extends jmri.util.swing.JmriPanelTest {
     public void setUp() {
         JUnitUtil.setUp();
        // this test is run separately because it leaves a lot of threads behind
-        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
+        assumeFalse( Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"), "Ignoring intermittent test");
         JUnitUtil.resetProfileManager();
         memo = new jmri.jmrix.can.CanSystemConnectionMemo();
         tc = new jmri.jmrix.can.TestTrafficController();
@@ -88,6 +91,7 @@ public class OpenLcbCanSendPaneTest extends jmri.util.swing.JmriPanelTest {
             title = null;
             InstanceManager.getDefault(IdTagManager.class).dispose();
         }
+        JUnitAppender.suppressWarnMessage("Can't get IP address to make NodeID. You should set a NodeID in the Connection preferences.");
         JUnitUtil.tearDown();
     }
 }


### PR DESCRIPTION
Non-specific exceptions
Assumes / Asserts JU4 > JU5
suppress log warns "Can't get IP address to make NodeID..."

**OlcbTestHelper**
classes can be static
memo and memo1 made volatile