### PR TITLE
Fix for #14752 

### DIFF
--- a/java/src/jmri/util/swing/OptionallyTabbedPanel.java
+++ b/java/src/jmri/util/swing/OptionallyTabbedPanel.java
@@ -123,7 +123,8 @@ public class OptionallyTabbedPanel extends JPanel {
         }
         tabbedPane.removeAll();
         singlePane.removeAll();
-
+        tabbedPane.setVisible(false);
+        singlePane.setVisible(true);
     }
 
 }


### PR DESCRIPTION
bug in removeAll of OptionallyTabbedPanel, when called single pane should be visible and tabbed hidden.

Fix for #14752 