### PR TITLE
fix: Empty MCAN message on JMRI shutdown

### DIFF
--- a/java/src/jmri/jmrix/marklin/MarklinMessage.java
+++ b/java/src/jmri/jmrix/marklin/MarklinMessage.java
@@ -310,11 +310,11 @@ public class MarklinMessage extends jmri.jmrix.AbstractMRMessage {
     }
 
     public static MarklinMessage getProgMode() {
-        return new MarklinMessage();
+        return null;
     }
 
     public static MarklinMessage getExitProgMode() {
-        return new MarklinMessage();
+        return null;
     }
 
     public static MarklinMessage getReadPagedCV(int cv) { //Rxxx

--- a/java/src/jmri/jmrix/marklin/MarklinTrafficController.java
+++ b/java/src/jmri/jmrix/marklin/MarklinTrafficController.java
@@ -97,7 +97,7 @@ public class MarklinTrafficController extends AbstractMRTrafficController implem
 
     /**
      * Marklin doesn't support this function.
-     * @return empty Marklin Message.
+     * @return null as no message is needed.
      */
     @Override
     protected AbstractMRMessage enterProgMode() {
@@ -106,7 +106,7 @@ public class MarklinTrafficController extends AbstractMRTrafficController implem
 
     /**
      * Marklin doesn't support this function.
-     * @return empty Marklin Message.
+     * @return null as no message is needed.
      */
     @Override
     protected AbstractMRMessage enterNormalMode() {


### PR DESCRIPTION
In the final comments of issue #14104 a CAN message log shows we send an invalid package when JMRI shuts down.

It turns out during JMRI shutdown, AbstractMRTrafficController.terminate():1239 calls enterNormalMode(), which in turn calls getExitProgMode(). This emits the malformed message instead of just doing nothing.

@ghfbsd Once this has passed the usual round of formal tests and a test build exist I'd like your opinion.


The way we currently build MarklinMessage and MarklinReply objects is error prone. We first initialize an invalid message object and then change it after the fact. In a future PR I will try to provide a more test-friendly framework for coding and decoding MCAN messages from/into MarklinMessage and MarklinReply types. For now, only the bug fix.