### PR TITLE
ArchitectureCheck - fix static override

### DIFF
--- a/java/test/jmri/ArchitectureCheck.java
+++ b/java/test/jmri/ArchitectureCheck.java
@@ -1,7 +1,5 @@
 package jmri;
 
-import org.junit.jupiter.api.*;
-
 import com.tngtech.archunit.junit.*;
 import com.tngtech.archunit.lang.*;
 import com.tngtech.archunit.library.freeze.*;


### PR DESCRIPTION
Use setUp / tearDown from inherited class.
Currently hiding static super methods.