### PR TITLE
ThrottleWindow : previous throttle with non null speed button not working

### DIFF
--- a/java/src/jmri/jmrit/throttle/ThrottleWindow.java
+++ b/java/src/jmri/jmrit/throttle/ThrottleWindow.java
@@ -746,7 +746,7 @@ public class ThrottleWindow extends JmriJFrame implements ThrottleControllersUIC
             ThrottleFrame cf = this.getCurentThrottleController();
             ThrottleFrame nf = null;            
             for (ThrottleFrame tf : throttleFrames) {
-                if (tf.isRunning()) {
+                if ((tf != cf) && tf.isRunning()) {
                     nf = tf;
                 }
                 if ((tf == cf) && (nf != null)) { // return the last one found before the curent one


### PR DESCRIPTION
sorry found a small bug this morning on 5.15.9, I did my dev branch from tag v5.15.9, hopefully this is ok.