### PR TITLE
update Maven plugins : ant / failsafe / surefire 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -399,7 +399,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
-                <version>1.8</version><!--$NO-MVN-MAN-VER$-->
+                <version>3.2.0</version><!--$NO-MVN-MAN-VER$-->
                 <!-- above line-end comment silences warning in Eclipse -->
                 <!--
                 <executions>


### PR DESCRIPTION
Updates Maven Surefire / Failsafe 2.22.0 > 3.5.4
Adds dependency override to force surefire-junit-platform in test runs.
By default, surefire 3.0.0+ incorrectly auto-detects JUnit4 Test Runner instead of JUnit Platform Runner
https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-surefire-plugin

maven antrun plugin 1.8 > 3.2.0

Updates maven ant 1.10.11 > 1.10.14
Although not the latest version of ant, no harm in running this updated version for a while for full proving before moving to 1.10.15

Prevents 2 JUnit properties found warning
Adds undeclared JUnit dependencies