### PR TITLE
DCC-EX EXRAIL Automations: remember last loco address within session

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -54,6 +54,10 @@
                 Entry details are fetched sequentially for reliability on hardware with small
                 WiFi buffers (Mega+WiFi)
                 (<a href="https://github.com/JMRI/JMRI/pull/15160">PR #15160</a>).</li>
+                <li>The <strong>EXRAIL Automations</strong> window now remembers the last loco
+                address you entered during the session - the prompt pre-fills it the next time
+                you trigger an automation. The dialog also validates the address (1-10293)
+                and re-prompts if the input is out of range or not a number.</li>
                 <li>The <strong>Virtual LCD</strong> window now supports
                     more than one display. Each display is shown in a single
                     row in the <strong>Virtual LCD</strong> window, with

--- a/java/src/jmri/jmrix/dccpp/swing/DCCppSwingBundle.properties
+++ b/java/src/jmri/jmrix/dccpp/swing/DCCppSwingBundle.properties
@@ -102,3 +102,6 @@ ExrailTypeAutomation = Automation
 ExrailButtonSet = Set
 ExrailLabelLocoAddress = Loco Address:
 ExrailTitleLocoDialog = Start Automation
+# Loco address input validation; {0} is replaced by DCCppConstants.MAX_LOCO_ADDRESS
+ExrailLocoAddressInvalid = Enter a number from 1 to {0}.
+ExrailLocoAddressInvalidTitle = Invalid Loco Address

--- a/java/src/jmri/jmrix/dccpp/swing/exrail/DCCppExrailFrame.java
+++ b/java/src/jmri/jmrix/dccpp/swing/exrail/DCCppExrailFrame.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.OptionalInt;
 import java.util.Queue;
 
 import javax.swing.JButton;
@@ -21,6 +22,7 @@ import javax.swing.table.AbstractTableModel;
 import javax.swing.table.TableCellRenderer;
 
 import jmri.jmrix.ConnectionStatus;
+import jmri.jmrix.dccpp.DCCppConstants;
 import jmri.jmrix.dccpp.DCCppExrailEntry;
 import jmri.jmrix.dccpp.DCCppInterface;
 import jmri.jmrix.dccpp.DCCppListener;
@@ -53,6 +55,7 @@ public class DCCppExrailFrame extends JmriJFrame implements DCCppListener {
     private ExrailTableModel _tableModel;
     private JTable _table;
     private PropertyChangeListener _connListener;
+    private String _lastLocoAddress; // last valid address entered this session; null until first successful trigger
 
     public DCCppExrailFrame(DCCppSystemConnectionMemo memo) {
         super(true, false); // save position; let user resize freely
@@ -127,25 +130,53 @@ public class DCCppExrailFrame extends JmriJFrame implements DCCppListener {
     private void handleRowTrigger(DCCppExrailEntry entry) {
         if (entry == null) return;
         if (entry.isAutomation()) {
-            String input = JmriJOptionPane.showInputDialog(this,
-                    Bundle.getMessage("ExrailLabelLocoAddress"),
-                    Bundle.getMessage("ExrailTitleLocoDialog"),
-                    JmriJOptionPane.QUESTION_MESSAGE);
-            if (input == null) return;
-            try {
-                triggerEntry(entry, Integer.parseInt(input.trim()));
-            } catch (NumberFormatException ex) {
-                log.warn("Invalid loco address entered: {}", input);
-            }
+            OptionalInt addr = promptLocoAddress();
+            if (addr.isPresent()) triggerEntry(entry, addr.getAsInt());
         } else {
             triggerEntry(entry, 0);
         }
     }
 
+    /** Prompts repeatedly until a valid loco address is entered or the user cancels. */
+    private OptionalInt promptLocoAddress() {
+        while (true) {
+            String input = (String) JmriJOptionPane.showInputDialog(this,
+                    Bundle.getMessage("ExrailLabelLocoAddress"),
+                    Bundle.getMessage("ExrailTitleLocoDialog"),
+                    JmriJOptionPane.QUESTION_MESSAGE,
+                    null, null, _lastLocoAddress);
+            if (input == null) return OptionalInt.empty();
+            try {
+                int addr = Integer.parseInt(input.trim());
+                if (addr >= 1 && addr <= DCCppConstants.MAX_LOCO_ADDRESS) {
+                    _lastLocoAddress = input.trim();
+                    return OptionalInt.of(addr);
+                }
+            } catch (NumberFormatException ex) { // invalid input — fall through to error dialog
+            }
+            showLocoAddressError();
+        }
+    }
+
+    /** Shows an error dialog when the entered loco address is out of range or non-numeric. */
+    private void showLocoAddressError() {
+        JmriJOptionPane.showMessageDialog(this,
+                Bundle.getMessage("ExrailLocoAddressInvalid", DCCppConstants.MAX_LOCO_ADDRESS),
+                Bundle.getMessage("ExrailLocoAddressInvalidTitle"),
+                JmriJOptionPane.ERROR_MESSAGE);
+    }
+
+    /** Returns the last loco address entered this session; used by tests. */
+    String getLastLocoAddress() {
+        return _lastLocoAddress;
+    }
+
     void triggerEntry(DCCppExrailEntry entry, int locoAddress) {
         if (entry.isAutomation()) {
+            log.debug("Triggering EXRAIL automation id={} locoAddress={}", entry.getId(), locoAddress);
             _tc.sendDCCppMessage(DCCppMessage.makeStartExrailMsg(entry.getId(), locoAddress), null);
         } else {
+            log.debug("Triggering EXRAIL route id={}", entry.getId());
             _tc.sendDCCppMessage(DCCppMessage.makeStartExrailMsg(entry.getId()), null);
         }
     }

--- a/java/src/jmri/jmrix/dccpp/swing/exrail/DCCppExrailFrame.java
+++ b/java/src/jmri/jmrix/dccpp/swing/exrail/DCCppExrailFrame.java
@@ -129,6 +129,7 @@ public class DCCppExrailFrame extends JmriJFrame implements DCCppListener {
     /** Prompt for loco address if needed and fire the entry. */
     private void handleRowTrigger(DCCppExrailEntry entry) {
         if (entry == null) return;
+        if (!isDisplayable()) return; // window already closing
         if (entry.isAutomation()) {
             OptionalInt addr = promptLocoAddress();
             if (addr.isPresent()) triggerEntry(entry, addr.getAsInt());
@@ -225,6 +226,9 @@ public class DCCppExrailFrame extends JmriJFrame implements DCCppListener {
 
     @Override
     public void dispose() {
+        if (_table != null && _table.isEditing()) {
+            _table.getCellEditor().cancelCellEditing(); // prevent spurious trigger on window close
+        }
         if (_connListener != null) {
             ConnectionStatus.instance().removePropertyChangeListener(_memo, _connListener);
             _connListener = null;

--- a/java/test/jmri/jmrix/dccpp/swing/exrail/DCCppExrailFrameTest.java
+++ b/java/test/jmri/jmrix/dccpp/swing/exrail/DCCppExrailFrameTest.java
@@ -11,7 +11,13 @@ import jmri.jmrix.dccpp.DCCppSystemConnectionMemo;
 import jmri.util.JUnitUtil;
 import jmri.util.junit.annotations.DisabledIfHeadless;
 
+import java.util.concurrent.atomic.AtomicReference;
+
 import org.junit.jupiter.api.*;
+import org.netbeans.jemmy.QueueTool;
+import org.netbeans.jemmy.operators.JButtonOperator;
+import org.netbeans.jemmy.operators.JDialogOperator;
+import org.netbeans.jemmy.operators.JTextFieldOperator;
 
 /**
  * Tests for DCCppExrailFrame.
@@ -245,6 +251,108 @@ public class DCCppExrailFrameTest extends jmri.util.JmriJFrameTestBase {
         exrailFrame.message(DCCppReply.parseDCCppReply("jB 1 \"Go!\""));
         Assertions.assertEquals("Station Loop", exrailFrame.getRowName(0),
                 "name column should always show description, not caption");
+    }
+
+    @Test
+    public void testLocoAddressStoredAfterSuccessfulTrigger() {
+        DCCppExrailFrame exrailFrame = (DCCppExrailFrame) frame;
+        exrailFrame.message(DCCppReply.parseDCCppReply("jA 1"));
+        exrailFrame.message(DCCppReply.parseDCCppReply("jA 1 A \"Yard Switcher\""));
+
+        Thread t = new Thread(() -> {
+            JDialogOperator d = new JDialogOperator("Start Automation");
+            new JTextFieldOperator(d).setText("1234");
+            new JButtonOperator(d, "OK").push();
+        });
+        t.start();
+        exrailFrame.triggerRowForTest(0);
+        JUnitUtil.waitFor(() -> !t.isAlive(), "jemmy thread finished");
+        new QueueTool().waitEmpty();
+
+        Assertions.assertEquals("1234", exrailFrame.getLastLocoAddress(),
+                "last loco address should be stored after successful trigger");
+    }
+
+    @Test
+    public void testLocoAddressPrefilledOnSecondTrigger() {
+        DCCppExrailFrame exrailFrame = (DCCppExrailFrame) frame;
+        exrailFrame.message(DCCppReply.parseDCCppReply("jA 1"));
+        exrailFrame.message(DCCppReply.parseDCCppReply("jA 1 A \"Yard Switcher\""));
+
+        Thread t1 = new Thread(() -> {
+            JDialogOperator d = new JDialogOperator("Start Automation");
+            new JTextFieldOperator(d).setText("1234");
+            new JButtonOperator(d, "OK").push();
+        });
+        t1.start();
+        exrailFrame.triggerRowForTest(0);
+        JUnitUtil.waitFor(() -> !t1.isAlive(), "first jemmy thread finished");
+        new QueueTool().waitEmpty();
+
+        AtomicReference<String> capturedInitial = new AtomicReference<>();
+        Thread t2 = new Thread(() -> {
+            JDialogOperator d = new JDialogOperator("Start Automation");
+            capturedInitial.set(new JTextFieldOperator(d).getText());
+            new JButtonOperator(d, "OK").push();
+        });
+        t2.start();
+        exrailFrame.triggerRowForTest(0);
+        JUnitUtil.waitFor(() -> !t2.isAlive(), "second jemmy thread finished");
+        new QueueTool().waitEmpty();
+
+        Assertions.assertEquals("1234", capturedInitial.get(),
+                "second dialog should pre-fill the last entered address");
+    }
+
+    @Test
+    public void testInvalidLocoAddressShowsErrorAndRePrompts() {
+        DCCppExrailFrame exrailFrame = (DCCppExrailFrame) frame;
+        exrailFrame.message(DCCppReply.parseDCCppReply("jA 1"));
+        exrailFrame.message(DCCppReply.parseDCCppReply("jA 1 A \"Yard Switcher\""));
+
+        Thread t = new Thread(() -> {
+            JDialogOperator input1 = new JDialogOperator("Start Automation");
+            new JTextFieldOperator(input1).setText("0");
+            new JButtonOperator(input1, "OK").push();
+
+            new JButtonOperator(new JDialogOperator("Invalid Loco Address"), "OK").push();
+
+            JDialogOperator input2 = new JDialogOperator("Start Automation");
+            new JTextFieldOperator(input2).setText("1234");
+            new JButtonOperator(input2, "OK").push();
+        });
+        t.start();
+        exrailFrame.triggerRowForTest(0);
+        JUnitUtil.waitFor(() -> !t.isAlive(), "jemmy thread finished");
+        new QueueTool().waitEmpty();
+
+        Assertions.assertEquals("1234", exrailFrame.getLastLocoAddress(),
+                "valid address entered after retry should be stored");
+    }
+
+    @Test
+    public void testCancelAfterErrorExitsWithoutSending() {
+        DCCppExrailFrame exrailFrame = (DCCppExrailFrame) frame;
+        exrailFrame.message(DCCppReply.parseDCCppReply("jA 1"));
+        exrailFrame.message(DCCppReply.parseDCCppReply("jA 1 A \"Yard Switcher\""));
+        int outboundBefore = tc.outbound.size();
+
+        Thread t = new Thread(() -> {
+            JDialogOperator input1 = new JDialogOperator("Start Automation");
+            new JTextFieldOperator(input1).setText("abc");
+            new JButtonOperator(input1, "OK").push();
+
+            new JButtonOperator(new JDialogOperator("Invalid Loco Address"), "OK").push();
+
+            new JButtonOperator(new JDialogOperator("Start Automation"), "Cancel").push();
+        });
+        t.start();
+        exrailFrame.triggerRowForTest(0);
+        JUnitUtil.waitFor(() -> !t.isAlive(), "dialog sequence complete");
+        new QueueTool().waitEmpty();
+
+        Assertions.assertEquals(outboundBefore, tc.outbound.size(), "cancel after error should not send a command");
+        Assertions.assertNull(exrailFrame.getLastLocoAddress(), "cancel after error should not store an address");
     }
 
     @BeforeEach

--- a/java/test/jmri/jmrix/dccpp/swing/exrail/DCCppExrailFrameTest.java
+++ b/java/test/jmri/jmrix/dccpp/swing/exrail/DCCppExrailFrameTest.java
@@ -254,6 +254,22 @@ public class DCCppExrailFrameTest extends jmri.util.JmriJFrameTestBase {
     }
 
     @Test
+    public void testNoDialogAfterWindowDisposed() {
+        DCCppExrailFrame exrailFrame = (DCCppExrailFrame) frame;
+        exrailFrame.message(DCCppReply.parseDCCppReply("jA 1"));
+        exrailFrame.message(DCCppReply.parseDCCppReply("jA 1 A \"Yard Switcher\""));
+
+        // Dispose the frame, then fire a trigger — no dialog should appear.
+        exrailFrame.dispose();
+        exrailFrame.triggerRowForTest(0);
+        new QueueTool().waitEmpty();
+
+        // If a dialog had appeared it would block the test; reaching here means it didn't.
+        Assertions.assertNull(exrailFrame.getLastLocoAddress(),
+                "no address should be stored when window is disposed before trigger fires");
+    }
+
+    @Test
     public void testLocoAddressStoredAfterSuccessfulTrigger() {
         DCCppExrailFrame exrailFrame = (DCCppExrailFrame) frame;
         exrailFrame.message(DCCppReply.parseDCCppReply("jA 1"));


### PR DESCRIPTION
Closes #15171

The loco address prompt in the EXRAIL Automations window now pre-fills with the last value you entered. Resets when you close the window.

Also added input validation - if the address is out of range or not a number, you get an error dialog and the prompt comes back. Cancel still exits cleanly.

Tests cover the pre-fill behavior, the validation retry loop, and cancel.