### PR TITLE
Fix STL Editor parsing bug

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -126,7 +126,7 @@
 
         <h4><a href="http://openlcb.org">OpenLCB</a> / LCC</h4>
             <ul>
-                <li></li>
+                <li>Fix STL Editor bug introduced in PR 14625.</li>
             </ul>
 
         <h4>Powerline</h4>
@@ -663,9 +663,9 @@
    <h3>Web Server</h3>
         <a id="server" name="server"></a>
         <ul>
-            <li>JSON Schema support has been upgraded from draft-04 to draft-2020-12, 
-                providing improved validation capabilities and modern schema features 
-                for JSON API responses. This includes updates to 95 JSON schema files 
+            <li>JSON Schema support has been upgraded from draft-04 to draft-2020-12,
+                providing improved validation capabilities and modern schema features
+                for JSON API responses. This includes updates to 95 JSON schema files
                 and the underlying NetworkNT JSON Schema Validator library (from 1.0.28 to 1.3.3).</li>
         </ul>
 

--- a/java/src/jmri/jmrix/openlcb/swing/stleditor/StlEditorPane.java
+++ b/java/src/jmri/jmrix/openlcb/swing/stleditor/StlEditorPane.java
@@ -924,13 +924,12 @@ public class StlEditorPane extends jmri.util.swing.JmriPanel
      * @param group The CDI group.
      */
     private void createTokenMap(GroupRow group) {
+        _messages.clear();
+        _tokenMap = new TreeMap<>();
         var line = group.getMultiLine();
         if (line.length() == 0) {
             return;
         }
-
-        _messages.clear();
-        _tokenMap = new TreeMap<>();
 
         // Find label locations
         log.debug("Find label locations");


### PR DESCRIPTION
Empty group lines were using the previous token map which resulted in duplicate logic.