### PR TITLE
Add option to disable popup menu for loco markers

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -546,7 +546,11 @@
    <h3>Panel Editor</h3>
         <a id="PE" name="PE"></a>
         <ul>
-            <li></li>
+            <li>The option <strong>Loco marker popup menus active</strong> has been added
+                to the Panel Editor editor. If it's deselected, it's possible to move around
+                loco markers but it's not possible to open the popup menu for loco markers.
+                This is useful for dispatcher that wants to move the loco markers but doesn't
+                want to edit the loco markers.</li>
         </ul>
 
     <h3>Permissions</h3>

--- a/java/src/jmri/jmrit/display/DisplayBundle.properties
+++ b/java/src/jmri/jmrit/display/DisplayBundle.properties
@@ -238,6 +238,7 @@ PromptNewName   = Enter new name:
 
 CheckBoxGlobalFlags  = Override individual Position & Control settings
 CheckBoxEditable     = Panel items popup menus active
+CheckBoxLocoMarkerEditable     = Loco marker popup menus active
 CheckBoxPositionable = All panel items can be repositioned
 CheckBoxHidden       = Show all hidden Items
 CheckBoxShowCoordinates = Show item coordinates in popup menu

--- a/java/src/jmri/jmrit/display/Editor.java
+++ b/java/src/jmri/jmrit/display/Editor.java
@@ -750,7 +750,7 @@ public abstract class Editor extends JmriJFrameWithPermissions
 
     /**
      * Control whether loco markers are editable. Does this by invoke the
-     * {@link Positionable#setLocoMarkerEditable(boolean)} function of each
+     * {@link LocoIcon#setLocoMarkerEditable(boolean)} function of each
      * loco marker on the target panel. This also controls the relevant pop-up
      * menu items (which are the primary way that items are edited).
      *

--- a/java/src/jmri/jmrit/display/Editor.java
+++ b/java/src/jmri/jmrit/display/Editor.java
@@ -125,6 +125,7 @@ public abstract class Editor extends JmriJFrameWithPermissions
     // Option menu items
     protected int _scrollState = SCROLL_NONE;
     protected boolean _editable = true;
+    private boolean _locoMarkerEditable = true;
     private boolean _positionable = true;
     private boolean _controlLayout = true;
     private boolean _showHidden = true;
@@ -747,6 +748,23 @@ public abstract class Editor extends JmriJFrameWithPermissions
         }
     }
 
+    /**
+     * Control whether loco markers are editable. Does this by invoke the
+     * {@link Positionable#setLocoMarkerEditable(boolean)} function of each
+     * loco marker on the target panel. This also controls the relevant pop-up
+     * menu items (which are the primary way that items are edited).
+     *
+     * @param state true for editable.
+     */
+    public void setLocoMarkerEditable(boolean state) {
+        _locoMarkerEditable = state;
+        for (Positionable _content : _contents) {
+            if (_content instanceof LocoIcon) {
+                ((LocoIcon)_content).setLocoMarkerEditable(state);
+            }
+        }
+    }
+
     public void deselectSelectionGroup() {
         if (_selectionGroup == null) {
             return;
@@ -763,6 +781,10 @@ public abstract class Editor extends JmriJFrameWithPermissions
     // accessor routines for persistent information
     public boolean isEditable() {
         return _editable;
+    }
+
+    public boolean isLocoMarkerEditable() {
+        return _locoMarkerEditable;
     }
 
     /**

--- a/java/src/jmri/jmrit/display/LocoIcon.java
+++ b/java/src/jmri/jmrit/display/LocoIcon.java
@@ -41,6 +41,7 @@ public class LocoIcon extends PositionableLabel {
 
     public static final Color COLOR_BLUE = new Color(40, 140, 255);
 
+    private boolean _locoMarkerEditable = true;
     private int _dockX = 0;
     private int _dockY = 0;
     private Color _locoColor;
@@ -80,11 +81,21 @@ public class LocoIcon extends PositionableLabel {
     }
 
     protected Positionable finishClone(LocoIcon pos) {
+        pos._locoMarkerEditable = _locoMarkerEditable;
         if (_entry != null) {
             pos.setRosterEntry(getRosterEntry());
         }
         pos.setText(getText());
         return super.finishClone(pos);
+    }
+
+    public void setLocoMarkerEditable(boolean enabled) {
+        _locoMarkerEditable = enabled;
+        showHidden();
+    }
+
+    public boolean isLocoMarkerEditable() {
+        return _locoMarkerEditable;
     }
 
     // Marker tool tips are always disabled
@@ -112,6 +123,9 @@ public class LocoIcon extends PositionableLabel {
      */
     @Override
     public boolean showPopUp(JPopupMenu popup) {
+        if (!_locoMarkerEditable) {
+            return true;
+        }
         if (_entry != null) {
             popup.add(new AbstractAction("Throttle") {
                 @Override

--- a/java/src/jmri/jmrit/display/configurexml/LocoIconXml.java
+++ b/java/src/jmri/jmrit/display/configurexml/LocoIconXml.java
@@ -7,6 +7,7 @@ import jmri.jmrit.display.LocoIcon;
 import jmri.jmrit.roster.Roster;
 import jmri.jmrit.roster.RosterEntry;
 
+import org.jdom2.DataConversionException;
 import org.jdom2.Element;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,6 +44,9 @@ public class LocoIconXml extends PositionableLabelXml {
         }
         storeTextInfo(p, element);
         element.setAttribute("icon", "yes");
+        if (!p.isLocoMarkerEditable()) {
+            element.setAttribute("locoMarkerEditable", "no");
+        }
         element.setAttribute("dockX", "" + p.getDockX());
         element.setAttribute("dockY", "" + p.getDockY());
         element.addContent(storeIcon("icon", (NamedIcon) p.getIcon()));
@@ -99,6 +103,13 @@ public class LocoIconXml extends PositionableLabelXml {
         }
         l.updateIcon(icon);
 
+        try {
+            l.setLocoMarkerEditable(element.getAttribute("locoMarkerEditable").getBooleanValue());
+        } catch (DataConversionException e) {
+            log.warn("unable to convert positionable label editable attribute");
+        } catch (NullPointerException e) {
+            // considered normal if the attribute not present
+        }
         try {
             int x = element.getAttribute("dockX").getIntValue();
             int y = element.getAttribute("dockY").getIntValue();

--- a/java/src/jmri/jmrit/display/panelEditor/PanelEditor.java
+++ b/java/src/jmri/jmrit/display/panelEditor/PanelEditor.java
@@ -114,6 +114,7 @@ public class PanelEditor extends Editor implements ItemListener {
     private final JTextField nextY = new JTextField("0", 4);
 
     private final JCheckBox editableBox = new JCheckBox(Bundle.getMessage("CheckBoxEditable"));
+    private final JCheckBox locoMarkerEditableBox = new JCheckBox(Bundle.getMessage("CheckBoxLocoMarkerEditable"));
     private final JCheckBox positionableBox = new JCheckBox(Bundle.getMessage("CheckBoxPositionable"));
     private final JCheckBox controllingBox = new JCheckBox(Bundle.getMessage("CheckBoxControlling"));
     //private JCheckBox showCoordinatesBox = new JCheckBox(Bundle.getMessage("CheckBoxShowCoordinates"));
@@ -149,6 +150,7 @@ public class PanelEditor extends Editor implements ItemListener {
         common.add(nextY);
         contentPane.add(common);
         setAllEditable(true);
+        setLocoMarkerEditable(true);
         setShowHidden(true);
         super.setTargetPanel(null, makeFrame(name));
         super.setTargetPanelSize(400, 300);
@@ -305,6 +307,12 @@ public class PanelEditor extends Editor implements ItemListener {
                 hiddenCheckBoxListener();
             });
             editableBox.setSelected(isEditable());
+            // loco marker editable
+            contentPane.add(locoMarkerEditableBox);
+            locoMarkerEditableBox.addActionListener(event -> {
+                setLocoMarkerEditable(locoMarkerEditableBox.isSelected());
+            });
+            locoMarkerEditableBox.setSelected(isLocoMarkerEditable());
             // positionable item
             contentPane.add(positionableBox);
             positionableBox.addActionListener(event -> setAllPositionable(positionableBox.isSelected()));
@@ -406,6 +414,7 @@ public class PanelEditor extends Editor implements ItemListener {
     @Override
     public void initView() {
         editableBox.setSelected(isEditable());
+        locoMarkerEditableBox.setSelected(isLocoMarkerEditable());
         positionableBox.setSelected(allPositionable());
         controllingBox.setSelected(allControlling());
         //showCoordinatesBox.setSelected(showCoordinates());

--- a/java/src/jmri/jmrit/display/panelEditor/configurexml/PanelEditorXml.java
+++ b/java/src/jmri/jmrit/display/panelEditor/configurexml/PanelEditorXml.java
@@ -52,6 +52,9 @@ public class PanelEditorXml extends AbstractXmlAdapter {
         panel.setAttribute("height", "" + size.height);
         panel.setAttribute("width", "" + size.width);
         panel.setAttribute("editable", "" + (p.isEditable() ? "yes" : "no"));
+        if (!p.isLocoMarkerEditable()) {
+            panel.setAttribute("locoMarkerEditable", "no");
+        }
         panel.setAttribute("positionable", "" + (p.allPositionable() ? "yes" : "no"));
         //panel.setAttribute("showcoordinates", ""+(p.showCoordinates()?"yes":"no"));
         panel.setAttribute("showtooltips", "" + (p.showToolTip() ? "yes" : "no"));
@@ -164,6 +167,7 @@ public class PanelEditorXml extends AbstractXmlAdapter {
         // Load editor option flags. This has to be done before the content
         // items are loaded, to preserve the individual item settings
         panel.setAllEditable(!shared.getAttributeValue("editable","yes").equals("no"));
+        panel.setLocoMarkerEditable(!shared.getAttributeValue("locoMarkerEditable","yes").equals("no"));
         panel.setAllPositionable(!shared.getAttributeValue("positionable","yes").equals("no"));
         //panel.setShowCoordinates(shared.getAttributeValue("showcoordinates","no").equals("yes"));
         panel.setAllShowToolTip(!shared.getAttributeValue("showtooltips","yes").equals("no"));
@@ -209,6 +213,7 @@ public class PanelEditorXml extends AbstractXmlAdapter {
         // display the results, with the editor in back
         panel.pack();
         panel.setAllEditable(panel.isEditable());
+        panel.setLocoMarkerEditable(panel.isLocoMarkerEditable());
 
         // we don't pack the target frame here, because size was specified
         // TODO: Work out why, when calling this method, panel size is increased

--- a/xml/schema/types/editors.xsd
+++ b/xml/schema/types/editors.xsd
@@ -1612,6 +1612,7 @@
 
       <xs:attribute name="class" type="classType" use="required"></xs:attribute>
       <xs:attribute name="icon" type="xs:string"></xs:attribute>
+      <xs:attribute name="locoMarkerEditable" type="yesNoType"></xs:attribute>
       <xs:attribute name="dockX" type="xs:string"></xs:attribute>
       <xs:attribute name="dockY" type="xs:string"></xs:attribute>
       <xs:attribute name="text" type="xs:string"></xs:attribute>

--- a/xml/schema/types/paneleditor.xsd
+++ b/xml/schema/types/paneleditor.xsd
@@ -84,6 +84,7 @@
         <xs:annotation><xs:documentation>Optional as of JMRI 4.15.6</xs:documentation></xs:annotation>
       </xs:attribute>
       <xs:attribute name="editable" type="yesNoType" default="yes"></xs:attribute>
+      <xs:attribute name="locoMarkerEditable" type="yesNoType" default="yes"></xs:attribute>
       <xs:attribute name="positionable" type="yesNoType" default="yes"></xs:attribute>
       <xs:attribute name="controlling" type="yesNoType" default="yes"></xs:attribute>
       <xs:attribute name="hide" type="yesNoType" default="no"></xs:attribute>


### PR DESCRIPTION
For background, see: https://groups.io/g/jmriusers/message/252938

Adds the option `Loco marker popup menus active`. If disabled, right-click doesn't show the popup menu for loco markers. But it's still possible to move the loco markers. This is useful for a dispatcher that doesn't want to change the loco markers but wants to move the markers around on the panel.

<img width="428" height="398" alt="JMRI_LocoMarkers" src="https://github.com/user-attachments/assets/61145c2e-8fe1-4b86-abea-d777f6bf5cf1" />