### PR TITLE
WIP - Listen on when a connection connects/disconnects

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -653,6 +653,10 @@
     <h3>Miscellaneous</h3>
         <a id="Misc" name="Misc"></a>
         <ul>
+            <li>It's now possible to listen on connections for when
+                they connects/disconnects. It's currently implemented
+                for DCC-EX network connections, but is intended to be
+                supported by other connections as well.</li>
             <li></li>
         </ul>
 

--- a/java/src/jmri/jmrix/AbstractNetworkPortController.java
+++ b/java/src/jmri/jmrix/AbstractNetworkPortController.java
@@ -38,6 +38,27 @@ abstract public class AbstractNetworkPortController extends AbstractPortControll
         connect();
     }
 
+    private long lastAttemptingOpeningConnectionTime = 0;
+    private long lastErrorOpeningConnectionTime = 0;
+
+    private void logAttemptingOpeningConnectionMessage(String hostName, int port) {
+        // Show a message no more often than 30 seconds.
+        // This is relevant when trying to reconnect.
+        if ((System.currentTimeMillis() - lastAttemptingOpeningConnectionTime) > 30*1000) {
+            log.info("Attempting to open connection to {}:{}", hostName, port);
+            lastAttemptingOpeningConnectionTime = System.currentTimeMillis();
+        }
+    }
+
+    private void logErrorOpeningConnectionMessage(String hostName, String exceptionMessage) {
+        // Show a message no more often than 30 seconds.
+        // This is relevant when trying to reconnect.
+        if ((System.currentTimeMillis() - lastErrorOpeningConnectionTime) > 30*1000) {
+            log.error("Error opening network connection to {} because {}", hostName, exceptionMessage);
+            lastErrorOpeningConnectionTime = System.currentTimeMillis();
+        }
+    }
+
     @Override
     public void connect() throws IOException {
         log.debug("connect() starts to {}:{}", getHostName(), getPort());
@@ -48,13 +69,16 @@ abstract public class AbstractNetworkPortController extends AbstractPortControll
         }
         try {
             var address = getHostAddress();
-            log.info("Attempting to open connection to {}:{}", address, m_port);
+            // Show connection message, but not too often
+            logAttemptingOpeningConnectionMessage(address, m_port);
             socketConn = new Socket(address, m_port);
             socketConn.setKeepAlive(true);
             socketConn.setSoTimeout(getConnectionTimeout());
             opened = true;
+            notifyOpenedConnection();
         } catch (IOException e) {
-            log.error("Error opening network connection to {} because {}", getHostName(), e.getMessage()); // nothing to help user in full exception
+            // Show exception message, but not too often
+            logErrorOpeningConnectionMessage(getHostName(), e.getMessage()); // nothing to help user in full exception
             if (m_port != 0) {
                 ConnectionStatus.instance().setConnectionState(
                         getUserName(), m_HostName + ":" + m_port, ConnectionStatus.CONNECTION_DOWN);
@@ -284,7 +308,7 @@ abstract public class AbstractNetworkPortController extends AbstractPortControll
         }
         return null;
     }
-    
+
     /**
      * {@inheritDoc}
      */
@@ -296,6 +320,7 @@ abstract public class AbstractNetworkPortController extends AbstractPortControll
             log.trace("Unable to close socket", e);
         }
         opened=false;
+        notifyClosedConnection();
     }
 
     /**
@@ -305,7 +330,7 @@ abstract public class AbstractNetworkPortController extends AbstractPortControll
     @Override
     protected void resetupConnection() {
     }
-    
+
     /**
      * {@inheritDoc}
      */

