### PR TITLE
LCC usability updates

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -129,6 +129,10 @@
             <ul>
                 <li>Updated the OpenLCB_Java library to include an 
                     improvement in how unknown-MTI messages are displayed.</li>
+                <li>The event-entry field on the Send Frame panel will now 
+                    allow entry of event names.</li>
+                <li>The popup menu on event entry fields now lets you copy
+                    the numerical event ID even if a event name has been entered.</li>
             </ul>
 
         <h4>Powerline</h4>

--- a/java/src/jmri/jmrix/openlcb/swing/NamedEventIdTextField.java
+++ b/java/src/jmri/jmrix/openlcb/swing/NamedEventIdTextField.java
@@ -1,11 +1,16 @@
 package jmri.jmrix.openlcb.swing;
 
+import java.awt.Toolkit;
+import java.awt.datatransfer.*;
 import java.awt.event.*;
+
+import javax.swing.*;
 
 import jmri.util.swing.*;
 import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.jmrix.openlcb.OlcbAddress;
 
+import org.openlcb.EventID;
 import org.openlcb.swing.EventIdTextField;
 
 /**
@@ -48,8 +53,31 @@ public class NamedEventIdTextField extends OvertypeTextArea {
             @Override public void focusLost(FocusEvent e) {}
         });
 
-        EventIdTextField.configurePopUp(this);
-        
+        var popup = EventIdTextField.createPopupMenu(this);
+        // add a custom copy operator to capture the numerical value
+        JMenuItem menuItem = new JMenuItem("Copy Numerical Event ID");
+        popup.add(menuItem);
+        var self = this;
+        menuItem.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                String s = new OlcbAddress(self.getText(), memo).toDottedString();
+                SwingUtilities.invokeLater(new Runnable() {
+                    @Override
+                    public void run() {
+                        self.selectAll();
+                    }
+                });
+                StringSelection eventToCopy = new StringSelection(s);
+                Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
+                clipboard.setContents(eventToCopy, new ClipboardOwner() {
+                    @Override
+                    public void lostOwnership(Clipboard clipboard, Transferable transferable) {
+                    }
+                });
+            }
+        });
+        this.setComponentPopupMenu(popup);
     }
 
     final CanSystemConnectionMemo memo;
@@ -61,6 +89,10 @@ public class NamedEventIdTextField extends OvertypeTextArea {
         }
         return "Enter an event ID or event name";
     }    
+    
+    public EventID getEventID() {
+        return new EventID(new OlcbAddress(getText(), memo).toDottedString());
+    }
     
     // private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(NamedEventIdTextField.class);
 }

--- a/java/src/jmri/jmrix/openlcb/swing/send/OpenLcbCanSendPane.java
+++ b/java/src/jmri/jmrix/openlcb/swing/send/OpenLcbCanSendPane.java
@@ -11,7 +11,6 @@ import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
 import javax.swing.JComponent;
-import javax.swing.JFormattedTextField;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JSeparator;
@@ -25,6 +24,7 @@ import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.jmrix.can.TrafficController;
 import jmri.jmrix.can.cbus.CbusAddress;
 import jmri.jmrix.openlcb.swing.ClientActions;
+import jmri.jmrix.openlcb.swing.NamedEventIdTextField;
 import jmri.util.StringUtil;
 import jmri.util.javaworld.GridLayout2;
 import jmri.util.swing.WrapLayout;
@@ -32,7 +32,6 @@ import jmri.util.swing.WrapLayout;
 import org.openlcb.*;
 import org.openlcb.can.AliasMap;
 import org.openlcb.implementations.MemoryConfigurationService;
-import org.openlcb.swing.EventIdTextField;
 import org.openlcb.swing.NodeSelector;
 import org.openlcb.swing.MemorySpaceSelector;
 
@@ -64,7 +63,7 @@ public class OpenLcbCanSendPane extends jmri.jmrix.can.swing.CanPanel implements
 
     final JTextField srcAliasField = new JTextField(4);
     NodeSelector nodeSelector;
-    final JFormattedTextField sendEventField = new EventIdTextField();// NOI18N
+    NamedEventIdTextField sendEventField;
     final JTextField datagramContentsField = new JTextField("20 61 00 00 00 00 08");  // NOI18N
     final JTextField configNumberField = new JTextField("40");                        // NOI18N
     final JTextField configAddressField = new JTextField("000000");                   // NOI18N
@@ -99,6 +98,8 @@ public class OpenLcbCanSendPane extends jmri.jmrix.can.swing.CanPanel implements
         srcNodeID = memo.get(org.openlcb.NodeID.class);
         aliasMap = memo.get(org.openlcb.can.AliasMap.class);
 
+        sendEventField = new NamedEventIdTextField(memo);
+        
         // register request for notification
         Connection.ConnectionListener cl = new Connection.ConnectionListener() {
             @Override
@@ -418,8 +419,7 @@ public class OpenLcbCanSendPane extends jmri.jmrix.can.swing.CanPanel implements
     }
 
     EventID eventID() {
-        return new EventID(jmri.util.StringUtil.bytesFromHexString(sendEventField.getText()
-                .replace(".", " ")));
+        return sendEventField.getEventID();
     }
 
     public void sendVerifyNodeGlobal(java.awt.event.ActionEvent e) {

--- a/java/test/jmri/jmrix/openlcb/swing/send/OpenLcbCanSendPaneTest.java
+++ b/java/test/jmri/jmrix/openlcb/swing/send/OpenLcbCanSendPaneTest.java
@@ -44,6 +44,8 @@ public class OpenLcbCanSendPaneTest extends jmri.util.swing.JmriPanelTest {
         assumeFalse( Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"), "Ignoring intermittent test");
         OpenLcbCanSendPane p = (OpenLcbCanSendPane) panel;
 
+        panel.initContext(memo);
+
         p.sendEventField.setText("05.01.01.01.14.FF.01.02");
         EventID expected = new EventID(new byte[]{0x05, 0x01, 0x01, 0x01, 0x14, (byte) 0xff, 0x01, 0x02});
         assertEquals(expected, p.eventID());
@@ -53,6 +55,8 @@ public class OpenLcbCanSendPaneTest extends jmri.util.swing.JmriPanelTest {
     public void testEventIdDotted() {
         assumeFalse( Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"), "Ignoring intermittent test");
         OpenLcbCanSendPane p = (OpenLcbCanSendPane) panel;
+
+        panel.initContext(memo);
 
         p.sendEventField.setText("05.01.01.01.14.FF.01.02");
         EventID expected = new EventID(new byte[]{0x05, 0x01, 0x01, 0x01, 0x14, (byte) 0xff, 0x01, 0x02});


### PR DESCRIPTION
* Allow user to enter an event name on the Send Frame panel
* Provide a popup item on event-entry fields to copy the raw numerical value
* Some minor refactoring.