### PR TITLE
Fix Z21 UDP receive buffer truncating combined datasets

### DIFF
--- a/java/src/jmri/jmrix/roco/z21/Z21TrafficController.java
+++ b/java/src/jmri/jmrix/roco/z21/Z21TrafficController.java
@@ -17,6 +17,10 @@ import org.slf4j.LoggerFactory;
  */
 public class Z21TrafficController extends jmri.jmrix.AbstractMRTrafficController implements Z21Interface {
 
+    // Z21 LAN Protocol Specification v1.13 section 1.3 allows combined datasets
+    // up to the Ethernet MTU payload: 1472 = 1500-byte MTU - IPv4 - UDP headers.
+    private static final int MAX_UDP_PAYLOAD = 1472;
+
     private java.net.InetAddress host;
     private int port;
 
@@ -262,12 +266,10 @@ public class Z21TrafficController extends jmri.jmrix.AbstractMRTrafficController
         // threading to let other stuff happen
 
         // create a buffer to hold the incoming data.
-        byte[] buffer = new byte[100];  // the size here just needs to be longer
-        // than the longest protocol message.
-        // Otherwise, the receive will truncate.
+        byte[] buffer = new byte[MAX_UDP_PAYLOAD];
 
         // create the packet.
-        DatagramPacket receivePacket = new DatagramPacket(buffer, 100, host, port);
+        DatagramPacket receivePacket = new DatagramPacket(buffer, MAX_UDP_PAYLOAD, host, port);
 
         // and wait to receive data in the packet.
         try {

--- a/java/test/jmri/jmrix/roco/z21/Z21TrafficControllerTest.java
+++ b/java/test/jmri/jmrix/roco/z21/Z21TrafficControllerTest.java
@@ -1,5 +1,14 @@
 package jmri.jmrix.roco.z21;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.lang.reflect.Field;
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.util.ArrayList;
+import java.util.List;
+
 import jmri.util.JUnitUtil;
 
 import org.junit.jupiter.api.*;
@@ -11,11 +20,49 @@ import org.junit.jupiter.api.*;
  */
 public class Z21TrafficControllerTest extends jmri.jmrix.AbstractMRTrafficControllerTest {
 
+    @Test
+    public void testReceivesCombinedPacketLongerThan100Bytes() throws Exception {
+        TestTrafficController controller = (TestTrafficController) tc;
+        List<Z21Reply> replies = new ArrayList<>();
+
+        controller.addz21Listener(new Z21Listener() {
+            @Override
+            public void reply(Z21Reply msg) {
+                replies.add(msg);
+            }
+
+            @Override
+            public void message(Z21Message msg) {
+            }
+        });
+
+        InetAddress loopback = InetAddress.getLoopbackAddress();
+
+        try (DatagramSocket receiveSocket = new DatagramSocket(0, loopback);
+                DatagramSocket sendSocket = new DatagramSocket()) {
+            receiveSocket.setSoTimeout(5000);
+            controller.controller = new TestZ21Adapter(receiveSocket);
+            setControllerEndpoint(controller, loopback, receiveSocket.getLocalPort());
+
+            byte[] combinedReply = createCombinedReply(26);
+            sendSocket.send(new DatagramPacket(combinedReply, combinedReply.length,
+                    loopback, receiveSocket.getLocalPort()));
+
+            controller.handleOneIncomingReply();
+        } finally {
+            controller.controller = null;
+        }
+
+        assertEquals(26, replies.size());
+        assertEquals("04 00 88 00", replies.get(0).toString());
+        assertEquals("04 00 88 00", replies.get(replies.size() - 1).toString());
+    }
+
     @Override
     @BeforeEach
     public void setUp() {
         JUnitUtil.setUp();
-        tc = new Z21TrafficController();
+        tc = new TestTrafficController();
     }
 
     @Override
@@ -26,4 +73,49 @@ public class Z21TrafficControllerTest extends jmri.jmrix.AbstractMRTrafficContro
         JUnitUtil.tearDown();
     }
 
+    private static byte[] createCombinedReply(int replyCount) {
+        byte[] combinedReply = new byte[replyCount * 4];
+        for (int offset = 0; offset < combinedReply.length; offset += 4) {
+            combinedReply[offset] = 0x04;
+            combinedReply[offset + 1] = 0x00;
+            combinedReply[offset + 2] = (byte) 0x88;
+            combinedReply[offset + 3] = 0x00;
+        }
+        return combinedReply;
+    }
+
+    private static void setControllerEndpoint(Z21TrafficController controller,
+            InetAddress host, int port) throws NoSuchFieldException, IllegalAccessException {
+        setControllerField(controller, "host", host);
+        setControllerField(controller, "port", port);
+    }
+
+    private static void setControllerField(Z21TrafficController controller, String fieldName,
+            Object value) throws NoSuchFieldException, IllegalAccessException {
+        Field field = Z21TrafficController.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(controller, value);
+    }
+
+    private static class TestTrafficController extends Z21TrafficController {
+
+        TestTrafficController() {
+            xmtRunnable = () -> {
+            };
+        }
+    }
+
+    private static class TestZ21Adapter extends Z21Adapter {
+
+        private final DatagramSocket socket;
+
+        TestZ21Adapter(DatagramSocket socket) {
+            this.socket = socket;
+        }
+
+        @Override
+        public DatagramSocket getSocket() {
+            return socket;
+        }
+    }
 }


### PR DESCRIPTION
## Summary

`Z21TrafficController.handleOneIncomingReply()` allocated a fixed 100-byte buffer and capped the `DatagramPacket` receive length at 100 bytes. The Z21 LAN Protocol Specification (v1.13, section 1.3) allows several independent Z21 datasets to be combined into a single UDP packet, up to the Ethernet MTU payload. When a device sent a combined packet larger than 100 bytes, `DatagramSocket.receive()` silently truncated it, and the combined-reply parsing loop then walked past the truncation point and produced a wrong or mis-parsed final reply.

## Change

- Introduce a named constant `MAX_UDP_PAYLOAD = 1472` (1500-byte MTU minus the 20-byte IPv4 and 8-byte UDP headers) with a comment citing the spec rationale.
- Use the constant for both `new byte[...]` and the `DatagramPacket` receive-length argument so the two can never drift.
- The existing combined-reply parsing loop is unchanged; the only behavioral difference is that large combined packets are no longer truncated.

This is a single-source-file change in the `roco/z21` module with no API-surface or wiring changes.

## Why this matters

The original buffer comment said it "just needs to be longer than the longest protocol message," but the protocol explicitly permits multiple datasets in one datagram, so a single combined packet can exceed 100 bytes even when no individual message does. Silent truncation by `receive()` is not surfaced anywhere, so the symptom is intermittent wrong replies that are hard to diagnose in the field. Sizing the buffer to the real Z21 UDP payload maximum eliminates the truncation while keeping the existing parsing logic untouched.

## Testing

- Added `testReceivesCombinedPacketLongerThan100Bytes` to `Z21TrafficControllerTest`, which sends a 104-byte combined UDP datagram over a loopback socket and asserts all 26 datasets are received and split into the correct `Z21Reply` objects (previously truncated at 100 bytes).
- The full `Z21TrafficControllerTest` suite passes (7 tests, 0 failures).

Fixes #15126
