### PR TITLE
Two LCC improvements

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -126,7 +126,10 @@
 
         <h4><a href="http://openlcb.org">OpenLCB</a> / LCC</h4>
             <ul>
-                <li></li>
+                <li>Suppress the 'Make Turnouts' and 'Make Sensors' buttons in the configuration
+                    window when they aren't going to do any adds.</li>
+                <li>Add option to the popup menu in eventID-entry fields that lets you
+                    name the event ID right there.</li>
             </ul>
 
         <h4>Powerline</h4>

--- a/java/src/jmri/jmrix/openlcb/swing/ClientActions.java
+++ b/java/src/jmri/jmrix/openlcb/swing/ClientActions.java
@@ -164,7 +164,7 @@ public class ClientActions {
                         final jmri.jmrix.openlcb.swing.NamedEventIdTextField mevt2 = evt2;
                     });
                     if (!haveButtons) {
-                        log.debug("create Make Turnout/Sensor buttons, starting with ", desc.getText());
+                        log.debug("create Make Turnout/Sensor buttons, starting with {}", desc.getText());
                         log.debug("events {} {}", evt1.getText(), evt2.getText());
                         
                         haveButtons = true;

--- a/java/src/jmri/jmrix/openlcb/swing/ClientActions.java
+++ b/java/src/jmri/jmrix/openlcb/swing/ClientActions.java
@@ -118,7 +118,11 @@ public class ClientActions {
 
             @Override
             public void handleGroupPaneEnd(JPanel pane) {
-                if (gpane != null && evt1 != null && evt2 != null && desc != null) {
+                if (gpane != null 
+                        && evt1 != null && !evt1.getText().isEmpty() 
+                        && evt2 != null && !evt2.getText().isEmpty()
+                        && desc != null) {
+                    log.debug("handleGroupPaneEnd for {}", desc.getText());
                     JPanel p = new JPanel();
                     p.setLayout(new WrapLayout());
                     p.setAlignmentX(-1.0f);
@@ -156,10 +160,13 @@ public class ClientActions {
                         }
 
                         final JTextField mdesc = desc;
-                        final JTextComponent mevt1 = evt1;
-                        final JTextComponent mevt2 = evt2;
+                        final jmri.jmrix.openlcb.swing.NamedEventIdTextField mevt1 = evt1;
+                        final jmri.jmrix.openlcb.swing.NamedEventIdTextField mevt2 = evt2;
                     });
                     if (!haveButtons) {
+                        log.debug("create Make Turnout/Sensor buttons, starting with ", desc.getText());
+                        log.debug("events {} {}", evt1.getText(), evt2.getText());
+                        
                         haveButtons = true;
                         cdiPanel.addButtonToFooter(buttonForList(sensorButtonList, Bundle.getMessage("CdiPanelMakeAllSensors")));
                         cdiPanel.addButtonToFooter(buttonForList(turnoutButtonList, Bundle.getMessage("CdiPanelMakeAllTurnouts")));
@@ -199,6 +206,7 @@ public class ClientActions {
              * {@inheritDoc}
              */
             public void makeSensor(String ev, String mdesc) {
+                log.debug("MakeSensor() invoked for {}",mdesc, new Exception("for traceback"));
                 jmri.Sensor sensor =
                         jmri.InstanceManager.sensorManagerInstance()
                                 .provideSensor(memo.getSystemPrefix() + "S" + ev);
@@ -210,8 +218,8 @@ public class ClientActions {
 
             JPanel gpane = null;
             JTextField desc = null;
-            JTextComponent evt1 = null;
-            JTextComponent evt2 = null;
+            jmri.jmrix.openlcb.swing.NamedEventIdTextField evt1 = null;
+            jmri.jmrix.openlcb.swing.NamedEventIdTextField evt2 = null;
         };
         ConfigRepresentation rep = iface.getConfigForNode(destNode);
         rep.eventNameStore = memo.get(OlcbEventNameStore.class);

--- a/java/src/jmri/jmrix/openlcb/swing/NamedEventIdTextField.java
+++ b/java/src/jmri/jmrix/openlcb/swing/NamedEventIdTextField.java
@@ -9,6 +9,7 @@ import javax.swing.*;
 import jmri.util.swing.*;
 import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.jmrix.openlcb.OlcbAddress;
+import jmri.jmrix.openlcb.OlcbEventNameStore;
 
 import org.openlcb.EventID;
 import org.openlcb.swing.EventIdTextField;
@@ -77,6 +78,27 @@ public class NamedEventIdTextField extends OvertypeTextArea {
                 });
             }
         });
+        // add a custom operator to set an event name
+        menuItem = new JMenuItem("Name This Event");
+        popup.add(menuItem);
+        menuItem.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                String name = JmriJOptionPane.showInputDialog(
+                    self,
+                    "Enter a Name for the Event ID",
+                    "" )        ;
+                   
+                if (name == null || name.isEmpty() ) return; // no new name entered
+                        
+                memo.get(OlcbEventNameStore.class).addMatch(getEventID(), name);
+                // and update the NEITF object to get name displayed
+                self.setText(name);
+                self.repaint();
+            }
+        });
+       
+        // and set the updated popup menu
         this.setComponentPopupMenu(popup);
     }
 


### PR DESCRIPTION
 - Suppress the 'Make Turnouts' and 'Make Sensors' buttons in the configuration window when they won't do anything

 - You can now use a pop-up menu item to name an Event ID in any EventID-entry field