### PR TITLE
Add menu item to clear the LogixNG clipboard

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -481,6 +481,9 @@
     <h3>LogixNG</h3>
         <a id="LogixNG" name="LogixNG"></a>
         <ul>
+          <li>The LogixNG clipboard now has the menu item
+              <strong>Clear clipboard</strong> in the <strong>Tools</strong>
+              menu. It allows you to clear the entire clipboard.</li>
           <li></li>
         </ul>
 

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -481,7 +481,7 @@
     <h3>LogixNG</h3>
         <a id="LogixNG" name="LogixNG"></a>
         <ul>
-          <li>The LogixNG clipboard now has the menu item
+          <li>The LogixNG clipboard window now has the menu item
               <strong>Clear clipboard</strong> in the <strong>Tools</strong>
               menu. It allows you to clear the entire clipboard.</li>
           <li></li>

--- a/java/src/jmri/jmrit/logixng/BaseManager.java
+++ b/java/src/jmri/jmrit/logixng/BaseManager.java
@@ -9,13 +9,13 @@ import jmri.NamedBean;
 
 /**
  * Base interface for the LogixNG action and expression managers.
- * 
+ *
  * @param <E> the type of NamedBean supported by this manager
- * 
+ *
  * @author Daniel Bergqvist 2020
  */
 public interface BaseManager<E extends NamedBean> extends Manager<E> {
-    
+
     /**
      * Remember a NamedBean Object created outside the manager.
      * <p>
@@ -28,7 +28,7 @@ public interface BaseManager<E extends NamedBean> extends Manager<E> {
      *                                                the manager
      */
     E registerBean(@Nonnull E maleSocket);
-    
+
     /**
      * Method for a UI to delete a bean.
      * <p>
@@ -49,23 +49,44 @@ public interface BaseManager<E extends NamedBean> extends Manager<E> {
      *                                          delete to be aborted (see above)
      */
     void deleteBean(@Nonnull MaleSocket maleSocket, @Nonnull String property) throws PropertyVetoException;
-    
+
+    /**
+     * Method for a UI to delete the children of a bean.
+     * <p>
+     * The UI should first request a "CanDelete", this will return a list of
+     * locations (and descriptions) where the bean is in use via throwing a
+     * VetoException, then if that comes back clear, or the user agrees with the
+     * actions, then a "DoDelete" can be called which inform the listeners to
+     * delete the children of the bean, then it will be deregistered and disposed of.
+     * <p>
+     * If a property name of "DoNotDelete" is thrown back in the VetoException
+     * then the delete process should be aborted.
+     *
+     * @param maleSocket The MaleSocket of which the children are to be deleted
+     * @param property   The programmatic name of the request. "CanDelete" will
+     *                   enquire with all listeners if the item can be deleted.
+     *                   "DoDelete" tells the listener to delete the item
+     * @throws java.beans.PropertyVetoException If the recipients wishes the
+     *                                          delete to be aborted (see above)
+     */
+    void deleteChildren(@Nonnull MaleSocket maleSocket, @Nonnull String property) throws PropertyVetoException;
+
     /**
      * Get the default male socket class
      * @return the class
      */
     Class<? extends MaleSocket> getMaleSocketClass();
-    
+
     /**
      * Get the last item registered in the mananger.
      * @return the last item
      */
     MaleSocket getLastRegisteredMaleSocket();
-    
+
     /**
      * Register a male socket factory.
      * @param factory the factory
      */
     void registerMaleSocketFactory(MaleSocketFactory<E> factory);
-    
+
 }

--- a/java/src/jmri/jmrit/logixng/implementation/AbstractBaseManager.java
+++ b/java/src/jmri/jmrit/logixng/implementation/AbstractBaseManager.java
@@ -89,6 +89,22 @@ public abstract class AbstractBaseManager<E extends NamedBean> extends AbstractM
     /** {@inheritDoc} */
     @Override
     @OverridingMethodsMustInvokeSuper
