### PR TITLE
update CbusReporter test

### DIFF
--- a/java/test/jmri/implementation/AbstractReporterTestBase.java
+++ b/java/test/jmri/implementation/AbstractReporterTestBase.java
@@ -1,8 +1,13 @@
 package jmri.implementation;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import jmri.Reporter;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.*;
 
 /**
@@ -32,10 +37,10 @@ abstract public class AbstractReporterTestBase {
     @Test
     public void testCtor() {
         // Check that it is not a null object
-        Assert.assertNotNull("Created Reporter not null", r);
+        assertNotNull(r, "Created Reporter not null");
         // Check that CurrentReport and LastReport return a null object
-        Assert.assertNull("CurrentReport at initialisation is 'null'", r.getCurrentReport());
-        Assert.assertNull("LastReport at initialisation is 'null'", r.getLastReport());
+        assertNull(r.getCurrentReport(), "CurrentReport at initialisation is 'null'");
+        assertNull(r.getLastReport(), "LastReport at initialisation is 'null'");
     }
 
     @Test
@@ -43,21 +48,21 @@ abstract public class AbstractReporterTestBase {
         // Report a String
         r.setReport(generateObjectToReport());
         // Check that both CurrentReport and LastReport are not null
-        Assert.assertNotNull("CurrentReport Object exists", r.getCurrentReport());
-        Assert.assertNotNull("LastReport Object exists", r.getLastReport());
+        assertNotNull(r.getCurrentReport(), "CurrentReport Object exists");
+        assertNotNull(r.getLastReport(), "LastReport Object exists");
         // Check the value of both CurrentReport and LastReport
-        Assert.assertEquals("CurrentReport equals LastReport",r.getLastReport(), r.getCurrentReport());
+        assertEquals(r.getLastReport(), r.getCurrentReport(), "CurrentReport equals LastReport");
 
         // Nothing to report now
         r.setReport(null);
         // Check that CurrentReport returns a null value, but LastReport returns the reported String
-        Assert.assertNull("After null report, CurrentReport is null", r.getCurrentReport());
-        Assert.assertNotNull("After null report, LastReport String is not null",r.getLastReport());
+        assertNull(r.getCurrentReport(), "After null report, CurrentReport is null");
+        assertNotNull(r.getLastReport(), "After null report, LastReport String is not null");
     }
 
     @Test
     public void testGetBeanType(){
-         Assert.assertEquals("bean type",r.getBeanType(),Bundle.getMessage("BeanNameReporter"));
+         assertEquals(Bundle.getMessage("BeanNameReporter"), r.getBeanType(), "bean type");
     }
 
     @Test
@@ -68,26 +73,26 @@ abstract public class AbstractReporterTestBase {
         // Report a String
         r.setReport(generateObjectToReport());
         // Check that both CurrentReport and LastReport were seen
-        Assert.assertTrue("CurrentReport seen", currentReportSeen);
-        Assert.assertTrue("LastReport seen", lastReportSeen);
+        assertTrue(currentReportSeen, "CurrentReport seen");
+        assertTrue(lastReportSeen, "LastReport seen");
 
         // Nothing to report now
         currentReportSeen = false;
         lastReportSeen = false;
         r.setReport(null);
         // Check that CurrentReport was seen
-        Assert.assertTrue("CurrentReport seen after null", currentReportSeen);
+        assertTrue(currentReportSeen, "CurrentReport seen after null");
         // Check that LastReport was not seen (no change on null)
-        Assert.assertFalse("LastReport seen after null", lastReportSeen);
+        assertFalse(lastReportSeen, "LastReport seen after null");
     }
-    
+
     @Test
     public void testAddRemoveListener() {
-        Assert.assertEquals("starts 0 listeners", 0, r.getNumPropertyChangeListeners());
+        int initialListeners = r.getNumPropertyChangeListeners();
         r.addPropertyChangeListener(new TestReporterListener());
-        Assert.assertEquals("controller listener added", 1, r.getNumPropertyChangeListeners());
+        assertEquals(initialListeners+1, r.getNumPropertyChangeListeners(), "controller listener added");
         r.dispose();
-        Assert.assertTrue("controller listeners remaining < 1", r.getNumPropertyChangeListeners() < 1);
+        assertEquals(0, r.getNumPropertyChangeListeners(), "0 listeners after dispose");
     }
 
     protected boolean currentReportSeen = false;

--- a/java/test/jmri/jmrix/can/TrafficControllerScaffold.java
+++ b/java/test/jmri/jmrix/can/TrafficControllerScaffold.java
@@ -7,9 +7,6 @@ import jmri.jmrix.AbstractMRListener;
 import jmri.jmrix.AbstractMRMessage;
 import jmri.jmrix.AbstractMRReply;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
  * Stands in for the can.TrafficController class
  *
@@ -84,6 +81,18 @@ public class TrafficControllerScaffold extends TrafficController {
         inbound.addElement(r);
     }
 
+    public void sendToListeners(CanReply r) {
+        for ( AbstractMRListener listener : cmdListeners ) {
+            ((CanListener) listener).reply(r);
+        }
+    }
+
+    public void sendToListeners(CanMessage m) {
+        for ( AbstractMRListener listener : cmdListeners ) {
+            ((CanListener) listener).message(m);
+        }
+    }
+
     /*
      * Check number of listeners, used for testing dispose()
      */
