### PR TITLE
OperationsPro add missing car attribute utility car

### DIFF
--- a/java/src/jmri/jmrit/operations/rollingstock/cars/Car.java
+++ b/java/src/jmri/jmrit/operations/rollingstock/cars/Car.java
@@ -98,6 +98,7 @@ public class Car extends RollingStock {
         car.setCaboose(isCaboose());
         car.setFred(hasFred());
         car.setPassenger(isPassenger());
+        car.setUtility(isUtility());
         car.setLoadGeneratedFromStaging(isLoadGeneratedFromStaging());
         car.loaded = true;
         return car;


### PR DESCRIPTION
I'd like to add this PR to the production release.   When creating a "clone" the utility attribute wasn't correctly copied.  This affects Manifest and switch lists that are created using the new quick service feature for a track.