+    public void deleteChildren(@Nonnull MaleSocket socket, @Nonnull String property) throws PropertyVetoException {
+        for (int i=socket.getChildCount()-1; i >= 0; i--) {
+            FemaleSocket child = socket.getChild(i);
+            if (child.isConnected()) {
+                MaleSocket maleSocket = child.getConnectedSocket();
+                maleSocket.getManager().deleteBean(maleSocket, property);
+                if (property.equals("DoDelete")) { // NOI18N
+                    child.disconnect();
+                }
+            }
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    @OverridingMethodsMustInvokeSuper
     public void deregister(@Nonnull E s) {
         // A LogixNG action or expression is contained in one or more male
         // sockets. A male socket might be contained in another male socket.

--- a/java/src/jmri/jmrit/logixng/implementation/DefaultClipboard.java
+++ b/java/src/jmri/jmrit/logixng/implementation/DefaultClipboard.java
@@ -7,13 +7,13 @@ import jmri.jmrit.logixng.*;
 
 /**
  * Default implementation of the clipboard
- * 
+ *
  * @author Daniel Bergqvist (C) 2020
  */
 public class DefaultClipboard extends AbstractBase implements Clipboard {
 
     private ClipboardMany _clipboardItems = new ClipboardMany("", null);
-    
+
     private final FemaleAnySocket _femaleSocket = new DefaultFemaleAnySocket(this, new FemaleSocketListener() {
         @Override
         public void connected(FemaleSocket socket) {
@@ -25,16 +25,16 @@ public class DefaultClipboard extends AbstractBase implements Clipboard {
             // Do nothing
         }
     }, "A");
-    
-    
+
+
     public DefaultClipboard() {
         super("IQClipboard");
-        
+
         // Listeners should never be enabled for the clipboard
         _femaleSocket.setEnableListeners(false);
-        
+
         try {
-            _femaleSocket.connect(new MaleRootSocket(null));
+            _femaleSocket.connect(new MaleRootSocket(new MaleRootManager()));
         } catch (SocketAlreadyConnectedException ex) {
             // This should never happen
             throw new RuntimeException("Program error", ex);
@@ -44,7 +44,7 @@ public class DefaultClipboard extends AbstractBase implements Clipboard {
         }
         _clipboardItems.setParent(_femaleSocket.getConnectedSocket());
     }
-    
+
     @Override
     public boolean isEmpty() {
         return _clipboardItems.getChildCount() == 0;
@@ -60,7 +60,7 @@ public class DefaultClipboard extends AbstractBase implements Clipboard {
             throw new RuntimeException("Cannot add socket", ex);
         }
     }
-    
+
     @Override
     public MaleSocket fetchTopItem() {
         if (!isEmpty()) {
@@ -71,7 +71,7 @@ public class DefaultClipboard extends AbstractBase implements Clipboard {
             return null;
         }
     }
-    
+
     @Override
     public MaleSocket getTopItem() {
         if (!isEmpty()) {
@@ -106,14 +106,14 @@ public class DefaultClipboard extends AbstractBase implements Clipboard {
     public void setup() {
         _clipboardItems.setup();
     }
-    
+
     public boolean replaceClipboardItems(ClipboardMany clipboardItems, List<String> errors) {
         _clipboardItems = clipboardItems;
-        
+
         _femaleSocket.disconnect();
-        
+
         try {
-            _femaleSocket.connect(new MaleRootSocket(null));
+            _femaleSocket.connect(new MaleRootSocket(new MaleRootManager()));
         } catch (SocketAlreadyConnectedException ex) {
             // This should never happen
             throw new RuntimeException("Program error", ex);
@@ -193,13 +193,13 @@ public class DefaultClipboard extends AbstractBase implements Clipboard {
         throw new UnsupportedOperationException("Not supported");
     }
 
-    
+
     private class MaleRootSocket extends AbstractMaleSocket {
 
         public MaleRootSocket(BaseManager<? extends NamedBean> manager) {
             super(manager, _clipboardItems);
         }
-        
+
         @Override
         protected void registerListenersForThisClass() {
             throw new UnsupportedOperationException("Not supported");
@@ -256,5 +256,45 @@ public class DefaultClipboard extends AbstractBase implements Clipboard {
         }
 
     }
-    
+
+
+    private static class MaleRootManager extends AbstractBaseManager {
+
+        @Override
+        protected NamedBean castBean(MaleSocket maleSocket) {
+            throw new UnsupportedOperationException("Not supported");
+        }
+
+        @Override
+        public char typeLetter() {
+            throw new UnsupportedOperationException("Not supported");
+        }
+
+        @Override
+        public Class getNamedBeanClass() {
+            return MaleRootSocket.class;
+        }
+
+        @Override
+        public int getXMLOrder() {
+            return Integer.MAX_VALUE;
+        }
+
+        @Override
+        public String getBeanTypeHandled(boolean plural) {
+            throw new UnsupportedOperationException("Not supported");
+        }
+
+        @Override
+        public Class getMaleSocketClass() {
+            throw new UnsupportedOperationException("Not supported");
+        }
+
+        @Override
+        public MaleSocket getLastRegisteredMaleSocket() {
+            throw new UnsupportedOperationException("Not supported");
+        }
+
+    }
+
 }

--- a/java/src/jmri/jmrit/logixng/implementation/DefaultClipboard.java
+++ b/java/src/jmri/jmrit/logixng/implementation/DefaultClipboard.java
@@ -335,7 +335,7 @@ public class DefaultClipboard extends AbstractBase implements Clipboard {
         }
 
         @Override
-        public Class getMaleSocketClass() {
+        public Class<ClipboardManySocket> getMaleSocketClass() {
             throw new UnsupportedOperationException("Not supported");
         }
 

--- a/java/src/jmri/jmrit/logixng/implementation/DefaultClipboard.java
+++ b/java/src/jmri/jmrit/logixng/implementation/DefaultClipboard.java
@@ -180,12 +180,12 @@ public class DefaultClipboard extends AbstractBase implements Clipboard {
 
     @Override
     public FemaleSocket getChild(int index) throws IllegalArgumentException, UnsupportedOperationException {
-        throw new UnsupportedOperationException("Not supported");
+        return _clipboardItems.getChild(index);
     }
 
     @Override
     public int getChildCount() {
-        throw new UnsupportedOperationException("Not supported");
+        return _clipboardItems.getChildCount();
     }
 
     @Override
@@ -194,7 +194,11 @@ public class DefaultClipboard extends AbstractBase implements Clipboard {
     }
 
 
-    private class MaleRootSocket extends AbstractMaleSocket {
+    private interface ClipboardManySocket extends NamedBean, MaleSocket {
+    }
+
+
+    private class MaleRootSocket extends AbstractMaleSocket implements ClipboardManySocket {
 
         public MaleRootSocket(BaseManager<? extends NamedBean> manager) {
             super(manager, _clipboardItems);
@@ -255,13 +259,58 @@ public class DefaultClipboard extends AbstractBase implements Clipboard {
             throw new UnsupportedOperationException("Not supported");
         }
 
+        @Override
+        public void setState(int s) throws JmriException {
+            throw new UnsupportedOperationException("Not supported");
+        }
+
+        @Override
+        public int getState() {
+            throw new UnsupportedOperationException("Not supported");
+        }
+
+        @Override
+        public String describeState(int state) {
+            throw new UnsupportedOperationException("Not supported");
+        }
+
+        @Override
+        public void setProperty(String key, Object value) {
+            throw new UnsupportedOperationException("Not supported");
+        }
+
+        @Override
+        public Object getProperty(String key) {
+            throw new UnsupportedOperationException("Not supported");
+        }
+
+        @Override
+        public void removeProperty(String key) {
+            throw new UnsupportedOperationException("Not supported");
+        }
+
+        @Override
+        public Set<String> getPropertyKeys() {
+            throw new UnsupportedOperationException("Not supported");
+        }
+
+        @Override
+        public String getBeanType() {
+            throw new UnsupportedOperationException("Not supported");
+        }
+
+        @Override
+        public int compareSystemNameSuffix(String suffix1, String suffix2, NamedBean n2) {
+            throw new UnsupportedOperationException("Not supported");
+        }
+
     }
 
 
-    private static class MaleRootManager extends AbstractBaseManager {
+    private static class MaleRootManager extends AbstractBaseManager<ClipboardManySocket> {
 
         @Override
-        protected NamedBean castBean(MaleSocket maleSocket) {
+        protected ClipboardManySocket castBean(MaleSocket maleSocket) {
             throw new UnsupportedOperationException("Not supported");
         }
 
@@ -271,8 +320,8 @@ public class DefaultClipboard extends AbstractBase implements Clipboard {
         }
 
         @Override
-        public Class getNamedBeanClass() {
-            return MaleRootSocket.class;
+        public Class<ClipboardManySocket> getNamedBeanClass() {
+            return ClipboardManySocket.class;
         }
 
         @Override

--- a/java/src/jmri/jmrit/logixng/implementation/configurexml/DefaultClipboard.java
+++ b/java/src/jmri/jmrit/logixng/implementation/configurexml/DefaultClipboard.java
@@ -1,0 +1,21 @@
+package jmri.jmrit.logixng.implementation.configurexml;
+
+import org.jdom2.Element;
+
+/**
+ * XML class for the DefaultClipboard.MaleRootManager class.
+ * @author Daniel Bergqvist (C) 2026
+ */
+public class DefaultClipboard {
+
+    public static class MaleRootManagerXml extends AbstractManagerXml {
+
+        @Override
+        public Element store(Object o) {
+            // Never store anything.
+            return null;
+        }
+
+    }
+
+}

--- a/java/src/jmri/jmrit/logixng/tools/swing/ClipboardEditor.java
+++ b/java/src/jmri/jmrit/logixng/tools/swing/ClipboardEditor.java
@@ -4,12 +4,16 @@ import java.awt.event.*;
 import java.util.*;
 import java.util.List;
 
+import javax.swing.JMenu;
+import javax.swing.JMenuItem;
+import javax.swing.tree.TreePath;
+
 import jmri.InstanceManager;
 import jmri.jmrit.logixng.*;
 
 /**
  * Editor of the clipboard
- * 
+ *
  * @author Daniel Bergqvist 2020
  */
 public class ClipboardEditor extends TreeEditor {
@@ -18,13 +22,13 @@ public class ClipboardEditor extends TreeEditor {
      * Maintain a list of listeners -- normally only one.
      */
     private final List<ClipboardEventListener> listenerList = new ArrayList<>();
-    
+
     /**
      * This contains a list of commands to be processed by the listener
      * recipient.
      */
     final HashMap<String, String> clipboardData = new HashMap<>();
-    
+
     /**
      * Construct a ConditionalEditor.
      */
@@ -35,12 +39,29 @@ public class ClipboardEditor extends TreeEditor {
                 EnableRootPopup.DisableRootPopup,
                 EnableExecuteEvaluate.DisableExecuteEvaluate
         );
-        
+
         ClipboardEditor.this.setTitle(Bundle.getMessage("TitleClipboardEditor"));
-        
+
         ClipboardEditor.this.setRootVisible(false);
     }
-    
+
+    /** {@inheritDoc} */
+    @Override
+    protected void addExtraItemsToToolsMenu(JMenu toolsMenu) {
+        JMenuItem openClipboardItem = new JMenuItem(Bundle.getMessage("MenuClearClipboard"));
+        openClipboardItem.addActionListener((ActionEvent e) -> {
+            FemaleSocket clipboardFemaleSocket =
+                    InstanceManager.getDefault(LogixNG_Manager.class).getClipboard().getFemaleSocket();
+            DeleteBeanWorker worker = new DeleteBeanWorker(
+                    clipboardFemaleSocket,
+                    new TreePath(new Object[]{ _treePane._tree.getModel().getRoot() }),
+                    true,   // Delete only the children
+                    Bundle.getMessage("ClearClipboardPrompt"));
+            worker.execute();
+        });
+        toolsMenu.add(openClipboardItem);
+    }
+
     /** {@inheritDoc} */
     @Override
     public void windowClosed(WindowEvent e) {
@@ -48,11 +69,11 @@ public class ClipboardEditor extends TreeEditor {
         clipboardData.put("Finish", "Clipboard");  // NOI18N
         fireClipboardEvent();
     }
-    
+
     public void addClipboardEventListener(ClipboardEventListener listener) {
         listenerList.add(listener);
     }
-    
+
     /**
      * Notify the listeners to check for new data.
      */
@@ -61,14 +82,14 @@ public class ClipboardEditor extends TreeEditor {
             l.clipboardEventOccurred();
         }
     }
-    
-    
+
+
     public interface ClipboardEventListener extends EventListener {
-        
+
         public void clipboardEventOccurred();
     }
-    
-    
+
+
 //    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ClipboardEditor.class);
 
 }

--- a/java/src/jmri/jmrit/logixng/tools/swing/LogixNGSwingBundle.properties
+++ b/java/src/jmri/jmrit/logixng/tools/swing/LogixNGSwingBundle.properties
@@ -9,6 +9,7 @@ MenuStopLogixNG             = Stop LogixNG
 MenuLogixNGInitializationTable  = LogixNG Initialization table
 MenuImportLogix             = Import Logix
 MenuOpenClipboard           = Open clipboard
+MenuClearClipboard          = Clear clipboard
 MenuInlineLogixNGs          = Inline LogixNGs
 BrowseAllLogixNGs           = Browse All LogixNGs
 
@@ -180,6 +181,7 @@ ValidateFemaleSocketTitle   = Error
 DeletePrompt                = Are you sure you want to delete {0}?
 DeleteWithChildrenPrompt    = Are you sure you want to delete {0} and its children?
 VetoDeleteBean              = {0} {1} Can not be deleted\n{2}
+ClearClipboardPrompt        = Are you sure you want to clear the clipboard?
 
 PopupMenuRenameSocket   = Rename socket
 PopupMenuAdd        = Add

--- a/java/src/jmri/jmrit/logixng/tools/swing/TreeEditor.java
+++ b/java/src/jmri/jmrit/logixng/tools/swing/TreeEditor.java
@@ -135,6 +135,7 @@ public class TreeEditor extends TreeViewer {
             });
             toolsMenu.add(openClipboardItem);
         }
+        addExtraItemsToToolsMenu(toolsMenu);
         menuBar.add(toolsMenu);
 
         JTree tree = _treePane._tree;
@@ -282,6 +283,14 @@ public class TreeEditor extends TreeViewer {
                     }
                 }
         );
+    }
+
+    /**
+     * Adds extra menu items to the tools menu.
+     * This method is used for sub classes.
+     * @param toolsMenu the tools menu
+     */
+    protected void addExtraItemsToToolsMenu(JMenu toolsMenu) {
     }
 
     private void openPopupMenu(JTree tree, TreePath path, int x, int y, boolean onlyAddItems) {
@@ -2002,16 +2011,28 @@ public class TreeEditor extends TreeViewer {
 
 
     // This class is copied from BeanTableDataModel
-    private class DeleteBeanWorker extends SwingWorker<Void, Void> {
+    protected class DeleteBeanWorker extends SwingWorker<Void, Void> {
 
         private final FemaleSocket _currentFemaleSocket;
         private final TreePath _currentPath;
-        MaleSocket _maleSocket;
+        private final MaleSocket _maleSocket;
+        private final boolean _deleteOnlyChildren;
+        private final String _deleteQuestion;
 
         public DeleteBeanWorker(FemaleSocket currentFemaleSocket, TreePath currentPath) {
+            this(currentFemaleSocket, currentPath, false, null);
+        }
+
+        public DeleteBeanWorker(
+                FemaleSocket currentFemaleSocket,
+                TreePath currentPath,
+                boolean deleteOnlyChildren,
+                String deleteQuestion) {
             _currentFemaleSocket = currentFemaleSocket;
             _currentPath = currentPath;
             _maleSocket = _currentFemaleSocket.getConnectedSocket();
+            _deleteOnlyChildren = deleteOnlyChildren;
+            _deleteQuestion = deleteQuestion;
         }
 
         public int getDisplayDeleteMsg() {
@@ -2025,8 +2046,12 @@ public class TreeEditor extends TreeViewer {
         public void doDelete() {
             _treePane._femaleRootSocket.unregisterListeners();
             try {
-                _currentFemaleSocket.disconnect();
-                _maleSocket.getManager().deleteBean(_maleSocket, "DoDelete");
+                if (_deleteOnlyChildren) {
+                    _maleSocket.getManager().deleteChildren(_maleSocket, "DoDelete");
+                } else {
+                    _currentFemaleSocket.disconnect();
+                    _maleSocket.getManager().deleteBean(_maleSocket, "DoDelete");
+                }
             } catch (PropertyVetoException e) {
                 //At this stage the DoDelete shouldn't fail, as we have already done a can delete, which would trigger a veto
                 log.error("Unexpected doDelete failure for {}, {}", _maleSocket, e.getMessage() );
@@ -2044,7 +2069,11 @@ public class TreeEditor extends TreeViewer {
         public Void doInBackground() {
             StringBuilder message = new StringBuilder();
             try {
-                _maleSocket.getManager().deleteBean(_maleSocket, "CanDelete");  // NOI18N
+                if (_deleteOnlyChildren) {
+                    _maleSocket.getManager().deleteChildren(_maleSocket, "CanDelete");
+                } else {
+                    _maleSocket.getManager().deleteBean(_maleSocket, "CanDelete");  // NOI18N
+                }
             } catch (PropertyVetoException e) {
                 if (e.getPropertyChangeEvent().getPropertyName().equals("DoNotDelete")) { // NOI18N
                     log.warn("Do not Delete {}, {}", _maleSocket, e.getMessage());
@@ -2075,20 +2104,24 @@ public class TreeEditor extends TreeViewer {
                 container.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
                 container.setLayout(new BoxLayout(container, BoxLayout.Y_AXIS));
                 if (count > 0) { // warn of listeners attached before delete
-
-                    String prompt = _maleSocket.getChildCount() > 0 ? "DeleteWithChildrenPrompt" : "DeletePrompt";
-                    JLabel question = new JLabel(Bundle.getMessage(
-                            prompt,
-                            ((NamedBean)_maleSocket.getObject())
-                                    .getDisplayName(NamedBean.DisplayOptions.USERNAME_SYSTEMNAME)));
-                    question.setAlignmentX(Component.CENTER_ALIGNMENT);
-                    container.add(question);
+                    JLabel questionLabel;
+                    if (_deleteQuestion != null) {
+                        questionLabel = new JLabel(_deleteQuestion);
+                    } else {
+                        String prompt = _maleSocket.getChildCount() > 0 ? "DeleteWithChildrenPrompt" : "DeletePrompt";
+                        questionLabel = new JLabel(Bundle.getMessage(
+                                prompt,
+                                ((NamedBean)_maleSocket.getObject())
+                                        .getDisplayName(NamedBean.DisplayOptions.USERNAME_SYSTEMNAME)));
+                    }
+                    questionLabel.setAlignmentX(Component.CENTER_ALIGNMENT);
+                    container.add(questionLabel);
 
                     ArrayList<String> tempListenerRefs = new ArrayList<>();
 
                     tempListenerRefs.addAll(listenerRefs);
 
-                    if (tempListenerRefs.size() > 0) {
+                    if (!tempListenerRefs.isEmpty()) {
                         ArrayList<String> listeners = new ArrayList<>();
                         for (int i = 0; i < tempListenerRefs.size(); i++) {
                             if (!listeners.contains(tempListenerRefs.get(i))) {
@@ -2114,12 +2147,17 @@ public class TreeEditor extends TreeViewer {
                         container.add(jScrollPane);
                     }
                 } else {
-                    String prompt = _maleSocket.getChildCount() > 0 ? "DeleteWithChildrenPrompt" : "DeletePrompt";
-                    String msg = MessageFormat.format(Bundle.getMessage(prompt),
-                            new Object[]{_maleSocket.getSystemName()});
-                    JLabel question = new JLabel(msg);
-                    question.setAlignmentX(Component.CENTER_ALIGNMENT);
-                    container.add(question);
+                    JLabel questionLabel;
+                    if (_deleteQuestion != null) {
+                        questionLabel = new JLabel(_deleteQuestion);
+                    } else {
+                        String prompt = _maleSocket.getChildCount() > 0 ? "DeleteWithChildrenPrompt" : "DeletePrompt";
+                        String msg = MessageFormat.format(Bundle.getMessage(prompt),
+                                new Object[]{_maleSocket.getSystemName()});
+                        questionLabel = new JLabel(msg);
+                    }
+                    questionLabel.setAlignmentX(Component.CENTER_ALIGNMENT);
+                    container.add(questionLabel);
                 }
 
                 final JCheckBox remember = new JCheckBox(Bundle.getMessage("MessageRememberSetting"));
@@ -2141,13 +2179,15 @@ public class TreeEditor extends TreeViewer {
                 });
 
                 yesButton.addActionListener((ActionEvent e) -> {
-                    if (remember.isSelected()) {
+                    if (remember.isSelected() && _deleteQuestion == null) {
                         setDisplayDeleteMsg(0x02);
                     }
                     doDelete();
                     dialog.dispose();
                 });
-                container.add(remember);
+                if (_deleteQuestion == null) {
+                    container.add(remember);
+                }
                 container.setAlignmentX(Component.CENTER_ALIGNMENT);
                 container.setAlignmentY(Component.CENTER_ALIGNMENT);
                 dialog.getContentPane().add(container);

--- a/java/src/jmri/jmrit/logixng/tools/swing/TreeEditor.java
+++ b/java/src/jmri/jmrit/logixng/tools/swing/TreeEditor.java
@@ -2094,7 +2094,8 @@ public class TreeEditor extends TreeViewer {
             _maleSocket.getListenerRefsIncludingChildren(listenerRefs);
             int count = listenerRefs.size();
             log.debug("Delete with {}", count);
-            if (getDisplayDeleteMsg() == 0x02 && message.toString().isEmpty()) {
+            if (getDisplayDeleteMsg() == 0x02 && message.toString().isEmpty()
+                    && _deleteQuestion == null) {
                 doDelete();
             } else {
                 final JDialog dialog = new JDialog();


### PR DESCRIPTION
This PR lets the user clear the entire LogixNG clipboard using the menu item Tools -> Clear clipboard.