### PR TITLE
Add option to disable popup menu for loco markers

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -446,7 +446,11 @@
     <h3>Control Panel Editor</h3>
         <a id="CPE" name="CPE"></a>
         <ul>
-            <li></li>
+            <li>The option <strong>Disable loco marker popup menus</strong> has been added
+                to the <strong>Marker</strong> menu. If it's selected, it's possible to
+                move around loco markers but it's not possible to open the popup menu for
+                loco markers. This is useful for dispatcher that wants to move
+                the loco markers but doesn't want to edit the loco markers.</li>
         </ul>
         <h4>Circuit Builder</h4>
             <a id="CPE-CB" name="CPE-CB"></a>
@@ -494,6 +498,11 @@
         <ul>
             <li>Improved the layout of the edit tools to reduce the need for
                 vertical scrolling when they're at the top or bottom of the window.</li>
+            <li>The option <strong>Disable loco marker popup menus</strong> has been added
+                to the <strong>Marker</strong> menu. If it's selected, it's possible to
+                move around loco markers but it's not possible to open the popup menu for
+                loco markers. This is useful for dispatcher that wants to move
+                the loco markers but doesn't want to edit the loco markers.</li>
         </ul>
 
         <h4>NX - Entry/Exit Tool</h4>
@@ -546,7 +555,11 @@
    <h3>Panel Editor</h3>
         <a id="PE" name="PE"></a>
         <ul>
-            <li></li>
+            <li>The option <strong>Disable loco marker popup menus</strong> has been added
+                to the <strong>Marker</strong> menu. If it's selected, it's possible to
+                move around loco markers but it's not possible to open the popup menu for
+                loco markers. This is useful for dispatcher that wants to move
+                the loco markers but doesn't want to edit the loco markers.</li>
         </ul>
 
     <h3>Permissions</h3>

--- a/java/src/jmri/jmrit/display/DisplayBundle.properties
+++ b/java/src/jmri/jmrit/display/DisplayBundle.properties
@@ -30,6 +30,7 @@ MenuWarrant     = Warrants
 AddLoco         = Add Loco
 AddLocoRoster   = Add Loco from Roster
 RemoveMarkers   = Remove markers
+DisableLocoMarkerPopup = Disable loco marker popup menus
 LocoFromRoster  = Loco Marker from Roster
 SelectLoco      = Select Loco
 EnterLocoMarker = Enter Loco Marker

--- a/java/src/jmri/jmrit/display/Editor.java
+++ b/java/src/jmri/jmrit/display/Editor.java
@@ -242,6 +242,26 @@ public abstract class Editor extends JmriJFrameWithPermissions
         return _newIcon;
     }
 
