### PR TITLE
WIP - Listen on when a connection connects/disconnects

### DIFF
--- a/java/src/jmri/jmrix/AbstractNetworkPortController.java
+++ b/java/src/jmri/jmrix/AbstractNetworkPortController.java
@@ -38,6 +38,27 @@ abstract public class AbstractNetworkPortController extends AbstractPortControll
         connect();
     }
 
+    private long lastAttemptingOpeningConnectionTime = 0;
+    private long lastErrorOpeningConnectionTime = 0;
+
+    private void logAttemptingOpeningConnectionMessage(String hostName, int port) {
+        // Show a message no more often than 30 seconds.
+        // This is relevant when trying to reconnect.
+        if ((System.currentTimeMillis() - lastAttemptingOpeningConnectionTime) > 30*1000) {
+            log.info("Attempting to open connection to {}:{}", hostName, port);
+            lastAttemptingOpeningConnectionTime = System.currentTimeMillis();
+        }
+    }
+
+    private void logErrorOpeningConnectionMessage(String hostName, String exceptionMessage) {
+        // Show a message no more often than 30 seconds.
+        // This is relevant when trying to reconnect.
+        if ((System.currentTimeMillis() - lastErrorOpeningConnectionTime) > 30*1000) {
+            log.warn("Error opening network connection to {} because {}", hostName, exceptionMessage);
+            lastErrorOpeningConnectionTime = System.currentTimeMillis();
+        }
+    }
+
     @Override
     public void connect() throws IOException {
         log.debug("connect() starts to {}:{}", getHostName(), getPort());
@@ -48,13 +69,16 @@ abstract public class AbstractNetworkPortController extends AbstractPortControll
         }
         try {
             var address = getHostAddress();
-            log.info("Attempting to open connection to {}:{}", address, m_port);
+            // Show connection message, but not too often
+            logAttemptingOpeningConnectionMessage(address, m_port);
             socketConn = new Socket(address, m_port);
             socketConn.setKeepAlive(true);
             socketConn.setSoTimeout(getConnectionTimeout());
             opened = true;
+            notifyOpenedConnection();
         } catch (IOException e) {
-            log.error("Error opening network connection to {} because {}", getHostName(), e.getMessage()); // nothing to help user in full exception
+            // Show exception message, but not too often
+            logErrorOpeningConnectionMessage(getHostName(), e.getMessage()); // nothing to help user in full exception
             if (m_port != 0) {
                 ConnectionStatus.instance().setConnectionState(
                         getUserName(), m_HostName + ":" + m_port, ConnectionStatus.CONNECTION_DOWN);
@@ -284,7 +308,7 @@ abstract public class AbstractNetworkPortController extends AbstractPortControll
         }
         return null;
     }
-    
+
     /**
      * {@inheritDoc}
      */
@@ -296,6 +320,7 @@ abstract public class AbstractNetworkPortController extends AbstractPortControll
             log.trace("Unable to close socket", e);
         }
         opened=false;
+        notifyClosedConnection();
     }
 
     /**
@@ -305,7 +330,7 @@ abstract public class AbstractNetworkPortController extends AbstractPortControll
     @Override
     protected void resetupConnection() {
     }
-    
+
     /**
      * {@inheritDoc}
      */

