### PR TITLE
Honor shape level (z-order) when serving Control Panel XML

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -623,7 +623,10 @@
    <h3>Web Server</h3>
         <a id="server" name="server"></a>
         <ul>
-            <li></li>
+            <li>The web Control Panel now draws shapes and other positionables in
+                their display "level" (z-order), matching the desktop Control
+                Panel Editor. Previously elements were sent in list order, so
+                overlapping items could be stacked incorrectly in the browser.</li>
         </ul>
 
     <h3>Where Used</h3>

--- a/java/src/jmri/web/servlet/panel/ControlPanelServlet.java
+++ b/java/src/jmri/web/servlet/panel/ControlPanelServlet.java
@@ -1,5 +1,7 @@
 package jmri.web.servlet.panel;
 
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
@@ -64,8 +66,13 @@ public class ControlPanelServlet extends AbstractPanelServlet {
             panel.addContent(color);
         }
 
-        // include contents
-        List<Positionable> contents = editor.getContents();
+        // include contents, sorted by display level (z-order) so the web client,
+        // which draws elements in document order onto a single canvas, reproduces
+        // the desktop stacking order. Lower-level elements are emitted first and
+        // higher-level elements last. A stable sort preserves the existing relative
+        // order of elements that share a display level. See JMRI/JMRI#12794.
+        List<Positionable> contents = new ArrayList<>(editor.getContents());
+        contents.sort(Comparator.comparingInt(Positionable::getDisplayLevel));
         log.debug("N elements: {}", contents.size());
         for (Positionable sub : contents) {
             if (sub != null) {

--- a/java/test/jmri/web/servlet/panel/ControlPanelServletTest.java
+++ b/java/test/jmri/web/servlet/panel/ControlPanelServletTest.java
@@ -1,18 +1,27 @@
 package jmri.web.servlet.panel;
 
+import java.io.StringReader;
+import java.util.List;
+
 import jmri.InstanceManager;
 import jmri.configurexml.ConfigXmlManager;
+import jmri.jmrit.display.Editor;
+import jmri.jmrit.display.PositionableLabel;
 import jmri.jmrit.display.IndicatorTrackIcon;
+import jmri.jmrit.display.controlPanelEditor.ControlPanelEditor;
 import jmri.jmrit.logix.OBlock;
 import jmri.jmrit.logix.OBlockManager;
 import jmri.util.JUnitUtil;
+import jmri.util.junit.annotations.DisabledIfHeadless;
 
 import org.jdom2.Element;
+import org.jdom2.input.SAXBuilder;
 
 import org.junit.jupiter.api.*;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests for the jmri.web.servlet.panel.ControlPanelServlet class
@@ -45,6 +54,87 @@ public class ControlPanelServletTest {
         //assertEquals(systemName, e.getChild("oblocksysname").getValue()); / Child (element) not found, NPE
     }
 
+    /**
+     * The served Control Panel XML must list positionables in ascending display
+     * level (z-order) so the web client, which draws elements in document order,
+     * reproduces the desktop stacking order. See JMRI/JMRI#12794.
+     */
+    @Test
+    @DisabledIfHeadless
+    public void testContentsSortedByDisplayLevel() throws Exception {
+        String panelName = "CP Level Order Test";
+        ControlPanelEditor editor = new ControlPanelEditor(panelName);
+        try {
+            // add in reverse z-order (highest level first) on purpose
+            addLabel(editor, "high", Editor.MARKERS); // level 10
+            addLabel(editor, "low", Editor.TURNOUTS); // level 7
+
+            List<Element> labels = positionableLabels(
+                    new EditorBoundServlet(editor, panelName).getXmlPanel(panelName));
+            int idxLow = indexOfLabel(labels, "low");
+            int idxHigh = indexOfLabel(labels, "high");
+            assertTrue(idxLow >= 0 && idxHigh >= 0, "both labels emitted");
+            assertTrue(idxLow < idxHigh,
+                    "lower display level must be emitted before higher display level");
+
+            // the emitted level attributes themselves must be non-decreasing
+            int prev = Integer.MIN_VALUE;
+            for (Element label : labels) {
+                int level = Integer.parseInt(label.getAttributeValue("level"));
+                assertTrue(level >= prev, "emitted levels must be non-decreasing");
+                prev = level;
+            }
+        } finally {
+            JUnitUtil.dispose(editor);
+        }
+    }
+
+    /**
+     * Two positionables sharing the same display level must keep their original
+     * insertion order. Guards against an accidental unstable sort.
+     */
+    @Test
+    @DisabledIfHeadless
+    public void testSameDisplayLevelStable() throws Exception {
+        String panelName = "CP Level Stability Test";
+        ControlPanelEditor editor = new ControlPanelEditor(panelName);
+        try {
+            addLabel(editor, "first", Editor.LABELS); // level 4
+            addLabel(editor, "second", Editor.LABELS); // level 4
+
+            List<Element> labels = positionableLabels(
+                    new EditorBoundServlet(editor, panelName).getXmlPanel(panelName));
+            int idxFirst = indexOfLabel(labels, "first");
+            int idxSecond = indexOfLabel(labels, "second");
+            assertTrue(idxFirst >= 0 && idxSecond >= 0, "both labels emitted");
+            assertTrue(idxFirst < idxSecond,
+                    "same-level elements must retain insertion order (stable sort)");
+        } finally {
+            JUnitUtil.dispose(editor);
+        }
+    }
+
+    private void addLabel(Editor editor, String text, int level) throws Exception {
+        PositionableLabel l = new PositionableLabel(text, editor);
+        editor.putItem(l);
+        l.setDisplayLevel(level);
+    }
+
+    private List<Element> positionableLabels(String xml) throws Exception {
+        assertNotNull(xml, "panel xml produced");
+        Element panel = new SAXBuilder().build(new StringReader(xml)).getRootElement();
+        return panel.getChildren("positionablelabel");
+    }
+
+    private int indexOfLabel(List<Element> labels, String text) {
+        for (int i = 0; i < labels.size(); i++) {
+            if (text.equals(labels.get(i).getAttributeValue("text"))) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
     @BeforeEach
     public void setUp() {
         JUnitUtil.setUp();
@@ -52,6 +142,10 @@ public class ControlPanelServletTest {
 
     @AfterEach
     public void tearDown() {
+        // ControlPanelEditor instances created by the z-order tests register a
+        // BlockManager shutdown task; deregister it so the harness tearDown check
+        // does not flag a leftover shutdown callable.
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 
@@ -72,6 +166,27 @@ public class ControlPanelServletTest {
             return null;
         }
 
+    }
+
+    /**
+     * Test servlet that resolves {@code getEditor(name)} to a known editor so
+     * {@link ControlPanelServlet#getXmlPanel(String)} can be exercised directly
+     * without depending on frame-title lookup timing.
+     */
+    private static class EditorBoundServlet extends ControlPanelServlet {
+
+        private final Editor boundEditor;
+        private final String boundName;
+
+        EditorBoundServlet(Editor editor, String name) {
+            this.boundEditor = editor;
+            this.boundName = name;
+        }
+
+        @Override
+        protected Editor getEditor(String n) {
+            return boundName.equals(n) ? boundEditor : super.getEditor(n);
+        }
     }
 
 }


### PR DESCRIPTION
## Summary

`ControlPanelServlet.getXmlPanel(...)` previously emitted positionables in the
editor's raw list order, ignoring each element's display "level". Because the
web client draws elements in document order onto a single canvas, overlapping
shapes could stack incorrectly in the browser (e.g. gray rectangles drawn under
a yellow rounded rectangle that should sit beneath them).

This change takes a defensive copy of the editor contents and stably sorts it
ascending by `getDisplayLevel()` before emitting, so lower-level elements are
written first and higher-level elements last. This reproduces the desktop
Control Panel z-order in the served XML. Same-level elements keep their existing
relative order (stable sort), so panels that did not rely on level are
unaffected. This is the server-side approach (Option 1) preferred in the issue,
keeping the client's draw loop simple.

## Why this matters

The web Control Panel should match what users see in PanelPro; honoring shape
level fixes incorrect overlap rendering in the browser.
https://github.com/JMRI/JMRI/issues/12794

## Testing

Built the full main source tree with Maven (`mvn compile`, BUILD SUCCESS).
Added two non-headless unit tests to `ControlPanelServletTest` that build a real
`ControlPanelEditor`, add overlapping `PositionableLabel`s at different display
levels (and at the same level), drive the served XML through `getXmlPanel`, and
parse it: one asserts lower-level elements are emitted before higher-level ones
(and that emitted `level` attributes are non-decreasing), the other asserts
same-level elements retain insertion order. Ran via surefire:
`Tests run: 4, Failures: 0, Errors: 0, Skipped: 0`, BUILD SUCCESS. Added a
Web Server release note.

Fixes #12794
