### PR TITLE
Roster ALLENTRIES and  NOGROUPS symbol usage

### DIFF
--- a/java/src/jmri/jmrit/roster/RosterEntry.java
+++ b/java/src/jmri/jmrit/roster/RosterEntry.java
@@ -1145,8 +1145,8 @@ public class RosterEntry extends ArbitraryBean implements RosterObject, BasicRos
                 
                 // Special case:  If a No Name or All Entries
                 // group has been accidentally created, suppress that
-                if (key.equals(Roster.ROSTER_GROUP_PREFIX+"No Group") 
-                    || key.equals(Roster.ROSTER_GROUP_PREFIX+"All Entries")) {
+                if (key.equals(Roster.ROSTER_GROUP_PREFIX+Roster.NOGROUP) 
+                    || key.equals(Roster.ROSTER_GROUP_PREFIX+Roster.ALLENTRIES)) {
                         continue;
                     }
                     

--- a/java/src/jmri/jmrit/roster/swing/RosterGroupsPanel.java
+++ b/java/src/jmri/jmrit/roster/swing/RosterGroupsPanel.java
@@ -507,7 +507,7 @@ public class RosterGroupsPanel extends JPanel implements RosterGroupSelector {
                 if (RosterEntrySelection.rosterEntryFlavor.equals(flavor)) {
                     if (c instanceof JTree && ((JTree) c).getDropLocation() != null) {
                         var target = ((JTree) c).getDropLocation().getPath().getLastPathComponent().toString();
-                        if ("All Entries".equals(target) || "No Group".equals(target) ) {
+                        if (Roster.ALLENTRIES.equals(target) || Roster.NOGROUP.equals(target) ) {
                             return false;
                         } else {
                             return true;

--- a/java/src/jmri/jmrix/openlcb/swing/lccpro/Bundle.properties
+++ b/java/src/jmri/jmrix/openlcb/swing/lccpro/Bundle.properties
@@ -218,10 +218,7 @@ READMFG =  Reading Mfg Id CV 8
 READMFGVER =  Read MFG version - CV 7
 LONG\ ADDRESS\ -\ READ\ CV\ 18 = Long address - read CV 18
 
-ALLENTRIES = All Entries
-
 RosterEntryComboBoxNoSelection = Select Loco
-RosterGroupComboBoxNoGroups = No Groups
 RosterGroupComboBoxNoGroupsToolTip = No roster groups have been defined.
 
 EditOnly  = Edit Only

--- a/java/src/jmri/jmrix/openlcb/swing/lccpro/Bundle_cs.properties
+++ b/java/src/jmri/jmrix/openlcb/swing/lccpro/Bundle_cs.properties
@@ -218,8 +218,6 @@ READMFG = \u010cten\u00ed ID v\u00fdrobce CV 8
 READMFGVER = \u010cten\u00ed verze \u2013 CV 7 
 LONG\ ADDRESS\ -\ READ\ CV\ 18 = Dlouh\u00e1 adresa \u2013 \u010dten\u00ed CV 18
 
-ALLENTRIES = V\u0161echny z\u00e1znamy
-
 RosterEntryComboBoxNoSelection = Vybrat lokomotivu
 RosterGroupComboBoxNoGroups = \u017d\u00e1dn\u00e1 skupina
 RosterGroupComboBoxNoGroupsToolTip = Nebyla definovan\u00e1 \u017e\u00e1dn\u00e1 skupina evidence.


### PR DESCRIPTION
- Replace references to "All Entries" and "No Groups" strings with constant references from Roster
- Remove some unused symbols from LccPro bundles

Note:  This does not address the servers use of localized versions of those symbols.  That needs some further study.  If it's broken, nobody has reported it yet, so perhaps it's actually OK.