--- a/java/src/jmri/jmrix/AbstractPortController.java
+++ b/java/src/jmri/jmrix/AbstractPortController.java
@@ -5,8 +5,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Set;
+import java.util.*;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
@@ -27,6 +26,8 @@ import jmri.SystemConnectionMemo;
  * @author Bob Jacobsen Copyright (C) 2001, 2002
  */
 abstract public class AbstractPortController implements PortAdapter {
+
+    private final List<ConnectionListener> connectedListeners = new ArrayList<>();
 
     /**
      * {@inheritDoc}
@@ -648,6 +649,42 @@ abstract public class AbstractPortController implements PortAdapter {
             throw new NullPointerException();
         }
         this.connectionMemo = connectionMemo;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void addConnectionListener(ConnectionListener l) {
+        connectedListeners.add(l);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void removeConnectionListener(ConnectionListener l) {
+        connectedListeners.remove(l);
+    }
+
+    /**
+     * Notify listeners that the connection has been opened.
+     */
+    public void notifyOpenedConnection() {
+        log.debug("Notify opened connection: {}", this);
+        for (var l : connectedListeners) {
+            l.connected(this);
+        }
+    }
+
+    /**
+     * Notify listeners that the connection has been closed.
+     */
+    public void notifyClosedConnection() {
+        log.debug("Notify closed connection: {}", this);
+        for (var l : connectedListeners) {
+            l.disconnected(this);
+        }
     }
 
     private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(AbstractPortController.class);

--- a/java/src/jmri/jmrix/ConnectionListener.java
+++ b/java/src/jmri/jmrix/ConnectionListener.java
@@ -1,0 +1,25 @@
+package jmri.jmrix;
+
+/**
+ * A connection listener listens on a connection for when the connection
+ * connects or disconnects.
+ *
+ * @author Daniel Bergqvist (C) 2026
+ */
+public interface ConnectionListener {
+
+    /**
+     * The connection has connected.
+     *
+     * @param adapter the adapter for the connection
+     */
+    void connected(PortAdapter adapter);
+
+    /**
+     * The connection has disconnected.
+     *
+     * @param adapter the adapter for the connection
+     */
+    void disconnected(PortAdapter adapter);
+
+}

--- a/java/src/jmri/jmrix/PortAdapter.java
+++ b/java/src/jmri/jmrix/PortAdapter.java
@@ -13,11 +13,11 @@ import jmri.SystemConnectionMemo;
  * connection types (network, serial, etc).
  * <p>
  * For historical reasons, this provides both four specific options (option1 to option4)
- * plus a more flexible interface based on a String array.  The more flexible 
- * interface is the preferred one for new work, but the 1-4 form hasn't been 
+ * plus a more flexible interface based on a String array.  The more flexible
+ * interface is the preferred one for new work, but the 1-4 form hasn't been
  * deprecated yet.
  * <p>
- * General design documentation is available on the 
+ * General design documentation is available on the
  * <a href="http://jmri.org/help/en/html/doc/Technical/SystemStructure.shtml">Structure of External System Connections page</a>.
  *
  * @author Bob Jacobsen Copyright (C) 2001, 2003, 2008, 2010
@@ -144,14 +144,14 @@ public interface PortAdapter {
      * @return true for text representation preferred
      */
     boolean isOptionTypeText(String option);
-    
+
     /**
      * Should this option be represented by a password field
      * @param option Name of the option to check
      * @return true for text representation preferred
      */
     boolean isOptionTypePassword(String option);
-    
+
     /**
      * Get the system manufacturer's name.
      *
@@ -251,26 +251,26 @@ public interface PortAdapter {
      * @return true if application needs to restart, false otherwise
      */
     boolean isRestartRequired();
-    
+
     /**
      * Set the maximum interval between reconnection attempts.
      * @param maxInterval in seconds.
      */
     void setReconnectMaxInterval(int maxInterval);
-    
+
     /**
      * Set the maximum number of reconnection attempts.
      * -1 will set an infinite number of attempts.
      * @param maxAttempts total maximum reconnection attempts.
      */
     void setReconnectMaxAttempts(int maxAttempts);
-    
+
     /**
      * Get the maximum interval between reconnection attempts.
      * @return maximum interval in seconds.
      */
     int getReconnectMaxInterval();
-    
+
     /**
      * Get the maximum number of reconnection attempts which should be made.
      * A value of -1 means no maximum value, i.e. infinite attempts.
@@ -289,5 +289,19 @@ public interface PortAdapter {
      * @param allow true to enable recovery.
      */
     void setAllowConnectionRecovery(boolean allow);
+
+    /**
+     * Add a connection listener.
+     *
+     * @param l the listener
+     */
+    void addConnectionListener(ConnectionListener l);
+
+    /**
+     * Remove a connection listener.
+     *
+     * @param l the listener
+     */
+    void removeConnectionListener(ConnectionListener l);
 
 }

--- a/java/src/jmri/jmrix/dccpp/swing/virtuallcd/VirtualLCDFrame.java
+++ b/java/src/jmri/jmrix/dccpp/swing/virtuallcd/VirtualLCDFrame.java
@@ -6,6 +6,8 @@ import java.util.ArrayList;
 
 import javax.swing.*;
 
+import jmri.jmrix.ConnectionListener;
+import jmri.jmrix.PortAdapter;
 import jmri.jmrix.dccpp.*;
 import jmri.util.JmriJFrame;
 
@@ -23,23 +25,35 @@ public class VirtualLCDFrame extends JmriJFrame implements DCCppListener  {
 
     static final int TOTALLINES = 64;
     private ArrayList<JLabel> lines;
-    
+
     public VirtualLCDFrame(DCCppSystemConnectionMemo memo) {
         super();
         _tc = memo.getDCCppTrafficController();
         _memo = memo;
-        _tc.sendDCCppMessage(DCCppMessage.makeLCDRequestMsg(), null);        
+        _tc.sendDCCppMessage(DCCppMessage.makeLCDRequestMsg(), null);
         lines = new ArrayList<>(TOTALLINES + 1);
+
+        _tc.controller.addConnectionListener(new ConnectionListener(){
+            @Override
+            public void connected(PortAdapter adapter) {
+                log.debug("VirtualLCDFrame.Connected: {}", adapter.getSystemPrefix());
+                _tc.sendDCCppMessage(DCCppMessage.makeLCDRequestMsg(), null);
+            }
+            @Override
+            public void disconnected(PortAdapter adapter) {
+                log.debug("VirtualLCDFrame.Disconnected: {}", adapter.getSystemPrefix());
+            }
+        });
     }
 
-    /** 
+    /**
      * {@inheritDoc}
      */
     @Override
     public void message(DCCppMessage msg) {
     }
-    
-    /** 
+
+    /**
      * {@inheritDoc}
      */
     @Override
@@ -50,23 +64,23 @@ public class VirtualLCDFrame extends JmriJFrame implements DCCppListener  {
                 int lineNumber = msg.getLCDLineNumInt();
                 if (lineNumber < TOTALLINES) {
                     lines.get(lineNumber).setText(msg.getLCDTextString()+"   "); // padding for appearance
-                    pack(); 
+                    pack();
                 } else {
-                    log.warn("Received LCD message for line {}, but configured for TOTALLINES limit of {}", 
+                    log.warn("Received LCD message for line {}, but configured for TOTALLINES limit of {}",
                                 lineNumber, TOTALLINES-1);
                 }
                 log.debug("Received LCD message for display# {}, only display 0 supported at this time.", displayNumber);
-            } 
+            }
         }
     }
