### PR TITLE
Write roster.xml atomically to prevent loss on shutdown failure

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -523,7 +523,7 @@
     <h3>Roster</h3>
         <a id="Roster" name="Roster"></a>
         <ul>
-            <li></li>
+            <li>Roster file saves are now atomic: the roster index is written to a temporary file and then moved into place, so an interrupted or failed write can no longer truncate or corrupt <code>roster.xml</code>. (PR #15228)</li>
         </ul>
 
     <h3>Routes</h3>

--- a/java/src/jmri/jmrit/roster/Roster.java
+++ b/java/src/jmri/jmrit/roster/Roster.java
@@ -1280,6 +1280,7 @@ public class Roster extends XmlFile implements RosterGroupSelector, PropertyChan
             }
             moveTempFile(temp, target);
         } catch (IOException ex) {
+            setDirty(true);
             deleteTempFile(temp, ex);
             throw ex;
         }

--- a/java/src/jmri/jmrit/roster/Roster.java
+++ b/java/src/jmri/jmrit/roster/Roster.java
@@ -7,6 +7,10 @@ import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -1108,13 +1112,12 @@ public class Roster extends XmlFile implements RosterGroupSelector, PropertyChan
      * Store the roster in the default place, including making a backup if
      * needed.
      * <p>
-     * Uses writeFile(String), a protected method that can write to a specific
-     * location.
+     * Writes to a temporary file first, then backs up and replaces the roster
+     * index only after the temporary write succeeds.
      */
     public void writeRoster() {
-        this.makeBackupFile(this.getRosterIndexPath());
         try {
-            this.writeFile(this.getRosterIndexPath());
+            this.writeFileAtomic(this.getRosterIndexPath());
         } catch (IOException e) {
             log.error("Exception while writing the new roster file, may not be complete", e);
             try {
@@ -1212,13 +1215,10 @@ public class Roster extends XmlFile implements RosterGroupSelector, PropertyChan
             }
         }
 
-        log.debug("Making backup roster index file");
-        this.makeBackupFile(this.getRosterIndexPath());
         try {
             log.debug("Writing new index file");
-            roster.writeFile(this.getRosterIndexPath());
+            roster.writeFileAtomic(this.getRosterIndexPath());
         } catch (IOException ex) {
-            // TODO: error dialog, copy backup back to roster.xml
             log.error("Exception while writing the new roster file, may not be complete", ex);
         }
         log.debug("Reloading resulting roster index");
@@ -1255,6 +1255,50 @@ public class Roster extends XmlFile implements RosterGroupSelector, PropertyChan
 
     public String getRosterIndexPath() {
         return this.getRosterLocation() + this.getRosterIndexFileName();
+    }
+
+    private void writeFileAtomic(String name) throws IOException {
+        File file = findFile(name);
+        if (file == null) {
+            file = new File(name);
+        }
+
+        Path target = file.toPath();
+        Path temp = target.resolveSibling(file.getName() + ".new"); // NOI18N
+
+        try {
+            writeFile(temp.toFile());
+        } catch (IOException ex) {
+            deleteTempFile(temp, ex);
+            throw ex;
+        }
+
+        try {
+            if (Files.exists(target)) {
+                Files.copy(target, new File(backupFileName(file.getAbsolutePath())).toPath(),
+                        StandardCopyOption.REPLACE_EXISTING);
+            }
+            moveTempFile(temp, target);
+        } catch (IOException ex) {
+            deleteTempFile(temp, ex);
+            throw ex;
+        }
+    }
+
+    private void moveTempFile(Path temp, Path target) throws IOException {
+        try {
+            Files.move(temp, target, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+        } catch (AtomicMoveNotSupportedException ex) {
+            Files.move(temp, target, StandardCopyOption.REPLACE_EXISTING);
+        }
+    }
+
+    private void deleteTempFile(Path temp, IOException originalException) {
+        try {
+            Files.deleteIfExists(temp);
+        } catch (IOException ex) {
+            originalException.addSuppressed(ex);
+        }
     }
 
     /*

--- a/java/test/jmri/jmrit/roster/RosterTest.java
+++ b/java/test/jmri/jmrit/roster/RosterTest.java
@@ -21,6 +21,7 @@ import jmri.jmrit.roster.swing.RosterEntryComboBox;
 import jmri.util.FileUtil;
 import jmri.util.JUnitAppender;
 import jmri.util.JUnitUtil;
+import jmri.util.junit.annotations.DisabledIfHeadless;
 import jmri.util.swing.JemmyUtil;
 
 import org.jdom2.JDOMException;
@@ -317,6 +318,7 @@ public class RosterTest {
     }
 
     @Test
+    @DisabledIfHeadless
     public void testWriteRosterPreservesOriginalWhenTempWriteFails(@TempDir File folder) throws IOException {
         File rosterDir = new File(folder, "roster");
         FileUtil.createDirectory(rosterDir);

--- a/java/test/jmri/jmrit/roster/RosterTest.java
+++ b/java/test/jmri/jmrit/roster/RosterTest.java
@@ -7,7 +7,10 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.awt.GraphicsEnvironment;
 import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.List;
 import java.util.Set;
 
@@ -16,7 +19,9 @@ import javax.swing.JComboBox;
 import jmri.InstanceManager;
 import jmri.jmrit.roster.swing.RosterEntryComboBox;
 import jmri.util.FileUtil;
+import jmri.util.JUnitAppender;
 import jmri.util.JUnitUtil;
+import jmri.util.swing.JemmyUtil;
 
 import org.jdom2.JDOMException;
 import org.junit.jupiter.api.*;
@@ -293,6 +298,53 @@ public class RosterTest {
     }
 
     @Test
+    public void testWriteRosterCreatesBackupAndRemovesTemp(@TempDir File folder) throws IOException, JDOMException {
+        File rosterDir = new File(folder, "roster");
+        Roster r = jmri.util.RosterTestUtil.createTestRoster(rosterDir, Roster.DEFAULT_ROSTER_INDEX);
+        File rosterFile = new File(rosterDir, Roster.DEFAULT_ROSTER_INDEX);
+        File backupFile = new File(rosterDir, Roster.DEFAULT_ROSTER_INDEX + ".bak");
+        File tempFile = new File(rosterDir, Roster.DEFAULT_ROSTER_INDEX + ".new");
+
+        r.writeRoster();
+        assertValidRosterFile(rosterFile);
+        assertFalse(tempFile.exists(), "temporary roster file should not remain after write");
+
+        r.writeRoster();
+        assertValidRosterFile(rosterFile);
+        assertTrue(backupFile.isFile(), "backup roster file should exist after replacing existing roster");
+        assertTrue(backupFile.length() > 0, "backup roster file should not be empty");
+        assertFalse(tempFile.exists(), "temporary roster file should not remain after replacement");
+    }
+
+    @Test
+    public void testWriteRosterPreservesOriginalWhenTempWriteFails(@TempDir File folder) throws IOException {
+        File rosterDir = new File(folder, "roster");
+        FileUtil.createDirectory(rosterDir);
+        File rosterFile = new File(rosterDir, Roster.DEFAULT_ROSTER_INDEX);
+        File tempFile = new File(rosterDir, Roster.DEFAULT_ROSTER_INDEX + ".new");
+        String originalContents = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                + "<roster-config><roster/></roster-config>\n";
+        Files.write(rosterFile.toPath(), originalContents.getBytes(StandardCharsets.UTF_8));
+
+        Roster r = new Roster() {
+            @Override
+            void writeFile(File file) throws IOException {
+                Files.write(file.toPath(), "partial".getBytes(StandardCharsets.UTF_8));
+                throw new IOException("forced write failure");
+            }
+        };
+        r.setRosterLocation(rosterDir.getAbsolutePath());
+
+        writeRosterClosingErrorDialog(r);
+        JUnitAppender.assertErrorMessage("Exception while writing the new roster file, may not be complete");
+
+        assertEquals(originalContents,
+                new String(Files.readAllBytes(rosterFile.toPath()), StandardCharsets.UTF_8),
+                "failed write should leave existing roster unchanged");
+        assertFalse(tempFile.exists(), "partial temporary roster file should be removed");
+    }
+
+    @Test
     public void testAttributeAccess() throws IOException {
         // create a test roster & store in file
         Roster r = jmri.util.RosterTestUtil.createTestRoster(new File(Roster.getDefault().getRosterLocation()), "rosterTest.xml");
@@ -418,6 +470,33 @@ public class RosterTest {
         assertEquals(1.0, rp.getThrottleSetting(5000, false), 0.0);
         assertEquals(0.5, rp.getThrottleSetting(2500, false), 0.0);
         assertEquals(0.25, rp.getThrottleSetting(1250, false), 0.0);
+    }
+
+    private static void assertValidRosterFile(File rosterFile) throws IOException, JDOMException {
+        assertTrue(rosterFile.isFile(), "roster file should exist");
+        assertTrue(rosterFile.length() > 0, "roster file should not be empty");
+        Roster r = new Roster();
+        r.readFile(rosterFile.getAbsolutePath());
+    }
+
+    private static void writeRosterClosingErrorDialog(Roster r) {
+        Thread okButtonThread = null;
+        if (!GraphicsEnvironment.isHeadless()) {
+            String okButtonText = javax.swing.UIManager.getString("OptionPane.okButtonText");
+            if (okButtonText == null) {
+                okButtonText = "OK";
+            }
+            okButtonThread = JemmyUtil.createModalDialogOperatorThread(
+                    Bundle.getMessage("ErrorSavingTitle"),
+                    okButtonText);
+        }
+
+        r.writeRoster();
+
+        if (okButtonThread != null) {
+            Thread thread = okButtonThread;
+            JUnitUtil.waitFor(() -> !thread.isAlive(), "error dialog closed");
+        }
     }
 
     @BeforeEach


### PR DESCRIPTION
## Summary

Make the roster index write atomic so a valid `roster.xml` always survives a
failed or interrupted save. The new content is written to a sibling temp file
(`roster.xml.new`) first; only after that write succeeds do we copy the existing
`roster.xml` to `roster.xml.bak` and move the temp file into place with an atomic
rename (falling back to a plain replace on filesystems that do not support atomic
move).

## Why this matters

Fixes #14834. The old sequence in `writeRoster()` and `reindexInternal()` renamed
`roster.xml` to `roster.xml.bak` (via `makeBackupFile`) before building and
writing the new file. If the process was interrupted or `writeFile` threw between
the rename and a successful write, the original `roster.xml` was gone and only the
`.bak` remained. Because `writeRoster()` swallows the exception, the program kept
running with no index file.

## Changes

- Add `writeFileAtomic(String)`: write to `<target>.new`, then copy the existing
  target to `<target>.bak` and `Files.move` the temp file into place with
  `ATOMIC_MOVE`, falling back to `REPLACE_EXISTING` when atomic move is not
  supported (cross-filesystem temp dirs).
- On a temp-write failure the partial `.new` file is deleted and the original
  `roster.xml` is left untouched. If the backup/move step fails after the temp
  write, the roster dirty flag is restored so the unsaved state is reported
  correctly.
- `writeRoster()` and `reindexInternal()` now call `writeFileAtomic` instead of
  `makeBackupFile` + `writeFile`. The `.new` and `.bak` files stay siblings of the
  target so the move can be atomic.
- `writeFile(File)`/`writeFile(String)` signatures are unchanged.

Known limitation: `writeFile(File)` fires the `Roster.SAVED` property change at the
end of writing the temp file, so on the rare backup/move failure path a `SAVED`
listener can be notified before the real file is replaced (the dirty flag is
restored, so close-without-save data loss is still prevented). Reordering the
`SAVED` notification would mean changing the shared `writeFile(File)` path, which
is out of scope for this fix. The OneDrive history-preservation request from the
issue comments is also out of scope.

## Testing

Added regression tests in `RosterTest`:
- Happy path: write twice, assert `roster.xml` exists, parses, and `.bak` exists.
- No leftover `roster.xml.new` after a successful write.
- Original `roster.xml` is preserved unchanged when the temp write fails.

`mvn -Dtest=jmri.jmrit.roster.RosterTest test` -> 23 tests, 0 failures, 0 errors.
A full project build was not run locally.

Fixes #14834
