### PR TITLE
DCC-EX: change default DCCppOverTCP port from 1235 to 2560

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -50,6 +50,7 @@
                     more than one display. Each display is shown in a single
                     row in the <strong>Virtual LCD</strong> window, with
                     the first display at the left.</li>
+                <li>Change default DCCppOverTCP port from 1235 to 2560 to match DCC-EX default.</li>
             </ul>
 
         <h4>DCC4pc</h4>

--- a/java/src/jmri/jmrix/dccpp/DCCppConstants.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppConstants.java
@@ -31,7 +31,7 @@ public final class DCCppConstants {
     public static final int NO_REGISTER_FREE = -1; // TODO: Should this be a unique value?
 
     // DCC-EX over TCP Port Number
-    public static final int DCCPP_OVER_TCP_PORT = 1235;
+    public static final int DCCPP_OVER_TCP_PORT = 2560;
 
     // Communications Port Info
     public static final int COMM_TYPE_SERIAL = 0;


### PR DESCRIPTION
DCC-EX communications default to port 2560, updating DCCppOverTCP default to match.