-    
-    /** 
+
+    /**
      * {@inheritDoc}
      */
     @Override
     public void notifyTimeout(DCCppMessage msg) {
     }
-    
+
     /**
      * {@inheritDoc}
      */
@@ -74,16 +88,16 @@ public class VirtualLCDFrame extends JmriJFrame implements DCCppListener  {
     public void initComponents() {
         super.initComponents();
         getContentPane().setLayout(new BoxLayout(getContentPane(), BoxLayout.Y_AXIS));
-        
+
         Font font = null;
         // load the custom 5x8 found
-        try { 
+        try {
             InputStream stream = new FileInputStream(new File("resources/fonts/5x8_lcd_hd44780u_a02.ttf"));
             font = Font.createFont(Font.TRUETYPE_FONT, stream).deriveFont(16f).deriveFont(Font.BOLD);
         } catch (IOException e1) { log.error("failed to find or open font file");
         } catch (FontFormatException e2) { log.error("font file not valid");
         }
-        
+
         var pane = new JPanel();
         pane.setLayout(new BoxLayout(pane, BoxLayout.Y_AXIS));
         // initialize the list of display lines
@@ -99,14 +113,14 @@ public class VirtualLCDFrame extends JmriJFrame implements DCCppListener  {
         pane.setOpaque(true);
         pane.setBackground(Color.BLACK);
         this.add(pane);
-        
-        // set the title, include prefix in event of multiple connections 
+
+        // set the title, include prefix in event of multiple connections
         setTitle(Bundle.getMessage("VirtualLCDFrameTitle") + " (" + _memo.getSystemPrefix() + ")");
-        
+
         // pack to layout display
         pack();
     }
-   
+
     private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(VirtualLCDFrame.class);
 
 }


### PR DESCRIPTION
This PR adds the possibility to listen on a connection for when it connects/disconnects. This is useful for example when some initialization needs to be done when the connection is reconnected after a disconnect.

It's currently implemented for DCC-EX network connections but it's generic and could be supported for any connection.