+    private String getDisableLocoMarkerPopupRef() {
+        return "DisableLocoMarkerPopup__"+getWindowFrameRef();
+    }
+
+    public void setLocoMarkerPopupDisabled(boolean value) {
+        var prefsMgr = InstanceManager.getOptionalDefault(UserPreferencesManager.class);
+        if (prefsMgr.isPresent()) {
+            prefsMgr.get().setCheckboxPreferenceState(getDisableLocoMarkerPopupRef(), value);
+        }
+    }
+
+    public boolean isLocoMarkerPopupDisabled() {
+        var prefsMgr = InstanceManager.getOptionalDefault(UserPreferencesManager.class);
+        if (prefsMgr.isPresent()) {
+            return prefsMgr.get().getCheckboxPreferenceState(getDisableLocoMarkerPopupRef(), false);
+        } else {
+            return false;
+        }
+    }
+
     public class UrlErrorDialog extends JDialog {
 
         private final JTextField _urlField;

--- a/java/src/jmri/jmrit/display/LocoIcon.java
+++ b/java/src/jmri/jmrit/display/LocoIcon.java
@@ -112,6 +112,9 @@ public class LocoIcon extends PositionableLabel {
      */
     @Override
     public boolean showPopUp(JPopupMenu popup) {
+        if (_editor.isLocoMarkerPopupDisabled()) {
+            return false;
+        }
         if (_entry != null) {
             popup.add(new AbstractAction("Throttle") {
                 @Override

--- a/java/src/jmri/jmrit/display/controlPanelEditor/ControlPanelEditor.java
+++ b/java/src/jmri/jmrit/display/controlPanelEditor/ControlPanelEditor.java
@@ -384,8 +384,8 @@ public class ControlPanelEditor extends Editor implements DropTargetListener, Cl
 
     private void enableDisableLocoMarkerPopups() {
         if (disableLocoMarkerPopupMenuItem != null) {
-            boolean enabled = disableLocoMarkerPopupMenuItem.isSelected();
-            setLocoMarkerPopupDisabled(enabled);
+            boolean selected = disableLocoMarkerPopupMenuItem.isSelected();
+            setLocoMarkerPopupDisabled(selected);
         }
     }
 

--- a/java/src/jmri/jmrit/display/controlPanelEditor/ControlPanelEditor.java
+++ b/java/src/jmri/jmrit/display/controlPanelEditor/ControlPanelEditor.java
@@ -32,9 +32,7 @@ import java.util.ResourceBundle;
 import javax.annotation.Nonnull;
 import javax.swing.*;
 
-import jmri.CatalogTreeManager;
-import jmri.ConfigureManager;
-import jmri.InstanceManager;
+import jmri.*;
 import jmri.jmrit.catalog.ImageIndexEditor;
 import jmri.jmrit.catalog.NamedIcon;
 import jmri.jmrit.display.CoordinateEdit;
@@ -107,6 +105,7 @@ public class ControlPanelEditor extends Editor implements DropTargetListener, Cl
     private boolean _disablePortalSelection = true;  // only select PortalIcon in CircuitBuilder
     private String _portalIconFamily = "Standard"; // initial default, must match xml, updated in setIconFamilysetPortalIconFamily
     private HashMap<String, NamedIcon> _portalIconMap;
+    private JCheckBoxMenuItem disableLocoMarkerPopupMenuItem;
 
     private final JCheckBoxMenuItem useGlobalFlagBox = new JCheckBoxMenuItem(Bundle.getMessage("CheckBoxGlobalFlags"));
     private final JCheckBoxMenuItem positionableBox = new JCheckBoxMenuItem(Bundle.getMessage("CheckBoxPositionable"));
@@ -369,6 +368,25 @@ public class ControlPanelEditor extends Editor implements DropTargetListener, Cl
                 removeMarkers();
             }
         });
+        InstanceManager.getOptionalDefault(UserPreferencesManager.class).ifPresent(prefsMgr -> {
+            _markerMenu.addSeparator();
+            disableLocoMarkerPopupMenuItem = new JCheckBoxMenuItem(
+                    new AbstractAction(Bundle.getMessage("DisableLocoMarkerPopup")) {
+                        @Override
+                        public void actionPerformed(ActionEvent e) {
+                            enableDisableLocoMarkerPopups();
+                        }
+            });
+            disableLocoMarkerPopupMenuItem.setSelected(isLocoMarkerPopupDisabled());
+            _markerMenu.add(disableLocoMarkerPopupMenuItem);
+        });
+    }
+
+    private void enableDisableLocoMarkerPopups() {
+        if (disableLocoMarkerPopupMenuItem != null) {
+            boolean enabled = disableLocoMarkerPopupMenuItem.isSelected();
+            setLocoMarkerPopupDisabled(enabled);
+        }
     }
 
     protected void makeOptionMenu() {
@@ -1651,7 +1669,7 @@ public class ControlPanelEditor extends Editor implements DropTargetListener, Cl
                 setRemoveMenu(p, popup);
             }
         } else {
-            if (p instanceof LocoIcon) {
+            if ((p instanceof LocoIcon) && !isLocoMarkerPopupDisabled()) {
                 setCopyMenu(p, popup);
             }
             p.showPopUp(popup);

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
@@ -2474,8 +2474,8 @@ public final class LayoutEditor extends PanelEditor implements MouseWheelListene
 
     private void enableDisableLocoMarkerPopups() {
         if (disableLocoMarkerPopupMenuItem != null) {
-            boolean enabled = disableLocoMarkerPopupMenuItem.isSelected();
-            setLocoMarkerPopupDisabled(enabled);
+            boolean selected = disableLocoMarkerPopupMenuItem.isSelected();
+            setLocoMarkerPopupDisabled(selected);
         }
     }
 

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
@@ -225,6 +225,8 @@ public final class LayoutEditor extends PanelEditor implements MouseWheelListene
     private List<SignalHeadIcon> signalList = new ArrayList<>();                // Signal Head Icons
     private List<SignalMastIcon> signalMastList = new ArrayList<>();            // Signal Mast Icons
 
+    private JCheckBoxMenuItem disableLocoMarkerPopupMenuItem;
+
     public final LayoutEditorViewContext gContext = new LayoutEditorViewContext(); // public for now, as things work access changes
 
     @Nonnull
@@ -623,7 +625,7 @@ public final class LayoutEditor extends PanelEditor implements MouseWheelListene
         // editToolBarScroll.getViewport().addChangeListener(e -> {
         // log.warn("scrollbars visible: " + editToolBarScroll.getHorizontalScrollBar().isVisible());
         //});
-        
+
         editToolBarContainerPanel.setMinimumSize(new Dimension(toolbarWidth, toolbarHeight));
         editToolBarContainerPanel.setPreferredSize(new Dimension(toolbarWidth, toolbarHeight));
 
@@ -2456,6 +2458,25 @@ public final class LayoutEditor extends PanelEditor implements MouseWheelListene
                 removeMarkers();
             }
         });
