### PR TITLE
WIP Call super.dispose() after listeners are removed

### DIFF
--- a/java/src/jmri/util/JmriJFrame.java
+++ b/java/src/jmri/util/JmriJFrame.java
@@ -1037,11 +1037,16 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
         // causes the windowClosing method to not be called. This in turn is an
         // issue because people have put code in the windowClosed method that
         // should really be in windowClosing.
-        ThreadingUtil.runOnGUIDelayed(() -> {
+        Runnable r = () -> {
             removeWindowListener(this);
             removeComponentListener(this);
             super.dispose();
-        }, 500);
+        };
+        if (ThreadingUtil.isGUIThread()) {
+            r.run();
+        } else {
+            ThreadingUtil.runOnGUIDelayed(r, 500);
+        }
     }
 
     /*

--- a/java/src/jmri/util/JmriJFrame.java
+++ b/java/src/jmri/util/JmriJFrame.java
@@ -1031,7 +1031,7 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
         synchronized (m) {
             m.remove(this);
         }
-        
+
         // workaround for code that directly calls dispose()
         // instead of dispatching a WINDOW_CLOSED event.  This
         // causes the windowClosing method to not be called. This in turn is an
@@ -1040,9 +1040,8 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
         ThreadingUtil.runOnGUIDelayed(() -> {
             removeWindowListener(this);
             removeComponentListener(this);
+            super.dispose();
         }, 500);
-        
-        super.dispose();
     }
 
     /*

--- a/java/src/jmri/util/JmriJFrame.java
+++ b/java/src/jmri/util/JmriJFrame.java
@@ -1037,7 +1037,7 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
         // causes the windowClosing method to not be called. This in turn is an
         // issue because people have put code in the windowClosed method that
         // should really be in windowClosing.
-        Runnable r = () -> {
+        jmri.util.ThreadingUtil.ThreadAction r = () -> {
             removeWindowListener(this);
             removeComponentListener(this);
             super.dispose();
@@ -1045,7 +1045,7 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
         if (ThreadingUtil.isGUIThread()) {
             r.run();
         } else {
-            ThreadingUtil.runOnGUIDelayed(r, 500);
+            ThreadingUtil.runOnGUI(r);
         }
     }
 


### PR DESCRIPTION
Fixes the "Problem with constant "Premature end of file" in user-interface.xml" issue.
https://groups.io/g/jmriusers/message/252500

PR #15164 has a lot of failures in Windows CI and this PR tries to solve that.