### PR TITLE
Add support to listen on Warrant.getRunningMessage()

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -611,7 +611,8 @@
    <h3>Warrants</h3>
         <a id="Wt" name="Wt"></a>
         <ul>
-            <li></li>
+            <li>It's now possible to listen on <strong>Warrant.getRunningMessage()</strong>
+                by listening on the property <strong>PROPERTY_RUNNING_MESSAGE</strong>.</li>
         </ul>
 
    <h3>Web Access</h3>

--- a/java/src/jmri/jmrit/logix/SCWarrant.java
+++ b/java/src/jmri/jmrit/logix/SCWarrant.java
@@ -181,7 +181,7 @@ public class SCWarrant extends Warrant {
      * {@inheritDoc}
      **/
     @Override
-    protected synchronized String getRunningMessage() {
+    protected synchronized String getRunningMessagePrim() {
         if (_throttle == null) {
             // The warrant is not active
             return super.getRunningMessage();
@@ -354,7 +354,7 @@ public class SCWarrant extends Warrant {
                     _trainName, _nextSignal.getDisplayName(),appearance,speed);
             } else {
                 String aspect = ((SignalMast) _nextSignal).getAspect();
-                speed = _speedMap.getAspectSpeed((aspect == null ? "" : aspect), 
+                speed = _speedMap.getAspectSpeed((aspect == null ? "" : aspect),
                     ((SignalMast) _nextSignal).getSignalSystem());
                 log.debug("{} SignalMast {} shows aspect {} which maps to speed {}",
                     _trainName, _nextSignal.getDisplayName(),aspect,speed);

--- a/java/src/jmri/jmrit/logix/Warrant.java
+++ b/java/src/jmri/jmrit/logix/Warrant.java
@@ -692,6 +692,13 @@ public class Warrant extends jmri.implementation.AbstractNamedBean implements Th
         return msg;
     }
 
+    /**
+     * Get the running message.
+     * This is a primitive method for the {@link #getRunningMessage()} method.
+     * It creates the message so that the method {@link #getRunningMessage()}
+     * can notify its listeners about the message.
+     * @return the message
+     */
     @SuppressWarnings("fallthrough")
     @SuppressFBWarnings(value = "SF_SWITCH_FALLTHROUGH")
     protected synchronized String getRunningMessagePrim() {

--- a/java/src/jmri/jmrit/logix/Warrant.java
+++ b/java/src/jmri/jmrit/logix/Warrant.java
@@ -112,6 +112,11 @@ public class Warrant extends jmri.implementation.AbstractNamedBean implements Th
      */
     public static final String PROPERTY_OCCUPY_OVERRUN = "OccupyOverrun";
 
+    /**
+     * String constant for running message.
+     */
+    public static final String PROPERTY_RUNNING_MESSAGE = "RunningMessage";
+
     // permanent members.
     private List<BlockOrder> _orders;
     private BlockOrder _viaOrder;
@@ -674,9 +679,22 @@ public class Warrant extends jmri.implementation.AbstractNamedBean implements Th
         return msg;
     }
 
+    /**
+     * Get the running message.
+     * It's possible to listen to this message by the property {@link #PROPERTY_RUNNING_MESSAGE}.
+     * @return the message
+     */
+    protected final synchronized String getRunningMessage() {
+        // Note that this method is final. To override it, you need
+        // to override the method getRunningMessagePrim().
+        String msg = getRunningMessagePrim();
+        firePropertyChange(PROPERTY_RUNNING_MESSAGE, null, msg);
+        return msg;
+    }
+
     @SuppressWarnings("fallthrough")
     @SuppressFBWarnings(value = "SF_SWITCH_FALLTHROUGH")
-    protected synchronized String getRunningMessage() {
+    protected synchronized String getRunningMessagePrim() {
         if (_delayStart) {
             return Bundle.getMessage("waitForDelayStart", _trainName, getBlockAt(0).getDisplayName());
         }


### PR DESCRIPTION
This PR allows the user to listen on `Warrant.getRunningMessage()` using a Jython script.

See: https://groups.io/g/jmriusers/topic/119890773#msg253502

Note that I don't use Warrants so I haven't been able to test this.

Also, I'm not sure whenever this could be merged now or if it should wait for after the next production release.