### PR TITLE
DCC-EX: Support several virtual displays

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -36,7 +36,10 @@
 
         <h4>DCC++ and DCC-EX</h4>
             <ul>
-                <li></li>
+                <li>The <strong>Virtual LCD</strong> window now supports
+                    more than one display. Each display is shown in a single
+                    row in the <strong>Virtual LCD</strong> window, with
+                    the first display at the left.</li>
             </ul>
 
         <h4>DCC4pc</h4>

--- a/java/src/jmri/jmrix/dccpp/swing/virtuallcd/VirtualLCDFrame.java
+++ b/java/src/jmri/jmrix/dccpp/swing/virtuallcd/VirtualLCDFrame.java
@@ -30,7 +30,7 @@ public class VirtualLCDFrame extends JmriJFrame implements DCCppListener  {
     private final Map<Integer, List<JLabel>> linesMap = new HashMap<>();
 
     public VirtualLCDFrame(DCCppSystemConnectionMemo memo) {
-        super(false, true); // Save window position but now window size
+        super(false, true); // Save window position but not window size
         _tc = memo.getDCCppTrafficController();
         _memo = memo;
         _tc.sendDCCppMessage(DCCppMessage.makeLCDRequestMsg(), null);
@@ -101,7 +101,7 @@ public class VirtualLCDFrame extends JmriJFrame implements DCCppListener  {
                 log.warn("Received LCD message for line {}, but configured for TOTALLINES limit of {}",
                             lineNumber, TOTALLINES-1);
             }
-            log.debug("Received LCD message for display# {}, only display 0 supported at this time.", displayNumber);
+            log.debug("Received LCD message for display# {}.", displayNumber);
         }
     }
 

--- a/java/src/jmri/jmrix/dccpp/swing/virtuallcd/VirtualLCDFrame.java
+++ b/java/src/jmri/jmrix/dccpp/swing/virtuallcd/VirtualLCDFrame.java
@@ -3,7 +3,8 @@ package jmri.jmrix.dccpp.swing.virtuallcd;
 import java.awt.*;
 import java.beans.PropertyChangeListener;
 import java.io.*;
-import java.util.ArrayList;
+import java.util.List;
+import java.util.*;
 
 import javax.swing.*;
 
