### PR TITLE
LocoNet-over-TCP automatic reconnect

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -116,7 +116,7 @@
 
         <h4>LocoNet</h4>
             <ul>
-                <li></li>
+                <li>LocoNet-over-TCP connections now automatically reconnect if the server goes away and comes back. Detection relies on a clean TCP close from the server; hard disconnects (network drop with no TCP FIN) are only detected when JMRI next tries to send a message.</li>
             </ul>
 
         <h4>Maple</h4>

--- a/java/src/jmri/jmrix/loconet/loconetovertcp/LnOverTcpPacketizer.java
+++ b/java/src/jmri/jmrix/loconet/loconetovertcp/LnOverTcpPacketizer.java
@@ -71,6 +71,14 @@ public class LnOverTcpPacketizer extends LnPacketizer {
         networkController = p;
     }
 
+    /** Starts a new receive thread after a reconnect. */
+    public void restartRcvThread() {
+        rcvThread = jmri.util.ThreadingUtil.newThread(rcvHandler, "LocoNet receive handler"); // NOI18N
+        rcvThread.setDaemon(true);
+        rcvThread.setPriority(Thread.MAX_PRIORITY);
+        rcvThread.start();
+    }
+
     /**
      * Break connection to existing LnPortnetworkController object. Once broken,
      * attempts to send via "message" member will fail.
@@ -122,7 +130,10 @@ public class LnOverTcpPacketizer extends LnPacketizer {
                         return;
                     }
                     if (rxLine == null) {
-                        log.warn("run: input stream returned null, exiting loop");
+                        log.info("run: server closed connection, attempting recovery");
+                        if (trafficController.networkController != null) {
+                            trafficController.networkController.recover();
+                        }
                         return;
                     }
 
@@ -270,6 +281,10 @@ public class LnOverTcpPacketizer extends LnPacketizer {
                         }
                     } catch (java.io.IOException e) {
                         log.warn("sendLocoNetMessage: IOException: {}", e.toString());
+                        // write failed; connection likely dropped
+                        if (networkController != null) {
+                            networkController.recover();
+                        }
                     }
                 } catch (InterruptedException ie) {
                     return; // ending the thread

--- a/java/src/jmri/jmrix/loconet/loconetovertcp/LnTcpDriverAdapter.java
+++ b/java/src/jmri/jmrix/loconet/loconetovertcp/LnTcpDriverAdapter.java
@@ -1,6 +1,7 @@
 package jmri.jmrix.loconet.loconetovertcp;
 
 import jmri.jmrix.loconet.LnNetworkPortController;
+import jmri.jmrix.loconet.LnTrafficController;
 import jmri.jmrix.loconet.LocoNetSystemConnectionMemo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -19,6 +20,8 @@ public class LnTcpDriverAdapter extends LnNetworkPortController {
 
     public LnTcpDriverAdapter(LocoNetSystemConnectionMemo m) {
         super(m);
+        allowConnectionRecovery = true;
+        reconnectMaxAttempts = -1; // retry indefinitely
         option2Name = "CommandStation";
         option3Name = "TurnoutHandle";
         options.put(option2Name, new Option(Bundle.getMessage("CommandStationTypeLabel"), commandStationNames, false));
@@ -35,6 +38,25 @@ public class LnTcpDriverAdapter extends LnNetworkPortController {
 
     public LnTcpDriverAdapter() {
         this(new LocoNetSystemConnectionMemo());
+    }
+
+    @Override
+    public void recover() {
+        if (allowConnectionRecovery && opened) {
+            log.info("Connection to {}:{} lost. Attempting to recover...", getHostName(), getPort());
+        }
+        super.recover();
+    }
+
+    // after reconnect, reattach the packetizer's streams and restart the receive thread
+    @Override
+    protected void resetupConnection() {
+        LnTrafficController tc = getSystemConnectionMemo().getLnTrafficController();
+        if (tc instanceof LnOverTcpPacketizer) {
+            LnOverTcpPacketizer packets = (LnOverTcpPacketizer) tc;
+            packets.connectPort(this);
+            packets.restartRcvThread();
+        }
     }
 
     /**
@@ -70,9 +92,6 @@ public class LnTcpDriverAdapter extends LnNetworkPortController {
     public boolean status() {
         return opened;
     }
-
-    // private control members
-    private final boolean opened = false;
 
     @Override
     public void configureOption1(String value) {

--- a/java/test/jmri/jmrix/loconet/loconetovertcp/LnTcpDriverAdapterTest.java
+++ b/java/test/jmri/jmrix/loconet/loconetovertcp/LnTcpDriverAdapterTest.java
@@ -26,6 +26,15 @@ public class LnTcpDriverAdapterTest {
         Assert.assertNotNull("exists", tm);
     }
 
+    @Test
+    public void testReconnectDefaultsOn() {
+        LnTcpDriverAdapter a = new LnTcpDriverAdapter();
+        Assert.assertTrue("automatic reconnect should be enabled by default",
+                a.getAllowConnectionRecovery());
+        Assert.assertEquals("default reconnect attempts should be unlimited",
+                -1, a.getReconnectMaxAttempts());
+    }
+
     @BeforeEach
     public void setUp() {
         JUnitUtil.setUp();


### PR DESCRIPTION
Follows the same pattern as #15115 — when the LocoNet-over-TCP server goes away and comes back, JMRI reconnects automatically rather than requiring a full restart. Addresses #14907.

Changes are all client-side (`LnTcpDriverAdapter` and `LnOverTcpPacketizer`):

- `allowConnectionRecovery = true`, unlimited retries — same defaults as the DCC-EX ethernet adapter
- `RcvHandler` calls `recover()` when `readLine()` returns null (clean server shutdown/restart)
- `XmtHandler` calls `recover()` when a write fails (hard disconnect, detected on next outbound message)
- `resetupConnection()` reattaches the packetizer's streams and restarts the receive thread after a successful reconnect

One gap: there's no keepalive. DCC-EX sends a heartbeat every 30s, which lets it use SO_TIMEOUT to detect hard disconnects proactively. I couldn't find a safe LocoNet message to send as a heartbeat — open to suggestions if a keepalive is a good idea. For now, hard disconnects are only detected when JMRI next tries to send a message. Clean shutdowns (the main use case) are detected instantly.

Tested against a live LocoNet-over-TCP server on a separate Pi. Confirmed clean disconnect detection, retry loop with backoff, and successful reconnect on server return. Connection indicator goes red during the retry loop and clears when reconnected.