### PR TITLE
Fix intermittent LinkedWarrantTest timing and Windows teardown failures

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -634,7 +634,27 @@
    <h3>Warrants</h3>
         <a id="Wt" name="Wt"></a>
         <ul>
-            <li></li>
+            <li>Fixed intermittent CI failures in linked/looped warrant tests caused by race conditions and test isolation issues:
+                <ul>
+                    <li><code>stopWarrant()</code> now captures <code>_idxCurrentOrder</code> before
+                        dispatching <code>deAllocate</code> asynchronously, so looped warrants correctly
+                        report <code>warrantComplete</code> rather than <code>warrantEnd</code>.</li>
+                    <li>Same-loco linked warrants now call <code>runWarrant()</code> directly on the
+                        engineer thread instead of the EDT, eliminating a debounce race in
+                        <code>WarrantTableFrame.runTrain()</code>.</li>
+                    <li>Fixed a missed-wakeup race in the Engineer block-sync wait: the block entry
+                        check is now re-evaluated inside the <code>synchronized</code> block, so a sensor
+                        that fires between the outer check and <code>wait()</code> can no longer leave the
+                        engineer stuck indefinitely.</li>
+                    <li>Warrant tests now wait for <code>PROPERTY_WARRANT_START</code> before firing
+                        block sensors for the next leg, ensuring sensors are not delivered before the
+                        new leg's engineer has started.</li>
+                    <li><code>IndicatorTrackPaths</code> now skips paint callbacks on disposed editor panels.</li>
+                    <li>Six logix test classes now use an isolated <code>NullProfile</code> per test
+                        rather than the shared <code>./temp/</code> directory, preventing
+                        <code>RosterConfigManager</code> failures on developer machines with real profile data.</li>
+                </ul>
+            </li>
         </ul>
 
    <h3>Web Access</h3>

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -639,9 +639,6 @@
                     <li><code>stopWarrant()</code> now captures <code>_idxCurrentOrder</code> before
                         dispatching <code>deAllocate</code> asynchronously, so looped warrants correctly
                         report <code>warrantComplete</code> rather than <code>warrantEnd</code>.</li>
-                    <li>Same-loco linked warrants now call <code>runWarrant()</code> directly on the
-                        engineer thread instead of the EDT, eliminating a debounce race in
-                        <code>WarrantTableFrame.runTrain()</code>.</li>
                     <li>Fixed a missed-wakeup race in the Engineer block-sync wait: the block entry
                         check is now re-evaluated inside the <code>synchronized</code> block, so a sensor
                         that fires between the outer check and <code>wait()</code> can no longer leave the
@@ -653,6 +650,7 @@
                     <li>Six logix test classes now use an isolated <code>NullProfile</code> per test
                         rather than the shared <code>./temp/</code> directory, preventing
                         <code>RosterConfigManager</code> failures on developer machines with real profile data.</li>
+                    <li>The changes above are done in <a href="https://github.com/JMRI/JMRI/pull/15151">PR #15151</a></li>
                 </ul>
             </li>
         </ul>

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -514,6 +514,8 @@
         <ul>
           <li>Added the ability to set the additional line tab size for Manifest and Switch Lists. Useful when using the smaller page widths. See "More Print Options" in the help.</li>
           <li>New feature, manual build for a train. See the OperationsPro help for more information.</li>
+          <li>Operations tests now use an isolated <code>NullProfile</code> per test via <code>@TempDir</code>,
+              preventing intermittent <code>RosterConfigManager</code> failures on machines with real JMRI profile data.</li>
         </ul>
 
    <h3>Panel Editor</h3>

--- a/help/en/releasenotes/jmri5.15-master.shtml
+++ b/help/en/releasenotes/jmri5.15-master.shtml
@@ -611,27 +611,7 @@
    <h3>Warrants</h3>
         <a id="Wt" name="Wt"></a>
         <ul>
-            <li>Fixed intermittent CI failures in linked/looped warrant tests caused by race conditions and test isolation issues:
-                <ul>
-                    <li><code>stopWarrant()</code> now captures <code>_idxCurrentOrder</code> before
-                        dispatching <code>deAllocate</code> asynchronously, so looped warrants correctly
-                        report <code>warrantComplete</code> rather than <code>warrantEnd</code>.</li>
-                    <li>Same-loco linked warrants now call <code>runWarrant()</code> directly on the
-                        engineer thread instead of the EDT, eliminating a debounce race in
-                        <code>WarrantTableFrame.runTrain()</code>.</li>
-                    <li>Fixed a missed-wakeup race in the Engineer block-sync wait: the block entry
-                        check is now re-evaluated inside the <code>synchronized</code> block, so a sensor
-                        that fires between the outer check and <code>wait()</code> can no longer leave the
-                        engineer stuck indefinitely.</li>
-                    <li>Warrant tests now wait for <code>PROPERTY_WARRANT_START</code> before firing
-                        block sensors for the next leg, ensuring sensors are not delivered before the
-                        new leg's engineer has started.</li>
-                    <li><code>IndicatorTrackPaths</code> now skips paint callbacks on disposed editor panels.</li>
-                    <li>Six logix test classes now use an isolated <code>NullProfile</code> per test
-                        rather than the shared <code>./temp/</code> directory, preventing
-                        <code>RosterConfigManager</code> failures on developer machines with real profile data.</li>
-                </ul>
-            </li>
+            <li></li>
         </ul>
 
    <h3>Web Access</h3>

--- a/help/en/releasenotes/jmri5.15-master.shtml
+++ b/help/en/releasenotes/jmri5.15-master.shtml
@@ -611,7 +611,20 @@
    <h3>Warrants</h3>
         <a id="Wt" name="Wt"></a>
         <ul>
-            <li></li>
+            <li>Fixed intermittent CI failures in linked/looped warrant tests caused by race conditions and test isolation issues:
+                <ul>
+                    <li><code>stopWarrant()</code> now captures <code>_idxCurrentOrder</code> before
+                        dispatching <code>deAllocate</code> asynchronously, so looped warrants correctly
+                        report <code>warrantComplete</code> rather than <code>warrantEnd</code>.</li>
+                    <li>Same-loco linked warrants now call <code>runWarrant()</code> directly on the
+                        engineer thread instead of the EDT, eliminating a debounce race in
+                        <code>WarrantTableFrame.runTrain()</code>.</li>
+                    <li><code>IndicatorTrackPaths</code> now skips paint callbacks on disposed editor panels.</li>
+                    <li>Six logix test classes now use an isolated <code>NullProfile</code> per test
+                        rather than the shared <code>./temp/</code> directory, preventing
+                        <code>RosterConfigManager</code> failures on developer machines with real profile data.</li>
+                </ul>
+            </li>
         </ul>
 
    <h3>Web Access</h3>

--- a/help/en/releasenotes/jmri5.15-master.shtml
+++ b/help/en/releasenotes/jmri5.15-master.shtml
@@ -619,6 +619,13 @@
                     <li>Same-loco linked warrants now call <code>runWarrant()</code> directly on the
                         engineer thread instead of the EDT, eliminating a debounce race in
                         <code>WarrantTableFrame.runTrain()</code>.</li>
