### PR TITLE
Better handle lost and found serial ports in config pane

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -1,7 +1,10 @@
 
     <h3>Hardware Support</h3>
         <ul>
-          <li></li>
+          <li>The list of ports on a connection configuration page is now updated
+            event time to click on it to open it.  This lets you e.g. pull out your
+            command station port, note the list of remaining ones, then reconnect
+            your command station and select the new port that just appeared.</li>
         </ul>
 
         <h4>Acela CTI</h4>

--- a/java/src/jmri/jmrix/AbstractSerialConnectionConfig.java
+++ b/java/src/jmri/jmrix/AbstractSerialConnectionConfig.java
@@ -23,6 +23,8 @@ import javax.swing.JSpinner;
 import javax.swing.JTextField;
 import javax.swing.ListCellRenderer;
 import javax.swing.SpinnerNumberModel;
+import javax.swing.event.PopupMenuEvent;
+import javax.swing.event.PopupMenuListener;
 
 import jmri.util.PortNameMapper;
 import jmri.util.PortNameMapper.SerialPortFriendlyName;
@@ -165,7 +167,8 @@ abstract public class AbstractSerialConnectionConfig extends AbstractConnectionC
     String invalidPort = null;
 
 //    @SuppressWarnings("UseOfObsoleteCollectionType")
-    public void refreshPortBox() {
+    protected void refreshPortBox() {
+        log.debug("entering refreshPortBox");
         if (!init) {
             v = getPortNames();
             portBox.setRenderer(new ComboBoxRenderer());
@@ -189,7 +192,17 @@ abstract public class AbstractSerialConnectionConfig extends AbstractConnectionC
             log.error("port name Vector v is null!");
             return;
         }
-
+        
+        // Display differences between the present and previous list of ports
+        if (originalList != null) {
+            Vector<String> newPorts = new Vector<>(v);
+            newPorts.removeAll(originalList);
+            for (var port : newPorts) { log.info("Found new port {}", port);}
+            Vector<String> lostPorts = new Vector<>(originalList);
+            lostPorts.removeAll(v);
+            for (var port : lostPorts) { log.info("Port {} no longer present", port);}
+        }
+        
         /* as we make amendments to the list of port in vector v, we keep a copy of it before
          modification, this copy is then used to validate against any changes in the port lists.
          */
@@ -206,6 +219,7 @@ abstract public class AbstractSerialConnectionConfig extends AbstractConnectionC
             v.add(0, Bundle.getMessage("noPortsFound"));
         }
         String portName = adapter.getCurrentPortName();
+        portBox.setForeground(Color.black);
         if (portName != null && !portName.equals(Bundle.getMessage("noneSelected")) && !portName.equals(Bundle.getMessage("noPortsFound"))) {
             if (!v.contains(portName)) {
                 v.add(0, portName);
@@ -247,8 +261,21 @@ abstract public class AbstractSerialConnectionConfig extends AbstractConnectionC
 
         // add a listener for later changes
         portBox.addActionListener((ActionEvent e) -> {
+            log.debug("portBox action listener fired");
             String port = PortNameMapper.getPortFromName((String) portBox.getSelectedItem());
             adapter.setPort(port);
+        });
+        portBox.addPopupMenuListener(new PopupMenuListener(){
+            public void popupMenuCanceled(PopupMenuEvent e) {
+                log.trace("popupMenuCanceled");
+            }
+            public void popupMenuWillBecomeInvisible(PopupMenuEvent e) {
+                log.trace("popupMenuWillBecomeInvisible");
+            }
+            public void popupMenuWillBecomeVisible(PopupMenuEvent e) {
+                log.debug("popupMenuWillBecomeVisible");
+                refreshPortBox();
+            }
         });
     }
 
@@ -623,7 +650,12 @@ abstract public class AbstractSerialConnectionConfig extends AbstractConnectionC
      */
 //    @SuppressWarnings("UseOfObsoleteCollectionType") // historical interface
     protected Vector<String> getPortNames() {
-        return AbstractSerialPortController.getActualPortNames();
+        log.trace("enter getPortNames");
+        var retval = AbstractSerialPortController.getActualPortNames();
+        for (var port : retval) {
+            log.trace("  port {}", port);
+        }
+        return retval;
     }
         
     /**

--- a/java/src/jmri/jmrix/jserialcomm/JSerialPort.java
+++ b/java/src/jmri/jmrix/jserialcomm/JSerialPort.java
@@ -340,8 +340,10 @@ public class JSerialPort implements SerialPort {
                         && portNameVector.contains(getSymlinkTarget(file))
                         && !portNameVector.contains(file.getName())).map(File::getName).collect(Collectors.toSet());
                 portNameVector.addAll(symlinkPorts);
-                log.info("Adding symlink port {}", symlinkPorts);
-
+                if (symlinkPorts.size() > 0) {
+                    log.info("Adding symlink port {}", symlinkPorts);
+                }
+                
                 // Let the user add additional serial ports
                 String portnamePattern = System.getProperty("purejavacomm.portnamepattern");
                 if (portnamePattern != null) {


### PR DESCRIPTION
*) Every time you open the port JComboBox on the configuration pane, it'll rescan and show you the current list of ports.  This lets you unplug, take note, and plug to find your port.

*) Found and lost ports are logged by name at INFO level so they show on the system console.