### PR TITLE
Sort replacement icon files by name

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -499,6 +499,8 @@
                 in fewer spurious changes if you're e.g. storing panel files in a
                 tracking system like Git.</li>
             <li>Fixed a problem when storing and loading the new Output Indicator icons</li>
+            <li>When changing icon images for turnouts, sensors and signal heads, the
+                resource files are now listed in alpha order by name.</li>
         </ul>
 
         <h4>NX - Entry/Exit Tool</h4>

--- a/java/src/jmri/jmrit/catalog/CatalogTreeModel.java
+++ b/java/src/jmri/jmrit/catalog/CatalogTreeModel.java
@@ -75,6 +75,9 @@ public class CatalogTreeModel extends DefaultTreeModel implements InstanceManage
                 return;
             }
 
+            // put in alpha order by filename
+            java.util.Arrays.sort(sp);
+            
             for (String item : sp) {
                 log.trace("Descend into resource: {}", item);
                 insertResourceNodes(item, pPath + "/" + item, newElement);
@@ -112,10 +115,15 @@ public class CatalogTreeModel extends DefaultTreeModel implements InstanceManage
             // work on the kids
             String[] sp = fp.list();
             if (sp!=null) {
+
+                // put in alpha order by filename
+                java.util.Arrays.sort(sp);
+
                 for (String sp1 : sp) {
                     log.debug("Descend into file: {}",sp1);
                     insertFileNodes(sp1, path + "/" + sp1, newElement);
                 }
+
             }
         }
     }


### PR DESCRIPTION
When changing icons for sensors, turnouts and signal heads in Layout Editor edit mode, the resource files are listed in name order.