### PR TITLE
update roco / rps tests

### DIFF
--- a/java/test/jmri/jmrix/roco/z21/Z21XNetReplyTest.java
+++ b/java/test/jmri/jmrix/roco/z21/Z21XNetReplyTest.java
@@ -1,8 +1,10 @@
 package jmri.jmrix.roco.z21;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import jmri.util.JUnitUtil;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.*;
 
 /**
@@ -17,15 +19,15 @@ public class Z21XNetReplyTest extends jmri.jmrix.lenz.XNetReplyTest {
     @Override
     public void testStringCtor() {
         msg = new Z21XNetReply("12 34 AB 03 19 06 0B B1");
-        Assert.assertEquals("length", 8, msg.getNumDataElements());
-        Assert.assertEquals("0th byte", 0x12, msg.getElement(0) & 0xFF);
-        Assert.assertEquals("1st byte", 0x34, msg.getElement(1) & 0xFF);
-        Assert.assertEquals("2nd byte", 0xAB, msg.getElement(2) & 0xFF);
-        Assert.assertEquals("3rd byte", 0x03, msg.getElement(3) & 0xFF);
-        Assert.assertEquals("4th byte", 0x19, msg.getElement(4) & 0xFF);
-        Assert.assertEquals("5th byte", 0x06, msg.getElement(5) & 0xFF);
-        Assert.assertEquals("6th byte", 0x0B, msg.getElement(6) & 0xFF);
-        Assert.assertEquals("7th byte", 0xB1, msg.getElement(7) & 0xFF);
+        assertEquals( 8, msg.getNumDataElements(), "length");
+        assertEquals( 0x12, msg.getElement(0) & 0xFF, "0th byte");
+        assertEquals( 0x34, msg.getElement(1) & 0xFF, "1st byte");
+        assertEquals( 0xAB, msg.getElement(2) & 0xFF, "2nd byte");
+        assertEquals( 0x03, msg.getElement(3) & 0xFF, "3rd byte");
+        assertEquals( 0x19, msg.getElement(4) & 0xFF, "4th byte");
+        assertEquals( 0x06, msg.getElement(5) & 0xFF, "5th byte");
+        assertEquals( 0x0B, msg.getElement(6) & 0xFF, "6th byte");
+        assertEquals( 0xB1, msg.getElement(7) & 0xFF, "7th byte");
     }
 
     // Test the string constructor with an empty string paramter.
@@ -33,8 +35,8 @@ public class Z21XNetReplyTest extends jmri.jmrix.lenz.XNetReplyTest {
     @Override
     public void testStringCtorEmptyString() {
         msg = new Z21XNetReply("");
-        Assert.assertEquals("length", 0, msg.getNumDataElements());
-        Assert.assertTrue("empty reply", msg.toString().equals(""));
+        assertEquals( 0, msg.getNumDataElements(), "length");
+        assertEquals( "", msg.toString(), "empty reply");
     }
 
     // Test the copy constructor.
@@ -43,15 +45,15 @@ public class Z21XNetReplyTest extends jmri.jmrix.lenz.XNetReplyTest {
     public void testCopyCtor() {
         Z21XNetReply x = new Z21XNetReply("12 34 AB 03 19 06 0B B1");
         msg = new Z21XNetReply(x);
-        Assert.assertEquals("length", x.getNumDataElements(), msg.getNumDataElements());
-        Assert.assertEquals("0th byte", x.getElement(0), msg.getElement(0));
-        Assert.assertEquals("1st byte", x.getElement(1), msg.getElement(1));
-        Assert.assertEquals("2nd byte", x.getElement(2), msg.getElement(2));
-        Assert.assertEquals("3rd byte", x.getElement(3), msg.getElement(3));
-        Assert.assertEquals("4th byte", x.getElement(4), msg.getElement(4));
-        Assert.assertEquals("5th byte", x.getElement(5), msg.getElement(5));
-        Assert.assertEquals("6th byte", x.getElement(6), msg.getElement(6));
-        Assert.assertEquals("7th byte", x.getElement(7), msg.getElement(7));
+        assertEquals( x.getNumDataElements(), msg.getNumDataElements(), "length");
+        assertEquals( x.getElement(0), msg.getElement(0), "0th byte");
+        assertEquals( x.getElement(1), msg.getElement(1), "1st byte");
+        assertEquals( x.getElement(2), msg.getElement(2), "2nd byte");
+        assertEquals( x.getElement(3), msg.getElement(3), "3rd byte");
+        assertEquals( x.getElement(4), msg.getElement(4), "4th byte");
+        assertEquals( x.getElement(5), msg.getElement(5), "5th byte");
+        assertEquals( x.getElement(6), msg.getElement(6), "6th byte");
+        assertEquals( x.getElement(7), msg.getElement(7), "7th byte");
     }
 
     // Test the XNetMessage constructor.
@@ -60,15 +62,15 @@ public class Z21XNetReplyTest extends jmri.jmrix.lenz.XNetReplyTest {
     public void testXNetMessageCtor() {
         Z21XNetMessage x = new Z21XNetMessage("12 34 AB 03 19 06 0B B1");
         msg = new Z21XNetReply(x);
-        Assert.assertEquals("length", x.getNumDataElements(), msg.getNumDataElements());
-        Assert.assertEquals("0th byte", x.getElement(0) & 0xFF, msg.getElement(0) & 0xFF);
-        Assert.assertEquals("1st byte", x.getElement(1) & 0xFF, msg.getElement(1) & 0xFF);
-        Assert.assertEquals("2nd byte", x.getElement(2) & 0xFF, msg.getElement(2) & 0xFF);
-        Assert.assertEquals("3rd byte", x.getElement(3) & 0xFF, msg.getElement(3) & 0xFF);
-        Assert.assertEquals("4th byte", x.getElement(4) & 0xFF, msg.getElement(4) & 0xFF);
-        Assert.assertEquals("5th byte", x.getElement(5) & 0xFF, msg.getElement(5) & 0xFF);
-        Assert.assertEquals("6th byte", x.getElement(6) & 0xFF, msg.getElement(6) & 0xFF);
-        Assert.assertEquals("7th byte", x.getElement(7) & 0xFF, msg.getElement(7) & 0xFF);
+        assertEquals( x.getNumDataElements(), msg.getNumDataElements(), "length");
+        assertEquals( x.getElement(0) & 0xFF, msg.getElement(0) & 0xFF, "0th byte");
+        assertEquals( x.getElement(1) & 0xFF, msg.getElement(1) & 0xFF, "1st byte");
+        assertEquals( x.getElement(2) & 0xFF, msg.getElement(2) & 0xFF, "2nd byte");
+        assertEquals( x.getElement(3) & 0xFF, msg.getElement(3) & 0xFF, "3rd byte");
+        assertEquals( x.getElement(4) & 0xFF, msg.getElement(4) & 0xFF, "4th byte");
+        assertEquals( x.getElement(5) & 0xFF, msg.getElement(5) & 0xFF, "5th byte");
+        assertEquals( x.getElement(6) & 0xFF, msg.getElement(6) & 0xFF, "6th byte");
+        assertEquals( x.getElement(7) & 0xFF, msg.getElement(7) & 0xFF, "7th byte");
     }
 
     // get information from specific types of messages.
@@ -78,33 +80,37 @@ public class Z21XNetReplyTest extends jmri.jmrix.lenz.XNetReplyTest {
     public void testIsServiceModeResponse() {
         // CV 1 in direct mode.
         Z21XNetReply r = new Z21XNetReply("64 14 00 14 05 61");
-        Assert.assertTrue(r.isServiceModeResponse());
+        assertTrue(r.isServiceModeResponse());
     }
 
     @Test
     @Override
     public void testToMonitorStringServiceModeDirectResponse() {
         Z21XNetReply r = new Z21XNetReply("64 14 00 14 05 61");
-        Assert.assertEquals("Monitor String", Bundle.getMessage("Z21LAN_X_CV_RESULT", 21, 5), r.toMonitorString());
+        assertEquals( Bundle.getMessage("Z21LAN_X_CV_RESULT", 21, 5), 
+            r.toMonitorString(), "Monitor String");
     }
 
     @Test
     public void testToMonitorStringZ21_LAN_X_TURNOUT_INFO() {
         Z21XNetReply r = new Z21XNetReply("43 00 01 01 43");
-        Assert.assertEquals("Monitor String", Bundle.getMessage("Z21LAN_X_TURNOUT_INFO", 2, "Closed"), r.toMonitorString());
+        assertEquals( Bundle.getMessage("Z21LAN_X_TURNOUT_INFO", 2, "Closed"),
+            r.toMonitorString(), "Monitor String");
     }
 
     @BeforeEach
     @Override
     public void setUp() {
         JUnitUtil.setUp();
-        m = msg = new Z21XNetReply();
+        msg = new Z21XNetReply();
+        m = msg;
     }
 
     @AfterEach
     @Override
     public void tearDown() {
-        m = msg = null;
+        m = null;
+        msg = null;
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrix/roco/z21/Z21XNetTurnoutTest.java
+++ b/java/test/jmri/jmrix/roco/z21/Z21XNetTurnoutTest.java
@@ -1,15 +1,15 @@
 package jmri.jmrix.roco.z21;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import jmri.Turnout;
 import jmri.jmrix.lenz.XNetInterfaceScaffold;
 import jmri.jmrix.lenz.XNetReply;
 import jmri.jmrix.lenz.XNetTurnout;
 import jmri.util.JUnitUtil;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Tests for the {@link jmri.jmrix.roco.z21.Z21XNetTurnout} class.
@@ -21,26 +21,30 @@ public class Z21XNetTurnoutTest extends jmri.jmrix.lenz.XNetTurnoutTest {
 
     @Override
     public void checkClosedMsgSent() {
-        Assert.assertEquals("closed message", "53 00 14 88 CF",
-                lnis.outbound.elementAt(lnis.outbound.size() - 1).toString());
+        assertEquals( "53 00 14 88 CF",
+                lnis.outbound.elementAt(lnis.outbound.size() - 1).toString(),
+                "closed message");
     }
 
     @Override
     public void checkThrownMsgSent() {
-        Assert.assertEquals("thrown message", "53 00 14 89 CE",
-                lnis.outbound.elementAt(lnis.outbound.size() - 1).toString());
+        assertEquals( "53 00 14 89 CE",
+                lnis.outbound.elementAt(lnis.outbound.size() - 1).toString(),
+                "thrown message");
     }
 
     @Override
     protected void checkClosedOffSent() {
-        Assert.assertEquals("thrown message", "53 00 14 80 C7",
-                lnis.outbound.elementAt(lnis.outbound.size() - 1).toString());
+        assertEquals( "53 00 14 80 C7",
+                lnis.outbound.elementAt(lnis.outbound.size() - 1).toString(),
+                "thrown message");
     }
 
     @Override
     protected void checkThrownOffSent() {
-        Assert.assertEquals("thrown message", "53 00 14 81 C6",
-                lnis.outbound.elementAt(lnis.outbound.size() - 1).toString());
+        assertEquals( "53 00 14 81 C6",
+                lnis.outbound.elementAt(lnis.outbound.size() - 1).toString(),
+                "thrown message");
     }
 
     // Test the Z21XNetTurnout message sequence.
@@ -50,15 +54,14 @@ public class Z21XNetTurnoutTest extends jmri.jmrix.lenz.XNetTurnoutTest {
         t.setFeedbackMode(jmri.Turnout.DIRECT);
         // prepare an interface
         // set closed
-        try {
-            t.setCommandedState(jmri.Turnout.CLOSED);
-        } catch (Exception e) {
-            log.error("TO exception: {}", e);
-        }
-        Assert.assertEquals(Turnout.CLOSED, t.getCommandedState());
+        assertDoesNotThrow( () -> t.setCommandedState( Turnout.CLOSED),
+            "TO exception: ");
 
-        Assert.assertEquals("on message sent", "53 00 14 88 CF",
-                lnis.outbound.elementAt(lnis.outbound.size() - 1).toString());
+        assertEquals(Turnout.CLOSED, t.getCommandedState());
+
+        assertEquals( "53 00 14 88 CF",
+                lnis.outbound.elementAt(lnis.outbound.size() - 1).toString(),
+                "on message sent");
 
         ((Z21XNetTurnout)t).message(lnis.outbound.elementAt(lnis.outbound.size()-1));
 
@@ -74,11 +77,11 @@ public class Z21XNetTurnoutTest extends jmri.jmrix.lenz.XNetTurnoutTest {
 
         ((jmri.jmrix.roco.z21.Z21XNetTurnout) t).message(m);
 
-        while (n == lnis.outbound.size()) {
-        } // busy loop.  Wait for 
-        // outbound size to change.
-        Assert.assertEquals("off message sent", "53 00 14 80 C7",
-                lnis.outbound.elementAt(n).toString());
+        JUnitUtil.waitFor( () -> n != lnis.outbound.size(), "Wait for outbound size to change");
+
+        assertEquals( "53 00 14 80 C7",
+                lnis.outbound.elementAt(n).toString(),
+            "off message sent");
 
         ((Z21XNetTurnout)t).message(lnis.outbound.elementAt(lnis.outbound.size()-1));
 
@@ -94,7 +97,7 @@ public class Z21XNetTurnoutTest extends jmri.jmrix.lenz.XNetTurnoutTest {
 
         // no wait here.  The last reply should cause the turnout to 
         // set it's state, but it will not cause another reply.
-        Assert.assertEquals(Turnout.CLOSED, t.getKnownState());
+        assertEquals(Turnout.CLOSED, t.getKnownState());
     }
 
     // Test that property change events are properly sent from the parent
@@ -104,39 +107,35 @@ public class Z21XNetTurnoutTest extends jmri.jmrix.lenz.XNetTurnoutTest {
     @Override
     public void testXNetTurnoutPropertyChange() {
         // prepare an interface
-        jmri.util.JUnitUtil.resetInstanceManager();
-        jmri.util.JUnitUtil.initInternalSensorManager();
+        JUnitUtil.resetInstanceManager();
+        JUnitUtil.initInternalSensorManager();
         t = new Z21XNetTurnout("X", 21, lnis);
 
         // set thrown
-        try {
-            t.setCommandedState(jmri.Turnout.THROWN);
-        } catch (Exception e) {
-            log.error("TO exception: {}", e);
-        }
-        Assert.assertEquals(Turnout.THROWN, t.getCommandedState());
+        assertDoesNotThrow( () -> t.setCommandedState( Turnout.THROWN),
+            "TO exception: ");
+        assertEquals(Turnout.THROWN, t.getCommandedState());
 
-        t.setFeedbackMode(jmri.Turnout.ONESENSOR);
+        t.setFeedbackMode( Turnout.ONESENSOR);
         jmri.Sensor s = jmri.InstanceManager.sensorManagerInstance().provideSensor("IS1");
-        try {
-            s.setState(jmri.Sensor.INACTIVE);
-            t.provideFirstFeedbackSensor("IS1");
-        } catch (Exception x1) {
-            log.error("TO exception: {}", x1);
-        }
-        try {
-            s.setState(jmri.Sensor.ACTIVE);
-        } catch (Exception x) {
-            log.error("TO exception: {}", x);
-        }
+        assertDoesNotThrow( () -> {
+                s.setState(jmri.Sensor.INACTIVE);
+                t.provideFirstFeedbackSensor("IS1");
+            }, "TO exception: ");
+
+        assertDoesNotThrow( () -> s.setState(jmri.Sensor.ACTIVE),
+            "SO exception: ");
+
         // check to see if the turnout state changes.
-        Assert.assertEquals(Turnout.THROWN, t.getKnownState());
+        assertEquals(Turnout.THROWN, t.getKnownState());
     }
+
     @Test
     @Override
     public void testDirectFeedback() {
         t.setFeedbackMode(Turnout.DIRECT);
-        Assert.assertEquals("Feedback Mode after set", Turnout.DIRECT, t.getFeedbackMode());
+        assertEquals( Turnout.DIRECT, t.getFeedbackMode(),
+            "Feedback Mode after set");
 
         listenStatus = Turnout.UNKNOWN;
         t.addPropertyChangeListener(new Listen());
@@ -149,9 +148,10 @@ public class Z21XNetTurnoutTest extends jmri.jmrix.lenz.XNetTurnoutTest {
         checkThrownOffSent();
         ((XNetTurnout) t).message(new XNetReply("01 04 05"));
         checkThrownOffSent();
-        jmri.util.JUnitUtil.waitFor(() -> listenStatus != Turnout.UNKNOWN, "Turnout state changed");
-        Assert.assertEquals(Turnout.THROWN,t.getState());
-        Assert.assertEquals("listener notified of change for DIRECT feedback", Turnout.THROWN, listenStatus);
+        JUnitUtil.waitFor(() -> listenStatus != Turnout.UNKNOWN, "Turnout state changed");
+        assertEquals(Turnout.THROWN,t.getState());
+        assertEquals( Turnout.THROWN, listenStatus,
+            "listener notified of change for DIRECT feedback");
 
         listenStatus = Turnout.UNKNOWN;
         t.setCommandedState(Turnout.CLOSED);
@@ -161,15 +161,17 @@ public class Z21XNetTurnoutTest extends jmri.jmrix.lenz.XNetTurnoutTest {
         checkClosedOffSent();
         ((XNetTurnout) t).message(new XNetReply("01 04 05"));
         checkClosedOffSent();
-        jmri.util.JUnitUtil.waitFor(() -> listenStatus != Turnout.UNKNOWN, "Turnout state changed");
-        Assert.assertEquals(Turnout.CLOSED,t.getState());
-        Assert.assertEquals("listener notified of change for DIRECT feedback", Turnout.CLOSED, listenStatus);
+        JUnitUtil.waitFor(() -> listenStatus != Turnout.UNKNOWN, "Turnout state changed");
+        assertEquals(Turnout.CLOSED,t.getState());
+        assertEquals( Turnout.CLOSED, listenStatus,
+            "listener notified of change for DIRECT feedback");
     }
 
     @Override
     @Test
     public void testMonitoringFeedback() {
-        Assert.assertEquals("Feedback Mode after set", Turnout.MONITORING, t.getFeedbackMode());
+        assertEquals( Turnout.MONITORING, t.getFeedbackMode(),
+            "Feedback Mode after set");
 
         listenStatus = Turnout.UNKNOWN;
         t.addPropertyChangeListener(new Listen());
@@ -183,9 +185,10 @@ public class Z21XNetTurnoutTest extends jmri.jmrix.lenz.XNetTurnoutTest {
         ((XNetTurnout) t).message(new XNetReply("01 04 05"));
         checkThrownOffSent();
         ((XNetTurnout) t).message(new XNetReply("01 04 05"));
-        jmri.util.JUnitUtil.waitFor(() -> listenStatus != Turnout.UNKNOWN, "Turnout state changed");
-        Assert.assertEquals(Turnout.THROWN,t.getState());
-        Assert.assertEquals("listener notified of change for DIRECT feedback", Turnout.THROWN, listenStatus);
+        JUnitUtil.waitFor(() -> listenStatus != Turnout.UNKNOWN, "Turnout state changed");
+        assertEquals(Turnout.THROWN,t.getState());
+        assertEquals( Turnout.THROWN, listenStatus,
+            "listener notified of change for DIRECT feedback");
 
         listenStatus = Turnout.UNKNOWN;
         t.setCommandedState(Turnout.CLOSED);
@@ -197,19 +200,20 @@ public class Z21XNetTurnoutTest extends jmri.jmrix.lenz.XNetTurnoutTest {
         checkClosedOffSent();
         ((XNetTurnout) t).message(new XNetReply("01 04 05"));
         checkClosedOffSent();
-        jmri.util.JUnitUtil.waitFor(() -> listenStatus != Turnout.UNKNOWN, "Turnout state changed");
-        Assert.assertEquals(Turnout.CLOSED,t.getState());
-        Assert.assertEquals("listener notified of change for DIRECT feedback", Turnout.CLOSED, listenStatus);
+        JUnitUtil.waitFor(() -> listenStatus != Turnout.UNKNOWN, "Turnout state changed");
+        assertEquals(Turnout.CLOSED,t.getState());
+        assertEquals( Turnout.CLOSED, listenStatus,
+            "listener notified of change for DIRECT feedback");
     }
 
     @Test
     @Override
     public void testDispose() {
-        t.setCommandedState(jmri.Turnout.CLOSED);    // in case registration with TrafficController
+        t.setCommandedState( Turnout.CLOSED);
+        // in case registration with TrafficController is deferred to after first use
 
-        //is deferred to after first use
         t.dispose();
-        Assert.assertEquals("controller listeners remaining", 1, numListeners());
+        assertEquals( 1, numListeners(), "controller listeners remaining");
     }
 
     @BeforeEach
@@ -231,6 +235,6 @@ public class Z21XNetTurnoutTest extends jmri.jmrix.lenz.XNetTurnoutTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(Z21XNetTurnoutTest.class);
+    // private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(Z21XNetTurnoutTest.class);
 
 }

--- a/java/test/jmri/jmrix/rps/MeasurementTest.java
+++ b/java/test/jmri/jmrix/rps/MeasurementTest.java
@@ -1,6 +1,7 @@
 package jmri.jmrix.rps;
 
-import org.junit.Assert;
+import jmri.util.JUnitUtil;
+
 import org.junit.jupiter.api.*;
 
 /**
@@ -14,7 +15,17 @@ public class MeasurementTest {
     public void testCtorAndID() {
         Reading r = new Reading("21", new double[]{0., 0., 0.});
         Measurement m = new Measurement(r);
-        Assert.assertEquals("ID ok", "21", m.getId());
+        Assertions.assertEquals( "21", m.getId(), "ID ok");
+    }
+
+    @BeforeEach
+    public void setUp() {
+        JUnitUtil.setUp();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        JUnitUtil.tearDown();
     }
 
 }

--- a/java/test/jmri/jmrix/rps/ReadingTest.java
+++ b/java/test/jmri/jmrix/rps/ReadingTest.java
@@ -1,6 +1,9 @@
 package jmri.jmrix.rps;
 
-import org.junit.Assert;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import jmri.util.JUnitUtil;
+
 import org.junit.jupiter.api.*;
 
 /**
@@ -14,17 +17,17 @@ public class ReadingTest {
     public void testCtorAndID() {
         double[] v = new double[]{0., 1., 2.};
         Reading r = new Reading("21", v);
-        Assert.assertEquals("ID ok", "21", r.getId());
+        assertEquals( "21", r.getId(), "ID ok");
     }
 
     @Test
     public void testValues() {
         Reading r1 = new Reading("21", new double[]{0., 1., 2.});
         double[] val = r1.getValues();
-        Assert.assertEquals("Value 1 array", 1, (int) val[1]);
-        Assert.assertEquals("Value 1 call ", 1, (int) r1.getValue(1));
-        Assert.assertEquals("Value 2 array", 2, (int) val[2]);
-        Assert.assertEquals("Value 2 call ", 2, (int) r1.getValue(2));
+        assertEquals( 1, (int) val[1], "Value 1 array");
+        assertEquals( 1, (int) r1.getValue(1), "Value 1 call ");
+        assertEquals( 2, (int) val[2], "Value 2 array");
+        assertEquals( 2, (int) r1.getValue(2), "Value 2 call ");
     }
 
     @Test
@@ -32,22 +35,32 @@ public class ReadingTest {
         Reading r1 = new Reading("21", new double[]{0., 1., 2.});
         double[] val = r1.getValues();
         val[1] = 3.;
-        Assert.assertEquals("Value 1 call ", 1, (int) r1.getValue(1));
-        Assert.assertEquals("Value 2 call ", 2, (int) r1.getValue(2));
+        assertEquals( 1, (int) r1.getValue(1), "Value 1 call ");
+        assertEquals( 2, (int) r1.getValue(2), "Value 2 call ");
     }
 
     @Test
     public void testCopyCtorID() {
         Reading r1 = new Reading("21", new double[]{0., 1., 2.});
         Reading r2 = new Reading(r1);
-        Assert.assertEquals("ID ok", "21", r2.getId());
+        assertEquals( "21", r2.getId(), "ID ok");
     }
 
     @Test
     public void testCopyCtorData() {
         Reading r1 = new Reading("21", new double[]{0., 1., 2.});
         Reading r2 = new Reading(r1);
-        Assert.assertEquals("value 1", 1, (int) r2.getValue(1));
+        assertEquals( 1, (int) r2.getValue(1), "value 1");
+    }
+
+    @BeforeEach
+    public void setUp() {
+        JUnitUtil.setUp();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        JUnitUtil.tearDown();
     }
 
 }

--- a/java/test/jmri/jmrix/rps/csvinput/CsvTest.java
+++ b/java/test/jmri/jmrix/rps/csvinput/CsvTest.java
@@ -1,12 +1,18 @@
 package jmri.jmrix.rps.csvinput;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+
+import jmri.util.JUnitUtil;
+
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
-import org.junit.Assert;
+
 import org.junit.jupiter.api.*;
 
 /**
@@ -18,32 +24,46 @@ public class CsvTest {
 
     @Test
     public void testCreateReader() throws java.io.IOException {
-        CSVParser parser = CSVParser.parse(new File("java/test/jmri/jmrix/rps/csvinput/testdata.csv"), StandardCharsets.UTF_8, CSVFormat.DEFAULT.withSkipHeaderRecord());
-        Assert.assertNotNull("exists", parser);
+        var format = CSVFormat.DEFAULT;
+        format.builder().setSkipHeaderRecord(true);
+        CSVParser parser = CSVParser.parse(new File("java/test/jmri/jmrix/rps/csvinput/testdata.csv"),
+            StandardCharsets.UTF_8, format);
+        assertNotNull( parser, "exists");
     }
 
     @Test
     public void testReading() throws java.io.IOException {
-        CSVParser parser = CSVParser.parse(new File("java/test/jmri/jmrix/rps/csvinput/testdata.csv"), StandardCharsets.UTF_8, CSVFormat.DEFAULT);
+        CSVParser parser = CSVParser.parse(new File("java/test/jmri/jmrix/rps/csvinput/testdata.csv"),
+            StandardCharsets.UTF_8, CSVFormat.DEFAULT);
         List<CSVRecord> records = parser.getRecords();
-        Assert.assertEquals("2 lines", 2, records.size());
-        
-        CSVRecord record = records.get(0);
-        Assert.assertNotNull("read 1st line", record);
-        Assert.assertEquals("1st line column count", 4, record.size());
+        assertEquals( 2, records.size(), "2 lines");
 
-        Assert.assertEquals("1st line datum 1", "1", record.get(0));
-        Assert.assertEquals("1st line datum 2", "2", record.get(1));
-        Assert.assertEquals("1st line datum 3", "3", record.get(2));
-        Assert.assertEquals("1st line datum 4", "4", record.get(3));
+        CSVRecord record = records.get(0);
+        assertNotNull( record, "read 1st line");
+        assertEquals( 4, record.size(), "1st line column count");
+
+        assertEquals( "1", record.get(0), "1st line datum 1");
+        assertEquals( "2", record.get(1), "1st line datum 2");
+        assertEquals( "3", record.get(2), "1st line datum 3");
+        assertEquals( "4", record.get(3), "1st line datum 4");
 
         record = records.get(1);
-        Assert.assertNotNull("read 2nd line", record);
+        assertNotNull( record, "read 2nd line");
 
-        Assert.assertEquals("2nd line datum 1", "4", record.get(0));
-        Assert.assertEquals("2nd line datum 2", "3", record.get(1));
-        Assert.assertEquals("2nd line datum 3", "2", record.get(2));
-        Assert.assertEquals("2nd line datum 4", "1", record.get(3));
+        assertEquals( "4", record.get(0), "2nd line datum 1");
+        assertEquals( "3", record.get(1), "2nd line datum 2");
+        assertEquals( "2", record.get(2), "2nd line datum 3");
+        assertEquals( "1", record.get(3), "2nd line datum 4");
+    }
+
+    @BeforeEach
+    public void setUp() {
+        JUnitUtil.setUp();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        JUnitUtil.tearDown();
     }
 
 }


### PR DESCRIPTION
Assertions JU4 > JU5
try / catch / error to assertion.
Use JUnitUtil waitFor tcis outbound
setUp / tearDown annotation

CsvTest - Refactors from deprecated usage of CSVFormat #withSkipHeaderRecord

