### PR TITLE
LogixNG Import / Import EntryExit tests update

### DIFF
--- a/java/test/jmri/jmrit/logixng/tools/ImportEntryExitTest.java
+++ b/java/test/jmri/jmrit/logixng/tools/ImportEntryExitTest.java
@@ -1,7 +1,13 @@
 package jmri.jmrit.logixng.tools;
 
-import java.awt.GraphicsEnvironment;
-import java.lang.reflect.InvocationTargetException;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+
 import java.lang.reflect.Method;
 
 import jmri.*;
@@ -9,11 +15,10 @@ import jmri.jmrit.entryexit.DestinationPoints;
 import jmri.jmrit.logix.*;
 import jmri.jmrit.logixng.ConditionalNG_Manager;
 import jmri.jmrit.logixng.LogixNG_Manager;
-import jmri.util.JUnitAppender;
-import jmri.util.JUnitUtil;
-import jmri.util.junit.rules.*;
+import jmri.util.*;
+import jmri.util.junit.annotations.DisabledIfHeadless;
 
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
 /**
  * Test import of Logix to LogixNG.
@@ -27,10 +32,8 @@ import org.junit.*;
  * @author Daniel Bergqvist  (C) 2021
  * @author Dave Sand         (C) 2021 (Dave Sand created the panel file)
  */
+@DisabledIfHeadless
 public class ImportEntryExitTest {
-
-    @Rule
-    public RetryRule retryRule = new RetryRule(2); // allow 2 retries
 
     private LogixManager logixManager;
     private LogixNG_Manager logixNG_Manager;
@@ -45,19 +48,23 @@ public class ImportEntryExitTest {
         }
     }
 