+                    <li>Fixed a missed-wakeup race in the Engineer block-sync wait: the block entry
+                        check is now re-evaluated inside the <code>synchronized</code> block, so a sensor
+                        that fires between the outer check and <code>wait()</code> can no longer leave the
+                        engineer stuck indefinitely.</li>
+                    <li>Warrant tests now wait for <code>PROPERTY_WARRANT_START</code> before firing
+                        block sensors for the next leg, ensuring sensors are not delivered before the
+                        new leg's engineer has started.</li>
                     <li><code>IndicatorTrackPaths</code> now skips paint callbacks on disposed editor panels.</li>
                     <li>Six logix test classes now use an isolated <code>NullProfile</code> per test
                         rather than the shared <code>./temp/</code> directory, preventing

--- a/java/src/jmri/jmrit/display/IndicatorTrackPaths.java
+++ b/java/src/jmri/jmrit/display/IndicatorTrackPaths.java
@@ -136,7 +136,8 @@ public class IndicatorTrackPaths {
             // don't paint loco icon 
             return;
         }
-        if (_loco != null || pt == null) {
+        // ed may have been disposed before this runOnGUIEventually callback fires
+        if (_loco != null || pt == null || !ed.isDisplayable()) {
             return;
         }
         trainName = trainName.trim();

--- a/java/src/jmri/jmrit/logix/Engineer.java
+++ b/java/src/jmri/jmrit/logix/Engineer.java
@@ -334,15 +334,9 @@ class Engineer extends Thread implements java.beans.PropertyChangeListener {
                 waitForSensor(ts.getNamedBeanHandle(), cmdVal);
                 break;
             case RUN_WARRANT:
-                NamedBean runBean = ts.getNamedBeanHandle().getBean();
-                if (runBean instanceof Warrant &&
-                        _warrant.getSpeedUtil().getDccAddress()
-                                .equals(((Warrant) runBean).getSpeedUtil().getDccAddress())) {
-                    runWarrant(ts.getNamedBeanHandle(), cmdVal); // same loco — no EDT needed
-                } else {
-                    ThreadingUtil.runOnGUIEventually(() ->
-                        runWarrant(ts.getNamedBeanHandle(), cmdVal)); // different loco — needs EDT
-                }
+                // must run on the GUI thread because runWarrant() calls WarrantTableFrame.runTrain() directly
+                ThreadingUtil.runOnGUIEventually(() ->
+                    runWarrant(ts.getNamedBeanHandle(), cmdVal));
                 break;
             case SPEEDSTEP:
                 break;
@@ -1162,6 +1156,7 @@ class Engineer extends Thread implements java.beans.PropertyChangeListener {
         }
 
         // send the messages on success of linked launch completion
+        // runs on CheckForTermination thread, not the GUI thread — avoid Swing calls here as they may cause race conditions or non-deterministic behavior
         private void checkerDone(Warrant oldWarrant, Warrant newWarrant) {
             OBlock endBlock = oldWarrant.getLastOrder().getBlock();
             if (oldWarrant.getRunMode() != Warrant.MODE_NONE) {

--- a/java/src/jmri/jmrit/logix/Engineer.java
+++ b/java/src/jmri/jmrit/logix/Engineer.java
@@ -331,8 +331,14 @@ class Engineer extends Thread implements java.beans.PropertyChangeListener {
                 waitForSensor(ts.getNamedBeanHandle(), cmdVal);
                 break;
             case RUN_WARRANT:
-                ThreadingUtil.runOnGUIEventually(() ->
-                    runWarrant(ts.getNamedBeanHandle(), cmdVal));
+                NamedBean runBean = ts.getNamedBeanHandle().getBean();
+                if (runBean instanceof Warrant && _warrant.getSpeedUtil().getDccAddress()
+                        .equals(((Warrant) runBean).getSpeedUtil().getDccAddress())) {
+                    runWarrant(ts.getNamedBeanHandle(), cmdVal); // same loco — no EDT needed
+                } else {
+                    ThreadingUtil.runOnGUIEventually(() ->
+                        runWarrant(ts.getNamedBeanHandle(), cmdVal)); // different loco — needs EDT
+                }
                 break;
             case SPEEDSTEP:
                 break;

--- a/java/src/jmri/jmrit/logix/Engineer.java
+++ b/java/src/jmri/jmrit/logix/Engineer.java
@@ -197,15 +197,18 @@ class Engineer extends Thread implements java.beans.PropertyChangeListener {
                         log.debug("{}: Wait for train to enter \"{}\".",
                                 _warrant.getDisplayName(), _synchBlock.getDisplayName());
                     }
-                    try {
-                        _synchLockObject.wait();
-                        _synchBlock = null;
-                    } catch (InterruptedException ie) {
-                        log.debug("InterruptedException during _waitForSync", ie);
-                        _warrant.debugInfo();
-                        Thread.currentThread().interrupt();
-                        _abort = true;
+                    // Re-check under lock: block may have fired between the outer check and here
+                    if (cmdBlockIdx > _warrant.getCurrentOrderIndex()) {
+                        try {
+                            _synchLockObject.wait();
+                        } catch (InterruptedException ie) {
+                            log.debug("InterruptedException during _waitForSync", ie);
+                            _warrant.debugInfo();
+                            Thread.currentThread().interrupt();
+                            _abort = true;
+                        }
                     }
+                    _synchBlock = null;
                 }
                 if (_abort) {
                     break;
@@ -332,8 +335,9 @@ class Engineer extends Thread implements java.beans.PropertyChangeListener {
                 break;
             case RUN_WARRANT:
                 NamedBean runBean = ts.getNamedBeanHandle().getBean();
-                if (runBean instanceof Warrant && _warrant.getSpeedUtil().getDccAddress()
-                        .equals(((Warrant) runBean).getSpeedUtil().getDccAddress())) {
+                if (runBean instanceof Warrant &&
+                        _warrant.getSpeedUtil().getDccAddress()
+                                .equals(((Warrant) runBean).getSpeedUtil().getDccAddress())) {
                     runWarrant(ts.getNamedBeanHandle(), cmdVal); // same loco — no EDT needed
                 } else {
                     ThreadingUtil.runOnGUIEventually(() ->

--- a/java/src/jmri/jmrit/logix/Warrant.java
+++ b/java/src/jmri/jmrit/logix/Warrant.java
@@ -133,9 +133,8 @@ public class Warrant extends jmri.implementation.AbstractNamedBean implements Th
     private boolean _lost;      // helps recovery if _idxCurrentOrder block goes inactive
     private boolean _overrun;   // train overran a signal or warrant stop
     private boolean _rampBlkOccupied;  // test for overruns when speed change block occupied by another train
-    private int _idxCurrentOrder; // Index of block at head of train (if running)
-
-    protected int _runMode = MODE_NONE;
+    private volatile int _idxCurrentOrder; // volatile: written on EDT, read by Engineer thread without lock coverage
+    protected volatile int _runMode = MODE_NONE; // volatile: polled by CheckForTermination from its own thread
     private Engineer _engineer; // thread that runs the train
     @GuardedBy("this")
     private CommandDelay _delayCommand; // thread for delayed ramp down

--- a/java/src/jmri/jmrit/logix/Warrant.java
+++ b/java/src/jmri/jmrit/logix/Warrant.java
@@ -133,7 +133,7 @@ public class Warrant extends jmri.implementation.AbstractNamedBean implements Th
     private boolean _lost;      // helps recovery if _idxCurrentOrder block goes inactive
     private boolean _overrun;   // train overran a signal or warrant stop
     private boolean _rampBlkOccupied;  // test for overruns when speed change block occupied by another train
-    private volatile int _idxCurrentOrder; // volatile: written on EDT, read by Engineer thread without lock coverage
+    private int _idxCurrentOrder;
     protected volatile int _runMode = MODE_NONE; // volatile: polled by CheckForTermination from its own thread
     private Engineer _engineer; // thread that runs the train
     @GuardedBy("this")

--- a/java/src/jmri/jmrit/logix/Warrant.java
+++ b/java/src/jmri/jmrit/logix/Warrant.java
@@ -947,27 +947,20 @@ public class Warrant extends jmri.implementation.AbstractNamedBean implements Th
         }
         _addTracker = false;
 
+        // capture before runOnGUI — deAllocate is async; CheckForTermination may reset _idxCurrentOrder on the GUI thread
+        final int capturedIdx = _idxCurrentOrder;
+        final String capturedBlockName = abort ? null : getCurrentBlockName();
+
         // insulate possible non-GUI thread making this call (e.g. Engineer)
         ThreadingUtil.runOnGUI(this::deAllocate);
 
         String bundleKey;
-        String blockName;
         if (abort) {
-            blockName = null;
-            if (_idxCurrentOrder <= 0) {
-                bundleKey = "warrantAnnull";
-            } else {
-                bundleKey = "warrantAbort";
-            }
+            bundleKey = capturedIdx <= 0 ? "warrantAnnull" : "warrantAbort";
         } else {
-            blockName = getCurrentBlockName();
-            if (_idxCurrentOrder == _orders.size() - 1) {
-                bundleKey = "warrantComplete";
-            } else {
-                bundleKey = "warrantEnd";
-            }
+            bundleKey = (capturedIdx == _orders.size() - 1) ? "warrantComplete" : "warrantEnd";
         }
-        fireRunStatus(PROPERTY_STOP_WARRANT, blockName, bundleKey);
+        fireRunStatus(PROPERTY_STOP_WARRANT, capturedBlockName, bundleKey);
     }
 
     /**

--- a/java/test/jmri/jmrit/logix/LearnControlPanelTest.java
+++ b/java/test/jmri/jmrit/logix/LearnControlPanelTest.java
@@ -1,9 +1,13 @@
 package jmri.jmrit.logix;
 
+import java.io.File;
+import java.io.IOException;
+
 import jmri.util.JUnitUtil;
 import jmri.util.junit.annotations.DisabledIfHeadless;
 
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  *
@@ -24,9 +28,9 @@ public class LearnControlPanelTest {
     }
 
     @BeforeEach
-    public void setUp() {
+    public void setUp(@TempDir File tempDir) throws IOException {
         JUnitUtil.setUp();
-        JUnitUtil.resetProfileManager();
+        JUnitUtil.resetProfileManager(new jmri.profile.NullProfile(tempDir));
         JUnitUtil.initConfigureManager();
         JUnitUtil.initRosterConfigManager();
         JUnitUtil.initDebugThrottleManager();

--- a/java/test/jmri/jmrit/logix/LearnFunctionPanelTest.java
+++ b/java/test/jmri/jmrit/logix/LearnFunctionPanelTest.java
@@ -1,9 +1,13 @@
 package jmri.jmrit.logix;
 
+import java.io.File;
+import java.io.IOException;
+
 import jmri.util.JUnitUtil;
 
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  *
@@ -24,9 +28,9 @@ public class LearnFunctionPanelTest {
     }
 
     @BeforeEach
-    public void setUp() {
+    public void setUp(@TempDir File tempDir) throws IOException {
         JUnitUtil.setUp();
-        JUnitUtil.resetProfileManager();
+        JUnitUtil.resetProfileManager(new jmri.profile.NullProfile(tempDir));
         JUnitUtil.initRosterConfigManager();
         JUnitUtil.initDebugThrottleManager();
     }

--- a/java/test/jmri/jmrit/logix/LearnSpeedPanelTest.java
+++ b/java/test/jmri/jmrit/logix/LearnSpeedPanelTest.java
@@ -1,9 +1,13 @@
 package jmri.jmrit.logix;
 
+import java.io.File;
+import java.io.IOException;
+
 import jmri.util.JUnitUtil;
 
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  *
@@ -20,9 +24,9 @@ public class LearnSpeedPanelTest {
     }
 
     @BeforeEach
-    public void setUp() {
+    public void setUp(@TempDir File tempDir) throws IOException {
         JUnitUtil.setUp();
-        JUnitUtil.resetProfileManager();
+        JUnitUtil.resetProfileManager(new jmri.profile.NullProfile(tempDir));
         JUnitUtil.initRosterConfigManager();
         JUnitUtil.initDebugThrottleManager();
     }

--- a/java/test/jmri/jmrit/logix/LearnThrottleFrameTest.java
+++ b/java/test/jmri/jmrit/logix/LearnThrottleFrameTest.java
@@ -4,10 +4,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.awt.GraphicsEnvironment;
 
+import java.io.File;
+import java.io.IOException;
+
 import jmri.util.JUnitUtil;
 
 import org.junit.Assume;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  *
@@ -26,9 +30,9 @@ public class LearnThrottleFrameTest {
     }
 
     @BeforeEach
-    public void setUp() {
+    public void setUp(@TempDir File tempDir) throws IOException {
         JUnitUtil.setUp();
-        jmri.util.JUnitUtil.resetProfileManager();
+        JUnitUtil.resetProfileManager(new jmri.profile.NullProfile(tempDir));
         JUnitUtil.initRosterConfigManager();
         JUnitUtil.initDebugThrottleManager();
     }

--- a/java/test/jmri/jmrit/logix/LinkedWarrantTest.java
+++ b/java/test/jmri/jmrit/logix/LinkedWarrantTest.java
@@ -1,8 +1,10 @@
 package jmri.jmrit.logix;
 
+import java.beans.PropertyChangeListener;
 import java.io.File;
 import java.util.List;
 import java.util.ArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
 import jmri.*;
 import jmri.util.JmriJFrame;
 import jmri.util.JUnitAppender;
@@ -65,7 +67,7 @@ public class LinkedWarrantTest {
             return lookingFor.equals(tableFrame.getStatus());
         }, "LoopDeLoop started first leg expected \"" + lookingFor + "\" but was \"" + tableFrame.getStatus()+"\"");
 
-        JUnitUtil.waitFor(() -> atOrPastCommand(warrant, 8), "Loopy 1 starts to move at 8th command");
+        JUnitUtil.waitFor(() -> WarrantTest.atOrPastCommand(warrant, 8), "Loopy 1 starts to move at 8th command");
 
         // Run the train, then checks end location
         assertDoesNotThrow( () -> {
@@ -77,7 +79,17 @@ public class LinkedWarrantTest {
         // It takes 600+ milliseconds per block to execute NXFrameTest.runtimes()
         // i.e. wait at least 600 * route.length for return
 
-        JUnitUtil.waitFor(() -> atOrPastCommand(warrant, 8), "Loopy 2 starts to move at 8th command");
+        JUnitUtil.waitFor(() -> WarrantTest.atOrPastCommand(warrant, 8), "Loopy 2 starts to move at 8th command");
+
+        // listener avoids polling a status that leg 3's immediate re-launch overwrites
+        AtomicBoolean leg2Done = new AtomicBoolean(false);
+        PropertyChangeListener legDone = evt -> {
+            if (Warrant.PROPERTY_STOP_WARRANT.equals(evt.getPropertyName())
+                    && "warrantComplete".equals(evt.getNewValue())) {
+                leg2Done.set(true);
+            }
+        };
+        warrant.addPropertyChangeListener(legDone);
 
         assertDoesNotThrow( () -> {
             assertEquals(block.getSensor(),
@@ -85,12 +97,10 @@ public class LinkedWarrantTest {
                 "LoopDeLoop Completes Second Leg");
         }, ("LoopDeLoop after Second leg Exception"));
 
-        String linkMsg = Bundle.getMessage("warrantComplete", warrant.getTrainName(), warrant.getDisplayName(), block.getDisplayName());
-        JUnitUtil.waitFor(() -> {
-            return linkMsg.equals(tableFrame.getStatus());
-        }, "LoopDeLoop finished second leg");
+        JUnitUtil.waitFor(leg2Done::get, "LoopDeLoop finished second leg");
+        warrant.removePropertyChangeListener(legDone);
 
-        JUnitUtil.waitFor(() -> atOrPastCommand(warrant, 8), "Loopy 3 starts to move at 8th command");
+        JUnitUtil.waitFor(() -> WarrantTest.atOrPastCommand(warrant, 8), "Loopy 3 starts to move at 8th command");
 
         assertDoesNotThrow( () -> {
             assertEquals(block.getSensor(),
@@ -148,7 +158,7 @@ public class LinkedWarrantTest {
         assertNull( ThreadingUtil.runOnGUIwithReturn(() ->
             tableFrame.runTrain(warrant, Warrant.MODE_RUN)),"Warrant starts"); // start run
 
-        JUnitUtil.waitFor(() -> atOrPastCommand(warrant, 8),
+        JUnitUtil.waitFor(() -> WarrantTest.atOrPastCommand(warrant, 8),
             () -> "Train starts to move at 8th command, but running message was " + warrant.getRunningMessage());
 
        // OBlock of route
@@ -169,7 +179,7 @@ public class LinkedWarrantTest {
         Warrant ww = _warrantMgr.getWarrant("WestToEast");
         assertNotNull(ww,"warrant WestToEast exists");
 
-        JUnitUtil.waitFor(() -> atOrPastCommand(ww, 9),
+        JUnitUtil.waitFor(() -> WarrantTest.atOrPastCommand(ww, 9),
             () -> "Train Fred starts to move at 9th command, was: " + ww.getRunningMessage());
 
         String[] route2 = {"OB1", "OB3", "OB5", "OB6", "OB7", "OB9", "OB11"};
@@ -242,7 +252,7 @@ public class LinkedWarrantTest {
         assertNull(ThreadingUtil.runOnGUIwithReturn( () ->
             tableFrame.runTrain(outWarrant, Warrant.MODE_RUN)),"Warrant starts"); // start run
 
-        JUnitUtil.waitFor(() -> atOrPastCommand(outWarrant, 8), "WestToEastLink starts to move at 8th command");
+        JUnitUtil.waitFor(() -> WarrantTest.atOrPastCommand(outWarrant, 8), "WestToEastLink starts to move at 8th command");
 
         // Run the train, then checks end location
         assertDoesNotThrow( () -> {
@@ -261,7 +271,7 @@ public class LinkedWarrantTest {
                                 outBlockName));
         }, "WestToEastLink finished first leg out");
 
-        JUnitUtil.waitFor(() -> atOrPastCommand(backWarrant, 8), "EastToWestLink starts to move at 8th command");
+        JUnitUtil.waitFor(() -> WarrantTest.atOrPastCommand(backWarrant, 8), "EastToWestLink starts to move at 8th command");
 
         assertDoesNotThrow( () -> {
             assertEquals(backEndSensor,
@@ -277,7 +287,7 @@ public class LinkedWarrantTest {
                     block1.getDisplayName()));
         }, "EastToWestLink finished second leg back");
 
-        JUnitUtil.waitFor(() -> atOrPastCommand(outWarrant, 8), "WestToEastLink starts to move at 8th command");
+        JUnitUtil.waitFor(() -> WarrantTest.atOrPastCommand(outWarrant, 8), "WestToEastLink starts to move at 8th command");
 
         assertDoesNotThrow( () -> {
             assertEquals(outEndSensor,
@@ -293,7 +303,7 @@ public class LinkedWarrantTest {
                     outBlockName));
         }, "WestToEastLink finished third leg");
 
-        JUnitUtil.waitFor(() -> atOrPastCommand(backWarrant, 8), "EastToWestLink starts to move at 8th command");
+        JUnitUtil.waitFor(() -> WarrantTest.atOrPastCommand(backWarrant, 8), "EastToWestLink starts to move at 8th command");
 
         assertDoesNotThrow( () -> {
             assertEquals(backEndSensor,
@@ -355,7 +365,8 @@ public class LinkedWarrantTest {
         // warrant can't be started
         assertNull(tableFrame.runTrain(w, Warrant.MODE_RUN),"Warrant starts"); // start run
 
-        JUnitUtil.waitFor(() -> atOrPastCommand(w, 8), "Tinker starts to move at 8th command");
+        JUnitUtil.waitFor(() -> WarrantTest.atOrPastCommand(w, 8),
+            () -> "Tinker starts to move at 8th command but was: " + w.getRunningMessage());
 
        // OBlock of route
         String[] route1 = {"OB0", "OB1", "OB2", "OB3", "OB4", "OB5", "OB10"};
@@ -373,7 +384,7 @@ public class LinkedWarrantTest {
 
         Warrant ww = _warrantMgr.getWarrant("Evers");
 
-        JUnitUtil.waitFor(() -> atOrPastCommand(ww, 8),
+        JUnitUtil.waitFor(() -> WarrantTest.atOrPastCommand(ww, 8),
             () -> "Evers starts to move at 8th command but was: " + ww.getRunningMessage());
 
         String[] route2 = {"OB7", "OB3", "OB2", "OB1"};
@@ -389,7 +400,7 @@ public class LinkedWarrantTest {
 
         Warrant www = _warrantMgr.getWarrant("Chance");
 
-        JUnitUtil.waitFor(() -> atOrPastCommand(www, 8),
+        JUnitUtil.waitFor(() -> WarrantTest.atOrPastCommand(www, 8),
             () -> "Chance starts to move at 8th command but was: " + www.getRunningMessage());
 
         String[] route3 = {"OB6", "OB3", "OB4", "OB5"};
@@ -422,26 +433,6 @@ public class LinkedWarrantTest {
 
     }
 
-    /**
-     * Returns true when the warrant's running message shows it is at or past
-     * the given command index (1-based). All warrant running messages that
-     * include a command position end with "Cmd #N." so parsing the trailing
-     * number avoids the race condition where the warrant advances past exactly
-     * command N before the polling loop wakes up.
-     */
-    private static boolean atOrPastCommand(Warrant w, int minCmd) {
-        String m = w.getRunningMessage();
-        int i = m.lastIndexOf("Cmd #");
-        if (i < 0) return false;
-        String rest = m.substring(i + 5);
-        int dot = rest.indexOf('.');
-        if (dot < 0) return false;
-        try {
-            return Integer.parseInt(rest.substring(0, dot)) >= minCmd;
-        } catch (NumberFormatException e) {
-            return false;
-        }
-    }
 
     @BeforeEach
     public void setUp() {

--- a/java/test/jmri/jmrit/logix/LinkedWarrantTest.java
+++ b/java/test/jmri/jmrit/logix/LinkedWarrantTest.java
@@ -1,9 +1,11 @@
 package jmri.jmrit.logix;
 
+import java.beans.PropertyChangeListener;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.ArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
 import jmri.*;
 import jmri.util.JmriJFrame;
 import jmri.util.JUnitAppender;
@@ -58,6 +60,10 @@ public class LinkedWarrantTest {
         OBlock block = _OBlockMgr.getOBlock("OB12");
         assertNotNull(block);
 
+        AtomicInteger startCount = new AtomicInteger(0);
+        warrant.addPropertyChangeListener(Warrant.PROPERTY_WARRANT_START,
+                evt -> startCount.incrementAndGet());
+
         // WarrantTable.runTrain() returns a string that is not null if the
         // warrant can't be started
         assertNull(tableFrame.runTrain(warrant, Warrant.MODE_RUN),"Warrant starts"); // start run
@@ -79,6 +85,7 @@ public class LinkedWarrantTest {
         // It takes 600+ milliseconds per block to execute NXFrameTest.runtimes()
         // i.e. wait at least 600 * route.length for return
 
+        JUnitUtil.waitFor(() -> startCount.get() >= 2, "Loopy 2 started");
         JUnitUtil.waitFor(() -> WarrantTest.atOrPastCommand(warrant, 8), "Loopy 2 starts to move at 8th command");
 
         assertDoesNotThrow( () -> {
@@ -87,10 +94,7 @@ public class LinkedWarrantTest {
                 "LoopDeLoop Completes Second Leg");
         }, ("LoopDeLoop after Second leg Exception"));
 
-        // leg 3's setRunMode(MODE_RUN) resets getCurrentOrderIndex() to 0 — use that as the signal
-        JUnitUtil.waitFor(() -> warrant.getCurrentOrderIndex() == 0 && warrant.getRunMode() == Warrant.MODE_RUN,
-                "LoopDeLoop finished second leg");
-
+        JUnitUtil.waitFor(() -> startCount.get() >= 3, "LoopDeLoop finished second leg");
         JUnitUtil.waitFor(() -> WarrantTest.atOrPastCommand(warrant, 8), "Loopy 3 starts to move at 8th command");
 
         assertDoesNotThrow( () -> {
@@ -238,6 +242,13 @@ public class LinkedWarrantTest {
         String[] routeBack = {"OB11", "OB9", "OB7", "OB6", "OB5", "OB3", "OB1"};
         Sensor backEndSensor = block1.getSensor();
 
+        AtomicInteger outStartCount = new AtomicInteger(0);
+        outWarrant.addPropertyChangeListener(Warrant.PROPERTY_WARRANT_START,
+                evt -> outStartCount.incrementAndGet());
+        AtomicInteger backStartCount = new AtomicInteger(0);
+        backWarrant.addPropertyChangeListener(Warrant.PROPERTY_WARRANT_START,
+                evt -> backStartCount.incrementAndGet());
+
         // WarrantTable.runTrain() returns a string that is not null if the
         // warrant can't be started
         assertNull(ThreadingUtil.runOnGUIwithReturn( () ->
@@ -262,6 +273,7 @@ public class LinkedWarrantTest {
                                 outBlockName));
         }, "WestToEastLink finished first leg out");
 
+        JUnitUtil.waitFor(() -> backStartCount.get() >= 1, "EastToWestLink started");
         JUnitUtil.waitFor(() -> WarrantTest.atOrPastCommand(backWarrant, 8), "EastToWestLink starts to move at 8th command");
 
         assertDoesNotThrow( () -> {
@@ -278,6 +290,7 @@ public class LinkedWarrantTest {
                     block1.getDisplayName()));
         }, "EastToWestLink finished second leg back");
 
+        JUnitUtil.waitFor(() -> outStartCount.get() >= 2, "WestToEastLink started second run");
         JUnitUtil.waitFor(() -> WarrantTest.atOrPastCommand(outWarrant, 8), "WestToEastLink starts to move at 8th command");
 
         assertDoesNotThrow( () -> {
@@ -294,6 +307,7 @@ public class LinkedWarrantTest {
                     outBlockName));
         }, "WestToEastLink finished third leg");
 
+        JUnitUtil.waitFor(() -> backStartCount.get() >= 2, "EastToWestLink started second run");
         JUnitUtil.waitFor(() -> WarrantTest.atOrPastCommand(backWarrant, 8), "EastToWestLink starts to move at 8th command");
 
         assertDoesNotThrow( () -> {

--- a/java/test/jmri/jmrit/logix/LinkedWarrantTest.java
+++ b/java/test/jmri/jmrit/logix/LinkedWarrantTest.java
@@ -1,6 +1,7 @@
 package jmri.jmrit.logix;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.List;
 import java.util.ArrayList;
 import jmri.*;
@@ -12,6 +13,7 @@ import jmri.util.junit.annotations.DisabledIfHeadless;
 
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.junit.jupiter.api.io.TempDir;
 import org.netbeans.jemmy.operators.JFrameOperator;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -424,10 +426,10 @@ public class LinkedWarrantTest {
 
 
     @BeforeEach
-    public void setUp() {
+    public void setUp(@TempDir File tempDir) throws IOException {
         JUnitUtil.setUp();
         JUnitUtil.resetInstanceManager();
-        JUnitUtil.resetProfileManager();
+        JUnitUtil.resetProfileManager(new jmri.profile.NullProfile(tempDir));
         JUnitUtil.initConfigureManager();
         JUnitUtil.initInternalTurnoutManager();
         JUnitUtil.initInternalLightManager();
@@ -452,6 +454,15 @@ public class LinkedWarrantTest {
     @AfterEach
     public void tearDown() {
         JUnitUtil.removeMatchingThreads("Engineer(");
+
+        // CheckForTermination calls runTrain() on finish, poisoning the next test's WarrantTableFrame.lastClicktime; evict after they complete
+        JUnitUtil.waitFor(() -> Thread.getAllStackTraces().keySet().stream()
+                .noneMatch(t -> t.isAlive() && t.getName().startsWith("CheckForTermination")),
+                "CheckForTermination threads to terminate");
+        WarrantTableFrame wtf = InstanceManager.getNullableDefault(WarrantTableFrame.class);
+        if (wtf != null) {
+            InstanceManager.deregister(wtf, WarrantTableFrame.class);
+        }
 
         _warrantMgr.dispose();
         _warrantMgr = null;

--- a/java/test/jmri/jmrit/logix/LinkedWarrantTest.java
+++ b/java/test/jmri/jmrit/logix/LinkedWarrantTest.java
@@ -1,6 +1,5 @@
 package jmri.jmrit.logix;
 
-import java.beans.PropertyChangeListener;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;

--- a/java/test/jmri/jmrit/logix/LinkedWarrantTest.java
+++ b/java/test/jmri/jmrit/logix/LinkedWarrantTest.java
@@ -1,10 +1,8 @@
 package jmri.jmrit.logix;
 
-import java.beans.PropertyChangeListener;
 import java.io.File;
 import java.util.List;
 import java.util.ArrayList;
-import java.util.concurrent.atomic.AtomicBoolean;
 import jmri.*;
 import jmri.util.JmriJFrame;
 import jmri.util.JUnitAppender;
@@ -81,24 +79,15 @@ public class LinkedWarrantTest {
 
         JUnitUtil.waitFor(() -> WarrantTest.atOrPastCommand(warrant, 8), "Loopy 2 starts to move at 8th command");
 
-        // listener avoids polling a status that leg 3's immediate re-launch overwrites
-        AtomicBoolean leg2Done = new AtomicBoolean(false);
-        PropertyChangeListener legDone = evt -> {
-            if (Warrant.PROPERTY_STOP_WARRANT.equals(evt.getPropertyName())
-                    && "warrantComplete".equals(evt.getNewValue())) {
-                leg2Done.set(true);
-            }
-        };
-        warrant.addPropertyChangeListener(legDone);
-
         assertDoesNotThrow( () -> {
             assertEquals(block.getSensor(),
                 NXFrameTest.runtimes(route, _OBlockMgr),
                 "LoopDeLoop Completes Second Leg");
         }, ("LoopDeLoop after Second leg Exception"));
 
-        JUnitUtil.waitFor(leg2Done::get, "LoopDeLoop finished second leg");
-        warrant.removePropertyChangeListener(legDone);
+        // leg 3's setRunMode(MODE_RUN) resets getCurrentOrderIndex() to 0 — use that as the signal
+        JUnitUtil.waitFor(() -> warrant.getCurrentOrderIndex() == 0 && warrant.getRunMode() == Warrant.MODE_RUN,
+                "LoopDeLoop finished second leg");
 
         JUnitUtil.waitFor(() -> WarrantTest.atOrPastCommand(warrant, 8), "Loopy 3 starts to move at 8th command");
 

--- a/java/test/jmri/jmrit/logix/LinkedWarrantTest.java
+++ b/java/test/jmri/jmrit/logix/LinkedWarrantTest.java
@@ -65,10 +65,7 @@ public class LinkedWarrantTest {
             return lookingFor.equals(tableFrame.getStatus());
         }, "LoopDeLoop started first leg expected \"" + lookingFor + "\" but was \"" + tableFrame.getStatus()+"\"");
 
-        JUnitUtil.waitFor(() -> {
-            String m =  warrant.getRunningMessage();
-            return m.endsWith("Cmd #8.");
-        }, "Loopy 1 starts to move at 8th command");
+        JUnitUtil.waitFor(() -> atOrPastCommand(warrant, 8), "Loopy 1 starts to move at 8th command");
 
         // Run the train, then checks end location
         assertDoesNotThrow( () -> {
@@ -80,10 +77,7 @@ public class LinkedWarrantTest {
         // It takes 600+ milliseconds per block to execute NXFrameTest.runtimes()
         // i.e. wait at least 600 * route.length for return
 
-        JUnitUtil.waitFor(() -> {
-            String m =  warrant.getRunningMessage();
-            return m.endsWith("Cmd #8.");
-        }, "Loopy 2 starts to move at 8th command");
+        JUnitUtil.waitFor(() -> atOrPastCommand(warrant, 8), "Loopy 2 starts to move at 8th command");
 
         assertDoesNotThrow( () -> {
             assertEquals(block.getSensor(),
@@ -96,10 +90,7 @@ public class LinkedWarrantTest {
             return linkMsg.equals(tableFrame.getStatus());
         }, "LoopDeLoop finished second leg");
 
-        JUnitUtil.waitFor(() -> {
-            String m =  warrant.getRunningMessage();
-            return m.endsWith("Cmd #8.");
-        }, "Loopy 3 starts to move at 8th command");
+        JUnitUtil.waitFor(() -> atOrPastCommand(warrant, 8), "Loopy 3 starts to move at 8th command");
 
         assertDoesNotThrow( () -> {
             assertEquals(block.getSensor(),
@@ -157,10 +148,8 @@ public class LinkedWarrantTest {
         assertNull( ThreadingUtil.runOnGUIwithReturn(() ->
             tableFrame.runTrain(warrant, Warrant.MODE_RUN)),"Warrant starts"); // start run
 
-        JUnitUtil.waitFor(() -> {
-            String m =  warrant.getRunningMessage();
-            return m.endsWith("Cmd #8.");
-        }, "Train starts to move at 8th command, but running message was " + warrant.getRunningMessage());
+        JUnitUtil.waitFor(() -> atOrPastCommand(warrant, 8),
+            () -> "Train starts to move at 8th command, but running message was " + warrant.getRunningMessage());
 
        // OBlock of route
         String[] route1 = {"OB12", "OB1", "OB3", "OB5", "OB6", "OB7", "OB9", "OB11", "OB12"};
@@ -180,10 +169,8 @@ public class LinkedWarrantTest {
         Warrant ww = _warrantMgr.getWarrant("WestToEast");
         assertNotNull(ww,"warrant WestToEast exists");
 
-        JUnitUtil.waitFor(() -> {
-            String m =  ww.getRunningMessage();
-            return m.endsWith("Cmd #9.");
-        }, "Train Fred starts to move at 8th command, was: " + ww.getRunningMessage());
+        JUnitUtil.waitFor(() -> atOrPastCommand(ww, 9),
+            () -> "Train Fred starts to move at 9th command, was: " + ww.getRunningMessage());
 
         String[] route2 = {"OB1", "OB3", "OB5", "OB6", "OB7", "OB9", "OB11"};
         final OBlock block = _OBlockMgr.getOBlock("OB11");
@@ -255,10 +242,7 @@ public class LinkedWarrantTest {
         assertNull(ThreadingUtil.runOnGUIwithReturn( () ->
             tableFrame.runTrain(outWarrant, Warrant.MODE_RUN)),"Warrant starts"); // start run
 
-        JUnitUtil.waitFor(() -> {
-            String m =  outWarrant.getRunningMessage();
-            return m.endsWith("Cmd #8.");
-        }, "WestToEastLink starts to move at 8th command");
+        JUnitUtil.waitFor(() -> atOrPastCommand(outWarrant, 8), "WestToEastLink starts to move at 8th command");
 
         // Run the train, then checks end location
         assertDoesNotThrow( () -> {
@@ -277,10 +261,7 @@ public class LinkedWarrantTest {
                                 outBlockName));
         }, "WestToEastLink finished first leg out");
 
-        JUnitUtil.waitFor(() -> {
-            String m =  backWarrant.getRunningMessage();
-            return m.endsWith("Cmd #8.");
-        }, "EastToWestLink starts to move at 8th command");
+        JUnitUtil.waitFor(() -> atOrPastCommand(backWarrant, 8), "EastToWestLink starts to move at 8th command");
 
         assertDoesNotThrow( () -> {
             assertEquals(backEndSensor,
@@ -296,10 +277,7 @@ public class LinkedWarrantTest {
                     block1.getDisplayName()));
         }, "EastToWestLink finished second leg back");
 
-        JUnitUtil.waitFor(() -> {
-            String m =  outWarrant.getRunningMessage();
-            return m.endsWith("Cmd #8.");
-        }, "WestToEastLink starts to move at 8th command");
+        JUnitUtil.waitFor(() -> atOrPastCommand(outWarrant, 8), "WestToEastLink starts to move at 8th command");
 
         assertDoesNotThrow( () -> {
             assertEquals(outEndSensor,
@@ -315,10 +293,7 @@ public class LinkedWarrantTest {
                     outBlockName));
         }, "WestToEastLink finished third leg");
 
-        JUnitUtil.waitFor(() -> {
-            String m =  backWarrant.getRunningMessage();
-            return m.endsWith("Cmd #8.") || m.endsWith("Cmd #9.");
-        }, "EastToWestLink starts to move at 8th command");
+        JUnitUtil.waitFor(() -> atOrPastCommand(backWarrant, 8), "EastToWestLink starts to move at 8th command");
 
         assertDoesNotThrow( () -> {
             assertEquals(backEndSensor,
@@ -380,10 +355,7 @@ public class LinkedWarrantTest {
         // warrant can't be started
         assertNull(tableFrame.runTrain(w, Warrant.MODE_RUN),"Warrant starts"); // start run
 
-        JUnitUtil.waitFor(() -> {
-            String m =  w.getRunningMessage();
-            return m.endsWith("Cmd #8.");
-        }, "Tinker starts to move at 8th command");
+        JUnitUtil.waitFor(() -> atOrPastCommand(w, 8), "Tinker starts to move at 8th command");
 
        // OBlock of route
         String[] route1 = {"OB0", "OB1", "OB2", "OB3", "OB4", "OB5", "OB10"};
@@ -401,11 +373,8 @@ public class LinkedWarrantTest {
 
         Warrant ww = _warrantMgr.getWarrant("Evers");
 
-        JUnitUtil.waitFor(() -> {
-            String m =  ww.getRunningMessage();
-            // Evers is already running so we check for both cmd#8 and cmd#9 in case it's fast
-            return m.endsWith("Cmd #8.")||m.endsWith("Cmd #9.");
-        }, "Evers starts to move at 8th or 9th command but was: " + ww.getRunningMessage());
+        JUnitUtil.waitFor(() -> atOrPastCommand(ww, 8),
+            () -> "Evers starts to move at 8th command but was: " + ww.getRunningMessage());
 
         String[] route2 = {"OB7", "OB3", "OB2", "OB1"};
         OBlock block1 = _OBlockMgr.getOBlock("OB1");
@@ -420,10 +389,8 @@ public class LinkedWarrantTest {
 
         Warrant www = _warrantMgr.getWarrant("Chance");
 
-        JUnitUtil.waitFor(() -> {
-            String m =  www.getRunningMessage();
-            return m.endsWith("Cmd #8.") || m.endsWith("Cmd #9.") || m.endsWith("Cmd #10."); // in case runs fast
-        }, "Chance starts to move at 8th command but was: " + www.getRunningMessage());
+        JUnitUtil.waitFor(() -> atOrPastCommand(www, 8),
+            () -> "Chance starts to move at 8th command but was: " + www.getRunningMessage());
 
         String[] route3 = {"OB6", "OB3", "OB4", "OB5"};
         OBlock block5 = _OBlockMgr.getOBlock("OB5");
@@ -453,6 +420,27 @@ public class LinkedWarrantTest {
         www.dispose();
         JUnitUtil.waitFor( () -> w.getState() == -1, "tinker warrant terminated");
 
+    }
+
+    /**
+     * Returns true when the warrant's running message shows it is at or past
+     * the given command index (1-based). All warrant running messages that
+     * include a command position end with "Cmd #N." so parsing the trailing
+     * number avoids the race condition where the warrant advances past exactly
+     * command N before the polling loop wakes up.
+     */
+    private static boolean atOrPastCommand(Warrant w, int minCmd) {
+        String m = w.getRunningMessage();
+        int i = m.lastIndexOf("Cmd #");
+        if (i < 0) return false;
+        String rest = m.substring(i + 5);
+        int dot = rest.indexOf('.');
+        if (dot < 0) return false;
+        try {
+            return Integer.parseInt(rest.substring(0, dot)) >= minCmd;
+        } catch (NumberFormatException e) {
+            return false;
+        }
     }
 
     @BeforeEach

--- a/java/test/jmri/jmrit/logix/NXFrameTest.java
+++ b/java/test/jmri/jmrit/logix/NXFrameTest.java
@@ -234,10 +234,7 @@ public class NXFrameTest {
             warrant.controlRunTrain(Warrant.RESUME);
         });
 
-        JUnitUtil.waitFor(() -> {
-            String m =  warrant.getRunningMessage();
-            return m.endsWith("Cmd #8.");
-        }, "Train starts to move at 8th command");
+        JUnitUtil.waitFor(() -> WarrantTest.atOrPastCommand(warrant, 8), "Train starts to move at 8th command");
 
         // OBlock sensor names
         String[] route = {"OB0", "OB1", "OB2", "OB3", "OB7", "OB5", "OB10"};
@@ -298,13 +295,7 @@ public class NXFrameTest {
         assertNotNull( warrant, "warrant");
 
         tableFrame.runTrain(warrant, Warrant.MODE_RUN);
-        JUnitUtil.waitFor(() -> {
-            String m =  warrant.getRunningMessage();
-            if ( m == null ) {
-                return false;
-            }
-            return m.endsWith("Cmd #3.");
-        }, "Train is moving at 3rd command");
+        JUnitUtil.waitFor(() -> WarrantTest.atOrPastCommand(warrant, 3), "Train is moving at 3rd command");
 
        // OBlock sensor names
         String[] route = {"OB3", "OB4", "OB5", "OB10", "OB0", "OB1", "OB2", "OB3"};
@@ -365,13 +356,7 @@ public class NXFrameTest {
         sp.setRampThrottleIncrement(0.15f);
         sp.setRampTimeIncrement(100);
 
-        JUnitUtil.waitFor(() -> {
-            String m =  warrant.getRunningMessage();
-            if ( m == null ) {
-                return false;
-            }
-            return m.endsWith("Cmd #8.");
-        }, "Train starts to move at 8th command");
+        JUnitUtil.waitFor(() -> WarrantTest.atOrPastCommand(warrant, 8), "Train starts to move at 8th command");
 
        // OBlock sensor names
         String[] route1 = {"OB1", "OB6", "OB3"};

--- a/java/test/jmri/jmrit/logix/RouteFinderTest.java
+++ b/java/test/jmri/jmrit/logix/RouteFinderTest.java
@@ -1,6 +1,8 @@
 package jmri.jmrit.logix;
 
 import java.awt.GraphicsEnvironment;
+import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -10,6 +12,7 @@ import jmri.ShutDownTask;
 import jmri.util.JUnitUtil;
 
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.Assume;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -34,9 +37,9 @@ public class RouteFinderTest {
     }
 
     @BeforeEach
-    public void setUp() {
+    public void setUp(@TempDir File tempDir) throws IOException {
         JUnitUtil.setUp();
-        JUnitUtil.resetProfileManager();
+        JUnitUtil.resetProfileManager(new jmri.profile.NullProfile(tempDir));
         JUnitUtil.initRosterConfigManager();
     }
 

--- a/java/test/jmri/jmrit/logix/SCWarrantTest.java
+++ b/java/test/jmri/jmrit/logix/SCWarrantTest.java
@@ -99,15 +99,15 @@ public class SCWarrantTest extends WarrantTest {
         //jmri.util.JUnitAppender.assertWarnMessage("Path NorthToWest in block North has length zero. Cannot run NXWarrants or ramp speeds through blocks with zero length.");
         ThreadingUtil.runOnLayoutWithJmriException( () ->
             sWest.setState(Sensor.ACTIVE));
-        JUnitUtil.waitFor(100); // What should we specifically waitFor?
+        JUnitUtil.waitFor(() -> bWest.isOccupied(), "West block occupied");
 
         ThreadingUtil.runOnLayoutWithJmriException( () ->
             sWest.setState(Sensor.INACTIVE));
-        JUnitUtil.waitFor(100); // What should we specifically waitFor?
+        JUnitUtil.waitFor(() -> !bWest.isOccupied(), "West block unoccupied");
 
         ThreadingUtil.runOnLayoutWithJmriException( () ->
             sSouth.setState(Sensor.ACTIVE));
-        JUnitUtil.waitFor(100); // What should we specifically waitFor?
+        JUnitUtil.waitFor(() -> bSouth.isOccupied(), "South block occupied");
 
         // wait for done
         JUnitUtil.waitFor(() -> {

--- a/java/test/jmri/jmrit/logix/WarrantFrameTest.java
+++ b/java/test/jmri/jmrit/logix/WarrantFrameTest.java
@@ -1,6 +1,7 @@
 package jmri.jmrit.logix;
 
 import java.io.File;
+import java.io.IOException;
 
 import jmri.*;
 import jmri.util.*;
@@ -8,6 +9,7 @@ import jmri.util.swing.JemmyUtil;
 
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.junit.jupiter.api.io.TempDir;
 
 import org.netbeans.jemmy.operators.JFrameOperator;
 import org.netbeans.jemmy.operators.JLabelOperator;
@@ -150,9 +152,9 @@ public class WarrantFrameTest {
     }
 
     @BeforeEach
-    public void setUp() {
+    public void setUp(@TempDir File tempDir) throws IOException {
         JUnitUtil.setUp();
-        JUnitUtil.resetProfileManager();
+        JUnitUtil.resetProfileManager(new jmri.profile.NullProfile(tempDir));
         JUnitUtil.initConfigureManager();
         JUnitUtil.initRosterConfigManager();
         JUnitUtil.initWarrantManager();

--- a/java/test/jmri/jmrit/logix/WarrantTest.java
+++ b/java/test/jmri/jmrit/logix/WarrantTest.java
@@ -222,6 +222,21 @@ public class WarrantTest {
 
     }
 
+    protected static boolean atOrPastCommand(Warrant w, int minCmd) {
+        String m = w.getRunningMessage();
+        if (m == null) return false;
+        int i = m.lastIndexOf("Cmd #");
+        if (i < 0) return false;
+        String rest = m.substring(i + 5);
+        int dot = rest.indexOf('.');
+        if (dot < 0) return false;
+        try {
+            return Integer.parseInt(rest.substring(0, dot)) >= minCmd;
+        } catch (NumberFormatException e) {
+            return false;
+        }
+    }
+
     protected static class WarrantListener implements PropertyChangeListener {
 
         Warrant warrant;

--- a/java/test/jmri/jmrit/operations/OperationsTestCase.java
+++ b/java/test/jmri/jmrit/operations/OperationsTestCase.java
@@ -2,11 +2,13 @@ package jmri.jmrit.operations;
 
 import static org.junit.jupiter.api.Assertions.fail;
 
+import java.io.File;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
 import org.netbeans.jemmy.QueueTool;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,6 +27,9 @@ import jmri.util.JUnitUtil;
  */
 public class OperationsTestCase {
 
+    @TempDir
+    File tempDir;
+
     @BeforeEach
     public void setUp() {
         JUnitUtil.setUp();
@@ -35,7 +40,7 @@ public class OperationsTestCase {
     // Set things up outside of operations
     public void reset() {
         JUnitUtil.resetInstanceManager();
-        JUnitUtil.resetProfileManager();
+        JUnitUtil.resetProfileManager(tempDir);
         JUnitUtil.initRosterConfigManager();
         JUnitUtil.initInternalTurnoutManager();
         JUnitUtil.initInternalLightManager();

--- a/java/test/jmri/util/JUnitUtil.java
+++ b/java/test/jmri/util/JUnitUtil.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.awt.*;
+import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.lang.reflect.Field;
@@ -1297,6 +1298,21 @@ public class JUnitUtil {
             log.error("Settings directory \"{}\" does not exist", FileUtil.SETTINGS);
         } catch (IOException | IllegalArgumentException ex) {
             log.error("Unable to create profile", ex);
+        }
+    }
+
+    /**
+     * Use when an isolated per-test profile directory is available (e.g. from
+     * {@literal @TempDir}). Guarantees a clean profile regardless of the host
+     * machine's JMRI settings directory.
+     *
+     * @param tempDir a writable directory for the profile, typically from {@literal @TempDir}
+     */
+    public static void resetProfileManager(File tempDir) {
+        try {
+            resetProfileManager(new NullProfile(tempDir));
+        } catch (IOException ex) {
+            log.error("Unable to create profile in {}", tempDir, ex);
         }
     }
 


### PR DESCRIPTION
Fixes #15141

`LinkedWarrantTest` was throwing intermittent failures on CI — the kind that pass locally, fail occasionally in the suite, and are annoying to pin down. Dug into the timing and found a few overlapping issues.

- `waitFor` conditions were checking for an exact command string (`endsWith("Cmd #8.")`), so if the warrant moved past that point before the poll fired, the condition was stuck false until timeout. Replaced with a `>= N` helper (`atOrPastCommand`) that doesn't care if it's a step late.
- `testLoopedWarrant` and `testBackAndForth` were firing block sensors for leg N+1 before the new leg's engineer had started. The `atOrPastCommand` guard between legs was being satisfied by the stale running message from the previous leg. Fixed by listening for `PROPERTY_WARRANT_START` and gating each `runtimes()` call on `startCount >= N`, so sensors are never delivered before the new leg's engineer is running.
- Engineer had a missed-wakeup race in the block-sync wait: `_synchBlock` was set and `wait()` called without re-checking `_idxCurrentOrder` under the lock. If a block sensor fired between the outer check and `wait()`, `clearWaitForSync()` would see `_synchBlock == null` and skip `notifyAll()`, leaving the engineer stuck. Added a re-check of `_idxCurrentOrder` inside the `synchronized` block before `wait()`.
- `_idxCurrentOrder` and `_runMode` were not `volatile`: the former is written on EDT and read by the engineer thread without lock coverage; the latter is polled by `CheckForTermination` from its own thread.
- `stopWarrant()` was reading `_idxCurrentOrder` to decide which completion event to fire, but deallocation is async — that state could already be reset by the time we read it. Fixed by capturing before the async call.
- Same-loco linked warrants were dispatching `runWarrant()` via `runOnGUIEventually`, which goes through `WarrantTableFrame.runTrain()` and its 1-second debounce guard. If a `CheckForTermination` thread fired after the next test's setUp, it poisoned `lastClicktime` on the fresh frame and the test's own `runTrain()` call silently returned null. Fixed by calling `runWarrant()` directly on the engineer thread for same-loco warrants (no GUI calls in that path).
- Teardown now waits for any lingering `CheckForTermination` threads before evicting the `WarrantTableFrame` from InstanceManager, so the next test always starts with a clean frame.
- Six logix test classes were using the no-arg `resetProfileManager()` which picks up real profile data from `./temp/` on developer machines, causing `RosterConfigManager` failures. Switched to `@TempDir` + `NullProfile` for proper test isolation.
- Windows teardown: `setLocoIcon()` runs async and the editor can be disposed before the callback fires. Added a displayability check to the existing guard in `IndicatorTrackPaths`.
