### PR TITLE
Improve Olcb monitor PCER display; internal refactor

### DIFF
--- a/java/src/jmri/jmrix/openlcb/swing/monitor/Bundle.properties
+++ b/java/src/jmri/jmrix/openlcb/swing/monitor/Bundle.properties
@@ -1,7 +1,7 @@
 
-CheckBoxShowNodeName = Show Name for Node
-CheckBoxShowEvent = Event (First)
-CheckBoxShowEventAll = Event (All)
+CheckBoxShowNodeName  = Show Name for Node
+CheckBoxShowEventName = Event Name
+CheckBoxShowEventUses = Event Uses
 
 TimeClockDefault     = Default Fast Clock
 TimeClockReal        = Real Time Clock

--- a/java/src/jmri/jmrix/openlcb/swing/monitor/Bundle_cs.properties
+++ b/java/src/jmri/jmrix/openlcb/swing/monitor/Bundle_cs.properties
@@ -1,7 +1,5 @@
 
 CheckBoxShowNodeName = Uk\u00e1zat N\u00e1zev pro Uzel
-CheckBoxShowEvent = Ud\u00e1lost (Prvn\u00ed)
-CheckBoxShowEventAll = Ud\u00e1lost (V\u0161e)
 
 TimeClockDefault     = V\u00fdchoz\u00ed modelov\u00e9 hodiny
 TimeClockReal        = Hodiny re\u00e1ln\u00e9ho \u010dasu

--- a/java/src/jmri/jmrix/openlcb/swing/monitor/MonitorPane.java
+++ b/java/src/jmri/jmrix/openlcb/swing/monitor/MonitorPane.java
@@ -1,6 +1,5 @@
 package jmri.jmrix.openlcb.swing.monitor;
 
-import jmri.IdTagManager;
 import jmri.InstanceManager;
 import jmri.UserPreferencesManager;
 import jmri.jmrix.can.CanListener;
@@ -8,7 +7,7 @@ import jmri.jmrix.can.CanMessage;
 import jmri.jmrix.can.CanReply;
 import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.jmrix.can.swing.CanPanelInterface;
-import jmri.jmrix.openlcb.OlcbConstants;
+import jmri.jmrix.openlcb.OlcbEventNameStore;
 
 import org.openlcb.AddressedMessage;
 import org.openlcb.EventID;
@@ -36,24 +35,22 @@ public class MonitorPane extends jmri.jmrix.AbstractMonPane implements CanListen
     public MonitorPane() {
         super();
         pm = InstanceManager.getDefault(UserPreferencesManager.class);
-        tagManager = InstanceManager.getDefault(IdTagManager.class);
     }
 
     CanSystemConnectionMemo memo;
     AliasMap aliasMap;
     MessageBuilder messageBuilder;
     OlcbInterface olcbInterface;
-
-    IdTagManager tagManager;
+    OlcbEventNameStore nameStore;
 
     /** show source node name on a separate line when available */
     final JCheckBox nodeNameCheckBox = new JCheckBox();
 
     /** Show the first EventID in the message on a separate line */
-    final JCheckBox eventCheckBox = new JCheckBox();
+    final JCheckBox eventNameCheckBox = new JCheckBox();
 
     /** Show all EventIDs in the message each on a separate line */
-    final JCheckBox eventAllCheckBox = new JCheckBox();
+    final JCheckBox eventUsesCheckBox = new JCheckBox();
 
     /* Preferences setup */
     final String nodeNameCheck = this.getClass().getName() + ".NodeName";
@@ -73,6 +70,8 @@ public class MonitorPane extends jmri.jmrix.AbstractMonPane implements CanListen
         this.memo = memo;
 
         memo.getTrafficController().addCanConsoleListener(this);
+        
+        nameStore = memo.get(OlcbEventNameStore.class);
 
         aliasMap = memo.get(org.openlcb.can.AliasMap.class);
         messageBuilder = new MessageBuilder(aliasMap);
@@ -110,8 +109,8 @@ public class MonitorPane extends jmri.jmrix.AbstractMonPane implements CanListen
         }
 
         pm.setSimplePreferenceState(nodeNameCheck, nodeNameCheckBox.isSelected());
-        pm.setSimplePreferenceState(eventCheck, eventCheckBox.isSelected());
-        pm.setSimplePreferenceState(eventAllCheck, eventAllCheckBox.isSelected());
+        pm.setSimplePreferenceState(eventCheck, eventNameCheckBox.isSelected());
+        pm.setSimplePreferenceState(eventAllCheck, eventUsesCheckBox.isSelected());
 
         super.dispose();
     }