@@ -99,6 +108,6 @@ public class TrafficControllerScaffold extends TrafficController {
         return cmdListeners;
     }
 
-    private final static Logger log = LoggerFactory.getLogger(TrafficControllerScaffold.class);
+    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(TrafficControllerScaffold.class);
 
 }

--- a/java/test/jmri/jmrix/can/cbus/CbusReporterTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusReporterTest.java
@@ -1,14 +1,20 @@
 package jmri.jmrix.can.cbus;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import jmri.IdTag;
+import jmri.Reporter;
+import jmri.ReporterManager;
+import jmri.Sensor;
 import jmri.jmrix.can.*;
 import jmri.util.JUnitUtil;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.*;
-
-// import org.slf4j.Logger;
-// import org.slf4j.LoggerFactory;
 
 /**
  *
@@ -25,11 +31,11 @@ public class CbusReporterTest extends jmri.implementation.AbstractReporterTestBa
     public void testRespondToClassicRfidCanReply(){
 
         // a new tag provided by Reporter4 then moves to Reporter 5
-        CbusReporter r4 = new CbusReporter("4",memo);
-        CbusReporter r5 = new CbusReporter("5",memo);
+        Reporter r4 = memo.get(ReporterManager.class).provideReporter("4");
+        Reporter r5 = memo.get(ReporterManager.class).provideReporter("5");
 
-        Assert.assertNotEquals("messages should be different",
-   r.describeState(IdTag.UNSEEN), r.describeState(IdTag.SEEN));
+        assertNotEquals(r.describeState(IdTag.UNSEEN), r.describeState(IdTag.SEEN),
+            "messages should be different");
 
         CanReply m = new CanReply(tcis.getCanid());
         m.setNumDataElements(8);
@@ -41,25 +47,23 @@ public class CbusReporterTest extends jmri.implementation.AbstractReporterTestBa
         m.setElement(5, 0x31); // tag3
         m.setElement(6, 0x30); // tag4
         m.setElement(7, 0xAB); // tag5
-        r4.reply(m);
-        r5.reply(m);
+        tcis.sendToListeners(m);
 
         // tag unseen = 2
         // tag seen = 3
 
-        Assert.assertEquals("r4 state set",r4.describeState(IdTag.SEEN),r4.describeState(r4.getState()));
-        Assert.assertNotNull("r4 report set",r4.getCurrentReport());
-        Assert.assertEquals("r5 state unset",r5.describeState(IdTag.UNKNOWN),r5.describeState(r5.getState()));
-        Assert.assertEquals("r5 report unset",null,r5.getCurrentReport());
+        assertEquals(r4.describeState(IdTag.SEEN),r4.describeState(r4.getState()), "r4 state set");
+        assertNotNull(r4.getCurrentReport(), "r4 report set");
+        assertEquals(r5.describeState(IdTag.UNKNOWN),r5.describeState(r5.getState()), "r5 state unset");
+        assertNull(r5.getCurrentReport(), "r5 report unset");
 
         m.setElement(2, 0x05); // ev lo
-        r4.reply(m);
-        r5.reply(m);
+        tcis.sendToListeners(m);
 
-        Assert.assertEquals("r5 tag seen",r5.describeState(IdTag.SEEN),r5.describeState(r5.getState()));
-        Assert.assertNotNull("r5 report set",r5.getCurrentReport());
-        Assert.assertEquals("r4 tag gone",r4.describeState(IdTag.UNSEEN),r4.describeState(r4.getState()));
-        Assert.assertEquals("r4 report unset",null,r4.getCurrentReport());
+        assertEquals(r5.describeState(IdTag.SEEN),r5.describeState(r5.getState()), "r5 tag seen");
+        assertNotNull(r5.getCurrentReport(), "r5 report set");
+        assertEquals(r4.describeState(IdTag.UNSEEN),r4.describeState(r4.getState()), "r4 tag gone");
+        assertNull(r4.getCurrentReport(), "r4 report unset");
 
         CanReply m2 = new CanReply(tcis.getCanid());
         m2.setNumDataElements(8);
@@ -72,35 +76,34 @@ public class CbusReporterTest extends jmri.implementation.AbstractReporterTestBa
         m2.setElement(6, 0x30); // tag4
         m2.setElement(7, 0xAB); // tag5
 
-        r4.reply(m2);
-        r5.reply(m2);
+        tcis.sendToListeners(m2);
 
-        Assert.assertEquals("r4 state set CBUS_ACDAT",r4.describeState(IdTag.SEEN),r4.describeState(r4.getState()));
-        Assert.assertNotNull("r4 report set CBUS_ACDAT",r4.getCurrentReport());
-        Assert.assertEquals("r5 state unset CBUS_ACDAT",r5.describeState(IdTag.UNSEEN),r5.describeState(r5.getState()));
-        Assert.assertEquals("r5 report unset CBUS_ACDAT",null,r5.getCurrentReport());
+        assertEquals(r4.describeState(IdTag.SEEN),r4.describeState(r4.getState()), "r4 state set CBUS_ACDAT");
+        assertNotNull(r4.getCurrentReport(), "r4 report set CBUS_ACDAT");
+        assertEquals(r5.describeState(IdTag.UNSEEN),r5.describeState(r5.getState()), "r5 state unset CBUS_ACDAT");
+        assertNull(r5.getCurrentReport(), "r5 report unset CBUS_ACDAT");
 
         m2.setElement(2, 0x05); // ev lo
 
         m2.setExtended(true);
-        r5.reply(m2);
-        Assert.assertEquals("r5 state unset extended",r5.describeState(IdTag.UNSEEN),r5.describeState(r5.getState()));
+        tcis.sendToListeners(m2);
+        assertEquals(r5.describeState(IdTag.UNSEEN),r5.describeState(r5.getState()), "r5 state unset extended");
 
         m2.setExtended(false);
         m2.setRtr(true);
-        r5.reply(m2);
-        Assert.assertEquals("r5 state unset rtr",r5.describeState(IdTag.UNSEEN),r5.describeState(r5.getState()));
+        tcis.sendToListeners(m2);
+        assertEquals(r5.describeState(IdTag.UNSEEN),r5.describeState(r5.getState()), "r5 state unset rtr");
 
         m2.setRtr(false);
         m2.setElement(0, 0x05); // random OPC not related to reporters
-        r5.reply(m2);
-        Assert.assertEquals("r5 state unset random opc",r5.describeState(IdTag.UNSEEN),r5.describeState(r5.getState()));
+        tcis.sendToListeners(m2);
+        assertEquals(r5.describeState(IdTag.UNSEEN),r5.describeState(r5.getState()), "r5 state unset random opc");
 
         m2.setElement(0, CbusConstants.CBUS_DDES); // put it back
-        r5.reply(m2);
-        Assert.assertEquals("r5 state set ok after incorrect msgs",r5.describeState(IdTag.SEEN),r5.describeState(r5.getState()));
+        tcis.sendToListeners(m2);
+        assertEquals(r5.describeState(IdTag.SEEN),r5.describeState(r5.getState()), "r5 state set ok after incorrect msgs");
 
-        Assert.assertEquals("r4 state unseen",r4.describeState(IdTag.UNSEEN),r4.describeState(r4.getState()));
+        assertEquals(r4.describeState(IdTag.UNSEEN),r4.describeState(r4.getState()), "r4 state unseen");
 
         CanMessage m3 = new CanMessage(tcis.getCanid());
         m3.setNumDataElements(8);
@@ -113,9 +116,9 @@ public class CbusReporterTest extends jmri.implementation.AbstractReporterTestBa
         m3.setElement(6, 0x30); // tag4
         m3.setElement(7, 0xAB); // tag5
 
-        r4.message(m3);
+        tcis.sendToListeners(m3);
 
-        Assert.assertEquals("r4 seen after CBUS_ACDAT outgoing message",IdTag.SEEN,r4.getState());
+        assertEquals(IdTag.SEEN,r4.getState(), "r4 seen after CBUS_ACDAT outgoing message");
 
         r4.dispose();
         r5.dispose();
@@ -123,26 +126,28 @@ public class CbusReporterTest extends jmri.implementation.AbstractReporterTestBa
 
     @Test
     public void testGetCbusReporterType(){
-        Assert.assertEquals("Classic RfID default type",CbusReporterManager.CBUS_DEFAULT_REPORTER_TYPE,((CbusReporter)r).getCbusReporterType());
+        assertEquals(CbusReporterManager.CBUS_DEFAULT_REPORTER_TYPE,((CbusReporter)r).getCbusReporterType(),
+            "Classic RfID default type");
 
         r.setProperty(CbusReporterManager.CBUS_REPORTER_DESCRIPTOR_KEY, CbusReporterManager.CBUS_REPORTER_TYPES[1]);
-        Assert.assertEquals("type changed",CbusReporterManager.CBUS_REPORTER_TYPES[1],((CbusReporter)r).getCbusReporterType());
+        assertEquals(CbusReporterManager.CBUS_REPORTER_TYPES[1],((CbusReporter)r).getCbusReporterType(),
+            "type changed");
     }
 
     @Test
     public void testMaintainSensorDefaultSetGet(){
-        Assert.assertFalse("maintain sensor default",((CbusReporter)r).getMaintainSensor());
+        assertFalse(((CbusReporter)r).getMaintainSensor(), "maintain sensor default");
         r.setProperty(CbusReporterManager.CBUS_MAINTAIN_SENSOR_DESCRIPTOR_KEY, true);
-        Assert.assertTrue("sensor maintained flag set true",((CbusReporter)r).getMaintainSensor());
+        assertTrue(((CbusReporter)r).getMaintainSensor(), "sensor maintained flag set true");
     }
 
     @Test
     public void testRespondToDdesRc522CanReply(){
 
         // a new tag provided by Reporter4 then moves to Reporter 5
-        CbusReporter r4 = new CbusReporter("4",memo);
+        Reporter r4 = memo.get(ReporterManager.class).provideReporter("4");
         r4.setProperty(CbusReporterManager.CBUS_REPORTER_DESCRIPTOR_KEY, CbusReporterManager.CBUS_REPORTER_TYPES[1]);
-        CbusReporter r5 = new CbusReporter("65534",memo);
+        Reporter r5 = memo.get(ReporterManager.class).provideReporter("65534");
         r5.setProperty(CbusReporterManager.CBUS_REPORTER_DESCRIPTOR_KEY, CbusReporterManager.CBUS_REPORTER_TYPES[1]);
 
         CanReply m = new CanReply(tcis.getCanid());
@@ -155,42 +160,40 @@ public class CbusReporterTest extends jmri.implementation.AbstractReporterTestBa
         m.setElement(5, 0x01); // tag ID lo
         m.setElement(6, 0xff); // ddes3
         m.setElement(7, 0xAB); // ddes4
-        r4.reply(m);
-        r5.reply(m);
+        tcis.sendToListeners(m);
 
-        Assert.assertEquals("r4 state set",r4.describeState(IdTag.SEEN),r4.describeState(r4.getState()));
-        Assert.assertNotNull("r4 report set",r4.getCurrentReport());
-        Assert.assertEquals("r5 state unset",r5.describeState(IdTag.UNKNOWN),r5.describeState(r5.getState()));
-        Assert.assertNull("r5 report unset",r5.getCurrentReport());
+        assertEquals(r4.describeState(IdTag.SEEN),r4.describeState(r4.getState()), "r4 state set");
+        assertNotNull(r4.getCurrentReport(), "r4 report set");
+        assertEquals(r5.describeState(IdTag.UNKNOWN),r5.describeState(r5.getState()), "r5 state unset");
+        assertNull(r5.getCurrentReport(), "r5 report unset");
 
         IdTag tag = jmri.InstanceManager.getDefault(jmri.IdTagManager.class).getByTagID("1");
-        Assert.assertNotNull("tag created",tag);
+        assertNotNull(tag, "tag created");
 
         m.setElement(1, 0xff); // ev hi
         m.setElement(2, 0xfe); // ev lo
-        r4.reply(m);
-        r5.reply(m);
+        tcis.sendToListeners(m);
 
-        Assert.assertEquals("r5 tag seen",r5.describeState(IdTag.SEEN),r5.describeState(r5.getState()));
-        Assert.assertNotNull("r5 report set",r5.getCurrentReport());
-        Assert.assertEquals("r4 tag gone",r4.describeState(IdTag.UNSEEN),r4.describeState(r4.getState()));
-        Assert.assertNull("r4 report unset",r4.getCurrentReport());
+        assertEquals(r5.describeState(IdTag.SEEN),r5.describeState(r5.getState()), "r5 tag seen");
+        assertNotNull(r5.getCurrentReport(), "r5 report set");
+        assertEquals(r4.describeState(IdTag.UNSEEN),r4.describeState(r4.getState()), "r4 tag gone");
+        assertNull(r4.getCurrentReport(), "r4 report unset");
 
-        r5.reply(m); // same tag
-        Assert.assertEquals("r5 tag seen",r5.describeState(IdTag.SEEN),r5.describeState(r5.getState()));
-        Assert.assertNotNull("r5 report set",r5.getCurrentReport());
+        tcis.sendToListeners(m);
+        assertEquals(r5.describeState(IdTag.SEEN),r5.describeState(r5.getState()), "r5 tag seen");
+        assertNotNull(r5.getCurrentReport(), "r5 report set");
 
 
         m.setElement(4, 0xff); // tag ID hi
         m.setElement(5, 0xff); // tag ID lo
-        r5.reply(m); // same tag
-        Assert.assertEquals("r5 tag seen",r5.describeState(IdTag.SEEN),r5.describeState(r5.getState()));
-        Assert.assertNotNull("r5 report set",r5.getCurrentReport());
+        tcis.sendToListeners(m);
+        assertEquals(r5.describeState(IdTag.SEEN),r5.describeState(r5.getState()), "r5 tag seen");
+        assertNotNull(r5.getCurrentReport(), "r5 report set");
 
         tag = jmri.InstanceManager.getDefault(jmri.IdTagManager.class).getByTagID("65535");
-        Assert.assertNotNull("tag 65535 created",tag);
-        Assert.assertEquals("r5 tag seen 65535",tag,r5.getCurrentReport());
-        Assert.assertEquals("r5 tag seen 65535",r5,tag.getWhereLastSeen());
+        assertNotNull(tag, "tag 65535 created");
+        assertEquals(tag,r5.getCurrentReport(), "r5 tag seen 65535");
+        assertEquals(r5,tag.getWhereLastSeen(), "r5 tag seen 65535");
 
 
         r4.dispose();
@@ -206,12 +209,12 @@ public class CbusReporterTest extends jmri.implementation.AbstractReporterTestBa
 
         r.setProperty(CbusReporterManager.CBUS_MAINTAIN_SENSOR_DESCRIPTOR_KEY, true);
 
-        Assertions.assertNotNull(memo);
+        assertNotNull(memo);
         jmri.SensorManager sm = memo.get(jmri.SensorManager.class);
-        jmri.Sensor followerSensor = sm.getBySystemName(sm.createSystemName("+1",sm.getSystemPrefix()));
-        Assert.assertNull("No sensor at start",followerSensor);
+        Sensor followerSensor = sm.getBySystemName(sm.createSystemName("+1",sm.getSystemPrefix()));
+        assertNull(followerSensor, "No sensor at start");
 
-        CbusReporterManager rm = (CbusReporterManager) memo.get(jmri.ReporterManager.class);
+        CbusReporterManager rm = (CbusReporterManager) memo.get(ReporterManager.class);
         rm.setTimeout(30); // ms for testing
 
 
@@ -226,19 +229,19 @@ public class CbusReporterTest extends jmri.implementation.AbstractReporterTestBa
         m.setElement(6, 0x30); // tag4
         m.setElement(7, 0xAB); // tag5
         ((CbusReporter)r).reply(m);
-        r2.reply(m);
+        tcis.sendToListeners(m);
 
         followerSensor = sm.getBySystemName(sm.createSystemName("+1",sm.getSystemPrefix()));
-        Assert.assertNotNull("Sensor created by reporter",followerSensor);
-        Assert.assertEquals("sensor active", jmri.Sensor.ACTIVE, followerSensor.getState());
+        assertNotNull(followerSensor, "Sensor created by reporter");
+        assertEquals(Sensor.ACTIVE, followerSensor.getState(), "sensor active");
 
         m.setElement(2, 0x02); // ev lo
-        ((CbusReporter)r).reply(m);
+        tcis.sendToListeners(m);
         r2.reply(m);
 
         final int status = followerSensor.getState();
         JUnitUtil.waitFor(() -> {
-            return (status==jmri.Sensor.INACTIVE);
+            return (status==Sensor.INACTIVE);
         }, "sensor triggered to inactive when spot report complete");
 
     }
@@ -258,7 +261,7 @@ public class CbusReporterTest extends jmri.implementation.AbstractReporterTestBa
 
         memo.setProtocol(ConfigurationManager.MERGCBUS);
         memo.configureManagers();
-        r = new CbusReporter("1", memo);
+        r = memo.get(ReporterManager.class).provide("1");
     }
 
     @AfterEach
@@ -268,7 +271,7 @@ public class CbusReporterTest extends jmri.implementation.AbstractReporterTestBa
         if (r!=null) {
             r.dispose();
         }
-        Assertions.assertNotNull(memo);
+        assertNotNull(memo);
         memo.dispose();
         memo = null;
         tcis.terminateThreads();
@@ -279,6 +282,6 @@ public class CbusReporterTest extends jmri.implementation.AbstractReporterTestBa
 
     }
 
-    // private final static Logger log = LoggerFactory.getLogger(CbusReporterTest.class);
+    // private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(CbusReporterTest.class);
 
 }


### PR DESCRIPTION
Creates CbusReporter via CbusReporterManager
Send replies intended to reach CbusReporter via the traffic controller.
This tests the CanFrames are being routed OK via CbusReporterManager.

**TrafficControllerScaffold** (CAN)
Adds methods to distribute CanReply / CanMessage to listeners.

**AbstractReporterTestBase** testAddRemoveListener
Do not assert 0 listeners at start of test

Assertions JU4 > JU5