### PR TITLE
docs: clarify PR3/PR4 throttle limits in programming-only mode

### DIFF
--- a/help/en/html/hardware/loconet/PR3.shtml
+++ b/help/en/html/hardware/loconet/PR3.shtml
@@ -165,14 +165,13 @@
 
       <h1>Usage suggestions</h1>
 
-      <p><strong>If a loco on your main track will not move:</strong> When the PR3 is configured as
-      a "PR3 Standalone Programmer" (a programming-track-only mode), JMRI still lets you open a
-      throttle, but that throttle can only control a loco sitting on the PR3's dedicated programming
-      track -- it cannot run a loco on the main track, so a main-track loco will appear unresponsive
-      even though the throttle looks like it is working. The PR3 can act as a programmer OR as a
-      LocoNet interface, but not both at once; to run trains on the main track, set up the PR3 as a
-      LocoNet Interface by selecting your actual command-station type, not "PR3 Standalone
-      Programmer".</p>
+      <p><strong>You cannot run a loco on the main track while the PR3 is configured as a
+      "PR3 Standalone Programmer".</strong> In that programming-track-only mode JMRI still lets
+      you open a throttle, but the throttle can only control a loco sitting on the PR3's dedicated
+      programming track, so a main-track loco will appear unresponsive even though the throttle
+      looks like it is working. The PR3 can act as a programmer OR as a LocoNet interface, but not
+      both at once; to run trains on the main track, set up the PR3 as a LocoNet Interface by
+      selecting your actual command-station type, not "PR3 Standalone Programmer".</p>
 
       <p>You can use a JMRI throttle to control the locomotive connected to the PR3 Programmer. Use
       the JMRI Power Control or the "Power" menu item on the Throttle's menu bar to turn on track

--- a/help/en/html/hardware/loconet/PR3.shtml
+++ b/help/en/html/hardware/loconet/PR3.shtml
@@ -165,6 +165,15 @@
 
       <h1>Usage suggestions</h1>
 
+      <p><strong>If a loco on your main track will not move:</strong> When the PR3 is configured as
+      a "PR3 Standalone Programmer" (a programming-track-only mode), JMRI still lets you open a
+      throttle, but that throttle can only control a loco sitting on the PR3's dedicated programming
+      track -- it cannot run a loco on the main track, so a main-track loco will appear unresponsive
+      even though the throttle looks like it is working. The PR3 can act as a programmer OR as a
+      LocoNet interface, but not both at once; to run trains on the main track, set up the PR3 as a
+      LocoNet Interface by selecting your actual command-station type, not "PR3 Standalone
+      Programmer".</p>
+
       <p>You can use a JMRI throttle to control the locomotive connected to the PR3 Programmer. Use
       the JMRI Power Control or the "Power" menu item on the Throttle's menu bar to turn on track
       power, and then you can operate the locomotive normally.</p>

--- a/help/en/html/hardware/loconet/PR4.shtml
+++ b/help/en/html/hardware/loconet/PR4.shtml
@@ -148,14 +148,14 @@
         profile, so that you may perform some other type of work.</li>
       </ul>
 
-      <p><strong>If a loco on your main track will not move:</strong> When the PR4 is configured as
-      a "PR4 Standalone Programmer" (a programming-track-only mode), JMRI still lets you open a
-      throttle, but that throttle can only control a loco sitting on the PR4's dedicated programming
-      track -- it cannot run a loco on the main track, so a main-track loco will appear unresponsive
-      even though the throttle looks like it is working. To run trains on the main track, configure
-      the connection as a LocoNet Interface by selecting your actual command-station type (see the
-      "LocoNet Interface, Decoder Programming" row in the table above) instead of the "PR4
-      Standalone Programmer" type.</p>
+      <p><strong>You cannot run a loco on the main track while the PR4 is configured as a
+      "PR4 Standalone Programmer".</strong> In that programming-track-only mode JMRI still lets
+      you open a throttle, but the throttle can only control a loco sitting on the PR4's dedicated
+      programming track, so a main-track loco will appear unresponsive even though the throttle
+      looks like it is working. To run trains on the main track, configure the connection as a
+      LocoNet Interface by selecting your actual command-station type (see the "LocoNet Interface,
+      Decoder Programming" row in the table above) instead of the "PR4 Standalone Programmer"
+      type.</p>
 
       <h2>PR4 as a stand-alone decoder programmer</h2>
       <img src="images/PR3-PR4StandaloneProgConnections.png" alt=

--- a/help/en/html/hardware/loconet/PR4.shtml
+++ b/help/en/html/hardware/loconet/PR4.shtml
@@ -148,6 +148,15 @@
         profile, so that you may perform some other type of work.</li>
       </ul>
 
+      <p><strong>If a loco on your main track will not move:</strong> When the PR4 is configured as
+      a "PR4 Standalone Programmer" (a programming-track-only mode), JMRI still lets you open a
+      throttle, but that throttle can only control a loco sitting on the PR4's dedicated programming
+      track -- it cannot run a loco on the main track, so a main-track loco will appear unresponsive
+      even though the throttle looks like it is working. To run trains on the main track, configure
+      the connection as a LocoNet Interface by selecting your actual command-station type (see the
+      "LocoNet Interface, Decoder Programming" row in the table above) instead of the "PR4
+      Standalone Programmer" type.</p>
+
       <h2>PR4 as a stand-alone decoder programmer</h2>
       <img src="images/PR3-PR4StandaloneProgConnections.png" alt=
       "Connections for PR4 acting as a standalone programmer" width="350">


### PR DESCRIPTION
## What

Adds a clearly visible callout to the PR4 and PR3 LocoNet help pages explaining a confusing throttle behavior: when the interface is configured in a programming-track-only operating mode (the "Standalone Programmer" command-station type), JMRI still lets you open a throttle, but that throttle can only control a loco on the device's dedicated programming track, not the main track. A loco on the main track will appear unresponsive even though the throttle looks like it is working.

## Why

Per #15133, a user spent hours unable to run a loco on the main track because nothing in the docs explained that the PR4's single output, when set to standalone-programmer mode, drives only the dedicated programming track. The note points the reader to the LocoNet Interface configuration (selecting the real command-station type) needed to run trains on the main track.

## Changes

- `help/en/html/hardware/loconet/PR4.shtml` -- note after the "Choosing the PR4 operating mode" list.
- `help/en/html/hardware/loconet/PR3.shtml` -- parallel note at the top of "Usage suggestions".

Documentation only; no code is changed and the SPROG single-throttle-in-programmer behavior is untouched. This is the help-text first step described in the issue discussion; a follow-up UI change to disable the Throttle button in programming-only PR3/PR4 modes can be scoped separately against real hardware.

Refs #15133
