### PR TITLE
Prevent ClassCastException

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -120,9 +120,9 @@
 
         <h4>LocoNet</h4>
             <ul>
-                <li>LocoNet-over-TCP connections now automatically reconnect if the server 
-                    goes away and comes back. Detection relies on a clean TCP close 
-                    from the server; hard disconnects (network drop with no TCP FIN) 
+                <li>LocoNet-over-TCP connections now automatically reconnect if the server
+                    goes away and comes back. Detection relies on a clean TCP close
+                    from the server; hard disconnects (network drop with no TCP FIN)
                     are only detected when JMRI next tries to send a message.</li>
             </ul>
 
@@ -163,8 +163,8 @@
 
         <h4><a href="http://openlcb.org">OpenLCB</a> / LCC</h4>
             <ul>
-                <li>Fixed a bug which could cause the Event Table to 
-                    refresh too often, which annoyingly caused it to 
+                <li>Fixed a bug which could cause the Event Table to
+                    refresh too often, which annoyingly caused it to
                     lose your current selected row.</li>
             </ul>
 
@@ -477,7 +477,7 @@
     <h3>DecoderPro</h3>
         <a id="DecoderPro" name="DecoderPro"></a>
         <ul>
-            <li>Fixed a bug were DecoderPro was include the height of 
+            <li>Fixed a bug were DecoderPro was include the height of
                 non-visible columns in the row height calculation.</li>
         </ul>
 
@@ -511,6 +511,10 @@
                 move around loco markers but it's not possible to open the popup menu for
                 loco markers. This is useful for dispatcher that wants to move
                 the loco markers but doesn't want to edit the loco markers.</li>
+            <li>Prevent a possible <strong>ClassCastException</strong> introduced by PR #14492
+            and PR #14928 to support signals on turntables and traversers. The exception occurs when
+            Entry/Exit is used and a panel has a turntable and/or a traverser. The added logic
+            did not consider that the <strong>bean</strong> might be an Entry/Exit sensor.</li>
         </ul>
 
         <h4>NX - Entry/Exit Tool</h4>

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutBlockManager.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutBlockManager.java
@@ -1997,7 +1997,7 @@ public class LayoutBlockManager extends AbstractManager<LayoutBlock> implements 
             @Nonnull LayoutEditor panel) {
         List<LayoutBlock> protectingBlocks = new ArrayList<>();
 
-        // Check for turntable approach masts first, as they are a special case.
+        // Check for turntable approach masts first, as they are a special case. Ignore NX sensor beans.
         for (LayoutTurntable turntable : panel.getLayoutTurntables()) {
             if (bean instanceof SignalMast && turntable.isApproachMast((SignalMast) bean)) {
                 if (turntable.getLayoutBlock() != null) {
@@ -2018,7 +2018,7 @@ public class LayoutBlockManager extends AbstractManager<LayoutBlock> implements 
             }
         }
 
-        // Check for traverser approach masts first, as they are a special case.
+        // Check for traverser approach masts first, as they are a special case. Ignore NX sensor beans.
         for (LayoutTraverser traverser : panel.getLayoutTraversers()) {
             if (bean instanceof SignalMast && traverser.isApproachMast((SignalMast) bean)) {
                 if (traverser.getLayoutBlock() != null) {
@@ -2323,7 +2323,7 @@ public class LayoutBlockManager extends AbstractManager<LayoutBlock> implements 
     private LayoutBlock getFacingBlockByBeanByPanel(
             @Nonnull NamedBean bean,
             @Nonnull LayoutEditor panel) {
-        // Check for turntable masts first, as they are a special case.
+        // Check for turntable masts first, as they are a special case. Ignore NX sensor beans.
         for (LayoutTurntable turntable : panel.getLayoutTurntables()) {
             if (bean.equals(turntable.getBufferMast())) {
                 return turntable.getLayoutBlock();
@@ -2342,7 +2342,7 @@ public class LayoutBlockManager extends AbstractManager<LayoutBlock> implements 
                 }
             }
         }
-        // Check for traverser masts, as they are a special case.
+        // Check for traverser masts, as they are a special case. Ignore NX sensor beans.
         for (LayoutTraverser traverser : panel.getLayoutTraversers()) {
             if (bean.equals(traverser.getBufferMast())) {
                 return traverser.getLayoutBlock();

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutBlockManager.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutBlockManager.java
@@ -1491,7 +1491,7 @@ public class LayoutBlockManager extends AbstractManager<LayoutBlock> implements 
     public NamedBean getFacingBean(@CheckForNull Block facingBlock,
             @CheckForNull Block protectedBlock,
             @CheckForNull LayoutEditor panel, Class< ?> T) {
-        //check input        
+        //check input
         if ((facingBlock == null) || (protectedBlock == null)) {
             log.error("null block in call to getFacingSignalMast");
             return null;
@@ -1999,7 +1999,7 @@ public class LayoutBlockManager extends AbstractManager<LayoutBlock> implements 
 
         // Check for turntable approach masts first, as they are a special case.
         for (LayoutTurntable turntable : panel.getLayoutTurntables()) {
-            if (turntable.isApproachMast((SignalMast) bean)) {
+            if (bean instanceof SignalMast && turntable.isApproachMast((SignalMast) bean)) {
                 if (turntable.getLayoutBlock() != null) {
                     protectingBlocks.add(turntable.getLayoutBlock());
                     return protectingBlocks;
@@ -2020,7 +2020,7 @@ public class LayoutBlockManager extends AbstractManager<LayoutBlock> implements 
 
         // Check for traverser approach masts first, as they are a special case.
         for (LayoutTraverser traverser : panel.getLayoutTraversers()) {
-            if (traverser.isApproachMast((SignalMast) bean)) {
+            if (bean instanceof SignalMast && traverser.isApproachMast((SignalMast) bean)) {
                 if (traverser.getLayoutBlock() != null) {
                     protectingBlocks.add(traverser.getLayoutBlock());
                     return protectingBlocks;
@@ -2331,7 +2331,7 @@ public class LayoutBlockManager extends AbstractManager<LayoutBlock> implements 
             if (bean.equals(turntable.getExitSignalMast())) {
                 return turntable.getLayoutBlock();
             }
-            if (turntable.isApproachMast((SignalMast) bean)) {
+            if (bean instanceof SignalMast && turntable.isApproachMast((SignalMast) bean)) {
                 for (LayoutTurntable.RayTrack ray : turntable.getRayTrackList()) {
                     if (bean.equals(ray.getApproachMast())) {
                         TrackSegment connectedTrack = ray.getConnect();
@@ -2350,7 +2350,7 @@ public class LayoutBlockManager extends AbstractManager<LayoutBlock> implements 
             if (bean.equals(traverser.getExitSignalMast())) {
                 return traverser.getLayoutBlock();
             }
-            if (traverser.isApproachMast((SignalMast) bean)) {
+            if (bean instanceof SignalMast && traverser.isApproachMast((SignalMast) bean)) {
                 for (LayoutTraverser.SlotTrack slot : traverser.getSlotList()) {
                     if (bean.equals(slot.getApproachMast())) {
                         TrackSegment connectedTrack = slot.getConnect();


### PR DESCRIPTION
A **ClassCastException** occurs when Entry/Exit is used and a panel has a turntable and/or a traverser.  

PR #14492 and PR #14928 added support for signal masts on turntables and traversers.  This required changes to layout block logic.  In two `LayoutBlockManager` methods the added logic did not consider that the **bean** might be an Entry/Exit sensor.