@@ -23,16 +24,16 @@ public class VirtualLCDFrame extends JmriJFrame implements DCCppListener  {
     private final DCCppTrafficController _tc;
     private final DCCppSystemConnectionMemo _memo;
     private final PropertyChangeListener _listener;
+    private Font font;
 
     static final int TOTALLINES = 64;
-    private final ArrayList<JLabel> lines;
+    private final Map<Integer, List<JLabel>> linesMap = new HashMap<>();
 
     public VirtualLCDFrame(DCCppSystemConnectionMemo memo) {
-        super();
+        super(false, true); // Save window position but now window size
         _tc = memo.getDCCppTrafficController();
         _memo = memo;
         _tc.sendDCCppMessage(DCCppMessage.makeLCDRequestMsg(), null);
-        lines = new ArrayList<>(TOTALLINES + 1);
 
         _listener = evt -> {
             if (ConnectionStatus.CONNECTION_UP.equals(
@@ -56,6 +57,34 @@ public class VirtualLCDFrame extends JmriJFrame implements DCCppListener  {
     public void message(DCCppMessage msg) {
     }
 
+    private List<JLabel> createNewDisplay(int displayNumber) {
+        // Add space between displays if this is not the first display
+        if (this.getContentPane().getComponentCount() > 0) {
+            Component c = Box.createHorizontalStrut(10);
+            this.add(c);
+        }
+
+        var lines = new ArrayList<JLabel>(TOTALLINES + 1);
+        var pane = new JPanel();
+        pane.setLayout(new BoxLayout(pane, BoxLayout.Y_AXIS));
+        // initialize the list of display lines
+        for (int i = 0; i<TOTALLINES; i++) {
+            var label = new JLabel();
+            if (font != null) label.setFont(font);
+            label.setOpaque(true);
+            label.setBackground(Color.BLACK);
+            label.setForeground(Color.WHITE);
+            lines.add(label);
+            pane.add(lines.get(i));
+        }
+        pane.setOpaque(true);
+        pane.setBackground(Color.BLACK);
+        pane.setAlignmentY(Component.TOP_ALIGNMENT);
+        this.add(pane);
+        pack();
+        return lines;
+    }
+
     /**
      * {@inheritDoc}
      */
@@ -63,17 +92,16 @@ public class VirtualLCDFrame extends JmriJFrame implements DCCppListener  {
     public void message(DCCppReply msg) {
         if (msg.isLCDTextReply()) { // <@ display# line# "message text">
             int displayNumber = msg.getLCDDisplayNumInt();
-            if (displayNumber == 0) {  //TODO: add support for multiple LCD displays
-                int lineNumber = msg.getLCDLineNumInt();
-                if (lineNumber < TOTALLINES) {
-                    lines.get(lineNumber).setText(msg.getLCDTextString()+"   "); // padding for appearance
-                    pack();
-                } else {
-                    log.warn("Received LCD message for line {}, but configured for TOTALLINES limit of {}",
-                                lineNumber, TOTALLINES-1);
-                }
-                log.debug("Received LCD message for display# {}, only display 0 supported at this time.", displayNumber);
+            var lines = linesMap.computeIfAbsent(displayNumber, display -> createNewDisplay(display));
+            int lineNumber = msg.getLCDLineNumInt();
+            if (lineNumber < TOTALLINES) {
+                lines.get(lineNumber).setText(msg.getLCDTextString()+"   "); // padding for appearance
+                pack();
+            } else {
+                log.warn("Received LCD message for line {}, but configured for TOTALLINES limit of {}",
+                            lineNumber, TOTALLINES-1);
             }
+            log.debug("Received LCD message for display# {}, only display 0 supported at this time.", displayNumber);
         }
     }
 
@@ -90,9 +118,8 @@ public class VirtualLCDFrame extends JmriJFrame implements DCCppListener  {
     @Override
     public void initComponents() {
         super.initComponents();
-        getContentPane().setLayout(new BoxLayout(getContentPane(), BoxLayout.Y_AXIS));
+        getContentPane().setLayout(new BoxLayout(getContentPane(), BoxLayout.X_AXIS));
 
-        Font font = null;
         // load the custom 5x8 found
         try {
             InputStream stream = new FileInputStream(new File("resources/fonts/5x8_lcd_hd44780u_a02.ttf"));
@@ -100,22 +127,6 @@ public class VirtualLCDFrame extends JmriJFrame implements DCCppListener  {
         } catch (IOException e1) { log.error("failed to find or open font file");
         } catch (FontFormatException e2) { log.error("font file not valid");
         }
-
-        var pane = new JPanel();
-        pane.setLayout(new BoxLayout(pane, BoxLayout.Y_AXIS));
-        // initialize the list of display lines
-        for (int i = 0; i<TOTALLINES; i++) {
-            var label = new JLabel();
-            if (font != null) label.setFont(font);
-            label.setOpaque(true);
-            label.setBackground(Color.BLACK);
-            label.setForeground(Color.WHITE);
-            lines.add(label);
-            pane.add(lines.get(i));
-        }
-        pane.setOpaque(true);
-        pane.setBackground(Color.BLACK);
-        this.add(pane);
 
         // set the title, include prefix in event of multiple connections
         setTitle(Bundle.getMessage("VirtualLCDFrameTitle") + " (" + _memo.getSystemPrefix() + ")");


### PR DESCRIPTION
This PR changes DCC-EX Virtual display so that it supports several virtual displays. Each display is put on a line with the first display at the left.

The PR assumes that the displays are sent in order from DCC-EX so that the first display, #0, is sent first.

<img width="628" height="134" alt="DCC-EX - Two virtual displays" src="https://github.com/user-attachments/assets/70487ef0-222a-40eb-9039-a779d7766752" />
