### PR TITLE
update LogixNG ExecuteDelayedTest - retain disabled JUnit4 annotation for now

### DIFF
--- a/java/test/jmri/jmrit/logixng/actions/ExecuteDelayedTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ExecuteDelayedTest.java
@@ -18,10 +18,7 @@ import jmri.util.JUnitUtil;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 
 /**
  * Test ExecuteDelayed
@@ -203,6 +200,7 @@ public class ExecuteDelayedTest extends AbstractDigitalActionTestBase {
     @Disabled("Error: ProtectedTimerTask Cannot stop timer")
     @Ignore("ProtectedTimerTask Cannot stop timer")
     @Test
+    @org.junit.Test
     @Override
     public void testIsActive() {
         _logixNG.setEnabled(true);
@@ -213,6 +211,7 @@ public class ExecuteDelayedTest extends AbstractDigitalActionTestBase {
     @Disabled("Error: ProtectedTimerTask Cannot stop timer")
     @Ignore("ProtectedTimerTask Cannot stop timer")
     @Test
+    @org.junit.Test
     @Override
     public void testMaleSocketIsActive() {
         _logixNG.setEnabled(true);


### PR DESCRIPTION
Add JU4 Test annotation to disable overridden JU4 Test
Use JUnit4 Ignore annotation for JU4 tests run from a super class.