+        InstanceManager.getOptionalDefault(UserPreferencesManager.class).ifPresent(prefsMgr -> {
+            markerMenu.addSeparator();
+            disableLocoMarkerPopupMenuItem = new JCheckBoxMenuItem(
+                    new AbstractAction(Bundle.getMessage("DisableLocoMarkerPopup")) {
+                        @Override
+                        public void actionPerformed(ActionEvent e) {
+                            enableDisableLocoMarkerPopups();
+                        }
+            });
+            disableLocoMarkerPopupMenuItem.setSelected(isLocoMarkerPopupDisabled());
+            markerMenu.add(disableLocoMarkerPopupMenuItem);
+        });
+    }
+
+    private void enableDisableLocoMarkerPopups() {
+        if (disableLocoMarkerPopupMenuItem != null) {
+            boolean enabled = disableLocoMarkerPopupMenuItem.isSelected();
+            setLocoMarkerPopupDisabled(enabled);
+        }
     }
 
     private void setupDispatcherMenu(@Nonnull JMenuBar menuBar) {

--- a/java/src/jmri/jmrit/display/panelEditor/PanelEditor.java
+++ b/java/src/jmri/jmrit/display/panelEditor/PanelEditor.java
@@ -569,8 +569,8 @@ public class PanelEditor extends Editor implements ItemListener {
 
     private void enableDisableLocoMarkerPopups() {
         if (disableLocoMarkerPopupMenuItem != null) {
-            boolean enabled = disableLocoMarkerPopupMenuItem.isSelected();
-            setLocoMarkerPopupDisabled(enabled);
+            boolean selected = disableLocoMarkerPopupMenuItem.isSelected();
+            setLocoMarkerPopupDisabled(selected);
         }
     }
 

--- a/java/src/jmri/jmrit/display/panelEditor/PanelEditor.java
+++ b/java/src/jmri/jmrit/display/panelEditor/PanelEditor.java
@@ -39,9 +39,7 @@ import javax.swing.JPanel;
 import javax.swing.JPopupMenu;
 import javax.swing.JTextField;
 
-import jmri.CatalogTreeManager;
-import jmri.ConfigureManager;
-import jmri.InstanceManager;
+import jmri.*;
 import jmri.configurexml.ConfigXmlManager;
 import jmri.configurexml.XmlAdapter;
 import jmri.jmrit.catalog.ImageIndexEditor;
@@ -122,6 +120,7 @@ public class PanelEditor extends Editor implements ItemListener {
     private final JCheckBox menuBox = new JCheckBox(Bundle.getMessage("CheckBoxMenuBar"));
     private final JLabel scrollableLabel = new JLabel(Bundle.getMessage("ComboBoxScrollable"));
     private final JComboBox<String> scrollableComboBox = new JComboBox<>();
+    private JCheckBoxMenuItem disableLocoMarkerPopupMenuItem;
 
     private final JButton labelAdd = new JButton(Bundle.getMessage("ButtonAddText"));
     private final JTextField nextLabel = new JTextField(10);
@@ -546,6 +545,18 @@ public class PanelEditor extends Editor implements ItemListener {
                 removeMarkers();
             }
         });
+        InstanceManager.getOptionalDefault(UserPreferencesManager.class).ifPresent(prefsMgr -> {
+            markerMenu.addSeparator();
+            disableLocoMarkerPopupMenuItem = new JCheckBoxMenuItem(
+                    new AbstractAction(Bundle.getMessage("DisableLocoMarkerPopup")) {
+                        @Override
+                        public void actionPerformed(ActionEvent e) {
+                            enableDisableLocoMarkerPopups();
+                        }
+            });
+            disableLocoMarkerPopupMenuItem.setSelected(isLocoMarkerPopupDisabled());
+            markerMenu.add(disableLocoMarkerPopupMenuItem);
+        });
 
         JMenu warrantMenu = jmri.jmrit.logix.WarrantTableAction.getDefault().makeWarrantMenu(isEditable());
         if (warrantMenu != null) {
@@ -554,6 +565,13 @@ public class PanelEditor extends Editor implements ItemListener {
 
         targetFrame.addHelpMenu("package.jmri.jmrit.display.PanelTarget", true);
         return targetFrame;
+    }
+
+    private void enableDisableLocoMarkerPopups() {
+        if (disableLocoMarkerPopupMenuItem != null) {
+            boolean enabled = disableLocoMarkerPopupMenuItem.isSelected();
+            setLocoMarkerPopupDisabled(enabled);
+        }
     }
 
     /*

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorTest.java
@@ -822,7 +822,7 @@ public class LayoutEditorTest extends AbstractEditorTestBase<LayoutEditor> {
     public void checkMarkerMenuExists() {
         JMenuOperator jmo = new JMenuOperator(jfo, Bundle.getMessage("MenuMarker"));
         assertNotNull( jmo, "Marker Menu Exists");
-        assertEquals( 3, jmo.getItemCount(), "Menu Item Count");
+        assertEquals( 5, jmo.getItemCount(), "Menu Item Count");
     }
 
     @Test


### PR DESCRIPTION
For background, see: https://groups.io/g/jmriusers/message/252938

Adds the checkbox menu item `Disable loco marker popup menus` to the `Markers` menu in Layout Editor, Panel Editor and Control Panel Editor. If it's selected, right-click on a loco marker doesn't open the popup menu.