### PR TITLE
Fix two bugs

### DIFF
--- a/java/src/jmri/jmrix/dccpp/swing/virtuallcd/ConfigureVirtualLCD.java
+++ b/java/src/jmri/jmrix/dccpp/swing/virtuallcd/ConfigureVirtualLCD.java
@@ -312,22 +312,26 @@ public class ConfigureVirtualLCD extends JmriJFrame {
         maxDisplayNoComboBox.removeAllItems();
         for (int i=0; i <= highestDisplayNoMap.getOrDefault(memo,0); i++) {
             displayNoComboBox.addItem(i);
-            if (i == virtualLCDConfiguration.getDisplayNo()) {
+            if (virtualLCDConfiguration != null
+                    && i == virtualLCDConfiguration.getDisplayNo()) {
                 displayNoComboBox.setSelectedItem(i);
             }
 
             minDisplayNoComboBox.addItem(i);
-            if (i == virtualLCDConfiguration.getMinDisplayNo()) {
+            if (virtualLCDConfiguration != null
+                    && i == virtualLCDConfiguration.getMinDisplayNo()) {
                 minDisplayNoComboBox.setSelectedItem(i);
             }
 
             maxDisplayNoComboBox.addItem(i);
-            if (i == virtualLCDConfiguration.getMaxDisplayNo()) {
+            if (virtualLCDConfiguration != null
+                    && i == virtualLCDConfiguration.getMaxDisplayNo()) {
                 maxDisplayNoComboBox.setSelectedItem(i);
             }
 
             JCheckBox cb = new JCheckBox(Bundle.getMessage("ConfigureVirtualLCD_SelectedDisplays_CheckBox", i));
-            if (virtualLCDConfiguration.getSelectedDisplays().contains(i)) {
+            if (virtualLCDConfiguration != null
+                    && virtualLCDConfiguration.getSelectedDisplays().contains(i)) {
                 cb.setSelected(true);
             }
             selectDisplayNoCheckBox.put(i, cb);

--- a/java/src/jmri/jmrix/dccpp/swing/virtuallcd/ConfigureVirtualLCD.java
+++ b/java/src/jmri/jmrix/dccpp/swing/virtuallcd/ConfigureVirtualLCD.java
@@ -110,8 +110,8 @@ public class ConfigureVirtualLCD extends JmriJFrame {
         c.gridx = 0;
         c.gridy = 0;
         c.anchor = java.awt.GridBagConstraints.EAST;
-        if (virtualLCDConfiguration != null
-                && virtualLCDConfiguration.isMemoEditable()) {
+        if (virtualLCDConfiguration == null
+                || virtualLCDConfiguration.isMemoEditable()) {
             p.add(memoLabel, c);
             memoLabel.setLabelFor(_memoComboBox);
         }
@@ -138,8 +138,8 @@ public class ConfigureVirtualLCD extends JmriJFrame {
         c.anchor = java.awt.GridBagConstraints.WEST;
         c.weightx = 1.0;
         c.fill = java.awt.GridBagConstraints.HORIZONTAL;  // text field will expand
-        if (virtualLCDConfiguration != null
-                && virtualLCDConfiguration.isMemoEditable()) {
+        if (virtualLCDConfiguration == null
+                || virtualLCDConfiguration.isMemoEditable()) {
             p.add(_memoComboBox, c);
         }
         c.gridy = 1;


### PR DESCRIPTION
Fix two bugs in PR #15156

Right-click on a VirtualLCD didn't opened the popup menu to edit the VirtualLCD on a Panel editor.

Adding a VirtualLCD to a panel didn't let the user select memo.