-    private void runTestActionEntryExit(DestinationPoints dp, Sensor sensor) throws JmriException, NoSuchMethodException, IllegalAccessException, IllegalArgumentException, InvocationTargetException {
-        Assert.assertFalse(dp.isEnabled());
+    private void runTestActionEntryExit(DestinationPoints dp, Sensor sensor, String where) throws JmriException {
+        assertFalse(dp.isEnabled());
         sensor.setState(Sensor.INACTIVE);
-        JUnitUtil.waitFor(() -> (dp.isEnabled()),"destination point enabled");
-        Assert.assertTrue(dp.isEnabled());
+
+        JUnitUtil.waitFor(() -> (dp.isEnabled()),
+            () -> "destination point " + dp.getDisplayName() + " enabled in " + where);
+        assertTrue(dp.isEnabled());
         sensor.setState(Sensor.ACTIVE);
-        JUnitUtil.waitFor(() -> (!dp.isEnabled()),"destination point disabled");
-        Assert.assertFalse(dp.isEnabled());
+        JUnitUtil.waitFor(() -> (!dp.isEnabled()),
+            () -> "destination point " + dp.getDisplayName() + " disabled in " + where);
+        assertFalse(dp.isEnabled());
     }
 
     @Test
-    public void testActionEntryExit() throws InterruptedException, JmriException, NoSuchMethodException, IllegalAccessException, IllegalArgumentException, InvocationTargetException {
-        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
+    public void testActionEntryExit() throws JmriException {
+        assumeFalse( Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"),
+            "Ignoring intermittent test");
 
         // ENTRYEXIT
         // SET_NXPAIR_ENABLED
@@ -75,15 +82,15 @@ public class ImportEntryExitTest {
         }
 */
         Sensor sensor201 = InstanceManager.getDefault(SensorManager.class).getByUserName("Set NX Enabled");
-        Assert.assertNotNull(sensor201);
+        assertNotNull(sensor201);
         sensor201.setState(Sensor.ACTIVE);
-        Assert.assertEquals(Sensor.ACTIVE, sensor201.getState());
+        assertEquals(Sensor.ACTIVE, sensor201.getState());
 
         DestinationPoints dp = InstanceManager.getDefault(jmri.jmrit.entryexit.EntryExitPairs.class).getNamedBean("NX-Left-TO-A (Left-TO-A) to NX-Right-TO-B (Right-TO-B)");
-        Assert.assertNotNull(dp);
+        assertNotNull(dp);
 
         // Test entry/exit
-        runTestActionEntryExit(dp, sensor201);
+        runTestActionEntryExit(dp, sensor201, "run1");
 
         for (Logix l : logixManager.getNamedBeanSet()) {
             ImportLogix il = new ImportLogix(l, true);
@@ -94,40 +101,47 @@ public class ImportEntryExitTest {
         deleteAllLogixs();
 
         // Test entry/exit
-        runTestActionEntryExit(dp, sensor201);
+        runTestActionEntryExit(dp, sensor201, "run2");
     }
 
-    private void setActiveEntryExit(DestinationPoints dp, boolean boo) throws NoSuchMethodException, IllegalAccessException, IllegalArgumentException, InvocationTargetException {
+    private void setActiveEntryExit(DestinationPoints dp, boolean boo) {
 //        Method retrieveItems = dp.getClass().getDeclaredMethod("isEnabled", String.class);
-        Method setActiveEntryExit = dp.getClass().getDeclaredMethod("setActiveEntryExit", boolean.class);
-        setActiveEntryExit.setAccessible(true);
-        setActiveEntryExit.invoke(dp, boo);
+        assertDoesNotThrow( () -> {
+            Method setActiveEntryExit = dp.getClass().getDeclaredMethod("setActiveEntryExit", boolean.class);
+            setActiveEntryExit.setAccessible(true);
+            setActiveEntryExit.invoke(dp, boo);
+        });
     }
 
-    private void runTestExpressionEntryExit(DestinationPoints dp, Sensor sensor) throws JmriException, NoSuchMethodException, IllegalAccessException, IllegalArgumentException, InvocationTargetException {
-        Assert.assertEquals(Sensor.INACTIVE, sensor.getState());
+    private void runTestExpressionEntryExit(DestinationPoints dp, Sensor sensor, String comment) {
+        assertEquals(Sensor.INACTIVE, sensor.getState());
         setActiveEntryExit(dp, true);
-        JUnitUtil.waitFor(() -> (Sensor.ACTIVE == sensor.getState()),"Sensor goes active");
-        Assert.assertEquals(Sensor.ACTIVE, sensor.getState());
+        JUnitUtil.waitFor(() -> (Sensor.ACTIVE == sensor.getState()),
+            () -> "Sensor '" + sensor.getDisplayName() + "' goes active on " + comment);
+        assertEquals(Sensor.ACTIVE, sensor.getState());
         setActiveEntryExit(dp, false);
-        JUnitUtil.waitFor(() -> (Sensor.INACTIVE == sensor.getState()),"Sensor goes inactive");
-        Assert.assertEquals(Sensor.INACTIVE, sensor.getState());
+        JUnitUtil.waitFor(() -> (Sensor.INACTIVE == sensor.getState()),
+            () -> "Sensor '" + sensor.getDisplayName() + "' goes inactive on " + comment);
+        assertEquals(Sensor.INACTIVE, sensor.getState());
     }
 
     @Test
-    public void testExpressionEntryExit() throws InterruptedException, JmriException, NoSuchMethodException, IllegalAccessException, IllegalArgumentException, InvocationTargetException {
-        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
+    public void testExpressionEntryExit() throws JmriException {
+        assumeFalse( Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"),
+            "Ignoring intermittent test");
 
         Sensor sensor211 = InstanceManager.getDefault(SensorManager.class).getByUserName("NX Active");
-        Assert.assertNotNull(sensor211);
+        assertNotNull(sensor211);
         sensor211.setState(Sensor.INACTIVE);
-        Assert.assertEquals(Sensor.INACTIVE, sensor211.getState());
+        assertEquals(Sensor.INACTIVE, sensor211.getState());
 
-        DestinationPoints dp = jmri.InstanceManager.getDefault(jmri.jmrit.entryexit.EntryExitPairs.class).getNamedBean("NX-Left-TO-A (Left-TO-A) to NX-Right-TO-C (Right-TO-C)");
-        Assert.assertNotNull(dp);
+        DestinationPoints dp = InstanceManager.getDefault(jmri.jmrit.entryexit.EntryExitPairs.class).getNamedBean("NX-Left-TO-A (Left-TO-A) to NX-Right-TO-C (Right-TO-C)");
+        assertNotNull(dp);
 
         // Test entry/exit
-        runTestExpressionEntryExit(dp, sensor211);
+        runTestExpressionEntryExit(dp, sensor211, "run1");
+
+        JUnitUtil.waitFor(150);
 
         for (Logix l : logixManager.getNamedBeanSet()) {
             ImportLogix il = new ImportLogix(l, true);
@@ -136,15 +150,14 @@ public class ImportEntryExitTest {
         }
 
         deleteAllLogixs();
+        JUnitUtil.waitFor(150);
 
         // Test entry/exit
-        runTestExpressionEntryExit(dp, sensor211);
+        runTestExpressionEntryExit(dp, sensor211, "run2");
     }
 
-    @Before
+    @BeforeEach
     public void setUp() throws JmriException {
-
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
 
         JUnitUtil.setUp();
         JUnitUtil.resetInstanceManager();
@@ -164,11 +177,12 @@ public class ImportEntryExitTest {
         logixNG_Manager = InstanceManager.getDefault(LogixNG_Manager.class);
 
 
-        ConfigureManager cm = InstanceManager.getNullableDefault(jmri.ConfigureManager.class);
-        Assert.assertNotNull(cm);
+        ConfigureManager cm = InstanceManager.getNullableDefault( ConfigureManager.class);
+        assertNotNull(cm);
         java.io.File file = new java.io.File("java/test/jmri/jmrit/logixng/tools/LogixNG_Test_Dave_Sand.xml");
-        boolean results = cm.load(file);
-        Assert.assertTrue(results);
+        boolean results = ThreadingUtil.runOnGUIwithReturn( () ->
+            assertDoesNotThrow( () -> cm.load(file)));
+        assertTrue(results);
 
         logixManager.activateAllLogixs();
         logixNG_Manager.activateAllLogixNGs();
@@ -208,12 +222,15 @@ public class ImportEntryExitTest {
 */
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
 
-        JUnitUtil.resetWindows(false, false);
+        JUnitUtil.disposeFrame("My Layout", false, true);
 
-        JUnitAppender.suppressWarnMessageStartsWith("Import Conditional 'IX1C1' to LogixNG 'IQ:AUTO:000'");
+        JUnitAppender.suppressWarnMessage("Import Conditional 'IX:AUTO:0001C1' to LogixNG 'IQ:AUTO:0001'");
+        JUnitAppender.suppressWarnMessage("Import Conditional 'IX:AUTO:0002C1' to LogixNG 'IQ:AUTO:0002'");
+        JUnitAppender.suppressWarnMessage("Import Conditional 'IX:AUTO:0003C1' to LogixNG 'IQ:AUTO:0003'");
+        JUnitAppender.suppressWarnMessage("Import Conditional 'IX:AUTO:0004C1' to LogixNG 'IQ:AUTO:0004'");
         JUnitAppender.suppressWarnMessage("Import Conditional 'IX:RTXINITIALIZER1T' to LogixNG 'IQ:AUTO:0005'");
 
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();


### PR DESCRIPTION
Tests and Assertions JU4 > JU5
Removes JUnit4 Retry Rule.
Loads panel file on GUI thread.
Adds pause just before / after NX import for improved reliability.
Suppress various import related warn messages.