### PR TITLE
Ant version - warnings / warnings-check targets

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -485,7 +485,9 @@
         </filterset>
     </target>
 
-    <target name="check-ant-requirements"> <!-- check build system requirements, not for user use -->
+    <!-- check build system requirements, not for user use -->
+    <!-- Used in the warnings and warnings-check targets -->
+    <target name="check-ant-requirements"> 
       <antversion property="ant-version-ok" atleast="1.10.6"/>
       <antversion property="ant-version-actual"/>
       <fail unless="ant-version-ok" message="Minimum ant version required is 1.10.6, this is ${ant-version-actual}"/>


### PR DESCRIPTION
Bump minimum ant version from 1.8.0 > 1.10.6
https://mvnrepository.com/artifact/org.apache.ant/ant/versions

Minimum ant version is checked on call to the ant targets `warnings` and `warnings-check`

1.10.6 was chosen as it's the version used on the main build server.
When that version is updated it would be good to also increase this minimum version.

Very unlikely that this will force a deveoper to update their version.
If it does, the error message in the build advising this is straight-foward.