### PR TITLE
DCC-EX: fix broadcast frame parsing for messages containing angle brackets

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -71,6 +71,10 @@
                 registered as bogus turnouts.</li>
                 <li>DCC-EX Traffic Monitor: the display limit has been raised from 500 to 2000
                 lines, sufficient for large layouts that enumerate many turnouts on startup.</li>
+                <li>DCC-EX: broadcast messages (&lt;* ... *&gt;) containing angle brackets
+                in the body are now parsed correctly. Previously the first &gt; inside the
+                body terminated the frame early, which could leave the programmer stuck
+                waiting for a reply that never arrived.</li>
             </ul>
 
         <h4>DCC4pc</h4>

--- a/java/src/jmri/jmrix/dccpp/DCCppPacketizer.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppPacketizer.java
@@ -166,8 +166,7 @@ public class DCCppPacketizer extends DCCppTrafficController {
             ch = readByteProtected(istream);
             if (broadcast) {
                 if (prevStar && ch == '>') {
-                    body.setLength(body.length() - 1); // drop the trailing * before >
-                    return body.toString();
+                    return body.toString(); // drop > only; trailing * stays in body for parseDCCppReply
                 }
                 prevStar = (ch == '*');
             } else {

--- a/java/src/jmri/jmrix/dccpp/DCCppPacketizer.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppPacketizer.java
@@ -137,43 +137,47 @@ public class DCCppPacketizer extends DCCppTrafficController {
     // TODO: Can this method be folded back up into the parent DCCppTrafficController class?
     @Override
     protected void loadChars(jmri.jmrix.AbstractMRReply msg, java.io.DataInputStream istream) throws java.io.IOException {
-        int i;
-        StringBuilder m = new StringBuilder();
         log.trace("loading characters from port");
-
         if (!(msg instanceof DCCppReply)) {
-            log.error("SerialDCCppPacketizer.loadChars called on non-DCCppReply msg!");
+            log.error("loadChars called on non-DCCppReply msg!");
             return;
         }
-
         byte char1 = readByteProtected(istream);
         while (char1 != '<') {
-            // Spin waiting for '<'
             char1 = readByteProtected(istream);
-            if (char1 != '<') {
-                log.trace("skipping char: ({})", (char) char1);
-            }
+            if (char1 != '<') log.trace("skipping char: ({})", (char) char1);
         }
         log.trace("Message started");
-        // Read until '>'; ignore '>' inside quoted strings (e.g. captions).
+        String body = readFrameBody(istream, msg.maxSize());
+        log.debug("Received: '{}'", body);
+        ((DCCppReply) msg).parseReply(body);
+    }
+
+    /** Reads one frame body after {@code <}: broadcast ({@code <* *>}) or regular up to {@code >}. */
+    String readFrameBody(java.io.DataInputStream istream, int maxSize) throws java.io.IOException {
+        StringBuilder body = new StringBuilder();
+        byte ch = readByteProtected(istream);
+        body.append((char) ch);
+        boolean broadcast = (ch == '*');
+        boolean prevStar = broadcast;
         boolean inQuotes = false;
-        for (i = 0; i < msg.maxSize(); i++) {
-            char1 = readByteProtected(istream);
-            if (char1 == '"') {
-                inQuotes = !inQuotes;
-                m.append((char) char1);
-            } else if (char1 == '>' && !inQuotes) {
-                log.debug("Received: '{}'", m);
-                // NOTE: Cast is OK because we checked runtime type of msg above.
-                ((DCCppReply) msg).parseReply(m.toString());
-                return;
+
+        while (body.length() < maxSize) {
+            ch = readByteProtected(istream);
+            if (broadcast) {
+                if (prevStar && ch == '>') {
+                    body.setLength(body.length() - 1); // drop the trailing * before >
+                    return body.toString();
+                }
+                prevStar = (ch == '*');
             } else {
-                m.append((char) char1);
-                log.trace("msg char[{}]: {} ({})", i, char1, (char) char1);
+                if (ch == '"') inQuotes = !inQuotes;
+                else if (ch == '>' && !inQuotes) return body.toString();
             }
+            body.append((char) ch);
         }
-        log.warn("msg size {} exceeded before end of msg char '>' encountered.", msg.maxSize());
-        log.warn("msg truncated to: '{}'", m);
+        log.warn("msg size {} exceeded before end of msg encountered.", maxSize);
+        return body.toString();
     }
 
     private static final Logger log = LoggerFactory.getLogger(DCCppPacketizer.class);

--- a/java/test/jmri/jmrix/dccpp/DCCppPacketizerTest.java
+++ b/java/test/jmri/jmrix/dccpp/DCCppPacketizerTest.java
@@ -3,7 +3,10 @@ package jmri.jmrix.dccpp;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import jmri.util.JUnitAppender;
 import jmri.util.JUnitUtil;
@@ -138,7 +141,7 @@ public class DCCppPacketizerTest extends DCCppTrafficControllerTest {
 
         String body = "jA 4 A \"" + caption + "\"";
         p.tistream.write('<');
-        for (byte b : body.getBytes(java.nio.charset.StandardCharsets.US_ASCII)) {
+        for (byte b : body.getBytes(StandardCharsets.US_ASCII)) {
             p.tistream.write(b);
         }
         p.tistream.write('>');
@@ -162,6 +165,50 @@ public class DCCppPacketizerTest extends DCCppTrafficControllerTest {
             log.warn("waitForReply saw an immediate return; is threading right?");
         }
         return i < 100;
+    }
+
+    // --- readFrameBody direct tests (no threading required) ---
+
+    @Test
+    public void testReadFrameBodyNormalMessage() throws IOException {
+        assertEquals("H 22 1", parseBody("H 22 1>"));
+    }
+
+    @Test
+    public void testReadFrameBodyQuotedGreaterThan() throws IOException {
+        assertEquals("jA 4 A \"Round > bend\"", parseBody("jA 4 A \"Round > bend\">"));
+    }
+
+    @Test
+    public void testReadFrameBodyBroadcastSimple() throws IOException {
+        assertEquals("* hello world ", parseBody("* hello world *>"));
+    }
+
+    @Test
+    public void testReadFrameBodyBroadcastWithGreaterThan() throws IOException {
+        assertEquals("* value > 16 ", parseBody("* value > 16 *>"));
+    }
+
+    @Test
+    public void testReadFrameBodyBroadcastWithNestedAngles() throws IOException {
+        // The actual failure case: DCC-EX rejects <V 1025 0> and embeds the
+        // command in the broadcast body — the '>' inside must not split the frame.
+        String body = "* Command format <V cv value> failed CHECK(cv 1 .. 1023)\n  <V 1025 0> ";
+        assertEquals(body, parseBody(body + "*>"));
+    }
+
+    @Test
+    public void testReadFrameBodyBroadcastWithCommandContainingLessThan() throws IOException {
+        // '<' in a quoted arg inside the broadcast body, e.g. echo of <m 0 1 "voltage  < 16 ">.
+        String body = "* Command format <m 0 1 \"voltage  < 16 \"> failed ";
+        assertEquals(body, parseBody(body + "*>"));
+    }
+
+    /** Synchronous helper: feed raw bytes directly to readFrameBody and return the result. */
+    private String parseBody(String input) throws IOException {
+        DataInputStream is = new DataInputStream(
+            new ByteArrayInputStream(input.getBytes(StandardCharsets.US_ASCII)));
+        return ((DCCppPacketizer) tc).readFrameBody(is, 2048);
     }
 
     @Test

--- a/java/test/jmri/jmrix/dccpp/DCCppPacketizerTest.java
+++ b/java/test/jmri/jmrix/dccpp/DCCppPacketizerTest.java
@@ -181,27 +181,48 @@ public class DCCppPacketizerTest extends DCCppTrafficControllerTest {
 
     @Test
     public void testReadFrameBodyBroadcastSimple() throws IOException {
-        assertEquals("* hello world ", parseBody("* hello world *>"));
+        assertEquals("* hello world *", parseBody("* hello world *>"));
     }
 
     @Test
     public void testReadFrameBodyBroadcastWithGreaterThan() throws IOException {
-        assertEquals("* value > 16 ", parseBody("* value > 16 *>"));
+        assertEquals("* value > 16 *", parseBody("* value > 16 *>"));
     }
 
     @Test
     public void testReadFrameBodyBroadcastWithNestedAngles() throws IOException {
         // The actual failure case: DCC-EX rejects <V 1025 0> and embeds the
         // command in the broadcast body — the '>' inside must not split the frame.
-        String body = "* Command format <V cv value> failed CHECK(cv 1 .. 1023)\n  <V 1025 0> ";
-        assertEquals(body, parseBody(body + "*>"));
+        String body = "* Command format <V cv value> failed CHECK(cv 1 .. 1023)\n  <V 1025 0> *";
+        assertEquals(body, parseBody(body + ">"));
     }
 
     @Test
     public void testReadFrameBodyBroadcastWithCommandContainingLessThan() throws IOException {
         // '<' in a quoted arg inside the broadcast body, e.g. echo of <m 0 1 "voltage  < 16 ">.
-        String body = "* Command format <m 0 1 \"voltage  < 16 \"> failed ";
-        assertEquals(body, parseBody(body + "*>"));
+        String body = "* Command format <m 0 1 \"voltage  < 16 \"> failed *";
+        assertEquals(body, parseBody(body + ">"));
+    }
+
+    @Test
+    public void testInboundBroadcastMessage() throws IOException {
+        // Full pipeline test: verify broadcast frames reach parseReply and are recognised as diag replies.
+        DCCppPacketizer c = (DCCppPacketizer) tc;
+        DCCppPortControllerScaffold p = new DCCppPortControllerScaffold();
+        c.connectPort(p);
+        DCCppListenerScaffold l = new DCCppListenerScaffold();
+        c.addDCCppListener(~0, l);
+
+        String payload = "* Command format <V cv value> failed CHECK(cv 1 .. 1023)  <V 1025 0> *";
+        p.tistream.write('<');
+        for (byte b : payload.getBytes(StandardCharsets.US_ASCII)) {
+            p.tistream.write(b);
+        }
+        p.tistream.write('>');
+
+        assertTrue(waitForReply(l), "reply received");
+        assertEquals(payload, l.rcvdRply.toString(), "full body delivered");
+        assertTrue(l.rcvdRply.isDiagReply(), "reply parsed as diag");
     }
 
     /** Synchronous helper: feed raw bytes directly to readFrameBody and return the result. */


### PR DESCRIPTION
Fixes #15204.

DCC-EX has two frame types: regular commands end with bare `>`, but broadcast messages end with the two-character sequence `*>` — the full frame looks like `<* message body *>`. The old `loadChars()` only knew about bare `>`, so when a broadcast body contained embedded commands like `<V 1025 0>`, it terminated on that inner `>` and split the frame early. Practically: when DCC-EX rejects a CV read and echoes the offending command in the error broadcast, the programmer gets stuck waiting for a reply that never arrives, retries three times, then fails with a 90-second timeout.

The fix is in `DCCppPacketizer.readFrameBody()`, extracted from `loadChars()`. The first character after `<` determines the mode: broadcast reads until `*>`, tracking whether the previous char was `*`; normal reads until the first unquoted `>`. One loop, two boolean flags, covers both cases.

Extracting `readFrameBody` also made it directly testable without threading scaffolding. Seven new tests: six direct `readFrameBody` tests covering normal frames, quoted `>`, broadcast with bare `>`, broadcast with embedded `<...>` pairs (the actual failure case), and broadcast with `<` in a quoted arg; plus one full-pipeline test that writes the real error payload through the port scaffold and confirms the reply is recognised as a diag reply end-to-end.

I focused on unit test coverage of the edge cases rather than live bench testing — if anyone has means to reproduce the original error scenario with CV programming on a 5.7.4+ command station, bench confirmation would be welcome.