### PR TITLE
Update copyright and update update instructions

### DIFF
--- a/help/en/parts/Footer.shtml
+++ b/help/en/parts/Footer.shtml
@@ -9,8 +9,8 @@
         group.
         </p>
 
-        <p>Copyright &copy; 1997 - 2024 JMRI Community.
-        JMRI&reg;, DecoderPro&reg;, PanelPro&trade;, DispatcherPro&trade;, OperationsPro&trade;, SignalPro&trade;, SoundPro&trade;, LccPro&trade;, TrainPro&trade;, Logix&trade;, LogixNG&trade; and associated logos are our trademarks.
+       <p>Copyright &copy; 1997 - 2026 JMRI Community.
+       JMRI&reg;, DecoderPro&reg;, PanelPro&trade;, DispatcherPro&trade;, OperationsPro&trade;, SignalPro&trade;, SoundPro&trade;, TrainPro&trade;, Logix&trade;, LogixNG&trade; and associated logos are our trademarks.
         <a href="/copyright.shtml">Additional information on copyright, trademarks and licenses is linked here.</a>
         </p>
 

--- a/scripts/HOWTO-distribution.md
+++ b/scripts/HOWTO-distribution.md
@@ -130,6 +130,7 @@ This is the next release in the 5.15 cycle. It's intended to be created from the
     JMRI:
     * build.xml in the jmri.copyright.years property value
     * project.properties
+    * help/en/parts/Footer.shtml
     * xml/XSLT/build.xml
     * A flock of .xsl files in xml/XSLT/
     * scripts/WinInstallFiles/LaunchJMRI.nsi


### PR DESCRIPTION
Fixed overlooked copyright reference in a footer include, and fix the instructions for updating copyrights.

Thanks to @PUlvestad for noticing this!