### PR TITLE
Monitor displays Hub-sourced traffic with "H" prefix

### DIFF
--- a/help/en/package/jmri/jmrix/openlcb/swing/monitor/MonitorPane.shtml
+++ b/help/en/package/jmri/jmrix/openlcb/swing/monitor/MonitorPane.shtml
@@ -116,7 +116,11 @@
         <li>"17:49:57.335" is the local time that the message was processed
         <li>"<code>[[19968a90] 03 19                  ]</code>" is the contents of the
             CAN frame that was received in this case.
-        <li>"S:" indicates this was sent by JMRI; R: indicates it was received by JMRI
+        <li>"S:" indicates this was sent by JMRI; R: indicates it was received by JMRI;
+            if you're running an 
+            <a href="../hub/HubPane.shtml">OpenLCB/LCC hub<a>, 
+            traffic from  the hub will be indicated by H:
+            
         <li>"02.01.12.FE.77.16" is the node ID of the sending node, in this case JMRI
         <li>"09.00.99.03.00.35" is the node ID of the destination node.  If this is a 
                 global message, this will be blank

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -128,7 +128,9 @@
             <ul>
                 <li>Fixed a problem adding signal masts when the
                     OpenLCB or LCC system letter is not "M".</li>
-                <li>Improved display of stream data frames in the Monitor</li>
+                <li>Improved display of stream data frames in the Monitor.</li>
+                <li>Improved how traffic from an internal hub is 
+                    displayed in the Monitor.</li>
             </ul>
 
         <h4>Powerline</h4>

--- a/java/src/jmri/jmrix/AbstractMRMessage.java
+++ b/java/src/jmri/jmrix/AbstractMRMessage.java
@@ -294,6 +294,16 @@ abstract public class AbstractMRMessage extends AbstractMessage {
         return s;
     }
 
+    protected String sourceLetter = "S";
+    /** 
+     * Get the letter representing where this message originated.
+     * This is used by e.g. some Monitor implementations.
+     * Defaults to "S" for "Sent"
+     */
+    public String getSourceLetter() {
+        return sourceLetter;
+    } 
+
     private final static Logger log = LoggerFactory.getLogger(AbstractMRMessage.class);
 
 }

--- a/java/src/jmri/jmrix/AbstractMRReply.java
+++ b/java/src/jmri/jmrix/AbstractMRReply.java
@@ -212,6 +212,16 @@ abstract public class AbstractMRReply extends AbstractMessage {
     }
     static public final int DEFAULTMAXSIZE = 120;
 
+    protected String sourceLetter = "R";
+    /** 
+     * Get the letter representing where this reply originated.
+     * This is used by e.g. some Monitor implementations.
+     * Defaults to "R" for "Received"
+     */
+    public String getSourceLetter() {
+        return sourceLetter;
+    } 
+    
     // contents
     private boolean unsolicited;
 

--- a/java/src/jmri/jmrix/can/CanMessage.java
+++ b/java/src/jmri/jmrix/can/CanMessage.java
@@ -249,6 +249,10 @@ public class CanMessage extends AbstractMRMessage implements CanMutableFrame {
         _isRtr = b;
     }
 
+    public void setSourceLetter(String source) {
+        sourceLetter = source;
+    }
+
     // contents (package access)
     int _header;
     boolean _isExtended;

--- a/java/src/jmri/jmrix/can/CanReply.java
+++ b/java/src/jmri/jmrix/can/CanReply.java
@@ -223,6 +223,10 @@ public class CanReply extends AbstractMRReply implements CanMutableFrame {
         return monString();
     }
 
+    public void setSourceLetter(String source) {
+        sourceLetter = source;
+    }
+    
     // contents (package access)
     int _header;
     boolean _isExtended;

--- a/java/src/jmri/jmrix/openlcb/swing/hub/HubPane.java
+++ b/java/src/jmri/jmrix/openlcb/swing/hub/HubPane.java
@@ -189,6 +189,7 @@ public class HubPane extends jmri.util.swing.JmriPanel implements CanListener, C
             }
 
             CanReply workingReply = msg.createReply();
+            workingReply.setSourceLetter("H");
             workingReplySet.add(workingReply);  // save for later recognition
 
             CanMessage result = new CanMessage(workingReply.getNumDataElements(), workingReply.getHeader());
@@ -196,6 +197,7 @@ public class HubPane extends jmri.util.swing.JmriPanel implements CanListener, C
                 result.setElement(i, workingReply.getElement(i));
             }
             result.setExtended(workingReply.isExtended());
+            result.setSourceLetter("H");
             workingMessageSet.add(result);
             log.trace("Hub forwarder create reply {}", workingReply);
 

--- a/java/src/jmri/jmrix/openlcb/swing/monitor/MonitorPane.java
+++ b/java/src/jmri/jmrix/openlcb/swing/monitor/MonitorPane.java
@@ -548,13 +548,17 @@ public class MonitorPane extends jmri.jmrix.AbstractMonPane implements CanListen
     @Override
     public synchronized void message(CanMessage l) {  // receive a message and log it
         log.debug("Message: {}", l);
-        format("S", l.isExtended(), l.getHeader(), l.getNumDataElements(), l.getData());
+        if ("H".equals(l.getSourceLetter())) {
+            log.debug("Suppressing message with source==H to avoid double counting");
+            return;
+        }
+        format(l.getSourceLetter(), l.isExtended(), l.getHeader(), l.getNumDataElements(), l.getData());
     }
 
     @Override
     public synchronized void reply(CanReply l) {  // receive a reply and log it
         log.debug("Reply: {}", l);
-        format("R", l.isExtended(), l.getHeader(), l.getNumDataElements(), l.getData());
+        format(l.getSourceLetter(), l.isExtended(), l.getHeader(), l.getNumDataElements(), l.getData());
     }
 
     private final static Logger log = LoggerFactory.getLogger(MonitorPane.class);


### PR DESCRIPTION
With this change, the OpenLCB/LCC Monitor will display
 - R for traffic received on a CAN link or network link defined in the JMRI connection
 - S for traffic originating inside JMRI itself
 - H for traffic that originated on the internal Hub, if running
