### PR TITLE
Prefer use of perNode hostname and port number if available in configuration

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -1,7 +1,11 @@
 
     <h3>Hardware Support</h3>
         <ul>
-          <li></li>
+            <li>Network connections now take their host name/address and port number
+                from the per-node individual configuration, if available,
+                and from the shared configurations is not.  This will allow
+                you to have different host name/address for different
+                computers sharing the same JMRI profile.</li>
         </ul>
 
         <h4>Acela CTI</h4>

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -3,7 +3,7 @@
         <ul>
             <li>Network connections now take their host name/address and port number
                 from the per-node individual configuration, if available,
-                and from the shared configurations is not.  This will allow
+                and from the shared configurations if not.  This will allow
                 you to have different host name/address for different
                 computers sharing the same JMRI profile.</li>
         </ul>

--- a/java/src/jmri/jmrix/configurexml/AbstractNetworkConnectionConfigXml.java
+++ b/java/src/jmri/jmrix/configurexml/AbstractNetworkConnectionConfigXml.java
@@ -141,13 +141,17 @@ abstract public class AbstractNetworkConnectionConfigXml extends AbstractConnect
             // configure host name
             String hostName = null;
             try {
-                hostName = shared.getAttribute("address").getValue();
+                var attr = perNode.getAttribute("address");
+                if (attr == null) attr = shared.getAttribute("address");
+                hostName = attr.getValue();
             } catch (NullPointerException ex) {  // considered normal if the attributes are not present
             }
             adapter.setHostName(hostName);
 
             try {
-                int port = shared.getAttribute("port").getIntValue();
+                var attr = perNode.getAttribute("port");
+                if (attr == null) attr = shared.getAttribute("port");
+                int port = attr.getIntValue();
                 adapter.setPort(port);
             } catch (org.jdom2.DataConversionException ex) {
                 log.warn("Could not parse port attribute: {}", shared.getAttribute("port"));


### PR DESCRIPTION
Network connections now take their host name/address and port number from the per-node individual configuration, if available, and from the shared configurations is not.  This will allow the user to have different host name/address for different computers sharing the same JMRI profile.