### PR TITLE
Improve RFID decoding for MERG CBUS implementations

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -101,7 +101,8 @@
 
         <h4>MERG</h4>
             <ul>
-                <li></li>
+                <li>Fixed a problem introduced in 5.15.4 where some RFID messages
+                    would be improperly decoded as RailCom reports.</li>
             </ul>
 
         <h4>MQTT</h4>

--- a/java/src/jmri/jmrix/can/cbus/CbusReporter.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusReporter.java
@@ -122,7 +122,12 @@ public class CbusReporter extends AbstractRailComReporter implements CanListener
             if (m.getOpCode() == CbusConstants.CBUS_DDES && !getCbusReporterType().equals(CbusReporterManager.CBUS_REPORTER_TYPE_CLASSIC)  ) {
                 ddesReport(m);
             } else {
-                classicRFIDReport(m);
+                int least_significant_bit = m.getElement(3) & 1;
+                if ( least_significant_bit == 0 ) {
+                    classicRFIDReport(m);
+                } else {
+                    canRcomReport(m);
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes something that was recently broken by the addition of RailCom support