### PR TITLE
Roster unavailable dialog: dismissing with X now quits

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -532,7 +532,10 @@
     <h3>Roster</h3>
         <a id="Roster" name="Roster"></a>
         <ul>
-            <li></li>
+            <li>The Continue/Quit dialog shown at startup when the configured roster
+            location is unavailable now treats dismissing the dialog (the close button)
+            as Quit, matching the behavior of the profile chooser. Previously the close
+            button fell through to Continue (issue #15148).</li>
         </ul>
 
     <h3>Routes</h3>

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -535,7 +535,7 @@
             <li>The Continue/Quit dialog shown at startup when the configured roster
             location is unavailable now treats dismissing the dialog (the close button)
             as Quit, matching the behavior of the profile chooser. Previously the close
-            button fell through to Continue (issue #15148).</li>
+            button fell through to Continue (<a href="https://github.com/JMRI/JMRI/issues/15148">issue #15148</a>).</li>
         </ul>
 
     <h3>Routes</h3>

--- a/java/src/jmri/implementation/JmriConfigurationManager.java
+++ b/java/src/jmri/implementation/JmriConfigurationManager.java
@@ -281,8 +281,9 @@ public class JmriConfigurationManager implements ConfigureManager {
     /**
      * Show a Continue/Quit dialog when the configured roster location is
      * unavailable at startup. Returns true if the user chose Quit (in which
-     * case {@link #handleQuit()} has been invoked); returns false if the user
-     * chose Continue or dismissed the dialog.
+     * case {@link #handleQuit()} has been invoked); returns false only if the
+     * user explicitly chose Continue. Dismissing the dialog (close button) is
+     * treated as Quit, matching the profile chooser dialog's behavior.
      *
      * @param ex the exception describing the unavailable roster location
      * @return true if the user chose to quit
@@ -305,11 +306,11 @@ public class JmriConfigurationManager implements ConfigureManager {
                 null,
                 options,
                 options[0]);
-        if (choice == 1) {
-            handleQuit();
-            return true;
+        if (choice == 0) {
+            return false; // explicit Continue
         }
-        return false;
+        handleQuit();
+        return true;
     }
 
     private Object getErrorListObject(List<String> errors) {


### PR DESCRIPTION
Fixes #15148, follow-up to #14666 per [Phil's feedback](https://github.com/JMRI/JMRI/issues/14666#issuecomment-4396572626).

The Continue/Quit dialog shown when the roster directory is unavailable at startup was treating the close button (X) as Continue. The profile chooser treats X as Quit — this matches that.