--- a/java/src/jmri/jmrix/AbstractPortController.java
+++ b/java/src/jmri/jmrix/AbstractPortController.java
@@ -5,8 +5,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Set;
+import java.util.*;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
@@ -27,6 +26,44 @@ import jmri.SystemConnectionMemo;
  * @author Bob Jacobsen Copyright (C) 2001, 2002
  */
 abstract public class AbstractPortController implements PortAdapter {
+
+    private final List<ConnectionListener> connectedListeners = new ArrayList<>();
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void addConnectionListener(ConnectionListener l) {
+        connectedListeners.add(l);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void removeConnectionListener(ConnectionListener l) {
+        connectedListeners.remove(l);
+    }
+
+    /**
+     * Notify listeners that the connection has been opened.
+     */
+    public void notifyOpenedConnection() {
+        log.debug("Notify opened connection: {}", this);
+        for (var l : connectedListeners) {
+            l.connected(this);
+        }
+    }
+
+    /**
+     * Notify listeners that the connection has been closed.
+     */
+    public void notifyClosedConnection() {
+        log.debug("Notify closed connection: {}", this);
+        for (var l : connectedListeners) {
+            l.disconnected(this);
+        }
+    }
 
     /**
      * {@inheritDoc}

--- a/java/src/jmri/jmrix/PortAdapter.java
+++ b/java/src/jmri/jmrix/PortAdapter.java
@@ -13,11 +13,11 @@ import jmri.SystemConnectionMemo;
  * connection types (network, serial, etc).
  * <p>
  * For historical reasons, this provides both four specific options (option1 to option4)
- * plus a more flexible interface based on a String array.  The more flexible 
- * interface is the preferred one for new work, but the 1-4 form hasn't been 
+ * plus a more flexible interface based on a String array.  The more flexible
+ * interface is the preferred one for new work, but the 1-4 form hasn't been
  * deprecated yet.
  * <p>
- * General design documentation is available on the 
+ * General design documentation is available on the
  * <a href="http://jmri.org/help/en/html/doc/Technical/SystemStructure.shtml">Structure of External System Connections page</a>.
  *
  * @author Bob Jacobsen Copyright (C) 2001, 2003, 2008, 2010
@@ -25,6 +25,30 @@ import jmri.SystemConnectionMemo;
  * @since 2.3.1
  */
 public interface PortAdapter {
+
+
+    public interface ConnectionListener {
+
+        void connected(PortAdapter adapter);
+
+        void disconnected(PortAdapter adapter);
+
+    }
+
+
+    /**
+     * Add a connection listener.
+     *
+     * @param l the listener
+     */
+    void addConnectionListener(ConnectionListener l);
+
+    /**
+     * Remove a connection listener.
+     *
+     * @param l the listener
+     */
+    void removeConnectionListener(ConnectionListener l);
 
     /**
      * Configure all of the other jmrix widgets needed to work with this adapter.
@@ -144,14 +168,14 @@ public interface PortAdapter {
      * @return true for text representation preferred
      */
     boolean isOptionTypeText(String option);
-    
+
     /**
      * Should this option be represented by a password field
      * @param option Name of the option to check
      * @return true for text representation preferred
      */
     boolean isOptionTypePassword(String option);
-    
+
     /**
      * Get the system manufacturer's name.
      *
@@ -251,26 +275,26 @@ public interface PortAdapter {
      * @return true if application needs to restart, false otherwise
      */
     boolean isRestartRequired();
-    
+
     /**
      * Set the maximum interval between reconnection attempts.
      * @param maxInterval in seconds.
      */
     void setReconnectMaxInterval(int maxInterval);
-    
+
     /**
      * Set the maximum number of reconnection attempts.
      * -1 will set an infinite number of attempts.
      * @param maxAttempts total maximum reconnection attempts.
      */
     void setReconnectMaxAttempts(int maxAttempts);
-    
+
     /**
      * Get the maximum interval between reconnection attempts.
      * @return maximum interval in seconds.
      */
     int getReconnectMaxInterval();
-    
+
     /**
      * Get the maximum number of reconnection attempts which should be made.
      * A value of -1 means no maximum value, i.e. infinite attempts.

--- a/java/src/jmri/jmrix/bidib/BiDiBNetworkPortController.java
+++ b/java/src/jmri/jmrix/bidib/BiDiBNetworkPortController.java
@@ -6,7 +6,6 @@ import org.bidib.jbidibc.core.BidibInterface;
 import org.bidib.jbidibc.core.MessageListener;
 import org.bidib.jbidibc.core.NodeListener;
 import org.bidib.jbidibc.core.node.listener.TransferListener;
-import org.bidib.jbidibc.messages.ConnectionListener;
 import org.bidib.jbidibc.messages.helpers.Context;
 import org.bidib.jbidibc.messages.helpers.DefaultContext;
 
@@ -27,7 +26,7 @@ public abstract class BiDiBNetworkPortController extends jmri.jmrix.AbstractNetw
 
     @Override
     public abstract void connect(String host, int port) throws IOException;
-    
+
     /**
      * {@inheritDoc}
      */
@@ -40,31 +39,34 @@ public abstract class BiDiBNetworkPortController extends jmri.jmrix.AbstractNetw
 
     /**
      * Get the physical port name used with jbidibc
-     * 
+     *
      * @return physical port name
      */
     @Override
     public String getRealPortName() {
         return getCurrentPortName(); //default implemention
     }
-    
+
     /**
      * Register all Listeners to the specific BiDiB Object.
      * We need this here since the BidibInterface does not
      * provide this method.
-     * 
+     *
      * @param connectionListener add to this
      * @param nodeListeners listeners to add
      * @param messageListeners listeners to add
      * @param transferListeners  listeners to add
-     */    
+     */
     @Override
-    public abstract void registerAllListeners(ConnectionListener connectionListener, Set<NodeListener> nodeListeners,
-        Set<MessageListener> messageListeners, Set<TransferListener> transferListeners);
-    
+    public abstract void registerAllListeners(
+            org.bidib.jbidibc.messages.ConnectionListener connectionListener,
+            Set<NodeListener> nodeListeners,
+            Set<MessageListener> messageListeners,
+            Set<TransferListener> transferListeners);
+
     /**
      * Get the Bidib adapter context
-     * 
+     *
      * @return Context
      */
     @Override

--- a/java/src/jmri/jmrix/bidib/BiDiBPortController.java
+++ b/java/src/jmri/jmrix/bidib/BiDiBPortController.java
@@ -4,7 +4,6 @@ import java.util.Set;
 import org.bidib.jbidibc.core.MessageListener;
 import org.bidib.jbidibc.core.NodeListener;
 import org.bidib.jbidibc.core.node.listener.TransferListener;
-import org.bidib.jbidibc.messages.ConnectionListener;
 import org.bidib.jbidibc.messages.helpers.Context;
 
 /**
@@ -15,27 +14,30 @@ public interface BiDiBPortController extends jmri.jmrix.PortAdapter {
 
     /**
      * Get the physical port name used with jbidibc
-     * 
+     *
      * @return physical port name
      */
     public String getRealPortName();
-    
+
     /**
      * Register all Listeners to the specific BiDiB Object.
      * We need this here since the BidibInterface does not
      * provide this method.
-     * 
+     *
      * @param connectionListener register to this
-     * @param nodeListeners listeners to add 
-     * @param messageListeners listeners to add 
-     * @param transferListeners  listeners to add 
-     */    
-    public abstract void registerAllListeners(ConnectionListener connectionListener, Set<NodeListener> nodeListeners,
-        Set<MessageListener> messageListeners, Set<TransferListener> transferListeners);
-    
+     * @param nodeListeners listeners to add
+     * @param messageListeners listeners to add
+     * @param transferListeners  listeners to add
+     */
+    public abstract void registerAllListeners(
+            org.bidib.jbidibc.messages.ConnectionListener connectionListener,
+            Set<NodeListener> nodeListeners,
+            Set<MessageListener> messageListeners,
+            Set<TransferListener> transferListeners);
+
     /**
      * Get the Bidib adapter context
-     * 
+     *
      * @return Context
      */
     public Context getContext();

--- a/java/src/jmri/jmrix/bidib/BiDiBSerialPortController.java
+++ b/java/src/jmri/jmrix/bidib/BiDiBSerialPortController.java
@@ -1,11 +1,11 @@
 package jmri.jmrix.bidib;
 
 import java.util.Set;
+
 import org.bidib.jbidibc.core.BidibInterface;
 import org.bidib.jbidibc.core.MessageListener;
 import org.bidib.jbidibc.core.NodeListener;
 import org.bidib.jbidibc.core.node.listener.TransferListener;
-import org.bidib.jbidibc.messages.ConnectionListener;
 import org.bidib.jbidibc.messages.helpers.Context;
 import org.bidib.jbidibc.messages.helpers.DefaultContext;
 
@@ -25,7 +25,7 @@ public abstract class BiDiBSerialPortController extends jmri.jmrix.AbstractSeria
     }
 
     // Implementation of the BiDiBPortController interface
-    
+
     /**
      * {@inheritDoc}
      */
@@ -36,31 +36,34 @@ public abstract class BiDiBSerialPortController extends jmri.jmrix.AbstractSeria
 
     /**
      * Get the physical port name used with jbidibc
-     * 
+     *
      * @return physical port name
      */
     @Override
     public String getRealPortName() {
         return getCurrentPortName(); //default implemention
     }
-    
+
     /**
      * Register all Listeners to the specific BiDiB Object.
      * We need this here since the BidibInterface does not
      * provide this method.
-     * 
+     *
      * @param connectionListener where to add
      * @param nodeListeners listeners to add
      * @param messageListeners listeners to add
      * @param transferListeners listeners to add
-     */    
+     */
     @Override
-    public abstract void registerAllListeners(ConnectionListener connectionListener, Set<NodeListener> nodeListeners,
-        Set<MessageListener> messageListeners, Set<TransferListener> transferListeners);
-    
+    public abstract void registerAllListeners(
+            org.bidib.jbidibc.messages.ConnectionListener connectionListener,
+            Set<NodeListener> nodeListeners,
+            Set<MessageListener> messageListeners,
+            Set<TransferListener> transferListeners);
+
     /**
      * Get the Bidib adapter context
-     * 
+     *
      * @return Context
      */
     @Override

--- a/java/src/jmri/jmrix/bidib/bidibovertcp/BiDiBOverTcpAdapter.java
+++ b/java/src/jmri/jmrix/bidib/bidibovertcp/BiDiBOverTcpAdapter.java
@@ -7,10 +7,10 @@ import java.util.Set;
 
 import jmri.jmrix.bidib.BiDiBNetworkPortController;
 import jmri.jmrix.bidib.BiDiBTrafficController;
+
 import org.bidib.jbidibc.core.MessageListener;
 import org.bidib.jbidibc.core.NodeListener;
 import org.bidib.jbidibc.core.node.listener.TransferListener;
-import org.bidib.jbidibc.messages.ConnectionListener;
 import org.bidib.jbidibc.net.serialovertcp.NetBidib;
 import org.bidib.jbidibc.messages.helpers.Context;
 
@@ -23,7 +23,7 @@ import org.slf4j.LoggerFactory;
  * <p>
  * This connects a DCC++ via a telnet connection. Normally controlled by the
  * DCCppTcpDriverFrame class.
- * 
+ *
  *
  * @author Bob Jacobsen Copyright (C) 2001, 2002, 2003
  * @author Alex Shepherd Copyright (C) 2003, 2006
@@ -38,7 +38,7 @@ public class BiDiBOverTcpAdapter extends BiDiBNetworkPortController {
         //super(new BiDiBSystemConnectionMemo());
         setManufacturer(jmri.jmrix.bidib.BiDiBConnectionTypeList.BIDIB);
     }
-    
+
     @Override
     public void connect(String host, int port) throws IOException {
         setHostName(host);
@@ -49,7 +49,7 @@ public class BiDiBOverTcpAdapter extends BiDiBNetworkPortController {
     /**
      * This methods is called from network connection config and creates the BiDiB object from jbidibc and opens it.
      * The connectPort method of the traffic controller is called for generic initialisation.
-     * 
+     *
      */
     @Override
     public void connect() {// throws IOException {
@@ -72,7 +72,7 @@ public class BiDiBOverTcpAdapter extends BiDiBNetworkPortController {
         }
     }
 
-    
+
     @Override
     public void configure() {
         log.debug("configure");
@@ -83,14 +83,17 @@ public class BiDiBOverTcpAdapter extends BiDiBNetworkPortController {
      * {@inheritDoc}
      */
     @Override
-    public void registerAllListeners(ConnectionListener connectionListener, Set<NodeListener> nodeListeners,
-                Set<MessageListener> messageListeners, Set<TransferListener> transferListeners) {
-        
+    public void registerAllListeners(
+            org.bidib.jbidibc.messages.ConnectionListener connectionListener,
+            Set<NodeListener> nodeListeners,
+            Set<MessageListener> messageListeners,
+            Set<TransferListener> transferListeners) {
+
         NetBidib b = (NetBidib)bidib;
         b.setConnectionListener(connectionListener);
         b.registerListeners(nodeListeners, messageListeners, transferListeners);
     }
-    
+
     // base class methods for the BiDiBNetworkPortController interface
     // not used but must be implemented
 
@@ -107,5 +110,5 @@ public class BiDiBOverTcpAdapter extends BiDiBNetworkPortController {
 
     private static final Logger log = LoggerFactory.getLogger(BiDiBOverTcpAdapter.class);
 
-    
+
 }

--- a/java/src/jmri/jmrix/bidib/netbidib/NetBiDiBAdapter.java
+++ b/java/src/jmri/jmrix/bidib/netbidib/NetBiDiBAdapter.java
@@ -7,7 +7,9 @@ import java.io.DataOutputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Set;
+
 import jmri.util.FileUtil;
+
 import java.util.Enumeration;
 import java.util.ArrayList;
 import java.util.List;
@@ -17,9 +19,11 @@ import java.net.InetAddress;
 import java.net.NetworkInterface;
 import java.net.UnknownHostException;
 import java.util.Arrays;
+
 import javax.jmdns.ServiceInfo;
 
 //import jmri.InstanceManager;
+
 import jmri.jmrix.bidib.BiDiBNetworkPortController;
 import jmri.jmrix.bidib.BiDiBPortController;
 import jmri.jmrix.bidib.BiDiBSystemConnectionMemo;
@@ -30,7 +34,6 @@ import jmri.util.zeroconf.ZeroConfClient;
 import org.bidib.jbidibc.core.MessageListener;
 import org.bidib.jbidibc.core.NodeListener;
 import org.bidib.jbidibc.core.node.listener.TransferListener;
-import org.bidib.jbidibc.messages.ConnectionListener;
 import org.bidib.jbidibc.netbidib.client.NetBidibClient;
 import org.bidib.jbidibc.netbidib.client.BidibNetAddress;
 import org.bidib.jbidibc.netbidib.pairingstore.LocalPairingStore;
@@ -64,30 +67,30 @@ public class NetBiDiBAdapter extends BiDiBNetworkPortController {
     public static final String NET_BIDIB_DEFAULT_PAIRING_STORE_FILE = "preference:netBiDiBPairingStore.bidib";
     static final String OPTION_DEVICE_LIST = "AvailableDeviceList";
     static final String OPTION_UNIQUE_ID = "UniqueID";
-    
+
     // The PID (product id as part of the Unique ID) was registered for JMRI with bidib.org (thanks to Andreas Kuhtz and Wolfgang Kufer)
     static final int BIDIB_JMRI_PID = 0x00FE; //don't touch without synchronizing with bidib.org
-    
+
     private final Map<Long, NetBiDiDDevice> deviceList = new LinkedHashMap<>();
     private boolean mDNSConfigure = false;
     private final javax.swing.Timer delayedCloseTimer;
     private PairingStore pairingStore = null;
     private NetBiDiBPairingRequestDialog pairingDialog = null;
     private ActionListener pairingListener = null;
-    
+
     private Long uniqueId = null; //also used as mDNS advertisement name
     long timeout;
     private ZeroConfClient mdnsClient = null;
 
     private final BiDiBPortController portController = this; //this instance is used from a listener class
-    
+
     protected static class NetBiDiDDevice {
         private PairingStoreEntry pairingStoreEntry = new PairingStoreEntry();
         private BidibNetAddress bidibAddress = null;
 
         public NetBiDiDDevice() {
         }
-        
+
         public PairingStoreEntry getPairingStoreEntry() {
             return pairingStoreEntry;
         }
@@ -95,7 +98,7 @@ public class NetBiDiBAdapter extends BiDiBNetworkPortController {
             this.pairingStoreEntry = pairingStoreEntry;
             //uniqueID = ByteUtils.parseHexUniqueId(pairingStoreEntry.getUid());
         }
-        
+
         public Long getUniqueId() {
             //return ByteUtils.parseHexUniqueId(pairingStoreEntry.getUid());
             //return uniqueID & 0xFFFFFFFFFFL;
@@ -104,7 +107,7 @@ public class NetBiDiBAdapter extends BiDiBNetworkPortController {
         public void setUniqueId(Long uid) {
             pairingStoreEntry.setUid(ByteUtils.formatHexUniqueId(uid));
         }
-        
+
         public void setAddressAndPort(String addr, String port) {
             InetAddress address = null;
             try {
@@ -140,11 +143,11 @@ public class NetBiDiBAdapter extends BiDiBNetworkPortController {
         public void setPort(int port) {
             bidibAddress = new BidibNetAddress(getAddress(), port);
         }
-        
+
         public String getProductName() {
             return pairingStoreEntry.getProductName();
         }
-        
+
         public void setProductName(String productName) {
             pairingStoreEntry.setProductName(productName);
         }
@@ -152,7 +155,7 @@ public class NetBiDiBAdapter extends BiDiBNetworkPortController {
         public String getUserName() {
             return pairingStoreEntry.getUserName();
         }
-        
+
         public void setUserName(String userName) {
             pairingStoreEntry.setUserName(userName);
         }
@@ -160,7 +163,7 @@ public class NetBiDiBAdapter extends BiDiBNetworkPortController {
         public boolean isPaired() {
             return pairingStoreEntry.isPaired();
         }
-        
+
         public void setPaired(boolean paired) {
             pairingStoreEntry.setPaired(paired);
         }
@@ -195,11 +198,11 @@ public class NetBiDiBAdapter extends BiDiBNetworkPortController {
             log.warn("pairing store file is invalid: {}", ex.getMessage());
         }
         //deviceListAddFromPairingStore();
-        
+
         options.put("ConnectionKeepAlive", new Option(Bundle.getMessage("KeepAlive"),
                 new String[]{Bundle.getMessage("KeepAliveLocalPing"),Bundle.getMessage("KeepAliveNone")} )); // NOI18N
     }
-    
+
     public void deviceListAddFromPairingStore() {
         pairingStore.load();
         List<PairingStoreEntry> entries = pairingStore.getPairingStoreEntries();
@@ -217,7 +220,7 @@ public class NetBiDiBAdapter extends BiDiBNetworkPortController {
             }
         }
     }
-    
+
     @Override
     public void connect(String host, int port) throws IOException {
         setHostName(host);
@@ -228,24 +231,24 @@ public class NetBiDiBAdapter extends BiDiBNetworkPortController {
     /**
      * This methods is called from network connection config. It creates the BiDiB object from jbidibc and opens it.
      * The connectPort method of the traffic controller is called for generic initialisation.
-     * 
+     *
      */
     @Override
     public void connect() {// throws IOException {
         log.debug("connect() starts to {}:{}", getHostName(), getPort());
-        
+
         opened = false;
-        
+
         prepareOpenContext();
-        
+
         // create the BiDiB instance
         bidib = NetBidibClient.createInstance(getContext());
         // create the correspondent traffic controller
         BiDiBTrafficController tc = new BiDiBTrafficController(bidib);
         this.getSystemConnectionMemo().setBiDiBTrafficController(tc);
-        
+
         log.debug("memo: {}, netBiDiB: {}", this.getSystemConnectionMemo(), bidib);
-        
+
         // connect to the device
         context = tc.connnectPort(this); //must be done before configuring managers since they may need features from the device
 
@@ -258,7 +261,7 @@ public class NetBiDiBAdapter extends BiDiBNetworkPortController {
             log.warn("No device found on port {} ({}})",
                     getCurrentPortName(), getCurrentPortName());
         }
-        
+
 // DEBUG!
 //        final NetBidibLinkData clientLinkData = ctx.get(Context.NET_BIDIB_CLIENT_LINK_DATA, NetBidibLinkData.class, null);
 //        try {
@@ -275,7 +278,7 @@ public class NetBiDiBAdapter extends BiDiBNetworkPortController {
 // /DEBUG!
 
     }
-    
+
     private void prepareOpenContext() {
         if (getContext() == null) {
             context = new DefaultContext();
@@ -322,15 +325,15 @@ public class NetBiDiBAdapter extends BiDiBNetworkPortController {
 
                 log.info("Register the created client link data in the create context: {}", localClientLinkData);
                 ctx.register(Context.NET_BIDIB_CLIENT_LINK_DATA, localClientLinkData);
-            
+
         }
-        
+
         ctx.register(BiDiBTrafficController.ASYNCCONNECTIONINIT, true); //netBiDiB uses asynchroneous initialization
         ctx.register(BiDiBTrafficController.ISNETBIDIB, true);
         ctx.register(BiDiBTrafficController.USELOCALPING, getOptionState("ConnectionKeepAlive").equals(Bundle.getMessage("KeepAliveLocalPing")));
 
         log.debug("Context: {}", ctx);
-        
+
     }
 
     /**
@@ -357,30 +360,33 @@ public class NetBiDiBAdapter extends BiDiBNetworkPortController {
      * {@inheritDoc}
      */
     @Override
-    public void registerAllListeners(ConnectionListener connectionListener, Set<NodeListener> nodeListeners,
-                Set<MessageListener> messageListeners, Set<TransferListener> transferListeners) {
-        
+    public void registerAllListeners(
+            org.bidib.jbidibc.messages.ConnectionListener connectionListener,
+            Set<NodeListener> nodeListeners,
+            Set<MessageListener> messageListeners,
+            Set<TransferListener> transferListeners) {
+
         NetBidibClient b = (NetBidibClient)bidib;
         b.setConnectionListener(connectionListener);
         b.registerListeners(nodeListeners, messageListeners, transferListeners);
     }
-    
+
     /**
      * Get a unique id for ourself. The product id part is fixed and registered with bidib.org.
      * The serial number is a hash from the MAC address.
-     * 
+     *
      * This is a variation of org.bidib.wizard.core.model.settings.NetBidibSettings.getNetBidibUniqueId().
      * Instead of just using the network interface from InetAddress.getLocalHost() - which can result to the loopback-interface,
      * which does not have a hardware address - we loop through the list of interfaces until we find an interface which is up and
      * not a loopback. It would be even better, if we check for virtual interfaces (those could be present if VMs run on the machine)
      * and then exclude them. But there is no generic method to find those interfaces. So we just return an UID derived from the first
      * found non-loopback interface or the default UID if there is no such interface.
-     * 
+     *
      * @return Unique ID as long
      */
     public Long getNetBidibUniqueId() {
         // set a default UID
-        byte[] uniqueId = 
+        byte[] uniqueId =
                 new byte[] { 0x00, 0x00, 0x0D, ByteUtils.getLowByte(BIDIB_JMRI_PID), ByteUtils.getHighByte(BIDIB_JMRI_PID),
                     0x00, (byte) 0xE8 };
 
@@ -433,7 +439,7 @@ public class NetBiDiBAdapter extends BiDiBNetworkPortController {
     public DataOutputStream getOutputStream() {
         return null;
     }
-    
+
     // autoconfig via mDNS
 
     /**
@@ -447,7 +453,7 @@ public class NetBiDiBAdapter extends BiDiBNetworkPortController {
         log.debug("Setting netBiDiB adapter autoconfiguration to: {}", autoconfig);
         mDNSConfigure = autoconfig;
     }
-    
+
     /**
      * Get whether or not this adapter is configured
      * to use autoconfiguration via MDNS.
@@ -458,7 +464,7 @@ public class NetBiDiBAdapter extends BiDiBNetworkPortController {
     public boolean getMdnsConfigure() {
         return mDNSConfigure;
     }
-    
+
     /**
      * Set the server's host name and port
      * using mdns autoconfiguration.
@@ -545,7 +551,7 @@ public class NetBiDiBAdapter extends BiDiBNetworkPortController {
                 dev.setProductName(serviceInfo.getPropertyString("prod"));
                 dev.setUserName(serviceInfo.getPropertyString("user"));
                 deviceList.put(uid, dev);
-                
+
                 log.info("Found announcement: {}", dev.getString());
 
                 // if no current unique id is known, try the known IP address if valid
@@ -564,7 +570,7 @@ public class NetBiDiBAdapter extends BiDiBNetworkPortController {
                     setHostName(dev.getAddress().getHostAddress());
                     setPort(dev.getPort());
                     foundUniqueId = uid; //we have found what we have looked for
-                    //break; //exit the for loop as 
+                    //break; //exit the for loop as
                 }
             }
             if (foundUniqueId != null) {
@@ -576,7 +582,7 @@ public class NetBiDiBAdapter extends BiDiBNetworkPortController {
                 /* Stub */
             }
         }
-        
+
         // some log info
         if (foundUniqueId == null) {
             // Write out a warning if we have been looking for a known uid.
@@ -596,7 +602,7 @@ public class NetBiDiBAdapter extends BiDiBNetworkPortController {
      * Get and set the ZeroConf/mDNS advertisement name.
      * <p>
      * This value is the unique id in BiDiB.
-     * 
+     *
      * @return advertisement name.
      */
     @Override
@@ -606,7 +612,7 @@ public class NetBiDiBAdapter extends BiDiBNetworkPortController {
         /////// use "VnnPnnnnnn" instead
         return ByteUtils.getUniqueIdAsStringCompact(getUniqueId());
     }
-    
+
     @Override
     public void setAdvertisementName(String AdName) {
         // AdName has the format "VvvPppppssss"
@@ -618,22 +624,22 @@ public class NetBiDiBAdapter extends BiDiBNetworkPortController {
      * <p>
      * This value is fixed in BiDiB, so return the default
      * value.
-     * 
+     *
      * @return service type.
      */
     @Override
     public String getServiceType() {
         return Bundle.getMessage("defaultMDNSServiceType");
     }
-    
+
     // netBiDiB Adapter specific methods
-    
+
     /**
      * Get the device list of all found devices and return them as a map
      * of strings suitable for display and indexed by the unique id.
-     * 
+     *
      * This is used by the connection config.
-     * 
+     *
      * @return map of strings containing device info.
      */
 
@@ -644,10 +650,10 @@ public class NetBiDiBAdapter extends BiDiBNetworkPortController {
         }
         return stringList;
     }
-    
+
     /**
      * Set hostname, port and unique id from the device list entry selected by a given index.
-     * 
+     *
      * @param i selected index into device list
      */
     public void selectDeviceListItem(int i) {
@@ -661,13 +667,13 @@ public class NetBiDiBAdapter extends BiDiBNetworkPortController {
             setUniqueId(dev.getUniqueId());
         }
     }
-    
+
     /**
      * Get and set the BiDiB Unique ID.
      * <p>
      * If we haven't set the unique ID of the connection before, try to find it from the root node
      * of the connection. This will work only if the connection is open and not detached.
-     * 
+     *
      * @return unique Id as Long
      */
     public Long getUniqueId() {
@@ -680,11 +686,11 @@ public class NetBiDiBAdapter extends BiDiBNetworkPortController {
         }
         return uniqueId;
     }
-    
+
     public void setUniqueId(Long uniqueId) {
         this.uniqueId = uniqueId;
     }
-    
+
 //UNUSED
 //    public boolean isLocalPaired() {
 //        if (getUniqueId() != null) {
@@ -698,7 +704,7 @@ public class NetBiDiBAdapter extends BiDiBNetworkPortController {
 
     /**
      * Get the connection ready status from the traffic controller
-     * 
+     *
      * @return true if the connection is opened and ready to use (paired and logged in)
      */
     public boolean isConnectionReady() {
@@ -711,20 +717,20 @@ public class NetBiDiBAdapter extends BiDiBNetworkPortController {
         }
         return false;
     }
-    
+
     /**
      * Set new pairing state.
-     * 
+     *
      * If the pairing should be removed, close the connection, set pairing state in
      * the device list and update the pairing store.
-     * 
+     *
      * If pairing should be initiated, a connection is temporary opened and a pariring dialog
      * is displayed which informs the user to confirm the pairing on the remote device.
      * If the process has completed, the temporary connection is closed.
-     * 
+     *
      * Pairing and unpairing is an asynchroneous process, so an action listener may be provided which
      * is called when the process has completed.
-     * 
+     *
      * @param paired - true if the pairing should be initiated, false if pairing should be removed
      * @param l - and event listener, called when pairing or unpairing has finished.
      */
@@ -770,8 +776,8 @@ public class NetBiDiBAdapter extends BiDiBNetworkPortController {
                 log.warn("Pairing request - BiDiB instance is already opened. This should never happen.");
                 return;
             }
-            ConnectionListener connectionListener = new ConnectionListener() {
-                
+            var connectionListener = new org.bidib.jbidibc.messages.ConnectionListener() {
+
                 @Override
                 public void opened(String port) {
                     // no implementation
@@ -794,7 +800,7 @@ public class NetBiDiBAdapter extends BiDiBNetworkPortController {
                 public void status(String messageKey, Context context) {
                     // no implementation
                 }
-                
+
                 @Override
                 public void pairingFinished(final PairingResult pairingResult, long uniqueId) {
                     log.debug("** pairingFinished - result: {}, uniqueId: {}", pairingResult,
@@ -835,10 +841,10 @@ public class NetBiDiBAdapter extends BiDiBNetworkPortController {
                             // Show the dialog.
                             pairingDialog.show();
                         }
-                    }       
+                    }
                 }
 
-                
+
             };
             // open the device
             String portName = getRealPortName();
@@ -855,11 +861,11 @@ public class NetBiDiBAdapter extends BiDiBNetworkPortController {
             }
         }
     }
-    
+
     /**
      * Check of the connection is opened.
      * This does not mean that it is paired or logged on.
-     * 
+     *
      * @return true if opened
      */
     public boolean isOpened() {
@@ -868,26 +874,26 @@ public class NetBiDiBAdapter extends BiDiBNetworkPortController {
         }
         return false;
     }
-    
+
     /**
      * Check if the connection is detached i.e. it is opened, paired
      * but the logon has been rejected.
-     * 
+     *
      * @return true if detached
      */
     public boolean isDetached() {
         return getSystemConnectionMemo().getBiDiBTrafficController().isDetached();
     }
-    
+
     /**
      * Set or remove the detached state.
-     * 
+     *
      * @param logon - true for logon (attach), false for logoff (detach)
      */
     public void setLogon(boolean logon) {
         getSystemConnectionMemo().getBiDiBTrafficController().setLogon(logon);
     }
-    
+
     public void addConnectionChangedListener(ActionListener l) {
         getSystemConnectionMemo().getBiDiBTrafficController().addConnectionChangedListener(l);
     }
@@ -918,5 +924,5 @@ public class NetBiDiBAdapter extends BiDiBNetworkPortController {
 
     private static final Logger log = LoggerFactory.getLogger(NetBiDiBAdapter.class);
 
-    
+
 }

--- a/java/src/jmri/jmrix/bidib/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/bidib/serialdriver/SerialDriverAdapter.java
@@ -11,9 +11,11 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Collections;
 import java.util.Set;
+
 import jmri.util.SystemType;
 import jmri.jmrix.bidib.BiDiBSerialPortController;
 import jmri.jmrix.bidib.BiDiBTrafficController;
+
 import org.bidib.jbidibc.core.BidibFactory;
 import org.bidib.jbidibc.core.BidibInterface;
 import org.bidib.jbidibc.core.MessageListener;
@@ -23,7 +25,6 @@ import org.bidib.jbidibc.messages.exception.PortNotFoundException;
 import org.bidib.jbidibc.messages.exception.PortNotOpenedException;
 import org.bidib.jbidibc.messages.helpers.DefaultContext;
 import org.bidib.jbidibc.core.node.BidibNode;
-import org.bidib.jbidibc.messages.ConnectionListener;
 import org.bidib.jbidibc.messages.helpers.Context;
 import org.bidib.jbidibc.messages.utils.ByteUtils;
 import org.bidib.jbidibc.jserialcomm.JSerialCommSerialBidib;
@@ -47,17 +48,17 @@ public class SerialDriverAdapter extends BiDiBSerialPortController {
     private static final boolean usePurjavacomm = !useJSerailComm;
     private static final boolean useScm = false;
     private static final Map<String, Long> connectionRootNodeList = new HashMap<>(); //our static connection list
-    
+
     protected String portNameFilter = "";
     protected Long rootNodeUid;
     protected boolean useAutoScan = false;
-    
+
 //    @SuppressWarnings("OverridableMethodCallInConstructor")
     public SerialDriverAdapter() {
         //super(new BiDiBSystemConnectionMemo());
         setManufacturer(jmri.jmrix.bidib.BiDiBConnectionTypeList.BIDIB);
         configureBaudRate(validSpeeds[0]);
-        
+
         if (SystemType.isLinux()) {
             //portNameFilter = "/dev/ttyUSB*";
             portNameFilter = "ttyUSB*";
@@ -67,7 +68,7 @@ public class SerialDriverAdapter extends BiDiBSerialPortController {
         List<String> portList = getPortIdentifiers();
         log.info("portList: {}", portList);
     }
-    
+
     /**
      * Get the filter string for port names to scan when autoScan is on
      * @return port name filter as a string (wildcard is allowed at the end)
@@ -75,7 +76,7 @@ public class SerialDriverAdapter extends BiDiBSerialPortController {
     public String getPortNameFilter() {
         return portNameFilter;
     }
-    
+
     /**
      * Set the port name filter
      * @param filter filter string
@@ -83,7 +84,7 @@ public class SerialDriverAdapter extends BiDiBSerialPortController {
     public void setPortNameFilter(String filter) {
         portNameFilter = filter;
     }
-    
+
     /**
      * Get the root node unique ID
      * @return UID as Long
@@ -91,7 +92,7 @@ public class SerialDriverAdapter extends BiDiBSerialPortController {
     public Long getRootNodeUid() {
         return rootNodeUid;
     }
-    
+
     /**
      * Set the root node unique ID
      * @param uid Unique ID as Long
@@ -99,7 +100,7 @@ public class SerialDriverAdapter extends BiDiBSerialPortController {
     public void setRootNodeUid(Long uid) {
         rootNodeUid = uid;
     }
-    
+
     /**
      * Get the AutoScan status
      * @return true of autoScan is on, false if not
@@ -107,7 +108,7 @@ public class SerialDriverAdapter extends BiDiBSerialPortController {
     public boolean getUseAutoScan() {
         return useAutoScan;
     }
-    
+
     /**
      * Set the AutoScan status
      * @param flag true of ON is requested
@@ -115,10 +116,10 @@ public class SerialDriverAdapter extends BiDiBSerialPortController {
     public void setUseAutoScan(boolean flag) {
         useAutoScan = flag;
     }
-    
+
     /**
      * {@inheritDoc}
-     * 
+     *
      * Get the port name in the format which is used by jbidibc
      * @return real port name
      */
@@ -130,7 +131,7 @@ public class SerialDriverAdapter extends BiDiBSerialPortController {
     /**
      * Get the canonical port name from the underlying operating system.
      * For a symbolic link, the real path is returned.
-     * 
+     *
      * @param portName human-readable name
      * @return canonical path
      */
@@ -146,7 +147,7 @@ public class SerialDriverAdapter extends BiDiBSerialPortController {
         }
         return portName;
     }
-    
+
     /**
      * Static function to get the port name in the format which is used by jbidibc
      * @param portName displayed port name
@@ -159,11 +160,11 @@ public class SerialDriverAdapter extends BiDiBSerialPortController {
         // TODO: MaxOSX. Windows just uses the displayed port name (COMx:)
         return getCanonicalPortName(portName);
     }
-    
+
     /**
      * This methods is called from serial connection config and creates the BiDiB object from jbidibc and opens it.
      * The connectPort method of the traffic controller is called for generic initialisation.
-     * 
+     *
      * @param portName port name from XML
      * @param appName not used
      * @return error string to be displayed by JMRI. null of no error
@@ -171,7 +172,7 @@ public class SerialDriverAdapter extends BiDiBSerialPortController {
     @Override
     public String openPort(String portName, String appName) {
         log.debug("openPort called for {}, driver: {}, expected UID: {}", portName, getRealPortName(), ByteUtils.formatHexUniqueId(rootNodeUid));
-        
+
         MSG_RAW_LOGGER.debug("RAW> create BiDiB Instance for port {}", getCurrentPortName());
         //BidibInterface bidib = createSerialBidib();
         if (useAutoScan) {
@@ -217,7 +218,7 @@ public class SerialDriverAdapter extends BiDiBSerialPortController {
             connectionRootNodeList.put(getRealPortName(), null); //this port does not have a BiDiB device connected - remember this
             return "No device found on port " + getCurrentPortName() + "(" + getCurrentPortName() + ")";
         }
-        
+
         return null; // indicates OK return
 //        return "CANT DO!!"; //DEBUG
 
@@ -232,12 +233,12 @@ public class SerialDriverAdapter extends BiDiBSerialPortController {
         log.debug("configure");
         this.getSystemConnectionMemo().configureManagers();
     }
-    
+
     /**
      * Create a BiDiB object. jbidibc has support for various serial implementations.
      * We tested SCM, PUREJAVACOMM and later JSerialComm. All worked without problems. Since
      * JMRI generally uses JSerialComm, we also use it here
-     * 
+     *
      * @return a BiDiB object from jbidibc
      */
     private static BidibInterface createSerialBidib(Context context) {
@@ -252,14 +253,17 @@ public class SerialDriverAdapter extends BiDiBSerialPortController {
         }
         return null;
     }
-    
+
     /**
      * {@inheritDoc}
      */
     @Override
-    public void registerAllListeners(ConnectionListener connectionListener, Set<NodeListener> nodeListeners,
-                Set<MessageListener> messageListeners, Set<TransferListener> transferListeners) {
-        
+    public void registerAllListeners(
+            org.bidib.jbidibc.messages.ConnectionListener connectionListener,
+            Set<NodeListener> nodeListeners,
+            Set<MessageListener> messageListeners,
+            Set<TransferListener> transferListeners) {
+
         if (useScm) { //NOT SUPPORTED ANY MORE
 //            PureJavaCommSerialBidib b = (ScmSerialBidib)bidib;
 //            b.setConnectionListener(connectionListener);
@@ -276,7 +280,7 @@ public class SerialDriverAdapter extends BiDiBSerialPortController {
             b.registerListeners(nodeListeners, messageListeners, transferListeners);
         }
     }
-    
+
     /**
      * Get a list of available port names
      * @return list of portnames
@@ -309,7 +313,7 @@ public class SerialDriverAdapter extends BiDiBSerialPortController {
         }
         return ret;
     }
-    
+
     /**
      * Internal method to find a port, possibly with already created BiDiB object
      * @param requid requested unique ID of the root node
@@ -363,10 +367,10 @@ public class SerialDriverAdapter extends BiDiBSerialPortController {
         }
         return null;
     }
-    
+
     /**
      * Scan all ports (filtered by portNameFilter) for a unique ID of the root node.
-     * 
+     *
      * @param requid requested unique ID of the root node
      * @param portNameFilter a port name filter (e.g. /dev/ttyUSB* for Linux)
      * @return found port name (e.g. /dev/ttyUSB0) or null of not found
@@ -392,11 +396,11 @@ public class SerialDriverAdapter extends BiDiBSerialPortController {
         }
         return null;
     }
-    
+
     /**
      * Check if the given port is a BiDiB connection and returns the unique ID of the root node.
      * Return the UID from cache if we already know the UID.
-     * 
+     *
      * @param portName port name to check
      * @return unique ID of the root node
      */
@@ -415,7 +419,7 @@ public class SerialDriverAdapter extends BiDiBSerialPortController {
     /**
      * Internal method to check if the given port is a BiDiB connection and returns the unique ID of the root node.
      * Return the UID from cache if we already know the UID.
-     * 
+     *
 //     * @param bidib a BiDiB object from jbidibc
      * @param portName port name to check
      * @return unique ID of the root node
@@ -438,11 +442,11 @@ public class SerialDriverAdapter extends BiDiBSerialPortController {
             String realPortName = getRealPortName(portName);
             bidib.open(realPortName, null, Collections.<NodeListener> emptySet(), Collections.<MessageListener> emptySet(), Collections.<TransferListener> emptySet(), context);
             BidibNode rootNode = bidib.getRootNode();
-            
+
             uid = rootNode.getUniqueId() & 0x0000ffffffffffL; //mask the classid
             log.info("root node UID: {}", ByteUtils.formatHexUniqueId(uid));
             connectionRootNodeList.put(realPortName, uid);
-            
+
         }
         catch (PortNotOpenedException ex) {
             log.warn("port not opened: {}", portName);
@@ -459,10 +463,10 @@ public class SerialDriverAdapter extends BiDiBSerialPortController {
         }
         return uid;
     }
-    
+
     /**
      * Check if the port name of a given UID already exists in the cache.
-     * 
+     *
      * @param reqUid requested UID
      * @return port name or null if not found in cache
      */
@@ -479,7 +483,7 @@ public class SerialDriverAdapter extends BiDiBSerialPortController {
         return null;
     }
 
-    
+
 
     // base class methods for the BiDiBSerialPortController interface
     // not used but must be implemented

--- a/java/src/jmri/jmrix/bidib/simulator/BiDiBSimulatorAdapter.java
+++ b/java/src/jmri/jmrix/bidib/simulator/BiDiBSimulatorAdapter.java
@@ -4,17 +4,18 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.File;
 import java.util.Set;
+
 import jmri.util.FileUtil;
 
 import jmri.jmrix.bidib.BiDiBSerialPortController;
 import jmri.jmrix.bidib.BiDiBTrafficController;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.bidib.jbidibc.core.MessageListener;
 import org.bidib.jbidibc.core.NodeListener;
 import org.bidib.jbidibc.core.node.listener.TransferListener;
-import org.bidib.jbidibc.messages.ConnectionListener;
 import org.bidib.jbidibc.simulation.comm.SimulationBidib;
 import org.bidib.jbidibc.simulation.SimulationInterface;
 
@@ -41,7 +42,7 @@ public class BiDiBSimulatorAdapter extends BiDiBSerialPortController {
     public String getSimulationFile() {
         return simulationFile;
     }
-    
+
     public void setSimulationFile(String f) {
         if (loadedSimulationFilename == null) {
             loadedSimulationFilename = f;
@@ -65,9 +66,9 @@ public class BiDiBSimulatorAdapter extends BiDiBSerialPortController {
         log.debug("isRestartRequired");
         return super.isRestartRequired();
     }
-    
-    
-    
+
+
+
     /**
      * {@inheritDoc}
      */
@@ -80,10 +81,10 @@ public class BiDiBSimulatorAdapter extends BiDiBSerialPortController {
             return absoluteSimulationFile;
         }
     }
-    
+
     /**
      * {@inheritDoc}
-     * 
+     *
      * Get the "port name" in the format which is used by jbidibc - this is absolute path to the simulation XML file
      * @return real port name
      */
@@ -92,13 +93,13 @@ public class BiDiBSimulatorAdapter extends BiDiBSerialPortController {
         File f = new File(FileUtil.getExternalFilename("profile:" + getSimulationFile()));
         return f.getAbsolutePath();
     }
-    
+
 //    @Override
 //    public void recover() {
 //        log.debug("recover called - ignored.");
 //        // nothing
 //    }
-//    
+//
 //    /**
 //     * {@inheritDoc}
 //     */
@@ -110,7 +111,7 @@ public class BiDiBSimulatorAdapter extends BiDiBSerialPortController {
 
     /**
      * Here we do not really open something.
-     * 
+     *
      * @param fileName name of simulation file
      * @param appName not used
      * @return error string, null if no error
@@ -156,7 +157,7 @@ public class BiDiBSimulatorAdapter extends BiDiBSerialPortController {
     public void configure() {
         log.debug("configure");
         MSG_RAW_LOGGER.debug("RAW> create BiDiB Instance");
-        
+
         bidib = SimulationBidib.createInstance(getContext());
         BiDiBTrafficController tc = new BiDiBTrafficController(bidib);
         log.debug("memo: {}, bidib simulator: {}", this.getSystemConnectionMemo(), bidib);
@@ -177,14 +178,17 @@ public class BiDiBSimulatorAdapter extends BiDiBSerialPortController {
      * {@inheritDoc}
      */
     @Override
-    public void registerAllListeners(ConnectionListener connectionListener, Set<NodeListener> nodeListeners,
-                Set<MessageListener> messageListeners, Set<TransferListener> transferListeners) {
-        
+    public void registerAllListeners(
+            org.bidib.jbidibc.messages.ConnectionListener connectionListener,
+            Set<NodeListener> nodeListeners,
+            Set<MessageListener> messageListeners,
+            Set<TransferListener> transferListeners) {
+
         SimulationInterface b = (SimulationInterface)bidib;
         b.setConnectionListener(connectionListener);
         b.registerListeners(nodeListeners, messageListeners, transferListeners);
     }
-    
+
     // base class methods for the BiDiBSerialPortController interface
     // not used but must be implemented
 

--- a/java/src/jmri/jmrix/dccpp/swing/virtuallcd/VirtualLCDFrame.java
+++ b/java/src/jmri/jmrix/dccpp/swing/virtuallcd/VirtualLCDFrame.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 
 import javax.swing.*;
 
+import jmri.jmrix.PortAdapter;
 import jmri.jmrix.dccpp.*;
 import jmri.util.JmriJFrame;
 
@@ -23,23 +24,36 @@ public class VirtualLCDFrame extends JmriJFrame implements DCCppListener  {
 
     static final int TOTALLINES = 64;
     private ArrayList<JLabel> lines;
-    
+
     public VirtualLCDFrame(DCCppSystemConnectionMemo memo) {
         super();
         _tc = memo.getDCCppTrafficController();
         _memo = memo;
-        _tc.sendDCCppMessage(DCCppMessage.makeLCDRequestMsg(), null);        
+        _tc.sendDCCppMessage(DCCppMessage.makeLCDRequestMsg(), null);
         lines = new ArrayList<>(TOTALLINES + 1);
+
+        _tc.controller.addConnectionListener(new PortAdapter.ConnectionListener(){
+            @Override
+            public void connected(PortAdapter adapter) {
+                log.debug("VirtualLCDFrame.Connected: {}", adapter.getSystemPrefix());
+                _tc.sendDCCppMessage(DCCppMessage.makeLCDRequestMsg(), null);
+            }
+            @Override
+            public void disconnected(PortAdapter adapter) {
+                log.debug("VirtualLCDFrame.Disconnected: {}", adapter.getSystemPrefix());
+            }
+        });
+
     }
 
-    /** 
+    /**
      * {@inheritDoc}
      */
     @Override
     public void message(DCCppMessage msg) {
     }
-    
-    /** 
+
+    /**
      * {@inheritDoc}
      */
     @Override
@@ -50,23 +64,23 @@ public class VirtualLCDFrame extends JmriJFrame implements DCCppListener  {
                 int lineNumber = msg.getLCDLineNumInt();
                 if (lineNumber < TOTALLINES) {
                     lines.get(lineNumber).setText(msg.getLCDTextString()+"   "); // padding for appearance
-                    pack(); 
+                    pack();
                 } else {
-                    log.warn("Received LCD message for line {}, but configured for TOTALLINES limit of {}", 
+                    log.warn("Received LCD message for line {}, but configured for TOTALLINES limit of {}",
                                 lineNumber, TOTALLINES-1);
                 }
                 log.debug("Received LCD message for display# {}, only display 0 supported at this time.", displayNumber);
-            } 
+            }
         }
     }
-    
-    /** 
+
+    /**
      * {@inheritDoc}
      */
     @Override
     public void notifyTimeout(DCCppMessage msg) {
     }
-    
+
     /**
      * {@inheritDoc}
      */
@@ -74,16 +88,16 @@ public class VirtualLCDFrame extends JmriJFrame implements DCCppListener  {
     public void initComponents() {
         super.initComponents();
         getContentPane().setLayout(new BoxLayout(getContentPane(), BoxLayout.Y_AXIS));
-        
+
         Font font = null;
         // load the custom 5x8 found
-        try { 
+        try {
             InputStream stream = new FileInputStream(new File("resources/fonts/5x8_lcd_hd44780u_a02.ttf"));
             font = Font.createFont(Font.TRUETYPE_FONT, stream).deriveFont(16f).deriveFont(Font.BOLD);
         } catch (IOException e1) { log.error("failed to find or open font file");
         } catch (FontFormatException e2) { log.error("font file not valid");
         }
-        
+
         var pane = new JPanel();
         pane.setLayout(new BoxLayout(pane, BoxLayout.Y_AXIS));
         // initialize the list of display lines
@@ -99,14 +113,14 @@ public class VirtualLCDFrame extends JmriJFrame implements DCCppListener  {
         pane.setOpaque(true);
         pane.setBackground(Color.BLACK);
         this.add(pane);
-        
-        // set the title, include prefix in event of multiple connections 
+
+        // set the title, include prefix in event of multiple connections
         setTitle(Bundle.getMessage("VirtualLCDFrameTitle") + " (" + _memo.getSystemPrefix() + ")");
-        
+
         // pack to layout display
         pack();
     }
-   
+
     private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(VirtualLCDFrame.class);
 
 }


### PR DESCRIPTION
This PR adds the possibility to listen on a connection for when it connects/disconnects. This is useful for example when some initialization needs to be done when the connection is reconnected after a disconnect.

It's currently implemented for DCC-EX network connections but it's generic and could be supported for any connection.