@@ -126,15 +125,15 @@ public class MonitorPane extends jmri.jmrix.AbstractMonPane implements CanListen
         nodeNameCheckBox.setSelected(pm.getSimplePreferenceState(nodeNameCheck));
         p.add(nodeNameCheckBox);
 
-        eventCheckBox.setText(Bundle.getMessage("CheckBoxShowEvent"));
-        eventCheckBox.setVisible(true);
-        eventCheckBox.setSelected(pm.getSimplePreferenceState(eventCheck));
-        p.add(eventCheckBox);
+        eventNameCheckBox.setText(Bundle.getMessage("CheckBoxShowEventName"));
+        eventNameCheckBox.setVisible(true);
+        eventNameCheckBox.setSelected(pm.getSimplePreferenceState(eventCheck));
+        p.add(eventNameCheckBox);
 
-        eventAllCheckBox.setText(Bundle.getMessage("CheckBoxShowEventAll"));
-        eventAllCheckBox.setVisible(true);
-        eventAllCheckBox.setSelected(pm.getSimplePreferenceState(eventAllCheck));
-        p.add(eventAllCheckBox);
+        eventUsesCheckBox.setText(Bundle.getMessage("CheckBoxShowEventUses"));
+        eventUsesCheckBox.setVisible(true);
+        eventUsesCheckBox.setSelected(pm.getSimplePreferenceState(eventAllCheck));
+        p.add(eventUsesCheckBox);
 
         parent.add(p);
         super.addCustomControlPanes(parent);
@@ -292,42 +291,37 @@ public class MonitorPane extends jmri.jmrix.AbstractMonPane implements CanListen
                         }
                     }
                 }
-                if ((eventCheckBox.isSelected() || eventAllCheckBox.isSelected()) && olcbInterface != null 
+                if ((eventNameCheckBox.isSelected() || eventUsesCheckBox.isSelected()) && olcbInterface != null 
                         && msg instanceof EventMessage) {
                     EventID ev = ((EventMessage) msg).getEventID();
-                    log.debug("event message with event {}", ev);
+                    log.trace("event message with event {}", ev);
 
-                    // this could be converted to EventTablePane.isEventNameTagPresent
-                    // but that would duplicate the retrieval of the bean and user name
-                    var tag = tagManager.getIdTag(OlcbConstants.tagPrefix+ev.toShortString());
-                    String tagname = null;
-                    if (tag != null
-                            && (tagname = tag.getUserName()) != null) {
-                        if (! tagname.isEmpty()) {
-                            sb.append("\n   Name: ");
-                            sb.append(tagname);
+                    if (eventNameCheckBox.isSelected()) {
+                        if (nameStore.hasEventName(ev)) {   
+                            sb.append("    Name: ");        // append to PCER line
+                            sb.append(nameStore.getEventName(ev));
+                        }
+                        
+                        // check for time message
+                        if ((content[0] == 1) && (content[1] == 1) && (content[2] == 0) && (content[3] == 0) && (content[4] == 1)) {
+                            sb.append("    ");  // spaces for formatting like Name: above
+                            sb.append(formatTimeMessage(content));
                         }
                     }
 
-                    // check for time message
-                    if ((content[0] == 1) && (content[1] == 1) && (content[2] == 0) && (content[3] == 0) && (content[4] == 1)) {
-                        sb.append("\n    ");
-                        sb.append(formatTimeMessage(content));
-                    }
+                    if (eventUsesCheckBox.isSelected()) {
+                        EventTable.EventTableEntry[] descr =
+                                olcbInterface.getEventTable().getEventInfo(ev).getAllEntries();
+                        if (descr.length > 0) {
+                            sb.append("\n   Uses: ");
+                            sb.append(descr[0].getDescription());
 
-                    EventTable.EventTableEntry[] descr =
-                            olcbInterface.getEventTable().getEventInfo(ev).getAllEntries();
-                    if (descr.length > 0) {
-                        sb.append("\n   Uses: ");
-                        sb.append(descr[0].getDescription());
-
-                        if (eventAllCheckBox.isSelected()) {
                             for (int i = 1; i < descr.length; i++) {  // entry 0 done above, so skipped here
                                 sb.append("\n         ");
                                 sb.append(descr[i].getDescription());
                             }
                         }
-                    }                        
+                    }                    
                 }
                 formatted = sb.toString();
             }


### PR DESCRIPTION
 - better location for display of event name
 - Properly name the "show event" and "show uses" checkboxes, as that's what they do
   - Internal variable rename for consistency
   - Some minor refactoring to clarify structure of code
