### PR TITLE
Call super.dispose() after listeners are removed

### DIFF
--- a/java/src/jmri/util/JmriJFrame.java
+++ b/java/src/jmri/util/JmriJFrame.java
@@ -1031,7 +1031,7 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
         synchronized (m) {
             m.remove(this);
         }
-        
+
         // workaround for code that directly calls dispose()
         // instead of dispatching a WINDOW_CLOSED event.  This
         // causes the windowClosing method to not be called. This in turn is an
@@ -1040,9 +1040,8 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
         ThreadingUtil.runOnGUIDelayed(() -> {
             removeWindowListener(this);
             removeComponentListener(this);
+            super.dispose();
         }, 500);
-        
-        super.dispose();
     }
 
     /*


### PR DESCRIPTION
Fixes the "Problem with constant "Premature end of file" in user-interface.xml" issue.
https://groups.io/g/jmriusers/message/252500