### PR TITLE
update Lenz MessageFormatter tests

### DIFF
--- a/java/test/jmri/jmrix/lenz/hornbyelite/messageformatters/HornbyEliteMultiUnitInfoReplyFormatterTest.java
+++ b/java/test/jmri/jmrix/lenz/hornbyelite/messageformatters/HornbyEliteMultiUnitInfoReplyFormatterTest.java
@@ -1,19 +1,19 @@
 package jmri.jmrix.lenz.hornbyelite.messageformatters;
 
+import jmri.jmrix.AbstractMessageFormatterTest;
 import jmri.jmrix.lenz.XNetReply;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+
+import org.junit.jupiter.api.*;
 
 /**
  * Tests for the HornbyEliteMultiUnitInfoReplFormatter class
  *
  * @author Paul Bender Copyright (C) 2025
  */
-public class HornbyEliteMultiUnitInfoReplyFormatterTest {
+public class HornbyEliteMultiUnitInfoReplyFormatterTest extends AbstractMessageFormatterTest {
 
     @Test
     public void testToMonitorStringMultiUnitInfoResponse() {
-        HornbyEliteMultiUnitInfoReplyFormatter formatter = new HornbyEliteMultiUnitInfoReplyFormatter();
         XNetReply r = new XNetReply("E5 F8 C1 04 00 00 34");
         Assertions.assertTrue(formatter.handlesMessage(r));
         Assertions.assertEquals("Elite Speed/Direction Information: Locomotive 260,Reverse,in 14 Speed Step Mode,Speed Step: 0. Address is Free for Operation. ",
@@ -22,10 +22,17 @@ public class HornbyEliteMultiUnitInfoReplyFormatterTest {
 
     @Test
     public void testToMonitorStringMultiUnitFnInfoResponse() {
-        HornbyEliteMultiUnitInfoReplyFormatter formatter = new HornbyEliteMultiUnitInfoReplyFormatter();
         XNetReply r = new XNetReply("E5 F9 C1 04 00 00 34");
         Assertions.assertTrue(formatter.handlesMessage(r));
         Assertions.assertEquals("Elite Function Information: Locomotive 260 F0 Off; F1 Off; F2 Off; F3 Off; F4 Off; F5 Off; F6 Off; F7 Off; F8 Off; F9 Off; F10 Off; F11 Off; F12 Off; ",
                 formatter.formatMessage(r));
     }
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp(); // setup JUnit
+        formatter = new HornbyEliteMultiUnitInfoReplyFormatter();
+    }
+
 }

--- a/java/test/jmri/jmrix/lenz/messageformatters/XNet128SpeedStepModeSpeedAndDirectionFormatterTest.java
+++ b/java/test/jmri/jmrix/lenz/messageformatters/XNet128SpeedStepModeSpeedAndDirectionFormatterTest.java
@@ -1,18 +1,20 @@
 package jmri.jmrix.lenz.messageformatters;
 
+import jmri.jmrix.AbstractMessageFormatterTest;
 import jmri.jmrix.lenz.XNetMessage;
+
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
  * Tests for the XNet128SpeedStepModeSpeedAndDirectionFormatter class.
  * @author Paul Bender Copyright (C) 2024
  */
-public class XNet128SpeedStepModeSpeedAndDirectionFormatterTest {
+public class XNet128SpeedStepModeSpeedAndDirectionFormatterTest extends AbstractMessageFormatterTest {
 
     @Test
     public void testFormattingForwardHalfSpeed() {
-        XNet128SpeedStepModeSpeedAndDirectionFormatter formatter = new XNet128SpeedStepModeSpeedAndDirectionFormatter();
         XNetMessage msg = XNetMessage.getSpeedAndDirectionMsg(1234, jmri.SpeedStepMode.NMRA_DCC_128, 0.5f, true);
         Assertions.assertThat(formatter.handlesMessage(msg)).isTrue();
         Assertions.assertThat("Mobile Decoder Operations Request: Set Address 1234 to Speed Step 64 and direction Forward in 128 Speed Step Mode.").isEqualTo(formatter.formatMessage(msg));
@@ -20,7 +22,6 @@ public class XNet128SpeedStepModeSpeedAndDirectionFormatterTest {
 
     @Test
     public void testFormattingBackwardHalfSpeed() {
-        XNet128SpeedStepModeSpeedAndDirectionFormatter formatter = new XNet128SpeedStepModeSpeedAndDirectionFormatter();
         XNetMessage msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.NMRA_DCC_128,0.5f,false);
         Assertions.assertThat(formatter.handlesMessage(msg)).isTrue();
         Assertions.assertThat("Mobile Decoder Operations Request: Set Address 1234 to Speed Step 64 and direction Reverse in 128 Speed Step Mode.").isEqualTo(formatter.formatMessage(msg));
@@ -28,7 +29,6 @@ public class XNet128SpeedStepModeSpeedAndDirectionFormatterTest {
 
     @Test
     public void testFormattingForwardStopped() {
-        XNet128SpeedStepModeSpeedAndDirectionFormatter formatter = new XNet128SpeedStepModeSpeedAndDirectionFormatter();
         XNetMessage msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.NMRA_DCC_128,0,true);
         Assertions.assertThat(formatter.handlesMessage(msg)).isTrue();
         Assertions.assertThat("Mobile Decoder Operations Request: Set Address 1234 to Speed Step 0 and direction Forward in 128 Speed Step Mode.").isEqualTo(formatter.formatMessage(msg));
@@ -36,10 +36,16 @@ public class XNet128SpeedStepModeSpeedAndDirectionFormatterTest {
 
     @Test
     public void testFormattingBackwardStopped() {
-        XNet128SpeedStepModeSpeedAndDirectionFormatter formatter = new XNet128SpeedStepModeSpeedAndDirectionFormatter();
         XNetMessage msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.NMRA_DCC_128,0,false);
         Assertions.assertThat(formatter.handlesMessage(msg)).isTrue();
         Assertions.assertThat("Mobile Decoder Operations Request: Set Address 1234 to Speed Step 0 and direction Reverse in 128 Speed Step Mode.").isEqualTo(formatter.formatMessage(msg));
+    }
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp(); // setup JUnit
+        formatter = new XNet128SpeedStepModeSpeedAndDirectionFormatter();
     }
 
 }

--- a/java/test/jmri/jmrix/lenz/messageformatters/XNet14SpeedStepModeSpeedAndDirectionFormatterTest.java
+++ b/java/test/jmri/jmrix/lenz/messageformatters/XNet14SpeedStepModeSpeedAndDirectionFormatterTest.java
@@ -1,7 +1,10 @@
 package jmri.jmrix.lenz.messageformatters;
 
+import jmri.jmrix.AbstractMessageFormatterTest;
 import jmri.jmrix.lenz.XNetMessage;
+
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -9,11 +12,10 @@ import org.junit.jupiter.api.Test;
  *
  * @author Paul Bender Copyright (C) 2024
  */
-public class XNet14SpeedStepModeSpeedAndDirectionFormatterTest {
+public class XNet14SpeedStepModeSpeedAndDirectionFormatterTest extends AbstractMessageFormatterTest {
 
     @Test
     public void testFormattingForwardHalfSpeed() {
-        XNet14SpeedStepModeSpeedAndDirectionFormatter formatter = new XNet14SpeedStepModeSpeedAndDirectionFormatter();
         XNetMessage msg = XNetMessage.getSpeedAndDirectionMsg(1234, jmri.SpeedStepMode.NMRA_DCC_14, 0.5f, true);
         Assertions.assertThat(formatter.handlesMessage(msg)).isTrue();
         Assertions.assertThat("Mobile Decoder Operations Request: Set Address 1234 to Speed Step 8 and direction Forward in 14 Speed Step Mode.").isEqualTo(formatter.formatMessage(msg));
@@ -21,7 +23,6 @@ public class XNet14SpeedStepModeSpeedAndDirectionFormatterTest {
 
     @Test
     public void testFormattingBackwardHalfSpeed() {
-        XNet14SpeedStepModeSpeedAndDirectionFormatter formatter = new XNet14SpeedStepModeSpeedAndDirectionFormatter();
         XNetMessage msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.NMRA_DCC_14,0.5f,false);
         Assertions.assertThat(formatter.handlesMessage(msg)).isTrue();
         Assertions.assertThat("Mobile Decoder Operations Request: Set Address 1234 to Speed Step 8 and direction Reverse in 14 Speed Step Mode.").isEqualTo(formatter.formatMessage(msg));
@@ -29,7 +30,6 @@ public class XNet14SpeedStepModeSpeedAndDirectionFormatterTest {
 
     @Test
     public void testFormattingForwardStopped() {
-        XNet14SpeedStepModeSpeedAndDirectionFormatter formatter = new XNet14SpeedStepModeSpeedAndDirectionFormatter();
         XNetMessage msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.NMRA_DCC_14,0,true);
         Assertions.assertThat(formatter.handlesMessage(msg)).isTrue();
         Assertions.assertThat("Mobile Decoder Operations Request: Set Address 1234 to Speed Step 0 and direction Forward in 14 Speed Step Mode.").isEqualTo(formatter.formatMessage(msg));
@@ -37,10 +37,16 @@ public class XNet14SpeedStepModeSpeedAndDirectionFormatterTest {
 
     @Test
     public void testFormattingBackwardStopped() {
-        XNet14SpeedStepModeSpeedAndDirectionFormatter formatter = new XNet14SpeedStepModeSpeedAndDirectionFormatter();
         XNetMessage msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.NMRA_DCC_14,0,false);
         Assertions.assertThat(formatter.handlesMessage(msg)).isTrue();
         Assertions.assertThat("Mobile Decoder Operations Request: Set Address 1234 to Speed Step 0 and direction Reverse in 14 Speed Step Mode.").isEqualTo(formatter.formatMessage(msg));
+    }
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp(); // setup JUnit
+        formatter = new XNet14SpeedStepModeSpeedAndDirectionFormatter();
     }
 
 }

--- a/java/test/jmri/jmrix/lenz/messageformatters/XNet27SpeedStepModeSpeedAndDirectionFormatterTest.java
+++ b/java/test/jmri/jmrix/lenz/messageformatters/XNet27SpeedStepModeSpeedAndDirectionFormatterTest.java
@@ -1,7 +1,10 @@
 package jmri.jmrix.lenz.messageformatters;
 
+import jmri.jmrix.AbstractMessageFormatterTest;
 import jmri.jmrix.lenz.XNetMessage;
+
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -9,11 +12,10 @@ import org.junit.jupiter.api.Test;
  *
  * @author Paul Bender Copyright (C) 2024
  */
-public class XNet27SpeedStepModeSpeedAndDirectionFormatterTest {
+public class XNet27SpeedStepModeSpeedAndDirectionFormatterTest extends AbstractMessageFormatterTest {
 
     @Test
     public void testFormattingForwardHalfSpeed() {
-        XNet27SpeedStepModeSpeedAndDirectionFormatter formatter = new XNet27SpeedStepModeSpeedAndDirectionFormatter();
         XNetMessage msg = XNetMessage.getSpeedAndDirectionMsg(1234, jmri.SpeedStepMode.NMRA_DCC_27, 0.5f, true);
         Assertions.assertThat(formatter.handlesMessage(msg)).isTrue();
         Assertions.assertThat("Mobile Decoder Operations Request: Set Address 1234 to Speed Step 14 and direction Forward in 27 Speed Step Mode.").isEqualTo(formatter.formatMessage(msg));
@@ -21,7 +23,6 @@ public class XNet27SpeedStepModeSpeedAndDirectionFormatterTest {
 
     @Test
     public void testFormattingBackwardHalfSpeed() {
-        XNet27SpeedStepModeSpeedAndDirectionFormatter formatter = new XNet27SpeedStepModeSpeedAndDirectionFormatter();
         XNetMessage msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.NMRA_DCC_27,0.5f,false);
         Assertions.assertThat(formatter.handlesMessage(msg)).isTrue();
         Assertions.assertThat("Mobile Decoder Operations Request: Set Address 1234 to Speed Step 14 and direction Reverse in 27 Speed Step Mode.").isEqualTo(formatter.formatMessage(msg));
@@ -29,7 +30,6 @@ public class XNet27SpeedStepModeSpeedAndDirectionFormatterTest {
 
     @Test
     public void testFormattingForwardStopped() {
-        XNet27SpeedStepModeSpeedAndDirectionFormatter formatter = new XNet27SpeedStepModeSpeedAndDirectionFormatter();
         XNetMessage msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.NMRA_DCC_27,0,true);
         Assertions.assertThat(formatter.handlesMessage(msg)).isTrue();
         Assertions.assertThat("Mobile Decoder Operations Request: Set Address 1234 to Speed Step 0 and direction Forward in 27 Speed Step Mode.").isEqualTo(formatter.formatMessage(msg));
@@ -37,10 +37,16 @@ public class XNet27SpeedStepModeSpeedAndDirectionFormatterTest {
 
     @Test
     public void testFormattingBackwardStopped() {
-        XNet27SpeedStepModeSpeedAndDirectionFormatter formatter = new XNet27SpeedStepModeSpeedAndDirectionFormatter();
         XNetMessage msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.NMRA_DCC_27,0,false);
         Assertions.assertThat(formatter.handlesMessage(msg)).isTrue();
         Assertions.assertThat("Mobile Decoder Operations Request: Set Address 1234 to Speed Step 0 and direction Reverse in 27 Speed Step Mode.").isEqualTo(formatter.formatMessage(msg));
+    }
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp(); // setup JUnit
+        formatter = new XNet27SpeedStepModeSpeedAndDirectionFormatter();
     }
 
 }

--- a/java/test/jmri/jmrix/lenz/messageformatters/XNet28SpeedStepModeSpeedAndDirectionFormatterTest.java
+++ b/java/test/jmri/jmrix/lenz/messageformatters/XNet28SpeedStepModeSpeedAndDirectionFormatterTest.java
@@ -1,7 +1,10 @@
 package jmri.jmrix.lenz.messageformatters;
 
+import jmri.jmrix.AbstractMessageFormatterTest;
 import jmri.jmrix.lenz.XNetMessage;
+
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -9,11 +12,10 @@ import org.junit.jupiter.api.Test;
  *
  * @author Paul Bender Copyright (C) 2024
  */
-public class XNet28SpeedStepModeSpeedAndDirectionFormatterTest {
+public class XNet28SpeedStepModeSpeedAndDirectionFormatterTest extends AbstractMessageFormatterTest {
 
     @Test
     public void testFormattingForwardHalfSpeed() {
-        XNet28SpeedStepModeSpeedAndDirectionFormatter formatter = new XNet28SpeedStepModeSpeedAndDirectionFormatter();
         XNetMessage msg = XNetMessage.getSpeedAndDirectionMsg(1234, jmri.SpeedStepMode.NMRA_DCC_28, 0.5f, true);
         Assertions.assertThat(formatter.handlesMessage(msg)).isTrue();
         Assertions.assertThat("Mobile Decoder Operations Request: Set Address 1234 to Speed Step 14 and direction Forward in 28 Speed Step Mode.").isEqualTo(formatter.formatMessage(msg));
@@ -21,7 +23,6 @@ public class XNet28SpeedStepModeSpeedAndDirectionFormatterTest {
 
     @Test
     public void testFormattingBackwardHalfSpeed() {
-        XNet28SpeedStepModeSpeedAndDirectionFormatter formatter = new XNet28SpeedStepModeSpeedAndDirectionFormatter();
         XNetMessage msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.NMRA_DCC_28,0.5f,false);
         Assertions.assertThat(formatter.handlesMessage(msg)).isTrue();
         Assertions.assertThat("Mobile Decoder Operations Request: Set Address 1234 to Speed Step 14 and direction Reverse in 28 Speed Step Mode.").isEqualTo(formatter.formatMessage(msg));
@@ -29,7 +30,6 @@ public class XNet28SpeedStepModeSpeedAndDirectionFormatterTest {
 
     @Test
     public void testFormattingForwardStopped() {
-        XNet28SpeedStepModeSpeedAndDirectionFormatter formatter = new XNet28SpeedStepModeSpeedAndDirectionFormatter();
         XNetMessage msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.NMRA_DCC_28,0,true);
         Assertions.assertThat(formatter.handlesMessage(msg)).isTrue();
         Assertions.assertThat("Mobile Decoder Operations Request: Set Address 1234 to Speed Step 0 and direction Forward in 28 Speed Step Mode.").isEqualTo(formatter.formatMessage(msg));
@@ -37,10 +37,16 @@ public class XNet28SpeedStepModeSpeedAndDirectionFormatterTest {
 
     @Test
     public void testFormattingBackwardStopped() {
-        XNet28SpeedStepModeSpeedAndDirectionFormatter formatter = new XNet28SpeedStepModeSpeedAndDirectionFormatter();
         XNetMessage msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.NMRA_DCC_28,0,false);
         Assertions.assertThat(formatter.handlesMessage(msg)).isTrue();
         Assertions.assertThat("Mobile Decoder Operations Request: Set Address 1234 to Speed Step 0 and direction Reverse in 28 Speed Step Mode.").isEqualTo(formatter.formatMessage(msg));
+    }
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp(); // setup JUnit
+        formatter = new XNet28SpeedStepModeSpeedAndDirectionFormatter();
     }
 
 }

--- a/java/test/jmri/jmrix/lenz/messageformatters/XNetBCModelTimeFormatterTest.java
+++ b/java/test/jmri/jmrix/lenz/messageformatters/XNetBCModelTimeFormatterTest.java
@@ -1,6 +1,9 @@
 package jmri.jmrix.lenz.messageformatters;
 
+import jmri.jmrix.AbstractMessageFormatterTest;
 import jmri.jmrix.lenz.XNetReply;
+
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -10,14 +13,20 @@ import static org.assertj.core.api.Assertions.assertThat;
  * .
  * @author Paul Bender Copyright (C) 2025
  */
-public class XNetBCModelTimeFormatterTest {
+public class XNetBCModelTimeFormatterTest extends AbstractMessageFormatterTest {
 
     @Test
     public void testFormatMessage() {
-        XNetBCModelTimeFormatter formatter = new XNetBCModelTimeFormatter();
         XNetReply reply = new XNetReply("63 03 95 36 C3");
         assertThat(formatter.handlesMessage(reply)).isTrue();
         assertThat(formatter.formatMessage(reply)).isEqualTo("Fast Clock Broadcast: Day 4 time 21:54 clock is running");
+    }
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp(); // setup JUnit
+        formatter = new XNetBCModelTimeFormatter();
     }
 
 }

--- a/java/test/jmri/jmrix/lenz/messageformatters/XNetBroadcastEmergencyStopFormatterTest.java
+++ b/java/test/jmri/jmrix/lenz/messageformatters/XNetBroadcastEmergencyStopFormatterTest.java
@@ -1,21 +1,29 @@
 package jmri.jmrix.lenz.messageformatters;
 
+import jmri.jmrix.AbstractMessageFormatterTest;
 import jmri.jmrix.lenz.XNetReply;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+
+import org.junit.jupiter.api.*;
 
 /**
  * Tests for the XNetBroadcastEmergencyStopFormatter class.
  *
  * @author Paul Bender Copyright (C) 2025
  */
-public class XNetBroadcastEmergencyStopFormatterTest {
+public class XNetBroadcastEmergencyStopFormatterTest extends AbstractMessageFormatterTest {
 
     @Test
     public void testEmergencyStopFormatter(){
-        XNetBroadcastEmergencyStopFormatter formatter = new XNetBroadcastEmergencyStopFormatter();
         XNetReply r = new XNetReply("81 00 81");
         Assertions.assertTrue(formatter.handlesMessage(r));
         Assertions.assertEquals(Bundle.getMessage("XNetReplyBCEverythingStop"), formatter.formatMessage(r));
     }
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp(); // setup JUnit
+        formatter = new XNetBroadcastEmergencyStopFormatter();
+    }
+
 }

--- a/java/test/jmri/jmrix/lenz/messageformatters/XNetCSPowerOnStatusRequestMessageFormatterTest.java
+++ b/java/test/jmri/jmrix/lenz/messageformatters/XNetCSPowerOnStatusRequestMessageFormatterTest.java
@@ -1,29 +1,35 @@
 package jmri.jmrix.lenz.messageformatters;
 
+import jmri.jmrix.AbstractMessageFormatterTest;
 import jmri.jmrix.lenz.XNetMessage;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+
+import org.junit.jupiter.api.*;
 
 /**
  * Tests for the XNetCSPowerOnStatusRequestMessageFormatter class.
  * @author Paul Bender Copyright (C) 2024
  */
+public class XNetCSPowerOnStatusRequestMessageFormatterTest extends AbstractMessageFormatterTest {
 
-public class XNetCSPowerOnStatusRequestMessageFormatterTest {
-
-        @Test
-        public void testFormatCSPowerOnAutoRequestMessage() {
-            XNetCSPowerOnStatusRequestMessageFormatter formatter = new XNetCSPowerOnStatusRequestMessageFormatter();
-            XNetMessage msg = XNetMessage.getCSAutoStartMessage(true);
-            Assertions.assertTrue(formatter.handlesMessage(msg), "Formatter Handles Message");
-            Assertions.assertEquals("REQUEST: Set Power-up Mode to Automatic", formatter.formatMessage(msg), "Monitor String");
-        }
+    @Test
+    public void testFormatCSPowerOnAutoRequestMessage() {
+        XNetMessage msg = XNetMessage.getCSAutoStartMessage(true);
+        Assertions.assertTrue(formatter.handlesMessage(msg), "Formatter Handles Message");
+        Assertions.assertEquals("REQUEST: Set Power-up Mode to Automatic", formatter.formatMessage(msg), "Monitor String");
+    }
 
     @Test
     public void testFormatCSPowerOnManualRequestMessage() {
-        XNetCSPowerOnStatusRequestMessageFormatter formatter = new XNetCSPowerOnStatusRequestMessageFormatter();
         XNetMessage msg = XNetMessage.getCSAutoStartMessage(false);
         Assertions.assertTrue(formatter.handlesMessage(msg), "Formatter Handles Message");
         Assertions.assertEquals("REQUEST: Set Power-up Mode to Manual", formatter.formatMessage(msg), "Monitor String");
     }
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp(); // setup JUnit
+        formatter = new XNetCSPowerOnStatusRequestMessageFormatter();
+    }
+
 }

--- a/java/test/jmri/jmrix/lenz/messageformatters/XNetCSSoftwareVersionReplyFormatterTest.java
+++ b/java/test/jmri/jmrix/lenz/messageformatters/XNetCSSoftwareVersionReplyFormatterTest.java
@@ -1,14 +1,14 @@
 package jmri.jmrix.lenz.messageformatters;
 
+import jmri.jmrix.AbstractMessageFormatterTest;
 import jmri.jmrix.lenz.XNetReply;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
 
-public class XNetCSSoftwareVersionReplyFormatterTest {
+import org.junit.jupiter.api.*;
+
+public class XNetCSSoftwareVersionReplyFormatterTest extends AbstractMessageFormatterTest {
 
     @Test
     public void testHandlesLZ100Message() {
-        XNetCSSoftwareVersionReplyFormatter formatter = new XNetCSSoftwareVersionReplyFormatter();
         XNetReply r = new XNetReply("63 21 36 00 55");
         Assertions.assertTrue(formatter.handlesMessage(r));
         Assertions.assertEquals(Bundle.getMessage("XNetReplyCSVersion",3.6,Bundle.getMessage("CSTypeLZ100")), formatter.formatMessage(r));
@@ -16,7 +16,6 @@ public class XNetCSSoftwareVersionReplyFormatterTest {
 
     @Test
     public void testHandlesLH200Message() {
-        XNetCSSoftwareVersionReplyFormatter formatter = new XNetCSSoftwareVersionReplyFormatter();
         XNetReply r = new XNetReply("63 21 36 01 55");
         Assertions.assertTrue(formatter.handlesMessage(r));
         Assertions.assertEquals(Bundle.getMessage("XNetReplyCSVersion",3.6,Bundle.getMessage("CSTypeLH200")), formatter.formatMessage(r));
@@ -24,7 +23,6 @@ public class XNetCSSoftwareVersionReplyFormatterTest {
 
     @Test
     public void testHandlesCompactMessage() {
-        XNetCSSoftwareVersionReplyFormatter formatter = new XNetCSSoftwareVersionReplyFormatter();
         XNetReply r = new XNetReply("63 21 36 02 55");
         Assertions.assertTrue(formatter.handlesMessage(r));
         Assertions.assertEquals(Bundle.getMessage("XNetReplyCSVersion",3.6,Bundle.getMessage("CSTypeCompact")), formatter.formatMessage(r));
@@ -32,7 +30,6 @@ public class XNetCSSoftwareVersionReplyFormatterTest {
 
     @Test
     public void testHandlesMultiMausMessage() {
-        XNetCSSoftwareVersionReplyFormatter formatter = new XNetCSSoftwareVersionReplyFormatter();
         XNetReply r = new XNetReply("63 21 36 10 55");
         Assertions.assertTrue(formatter.handlesMessage(r));
         Assertions.assertEquals(Bundle.getMessage("XNetReplyCSVersion",3.6,Bundle.getMessage("CSTypeMultiMaus")), formatter.formatMessage(r));
@@ -40,10 +37,16 @@ public class XNetCSSoftwareVersionReplyFormatterTest {
 
     @Test
     public void testHandlesOtherCSMessage() {
-        XNetCSSoftwareVersionReplyFormatter formatter = new XNetCSSoftwareVersionReplyFormatter();
         XNetReply r = new XNetReply("63 21 36 20 55");
         Assertions.assertTrue(formatter.handlesMessage(r));
         Assertions.assertEquals(Bundle.getMessage("XNetReplyCSVersion",3.6,"32"), formatter.formatMessage(r));
+    }
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp(); // setup JUnit
+        formatter = new XNetCSSoftwareVersionReplyFormatter();
     }
 
 }

--- a/java/test/jmri/jmrix/lenz/messageformatters/XNetCSStatusReplyFormatterTest.java
+++ b/java/test/jmri/jmrix/lenz/messageformatters/XNetCSStatusReplyFormatterTest.java
@@ -1,19 +1,19 @@
 package jmri.jmrix.lenz.messageformatters;
 
+import jmri.jmrix.AbstractMessageFormatterTest;
 import jmri.jmrix.lenz.XNetReply;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+
+import org.junit.jupiter.api.*;
 
 /**
  * Tests for the XNetCSStatusReplyFormatter class.
  *
  * @author Paul Bender Copyright (C) 2025
  */
-public class XNetCSStatusReplyFormatterTest {
+public class XNetCSStatusReplyFormatterTest extends AbstractMessageFormatterTest {
 
     @Test
     void testHandlesSubsetStatusMessage() {
-        XNetCSStatusReplyFormatter formatter = new XNetCSStatusReplyFormatter();
         XNetReply r = new XNetReply("62 22 00 40");
         Assertions.assertTrue(formatter.handlesMessage(r));
         String targetString = Bundle.getMessage("XNetReplyCSStatus") + " ";
@@ -21,18 +21,25 @@ public class XNetCSStatusReplyFormatterTest {
         Assertions.assertEquals(targetString, formatter.formatMessage(r));
     }
 
-        @Test
-        void testHandlesCompleteStatusMessage() {
-            XNetCSStatusReplyFormatter formatter = new XNetCSStatusReplyFormatter();
-            XNetReply r = new XNetReply("62 22 FF BF");
-            Assertions.assertTrue(formatter.handlesMessage(r));
-            String targetString = Bundle.getMessage("XNetReplyCSStatus") + " ";
-            targetString += Bundle.getMessage("XNetCSStatusEmergencyOff") + "; ";
-            targetString += Bundle.getMessage("XNetCSStatusEmergencyStop") + "; ";
-            targetString += Bundle.getMessage("XNetCSStatusServiceMode") + "; ";
-            targetString += Bundle.getMessage("XNetCSStatusPoweringUp") + "; ";
-            targetString += Bundle.getMessage("XNetCSStatusPowerModeAuto") + "; ";
-            targetString += Bundle.getMessage("XNetCSStatusRamCheck");
-            Assertions.assertEquals(targetString, formatter.formatMessage(r));
+    @Test
+    void testHandlesCompleteStatusMessage() {
+        XNetReply r = new XNetReply("62 22 FF BF");
+        Assertions.assertTrue(formatter.handlesMessage(r));
+        String targetString = Bundle.getMessage("XNetReplyCSStatus") + " ";
+        targetString += Bundle.getMessage("XNetCSStatusEmergencyOff") + "; ";
+        targetString += Bundle.getMessage("XNetCSStatusEmergencyStop") + "; ";
+        targetString += Bundle.getMessage("XNetCSStatusServiceMode") + "; ";
+        targetString += Bundle.getMessage("XNetCSStatusPoweringUp") + "; ";
+        targetString += Bundle.getMessage("XNetCSStatusPowerModeAuto") + "; ";
+        targetString += Bundle.getMessage("XNetCSStatusRamCheck");
+        Assertions.assertEquals(targetString, formatter.formatMessage(r));
     }
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp(); // setup JUnit
+        formatter = new XNetCSStatusReplyFormatter();
+    }
+
 }

--- a/java/test/jmri/jmrix/lenz/messageformatters/XNetCommandStationInfoResponseFormatterTest.java
+++ b/java/test/jmri/jmrix/lenz/messageformatters/XNetCommandStationInfoResponseFormatterTest.java
@@ -1,6 +1,8 @@
 package jmri.jmrix.lenz.messageformatters;
 
+import jmri.jmrix.AbstractMessageFormatterTest;
 import jmri.jmrix.lenz.XNetReply;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -10,13 +12,7 @@ import org.junit.jupiter.api.Test;
  *
  * @author Paul Bender Copyright (C) 2025
  */
-public class XNetCommandStationInfoResponseFormatterTest {
-
-    XNetCommandStationInfoResponseFormatter formatter;
-    @BeforeEach
-    public void setUp() {
-        formatter = new XNetCommandStationInfoResponseFormatter();
-    }
+public class XNetCommandStationInfoResponseFormatterTest extends AbstractMessageFormatterTest {
 
     @Test
     public void testToMonitorStringBCEmergencyOff(){
@@ -100,6 +96,13 @@ public class XNetCommandStationInfoResponseFormatterTest {
         XNetReply r = new XNetReply("61 86 E7");
         Assertions.assertTrue(formatter.handlesMessage(r));
         Assertions.assertEquals(Bundle.getMessage("XNetReplyV1DHErrorNonZeroSpeed"), formatter.formatMessage(r));
+    }
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp(); // setup JUnit
+        formatter = new XNetCommandStationInfoResponseFormatter();
     }
 
 }

--- a/java/test/jmri/jmrix/lenz/messageformatters/XNetCommandStationRequestFormatterTest.java
+++ b/java/test/jmri/jmrix/lenz/messageformatters/XNetCommandStationRequestFormatterTest.java
@@ -1,27 +1,26 @@
 package jmri.jmrix.lenz.messageformatters;
 
+import jmri.jmrix.AbstractMessageFormatterTest;
 import jmri.jmrix.lenz.XNetMessage;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+
+import org.junit.jupiter.api.*;
 
 /**
  * Tests of XNetCommandStationRequestFormatter class
  *
  * @author Paul Bender Copyright (C) 2024
  */
-public class XNetCommandStationRequestFormatterTest {
+public class XNetCommandStationRequestFormatterTest extends AbstractMessageFormatterTest {
 
     @Test
     void testEmergencyOffMessage() {
-       XNetCommandStationRequestFormatter formatter = new XNetCommandStationRequestFormatter();
-       XNetMessage msg = XNetMessage.getEmergencyOffMsg();
-       Assertions.assertTrue(formatter.handlesMessage(msg), "Formatter Handles Message");
-       Assertions.assertEquals("REQUEST: Emergency Off",formatter.formatMessage(msg));
+        XNetMessage msg = XNetMessage.getEmergencyOffMsg();
+        Assertions.assertTrue(formatter.handlesMessage(msg), "Formatter Handles Message");
+        Assertions.assertEquals("REQUEST: Emergency Off",formatter.formatMessage(msg));
     }
 
     @Test
     void testResumeNormalOperationsRequestMessage() {
-        XNetCommandStationRequestFormatter formatter = new XNetCommandStationRequestFormatter();
         XNetMessage msg = XNetMessage.getResumeOperationsMsg();
         Assertions.assertTrue(formatter.handlesMessage(msg), "Formatter Handles Message");
         Assertions.assertEquals("REQUEST: Normal Operations Resumed",formatter.formatMessage(msg));
@@ -29,7 +28,6 @@ public class XNetCommandStationRequestFormatterTest {
 
     @Test
     void testServiceModeResultsRequestMessage() {
-        XNetCommandStationRequestFormatter formatter = new XNetCommandStationRequestFormatter();
         XNetMessage msg = XNetMessage.getServiceModeResultsMsg();
         Assertions.assertTrue(formatter.handlesMessage(msg), "Formatter Handles Message");
         Assertions.assertEquals("REQUEST: Service Mode Result", formatter.formatMessage(msg));
@@ -37,7 +35,6 @@ public class XNetCommandStationRequestFormatterTest {
 
     @Test
     void testOpsModeResultsRequestMessage() {
-        XNetCommandStationRequestFormatter formatter = new XNetCommandStationRequestFormatter();
         XNetMessage msg = XNetMessage.getOpsModeResultsMsg();
         Assertions.assertTrue(formatter.handlesMessage(msg), "Formatter Handles Message");
         Assertions.assertEquals("REQUEST: Ops Mode Result", formatter.formatMessage(msg));
@@ -45,7 +42,6 @@ public class XNetCommandStationRequestFormatterTest {
 
     @Test
     void testCSVersionRequestMessage() {
-        XNetCommandStationRequestFormatter formatter = new XNetCommandStationRequestFormatter();
         XNetMessage msg = XNetMessage.getCSVersionRequestMessage();
         Assertions.assertTrue(formatter.handlesMessage(msg), "Formatter Handles Message");
         Assertions.assertEquals("REQUEST: Command Station Version", formatter.formatMessage(msg));
@@ -53,9 +49,16 @@ public class XNetCommandStationRequestFormatterTest {
 
     @Test
     void testCSStatusRequestMessage() {
-        XNetCommandStationRequestFormatter formatter = new XNetCommandStationRequestFormatter();
         XNetMessage msg = XNetMessage.getCSStatusRequestMessage();
         Assertions.assertTrue(formatter.handlesMessage(msg), "Formatter Handles Message");
         Assertions.assertEquals("REQUEST: Command Station Status", formatter.formatMessage(msg));
     }
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp(); // setup JUnit
+        formatter = new XNetCommandStationRequestFormatter();
+    }
+
 }

--- a/java/test/jmri/jmrix/lenz/messageformatters/XNetDHandMUErrorMessageFormatterTest.java
+++ b/java/test/jmri/jmrix/lenz/messageformatters/XNetDHandMUErrorMessageFormatterTest.java
@@ -1,6 +1,8 @@
 package jmri.jmrix.lenz.messageformatters;
 
+import jmri.jmrix.AbstractMessageFormatterTest;
 import jmri.jmrix.lenz.XNetReply;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -10,14 +12,7 @@ import org.junit.jupiter.api.Test;
  *
  * @author Paul Bender Copyright (C) 2025
  */
-public class XNetDHandMUErrorMessageFormatterTest {
-
-    XNetDHandMUErrorMessageFormatter formatter;
-
-    @BeforeEach
-    public void setUp() {
-        formatter = new XNetDHandMUErrorMessageFormatter();
-    }
+public class XNetDHandMUErrorMessageFormatterTest extends AbstractMessageFormatterTest {
 
     @Test
     public void testToMonitorStringErrorNotOperated(){
@@ -80,6 +75,13 @@ public class XNetDHandMUErrorMessageFormatterTest {
         XNetReply r = new XNetReply("E1 89 69");
         Assertions.assertTrue(formatter.handlesMessage(r));
         Assertions.assertEquals(Bundle.getMessage("XNetReplyDHErrorOther", 9), formatter.formatMessage(r));
+    }
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp(); // setup JUnit
+        formatter = new XNetDHandMUErrorMessageFormatter();
     }
 
 }

--- a/java/test/jmri/jmrix/lenz/messageformatters/XNetDirectModelTimeFormatterTest.java
+++ b/java/test/jmri/jmrix/lenz/messageformatters/XNetDirectModelTimeFormatterTest.java
@@ -1,23 +1,32 @@
 package jmri.jmrix.lenz.messageformatters;
 
+import jmri.jmrix.AbstractMessageFormatterTest;
 import jmri.jmrix.lenz.XNetReply;
+
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.BeforeEach;
 
 /**
  * Tests for the XNetDirectModelTimeFormatter class
  * .
  * @author Paul Bender Copyright (C) 2025
  */
-public class XNetDirectModelTimeFormatterTest {
+public class XNetDirectModelTimeFormatterTest extends AbstractMessageFormatterTest {
 
     @Test
     public void testFormatMessage() {
-        XNetDirectModelTimeFormatter formatter = new XNetDirectModelTimeFormatter();
         XNetReply reply = new XNetReply("64 25 95 36 02 C3");
         assertThat(formatter.handlesMessage(reply)).isTrue();
         assertThat(formatter.formatMessage(reply)).isEqualTo("Fast Clock: Day 4 time 21:54 Rate: 2");
+    }
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp(); // setup JUnit
+        formatter = new XNetDirectModelTimeFormatter();
     }
 
 }

--- a/java/test/jmri/jmrix/lenz/messageformatters/XNetDoubleHeaderRequestMessageFormatterTest.java
+++ b/java/test/jmri/jmrix/lenz/messageformatters/XNetDoubleHeaderRequestMessageFormatterTest.java
@@ -1,19 +1,19 @@
 package jmri.jmrix.lenz.messageformatters;
 
+import jmri.jmrix.AbstractMessageFormatterTest;
 import jmri.jmrix.lenz.XNetMessage;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+
+import org.junit.jupiter.api.*;
 
 /**
  * Tests for XNetDoubleHeaderRequestMessageFormatter
  *
  * @author Paul Bender Copyright (C) 2024
  */
-public class XNetDoubleHeaderRequestMessageFormatterTest {
+public class XNetDoubleHeaderRequestMessageFormatterTest extends AbstractMessageFormatterTest {
 
     @Test
     void testFormatBuildDoubleHeader(){
-        XNetDoubleHeaderRequestMessageFormatter formatter = new XNetDoubleHeaderRequestMessageFormatter();
         XNetMessage msg = XNetMessage.getBuildDoubleHeaderMsg(1234,4567);
         Assertions.assertTrue(formatter.handlesMessage(msg));
         Assertions.assertEquals("Double Header Request: Establish Double Header with 1234 and 4567",formatter.formatMessage(msg));
@@ -21,9 +21,16 @@ public class XNetDoubleHeaderRequestMessageFormatterTest {
 
     @Test
     void testFormatDissolveDoubleHeader(){
-        XNetDoubleHeaderRequestMessageFormatter formatter = new XNetDoubleHeaderRequestMessageFormatter();
         XNetMessage msg = XNetMessage.getDisolveDoubleHeaderMsg(1234);
         Assertions.assertTrue(formatter.handlesMessage(msg));
         Assertions.assertEquals("Double Header Request: Dissolve Double Header that includes mobile decoder 1234",formatter.formatMessage(msg));
     }
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp(); // setup JUnit
+        formatter = new XNetDoubleHeaderRequestMessageFormatter();
+    }
+
 }

--- a/java/test/jmri/jmrix/lenz/messageformatters/XNetEstopAllRequestMessageFormatterTest.java
+++ b/java/test/jmri/jmrix/lenz/messageformatters/XNetEstopAllRequestMessageFormatterTest.java
@@ -1,20 +1,28 @@
 package jmri.jmrix.lenz.messageformatters;
 
+import jmri.jmrix.AbstractMessageFormatterTest;
 import jmri.jmrix.lenz.XNetMessage;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+
+import org.junit.jupiter.api.*;
 
 /**
  * Tests for the XNetEstopAllRequestMessageFormatter class.
  * @author Paul Bender Copyright (C) 2024
  */
-public class XNetEstopAllRequestMessageFormatterTest{
+public class XNetEstopAllRequestMessageFormatterTest extends AbstractMessageFormatterTest {
 
     @Test
     public void testFormatEstopAllRequestMessage() {
-        XNetEstopAllRequestMessageFormatter formatter = new XNetEstopAllRequestMessageFormatter();
         XNetMessage msg = XNetMessage.getEmergencyStopMsg();
         Assertions.assertTrue(formatter.handlesMessage(msg), "Formatter Handles Message");
         Assertions.assertEquals("REQUEST: Emergency Stop", formatter.formatMessage(msg), "Monitor String");
     }
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp(); // setup JUnit
+        formatter = new XNetEstopAllRequestMessageFormatter();
+    }
+
 }

--- a/java/test/jmri/jmrix/lenz/messageformatters/XNetEstopLocoRequestMessageFormatterTest.java
+++ b/java/test/jmri/jmrix/lenz/messageformatters/XNetEstopLocoRequestMessageFormatterTest.java
@@ -1,20 +1,28 @@
 package jmri.jmrix.lenz.messageformatters;
 
+import jmri.jmrix.AbstractMessageFormatterTest;
 import jmri.jmrix.lenz.XNetMessage;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+
+import org.junit.jupiter.api.*;
 
 /**
  * Tests for the XNetEstopLocoRequest class.
  * @author Paul Bender Copyright (C) 2024
  */
-public class XNetEstopLocoRequestMessageFormatterTest {
+public class XNetEstopLocoRequestMessageFormatterTest extends AbstractMessageFormatterTest {
 
     @Test
     public void testFormatEstopLocoRequestMessage() {
-        XNetEstopLocoRequestMessageFormatter formatter = new XNetEstopLocoRequestMessageFormatter();
         XNetMessage msg = XNetMessage.getAddressedEmergencyStop(1234);
         Assertions.assertTrue(formatter.handlesMessage(msg), "Formatter Handles Message");
         Assertions.assertEquals("Emergency Stop 1234", formatter.formatMessage(msg), "Monitor String");
     }
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp(); // setup JUnit
+        formatter = new XNetEstopLocoRequestMessageFormatter();
+    }
+
 }

--- a/java/test/jmri/jmrix/lenz/messageformatters/XNetFeedbackReplyFormatterTest.java
+++ b/java/test/jmri/jmrix/lenz/messageformatters/XNetFeedbackReplyFormatterTest.java
@@ -1,14 +1,14 @@
 package jmri.jmrix.lenz.messageformatters;
 
+import jmri.jmrix.AbstractMessageFormatterTest;
 import jmri.jmrix.lenz.XNetReply;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
 
-public class XNetFeedbackReplyFormatterTest {
+import org.junit.jupiter.api.*;
+
+public class XNetFeedbackReplyFormatterTest extends AbstractMessageFormatterTest {
 
     @Test
     void testTurnoutNotOperatedFeedbackMessageHandling() {
-        XNetFeedbackReplyFormatter formatter = new XNetFeedbackReplyFormatter();
         XNetReply r = new XNetReply("42 05 00 47");
         Assertions.assertTrue(formatter.handlesMessage(r));
         String targetString =
@@ -27,7 +27,6 @@ public class XNetFeedbackReplyFormatterTest {
 
     @Test
     void testTurnoutThrownLeftFeedbackMessageHandling() {
-        XNetFeedbackReplyFormatter formatter = new XNetFeedbackReplyFormatter();
         XNetReply r = new XNetReply("42 05 05 42");
         Assertions.assertTrue(formatter.handlesMessage(r));
         String targetString =
@@ -46,7 +45,6 @@ public class XNetFeedbackReplyFormatterTest {
 
     @Test
     void testTurnoutThrownRightFeedbackMessageHandling() {
-        XNetFeedbackReplyFormatter formatter = new XNetFeedbackReplyFormatter();
         XNetReply r = new XNetReply("42 05 0A 4C");
         Assertions.assertTrue(formatter.handlesMessage(r));
         String targetString =
@@ -65,7 +63,6 @@ public class XNetFeedbackReplyFormatterTest {
 
     @Test
     void testTurnoutInvalidPositionFeedbackMessageHandling() {
-        XNetFeedbackReplyFormatter formatter = new XNetFeedbackReplyFormatter();
         XNetReply r = new XNetReply("42 05 0F 48");
         Assertions.assertTrue(formatter.handlesMessage(r));
         String targetString =
@@ -84,7 +81,6 @@ public class XNetFeedbackReplyFormatterTest {
 
     @Test
     void testTurnoutNotOperatedMotionCompleteFeedbackMessageHandling() {
-        XNetFeedbackReplyFormatter formatter = new XNetFeedbackReplyFormatter();
         XNetReply r = new XNetReply("42 05 20 67");
         Assertions.assertTrue(formatter.handlesMessage(r));
         String targetString =
@@ -105,7 +101,6 @@ public class XNetFeedbackReplyFormatterTest {
 
     @Test
     void testTurnoutThrownLeftMotionCompleteFeedbackMessageHandling() {
-        XNetFeedbackReplyFormatter formatter = new XNetFeedbackReplyFormatter();
         XNetReply r = new XNetReply("42 05 25 62");
         Assertions.assertTrue(formatter.handlesMessage(r));
         String targetString =
@@ -126,7 +121,6 @@ public class XNetFeedbackReplyFormatterTest {
 
     @Test
     void testTurnoutThrownRightMotionCompleteFeedbackMessageHandling() {
-        XNetFeedbackReplyFormatter formatter = new XNetFeedbackReplyFormatter();
         XNetReply r = new XNetReply("42 05 2A 6C");
         Assertions.assertTrue(formatter.handlesMessage(r));
         String targetString =
@@ -147,7 +141,6 @@ public class XNetFeedbackReplyFormatterTest {
 
     @Test
     void testTurnoutInvalidPositionMotionCompleteFeedbackMessageHandling() {
-        XNetFeedbackReplyFormatter formatter = new XNetFeedbackReplyFormatter();
         XNetReply r = new XNetReply("42 05 2F 68");
         Assertions.assertTrue(formatter.handlesMessage(r));
         String targetString =
@@ -168,7 +161,6 @@ public class XNetFeedbackReplyFormatterTest {
 
     @Test
     void testSensorFeedbackOffMessageHandling() {
-        XNetFeedbackReplyFormatter formatter = new XNetFeedbackReplyFormatter();
         XNetReply r = new XNetReply("42 05 48 0F");
         Assertions.assertTrue(formatter.handlesMessage(r));
         String targetString =
@@ -191,7 +183,6 @@ public class XNetFeedbackReplyFormatterTest {
 
     @Test
     void testSensorFeedbackOnMessageHandling() {
-        XNetFeedbackReplyFormatter formatter = new XNetFeedbackReplyFormatter();
         XNetReply r = new XNetReply("42 05 57 0F");
         Assertions.assertTrue(formatter.handlesMessage(r));
         String targetString =
@@ -211,4 +202,12 @@ public class XNetFeedbackReplyFormatterTest {
         targetString += " " + Bundle.getMessage("PowerStateOff") + "; ";
         Assertions.assertEquals(targetString, formatter.formatMessage(r));
     }
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp(); // setup JUnit
+        formatter = new XNetFeedbackReplyFormatter();
+    }
+
 }

--- a/java/test/jmri/jmrix/lenz/messageformatters/XNetFeedbackRequestCommandMessageFormatterTest.java
+++ b/java/test/jmri/jmrix/lenz/messageformatters/XNetFeedbackRequestCommandMessageFormatterTest.java
@@ -1,36 +1,47 @@
 package jmri.jmrix.lenz.messageformatters;
 
+import jmri.jmrix.AbstractMessageFormatterTest;
 import jmri.jmrix.lenz.XNetMessage;
-import org.junit.Assert;
+
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
 /**
  * Tests for the XNetFeedbackRequestCommandMessageFormater class.
  * @author Paul Bender Copyright (C) 2024
  */
-public class XNetFeedbackRequestCommandMessageFormatterTest {
+public class XNetFeedbackRequestCommandMessageFormatterTest extends AbstractMessageFormatterTest {
 
     @Test
     public void testHandlesMessageValid() {
-        XNetFeedbackRequestCommandMessageFormatter formatter = new XNetFeedbackRequestCommandMessageFormatter();
         assertTrue(formatter.handlesMessage(XNetMessage.getFeedbackRequestMsg(5,true)));
     }
 
     @Test
     public void testHandlesMessageInvalid() {
-        XNetFeedbackRequestCommandMessageFormatter formatter = new XNetFeedbackRequestCommandMessageFormatter();
         assertFalse(formatter.handlesMessage(new XNetMessage("01 04 05")));
     }
 
     @Test
     public void testFormatMessage() {
-        XNetFeedbackRequestCommandMessageFormatter formatter = new XNetFeedbackRequestCommandMessageFormatter();
         XNetMessage message;
         message = XNetMessage.getFeedbackRequestMsg(5,true);
-        Assert.assertEquals("Monitor String","Accessory Decoder/Feedback Encoder Status Request: Base Address 1,Lower Nibble.",formatter.formatMessage(message));
+        assertEquals ( "Accessory Decoder/Feedback Encoder Status Request: Base Address 1,Lower Nibble.",
+            formatter.formatMessage(message), "Monitor String");
         message = XNetMessage.getFeedbackRequestMsg(5,false);
-        Assert.assertEquals("Monitor String","Accessory Decoder/Feedback Encoder Status Request: Base Address 1,Upper Nibble.",formatter.formatMessage(message));
+        assertEquals( "Accessory Decoder/Feedback Encoder Status Request: Base Address 1,Upper Nibble.",
+            formatter.formatMessage(message), "Monitor String");
     }
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp(); // setup JUnit
+        formatter = new XNetFeedbackRequestCommandMessageFormatter();
+    }
+
 }

--- a/java/test/jmri/jmrix/lenz/messageformatters/XNetFunctionGroup10MomentaryRequestMessageFormatterTest.java
+++ b/java/test/jmri/jmrix/lenz/messageformatters/XNetFunctionGroup10MomentaryRequestMessageFormatterTest.java
@@ -1,20 +1,19 @@
 package jmri.jmrix.lenz.messageformatters;
 
-
+import jmri.jmrix.AbstractMessageFormatterTest;
 import jmri.jmrix.lenz.XNetMessage;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+
+import org.junit.jupiter.api.*;
 
 /**
  * Tests of XNetFunctionGroup10MomentaryRequestMessageFormatter class
  *
  * @Paul Bender Copyright (C) 2024
  */
-public class XNetFunctionGroup10MomentaryRequestMessageFormatterTest {
+public class XNetFunctionGroup10MomentaryRequestMessageFormatterTest extends AbstractMessageFormatterTest {
 
     @Test
     public void testFormatMessageAllOff() {
-        XNetFunctionGroup10MomentaryRequestMessageFormatter formatter = new XNetFunctionGroup10MomentaryRequestMessageFormatter();
         XNetMessage msg = XNetMessage.getFunctionGroup10SetMomMsg(1234, false,false,false,false,false,false,false,false);
 
         Assertions.assertTrue(formatter.handlesMessage(msg));
@@ -23,10 +22,17 @@ public class XNetFunctionGroup10MomentaryRequestMessageFormatterTest {
 
     @Test
     public void testFormatMessageAllOn() {
-        XNetFunctionGroup10MomentaryRequestMessageFormatter formatter = new XNetFunctionGroup10MomentaryRequestMessageFormatter();
         XNetMessage msg = XNetMessage.getFunctionGroup10SetMomMsg(1234, true,true,true,true,true,true,true,true);
 
         Assertions.assertTrue(formatter.handlesMessage(msg));
         Assertions.assertEquals("Mobile Decoder Operations Request: Set Function Group 10 Momentary Status for Address: 1234 F61 Momentary; F62 Momentary; F63 Momentary; F64 Momentary; F65 Momentary; F66 Momentary; F67 Momentary; F68 Momentary; ",formatter.formatMessage(msg));
     }
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp(); // setup JUnit
+        formatter = new XNetFunctionGroup10MomentaryRequestMessageFormatter();
+    }
+
 }

--- a/java/test/jmri/jmrix/lenz/messageformatters/XNetFunctionGroup10OperateRequestMessageFormatterTest.java
+++ b/java/test/jmri/jmrix/lenz/messageformatters/XNetFunctionGroup10OperateRequestMessageFormatterTest.java
@@ -1,20 +1,19 @@
 package jmri.jmrix.lenz.messageformatters;
 
-
+import jmri.jmrix.AbstractMessageFormatterTest;
 import jmri.jmrix.lenz.XNetMessage;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+
+import org.junit.jupiter.api.*;
 
 /**
  * Tests of XNetFunctionGroup10OperateRequestMessageFormatter class
  *
  * @Paul Bender Copyright (C) 2024
  */
-public class XNetFunctionGroup10OperateRequestMessageFormatterTest {
+public class XNetFunctionGroup10OperateRequestMessageFormatterTest extends AbstractMessageFormatterTest {
 
     @Test
     public void testFormatMessageAllOff() {
-        XNetFunctionGroup10OperateRequestMessageFormatter formatter = new XNetFunctionGroup10OperateRequestMessageFormatter();
         XNetMessage msg = XNetMessage.getFunctionGroup10OpsMsg(1234, false,false,false,false,false,false,false,false);
 
         Assertions.assertTrue(formatter.handlesMessage(msg));
@@ -23,10 +22,17 @@ public class XNetFunctionGroup10OperateRequestMessageFormatterTest {
 
     @Test
     public void testFormatMessageAllOn() {
-        XNetFunctionGroup10OperateRequestMessageFormatter formatter = new XNetFunctionGroup10OperateRequestMessageFormatter();
         XNetMessage msg = XNetMessage.getFunctionGroup10OpsMsg(1234, true,true,true,true,true,true,true,true);
 
         Assertions.assertTrue(formatter.handlesMessage(msg));
         Assertions.assertEquals("Mobile Decoder Operations Request: Set Function Group 10 for Address: 1234 F61 On; F62 On; F63 On; F64 On; F65 On; F66 On; F67 On; F68 On; ",formatter.formatMessage(msg));
     }
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp(); // setup JUnit
+        formatter = new XNetFunctionGroup10OperateRequestMessageFormatter();
+    }
+
 }

--- a/java/test/jmri/jmrix/lenz/messageformatters/XNetFunctionGroup1MomentaryRequestMessageFormatterTest.java
+++ b/java/test/jmri/jmrix/lenz/messageformatters/XNetFunctionGroup1MomentaryRequestMessageFormatterTest.java
@@ -1,20 +1,19 @@
 package jmri.jmrix.lenz.messageformatters;
 
-
+import jmri.jmrix.AbstractMessageFormatterTest;
 import jmri.jmrix.lenz.XNetMessage;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+
+import org.junit.jupiter.api.*;
 
 /**
  * Tests of XNetFunctionGroup1MomentaryRequestMessageFormatter class
  *
  * @Paul Bender Copyright (C) 2024
  */
-public class XNetFunctionGroup1MomentaryRequestMessageFormatterTest {
+public class XNetFunctionGroup1MomentaryRequestMessageFormatterTest extends AbstractMessageFormatterTest {
 
     @Test
     public void testFormatMessageAllOff() {
-        XNetFunctionGroup1MomentaryRequestMessageFormatter formatter = new XNetFunctionGroup1MomentaryRequestMessageFormatter();
         XNetMessage msg = XNetMessage.getFunctionGroup1SetMomMsg(1234, false,false,false,false,false);
         Assertions.assertTrue(formatter.handlesMessage(msg));
         Assertions.assertEquals("Mobile Decoder Operations Request: Set Function Group 1 Momentary Status for Address: 1234 F0 Continuous; F1 Continuous; F2 Continuous; F3 Continuous; F4 Continuous; ",formatter.formatMessage(msg));
@@ -22,9 +21,16 @@ public class XNetFunctionGroup1MomentaryRequestMessageFormatterTest {
 
     @Test
     public void testFormatMessageAllOn() {
-        XNetFunctionGroup1MomentaryRequestMessageFormatter formatter = new XNetFunctionGroup1MomentaryRequestMessageFormatter();
         XNetMessage msg = XNetMessage.getFunctionGroup1SetMomMsg(1234, true,true,true,true,true);
         Assertions.assertTrue(formatter.handlesMessage(msg));
         Assertions.assertEquals("Mobile Decoder Operations Request: Set Function Group 1 Momentary Status for Address: 1234 F0 Momentary; F1 Momentary; F2 Momentary; F3 Momentary; F4 Momentary; ",formatter.formatMessage(msg));
     }
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp(); // setup JUnit
+        formatter = new XNetFunctionGroup1MomentaryRequestMessageFormatter();
+    }
+
 }

--- a/java/test/jmri/jmrix/lenz/messageformatters/XNetFunctionGroup1OperateRequestMessageFormatterTest.java
+++ b/java/test/jmri/jmrix/lenz/messageformatters/XNetFunctionGroup1OperateRequestMessageFormatterTest.java
@@ -1,20 +1,19 @@
 package jmri.jmrix.lenz.messageformatters;
 
-
+import jmri.jmrix.AbstractMessageFormatterTest;
 import jmri.jmrix.lenz.XNetMessage;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+
+import org.junit.jupiter.api.*;
 
 /**
  * Tests of XNetFunctionGroup1OperateRequestMessageFormatter class
  *
  * @Paul Bender Copyright (C) 2024
  */
-public class XNetFunctionGroup1OperateRequestMessageFormatterTest {
+public class XNetFunctionGroup1OperateRequestMessageFormatterTest extends AbstractMessageFormatterTest {
 
     @Test
     public void testFormatMessageAllOff() {
-        XNetFunctionGroup1OperateRequestMessageFormatter formatter = new XNetFunctionGroup1OperateRequestMessageFormatter();
         XNetMessage msg = XNetMessage.getFunctionGroup1OpsMsg(1234, false,false,false,false,false);
 
         Assertions.assertTrue(formatter.handlesMessage(msg));
@@ -23,10 +22,17 @@ public class XNetFunctionGroup1OperateRequestMessageFormatterTest {
 
     @Test
     public void testFormatMessageAllOn() {
-        XNetFunctionGroup1OperateRequestMessageFormatter formatter = new XNetFunctionGroup1OperateRequestMessageFormatter();
         XNetMessage msg = XNetMessage.getFunctionGroup1OpsMsg(1234, true,true,true,true,true);
 
         Assertions.assertTrue(formatter.handlesMessage(msg));
         Assertions.assertEquals("Mobile Decoder Operations Request: Set Function Group 1 for Address: 1234 F0 On; F1 On; F2 On; F3 On; F4 On; ",formatter.formatMessage(msg));
     }
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp(); // setup JUnit
+        formatter = new XNetFunctionGroup1OperateRequestMessageFormatter();
+    }
+
 }

--- a/java/test/jmri/jmrix/lenz/messageformatters/XNetFunctionGroup2MomentaryRequestMessageFormatterTest.java
+++ b/java/test/jmri/jmrix/lenz/messageformatters/XNetFunctionGroup2MomentaryRequestMessageFormatterTest.java
@@ -1,20 +1,19 @@
 package jmri.jmrix.lenz.messageformatters;
 
-
+import jmri.jmrix.AbstractMessageFormatterTest;
 import jmri.jmrix.lenz.XNetMessage;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+
+import org.junit.jupiter.api.*;
 
 /**
  * Tests of XNetFunctionGroup2MomentaryRequestMessageFormatter class
  *
  * @Paul Bender Copyright (C) 2024
  */
-public class XNetFunctionGroup2MomentaryRequestMessageFormatterTest {
+public class XNetFunctionGroup2MomentaryRequestMessageFormatterTest extends AbstractMessageFormatterTest {
 
     @Test
     public void testFormatMessageAllOff() {
-        XNetFunctionGroup2MomentaryRequestMessageFormatter formatter = new XNetFunctionGroup2MomentaryRequestMessageFormatter();
         XNetMessage msg = XNetMessage.getFunctionGroup2SetMomMsg(1234, false,false,false,false);
         Assertions.assertTrue(formatter.handlesMessage(msg));
         Assertions.assertEquals("Mobile Decoder Operations Request: Set Function Group 2 Momentary Status for Address: 1234 F5 Continuous; F6 Continuous; F7 Continuous; F8 Continuous; ",formatter.formatMessage(msg));
@@ -22,9 +21,16 @@ public class XNetFunctionGroup2MomentaryRequestMessageFormatterTest {
 
     @Test
     public void testFormatMessageAllOn() {
-        XNetFunctionGroup2MomentaryRequestMessageFormatter formatter = new XNetFunctionGroup2MomentaryRequestMessageFormatter();
         XNetMessage msg = XNetMessage.getFunctionGroup2SetMomMsg(1234, true,true,true,true);
         Assertions.assertTrue(formatter.handlesMessage(msg));
         Assertions.assertEquals("Mobile Decoder Operations Request: Set Function Group 2 Momentary Status for Address: 1234 F5 Momentary; F6 Momentary; F7 Momentary; F8 Momentary; ",formatter.formatMessage(msg));
     }
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp(); // setup JUnit
+        formatter = new XNetFunctionGroup2MomentaryRequestMessageFormatter();
+    }
+
 }

--- a/java/test/jmri/jmrix/lenz/messageformatters/XNetFunctionGroup2OperateRequestMessageFormatterTest.java
+++ b/java/test/jmri/jmrix/lenz/messageformatters/XNetFunctionGroup2OperateRequestMessageFormatterTest.java
@@ -1,20 +1,19 @@
 package jmri.jmrix.lenz.messageformatters;
 
-
+import jmri.jmrix.AbstractMessageFormatterTest;
 import jmri.jmrix.lenz.XNetMessage;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+
+import org.junit.jupiter.api.*;
 
 /**
  * Tests of XNetFunctionGroup2OperateRequestMessageFormatter class
  *
  * @Paul Bender Copyright (C) 2024
  */
-public class XNetFunctionGroup2OperateRequestMessageFormatterTest {
+public class XNetFunctionGroup2OperateRequestMessageFormatterTest extends AbstractMessageFormatterTest {
 
     @Test
     public void testFormatMessageAllOff() {
-        XNetFunctionGroup2OperateRequestMessageFormatter formatter = new XNetFunctionGroup2OperateRequestMessageFormatter();
         XNetMessage msg = XNetMessage.getFunctionGroup2OpsMsg(1234, false,false,false,false);
 
         Assertions.assertTrue(formatter.handlesMessage(msg));
@@ -23,10 +22,17 @@ public class XNetFunctionGroup2OperateRequestMessageFormatterTest {
 
     @Test
     public void testFormatMessageAllOn() {
-        XNetFunctionGroup2OperateRequestMessageFormatter formatter = new XNetFunctionGroup2OperateRequestMessageFormatter();
         XNetMessage msg = XNetMessage.getFunctionGroup2OpsMsg(1234, true,true,true,true);
 
         Assertions.assertTrue(formatter.handlesMessage(msg));
         Assertions.assertEquals("Mobile Decoder Operations Request: Set Function Group 2 for Address: 1234 F5 On; F6 On; F7 On; F8 On; ",formatter.formatMessage(msg));
     }
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp(); // setup JUnit
+        formatter = new XNetFunctionGroup2OperateRequestMessageFormatter();
+    }
+
 }

--- a/java/test/jmri/jmrix/lenz/messageformatters/XNetFunctionGroup3MomentaryRequestMessageFormatterTest.java
+++ b/java/test/jmri/jmrix/lenz/messageformatters/XNetFunctionGroup3MomentaryRequestMessageFormatterTest.java
@@ -1,20 +1,19 @@
 package jmri.jmrix.lenz.messageformatters;
 
-
+import jmri.jmrix.AbstractMessageFormatterTest;
 import jmri.jmrix.lenz.XNetMessage;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+
+import org.junit.jupiter.api.*;
 
 /**
  * Tests of XNetFunctionGroup3MomentaryRequestMessageFormatter class
  *
  * @Paul Bender Copyright (C) 2024
  */
-public class XNetFunctionGroup3MomentaryRequestMessageFormatterTest {
+public class XNetFunctionGroup3MomentaryRequestMessageFormatterTest extends AbstractMessageFormatterTest {
 
     @Test
     public void testFormatMessageAllOff() {
-        XNetFunctionGroup3MomentaryRequestMessageFormatter formatter = new XNetFunctionGroup3MomentaryRequestMessageFormatter();
         XNetMessage msg = XNetMessage.getFunctionGroup3SetMomMsg(1234, false,false,false,false);
 
         Assertions.assertTrue(formatter.handlesMessage(msg));
@@ -23,10 +22,17 @@ public class XNetFunctionGroup3MomentaryRequestMessageFormatterTest {
 
     @Test
     public void testFormatMessageAllOn() {
-        XNetFunctionGroup3MomentaryRequestMessageFormatter formatter = new XNetFunctionGroup3MomentaryRequestMessageFormatter();
         XNetMessage msg = XNetMessage.getFunctionGroup3SetMomMsg(1234, true,true,true,true);
 
         Assertions.assertTrue(formatter.handlesMessage(msg));
         Assertions.assertEquals("Mobile Decoder Operations Request: Set Function Group 3 Momentary Status for Address: 1234 F9 Momentary; F10 Momentary; F11 Momentary; F12 Momentary; ",formatter.formatMessage(msg));
     }
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp(); // setup JUnit
+        formatter = new XNetFunctionGroup3MomentaryRequestMessageFormatter();
+    }
+
 }

--- a/java/test/jmri/jmrix/lenz/messageformatters/XNetFunctionGroup3OperateRequestMessageFormatterTest.java
+++ b/java/test/jmri/jmrix/lenz/messageformatters/XNetFunctionGroup3OperateRequestMessageFormatterTest.java
@@ -1,20 +1,19 @@
 package jmri.jmrix.lenz.messageformatters;
 
-
+import jmri.jmrix.AbstractMessageFormatterTest;
 import jmri.jmrix.lenz.XNetMessage;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+
+import org.junit.jupiter.api.*;
 
 /**
  * Tests of XNetFunctionGroup3OperateRequestMessageFormatter class
  *
  * @Paul Bender Copyright (C) 2024
  */
-public class XNetFunctionGroup3OperateRequestMessageFormatterTest {
+public class XNetFunctionGroup3OperateRequestMessageFormatterTest extends AbstractMessageFormatterTest {
 
     @Test
     public void testFormatMessageAllOff() {
-        XNetFunctionGroup3OperateRequestMessageFormatter formatter = new XNetFunctionGroup3OperateRequestMessageFormatter();
         XNetMessage msg = XNetMessage.getFunctionGroup3OpsMsg(1234, false,false,false,false);
 
         Assertions.assertTrue(formatter.handlesMessage(msg));
@@ -23,10 +22,17 @@ public class XNetFunctionGroup3OperateRequestMessageFormatterTest {
 
     @Test
     public void testFormatMessageAllOn() {
-        XNetFunctionGroup3OperateRequestMessageFormatter formatter = new XNetFunctionGroup3OperateRequestMessageFormatter();
         XNetMessage msg = XNetMessage.getFunctionGroup3OpsMsg(1234, true,true,true,true);
 
         Assertions.assertTrue(formatter.handlesMessage(msg));
         Assertions.assertEquals("Mobile Decoder Operations Request: Set Function Group 3 for Address: 1234 F9 On; F10 On; F11 On; F12 On; ",formatter.formatMessage(msg));
     }
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp(); // setup JUnit
+        formatter = new XNetFunctionGroup3OperateRequestMessageFormatter();
+    }
+
 }

--- a/java/test/jmri/jmrix/lenz/messageformatters/XNetFunctionGroup4MomentaryRequestMessageFormatterTest.java
+++ b/java/test/jmri/jmrix/lenz/messageformatters/XNetFunctionGroup4MomentaryRequestMessageFormatterTest.java
@@ -1,20 +1,19 @@
 package jmri.jmrix.lenz.messageformatters;
 
-
+import jmri.jmrix.AbstractMessageFormatterTest;
 import jmri.jmrix.lenz.XNetMessage;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+
+import org.junit.jupiter.api.*;
 
 /**
  * Tests of XNetFunctionGroup4MomentaryRequestMessageFormatter class
  *
  * @Paul Bender Copyright (C) 2024
  */
-public class XNetFunctionGroup4MomentaryRequestMessageFormatterTest {
+public class XNetFunctionGroup4MomentaryRequestMessageFormatterTest extends AbstractMessageFormatterTest {
 
     @Test
     public void testFormatMessageAllOff() {
-        XNetFunctionGroup4MomentaryRequestMessageFormatter formatter = new XNetFunctionGroup4MomentaryRequestMessageFormatter();
         XNetMessage msg = XNetMessage.getFunctionGroup4SetMomMsg(1234, false,false,false,false,false,false,false,false);
 
         Assertions.assertTrue(formatter.handlesMessage(msg));
@@ -23,10 +22,17 @@ public class XNetFunctionGroup4MomentaryRequestMessageFormatterTest {
 
     @Test
     public void testFormatMessageAllOn() {
-        XNetFunctionGroup4MomentaryRequestMessageFormatter formatter = new XNetFunctionGroup4MomentaryRequestMessageFormatter();
         XNetMessage msg = XNetMessage.getFunctionGroup4SetMomMsg(1234, true,true,true,true,true,true,true,true);
 
         Assertions.assertTrue(formatter.handlesMessage(msg));
         Assertions.assertEquals("Mobile Decoder Operations Request: Set Function Group 4 Momentary Status for Address: 1234 F13 Momentary; F14 Momentary; F15 Momentary; F16 Momentary; F17 Momentary; F18 Momentary; F19 Momentary; F20 Momentary; ",formatter.formatMessage(msg));
     }
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp(); // setup JUnit
+        formatter = new XNetFunctionGroup4MomentaryRequestMessageFormatter();
+    }
+
 }

--- a/java/test/jmri/jmrix/lenz/messageformatters/XNetFunctionGroup4OperateRequestMessageFormatterTest.java
+++ b/java/test/jmri/jmrix/lenz/messageformatters/XNetFunctionGroup4OperateRequestMessageFormatterTest.java
@@ -1,20 +1,19 @@
 package jmri.jmrix.lenz.messageformatters;
 
-
+import jmri.jmrix.AbstractMessageFormatterTest;
 import jmri.jmrix.lenz.XNetMessage;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+
+import org.junit.jupiter.api.*;
 
 /**
  * Tests of XNetFunctionGroup4OperateRequestMessageFormatter class
  *
  * @Paul Bender Copyright (C) 2024
  */
-public class XNetFunctionGroup4OperateRequestMessageFormatterTest {
+public class XNetFunctionGroup4OperateRequestMessageFormatterTest extends AbstractMessageFormatterTest {
 
     @Test
     public void testFormatMessageAllOff() {
-        XNetFunctionGroup4OperateRequestMessageFormatter formatter = new XNetFunctionGroup4OperateRequestMessageFormatter();
         XNetMessage msg = XNetMessage.getFunctionGroup4OpsMsg(1234, false,false,false,false,false,false,false,false);
 
         Assertions.assertTrue(formatter.handlesMessage(msg));
@@ -23,10 +22,17 @@ public class XNetFunctionGroup4OperateRequestMessageFormatterTest {
 
     @Test
     public void testFormatMessageAllOn() {
-        XNetFunctionGroup4OperateRequestMessageFormatter formatter = new XNetFunctionGroup4OperateRequestMessageFormatter();
         XNetMessage msg = XNetMessage.getFunctionGroup4OpsMsg(1234, true,true,true,true,true,true,true,true);
 
         Assertions.assertTrue(formatter.handlesMessage(msg));
         Assertions.assertEquals("Mobile Decoder Operations Request: Set Function Group 4 for Address: 1234 F13 On; F14 On; F15 On; F16 On; F17 On; F18 On; F19 On; F20 On; ",formatter.formatMessage(msg));
     }
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp(); // setup JUnit
+        formatter = new XNetFunctionGroup4OperateRequestMessageFormatter();
+    }
+
 }

--- a/java/test/jmri/jmrix/lenz/messageformatters/XNetFunctionGroup5MomentaryRequestMessageFormatterTest.java
+++ b/java/test/jmri/jmrix/lenz/messageformatters/XNetFunctionGroup5MomentaryRequestMessageFormatterTest.java
@@ -1,20 +1,19 @@
 package jmri.jmrix.lenz.messageformatters;
 
-
+import jmri.jmrix.AbstractMessageFormatterTest;
 import jmri.jmrix.lenz.XNetMessage;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+
+import org.junit.jupiter.api.*;
 
 /**
  * Tests of XNetFunctionGroup5MomentaryRequestMessageFormatter class
  *
  * @Paul Bender Copyright (C) 2024
  */
-public class XNetFunctionGroup5MomentaryRequestMessageFormatterTest {
+public class XNetFunctionGroup5MomentaryRequestMessageFormatterTest extends AbstractMessageFormatterTest {
 
     @Test
     public void testFormatMessageAllOff() {
-        XNetFunctionGroup5MomentaryRequestMessageFormatter formatter = new XNetFunctionGroup5MomentaryRequestMessageFormatter();
         XNetMessage msg = XNetMessage.getFunctionGroup5SetMomMsg(1234, false,false,false,false,false,false,false,false);
 
         Assertions.assertTrue(formatter.handlesMessage(msg));
@@ -23,10 +22,17 @@ public class XNetFunctionGroup5MomentaryRequestMessageFormatterTest {
 
     @Test
     public void testFormatMessageAllOn() {
-        XNetFunctionGroup5MomentaryRequestMessageFormatter formatter = new XNetFunctionGroup5MomentaryRequestMessageFormatter();
         XNetMessage msg = XNetMessage.getFunctionGroup5SetMomMsg(1234, true,true,true,true,true,true,true,true);
 
         Assertions.assertTrue(formatter.handlesMessage(msg));
         Assertions.assertEquals("Mobile Decoder Operations Request: Set Function Group 5 Momentary Status for Address: 1234 F21 Momentary; F22 Momentary; F23 Momentary; F24 Momentary; F25 Momentary; F26 Momentary; F27 Momentary; F28 Momentary; ",formatter.formatMessage(msg));
     }
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp(); // setup JUnit
+        formatter = new XNetFunctionGroup5MomentaryRequestMessageFormatter();
+    }
+
 }

--- a/java/test/jmri/jmrix/lenz/messageformatters/XNetFunctionGroup5OperateRequestMessageFormatterTest.java
+++ b/java/test/jmri/jmrix/lenz/messageformatters/XNetFunctionGroup5OperateRequestMessageFormatterTest.java
@@ -1,20 +1,19 @@
 package jmri.jmrix.lenz.messageformatters;
 
-
+import jmri.jmrix.AbstractMessageFormatterTest;
 import jmri.jmrix.lenz.XNetMessage;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+
+import org.junit.jupiter.api.*;
 
 /**
  * Tests of XNetFunctionGroup5OperateRequestMessageFormatter class
  *
  * @Paul Bender Copyright (C) 2024
  */
-public class XNetFunctionGroup5OperateRequestMessageFormatterTest {
+public class XNetFunctionGroup5OperateRequestMessageFormatterTest extends AbstractMessageFormatterTest {
 
     @Test
     public void testFormatMessageAllOff() {
-        XNetFunctionGroup5OperateRequestMessageFormatter formatter = new XNetFunctionGroup5OperateRequestMessageFormatter();
         XNetMessage msg = XNetMessage.getFunctionGroup5OpsMsg(1234, false,false,false,false,false,false,false,false);
 
         Assertions.assertTrue(formatter.handlesMessage(msg));
@@ -23,10 +22,17 @@ public class XNetFunctionGroup5OperateRequestMessageFormatterTest {
 
     @Test
     public void testFormatMessageAllOn() {
-        XNetFunctionGroup5OperateRequestMessageFormatter formatter = new XNetFunctionGroup5OperateRequestMessageFormatter();
         XNetMessage msg = XNetMessage.getFunctionGroup5OpsMsg(1234, true,true,true,true,true,true,true,true);
 
         Assertions.assertTrue(formatter.handlesMessage(msg));
         Assertions.assertEquals("Mobile Decoder Operations Request: Set Function Group 5 for Address: 1234 F21 On; F22 On; F23 On; F24 On; F25 On; F26 On; F27 On; F28 On; ",formatter.formatMessage(msg));
     }
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp(); // setup JUnit
+        formatter = new XNetFunctionGroup5OperateRequestMessageFormatter();
+    }
+
 }

--- a/java/test/jmri/jmrix/lenz/messageformatters/XNetFunctionGroup6MomentaryRequestMessageFormatterTest.java
+++ b/java/test/jmri/jmrix/lenz/messageformatters/XNetFunctionGroup6MomentaryRequestMessageFormatterTest.java
@@ -1,20 +1,19 @@
 package jmri.jmrix.lenz.messageformatters;
 
-
+import jmri.jmrix.AbstractMessageFormatterTest;
 import jmri.jmrix.lenz.XNetMessage;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+
+import org.junit.jupiter.api.*;
 
 /**
  * Tests of XNetFunctionGroup6MomentaryRequestMessageFormatter class
  *
  * @Paul Bender Copyright (C) 2024
  */
-public class XNetFunctionGroup6MomentaryRequestMessageFormatterTest {
+public class XNetFunctionGroup6MomentaryRequestMessageFormatterTest extends AbstractMessageFormatterTest {
 
     @Test
     public void testFormatMessageAllOff() {
-        XNetFunctionGroup6MomentaryRequestMessageFormatter formatter = new XNetFunctionGroup6MomentaryRequestMessageFormatter();
         XNetMessage msg = XNetMessage.getFunctionGroup6SetMomMsg(1234, false,false,false,false,false,false,false,false);
 
         Assertions.assertTrue(formatter.handlesMessage(msg));
@@ -23,10 +22,17 @@ public class XNetFunctionGroup6MomentaryRequestMessageFormatterTest {
 
     @Test
     public void testFormatMessageAllOn() {
-        XNetFunctionGroup6MomentaryRequestMessageFormatter formatter = new XNetFunctionGroup6MomentaryRequestMessageFormatter();
         XNetMessage msg = XNetMessage.getFunctionGroup6SetMomMsg(1234, true,true,true,true,true,true,true,true);
 
         Assertions.assertTrue(formatter.handlesMessage(msg));
         Assertions.assertEquals("Mobile Decoder Operations Request: Set Function Group 6 Momentary Status for Address: 1234 F29 Momentary; F30 Momentary; F31 Momentary; F32 Momentary; F33 Momentary; F34 Momentary; F35 Momentary; F36 Momentary; ",formatter.formatMessage(msg));
     }
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp(); // setup JUnit
+        formatter = new XNetFunctionGroup6MomentaryRequestMessageFormatter();
+    }
+
 }

--- a/java/test/jmri/jmrix/lenz/messageformatters/XNetFunctionGroup6OperateRequestMessageFormatterTest.java
+++ b/java/test/jmri/jmrix/lenz/messageformatters/XNetFunctionGroup6OperateRequestMessageFormatterTest.java
@@ -1,20 +1,19 @@
 package jmri.jmrix.lenz.messageformatters;
 
-
+import jmri.jmrix.AbstractMessageFormatterTest;
 import jmri.jmrix.lenz.XNetMessage;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+
+import org.junit.jupiter.api.*;
 
 /**
  * Tests of XNetFunctionGroup6OperateRequestMessageFormatter class
  *
  * @Paul Bender Copyright (C) 2024
  */
-public class XNetFunctionGroup6OperateRequestMessageFormatterTest {
+public class XNetFunctionGroup6OperateRequestMessageFormatterTest extends AbstractMessageFormatterTest {
 
     @Test
     public void testFormatMessageAllOff() {
-        XNetFunctionGroup6OperateRequestMessageFormatter formatter = new XNetFunctionGroup6OperateRequestMessageFormatter();
         XNetMessage msg = XNetMessage.getFunctionGroup6OpsMsg(1234, false,false,false,false,false,false,false,false);
 
         Assertions.assertTrue(formatter.handlesMessage(msg));
@@ -23,10 +22,17 @@ public class XNetFunctionGroup6OperateRequestMessageFormatterTest {
 
     @Test
     public void testFormatMessageAllOn() {
-        XNetFunctionGroup6OperateRequestMessageFormatter formatter = new XNetFunctionGroup6OperateRequestMessageFormatter();
         XNetMessage msg = XNetMessage.getFunctionGroup6OpsMsg(1234, true,true,true,true,true,true,true,true);
 
         Assertions.assertTrue(formatter.handlesMessage(msg));
         Assertions.assertEquals("Mobile Decoder Operations Request: Set Function Group 6 for Address: 1234 F29 On; F30 On; F31 On; F32 On; F33 On; F34 On; F35 On; F36 On; ",formatter.formatMessage(msg));
     }
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp(); // setup JUnit
+        formatter = new XNetFunctionGroup6OperateRequestMessageFormatter();
+    }
+
 }

--- a/java/test/jmri/jmrix/lenz/messageformatters/XNetFunctionGroup7MomentaryRequestMessageFormatterTest.java
+++ b/java/test/jmri/jmrix/lenz/messageformatters/XNetFunctionGroup7MomentaryRequestMessageFormatterTest.java
@@ -1,20 +1,19 @@
 package jmri.jmrix.lenz.messageformatters;
 
-
+import jmri.jmrix.AbstractMessageFormatterTest;
 import jmri.jmrix.lenz.XNetMessage;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+
+import org.junit.jupiter.api.*;
 
 /**
  * Tests of XNetFunctionGroup7MomentaryRequestMessageFormatter class
  *
  * @Paul Bender Copyright (C) 2024
  */
-public class XNetFunctionGroup7MomentaryRequestMessageFormatterTest {
+public class XNetFunctionGroup7MomentaryRequestMessageFormatterTest extends AbstractMessageFormatterTest {
 
     @Test
     public void testFormatMessageAllOff() {
-        XNetFunctionGroup7MomentaryRequestMessageFormatter formatter = new XNetFunctionGroup7MomentaryRequestMessageFormatter();
         XNetMessage msg = XNetMessage.getFunctionGroup7SetMomMsg(1234, false,false,false,false,false,false,false,false);
 
         Assertions.assertTrue(formatter.handlesMessage(msg));
@@ -23,10 +22,17 @@ public class XNetFunctionGroup7MomentaryRequestMessageFormatterTest {
 
     @Test
     public void testFormatMessageAllOn() {
-        XNetFunctionGroup7MomentaryRequestMessageFormatter formatter = new XNetFunctionGroup7MomentaryRequestMessageFormatter();
         XNetMessage msg = XNetMessage.getFunctionGroup7SetMomMsg(1234, true,true,true,true,true,true,true,true);
 
         Assertions.assertTrue(formatter.handlesMessage(msg));
         Assertions.assertEquals("Mobile Decoder Operations Request: Set Function Group 7 Momentary Status for Address: 1234 F37 Momentary; F38 Momentary; F39 Momentary; F40 Momentary; F41 Momentary; F42 Momentary; F43 Momentary; F44 Momentary; ",formatter.formatMessage(msg));
     }
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp(); // setup JUnit
+        formatter = new XNetFunctionGroup7MomentaryRequestMessageFormatter();
+    }
+
 }

--- a/java/test/jmri/jmrix/lenz/messageformatters/XNetFunctionGroup7OperateRequestMessageFormatterTest.java
+++ b/java/test/jmri/jmrix/lenz/messageformatters/XNetFunctionGroup7OperateRequestMessageFormatterTest.java
@@ -1,20 +1,19 @@
 package jmri.jmrix.lenz.messageformatters;
 
-
+import jmri.jmrix.AbstractMessageFormatterTest;
 import jmri.jmrix.lenz.XNetMessage;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+
+import org.junit.jupiter.api.*;
 
 /**
  * Tests of XNetFunctionGroup7OperateRequestMessageFormatter class
  *
  * @Paul Bender Copyright (C) 2024
  */
-public class XNetFunctionGroup7OperateRequestMessageFormatterTest {
+public class XNetFunctionGroup7OperateRequestMessageFormatterTest extends AbstractMessageFormatterTest {
 
     @Test
     public void testFormatMessageAllOff() {
-        XNetFunctionGroup7OperateRequestMessageFormatter formatter = new XNetFunctionGroup7OperateRequestMessageFormatter();
         XNetMessage msg = XNetMessage.getFunctionGroup7OpsMsg(1234, false,false,false,false,false,false,false,false);
 
         Assertions.assertTrue(formatter.handlesMessage(msg));
@@ -23,10 +22,17 @@ public class XNetFunctionGroup7OperateRequestMessageFormatterTest {
 
     @Test
     public void testFormatMessageAllOn() {
-        XNetFunctionGroup7OperateRequestMessageFormatter formatter = new XNetFunctionGroup7OperateRequestMessageFormatter();
         XNetMessage msg = XNetMessage.getFunctionGroup7OpsMsg(1234, true,true,true,true,true,true,true,true);
 
         Assertions.assertTrue(formatter.handlesMessage(msg));
         Assertions.assertEquals("Mobile Decoder Operations Request: Set Function Group 7 for Address: 1234 F37 On; F38 On; F39 On; F40 On; F41 On; F42 On; F43 On; F44 On; ",formatter.formatMessage(msg));
     }
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp(); // setup JUnit
+        formatter = new XNetFunctionGroup7OperateRequestMessageFormatter();
+    }
+
 }

--- a/java/test/jmri/jmrix/lenz/messageformatters/XNetFunctionGroup8MomentaryRequestMessageFormatterTest.java
+++ b/java/test/jmri/jmrix/lenz/messageformatters/XNetFunctionGroup8MomentaryRequestMessageFormatterTest.java
@@ -1,20 +1,20 @@
 package jmri.jmrix.lenz.messageformatters;
 
 
+import jmri.jmrix.AbstractMessageFormatterTest;
 import jmri.jmrix.lenz.XNetMessage;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+
+import org.junit.jupiter.api.*;
 
 /**
  * Tests of XNetFunctionGroup8MomentaryRequestMessageFormatter class
  *
  * @Paul Bender Copyright (C) 2024
  */
-public class XNetFunctionGroup8MomentaryRequestMessageFormatterTest {
+public class XNetFunctionGroup8MomentaryRequestMessageFormatterTest extends AbstractMessageFormatterTest {
 
     @Test
     public void testFormatMessageAllOff() {
-        XNetFunctionGroup8MomentaryRequestMessageFormatter formatter = new XNetFunctionGroup8MomentaryRequestMessageFormatter();
         XNetMessage msg = XNetMessage.getFunctionGroup8SetMomMsg(1234, false,false,false,false,false,false,false,false);
 
         Assertions.assertTrue(formatter.handlesMessage(msg));
@@ -23,10 +23,17 @@ public class XNetFunctionGroup8MomentaryRequestMessageFormatterTest {
 
     @Test
     public void testFormatMessageAllOn() {
-        XNetFunctionGroup8MomentaryRequestMessageFormatter formatter = new XNetFunctionGroup8MomentaryRequestMessageFormatter();
         XNetMessage msg = XNetMessage.getFunctionGroup8SetMomMsg(1234, true,true,true,true,true,true,true,true);
 
         Assertions.assertTrue(formatter.handlesMessage(msg));
         Assertions.assertEquals("Mobile Decoder Operations Request: Set Function Group 8 Momentary Status for Address: 1234 F45 Momentary; F46 Momentary; F47 Momentary; F48 Momentary; F49 Momentary; F50 Momentary; F51 Momentary; F52 Momentary; ",formatter.formatMessage(msg));
     }
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp(); // setup JUnit
+        formatter = new XNetFunctionGroup8MomentaryRequestMessageFormatter();
+    }
+
 }

--- a/java/test/jmri/jmrix/lenz/messageformatters/XNetFunctionGroup8OperateRequestMessageFormatterTest.java
+++ b/java/test/jmri/jmrix/lenz/messageformatters/XNetFunctionGroup8OperateRequestMessageFormatterTest.java
@@ -1,20 +1,19 @@
 package jmri.jmrix.lenz.messageformatters;
 
-
+import jmri.jmrix.AbstractMessageFormatterTest;
 import jmri.jmrix.lenz.XNetMessage;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+
+import org.junit.jupiter.api.*;
 
 /**
  * Tests of XNetFunctionGroup8OperateRequestMessageFormatter class
  *
  * @Paul Bender Copyright (C) 2024
  */
-public class XNetFunctionGroup8OperateRequestMessageFormatterTest {
+public class XNetFunctionGroup8OperateRequestMessageFormatterTest extends AbstractMessageFormatterTest {
 
     @Test
     public void testFormatMessageAllOff() {
-        XNetFunctionGroup8OperateRequestMessageFormatter formatter = new XNetFunctionGroup8OperateRequestMessageFormatter();
         XNetMessage msg = XNetMessage.getFunctionGroup8OpsMsg(1234, false,false,false,false,false,false,false,false);
 
         Assertions.assertTrue(formatter.handlesMessage(msg));
@@ -23,10 +22,17 @@ public class XNetFunctionGroup8OperateRequestMessageFormatterTest {
 
     @Test
     public void testFormatMessageAllOn() {
-        XNetFunctionGroup8OperateRequestMessageFormatter formatter = new XNetFunctionGroup8OperateRequestMessageFormatter();
         XNetMessage msg = XNetMessage.getFunctionGroup8OpsMsg(1234, true,true,true,true,true,true,true,true);
 
         Assertions.assertTrue(formatter.handlesMessage(msg));
         Assertions.assertEquals("Mobile Decoder Operations Request: Set Function Group 8 for Address: 1234 F45 On; F46 On; F47 On; F48 On; F49 On; F50 On; F51 On; F52 On; ",formatter.formatMessage(msg));
     }
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp(); // setup JUnit
+        formatter = new XNetFunctionGroup8OperateRequestMessageFormatter();
+    }
+
 }

--- a/java/test/jmri/jmrix/lenz/messageformatters/XNetFunctionGroup9MomentaryRequestMessageFormatterTest.java
+++ b/java/test/jmri/jmrix/lenz/messageformatters/XNetFunctionGroup9MomentaryRequestMessageFormatterTest.java
@@ -1,20 +1,19 @@
 package jmri.jmrix.lenz.messageformatters;
 
-
+import jmri.jmrix.AbstractMessageFormatterTest;
 import jmri.jmrix.lenz.XNetMessage;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+
+import org.junit.jupiter.api.*;
 
 /**
  * Tests of XNetFunctionGroup9MomentaryRequestMessageFormatter class
  *
  * @Paul Bender Copyright (C) 2024
  */
-public class XNetFunctionGroup9MomentaryRequestMessageFormatterTest {
+public class XNetFunctionGroup9MomentaryRequestMessageFormatterTest extends AbstractMessageFormatterTest {
 
     @Test
     public void testFormatMessageAllOff() {
-        XNetFunctionGroup9MomentaryRequestMessageFormatter formatter = new XNetFunctionGroup9MomentaryRequestMessageFormatter();
         XNetMessage msg = XNetMessage.getFunctionGroup9SetMomMsg(1234, false,false,false,false,false,false,false,false);
 
         Assertions.assertTrue(formatter.handlesMessage(msg));
@@ -23,10 +22,17 @@ public class XNetFunctionGroup9MomentaryRequestMessageFormatterTest {
 
     @Test
     public void testFormatMessageAllOn() {
-        XNetFunctionGroup9MomentaryRequestMessageFormatter formatter = new XNetFunctionGroup9MomentaryRequestMessageFormatter();
         XNetMessage msg = XNetMessage.getFunctionGroup9SetMomMsg(1234, true,true,true,true,true,true,true,true);
 
         Assertions.assertTrue(formatter.handlesMessage(msg));
         Assertions.assertEquals("Mobile Decoder Operations Request: Set Function Group 9 Momentary Status for Address: 1234 F53 Momentary; F54 Momentary; F55 Momentary; F56 Momentary; F57 Momentary; F58 Momentary; F59 Momentary; F60 Momentary; ",formatter.formatMessage(msg));
     }
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp(); // setup JUnit
+        formatter = new XNetFunctionGroup9MomentaryRequestMessageFormatter();
+    }
+
 }

--- a/java/test/jmri/jmrix/lenz/messageformatters/XNetFunctionGroup9OperateRequestMessageFormatterTest.java
+++ b/java/test/jmri/jmrix/lenz/messageformatters/XNetFunctionGroup9OperateRequestMessageFormatterTest.java
@@ -1,20 +1,19 @@
 package jmri.jmrix.lenz.messageformatters;
 
-
+import jmri.jmrix.AbstractMessageFormatterTest;
 import jmri.jmrix.lenz.XNetMessage;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+
+import org.junit.jupiter.api.*;
 
 /**
- * Tests of XNetFunctionGroup10OperateRequestMessageFormatter class
+ * Tests of XNetFunctionGroup9OperateRequestMessageFormatter class
  *
  * @Paul Bender Copyright (C) 2024
  */
-public class XNetFunctionGroup9OperateRequestMessageFormatterTest {
+public class XNetFunctionGroup9OperateRequestMessageFormatterTest extends AbstractMessageFormatterTest {
 
     @Test
     public void testFormatMessageAllOff() {
-        XNetFunctionGroup9OperateRequestMessageFormatter formatter = new XNetFunctionGroup9OperateRequestMessageFormatter();
         XNetMessage msg = XNetMessage.getFunctionGroup9OpsMsg(1234, false,false,false,false,false,false,false,false);
 
         Assertions.assertTrue(formatter.handlesMessage(msg));
@@ -23,10 +22,17 @@ public class XNetFunctionGroup9OperateRequestMessageFormatterTest {
 
     @Test
     public void testFormatMessageAllOn() {
-        XNetFunctionGroup9OperateRequestMessageFormatter formatter = new XNetFunctionGroup9OperateRequestMessageFormatter();
         XNetMessage msg = XNetMessage.getFunctionGroup9OpsMsg(1234, true,true,true,true,true,true,true,true);
 
         Assertions.assertTrue(formatter.handlesMessage(msg));
         Assertions.assertEquals("Mobile Decoder Operations Request: Set Function Group 9 for Address: 1234 F53 On; F54 On; F55 On; F56 On; F57 On; F58 On; F59 On; F60 On; ",formatter.formatMessage(msg));
     }
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp(); // setup JUnit
+        formatter = new XNetFunctionGroup9OperateRequestMessageFormatter();
+    }
+
 }

--- a/java/test/jmri/jmrix/lenz/messageformatters/XNetLI101AddressReplyFormatterTest.java
+++ b/java/test/jmri/jmrix/lenz/messageformatters/XNetLI101AddressReplyFormatterTest.java
@@ -1,22 +1,29 @@
 package jmri.jmrix.lenz.messageformatters;
 
+import jmri.jmrix.AbstractMessageFormatterTest;
 import jmri.jmrix.lenz.XNetReply;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+
+import org.junit.jupiter.api.*;
 
 /**
  * Tests for the XNetLI101AddressReplyFormatter class.
  *
  * @author Paul Bender Copyright (C) 2025
  */
-public class XNetLI101AddressReplyFormatterTest {
+public class XNetLI101AddressReplyFormatterTest extends AbstractMessageFormatterTest {
 
     @Test
     public void testMonitorStringLIAddressReply(){
-        XNetLI101AddressReplyFormatter formatter = new XNetLI101AddressReplyFormatter();
         XNetReply r = new XNetReply("F2 01 01 F2");
         Assertions.assertTrue(formatter.handlesMessage(r));
         Assertions.assertEquals( Bundle.getMessage("XNetReplyLIAddress",1),formatter.formatMessage(r));
+    }
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp(); // setup JUnit
+        formatter = new XNetLI101AddressReplyFormatter();
     }
 
 }

--- a/java/test/jmri/jmrix/lenz/messageformatters/XNetLI101BaudReplyFormatterTest.java
+++ b/java/test/jmri/jmrix/lenz/messageformatters/XNetLI101BaudReplyFormatterTest.java
@@ -1,6 +1,8 @@
 package jmri.jmrix.lenz.messageformatters;
 
+import jmri.jmrix.AbstractMessageFormatterTest;
 import jmri.jmrix.lenz.XNetReply;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -10,14 +12,7 @@ import org.junit.jupiter.api.Test;
  * 
  * @author Paul Bender Copyright (C) 2025
  */
-public class XNetLI101BaudReplyFormatterTest {
-
-    private XNetLI101BaudReplyFormatter formatter;
-
-    @BeforeEach
-    public void setUp() {
-        formatter = new XNetLI101BaudReplyFormatter();
-    }
+public class XNetLI101BaudReplyFormatterTest extends AbstractMessageFormatterTest {
 
     @Test
     public void testToMonitorStringLIBaud1Reply(){
@@ -25,6 +20,7 @@ public class XNetLI101BaudReplyFormatterTest {
         Assertions.assertTrue(formatter.handlesMessage(r));
         Assertions.assertEquals(Bundle.getMessage("XNetReplyLIBaud","19,200 bps (default)" ),formatter.formatMessage(r));
     }
+
     @Test
     public void testToMonitorStringLIBaud2Reply(){
         XNetReply r = new XNetReply("F2 02 02 F2");
@@ -52,4 +48,12 @@ public class XNetLI101BaudReplyFormatterTest {
         Assertions.assertTrue(formatter.handlesMessage(r));
         Assertions.assertEquals(Bundle.getMessage("XNetReplyLIBaud","<undefined>"),formatter.formatMessage(r));
     }
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp(); // setup JUnit
+        formatter = new XNetLI101BaudReplyFormatter();
+    }
+
 }

--- a/java/test/jmri/jmrix/lenz/messageformatters/XNetLI101RequestMessageFormatterTest.java
+++ b/java/test/jmri/jmrix/lenz/messageformatters/XNetLI101RequestMessageFormatterTest.java
@@ -1,18 +1,18 @@
 package jmri.jmrix.lenz.messageformatters;
 
+import jmri.jmrix.AbstractMessageFormatterTest;
 import jmri.jmrix.lenz.XNetMessage;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+
+import org.junit.jupiter.api.*;
 
 /**
- * Tests for the XNetInterfaceRequestMessageFormatter class.
+ * Tests for the XNetLI101RequestMessageFormatter class.
  * @author Paul Bender copyright (C) 2024
  */
-public class XNetLI101RequestMessageFormatterTest {
+public class XNetLI101RequestMessageFormatterTest extends AbstractMessageFormatterTest {
 
     @Test
     public void testFormatLI101AddressRequestMessage() {
-        XNetLI101RequestMessageFormatter formatter = new XNetLI101RequestMessageFormatter();
         XNetMessage msg = XNetMessage.getLIAddressRequestMsg(1);
         Assertions.assertTrue(formatter.handlesMessage(msg), "Formatter Handles Message");
         Assertions.assertEquals("REQUEST LI101 Address 1",formatter.formatMessage(msg));
@@ -20,7 +20,6 @@ public class XNetLI101RequestMessageFormatterTest {
 
     @Test
     public void testFormatLISpeedRequestMessage1(){
-        XNetLI101RequestMessageFormatter formatter = new XNetLI101RequestMessageFormatter();
         XNetMessage msg = XNetMessage.getLISpeedRequestMsg(1);
         Assertions.assertTrue(formatter.handlesMessage(msg), "Formatter Handles Message");
         Assertions.assertEquals("REQUEST LI101 Baud Rate 19,200 bps (default)",formatter.formatMessage(msg));
@@ -28,7 +27,6 @@ public class XNetLI101RequestMessageFormatterTest {
 
     @Test
     public void testFormatLISpeedRequestMessage2(){
-        XNetLI101RequestMessageFormatter formatter = new XNetLI101RequestMessageFormatter();
         XNetMessage msg = XNetMessage.getLISpeedRequestMsg(2);
         Assertions.assertTrue(formatter.handlesMessage(msg), "Formatter Handles Message");
         Assertions.assertEquals("REQUEST LI101 Baud Rate 38,400 bps",formatter.formatMessage(msg));
@@ -36,7 +34,6 @@ public class XNetLI101RequestMessageFormatterTest {
 
     @Test
     public void testFormatLISpeedRequestMessage3(){
-        XNetLI101RequestMessageFormatter formatter = new XNetLI101RequestMessageFormatter();
         XNetMessage msg = XNetMessage.getLISpeedRequestMsg(3);
         Assertions.assertTrue(formatter.handlesMessage(msg), "Formatter Handles Message");
         Assertions.assertEquals("REQUEST LI101 Baud Rate 57,600 bps",formatter.formatMessage(msg));
@@ -44,7 +41,6 @@ public class XNetLI101RequestMessageFormatterTest {
 
     @Test
     public void testFormatLISpeedRequestMessage4(){
-        XNetLI101RequestMessageFormatter formatter = new XNetLI101RequestMessageFormatter();
         XNetMessage msg = XNetMessage.getLISpeedRequestMsg(4);
         Assertions.assertTrue(formatter.handlesMessage(msg), "Formatter Handles Message");
         Assertions.assertEquals("REQUEST LI101 Baud Rate 115,200 bps",formatter.formatMessage(msg));
@@ -52,9 +48,16 @@ public class XNetLI101RequestMessageFormatterTest {
 
     @Test
     public void testToMonitorStringLISpeedRequestMessage5(){
-        XNetLI101RequestMessageFormatter formatter = new XNetLI101RequestMessageFormatter();
         XNetMessage msg = XNetMessage.getLISpeedRequestMsg(5);
         Assertions.assertTrue(formatter.handlesMessage(msg), "Formatter Handles Message");
         Assertions.assertEquals("REQUEST LI101 Baud Rate <undefined>",formatter.formatMessage(msg));
     }
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp(); // setup JUnit
+        formatter = new XNetLI101RequestMessageFormatter();
+    }
+
 }

--- a/java/test/jmri/jmrix/lenz/messageformatters/XNetLIReplyFormatterTest.java
+++ b/java/test/jmri/jmrix/lenz/messageformatters/XNetLIReplyFormatterTest.java
@@ -1,8 +1,11 @@
 package jmri.jmrix.lenz.messageformatters;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jmri.jmrix.AbstractMessageFormatterTest;
 import jmri.jmrix.lenz.XNetReply;
-import org.junit.Assert;
-import org.junit.jupiter.api.Assertions;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -11,76 +14,76 @@ import org.junit.jupiter.api.Test;
  *
  * @author Paul Bender Copyright (C) 2025
  */
-public class XNetLIReplyFormatterTest {
-
-    XNetLIReplyFormatter formatter;
-
-    @BeforeEach
-    public void setUp() {
-        formatter = new XNetLIReplyFormatter();
-    }
+public class XNetLIReplyFormatterTest extends AbstractMessageFormatterTest {
 
     @Test
     public void testToMonitorStringErrorPCtoLI(){
         XNetReply r = new XNetReply("01 01 00");
-        Assertions.assertTrue(formatter.handlesMessage(r));
-        Assertions.assertEquals(Bundle.getMessage("XNetReplyErrorPCtoLI"),formatter.formatMessage(r));
+        assertTrue(formatter.handlesMessage(r));
+        assertEquals(Bundle.getMessage("XNetReplyErrorPCtoLI"),formatter.formatMessage(r));
     }
 
     @Test
     public void testToMonitorStringErrorLItoCS(){
         XNetReply r = new XNetReply("01 02 03");
-        Assertions.assertTrue(formatter.handlesMessage(r));
-        Assert.assertEquals("Monitor String", Bundle.getMessage("XNetReplyErrorLItoCS"),formatter.formatMessage(r));
+        assertTrue(formatter.handlesMessage(r));
+        assertEquals( Bundle.getMessage("XNetReplyErrorLItoCS"),formatter.formatMessage(r), "Monitor String");
     }
 
     @Test
     public void testToMonitorStringErrorUnknown(){
         XNetReply r = new XNetReply("01 03 02");
-        Assertions.assertTrue(formatter.handlesMessage(r));
-        Assert.assertEquals("Monitor String", Bundle.getMessage("XNetReplyErrorUnknown"),formatter.formatMessage(r));
+        assertTrue(formatter.handlesMessage(r));
+        assertEquals( Bundle.getMessage("XNetReplyErrorUnknown"),formatter.formatMessage(r), "Monitor String");
     }
 
     @Test
     public void testToMonitorStringErrorNoTimeslot(){
         XNetReply r = new XNetReply("01 05 04");
-        Assertions.assertTrue(formatter.handlesMessage(r));
-        Assert.assertEquals("Monitor String", Bundle.getMessage("XNetReplyErrorNoTimeSlot"),formatter.formatMessage(r));
+        assertTrue(formatter.handlesMessage(r));
+        assertEquals( Bundle.getMessage("XNetReplyErrorNoTimeSlot"),formatter.formatMessage(r), "Monitor String");
     }
 
     @Test
     public void testToMonitorStringErrorBufferOverflow(){
         XNetReply r = new XNetReply("01 06 07");
-        Assertions.assertTrue(formatter.handlesMessage(r));
-        Assert.assertEquals("Monitor String", Bundle.getMessage("XNetReplyErrorBufferOverflow"),formatter.formatMessage(r));
+        assertTrue(formatter.handlesMessage(r));
+        assertEquals( Bundle.getMessage("XNetReplyErrorBufferOverflow"),formatter.formatMessage(r), "Monitor String");
     }
 
     @Test
     public void testToMonitorStringTimeSlotRestored(){
         XNetReply r = new XNetReply("01 07 06");
-        Assertions.assertTrue(formatter.handlesMessage(r));
-        Assert.assertEquals("Monitor String", Bundle.getMessage("XNetReplyTimeSlotRestored"),formatter.formatMessage(r));
+        assertTrue(formatter.handlesMessage(r));
+        assertEquals( Bundle.getMessage("XNetReplyTimeSlotRestored"),formatter.formatMessage(r), "Monitor String");
     }
 
     @Test
     public void testToMonitorStringDataSentNoTimeslot(){
         XNetReply r = new XNetReply("01 08 09");
-        Assertions.assertTrue(formatter.handlesMessage(r));
-        Assert.assertEquals("Monitor String", Bundle.getMessage("XNetReplyRequestSentWhileNoTimeslot"),formatter.formatMessage(r));
+        assertTrue(formatter.handlesMessage(r));
+        assertEquals( Bundle.getMessage("XNetReplyRequestSentWhileNoTimeslot"),formatter.formatMessage(r), "Monitor String");
     }
 
     @Test
     public void testToMonitorStringErrorBadData(){
         XNetReply r = new XNetReply("01 09 08");
-        Assertions.assertTrue(formatter.handlesMessage(r));
-        Assert.assertEquals("Monitor String", Bundle.getMessage("XNetReplyBadDataInRequest"),formatter.formatMessage(r));
+        assertTrue(formatter.handlesMessage(r));
+        assertEquals( Bundle.getMessage("XNetReplyBadDataInRequest"),formatter.formatMessage(r), "Monitor String");
     }
 
     @Test
     public void testToMonitorStringRetransmissionRequested(){
         XNetReply r = new XNetReply("01 0A 0B");
-        Assertions.assertTrue(formatter.handlesMessage(r));
-        Assert.assertEquals("Monitor String", Bundle.getMessage("XNetReplyRetransmitRequest"),formatter.formatMessage(r));
+        assertTrue(formatter.handlesMessage(r));
+        assertEquals( Bundle.getMessage("XNetReplyRetransmitRequest"),formatter.formatMessage(r), "Monitor String");
+    }
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp(); // setup JUnit
+        formatter = new XNetLIReplyFormatter();
     }
 
 }

--- a/java/test/jmri/jmrix/lenz/messageformatters/XNetLIVersionReplyFormatterTest.java
+++ b/java/test/jmri/jmrix/lenz/messageformatters/XNetLIVersionReplyFormatterTest.java
@@ -1,21 +1,29 @@
 package jmri.jmrix.lenz.messageformatters;
 
+import jmri.jmrix.AbstractMessageFormatterTest;
 import jmri.jmrix.lenz.XNetReply;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+
+import org.junit.jupiter.api.*;
 
 /**
  * Tests for the XNetLIVersionReplyFormatter class.
  *
  * @author Paul Bender Copyright (C) 2025
  */
-public class XNetLIVersionReplyFormatterTest {
+public class XNetLIVersionReplyFormatterTest extends AbstractMessageFormatterTest {
 
     @Test
     public void testHandlesMessage() {
-        XNetLIVersionReplyFormatter formatter = new XNetLIVersionReplyFormatter();
         XNetReply r = new XNetReply("02 01 36 34");
         Assertions.assertTrue(formatter.handlesMessage(r));
         Assertions.assertEquals(Bundle.getMessage("XNetReplyLIVersion",0.1,3.6),formatter.formatMessage(r));
     }
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp(); // setup JUnit
+        formatter = new XNetLIVersionReplyFormatter();
+    }
+
 }

--- a/java/test/jmri/jmrix/lenz/messageformatters/XNetLocoFunctionMomentaryStatusReplyFormatterTest.java
+++ b/java/test/jmri/jmrix/lenz/messageformatters/XNetLocoFunctionMomentaryStatusReplyFormatterTest.java
@@ -1,19 +1,19 @@
 package jmri.jmrix.lenz.messageformatters;
 
+import jmri.jmrix.AbstractMessageFormatterTest;
 import jmri.jmrix.lenz.XNetReply;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+
+import org.junit.jupiter.api.*;
 
 /**
  * Tests for the XNetLocoFunctionMomentaryStatusReplyFormatter class.
  *
  * @author Paul Bender Copyright (C) 2025
  */
-public class XNetLocoFunctionMomentaryStatusReplyFormatterTest {
+public class XNetLocoFunctionMomentaryStatusReplyFormatterTest extends AbstractMessageFormatterTest {
 
     @Test
     public void testFormattMixed(){
-        XNetLocoFunctionMomentaryStatusReplyFormatter formatter = new XNetLocoFunctionMomentaryStatusReplyFormatter();
         XNetReply r= new XNetReply("E3 50 54 04 E3");
         Assertions.assertTrue(formatter.handlesMessage(r));
         Assertions.assertEquals("Locomotive Information Response: Locomotive Function Status: F0 Momentary; F1 Continuous; F2 Continuous; F3 Momentary; F4 Continuous; F5 Continuous; F6 Continuous; F7 Momentary; F8 Continuous; F9 Continuous; F10 Continuous; F11 Continuous; F12 Continuous; ",formatter.formatMessage(r));
@@ -21,7 +21,6 @@ public class XNetLocoFunctionMomentaryStatusReplyFormatterTest {
 
     @Test
     public void testFormattAllContinous() {
-        XNetLocoFunctionMomentaryStatusReplyFormatter formatter = new XNetLocoFunctionMomentaryStatusReplyFormatter();
         XNetReply r = new XNetReply("E3 50 00 00 93");
         Assertions.assertTrue(formatter.handlesMessage(r));
         Assertions.assertEquals("Locomotive Information Response: Locomotive Function Status: F0 Continuous; F1 Continuous; F2 Continuous; F3 Continuous; F4 Continuous; F5 Continuous; F6 Continuous; F7 Continuous; F8 Continuous; F9 Continuous; F10 Continuous; F11 Continuous; F12 Continuous; ",formatter.formatMessage(r));
@@ -29,9 +28,16 @@ public class XNetLocoFunctionMomentaryStatusReplyFormatterTest {
 
     @Test
     public void testFormattAllMomentary() {
-        XNetLocoFunctionMomentaryStatusReplyFormatter formatter = new XNetLocoFunctionMomentaryStatusReplyFormatter();
         XNetReply r= new XNetReply("E3 50 5F FF 13");
         Assertions.assertTrue(formatter.handlesMessage(r));
         Assertions.assertEquals("Locomotive Information Response: Locomotive Function Status: F0 Momentary; F1 Momentary; F2 Momentary; F3 Momentary; F4 Momentary; F5 Momentary; F6 Momentary; F7 Momentary; F8 Momentary; F9 Momentary; F10 Momentary; F11 Momentary; F12 Momentary; ",formatter.formatMessage(r));
     }
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp(); // setup JUnit
+        formatter = new XNetLocoFunctionMomentaryStatusReplyFormatter();
+    }
+
 }

--- a/java/test/jmri/jmrix/lenz/messageformatters/XNetLocoFunctionStatusHighReplyFormatterTest.java
+++ b/java/test/jmri/jmrix/lenz/messageformatters/XNetLocoFunctionStatusHighReplyFormatterTest.java
@@ -1,19 +1,19 @@
 package jmri.jmrix.lenz.messageformatters;
 
+import jmri.jmrix.AbstractMessageFormatterTest;
 import jmri.jmrix.lenz.XNetReply;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+
+import org.junit.jupiter.api.*;
 
 /**
  * Tests for the XNetLocoFunctionStatusHighReplyFormatter class.
  *
  * @author Paul Bender Copyright (C) 2025
  */
-public class XNetLocoFunctionStatusHighReplyFormatterTest {
+public class XNetLocoFunctionStatusHighReplyFormatterTest extends AbstractMessageFormatterTest {
 
     @Test
     void testMixedStatus() {
-        XNetLocoFunctionStatusHighReplyFormatter formatter = new XNetLocoFunctionStatusHighReplyFormatter();
         XNetReply r = new XNetReply("E3 52 54 04 E3");
         Assertions.assertTrue(formatter.handlesMessage(r));
         Assertions.assertEquals("Locomotive Information Response: Locomotive F13-F28 Status: F13 Off; F14 Off; F15 On; F16 Off; F17 On; F18 Off; F19 On; F20 Off; F21 Off; F22 Off; F23 On; F24 Off; F25 Off; F26 Off; F27 Off; F28 Off; ", formatter.formatMessage(r));
@@ -21,7 +21,6 @@ public class XNetLocoFunctionStatusHighReplyFormatterTest {
 
     @Test
     void testAllOff() {
-        XNetLocoFunctionStatusHighReplyFormatter formatter = new XNetLocoFunctionStatusHighReplyFormatter();
         XNetReply r = new XNetReply("E3 52 00 00 91");
         Assertions.assertTrue(formatter.handlesMessage(r));
         Assertions.assertEquals("Locomotive Information Response: Locomotive F13-F28 Status: F13 Off; F14 Off; F15 Off; F16 Off; F17 Off; F18 Off; F19 Off; F20 Off; F21 Off; F22 Off; F23 Off; F24 Off; F25 Off; F26 Off; F27 Off; F28 Off; ", formatter.formatMessage(r));
@@ -29,10 +28,16 @@ public class XNetLocoFunctionStatusHighReplyFormatterTest {
 
     @Test
     void testAllOn() {
-        XNetLocoFunctionStatusHighReplyFormatter formatter = new XNetLocoFunctionStatusHighReplyFormatter();
         XNetReply r = new XNetReply("E3 52 FF FF 91");
         Assertions.assertTrue(formatter.handlesMessage(r));
         Assertions.assertEquals("Locomotive Information Response: Locomotive F13-F28 Status: F13 On; F14 On; F15 On; F16 On; F17 On; F18 On; F19 On; F20 On; F21 On; F22 On; F23 On; F24 On; F25 On; F26 On; F27 On; F28 On; ", formatter.formatMessage(r));
+    }
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp(); // setup JUnit
+        formatter = new XNetLocoFunctionStatusHighReplyFormatter();
     }
 
 }

--- a/java/test/jmri/jmrix/lenz/messageformatters/XNetLocoInfoDHUnitFormatterTest.java
+++ b/java/test/jmri/jmrix/lenz/messageformatters/XNetLocoInfoDHUnitFormatterTest.java
@@ -1,21 +1,29 @@
 package jmri.jmrix.lenz.messageformatters;
 
+import jmri.jmrix.AbstractMessageFormatterTest;
 import jmri.jmrix.lenz.XNetReply;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+
+import org.junit.jupiter.api.*;
 
 /**
  * Tests for the XNetLocoInfoDHUnitFormatter class.
  *
  * @author Paul Bender Copyright (C) 2025
  */
-public class XNetLocoInfoDHUnitFormatterTest {
+public class XNetLocoInfoDHUnitFormatterTest extends AbstractMessageFormatterTest {
 
     @Test
     public void testHandlesMessage() {
-         XNetLocoInfoDHUnitFormatter formatter = new XNetLocoInfoDHUnitFormatter();
         XNetReply r = new XNetReply("E6 64 00 64 C1 C1 04 E2");
         Assertions.assertTrue(formatter.handlesMessage(r));
         Assertions.assertEquals("Locomotive Information Response: Locomotive in Double Header,Reverse,in 128 Speed Step Mode,Speed Step: 0. Address is Free for Operation. F0 Off; F1 Off; F2 Off; F3 On; F4 Off; F5 On; F6 Off; F7 Off; F8 Off; F9 Off; F10 Off; F11 On; F12 On;  Second Locomotive in Double Header is: 260",formatter.formatMessage(r));
     }
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp(); // setup JUnit
+        formatter = new XNetLocoInfoDHUnitFormatter();
+    }
+
 }

--- a/java/test/jmri/jmrix/lenz/messageformatters/XNetLocoInfoMUAddressFormatterTest.java
+++ b/java/test/jmri/jmrix/lenz/messageformatters/XNetLocoInfoMUAddressFormatterTest.java
@@ -1,22 +1,30 @@
 package jmri.jmrix.lenz.messageformatters;
 
+import jmri.jmrix.AbstractMessageFormatterTest;
 import jmri.jmrix.lenz.XNetReply;
+
 import org.junit.Assert;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 
 /**
  * Tests for the XNetLocoInfoMUAddressFormatter class.
  *
  * @author Paul Bender Copyright (C) 2025
  */
-public class XNetLocoInfoMUAddressFormatterTest {
+public class XNetLocoInfoMUAddressFormatterTest extends AbstractMessageFormatterTest {
 
     @Test
     void testFormatter() {
-        XNetLocoInfoMUAddressFormatter formatter = new XNetLocoInfoMUAddressFormatter();
         XNetReply r = new XNetReply("E2 14 C1 37");
         Assertions.assertTrue(formatter.handlesMessage(r));
         Assert.assertEquals("Locomotive Information Response: Multi Unit Base Address,Forward,in 128 Speed Step Mode,Speed Step: 64. Address is Free for Operation. ",formatter.formatMessage(r));
     }
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp(); // setup JUnit
+        formatter = new XNetLocoInfoMUAddressFormatter();
+    }
+
 }

--- a/java/test/jmri/jmrix/lenz/messageformatters/XNetLocoInfoNormalUnitHighFunctionMomentaryStatusFormatterTest.java
+++ b/java/test/jmri/jmrix/lenz/messageformatters/XNetLocoInfoNormalUnitHighFunctionMomentaryStatusFormatterTest.java
@@ -1,19 +1,19 @@
 package jmri.jmrix.lenz.messageformatters;
 
+import jmri.jmrix.AbstractMessageFormatterTest;
 import jmri.jmrix.lenz.XNetReply;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+
+import org.junit.jupiter.api.*;
 
 /**
  * Tests for the XNetLocoInfoNOrmalUnitHighFunctionMomentaryStatusFormatter class
  *
  * @author Paul Bender Copyright (C) 2025
  */
-public class XNetLocoInfoNormalUnitHighFunctionMomentaryStatusFormatterTest {
+public class XNetLocoInfoNormalUnitHighFunctionMomentaryStatusFormatterTest extends AbstractMessageFormatterTest {
 
     @Test
     public void testToMonitorStringLocoInfoNormalUnitHighFunctionMomentaryStatusMixedStatus() {
-        XNetLocoInfoNormalUnitHighFunctionMomentaryStatusFormatter formatter = new XNetLocoInfoNormalUnitHighFunctionMomentaryStatusFormatter();
         XNetReply r = new XNetReply("E4 51 00 54 04 E5");
         Assertions.assertTrue(formatter.handlesMessage(r));
         Assertions.assertEquals("Locomotive F13-F28 Momentary Status: F13 Continuous; F14 Continuous; F15 Continuous; F16 Continuous; F17 Continuous; F18 Continuous; F19 Continuous; F20 Continuous; F21 Continuous; F22 Continuous; F23 Momentary; F24 Continuous; F25 Momentary; F26 Continuous; F27 Momentary; F28 Continuous; ",
@@ -22,7 +22,6 @@ public class XNetLocoInfoNormalUnitHighFunctionMomentaryStatusFormatterTest {
 
     @Test
     public void testToMonitorStringLocoInfoNormalUnitHighFunctionMomentaryStatusAllContinuous() {
-        XNetLocoInfoNormalUnitHighFunctionMomentaryStatusFormatter formatter = new XNetLocoInfoNormalUnitHighFunctionMomentaryStatusFormatter();
         XNetReply r = new XNetReply("E4 51 00 00 00 95");
         Assertions.assertTrue(formatter.handlesMessage(r));
         Assertions.assertEquals("Locomotive F13-F28 Momentary Status: F13 Continuous; F14 Continuous; F15 Continuous; F16 Continuous; F17 Continuous; F18 Continuous; F19 Continuous; F20 Continuous; F21 Continuous; F22 Continuous; F23 Continuous; F24 Continuous; F25 Continuous; F26 Continuous; F27 Continuous; F28 Continuous; ",
@@ -31,11 +30,17 @@ public class XNetLocoInfoNormalUnitHighFunctionMomentaryStatusFormatterTest {
 
     @Test
     public void testToMonitorStringLocoInfoNormalUnitHighFunctionMomentaryStatusAllMomentary() {
-        XNetLocoInfoNormalUnitHighFunctionMomentaryStatusFormatter formatter = new XNetLocoInfoNormalUnitHighFunctionMomentaryStatusFormatter();
         XNetReply r = new XNetReply("E4 51 FF FF FF 45");
         Assertions.assertTrue(formatter.handlesMessage(r));
         Assertions.assertEquals("Locomotive F13-F28 Momentary Status: F13 Momentary; F14 Momentary; F15 Momentary; F16 Momentary; F17 Momentary; F18 Momentary; F19 Momentary; F20 Momentary; F21 Momentary; F22 Momentary; F23 Momentary; F24 Momentary; F25 Momentary; F26 Momentary; F27 Momentary; F28 Momentary; ",
                 formatter.formatMessage(r));
+    }
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp(); // setup JUnit
+        formatter = new XNetLocoInfoNormalUnitHighFunctionMomentaryStatusFormatter();
     }
 
 }

--- a/java/test/jmri/jmrix/lenz/messageformatters/XNetLocoInfoNormalUnitReplyFormatterTest.java
+++ b/java/test/jmri/jmrix/lenz/messageformatters/XNetLocoInfoNormalUnitReplyFormatterTest.java
@@ -1,86 +1,86 @@
 package jmri.jmrix.lenz.messageformatters;
 
+import jmri.jmrix.AbstractMessageFormatterTest;
 import jmri.jmrix.lenz.XNetReply;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+
+import org.junit.jupiter.api.*;
 
 /**
  * Tests for the XNetLocoInfoNormalUnitReplyFormatter class
  *
  * @author Paul Bender Copyright (C) 2024
  */
-public class XNetLocoInfoNormalUnitReplyFormatterTest {
+public class XNetLocoInfoNormalUnitReplyFormatterTest extends AbstractMessageFormatterTest {
 
-        @Test
-        public void testToMonitorStringNormalLocoInfoSSMode128Speed0Response() {
-            XNetLocoInfoNormalUnitReplyFormatter formatter = new XNetLocoInfoNormalUnitReplyFormatter();
-            XNetReply r = new XNetReply("E4 04 00 04 00 E4");
-            Assertions.assertTrue(formatter.handlesMessage(r));
-            Assertions.assertEquals("Locomotive Information Response: Normal Unit,Reverse,in 128 Speed Step Mode,Speed Step: 0. Address is Free for Operation. F0 Off; F1 Off; F2 Off; F3 On; F4 Off; F5 Off; F6 Off; F7 Off; F8 Off; F9 Off; F10 Off; F11 Off; F12 Off; ",
-                    formatter.formatMessage(r));
-        }
+    @Test
+    public void testToMonitorStringNormalLocoInfoSSMode128Speed0Response() {
+        XNetReply r = new XNetReply("E4 04 00 04 00 E4");
+        Assertions.assertTrue(formatter.handlesMessage(r));
+        Assertions.assertEquals("Locomotive Information Response: Normal Unit,Reverse,in 128 Speed Step Mode,Speed Step: 0. Address is Free for Operation. F0 Off; F1 Off; F2 Off; F3 On; F4 Off; F5 Off; F6 Off; F7 Off; F8 Off; F9 Off; F10 Off; F11 Off; F12 Off; ",
+                formatter.formatMessage(r));
+    }
 
-        @Test
-        public void testToMonitorStringNormalLocoInfoSSMode128Speed3Response() {
-            XNetLocoInfoNormalUnitReplyFormatter formatter = new XNetLocoInfoNormalUnitReplyFormatter();
-            XNetReply r = new XNetReply("E4 04 04 04 00 E0");
-            Assertions.assertTrue(formatter.handlesMessage(r));
-            Assertions.assertEquals(
-                    "Locomotive Information Response: Normal Unit,Reverse,in 128 Speed Step Mode,Speed Step: 3. Address is Free for Operation. F0 Off; F1 Off; F2 Off; F3 On; F4 Off; F5 Off; F6 Off; F7 Off; F8 Off; F9 Off; F10 Off; F11 Off; F12 Off; ",
-                    formatter.formatMessage(r));
-        }
+    @Test
+    public void testToMonitorStringNormalLocoInfoSSMode128Speed3Response() {
+        XNetReply r = new XNetReply("E4 04 04 04 00 E0");
+        Assertions.assertTrue(formatter.handlesMessage(r));
+        Assertions.assertEquals(
+                "Locomotive Information Response: Normal Unit,Reverse,in 128 Speed Step Mode,Speed Step: 3. Address is Free for Operation. F0 Off; F1 Off; F2 Off; F3 On; F4 Off; F5 Off; F6 Off; F7 Off; F8 Off; F9 Off; F10 Off; F11 Off; F12 Off; ",
+                formatter.formatMessage(r));
+    }
 
-        @Test
-        public void testToMonitorStringNormalLocoInfoSSMode28Speed0Response() {
-            XNetLocoInfoNormalUnitReplyFormatter formatter = new XNetLocoInfoNormalUnitReplyFormatter();
-            XNetReply r = new XNetReply("E4 0A 00 04 00 EA");
-            Assertions.assertTrue(formatter.handlesMessage(r));
-            Assertions.assertEquals("Locomotive Information Response: Normal Unit,Reverse,in 28 Speed Step Mode,Speed Step: 0. Address in use by another device. F0 Off; F1 Off; F2 Off; F3 On; F4 Off; F5 Off; F6 Off; F7 Off; F8 Off; F9 Off; F10 Off; F11 Off; F12 Off; ",
-                    formatter.formatMessage(r));
-        }
+    @Test
+    public void testToMonitorStringNormalLocoInfoSSMode28Speed0Response() {
+        XNetReply r = new XNetReply("E4 0A 00 04 00 EA");
+        Assertions.assertTrue(formatter.handlesMessage(r));
+        Assertions.assertEquals("Locomotive Information Response: Normal Unit,Reverse,in 28 Speed Step Mode,Speed Step: 0. Address in use by another device. F0 Off; F1 Off; F2 Off; F3 On; F4 Off; F5 Off; F6 Off; F7 Off; F8 Off; F9 Off; F10 Off; F11 Off; F12 Off; ",
+                formatter.formatMessage(r));
+    }
 
-        @Test
-        public void testToMonitorStringNormalLocoInfoSSMode28Speed17Response() {
-            XNetLocoInfoNormalUnitReplyFormatter formatter = new XNetLocoInfoNormalUnitReplyFormatter();
-            XNetReply r = new XNetReply("E4 0A 0A 04 00 E0");
-            Assertions.assertTrue(formatter.handlesMessage(r));
-            Assertions.assertEquals("Locomotive Information Response: Normal Unit,Reverse,in 28 Speed Step Mode,Speed Step: 17. Address in use by another device. F0 Off; F1 Off; F2 Off; F3 On; F4 Off; F5 Off; F6 Off; F7 Off; F8 Off; F9 Off; F10 Off; F11 Off; F12 Off; ",
-                    formatter.formatMessage(r));
-        }
-        @Test
-        public void testToMonitorStringNormalLocoInfoSSMode27Speed0Response() {
-            XNetLocoInfoNormalUnitReplyFormatter formatter = new XNetLocoInfoNormalUnitReplyFormatter();
-            XNetReply r = new XNetReply("E4 01 00 1F FF F5");
-            Assertions.assertTrue(formatter.handlesMessage(r));
-            Assertions.assertEquals("Locomotive Information Response: Normal Unit,Reverse,in 27 Speed Step Mode,Speed Step: 0. Address is Free for Operation. F0 On; F1 On; F2 On; F3 On; F4 On; F5 On; F6 On; F7 On; F8 On; F9 On; F10 On; F11 On; F12 On; ",
-                    formatter.formatMessage(r));
-        }
+    @Test
+    public void testToMonitorStringNormalLocoInfoSSMode28Speed17Response() {
+        XNetReply r = new XNetReply("E4 0A 0A 04 00 E0");
+        Assertions.assertTrue(formatter.handlesMessage(r));
+        Assertions.assertEquals("Locomotive Information Response: Normal Unit,Reverse,in 28 Speed Step Mode,Speed Step: 17. Address in use by another device. F0 Off; F1 Off; F2 Off; F3 On; F4 Off; F5 Off; F6 Off; F7 Off; F8 Off; F9 Off; F10 Off; F11 Off; F12 Off; ",
+                formatter.formatMessage(r));
+    }
+    @Test
+    public void testToMonitorStringNormalLocoInfoSSMode27Speed0Response() {
+        XNetReply r = new XNetReply("E4 01 00 1F FF F5");
+        Assertions.assertTrue(formatter.handlesMessage(r));
+        Assertions.assertEquals("Locomotive Information Response: Normal Unit,Reverse,in 27 Speed Step Mode,Speed Step: 0. Address is Free for Operation. F0 On; F1 On; F2 On; F3 On; F4 On; F5 On; F6 On; F7 On; F8 On; F9 On; F10 On; F11 On; F12 On; ",
+                formatter.formatMessage(r));
+    }
 
-        @Test
-        public void testToMonitorStringNormalLocoInfoSSMode27Speed7Response() {
-            XNetLocoInfoNormalUnitReplyFormatter formatter = new XNetLocoInfoNormalUnitReplyFormatter();
-            XNetReply r = new XNetReply("E4 01 05 1F FF F0");
-            Assertions.assertTrue(formatter.handlesMessage(r));
-            Assertions.assertEquals("Locomotive Information Response: Normal Unit,Reverse,in 27 Speed Step Mode,Speed Step: 7. Address is Free for Operation. F0 On; F1 On; F2 On; F3 On; F4 On; F5 On; F6 On; F7 On; F8 On; F9 On; F10 On; F11 On; F12 On; ",
-                    formatter.formatMessage(r));
-        }
+    @Test
+    public void testToMonitorStringNormalLocoInfoSSMode27Speed7Response() {
+        XNetReply r = new XNetReply("E4 01 05 1F FF F0");
+        Assertions.assertTrue(formatter.handlesMessage(r));
+        Assertions.assertEquals("Locomotive Information Response: Normal Unit,Reverse,in 27 Speed Step Mode,Speed Step: 7. Address is Free for Operation. F0 On; F1 On; F2 On; F3 On; F4 On; F5 On; F6 On; F7 On; F8 On; F9 On; F10 On; F11 On; F12 On; ",
+                formatter.formatMessage(r));
+    }
 
-        @Test
-        public void testToMonitorStringNormalLocoInfoSSMode14Speed0Response() {
-            XNetLocoInfoNormalUnitReplyFormatter formatter = new XNetLocoInfoNormalUnitReplyFormatter();
-            XNetReply r = new XNetReply("E4 00 00 00 00 E4");
-            Assertions.assertTrue(formatter.handlesMessage(r));
-            Assertions.assertEquals("Locomotive Information Response: Normal Unit,Reverse,in 14 Speed Step Mode,Speed Step: 0. Address is Free for Operation. F0 Off; F1 Off; F2 Off; F3 Off; F4 Off; F5 Off; F6 Off; F7 Off; F8 Off; F9 Off; F10 Off; F11 Off; F12 Off; ",
-                    formatter.formatMessage(r));
-        }
+    @Test
+    public void testToMonitorStringNormalLocoInfoSSMode14Speed0Response() {
+        XNetReply r = new XNetReply("E4 00 00 00 00 E4");
+        Assertions.assertTrue(formatter.handlesMessage(r));
+        Assertions.assertEquals("Locomotive Information Response: Normal Unit,Reverse,in 14 Speed Step Mode,Speed Step: 0. Address is Free for Operation. F0 Off; F1 Off; F2 Off; F3 Off; F4 Off; F5 Off; F6 Off; F7 Off; F8 Off; F9 Off; F10 Off; F11 Off; F12 Off; ",
+                formatter.formatMessage(r));
+    }
 
-        @Test
-        public void testToMonitorStringNormalLocoInfoSSMode14Speed3Response() {
-            XNetLocoInfoNormalUnitReplyFormatter formatter = new XNetLocoInfoNormalUnitReplyFormatter();
-            XNetReply r = new XNetReply("E4 00 04 00 00 E0");
-            Assertions.assertTrue(formatter.handlesMessage(r));
-            Assertions.assertEquals("Locomotive Information Response: Normal Unit,Reverse,in 14 Speed Step Mode,Speed Step: 3. Address is Free for Operation. F0 Off; F1 Off; F2 Off; F3 Off; F4 Off; F5 Off; F6 Off; F7 Off; F8 Off; F9 Off; F10 Off; F11 Off; F12 Off; ",
-                    formatter.formatMessage(r));
-        }
+    @Test
+    public void testToMonitorStringNormalLocoInfoSSMode14Speed3Response() {
+        XNetReply r = new XNetReply("E4 00 04 00 00 E0");
+        Assertions.assertTrue(formatter.handlesMessage(r));
+        Assertions.assertEquals("Locomotive Information Response: Normal Unit,Reverse,in 14 Speed Step Mode,Speed Step: 3. Address is Free for Operation. F0 Off; F1 Off; F2 Off; F3 Off; F4 Off; F5 Off; F6 Off; F7 Off; F8 Off; F9 Off; F10 Off; F11 Off; F12 Off; ",
+                formatter.formatMessage(r));
+    }
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp(); // setup JUnit
+        formatter = new XNetLocoInfoNormalUnitReplyFormatter();
+    }
 
 }

--- a/java/test/jmri/jmrix/lenz/messageformatters/XNetLocoStatusRequestMessageFormatterTest.java
+++ b/java/test/jmri/jmrix/lenz/messageformatters/XNetLocoStatusRequestMessageFormatterTest.java
@@ -1,14 +1,19 @@
 package jmri.jmrix.lenz.messageformatters;
 
+import jmri.jmrix.AbstractMessageFormatterTest;
 import jmri.jmrix.lenz.XNetMessage;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
 
-public class XNetLocoStatusRequestMessageFormatterTest {
+import org.junit.jupiter.api.*;
+
+/**
+ * Tests for the XNetLocoStatusRequestMessageFormatter class
+ *
+ * @author Paul Bender Copyright (C) 2025
+ */
+public class XNetLocoStatusRequestMessageFormatterTest extends AbstractMessageFormatterTest {
 
     @Test
     void testHandlesLocoInfoRequest(){
-        XNetLocoStatusRequestMessageFormatter formatter = new XNetLocoStatusRequestMessageFormatter();
         XNetMessage msg = XNetMessage.getLocomotiveInfoRequestMsg(1234);
         Assertions.assertTrue(formatter.handlesMessage(msg));
         Assertions.assertEquals("Request for Address 1234 speed/direction/function on/off status.",formatter.formatMessage(msg));
@@ -16,44 +21,46 @@ public class XNetLocoStatusRequestMessageFormatterTest {
 
     @Test
     void testHandlesLocoFunctionMomentaryStatusRequest(){
-        XNetLocoStatusRequestMessageFormatter formatter = new XNetLocoStatusRequestMessageFormatter();
         XNetMessage msg = XNetMessage.getLocomotiveFunctionStatusMsg(1234);
         Assertions.assertTrue(formatter.handlesMessage(msg));
         Assertions.assertEquals("Request for Address 1234 function momentary/continuous status.",formatter.formatMessage(msg));
     }
     @Test
     void testHandlesLocoFunctionHighStatusRequest(){
-        XNetLocoStatusRequestMessageFormatter formatter = new XNetLocoStatusRequestMessageFormatter();
         XNetMessage  msg = XNetMessage.getLocomotiveFunctionHighOnStatusMsg(1234);
         Assertions.assertTrue(formatter.handlesMessage(msg));
         Assertions.assertEquals("Request for Address 1234 F13-F28 on/off status.",formatter.formatMessage(msg));
     }
     @Test
     void testHandlesLocoFunctionHighMomentaryStatusRequest(){
-        XNetLocoStatusRequestMessageFormatter formatter = new XNetLocoStatusRequestMessageFormatter();
         XNetMessage msg = XNetMessage.getLocomotiveFunctionHighMomStatusMsg(1234);
         Assertions.assertTrue(formatter.handlesMessage(msg));
         Assertions.assertEquals("Request for Address 1234 F13-F28 momentary/continuous status.",formatter.formatMessage(msg));
     }
     @Test
     void testHandSearchStackForwardRequest(){
-        XNetLocoStatusRequestMessageFormatter formatter = new XNetLocoStatusRequestMessageFormatter();
         XNetMessage msg = XNetMessage.getNextAddressOnStackMsg(1234,true);
         Assertions.assertTrue(formatter.handlesMessage(msg));
         Assertions.assertEquals("Search Command Station Stack Forward - Start Address: 1234",formatter.formatMessage(msg));
     }
     @Test
     void testHandlesSearchStackBackwardsRequest(){
-        XNetLocoStatusRequestMessageFormatter formatter = new XNetLocoStatusRequestMessageFormatter();
         XNetMessage msg = XNetMessage.getNextAddressOnStackMsg(1234,false);
         Assertions.assertTrue(formatter.handlesMessage(msg));
         Assertions.assertEquals("Search Command Station Stack Backward - Start Address: 1234",formatter.formatMessage(msg));
     }
     @Test
     void testHandlesDeleteStackEntryRequest(){
-        XNetLocoStatusRequestMessageFormatter formatter = new XNetLocoStatusRequestMessageFormatter();
         XNetMessage msg = XNetMessage.getDeleteAddressOnStackMsg(1234);
         Assertions.assertTrue(formatter.handlesMessage(msg));
         Assertions.assertEquals("Delete Address 1234 from Command Station Stack.",formatter.formatMessage(msg));
     }
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp(); // setup JUnit
+        formatter = new XNetLocoStatusRequestMessageFormatter();
+    }
+
 }

--- a/java/test/jmri/jmrix/lenz/messageformatters/XNetMultiUnitInfoReplyFormatterTest.java
+++ b/java/test/jmri/jmrix/lenz/messageformatters/XNetMultiUnitInfoReplyFormatterTest.java
@@ -1,22 +1,30 @@
 package jmri.jmrix.lenz.messageformatters;
 
+import jmri.jmrix.AbstractMessageFormatterTest;
 import jmri.jmrix.lenz.XNetReply;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+
+import org.junit.jupiter.api.*;
 
 /**
- * Tests for the XNetMultiUnitInfoReplFormatter class
+ * Tests for the XNetMultiUnitInfoReplyFormatter class
  *
  * @author Paul Bender Copyright (C) 2025
  */
-public class XNetMultiUnitInfoReplyFormatterTest {
+public class XNetMultiUnitInfoReplyFormatterTest extends AbstractMessageFormatterTest {
 
     @Test
     public void testToMonitorStringMultiUnitInfoResponse() {
-        XNetMultiUnitInfoReplyFormatter formatter = new XNetMultiUnitInfoReplyFormatter();
         XNetReply r = new XNetReply("E5 14 C1 04 00 00 34");
         Assertions.assertTrue(formatter.handlesMessage(r));
         Assertions.assertEquals("Locomotive Information Response: Locomotive in Multiple Unit,Forward,in 128 Speed Step Mode,Speed Step: 64. Address is Free for Operation.F0 Off; F1 Off; F2 Off; F3 On; F4 Off; F5 Off; F6 Off; F7 Off; F8 Off; F9 Off; F10 Off; F11 Off; F12 Off; ",
                 formatter.formatMessage(r));
     }
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp(); // setup JUnit
+        formatter = new XNetMultiUnitInfoReplyFormatter();
+    }
+
 }

--- a/java/test/jmri/jmrix/lenz/messageformatters/XNetMultiUnitSearchRequestMessageFormatterTest.java
+++ b/java/test/jmri/jmrix/lenz/messageformatters/XNetMultiUnitSearchRequestMessageFormatterTest.java
@@ -1,13 +1,19 @@
 package jmri.jmrix.lenz.messageformatters;
 
+import jmri.jmrix.AbstractMessageFormatterTest;
 import jmri.jmrix.lenz.XNetMessage;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-public class XNetMultiUnitSearchRequestMessageFormatterTest {
+
+import org.junit.jupiter.api.*;
+
+/**
+ * Tests for the XNetMultiUnitSearchRequestMessageFormatter class
+ * .
+ * @author Paul Bender Copyright (C) 2025
+ */
+public class XNetMultiUnitSearchRequestMessageFormatterTest extends AbstractMessageFormatterTest {
 
     @Test
     void handleSearchForwardRequest() {
-        XNetMultiUnitSearchRequestMessageFormatter formatter = new XNetMultiUnitSearchRequestMessageFormatter();
         XNetMessage msg = XNetMessage.getDBSearchMsgConsistAddress(42, true);
         Assertions.assertTrue(formatter.handlesMessage(msg));
         Assertions.assertEquals("Search Command Station Stack Forward from Consist Address: 42", formatter.formatMessage(msg));
@@ -15,9 +21,16 @@ public class XNetMultiUnitSearchRequestMessageFormatterTest {
 
     @Test
     void handleSearchBackwardRequest() {
-        XNetMultiUnitSearchRequestMessageFormatter formatter = new XNetMultiUnitSearchRequestMessageFormatter();
         XNetMessage msg = XNetMessage.getDBSearchMsgConsistAddress(42,false);
         Assertions.assertTrue(formatter.handlesMessage(msg));
         Assertions.assertEquals("Search Command Station Stack Backward from Consist Address: 42", formatter.formatMessage(msg));
     }
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp(); // setup JUnit
+        formatter = new XNetMultiUnitSearchRequestMessageFormatter();
+    }
+
 }

--- a/java/test/jmri/jmrix/lenz/messageformatters/XNetOpsModeReadResultFormatterTest.java
+++ b/java/test/jmri/jmrix/lenz/messageformatters/XNetOpsModeReadResultFormatterTest.java
@@ -1,23 +1,32 @@
 package jmri.jmrix.lenz.messageformatters;
 
+import jmri.jmrix.AbstractMessageFormatterTest;
 import jmri.jmrix.lenz.XNetReply;
+
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Tests for the XNetDirectModelTimeFormatter class
+ * Tests for the XNetOpsModeReadResultFormatter class
  * .
  * @author Paul Bender Copyright (C) 2025
  */
-public class XNetOpsModeReadResultFormatterTest {
+public class XNetOpsModeReadResultFormatterTest extends AbstractMessageFormatterTest {
 
     @Test
     public void testFormatMessage() {
-        XNetOpsModeReadResultFormatter formatter = new XNetOpsModeReadResultFormatter();
         XNetReply reply = new XNetReply("64 24 00 00 00 40");
         assertThat(formatter.handlesMessage(reply)).isTrue();
         assertThat(formatter.formatMessage(reply)).isEqualTo("Ops Mode: Programming Response: Address: 0 Value:0");
+    }
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp(); // setup JUnit
+        formatter = new XNetOpsModeReadResultFormatter();
     }
 
 }

--- a/java/test/jmri/jmrix/lenz/messageformatters/XNetOpsModeRequestMessageFormatterTest.java
+++ b/java/test/jmri/jmrix/lenz/messageformatters/XNetOpsModeRequestMessageFormatterTest.java
@@ -1,18 +1,18 @@
 package jmri.jmrix.lenz.messageformatters;
 
+import jmri.jmrix.AbstractMessageFormatterTest;
 import jmri.jmrix.lenz.XNetMessage;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+
+import org.junit.jupiter.api.*;
 
 /**
  * Tests for the XNetOpsModeRequestMessageFormatter class.
  * @author Paul Bender Copyright (C) 2024
  */
-public class XNetOpsModeRequestMessageFormatterTest {
+public class XNetOpsModeRequestMessageFormatterTest extends AbstractMessageFormatterTest {
 
     @Test
     public void testFormatOpsModeRequestMessage() {
-        XNetOpsModeRequestMessageFormatter formatter = new XNetOpsModeRequestMessageFormatter();
         XNetMessage msg = XNetMessage.getWriteOpsModeCVMsg(0,5,29,5);
         Assertions.assertTrue(formatter.handlesMessage(msg), "Formatter Handles Message");
         Assertions.assertEquals("Operations Mode Programming Request: Byte Mode Write: 5 to CV 29 for Decoder Address 5", formatter.formatMessage(msg), "Monitor String");
@@ -20,7 +20,6 @@ public class XNetOpsModeRequestMessageFormatterTest {
 
     @Test
     public void testFormatOpsModeVerifyMessage() {
-        XNetOpsModeRequestMessageFormatter formatter = new XNetOpsModeRequestMessageFormatter();
         XNetMessage  msg = XNetMessage.getVerifyOpsModeCVMsg(0,5,29,5);
         Assertions.assertTrue(formatter.handlesMessage(msg), "Formatter Handles Message");
         Assertions.assertEquals("Operations Mode Programming Request: Byte Mode Verify: 5 to CV 29 for Decoder Address 5",formatter.formatMessage(msg));
@@ -28,7 +27,6 @@ public class XNetOpsModeRequestMessageFormatterTest {
 
     @Test
     public void testFormatWriteOpsBitModeCVMsg(){
-        XNetOpsModeRequestMessageFormatter formatter = new XNetOpsModeRequestMessageFormatter();
         XNetMessage  msg = XNetMessage.getBitWriteOpsModeCVMsg(0,5,29,2,true);
         Assertions.assertTrue(formatter.handlesMessage(msg), "Formatter Handles Message");
         Assertions.assertEquals("Operations Mode Programming Request: Bit Mode Write: 1 to CV 29 bit 2 for Decoder Address 5",formatter.formatMessage(msg));
@@ -39,7 +37,6 @@ public class XNetOpsModeRequestMessageFormatterTest {
 
     @Test
     public void testToMonitorStringVerifyOpsBitModeCVMsg(){
-        XNetOpsModeRequestMessageFormatter formatter = new XNetOpsModeRequestMessageFormatter();
         XNetMessage  msg = XNetMessage.getBitVerifyOpsModeCVMsg(0,5,29,2,true);
         Assertions.assertTrue(formatter.handlesMessage(msg), "Formatter Handles Message");
         Assertions.assertEquals("Operations Mode Programming Request: Bit Mode Verify: 1 to CV 29 bit 2 for Decoder Address 5",formatter.formatMessage(msg));
@@ -48,6 +45,11 @@ public class XNetOpsModeRequestMessageFormatterTest {
         Assertions.assertEquals("Operations Mode Programming Request: Bit Mode Verify: 0 to CV 29 bit 2 for Decoder Address 5",formatter.formatMessage(msg));
     }
 
-
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp(); // setup JUnit
+        formatter = new XNetOpsModeRequestMessageFormatter();
+    }
 
 }

--- a/java/test/jmri/jmrix/lenz/messageformatters/XNetProgReadMessageFormatterTest.java
+++ b/java/test/jmri/jmrix/lenz/messageformatters/XNetProgReadMessageFormatterTest.java
@@ -1,18 +1,18 @@
 package jmri.jmrix.lenz.messageformatters;
 
+import jmri.jmrix.AbstractMessageFormatterTest;
 import jmri.jmrix.lenz.XNetMessage;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+
+import org.junit.jupiter.api.*;
 
 /**
  * Tests for the XNetProgReadMessageFormatter class
  * @author Paul Bender Copyright (C) 2024
  */
-public class XNetProgReadMessageFormatterTest {
+public class XNetProgReadMessageFormatterTest extends AbstractMessageFormatterTest {
 
     @Test
     void handlesRegisterModeReadRequest(){
-        XNetProgReadMessageFormatter formatter = new XNetProgReadMessageFormatter();
         XNetMessage msg = XNetMessage.getReadRegisterMsg(5);
         Assertions.assertTrue(formatter.handlesMessage(msg));
         Assertions.assertEquals("Service Mode Request: Read Register 5", formatter.formatMessage(msg));
@@ -20,7 +20,6 @@ public class XNetProgReadMessageFormatterTest {
 
     @Test
     void handlesPagedModeReadRequest(){
-        XNetProgReadMessageFormatter formatter = new XNetProgReadMessageFormatter();
         XNetMessage msg = XNetMessage.getReadPagedCVMsg(29);
         Assertions.assertTrue(formatter.handlesMessage(msg));
         Assertions.assertEquals("Service Mode Request: Read CV 29 in Paged Mode", formatter.formatMessage(msg));
@@ -28,7 +27,6 @@ public class XNetProgReadMessageFormatterTest {
 
     @Test
     void handlesCVModeReadRequest(){
-        XNetProgReadMessageFormatter formatter = new XNetProgReadMessageFormatter();
         XNetMessage msg = XNetMessage.getReadDirectCVMsg(29);
         Assertions.assertTrue(formatter.handlesMessage(msg));
         Assertions.assertEquals("Service Mode Request: Read CV 29 in Direct Mode", formatter.formatMessage(msg));
@@ -36,7 +34,6 @@ public class XNetProgReadMessageFormatterTest {
 
     @Test
     void handlesV36CVModeReadRequest(){
-        XNetProgReadMessageFormatter formatter = new XNetProgReadMessageFormatter();
         XNetMessage msg = XNetMessage.getReadDirectCVMsg(300);
         Assertions.assertTrue(formatter.handlesMessage(msg));
         Assertions.assertEquals("Service Mode Request (V3.6): Read CV 300 in Direct Mode", formatter.formatMessage(msg));
@@ -50,4 +47,12 @@ public class XNetProgReadMessageFormatterTest {
         Assertions.assertTrue(formatter.handlesMessage(msg));
         Assertions.assertEquals("Service Mode Request (V3.6): Read CV 1024 in Direct Mode", formatter.formatMessage(msg));
     }
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp(); // setup JUnit
+        formatter = new XNetProgReadMessageFormatter();
+    }
+
 }

--- a/java/test/jmri/jmrix/lenz/messageformatters/XNetProgWriteMessageFormatterTest.java
+++ b/java/test/jmri/jmrix/lenz/messageformatters/XNetProgWriteMessageFormatterTest.java
@@ -1,18 +1,18 @@
 package jmri.jmrix.lenz.messageformatters;
 
+import jmri.jmrix.AbstractMessageFormatterTest;
 import jmri.jmrix.lenz.XNetMessage;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+
+import org.junit.jupiter.api.*;
 
 /**
  * Tests for the XNetProgWriteMessageFormatter class
  * @author Paul Bender Copyright (C) 2024
  */
-public class XNetProgWriteMessageFormatterTest {
+public class XNetProgWriteMessageFormatterTest extends AbstractMessageFormatterTest {
 
     @Test
     void handlesRegisterModeWriteRequest(){
-        XNetProgWriteMessageFormatter formatter = new XNetProgWriteMessageFormatter();
         XNetMessage msg = XNetMessage.getWriteRegisterMsg(5,5);
         Assertions.assertTrue(formatter.handlesMessage(msg));
         Assertions.assertEquals("Service Mode Request: Write 5 to Register 5", formatter.formatMessage(msg));
@@ -20,7 +20,6 @@ public class XNetProgWriteMessageFormatterTest {
 
     @Test
     void handlesPagedModeWriteRequest(){
-        XNetProgWriteMessageFormatter formatter = new XNetProgWriteMessageFormatter();
         XNetMessage msg = XNetMessage.getWritePagedCVMsg(29,5);
         Assertions.assertTrue(formatter.handlesMessage(msg));
         Assertions.assertEquals("Service Mode Request: Write 5 to CV 29 in Paged Mode", formatter.formatMessage(msg));
@@ -28,7 +27,6 @@ public class XNetProgWriteMessageFormatterTest {
 
     @Test
     void handlesCVModeWriteRequest(){
-        XNetProgWriteMessageFormatter formatter = new XNetProgWriteMessageFormatter();
         XNetMessage msg = XNetMessage.getWriteDirectCVMsg(29,5);
         Assertions.assertTrue(formatter.handlesMessage(msg));
         Assertions.assertEquals("Service Mode Request: Write 5 to CV 29 in Direct Mode", formatter.formatMessage(msg));
@@ -36,7 +34,6 @@ public class XNetProgWriteMessageFormatterTest {
 
     @Test
     void handlesV36CVModeWriteRequest(){
-        XNetProgWriteMessageFormatter formatter = new XNetProgWriteMessageFormatter();
         XNetMessage msg = XNetMessage.getWriteDirectCVMsg(300,5);
         Assertions.assertTrue(formatter.handlesMessage(msg));
         Assertions.assertEquals("Service Mode Request (V3.6): Write 5 to CV 300 in Direct Mode", formatter.formatMessage(msg));
@@ -49,6 +46,13 @@ public class XNetProgWriteMessageFormatterTest {
         msg = XNetMessage.getWriteDirectCVMsg(1024,5);
         Assertions.assertTrue(formatter.handlesMessage(msg));
         Assertions.assertEquals("Service Mode Request (V3.6): Write 5 to CV 1024 in Direct Mode", formatter.formatMessage(msg));
+    }
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp(); // setup JUnit
+        formatter = new XNetProgWriteMessageFormatter();
     }
 
 }

--- a/java/test/jmri/jmrix/lenz/messageformatters/XNetRequestMultiUnitAddLocoMessageFormatterTest.java
+++ b/java/test/jmri/jmrix/lenz/messageformatters/XNetRequestMultiUnitAddLocoMessageFormatterTest.java
@@ -1,19 +1,19 @@
 package jmri.jmrix.lenz.messageformatters;
 
+import jmri.jmrix.AbstractMessageFormatterTest;
 import jmri.jmrix.lenz.XNetMessage;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+
+import org.junit.jupiter.api.*;
 
 /**
  * Tests of XNetRequestMultiUnitAddLocoMessageFormatter class
  *
  * @author Paul Bender Copyright (C) 2024
  */
-public class XNetRequestMultiUnitAddLocoMessageFormatterTest {
+public class XNetRequestMultiUnitAddLocoMessageFormatterTest extends AbstractMessageFormatterTest {
 
     @Test
     public void testFormatAddNormalDirectionMessage() {
-        XNetRequestMultiUnitAddLocoMessageFormatter formatter = new XNetRequestMultiUnitAddLocoMessageFormatter();
         XNetMessage msg = XNetMessage.getAddLocoToConsistMsg(42,1234,true);
         Assertions.assertTrue(formatter.handlesMessage(msg));
         Assertions.assertEquals( "Mobile Decoder Operations Request: Add Locomotive: 1234 to Multi Unit Consist: 42 with Loco Direction Normal",formatter.formatMessage(msg));
@@ -23,10 +23,16 @@ public class XNetRequestMultiUnitAddLocoMessageFormatterTest {
 
     @Test
     public void testFormatAddReverseDirectionMessage() {
-        XNetRequestMultiUnitAddLocoMessageFormatter formatter = new XNetRequestMultiUnitAddLocoMessageFormatter();
         XNetMessage msg = XNetMessage.getAddLocoToConsistMsg(42,1234,false);
         Assertions.assertTrue(formatter.handlesMessage(msg));
         Assertions.assertEquals("Mobile Decoder Operations Request: Add Locomotive: 1234 to Multi Unit Consist: 42 with Loco Direction Reversed",formatter.formatMessage(msg));
+    }
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp(); // setup JUnit
+        formatter = new XNetRequestMultiUnitAddLocoMessageFormatter();
     }
 
 }

--- a/java/test/jmri/jmrix/lenz/messageformatters/XNetRequestMultiUnitRemoveLocoMessageFormatterTest.java
+++ b/java/test/jmri/jmrix/lenz/messageformatters/XNetRequestMultiUnitRemoveLocoMessageFormatterTest.java
@@ -1,22 +1,30 @@
 package jmri.jmrix.lenz.messageformatters;
 
+import jmri.jmrix.AbstractMessageFormatterTest;
 import jmri.jmrix.lenz.XNetMessage;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+
+import org.junit.jupiter.api.*;
 
 /**
  * Tests of XNetRequestMultiUnitRemoveLocoMessageFormatter class
  *
  * @author Paul Bender Copyright (C) 2024
  */
-public class XNetRequestMultiUnitRemoveLocoMessageFormatterTest {
+public class XNetRequestMultiUnitRemoveLocoMessageFormatterTest extends AbstractMessageFormatterTest {
 
     @Test
     public void testFormatter() {
-        XNetRequestMultiUnitRemoveLocoMessageFormatter formatter = new XNetRequestMultiUnitRemoveLocoMessageFormatter();
         XNetMessage msg = XNetMessage.getRemoveLocoFromConsistMsg(42,1234);
         Assertions.assertTrue(formatter.handlesMessage(msg));
         Assertions.assertEquals( "Mobile Decoder Operations Request: Remove Locomotive: 1234 from Multi Unit Consist: 42", formatter.formatMessage(msg));
 
     }
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp(); // setup JUnit
+        formatter = new XNetRequestMultiUnitRemoveLocoMessageFormatter();
+    }
+
 }

--- a/java/test/jmri/jmrix/lenz/messageformatters/XNetSearchMURequestMessageFormatterTest.java
+++ b/java/test/jmri/jmrix/lenz/messageformatters/XNetSearchMURequestMessageFormatterTest.java
@@ -1,19 +1,19 @@
 package jmri.jmrix.lenz.messageformatters;
 
+import jmri.jmrix.AbstractMessageFormatterTest;
 import jmri.jmrix.lenz.XNetMessage;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+
+import org.junit.jupiter.api.*;
 
 /**
  * Tests of XNetSearchMURequestMessageFormatter class
  *
  * @author Paul Bender Copyright (C) 2024
  */
-public class XNetSearchMURequestMessageFormatterTest {
+public class XNetSearchMURequestMessageFormatterTest extends AbstractMessageFormatterTest {
 
     @Test
     void testSearchMUForwardRequestMessage() {
-        XNetSearchMURequestMessageFormatter formatter = new XNetSearchMURequestMessageFormatter();
         XNetMessage msg = XNetMessage.getDBSearchMsgNextMULoco(42,1234,true);
         Assertions.assertTrue(formatter.handlesMessage(msg), "Formatter Handles Message");
         Assertions.assertEquals("Search Command Station Stack Forward for next address in Consist 42 Starting at 1234",formatter.formatMessage(msg));
@@ -21,9 +21,16 @@ public class XNetSearchMURequestMessageFormatterTest {
 
     @Test
     void testSearchMUBackwardRequestMessage() {
-        XNetSearchMURequestMessageFormatter formatter = new XNetSearchMURequestMessageFormatter();
         XNetMessage msg = XNetMessage.getDBSearchMsgNextMULoco(42,1234,false);
         Assertions.assertTrue(formatter.handlesMessage(msg), "Formatter Handles Message");
         Assertions.assertEquals("Search Command Station Stack Backward for next address in Consist 42 Starting at 1234",formatter.formatMessage(msg));
     }
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp(); // setup JUnit
+        formatter = new XNetSearchMURequestMessageFormatter();
+    }
+
 }

--- a/java/test/jmri/jmrix/lenz/messageformatters/XNetServiceModeResponseFormatterTest.java
+++ b/java/test/jmri/jmrix/lenz/messageformatters/XNetServiceModeResponseFormatterTest.java
@@ -1,19 +1,19 @@
 package jmri.jmrix.lenz.messageformatters;
 
+import jmri.jmrix.AbstractMessageFormatterTest;
 import jmri.jmrix.lenz.XNetReply;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+
+import org.junit.jupiter.api.*;
 
 /**
  * Tests for the XNetServiceModeResponseFormatter class.
 
  * @author Paul Bender Copyright (C) 2024
  */
-public class XNetServiceModeResponseFormatterTest {
+public class XNetServiceModeResponseFormatterTest extends AbstractMessageFormatterTest {
 
     @Test
     public void testDirectModeResponseFormatter() {
-        XNetServiceModeResponseFormatter formatter = new XNetServiceModeResponseFormatter();
         XNetReply r = new XNetReply("63 14 01 04 72");
         Assertions.assertTrue(formatter.handlesMessage(r));
         Assertions.assertEquals(Bundle.getMessage("XNetReplyServiceModeDirectResponse",1,4),formatter.formatMessage(r));
@@ -21,10 +21,16 @@ public class XNetServiceModeResponseFormatterTest {
 
     @Test
     public void testPagedModeResponseFormatter() {
-        XNetServiceModeResponseFormatter formatter = new XNetServiceModeResponseFormatter();
         XNetReply r = new XNetReply("63 10 01 04 76");
         Assertions.assertTrue(formatter.handlesMessage(r));
         Assertions.assertEquals(Bundle.getMessage("XNetReplyServiceModePagedResponse",1,4),formatter.formatMessage(r));
+    }
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp(); // setup JUnit
+        formatter = new XNetServiceModeResponseFormatter();
     }
 
 }

--- a/java/test/jmri/jmrix/lenz/messageformatters/XNetStackSearchReplyFormatterTest.java
+++ b/java/test/jmri/jmrix/lenz/messageformatters/XNetStackSearchReplyFormatterTest.java
@@ -1,6 +1,8 @@
 package jmri.jmrix.lenz.messageformatters;
 
+import jmri.jmrix.AbstractMessageFormatterTest;
 import jmri.jmrix.lenz.XNetReply;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -10,15 +12,7 @@ import org.junit.jupiter.api.Test;
  *
  * @author Paul Bender Copyright (C) 2025
  */
-
-public class XNetStackSearchReplyFormatterTest {
-
-    XNetStackSearchReplyFormatter formatter;
-
-    @BeforeEach
-    public void setUp(){
-        formatter = new XNetStackSearchReplyFormatter();
-    }
+public class XNetStackSearchReplyFormatterTest extends AbstractMessageFormatterTest {
 
     @Test
     public void testToMonitorStringSearchResponseNormalLoco(){
@@ -63,6 +57,13 @@ public class XNetStackSearchReplyFormatterTest {
         targetString += Bundle.getMessage("XNetReplySearchFailedLabel") + " 260";
         Assertions.assertTrue(formatter.handlesMessage(r));
         Assertions.assertEquals(targetString, formatter.formatMessage(r));
+    }
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp(); // setup JUnit
+        formatter = new XNetStackSearchReplyFormatter();
     }
 
 }

--- a/java/test/jmri/jmrix/lenz/messageformatters/XNetThrottleTakenOverReplyFormatterTest.java
+++ b/java/test/jmri/jmrix/lenz/messageformatters/XNetThrottleTakenOverReplyFormatterTest.java
@@ -1,19 +1,20 @@
 package jmri.jmrix.lenz.messageformatters;
 
+import jmri.jmrix.AbstractMessageFormatterTest;
 import jmri.jmrix.lenz.XNetReply;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+
+import org.junit.jupiter.api.*;
 
 /**
  * Tests for the XNetThrottleTakenOverReplyFormatter class.
  *
  * @author Paul Bender Copyright (C) 2024
  */
-public class XNetThrottleTakenOverReplyFormatterTest {
+public class XNetThrottleTakenOverReplyFormatterTest extends AbstractMessageFormatterTest {
 
     @Test
     public void testFormatTakenOverShortAddressReply() {
-        XNetThrottleTakenOverReplyFormatter formatter = new XNetThrottleTakenOverReplyFormatter();
+
         XNetReply r = new XNetReply("E3 40 00 04 57");
         Assertions.assertTrue(formatter.handlesMessage(r));
         String targetString = Bundle.getMessage("XNetReplyLocoLabel") + " ";
@@ -25,7 +26,7 @@ public class XNetThrottleTakenOverReplyFormatterTest {
 
     @Test
     public void testFormatTakenOverLongAddressReply() {
-        XNetThrottleTakenOverReplyFormatter formatter = new XNetThrottleTakenOverReplyFormatter();
+
         XNetReply r = new XNetReply("E3 40 C1 04 61");
         Assertions.assertTrue(formatter.handlesMessage(r));
         String targetString =
@@ -34,6 +35,13 @@ public class XNetThrottleTakenOverReplyFormatterTest {
         targetString += 260 + " ";
         targetString += Bundle.getMessage("XNetReplyLocoOperated");
         Assertions.assertEquals(targetString, formatter.formatMessage(r));
+    }
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp(); // setup JUnit
+        formatter = new XNetThrottleTakenOverReplyFormatter();
     }
 
 }

--- a/java/test/jmri/jmrix/lenz/messageformatters/XNetTurnoutCommandMessageFormatterTest.java
+++ b/java/test/jmri/jmrix/lenz/messageformatters/XNetTurnoutCommandMessageFormatterTest.java
@@ -1,8 +1,10 @@
 package jmri.jmrix.lenz.messageformatters;
 
+import jmri.jmrix.AbstractMessageFormatterTest;
 import jmri.jmrix.Message;
 import jmri.jmrix.lenz.XNetMessage;
-import org.junit.Assert;
+
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -11,11 +13,11 @@ import static org.junit.jupiter.api.Assertions.*;
  * Tests for the XNetTurnoutCommandMessageFormatter class.
  * @author Paul Bender Copyright (C) 2024
  */
-public class XNetTurnoutCommandMessageFormatterTest {
+public class XNetTurnoutCommandMessageFormatterTest extends AbstractMessageFormatterTest {
     // Test that the handlesMessage method returns true for a valid message
     @Test
     public void testHandlesMessageValid() {
-        XNetTurnoutCommandMessageFormatter formatter = new XNetTurnoutCommandMessageFormatter();
+
         XNetMessage message = XNetMessage.getTurnoutCommandMsg(5,false,true,true);
         assertTrue(formatter.handlesMessage(message));
     }
@@ -23,7 +25,7 @@ public class XNetTurnoutCommandMessageFormatterTest {
     // Test that the handlesMessage method returns false for an invalid message
     @Test
     public void testHandlesMessageInvalid() {
-        XNetTurnoutCommandMessageFormatter formatter = new XNetTurnoutCommandMessageFormatter();
+
         Message message = new XNetMessage("01 04 05");
         assertFalse(formatter.handlesMessage(message));
     }
@@ -31,19 +33,27 @@ public class XNetTurnoutCommandMessageFormatterTest {
     // Test that the formatMessage method returns the expected string
     @Test
     public void testFormatMessage() {
-        XNetTurnoutCommandMessageFormatter formatter = new XNetTurnoutCommandMessageFormatter();
+
         XNetMessage message;
         message = XNetMessage.getTurnoutCommandMsg(5,false,true,true);
-        Assert.assertEquals("Monitor String","Accessory Decoder Operations Request: Turnout Address 5(Base Address 1,Sub Address 0) Turn Output 1 On.",
-                formatter.formatMessage(message));
+        assertEquals( "Accessory Decoder Operations Request: Turnout Address 5(Base Address 1,Sub Address 0) Turn Output 1 On.",
+                formatter.formatMessage(message), "Monitor String");
         message = XNetMessage.getTurnoutCommandMsg(5,true,false,true);
-        Assert.assertEquals("Monitor String","Accessory Decoder Operations Request: Turnout Address 5(Base Address 1,Sub Address 0) Turn Output 0 On.",
-                formatter.formatMessage(message));
+        assertEquals( "Accessory Decoder Operations Request: Turnout Address 5(Base Address 1,Sub Address 0) Turn Output 0 On.",
+                formatter.formatMessage(message), "Monitor String");
         message = XNetMessage.getTurnoutCommandMsg(5,false,true,false);
-        Assert.assertEquals("Monitor String","Accessory Decoder Operations Request: Turnout Address 5(Base Address 1,Sub Address 0) Turn Output 1 Off.",
-                formatter.formatMessage(message));
+        assertEquals( "Accessory Decoder Operations Request: Turnout Address 5(Base Address 1,Sub Address 0) Turn Output 1 Off.",
+                formatter.formatMessage(message), "Monitor String");
         message = XNetMessage.getTurnoutCommandMsg(5,true,false,false);
-        Assert.assertEquals("Monitor String","Accessory Decoder Operations Request: Turnout Address 5(Base Address 1,Sub Address 0) Turn Output 0 Off.",
-                formatter.formatMessage(message));
+        assertEquals( "Accessory Decoder Operations Request: Turnout Address 5(Base Address 1,Sub Address 0) Turn Output 0 Off.",
+                formatter.formatMessage(message), "Monitor String");
     }
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp(); // setup JUnit
+        formatter = new XNetTurnoutCommandMessageFormatter();
+    }
+
 }

--- a/java/test/jmri/jmrix/lenz/messageformatters/XNetV1SoftwareVersionReplyFormatterTest.java
+++ b/java/test/jmri/jmrix/lenz/messageformatters/XNetV1SoftwareVersionReplyFormatterTest.java
@@ -1,21 +1,30 @@
 package jmri.jmrix.lenz.messageformatters;
 
+import jmri.jmrix.AbstractMessageFormatterTest;
 import jmri.jmrix.lenz.XNetReply;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+
+import org.junit.jupiter.api.*;
 
 /**
  * Tests for the XNetV1SoftwareVersionReplyFormatter class.
  *
  * @author Paul Bender Copyright (C) 2025
  */
-public class XNetV1SoftwareVersionReplyFormatterTest {
+public class XNetV1SoftwareVersionReplyFormatterTest extends AbstractMessageFormatterTest {
 
     @Test
     public void testV1SoftwareVersionReply() {
-        XNetV1SoftwareVersionReplyFormatter formatter = new XNetV1SoftwareVersionReplyFormatter();
+        formatter = new XNetV1SoftwareVersionReplyFormatter();
         XNetReply r = new XNetReply("62 21 21 62");
         Assertions.assertTrue(formatter.handlesMessage(r));
         Assertions.assertEquals(Bundle.getMessage("XNetReplyCSVersionV1",2.1,"32"),formatter.formatMessage(r));
     }
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp(); // setup JUnit
+        formatter = new XNetV1SoftwareVersionReplyFormatter();
+    }
+
 }

--- a/java/test/jmri/jmrix/lenz/messageformatters/XPressNetInterfaceVersionRequestMessageFormatterTest.java
+++ b/java/test/jmri/jmrix/lenz/messageformatters/XPressNetInterfaceVersionRequestMessageFormatterTest.java
@@ -1,21 +1,30 @@
 package jmri.jmrix.lenz.messageformatters;
 
+import jmri.jmrix.AbstractMessageFormatterTest;
 import jmri.jmrix.lenz.XNetMessage;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+
+import org.junit.jupiter.api.*;
 
 /**
  * Tests for the XPressNetInterfaceVersionRequestMessageFormatter class.
  * @author Paul Bender Copyright (C) 2024
  */
-public class XPressNetInterfaceVersionRequestMessageFormatterTest {
+public class XPressNetInterfaceVersionRequestMessageFormatterTest extends AbstractMessageFormatterTest {
 
     @Test
     void testHandleVersionRequest(){
-        XPressnetInterfaceVersionRequestMessageFormatter formatter = new XPressnetInterfaceVersionRequestMessageFormatter();
+        formatter = new XPressnetInterfaceVersionRequestMessageFormatter();
         XNetMessage msg = XNetMessage.getLIVersionRequestMessage();
         Assertions.assertTrue(formatter.handlesMessage(msg));
         Assertions.assertEquals("REQUEST LI10x hardware/software version",formatter.formatMessage(msg));
 
     }
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp(); // setup JUnit
+        formatter = new XPressnetInterfaceVersionRequestMessageFormatter();
+    }
+
 }


### PR DESCRIPTION
to extend from AbstractMessageFormatterTest
Ensures setUp / tearDown is called.