### PR TITLE
Add a log message when opening the socket for a system network connection

### DIFF
--- a/java/src/jmri/jmrix/AbstractNetworkPortController.java
+++ b/java/src/jmri/jmrix/AbstractNetworkPortController.java
@@ -47,7 +47,9 @@ abstract public class AbstractNetworkPortController extends AbstractPortControll
             return;
         }
         try {
-            socketConn = new Socket(getHostAddress(), m_port);
+            var address = getHostAddress();
+            log.info("Attempting to open connecton to {}:{}", address, m_port);
+            socketConn = new Socket(address, m_port);
             socketConn.setKeepAlive(true);
             socketConn.setSoTimeout(getConnectionTimeout());
             opened = true;


### PR DESCRIPTION
Adds in `info` message right before opening a socket for a system network connection.  If JMRI hangs because the open hangs, this helps in debugging the hang.