### PR TITLE
DCC-EX Traffic Monitor: layout fix, TX/RX direction marker, rename

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -36,10 +36,10 @@
 
         <h4>DCC++ and DCC-EX</h4>
             <ul>
-                <li>DCC-EX Traffic Monitor: the action buttons (Clear / Freeze) and log buttons
-                (Choose log file&hellip; / Start logging) now share a single row above the
-                checkboxes, so narrowing the window no longer clips the checkboxes off the visible
-                area (<a href="https://github.com/JMRI/JMRI/issues/15134">#15134</a>).
+                <li>DCC-EX Traffic Monitor: controls now wrap onto additional rows when the
+                window is narrowed and the controls area grows upward to keep everything visible,
+                rather than clipping checkboxes off the bottom
+                (<a href="https://github.com/JMRI/JMRI/issues/15134">#15134</a>).
                 The window title and menu action label also now read &quot;DCC-EX&quot; rather
                 than &quot;DCC++&quot;.</li>
                 <li>DCC-EX Traffic Monitor: traffic lines now show an explicit &quot;TX:&quot; or

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -36,11 +36,16 @@
 
         <h4>DCC++ and DCC-EX</h4>
             <ul>
-                <li>DCC-EX Traffic Monitor: action buttons (Clear / Freeze) now sit on their own
-                row above the checkboxes, so narrowing the window no longer clips the checkboxes
-                off the visible area (<a href="https://github.com/JMRI/JMRI/issues/15134">#15134</a>).
+                <li>DCC-EX Traffic Monitor: the action buttons (Clear / Freeze) and log buttons
+                (Choose log file&hellip; / Start logging) now share a single row above the
+                checkboxes, so narrowing the window no longer clips the checkboxes off the visible
+                area (<a href="https://github.com/JMRI/JMRI/issues/15134">#15134</a>).
                 The window title and menu action label also now read &quot;DCC-EX&quot; rather
                 than &quot;DCC++&quot;.</li>
+                <li>DCC-EX Traffic Monitor: traffic lines now show an explicit &quot;TX:&quot; or
+                &quot;RX:&quot; direction marker regardless of whether the translated text or raw
+                form is displayed, and the raw form is wrapped in &lt;&hellip;&gt; rather than
+                [&hellip;] to match DCC-EX's native command syntax.</li>
             </ul>
 
         <h4>DCC4pc</h4>

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -36,7 +36,11 @@
 
         <h4>DCC++ and DCC-EX</h4>
             <ul>
-                <li></li>
+                <li>DCC-EX Traffic Monitor: action buttons (Clear / Freeze) now sit on their own
+                row above the checkboxes, so narrowing the window no longer clips the checkboxes
+                off the visible area (<a href="https://github.com/JMRI/JMRI/issues/15134">#15134</a>).
+                The window title and menu action label also now read &quot;DCC-EX&quot; rather
+                than &quot;DCC++&quot;.</li>
             </ul>
 
         <h4>DCC4pc</h4>

--- a/java/src/jmri/jmrix/AbstractMonFrame.java
+++ b/java/src/jmri/jmrix/AbstractMonFrame.java
@@ -75,9 +75,8 @@ public abstract class AbstractMonFrame extends JmriJFrame {
     protected JTextField entryField = new JTextField();
     protected JButton enterButton = new JButton(Bundle.getMessage("ButtonAddMessage"));
 
-    /** Opening bracket wrapped around the raw data in the displayed line. Subclasses may override. */
+    /** Bracket characters wrapping the raw data in the displayed line; subclasses may override. */
     protected String rawOpenBracket = "[";
-    /** Closing bracket wrapped around the raw data in the displayed line. Subclasses may override. */
     protected String rawCloseBracket = "]";
 
     private final String rawDataCheck = this.getClass().getName() + ".RawData"; // NOI18N
@@ -125,15 +124,32 @@ public abstract class AbstractMonFrame extends JmriJFrame {
         // add items to GUI
         getContentPane().add(jScrollPane1);
 
-        JPanel paneA = new JPanel();
+        JPanel paneA;
+        if (useStackedControlsLayout()) {
+            // Track preferred height so WrapLayout-based control rows can grow when
+            // the window narrows; unconstrained width lets the area stretch.
+            paneA = new JPanel() {
+                @Override
+                public Dimension getMaximumSize() {
+                    return new Dimension(Short.MAX_VALUE, getPreferredSize().height);
+                }
+            };
+        } else {
+            paneA = new JPanel();
+        }
         paneA.setLayout(new BoxLayout(paneA, BoxLayout.Y_AXIS));
 
-        JPanel topActions = new JPanel();
-        topActions.add(getActionButtonsPanel());
-        topActions.add(getCheckBoxPanel());
-
-        paneA.add(topActions);
-        paneA.add(getLogToFilePanel());
+        if (useStackedControlsLayout()) {
+            paneA.add(getActionButtonsPanel());
+            paneA.add(getCheckBoxPanel());
+            paneA.add(getLogToFilePanel());
+        } else {
+            JPanel topActions = new JPanel();
+            topActions.add(getActionButtonsPanel());
+            topActions.add(getCheckBoxPanel());
+            paneA.add(topActions);
+            paneA.add(getLogToFilePanel());
+        }
 
         JPanel pane3 = new JPanel();
         pane3.setLayout(new BoxLayout(pane3, BoxLayout.X_AXIS));
@@ -153,10 +169,26 @@ public abstract class AbstractMonFrame extends JmriJFrame {
         // add help menu to window
         setHelp();
 
-        // prevent button areas from expanding
         pack();
-        paneA.setMaximumSize(paneA.getSize());
-        pack();
+        if (!useStackedControlsLayout()) {
+            // Legacy path pins the controls area at its packed size; the stacked
+            // path handles this via paneA's getMaximumSize override above.
+            paneA.setMaximumSize(paneA.getSize());
+            pack();
+        }
+    }
+
+    /**
+     * Whether to lay out the action, checkbox, and log button panels as separate
+     * stacked rows directly inside paneA (with paneA's height tracking its
+     * preferred so {@code WrapLayout}-based rows can grow when the window is
+     * narrowed). Defaults to {@code false} — legacy side-by-side layout with a
+     * FlowLayout wrapper and a static max-size pin. Subclasses opt in.
+     *
+     * @return true for stacked rows, false for the legacy layout
+     */
+    protected boolean useStackedControlsLayout() {
+        return false;
     }
 
     protected JPanel getCheckBoxPanel() {
@@ -259,9 +291,8 @@ public abstract class AbstractMonFrame extends JmriJFrame {
     }
 
     /**
-     * Handle display of traffic with an explicit direction marker (e.g. "TX:" or "RX:").
-     * If non-empty, the direction is shown between the timestamp and the raw bracketed
-     * section regardless of which display checkboxes are selected.
+     * Handle display of traffic with an explicit direction marker (e.g. "TX:" or "RX:")
+     * that is shown regardless of which display checkboxes are selected.
      * @param line is the traffic in 'normal form'. Should end with \n
      * @param raw is the "raw form", should NOT end with \n
      * @param direction direction marker to display, or null/empty to omit
@@ -274,7 +305,6 @@ public abstract class AbstractMonFrame extends JmriJFrame {
             sb.append(df.format(new Date())).append(": "); // NOI18N
         }
 
-        // direction marker (TX:/RX:) when supplied — always shown
         if (direction != null && !direction.isEmpty()) {
             sb.append(direction).append(' ');
         }

--- a/java/src/jmri/jmrix/AbstractMonFrame.java
+++ b/java/src/jmri/jmrix/AbstractMonFrame.java
@@ -74,6 +74,12 @@ public abstract class AbstractMonFrame extends JmriJFrame {
     protected JButton openFileChooserButton = new JButton(Bundle.getMessage("ButtonChooseLogFile"));
     protected JTextField entryField = new JTextField();
     protected JButton enterButton = new JButton(Bundle.getMessage("ButtonAddMessage"));
+
+    /** Opening bracket wrapped around the raw data in the displayed line. Subclasses may override. */
+    protected String rawOpenBracket = "[";
+    /** Closing bracket wrapped around the raw data in the displayed line. Subclasses may override. */
+    protected String rawCloseBracket = "]";
+
     private final String rawDataCheck = this.getClass().getName() + ".RawData"; // NOI18N
     private final String timeStampCheck = this.getClass().getName() + ".TimeStamp"; // NOI18N
     private final String alwaysOnTopCheck = this.getClass().getName() + ".alwaysOnTop"; // NOI18N
@@ -249,6 +255,18 @@ public abstract class AbstractMonFrame extends JmriJFrame {
      * @param raw is the "raw form" , should NOT end with \n
      */
     public void nextLine(String line, String raw) {
+        nextLine(line, raw, null);
+    }
+
+    /**
+     * Handle display of traffic with an explicit direction marker (e.g. "TX:" or "RX:").
+     * If non-empty, the direction is shown between the timestamp and the raw bracketed
+     * section regardless of which display checkboxes are selected.
+     * @param line is the traffic in 'normal form'. Should end with \n
+     * @param raw is the "raw form", should NOT end with \n
+     * @param direction direction marker to display, or null/empty to omit
+     */
+    public void nextLine(String line, String raw, String direction) {
         StringBuilder sb = new StringBuilder(120);
 
         // display the timestamp if requested
@@ -256,9 +274,14 @@ public abstract class AbstractMonFrame extends JmriJFrame {
             sb.append(df.format(new Date())).append(": "); // NOI18N
         }
 
+        // direction marker (TX:/RX:) when supplied — always shown
+        if (direction != null && !direction.isEmpty()) {
+            sb.append(direction).append(' ');
+        }
+
         // display the raw data if requested
         if (rawCheckBox.isSelected()) {
-            sb.append('[').append(raw).append("]  "); // NOI18N
+            sb.append(rawOpenBracket).append(raw).append(rawCloseBracket).append("  "); // NOI18N
         }
 
         // display decoded data

--- a/java/src/jmri/jmrix/dccpp/DCCppActionListBundle.properties
+++ b/java/src/jmri/jmrix/dccpp/DCCppActionListBundle.properties
@@ -3,7 +3,7 @@
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences
 
-jmri.jmrix.dccpp.swing.mon.DCCppMonAction = Open DCC++ Monitor
+jmri.jmrix.dccpp.swing.mon.DCCppMonAction = Open DCC-EX Monitor
 jmri.jmrix.dccpp.swing.virtuallcd.VirtualLCDAction = Open DCC-EX Virtual LCD
 jmri.jmrix.dccpp.swing.packetgen.PacketGenAction = Open Send DCC++ Command
 jmri.jmrix.dccpp.swing.ConfigBaseStationAction = Open Config DCC++ Base Station

--- a/java/src/jmri/jmrix/dccpp/swing/DCCppSwingBundle.properties
+++ b/java/src/jmri/jmrix/dccpp/swing/DCCppSwingBundle.properties
@@ -8,7 +8,7 @@ MenuItemSendDCCppCommand = Send DCC++ Command
 MenuItemVirtualLCDDisplay = Open DCC-EX Virtual LCD
 MenuItemConfigBaseStation = Configure Base Station
 MenuItemDCCppOverTCPServer = Load DCC++ over TCP Server
-DCCppMonFrameTitle = DCC++ Traffic Monitor
+DCCppMonFrameTitle = DCC-EX Traffic Monitor
 DCCppRosterExportTitle = Roster Export to DCC-EX
 
 MenuSend     = Send

--- a/java/src/jmri/jmrix/dccpp/swing/mon/DCCppMonFrame.java
+++ b/java/src/jmri/jmrix/dccpp/swing/mon/DCCppMonFrame.java
@@ -40,7 +40,10 @@ public class DCCppMonFrame extends jmri.jmrix.AbstractMonFrame implements DCCppL
 
     public DCCppMonFrame(DCCppSystemConnectionMemo memo) {
         super();
-        _memo = memo;        
+        _memo = memo;
+        // DCC-EX commands are natively bracketed with <...>; match that style in the raw display.
+        rawOpenBracket = "<";
+        rawCloseBracket = ">";
     }
 
     @Override
@@ -116,19 +119,18 @@ public class DCCppMonFrame extends jmri.jmrix.AbstractMonFrame implements DCCppL
         // display the decoded data
         StringBuilder text = new StringBuilder();
         if ( displayTranslatedCheckBox.isSelected() ) {
-            text.append("TX: ");
             text.append(l.toMonitorString());
         }
         text.append("\n");
 
-        nextLine(text.toString(), (rawCheckBox.isSelected() ? l.toString() : ""));
+        nextLine(text.toString(), (rawCheckBox.isSelected() ? l.toString() : ""), "TX:");
         refreshQueuedMessages();
 
     }
 
     @Override
     public void message(DCCppReply l) {
-        // receive a DCC++ message and log it
+        // receive a DCC-EX message and log it
         // display the raw data if requested
         if (log.isDebugEnabled()) {
             log.debug("Message in Monitor: '{}' opcode {}", l, Character.toString(l.getOpCodeChar()));
@@ -136,12 +138,11 @@ public class DCCppMonFrame extends jmri.jmrix.AbstractMonFrame implements DCCppL
 
         StringBuilder text = new StringBuilder();
         if ( displayTranslatedCheckBox.isSelected() ) {
-            text.append(" RX: ");
             text.append(l.toMonitorString());
         }
         text.append("\n");
 
-        nextLine( text.toString(), (rawCheckBox.isSelected() ? l.toString() : ""));
+        nextLine(text.toString(), (rawCheckBox.isSelected() ? l.toString() : ""), "RX:");
 
         //enable or disable the refresh pane based on support by command station
         if (l.isStatusReply()) { 
@@ -208,8 +209,13 @@ public class DCCppMonFrame extends jmri.jmrix.AbstractMonFrame implements DCCppL
 
     @Override
     protected JPanel getActionButtonsPanel() {
-        // Buttons are stacked above the checkboxes via getCheckBoxPanel() so a
-        // narrowed window can't clip them. Return an empty panel here.
+        // Relocated into getCheckBoxPanel below so action and log buttons share one row.
+        return new JPanel();
+    }
+
+    @Override
+    protected JPanel getLogToFilePanel() {
+        // Relocated into getCheckBoxPanel below so action and log buttons share one row.
         return new JPanel();
     }
 
@@ -223,9 +229,15 @@ public class DCCppMonFrame extends jmri.jmrix.AbstractMonFrame implements DCCppL
         displayTranslatedCheckBox.setSelected(!userPrefs.getSimplePreferenceState(doNotDisplayTranslatedCheck));
         rawCheckBoxEvent(null); // if neither raw nor translated selected, display translated.
 
+        // Row 1: action buttons (Clear / Freeze) + log buttons (Choose log file / Start logging).
+        JPanel buttons = new JPanel();
+        buttons.setLayout(new BoxLayout(buttons, BoxLayout.X_AXIS));
+        buttons.add(super.getActionButtonsPanel());
+        buttons.add(super.getLogToFilePanel());
+
         JPanel stacked = new JPanel();
         stacked.setLayout(new BoxLayout(stacked, BoxLayout.Y_AXIS));
-        stacked.add(super.getActionButtonsPanel());
+        stacked.add(buttons);
         stacked.add(checks);
         return stacked;
     }

--- a/java/src/jmri/jmrix/dccpp/swing/mon/DCCppMonFrame.java
+++ b/java/src/jmri/jmrix/dccpp/swing/mon/DCCppMonFrame.java
@@ -207,15 +207,27 @@ public class DCCppMonFrame extends jmri.jmrix.AbstractMonFrame implements DCCppL
     }
 
     @Override
+    protected JPanel getActionButtonsPanel() {
+        // Buttons are stacked above the checkboxes via getCheckBoxPanel() so a
+        // narrowed window can't clip them. Return an empty panel here.
+        return new JPanel();
+    }
+
+    @Override
     public JPanel getCheckBoxPanel(){
-        JPanel a = super.getCheckBoxPanel();
-        a.add(displayTranslatedCheckBox,0);
+        JPanel checks = super.getCheckBoxPanel();
+        checks.add(displayTranslatedCheckBox,0);
         displayTranslatedCheckBox.addActionListener(this::displayTranslatedEvent);
         rawCheckBox.addActionListener(this::rawCheckBoxEvent);
-        
+
         displayTranslatedCheckBox.setSelected(!userPrefs.getSimplePreferenceState(doNotDisplayTranslatedCheck));
-        rawCheckBoxEvent(null); // if neither raw on tranalated selected, display translated.
-        return a;
+        rawCheckBoxEvent(null); // if neither raw nor translated selected, display translated.
+
+        JPanel stacked = new JPanel();
+        stacked.setLayout(new BoxLayout(stacked, BoxLayout.Y_AXIS));
+        stacked.add(super.getActionButtonsPanel());
+        stacked.add(checks);
+        return stacked;
     }
 
     @Override

--- a/java/src/jmri/jmrix/dccpp/swing/mon/DCCppMonFrame.java
+++ b/java/src/jmri/jmrix/dccpp/swing/mon/DCCppMonFrame.java
@@ -9,9 +9,14 @@ import jmri.jmrix.dccpp.serial.SerialDCCppPacketizer;
 
 import java.awt.BorderLayout;
 import java.awt.Dimension;
+import java.awt.FlowLayout;
 import java.awt.event.ActionEvent;
+import java.awt.event.ComponentAdapter;
+import java.awt.event.ComponentEvent;
 
 import javax.swing.*;
+
+import jmri.util.swing.WrapLayout;
 
 /**
  * Frame displaying (and logging) DCCpp command messages.
@@ -41,7 +46,7 @@ public class DCCppMonFrame extends jmri.jmrix.AbstractMonFrame implements DCCppL
     public DCCppMonFrame(DCCppSystemConnectionMemo memo) {
         super();
         _memo = memo;
-        // DCC-EX commands are natively bracketed with <...>; match that style in the raw display.
+        // Match DCC-EX's native <...> command syntax for the raw display.
         rawOpenBracket = "<";
         rawCloseBracket = ">";
     }
@@ -209,37 +214,57 @@ public class DCCppMonFrame extends jmri.jmrix.AbstractMonFrame implements DCCppL
 
     @Override
     protected JPanel getActionButtonsPanel() {
-        // Relocated into getCheckBoxPanel below so action and log buttons share one row.
-        return new JPanel();
+        // Combine action + log buttons into one wrapping row so they stay grouped.
+        super.getActionButtonsPanel(); // wire listeners/tooltips on the shared buttons
+        super.getLogToFilePanel();
+        JPanel p = new JPanel(new WrapLayout(FlowLayout.CENTER, 5, 0));
+        p.add(clearButton);
+        p.add(freezeButton);
+        p.add(openFileChooserButton);
+        p.add(startLogButton);
+        p.add(stopLogButton);
+        return p;
     }
 
     @Override
     protected JPanel getLogToFilePanel() {
-        // Relocated into getCheckBoxPanel below so action and log buttons share one row.
-        return new JPanel();
+        return new JPanel(); // log buttons live in getActionButtonsPanel
     }
 
     @Override
     public JPanel getCheckBoxPanel(){
-        JPanel checks = super.getCheckBoxPanel();
-        checks.add(displayTranslatedCheckBox,0);
+        super.getCheckBoxPanel(); // wire listeners/tooltips on the shared checkboxes
         displayTranslatedCheckBox.addActionListener(this::displayTranslatedEvent);
         rawCheckBox.addActionListener(this::rawCheckBoxEvent);
-
         displayTranslatedCheckBox.setSelected(!userPrefs.getSimplePreferenceState(doNotDisplayTranslatedCheck));
-        rawCheckBoxEvent(null); // if neither raw nor translated selected, display translated.
+        rawCheckBoxEvent(null); // if neither raw nor translated selected, force translated on.
 
-        // Row 1: action buttons (Clear / Freeze) + log buttons (Choose log file / Start logging).
-        JPanel buttons = new JPanel();
-        buttons.setLayout(new BoxLayout(buttons, BoxLayout.X_AXIS));
-        buttons.add(super.getActionButtonsPanel());
-        buttons.add(super.getLogToFilePanel());
+        JPanel p = new JPanel(new WrapLayout(FlowLayout.CENTER, 5, 0));
+        p.add(displayTranslatedCheckBox);
+        p.add(rawCheckBox);
+        p.add(timeCheckBox);
+        p.add(alwaysOnTopCheckBox);
+        p.add(autoScrollCheckBox);
+        return p;
+    }
 
-        JPanel stacked = new JPanel();
-        stacked.setLayout(new BoxLayout(stacked, BoxLayout.Y_AXIS));
-        stacked.add(buttons);
-        stacked.add(checks);
-        return stacked;
+    @Override
+    protected boolean useStackedControlsLayout() {
+        return true;
+    }
+
+    @Override
+    public void initComponents() {
+        super.initComponents();
+        // BoxLayout's first pass after a resize computes child preferred-heights
+        // with the stale widths, so WrapLayout rows can be one pass out of date.
+        // Defer a second revalidate to settle layout using the new widths.
+        addComponentListener(new ComponentAdapter() {
+            @Override
+            public void componentResized(ComponentEvent e) {
+                SwingUtilities.invokeLater(DCCppMonFrame.this::revalidate);
+            }
+        });
     }
 
     @Override

--- a/java/test/jmri/jmrix/dccpp/swing/mon/DCCppMonFrameTest.java
+++ b/java/test/jmri/jmrix/dccpp/swing/mon/DCCppMonFrameTest.java
@@ -49,6 +49,40 @@ public class DCCppMonFrameTest extends jmri.util.JmriJFrameTestBase {
     }
 
     @Test
+    public void testDirectionMarkerAndBrackets() {
+
+        ThreadingUtil.runOnGUI(() -> {
+            frame.initComponents();
+            frame.setVisible(true);
+        });
+        JFrameOperator jfo = new JFrameOperator(frame);
+        JCheckBoxOperator raw = new JCheckBoxOperator(jfo, Bundle.getMessage("ButtonShowRaw"));
+        JCheckBoxOperator translation = new JCheckBoxOperator(jfo, Bundle.getMessage("ButtonShowTranslation"));
+        raw.setSelected(true);
+        translation.setSelected(true);
+
+        // TX: marker plus DCC-EX-native angle brackets in the raw section.
+        ((DCCppMonFrame)frame).message(DCCppMessage.makeWriteOpsModeCVMsg(17, 4, 3));
+        JUnitUtil.waitFor(() -> ((DCCppMonFrame)frame).getTextArea().getText().contains("TX: <"),
+                "TX message renders with TX: marker and < bracket");
+
+        // RX: marker on incoming replies.
+        ((DCCppMonFrame)frame).message(DCCppReply.parseDCCppReply("* test 12345 *"));
+        JUnitUtil.waitFor(() -> ((DCCppMonFrame)frame).getTextArea().getText().contains("RX: <"),
+                "RX reply renders with RX: marker and < bracket");
+
+        // Direction marker stays visible even when the translation is hidden.
+        translation.setSelected(false);
+        new JButtonOperator(jfo, Bundle.getMessage("ButtonClearScreen")).doClick();
+        ((DCCppMonFrame)frame).message(DCCppMessage.makeWriteOpsModeCVMsg(20, 5, 7));
+        JUnitUtil.waitFor(() -> ((DCCppMonFrame)frame).getTextArea().getText().contains("TX: <"),
+                "TX: marker still shown when only the raw form is displayed");
+
+        jfo.requestClose();
+        jfo.waitClosed();
+    }
+
+    @Test
     public void testCheckBoxesButtonsVisible(){
 
         ThreadingUtil.runOnGUI(() -> {


### PR DESCRIPTION
Closes #15134.

## Fixed

- Buttons and checkboxes no longer clip when the window narrows — controls wrap onto additional rows and the area grows upward to keep everything visible.
- `TX:`/`RX:` direction marker shows regardless of which display checkboxes are on (per habazut's ask). Field order: `TIMESTAMP TX/RX RAW TRANSLATED`.
- Raw lines use `<...>` brackets to match DCC-EX's native command syntax.
- Window title and menu action label now say "DCC-EX" instead of "DCC++".

## Blast radius

- Base-class layout change is opt-in and defaults off. Only DCC-EX turns it on; other monitors keep their existing behavior.
- TX/RX marker and bracket overrides are similarly non-breaking — other monitors render exactly as before.

## Testing

- Local mvn pass on the DCC-EX suite and every monitor-frame subclass test.
- Added a focused test for the TX:/RX: marker and bracket behavior.
- Bench-verified shrink/grow at a range of widths.