### PR TITLE
Fix bug in Panel Editor

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -499,7 +499,8 @@
    <h3>Panel Editor</h3>
         <a id="PE" name="PE"></a>
         <ul>
-            <li></li>
+            <li>Fixed a bug that caused copy-paste not work in Panel
+                Editor on Windows.</li>
         </ul>
 
     <h3>Permissions</h3>

--- a/java/src/jmri/jmrit/display/panelEditor/PanelEditor.java
+++ b/java/src/jmri/jmrit/display/panelEditor/PanelEditor.java
@@ -983,7 +983,7 @@ public class PanelEditor extends Editor implements ItemListener {
         } else {
             _currentSelection = null;
             if (event.isPopupTrigger()) {
-                if (_multiItemCopyGroup == null) {
+                if (_multiItemCopyGroup != null) {
                     pasteItemPopUp(event);
                 } else {
                     backgroundPopUp(event);


### PR DESCRIPTION
Closes #15246

@dsand47 
I think the problem you found in #15246 is a bug in Panel Editor, not in the JmriMouseListener.

The `pasteItemPopUp()` method checks if `_multiItemCopyGroup == null` and if so returns without doing anything. And for the other cases where `pasteItemPopUp()` is called, the check is always that `_multiItemCopyGroup != null`.