### PR TITLE
Make Event Name Table storage format more flexible

### DIFF
--- a/help/en/package/jmri/jmrix/openlcb/swing/eventtable/EventTablePane.shtml
+++ b/help/en/package/jmri/jmrix/openlcb/swing/eventtable/EventTablePane.shtml
@@ -156,6 +156,15 @@
                 in the 1st column and the desired name in the second column.
                 A header row, if present, is ignored. Extra columns are ignored.
         </ul>
+    
+    The table's information is automatically stored within an "eventnames/eventNames.xml" file
+    within your profile directory. Should you want to merge the event names from two or more
+    profiles, you can copy the "names" element and its contents from one file into the
+    end of another file.  I.e. you can have more than one "names" element in the file,
+    and they will be combined the next time the file is written out.  Duplicate names
+    for an event (i.e. same name appearing twice for the same event) in the file are not a problem,
+    they are automatically handled.
+    
       <!--#include virtual="/help/en/parts/Footer.shtml" -->
     </div>
   </div>

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -126,7 +126,9 @@
 
         <h4><a href="http://openlcb.org">OpenLCB</a> / LCC</h4>
             <ul>
-                <li></li>
+                <li>(Internal) The load and store process for the Event Table
+                    now permits multiple "names" elements. This makes it easier
+                    to merge Event Table information from several profiles.</li>
             </ul>
 
         <h4>Powerline</h4>

--- a/java/src/jmri/jmrix/openlcb/configurexml/OlcbEventNameStoreXml.java
+++ b/java/src/jmri/jmrix/openlcb/configurexml/OlcbEventNameStoreXml.java
@@ -209,13 +209,17 @@ public final class OlcbEventNameStoreXml extends XmlFile {
 
         // Now read name-id mapping information
         if (root.getChild("names") != null) { // NOI18N
-            List<Element> l = root.getChild("names").getChildren("entry"); // NOI18N
-            log.debug("readFile sees {} event names", l.size());
-            for (Element e : l) {
-                String eid = e.getChild("eventID").getText(); // NOI18N
-                String name = e.getChild("name").getText();
-                log.debug("read EventID {}", eid);
-                nameStore.addMatch(new EventID(eid), name);
+            List<Element> names = root.getChildren("names");
+            log.debug("readFile sees {} names elements", names.size());
+            for (Element n : names) {
+                List<Element> l = n.getChildren("entry"); // NOI18N
+                log.debug("    readFile sees {} event names", l.size());
+                for (Element e : l) {
+                    String eid = e.getChild("eventID").getText(); // NOI18N
+                    String name = e.getChild("name").getText();
+                    log.debug("        read EventID {}", eid);
+                    nameStore.addMatch(new EventID(eid), name);
+                }
             }
         }
     }


### PR DESCRIPTION
Make the event name table storage mechanism more flexible to make it easier to merge two name files, e.g. from two profiles.