### PR TITLE
Fix NX Cancel Route Issue

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -500,7 +500,7 @@
 
         <h4>NX - Entry/Exit Tool</h4>
             <ul>
-                <li></li>
+                <li>Fix an incomplete route cancel cleanup which leaves the protected block allocated.</li>
             </ul>
 
     <h3>LccPro</h3>

--- a/java/src/jmri/jmrit/entryexit/DestinationPoints.java
+++ b/java/src/jmri/jmrit/entryexit/DestinationPoints.java
@@ -844,11 +844,10 @@ public class DestinationPoints extends jmri.implementation.AbstractNamedBean {
         }
 
         // The block list for an interlocking NX still has the facing block if there are no signals.
-        boolean facing = getSource().getStart().getUseExtraColor();
+        LayoutBlock facing = getSource().getStart();
         for (LayoutBlock blk : routeDetails) {
-            if (facing) {
-                // skip the facing block when there is an active NX pair immediately before this one.
-                facing = false;
+            if (blk == facing) {
+                // Skip the facing block if it is still in the block list.
                 continue;
             }
             if ((getEntryExitType() == EntryExitPairs.FULLINTERLOCK)) {


### PR DESCRIPTION
A previous NX cancel fix, #11536, fixed a problem with the last block in the previous route having its allocation cancelled.  This situation occurred when the NX configuration did not have signals.  The side effect of this change was that NX configurations that **did** have signals would **not** have the allocation cancelled for the protected block when the route is cancelled.

This change handles both cases.