### PR TITLE
Doehler & Haass non-sound decoders: firmware 3.13, 3.14 and 3.15

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -265,6 +265,11 @@
                     and 4 available on the DH21A, DH21B, DH22A, DH22B, DH24A and FH22A as D&amp;H
                     document; those two bits were previously gated to identifiers that no longer
                     matched any model, so they never appeared.</li>
+                <li>Firmware 3.10 to 3.13 definitions: the CV144 GPIO brake settings (bits 3 and 4)
+                    are now shown on the decoders D&amp;H document them for. They had been gated to
+                    product IDs that no model in those files carries - and, for the FH22A, to a
+                    misspelt one - so neither setting was reachable on firmware 3.12 or 3.13, nor
+                    on any FH22A.</li>
             </ul>
 
         <h4>ESU</h4>

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -251,6 +251,14 @@
                     decoders, and CV137 bit 6, which applies those swappings to the SUSI functions
                     F1-F12 and was introduced in firmware 3.13.053. Both appear on a new
                     "Function Swapping" tab.</li>
+                <li>Firmware 3.13 definitions: added the DH24A and DHSP10A locomotive decoders
+                    and the FH16A vehicle function decoder. Note that on firmware 3.13 the DH24A
+                    AUX10-AUX12 outputs cannot be mapped, since CV101-103 only exist from
+                    firmware 3.15.</li>
+                <li>Firmware 3.13 definitions: corrected the product IDs of the DH21B and DH22B,
+                    which carried the values of their A variants and so could not be distinguished
+                    from them by decoder identification; and declared Motorola protocol support on
+                    the FH models, which D&amp;H document but which had never been listed.</li>
             </ul>
 
         <h4>ESU</h4>

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -248,6 +248,8 @@
 
         <h4>Doehler &amp; Haas</h4>
             <ul>
+                <li>The decoder schema now offers <code>E24</code> as a connector type (NEM 664 /
+                    RCN-124, marketed by ESU as "Next28"); the D&amp;H DH24A uses it.</li>
                 <li>New definitions for firmware 3.15.016, covering the non-sound decoders (DH05C,
                     DH06A, DH10C, DH12A, DH14B, DH16A, DH18A, DH21A, DH21B, DH22A, DH22B, DH24A,
                     DHSP10A, PD05A, PD06A, PD10MU, PD12A, PD18A, PD18MU, PD21A, FH05B, FH16A, FH18A

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -245,18 +245,20 @@
 
         <h4>Doehler &amp; Haas</h4>
             <ul>
+                <li>New definitions for firmware 3.15.016, covering the non-sound decoders (DH05C,
+                    DH06A, DH10C, DH12A, DH14B, DH16A, DH18A, DH21A, DH21B, DH22A, DH22B, DH24A,
+                    DHSP10A, PD05A, PD06A, PD10MU, PD12A, PD18A, PD18MU, PD21A, FH05B, FH16A, FH18A
+                    and FH22A). Adds shuttle mode (CV60), AUX10-AUX12 mapping (CV101-103), AUX3-AUX6
+                    dimming (CV461-467) and a wider CV112 range. Note that CV467 may read 255 after a
+                    firmware update; a reset (CV8 = 8) restores its default of 31.</li>
+                <li>New definitions for firmware 3.14.095, covering the same decoders, adding CV144
+                    bit 5 and the GPIO brake settings on the DH21B, DH22B and DH24A.</li>
                 <li>Non-sound decoders, firmware 3.13: added the CV401-412 function swapping settings
                     and CV137 bit 6, on a new Function Swapping tab.</li>
                 <li>Non-sound decoders, firmware 3.13: added the DH24A and DHSP10A locomotive decoders
                     and the FH16A function decoder.</li>
                 <li>Non-sound decoders, firmware 3.13: corrected the DH21B and DH22B product IDs, and
                     declared Motorola support on the FH decoders.</li>
-                <li>New non-sound definitions for firmware 3.14.095, adding CV144 bit 5 and the GPIO
-                    brake settings on the DH21B, DH22B and DH24A.</li>
-                <li>New non-sound definitions for firmware 3.15.016, adding shuttle mode (CV60),
-                    AUX10-AUX12 mapping (CV101-103), AUX3-AUX6 dimming (CV461-467) and a wider CV112
-                    range. Note that CV467 may read 255 after a firmware update; a reset (CV8 = 8)
-                    restores its default of 31.</li>
                 <li>Non-sound decoders, firmware 3.10 to 3.13: the CV144 GPIO brake settings are now
                     shown on the decoders that support them.</li>
                 <li>Non-sound decoders, firmware 3.12 to 3.14: CV112 is no longer shown on FH and

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -270,6 +270,12 @@
                     product IDs that no model in those files carries - and, for the FH22A, to a
                     misspelt one - so neither setting was reachable on firmware 3.12 or 3.13, nor
                     on any FH22A.</li>
+                <li>Firmware 3.12, 3.13 and 3.14 definitions: CV112, the analog speed reduction, is
+                    no longer offered on the FH series or the PD05A. D&amp;H have documented it as not
+                    relevant for those decoders since the 3.12 CV table, but the shared definition
+                    carried no such restriction. Earlier definitions are deliberately unchanged, as
+                    the CV tables up to 3.05 carry no such restriction. Separately, CV112's default
+                    is corrected from 0 to the documented value of 15 for all definitions.</li>
             </ul>
 
         <h4>ESU</h4>

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -265,6 +265,14 @@
                     and 4 available on the DH21A, DH21B, DH22A, DH22B, DH24A and FH22A as D&amp;H
                     document; those two bits were previously gated to identifiers that no longer
                     matched any model, so they never appeared.</li>
+                <li>New definitions for firmware 3.15.016: "Train Decoders (firmware 3.15+)" and
+                    "Function Decoders (firmware 3.15+)". Relative to firmware 3.14 these add the
+                    shuttle mode (Pendelbetrieb) and a brake-ramp minimum speed step in CV60,
+                    function mapping for AUX10-AUX12 in CV101-103 on the DH21B, DH22B and DH24A,
+                    dimming of AUX3-AUX6 in CV461/463/465/467, dimming mask bits for AUX3-AUX6 in
+                    CV156, and widen CV112 to 0-127. CV63 and CV65 take a second meaning depending
+                    on CV60. Note that CV467 ships reading 255 rather than its documented default
+                    of 31; a decoder reset (CV8 = 8) after the firmware update corrects it.</li>
                 <li>Firmware 3.10 to 3.13 definitions: the CV144 GPIO brake settings (bits 3 and 4)
                     are now shown on the decoders D&amp;H document them for. They had been gated to
                     product IDs that no model in those files carries - and, for the FH22A, to a

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -245,7 +245,12 @@
 
         <h4>Doehler &amp; Haas</h4>
             <ul>
-                <li></li>
+                <li>Firmware 3.13 definitions (Train Decoders (2023) and Function Decoders (2023)):
+                    added the CV401-412 function swapping settings, which D&amp;H have documented since
+                    firmware 3.12 or earlier but which had never been implemented for the non-sound
+                    decoders, and CV137 bit 6, which applies those swappings to the SUSI functions
+                    F1-F12 and was introduced in firmware 3.13.053. Both appear on a new
+                    "Function Swapping" tab.</li>
             </ul>
 
         <h4>ESU</h4>

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -245,45 +245,22 @@
 
         <h4>Doehler &amp; Haas</h4>
             <ul>
-                <li>Firmware 3.13 definitions (Train Decoders (2023) and Function Decoders (2023)):
-                    added the CV401-412 function swapping settings, which D&amp;H have documented since
-                    firmware 3.12 or earlier but which had never been implemented for the non-sound
-                    decoders, and CV137 bit 6, which applies those swappings to the SUSI functions
-                    F1-F12 and was introduced in firmware 3.13.053. Both appear on a new
-                    "Function Swapping" tab.</li>
-                <li>Firmware 3.13 definitions: added the DH24A and DHSP10A locomotive decoders
-                    and the FH16A vehicle function decoder. Note that on firmware 3.13 the DH24A
-                    AUX10-AUX12 outputs cannot be mapped, since CV101-103 only exist from
-                    firmware 3.15.</li>
-                <li>Firmware 3.13 definitions: corrected the product IDs of the DH21B and DH22B,
-                    which carried the values of their A variants and so could not be distinguished
-                    from them by decoder identification; and declared Motorola protocol support on
-                    the FH models, which D&amp;H document but which had never been listed.</li>
-                <li>New definitions for firmware 3.14.095: "Train Decoders (firmware 3.14+)" and
-                    "Function Decoders (firmware 3.14+)". Relative to firmware 3.13 these add CV144
-                    bit 5, which disables restoring the last driving state, and make CV144 bits 3
-                    and 4 available on the DH21A, DH21B, DH22A, DH22B, DH24A and FH22A as D&amp;H
-                    document; those two bits were previously gated to identifiers that no longer
-                    matched any model, so they never appeared.</li>
-                <li>New definitions for firmware 3.15.016: "Train Decoders (firmware 3.15+)" and
-                    "Function Decoders (firmware 3.15+)". Relative to firmware 3.14 these add the
-                    shuttle mode (Pendelbetrieb) and a brake-ramp minimum speed step in CV60,
-                    function mapping for AUX10-AUX12 in CV101-103 on the DH21B, DH22B and DH24A,
-                    dimming of AUX3-AUX6 in CV461/463/465/467, dimming mask bits for AUX3-AUX6 in
-                    CV156, and widen CV112 to 0-127. CV63 and CV65 take a second meaning depending
-                    on CV60. Note that CV467 ships reading 255 rather than its documented default
-                    of 31; a decoder reset (CV8 = 8) after the firmware update corrects it.</li>
-                <li>Firmware 3.10 to 3.13 definitions: the CV144 GPIO brake settings (bits 3 and 4)
-                    are now shown on the decoders D&amp;H document them for. They had been gated to
-                    product IDs that no model in those files carries - and, for the FH22A, to a
-                    misspelt one - so neither setting was reachable on firmware 3.12 or 3.13, nor
-                    on any FH22A.</li>
-                <li>Firmware 3.12, 3.13 and 3.14 definitions: CV112, the analog speed reduction, is
-                    no longer offered on the FH series or the PD05A. D&amp;H have documented it as not
-                    relevant for those decoders since the 3.12 CV table, but the shared definition
-                    carried no such restriction. Earlier definitions are deliberately unchanged, as
-                    the CV tables up to 3.05 carry no such restriction. Separately, CV112's default
-                    is corrected from 0 to the documented value of 15 for all definitions.</li>
+                <li>Firmware 3.13: added the CV401-412 function swapping settings and CV137 bit 6,
+                    on a new Function Swapping tab.</li>
+                <li>Firmware 3.13: added the DH24A and DHSP10A locomotive decoders and the FH16A
+                    function decoder.</li>
+                <li>Firmware 3.13: corrected the DH21B and DH22B product IDs, and declared Motorola
+                    support on the FH decoders.</li>
+                <li>New definitions for firmware 3.14.095, adding CV144 bit 5 and the GPIO brake
+                    settings on the DH21B, DH22B and DH24A.</li>
+                <li>New definitions for firmware 3.15.016, adding shuttle mode (CV60), AUX10-AUX12
+                    mapping (CV101-103), AUX3-AUX6 dimming (CV461-467) and a wider CV112 range.
+                    Note that CV467 may read 255 after a firmware update; a reset (CV8 = 8) restores
+                    its default of 31.</li>
+                <li>Firmware 3.10 to 3.13: the CV144 GPIO brake settings are now shown on the
+                    decoders that support them.</li>
+                <li>Firmware 3.12 to 3.14: CV112 is no longer shown on FH and PD05A decoders, and its
+                    default is corrected to 15.</li>
             </ul>
 
         <h4>ESU</h4>

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -245,22 +245,22 @@
 
         <h4>Doehler &amp; Haas</h4>
             <ul>
-                <li>Firmware 3.13: added the CV401-412 function swapping settings and CV137 bit 6,
-                    on a new Function Swapping tab.</li>
-                <li>Firmware 3.13: added the DH24A and DHSP10A locomotive decoders and the FH16A
-                    function decoder.</li>
-                <li>Firmware 3.13: corrected the DH21B and DH22B product IDs, and declared Motorola
-                    support on the FH decoders.</li>
-                <li>New definitions for firmware 3.14.095, adding CV144 bit 5 and the GPIO brake
-                    settings on the DH21B, DH22B and DH24A.</li>
-                <li>New definitions for firmware 3.15.016, adding shuttle mode (CV60), AUX10-AUX12
-                    mapping (CV101-103), AUX3-AUX6 dimming (CV461-467) and a wider CV112 range.
-                    Note that CV467 may read 255 after a firmware update; a reset (CV8 = 8) restores
-                    its default of 31.</li>
-                <li>Firmware 3.10 to 3.13: the CV144 GPIO brake settings are now shown on the
-                    decoders that support them.</li>
-                <li>Firmware 3.12 to 3.14: CV112 is no longer shown on FH and PD05A decoders, and its
-                    default is corrected to 15.</li>
+                <li>Non-sound decoders, firmware 3.13: added the CV401-412 function swapping settings
+                    and CV137 bit 6, on a new Function Swapping tab.</li>
+                <li>Non-sound decoders, firmware 3.13: added the DH24A and DHSP10A locomotive decoders
+                    and the FH16A function decoder.</li>
+                <li>Non-sound decoders, firmware 3.13: corrected the DH21B and DH22B product IDs, and
+                    declared Motorola support on the FH decoders.</li>
+                <li>New non-sound definitions for firmware 3.14.095, adding CV144 bit 5 and the GPIO
+                    brake settings on the DH21B, DH22B and DH24A.</li>
+                <li>New non-sound definitions for firmware 3.15.016, adding shuttle mode (CV60),
+                    AUX10-AUX12 mapping (CV101-103), AUX3-AUX6 dimming (CV461-467) and a wider CV112
+                    range. Note that CV467 may read 255 after a firmware update; a reset (CV8 = 8)
+                    restores its default of 31.</li>
+                <li>Non-sound decoders, firmware 3.10 to 3.13: the CV144 GPIO brake settings are now
+                    shown on the decoders that support them.</li>
+                <li>Non-sound decoders, firmware 3.12 to 3.14: CV112 is no longer shown on FH and
+                    PD05A decoders, and its default is corrected to 15.</li>
             </ul>
 
         <h4>ESU</h4>

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -259,6 +259,12 @@
                     which carried the values of their A variants and so could not be distinguished
                     from them by decoder identification; and declared Motorola protocol support on
                     the FH models, which D&amp;H document but which had never been listed.</li>
+                <li>New definitions for firmware 3.14.095: "Train Decoders (firmware 3.14+)" and
+                    "Function Decoders (firmware 3.14+)". Relative to firmware 3.13 these add CV144
+                    bit 5, which disables restoring the last driving state, and make CV144 bits 3
+                    and 4 available on the DH21A, DH21B, DH22A, DH22B, DH24A and FH22A as D&amp;H
+                    document; those two bits were previously gated to identifiers that no longer
+                    matched any model, so they never appeared.</li>
             </ul>
 
         <h4>ESU</h4>

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -263,6 +263,14 @@
                     shown on the decoders that support them.</li>
                 <li>Non-sound decoders, firmware 3.12 to 3.14: CV112 is no longer shown on FH and
                     PD05A decoders, and its default is corrected to 15.</li>
+                <li>Non-sound decoders: CV124, which selects the function keys that start the
+                    delay, is now shown on the DH Options tab. It is a bit mask over F1-F8 and is
+                    modelled as such; it was previously a single-choice list.</li>
+                <li>Non-sound decoders: corrected the default function assignments of CV131, CV132
+                    and CV133 (low beam light, shunting gear, deceleration off), which all
+                    defaulted to F1 instead of F8, F4 and F9.</li>
+                <li>Non-sound decoders: label and tooltip corrections on CV131-133 and CV137,
+                    using D&amp;H's own wording.</li>
             </ul>
 
         <h4>ESU</h4>

--- a/xml/decoders/Doehler_Haass_fw3.10-11_FH05B-18-22A.xml
+++ b/xml/decoders/Doehler_Haass_fw3.10-11_FH05B-18-22A.xml
@@ -12,6 +12,12 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+  <version version="4.2" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20260725"/>
+  <!--  Fixed the gating of CV144 bits 3 and 4, the two GPIO brake settings. They were
+        restricted to product IDs that no model in this file carries, so neither bit was
+        ever shown. Now provided by doehler_haass/cv144_bits1-4.xml, whose include list
+        covers every product ID form these decoders use.
+        -->
   <version version="4.1" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20210312"/>
   <!--  Removed Firmware pane (outdated since fw 3.06 and
         introduction of CVs260-265: fw info now on "DH Info" page)
@@ -333,7 +339,7 @@
       <!-- RK xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv137_energysaving_fw3.03.xml"/-->
 <!-- relevant für FH ??? Start-->
       <!--              - Extra general options as of fw3.10 -->
-      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv144_fw3.10.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv144_bits1-4.xml"/>
 <!-- relevant für FH ??? Ende-->
       <!-- SECTION 7    - Extra SUSI options as of fw3.03 -->
       <!-- RK xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv137_susi_fw3.03.xml"/-->

--- a/xml/decoders/Doehler_Haass_fw3.10_DH05-10C_12-16-18-21-22A_PD05-12A.xml
+++ b/xml/decoders/Doehler_Haass_fw3.10_DH05-10C_12-16-18-21-22A_PD05-12A.xml
@@ -12,6 +12,12 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+  <version version="6.3" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20260725"/>
+  <!--  Fixed the gating of CV144 bits 3 and 4, the two GPIO brake settings. They were
+        restricted to product IDs that no model in this file carries, so neither bit was
+        ever shown. Now provided by doehler_haass/cv144_bits1-4.xml, whose include list
+        covers every product ID form these decoders use.
+        -->
   <version version="6.2" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20210319"/>
   <!--  Fixed missing additional outputs for some decoders -->
     <version version="6.1" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20210312"/>
@@ -420,7 +426,7 @@
       <!-- SECTION 6    - Extra general options as of fw3.03 -->
       <!-- RK xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv137_energysaving_fw3.03.xml"/-->
       <!--              - Extra general options as of fw3.10 -->
-      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv144_fw3.10.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv144_bits1-4.xml"/>
       <!-- SECTION 7    - Extra SUSI options as of fw3.03 -->
       <!-- RK xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv137_susi_fw3.03.xml"/-->
       <!-- SECTION 8    - Motorola format as of fw3.06 -->

--- a/xml/decoders/Doehler_Haass_fw3.11_DH05-10C_12-16-18-21-22A_PD05-12A.xml
+++ b/xml/decoders/Doehler_Haass_fw3.11_DH05-10C_12-16-18-21-22A_PD05-12A.xml
@@ -12,6 +12,12 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+  <version version="6.3" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20260725"/>
+  <!--  Fixed the gating of CV144 bits 3 and 4, the two GPIO brake settings. They were
+        restricted to product IDs that no model in this file carries, so neither bit was
+        ever shown. Now provided by doehler_haass/cv144_bits1-4.xml, whose include list
+        covers every product ID form these decoders use.
+        -->
   <version version="6.2" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20210319"/>
   <!--  Fixed missing additional outputs for some decoders -->
     <version version="6.1" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20210312"/>
@@ -424,7 +430,7 @@
       <!-- SECTION 6    - Extra general options as of fw3.03 -->
       <!-- RK xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv137_energysaving_fw3.03.xml"/-->
       <!--              - Extra general options as of fw3.10 -->
-      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv144_fw3.10.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv144_bits1-4.xml"/>
       <!-- SECTION 7    - Extra SUSI options as of fw3.03 -->
       <!-- RK xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv137_susi_fw3.03.xml"/-->
       <!-- SECTION 8    - Motorola format as of fw3.06 -->

--- a/xml/decoders/Doehler_Haass_fw3.12_DH05-10C_12-16-18-21-22A_PD05-12A.xml
+++ b/xml/decoders/Doehler_Haass_fw3.12_DH05-10C_12-16-18-21-22A_PD05-12A.xml
@@ -12,6 +12,12 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+  <version version="1.9" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20260725"/>
+  <!--  Fixed the gating of CV144 bits 3 and 4, the two GPIO brake settings. They were
+        restricted to product IDs that no model in this file carries, so neither bit was
+        ever shown. Now provided by doehler_haass/cv144_bits1-4.xml, whose include list
+        covers every product ID form these decoders use.
+        -->
   <version version="1.8" author="Ronald Kuhn, ronald@wirkuhns.de" lastUpdated="20230731"/>
   <!--  Added update paths to newest fw 3.13.053 -->
   <version version="1.7" author="Ronald Kuhn, ronald@wirkuhns.de" lastUpdated="20230721"/>
@@ -585,7 +591,7 @@
       <!-- SECTION 6    - Extra general options as of fw3.03 -->
       <!-- RK xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv137_energysaving_fw3.03.xml"/-->
       <!--              - Extra general options as of fw3.10 -->
-      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv144_fw3.10.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv144_bits1-4.xml"/>
       <!-- SECTION 7    - Extra SUSI options as of fw3.03 -->
       <!-- RK xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv137_susi_fw3.03.xml"/-->
       <!-- SECTION 8    - Motorola format as of fw3.06 -->

--- a/xml/decoders/Doehler_Haass_fw3.12_DH05-10C_12-16-18-21-22A_PD05-12A.xml
+++ b/xml/decoders/Doehler_Haass_fw3.12_DH05-10C_12-16-18-21-22A_PD05-12A.xml
@@ -12,6 +12,12 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+  <version version="1.10" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20260725"/>
+  <!--  CV112 is not offered on the FH* series or the PD05A any more; the D&amp;H CV table for
+        this firmware marks it as not relevant for those, but the shared definition in
+        Vars_post2012_dc.xml carried no such restriction. Now provided by
+        doehler_haass/cv112_fw3.12-3.14.xml, which also carries D&amp;H's documented default of 15.
+        -->
   <version version="1.9" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20260725"/>
   <!--  Fixed the gating of CV144 bits 3 and 4, the two GPIO brake settings. They were
         restricted to product IDs that no model in this file carries, so neither bit was
@@ -592,6 +598,7 @@
       <!-- RK xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv137_energysaving_fw3.03.xml"/-->
       <!--              - Extra general options as of fw3.10 -->
       <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv144_bits1-4.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv112_fw3.12-3.14.xml"/>
       <!-- SECTION 7    - Extra SUSI options as of fw3.03 -->
       <!-- RK xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv137_susi_fw3.03.xml"/-->
       <!-- SECTION 8    - Motorola format as of fw3.06 -->

--- a/xml/decoders/Doehler_Haass_fw3.12_DH05-10C_12-16-18-21-22A_PD05-12A.xml
+++ b/xml/decoders/Doehler_Haass_fw3.12_DH05-10C_12-16-18-21-22A_PD05-12A.xml
@@ -12,17 +12,12 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
-  <version version="1.10" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20260725"/>
-  <!--  CV112 is not offered on the FH* series or the PD05A any more; the D&amp;H CV table for
-        this firmware marks it as not relevant for those, but the shared definition in
-        Vars_post2012_dc.xml carried no such restriction. Now provided by
-        doehler_haass/cv112_fw3.12-3.14.xml, which also carries D&amp;H's documented default of 15.
-        -->
   <version version="1.9" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20260725"/>
-  <!--  Fixed the gating of CV144 bits 3 and 4, the two GPIO brake settings. They were
-        restricted to product IDs that no model in this file carries, so neither bit was
-        ever shown. Now provided by doehler_haass/cv144_bits1-4.xml, whose include list
-        covers every product ID form these decoders use.
+  <!--  Two settings the D&amp;H CV table documents for this firmware but which were unreachable:
+        - CV144 bits 3 and 4, the GPIO brake settings, were gated to product IDs that no model
+          in this file carries, so neither was ever shown. Now from cv144_bits1-4.xml.
+        - CV112 is no longer offered on the FH* series or the PD05A, and carries the
+          documented default of 15. Now from cv112_fw3.12-3.14.xml.
         -->
   <version version="1.8" author="Ronald Kuhn, ronald@wirkuhns.de" lastUpdated="20230731"/>
   <!--  Added update paths to newest fw 3.13.053 -->

--- a/xml/decoders/Doehler_Haass_fw3.12_FH05B-18-22A.xml
+++ b/xml/decoders/Doehler_Haass_fw3.12_FH05B-18-22A.xml
@@ -12,17 +12,12 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
-  <version version="1.4" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20260725"/>
-  <!--  CV112 is not offered on the FH* series or the PD05A any more; the D&amp;H CV table for
-        this firmware marks it as not relevant for those, but the shared definition in
-        Vars_post2012_dc.xml carried no such restriction. Now provided by
-        doehler_haass/cv112_fw3.12-3.14.xml, which also carries D&amp;H's documented default of 15.
-        -->
   <version version="1.3" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20260725"/>
-  <!--  Fixed the gating of CV144 bits 3 and 4, the two GPIO brake settings. They were
-        restricted to product IDs that no model in this file carries, so neither bit was
-        ever shown. Now provided by doehler_haass/cv144_bits1-4.xml, whose include list
-        covers every product ID form these decoders use.
+  <!--  Two settings the D&amp;H CV table documents for this firmware but which were unreachable:
+        - CV144 bits 3 and 4, the GPIO brake settings, were gated to product IDs that no model
+          in this file carries, so neither was ever shown. Now from cv144_bits1-4.xml.
+        - CV112 is no longer offered on the FH* series or the PD05A, and carries the
+          documented default of 15. Now from cv112_fw3.12-3.14.xml.
         -->
   <version version="1.2" author="Ronald Kuhn, ronald@wirkuhns.de" lastUpdated="20230731"/>
   <!--  Added update paths to newest fw 3.13.053 -->

--- a/xml/decoders/Doehler_Haass_fw3.12_FH05B-18-22A.xml
+++ b/xml/decoders/Doehler_Haass_fw3.12_FH05B-18-22A.xml
@@ -12,6 +12,12 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+  <version version="1.3" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20260725"/>
+  <!--  Fixed the gating of CV144 bits 3 and 4, the two GPIO brake settings. They were
+        restricted to product IDs that no model in this file carries, so neither bit was
+        ever shown. Now provided by doehler_haass/cv144_bits1-4.xml, whose include list
+        covers every product ID form these decoders use.
+        -->
   <version version="1.2" author="Ronald Kuhn, ronald@wirkuhns.de" lastUpdated="20230731"/>
   <!--  Added update paths to newest fw 3.13.053 -->
   <version version="1.1" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20210312"/>
@@ -189,7 +195,7 @@
       <!-- RK xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv137_energysaving_fw3.03.xml"/-->
 <!-- relevant für FH ??? Start-->
       <!--              - Extra general options as of fw3.10 -->
-      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv144_fw3.10.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv144_bits1-4.xml"/>
 <!-- relevant für FH ??? Ende-->
       <!-- SECTION 7    - Extra SUSI options as of fw3.03 -->
       <!-- RK xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv137_susi_fw3.03.xml"/-->

--- a/xml/decoders/Doehler_Haass_fw3.12_FH05B-18-22A.xml
+++ b/xml/decoders/Doehler_Haass_fw3.12_FH05B-18-22A.xml
@@ -12,6 +12,12 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+  <version version="1.4" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20260725"/>
+  <!--  CV112 is not offered on the FH* series or the PD05A any more; the D&amp;H CV table for
+        this firmware marks it as not relevant for those, but the shared definition in
+        Vars_post2012_dc.xml carried no such restriction. Now provided by
+        doehler_haass/cv112_fw3.12-3.14.xml, which also carries D&amp;H's documented default of 15.
+        -->
   <version version="1.3" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20260725"/>
   <!--  Fixed the gating of CV144 bits 3 and 4, the two GPIO brake settings. They were
         restricted to product IDs that no model in this file carries, so neither bit was
@@ -196,6 +202,7 @@
 <!-- relevant für FH ??? Start-->
       <!--              - Extra general options as of fw3.10 -->
       <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv144_bits1-4.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv112_fw3.12-3.14.xml"/>
 <!-- relevant für FH ??? Ende-->
       <!-- SECTION 7    - Extra SUSI options as of fw3.03 -->
       <!-- RK xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv137_susi_fw3.03.xml"/-->

--- a/xml/decoders/Doehler_Haass_fw3.13_DH05-22B_PD05-21A.xml
+++ b/xml/decoders/Doehler_Haass_fw3.13_DH05-22B_PD05-21A.xml
@@ -12,6 +12,13 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+  <version version="1.1" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20260725"/>
+  <!--  Added CV401-412 function swapping (documented by D&amp;H since firmware 3.12 or earlier,
+        never implemented for the non-sound decoders) and CV137 bit 6, which applies those
+        swappings to SUSI F1-F12 and was introduced in firmware 3.13.053.
+        New fragments: doehler_haass/cv401-412.xml, doehler_haass/cv137_bit6_fw3.13.xml,
+        doehler_haass/Pane_function_swapping_nonsound.xml
+        -->
   <version version="1.0" author="Ronald Kuhn, ronald@wirkuhns.de" lastUpdated="20230720"/>
   <!--  Creation (new firmware 3.13.053).
         Based on Doehler_Haass_fw3.12_DH05-10C_12-16-18-21-22A_PD05-12A.xml
@@ -1061,6 +1068,8 @@
       <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv154-155_fw3.06.xml"/>
       <!-- SECTION 17    - advanced function options as of fw3.06 -->
       <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv137.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv137_bit6_fw3.13.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv401-412.xml"/>
     </variables>
     <resets>
      <factReset label="Reset All CVs" CV="8" default="8">
@@ -1078,6 +1087,7 @@
   <xi:include href="http://jmri.org/xml/decoders/doehler_haass/Pane_info.xml"/>
   <!-- Pane(s) valid for some decoders only  -->
   <xi:include href="http://jmri.org/xml/decoders/doehler_haass/Pane_functionmap.xml"/>
+  <xi:include href="http://jmri.org/xml/decoders/doehler_haass/Pane_function_swapping_nonsound.xml"/>
   <xi:include href="http://jmri.org/xml/decoders/doehler_haass/Pane_railcom.xml"/>
   <xi:include href="http://jmri.org/xml/decoders/doehler_haass/Pane_motorola.xml"/>
   <xi:include href="http://jmri.org/xml/decoders/doehler_haass/Pane_susi.xml"/>

--- a/xml/decoders/Doehler_Haass_fw3.13_DH05-22B_PD05-21A.xml
+++ b/xml/decoders/Doehler_Haass_fw3.13_DH05-22B_PD05-21A.xml
@@ -12,6 +12,12 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+  <version version="1.4" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20260725"/>
+  <!--  Fixed the gating of CV144 bits 3 and 4, the two GPIO brake settings. They were
+        restricted to product IDs that no model in this file carries, so neither bit was
+        ever shown. Now provided by doehler_haass/cv144_bits1-4.xml, whose include list
+        covers every product ID form these decoders use.
+        -->
   <version version="1.3" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20260725"/>
   <!--  Corrected the product IDs of DH21B (200 -&gt; 201) and DH22B (202 -&gt; 203), which had the
         values of their A variants and so could not be told apart from them by decoder
@@ -1169,7 +1175,7 @@
       <!-- SECTION 6    - Extra general options as of fw3.03 -->
       <!-- RK xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv137_energysaving_fw3.03.xml"/-->
       <!--              - Extra general options as of fw3.10 -->
-      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv144_fw3.10.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv144_bits1-4.xml"/>
       <!-- SECTION 7    - Extra SUSI options as of fw3.03 -->
       <!-- RK xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv137_susi_fw3.03.xml"/-->
       <!-- SECTION 8    - Motorola format as of fw3.06 -->

--- a/xml/decoders/Doehler_Haass_fw3.13_DH05-22B_PD05-21A.xml
+++ b/xml/decoders/Doehler_Haass_fw3.13_DH05-22B_PD05-21A.xml
@@ -795,7 +795,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH24A (firmware 3.13.053+)" lowVersionID="53" highVersionID="53" numOuts="13" numFns="16" productID="204" comment="DH24A, 24-pin E24 direct plug. AUX10-12 cannot be mapped on this firmware (CV101-103 exist from firmware 3.15)" maxInputVolts="30V" maxMotorCurrent="0.7A" maxTotalCurrent="1.5A" connector="other">
+      <model model="DH24A (firmware 3.13.053+)" lowVersionID="53" highVersionID="53" numOuts="13" numFns="16" productID="204" comment="DH24A, 24-pin E24 direct plug. AUX10-12 cannot be mapped on this firmware (CV101-103 exist from firmware 3.15)" maxInputVolts="30V" maxMotorCurrent="0.7A" maxTotalCurrent="1.5A" connector="E24">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>

--- a/xml/decoders/Doehler_Haass_fw3.13_DH05-22B_PD05-21A.xml
+++ b/xml/decoders/Doehler_Haass_fw3.13_DH05-22B_PD05-21A.xml
@@ -30,9 +30,9 @@
         identification. Values per the D&amp;H CV261 list.
         -->
   <version version="1.2" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20260725"/>
-  <!--  Added the DH24A, DHSP10A and FH16A models, which Doehler &amp; Haass document from
-        firmware 3.15 but which run this firmware too. On 3.13 the DH24A AUX10-AUX12
-        outputs cannot be mapped, as CV101-103 only exist from firmware 3.15.
+  <!--  Added the DH24A and DHSP10A models, which Doehler &amp; Haass document from firmware 3.15
+        but which run this firmware too. On 3.13 the DH24A AUX10-AUX12 outputs cannot be
+        mapped, as CV101-103 only exist from firmware 3.15.
         -->
   <version version="1.1" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20260725"/>
   <!--  Added CV401-412 function swapping (documented by D&amp;H since firmware 3.12 or earlier,

--- a/xml/decoders/Doehler_Haass_fw3.13_DH05-22B_PD05-21A.xml
+++ b/xml/decoders/Doehler_Haass_fw3.13_DH05-22B_PD05-21A.xml
@@ -12,6 +12,16 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+  <version version="1.3" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20260725"/>
+  <!--  Corrected the product IDs of DH21B (200 -&gt; 201) and DH22B (202 -&gt; 203), which had the
+        values of their A variants and so could not be told apart from them by decoder
+        identification. Values per the D&amp;H CV261 list.
+        -->
+  <version version="1.2" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20260725"/>
+  <!--  Added the DH24A, DHSP10A and FH16A models, which Doehler &amp; Haass document from
+        firmware 3.15 but which run this firmware too. On 3.13 the DH24A AUX10-AUX12
+        outputs cannot be mapped, as CV101-103 only exist from firmware 3.15.
+        -->
   <version version="1.1" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20260725"/>
   <!--  Added CV401-412 function swapping (documented by D&amp;H since firmware 3.12 or earlier,
         never implemented for the non-sound decoders) and CV137 bit 6, which applies those
@@ -577,7 +587,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH21B (firmware 3.13.053+)" lowVersionID="53" highVersionID="53" numOuts="10" numFns="16" productID="200" comment="DH21B" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="21MTC">
+      <model model="DH21B (firmware 3.13.053+)" lowVersionID="53" highVersionID="53" numOuts="10" numFns="16" productID="201" comment="DH21B" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="21MTC">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum frontal</label>
@@ -729,7 +739,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH22B (firmware 3.13.053+)" lowVersionID="53" highVersionID="53" numOuts="10" numFns="16" productID="202" comment="DH22B" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="PluX22">
+      <model model="DH22B (firmware 3.13.053+)" lowVersionID="53" highVersionID="53" numOuts="10" numFns="16" productID="203" comment="DH22B" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="PluX22">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -779,6 +789,122 @@
           <label xml:lang="ca">Marxa de maniobres</label>
         </output>
         <size length="20.7" width="15.8" height="5.2" units="mm"/>
+        <protocols>
+          <protocol>dcc</protocol>
+          <protocol>selectrix</protocol>
+          <protocol>motorola</protocol>
+        </protocols>
+      </model>
+      <model model="DH24A (firmware 3.13.053+)" lowVersionID="53" highVersionID="53" numOuts="13" numFns="16" productID="204" comment="DH24A, 24-pin E24 direct plug. AUX10-12 cannot be mapped on this firmware (CV101-103 exist from firmware 3.15)" maxInputVolts="30V" maxMotorCurrent="0.7A" maxTotalCurrent="1.5A" connector="other">
+        <output name="1" label="Front|Light" maxcurrent="150mA">
+          <label xml:lang="de">LV</label>
+          <label xml:lang="ca">Llum Frontal</label>
+        </output>
+        <output name="2" label="Rear|Light" maxcurrent="150mA">
+          <label xml:lang="de">LR</label>
+          <label xml:lang="ca">Llum Posterior</label>
+        </output>
+        <output name="3" label="AUX|1" maxcurrent="300mA">
+          <label xml:lang="de">AUX 1</label>
+          <label xml:lang="ca">AUX 1</label>
+        </output>
+        <output name="4" label="AUX|2" maxcurrent="300mA">
+          <label xml:lang="de">AUX 2</label>
+          <label xml:lang="ca">AUX 2</label>
+        </output>
+        <output name="5" label="AUX|3" maxcurrent="NC - Logic Level">
+          <label xml:lang="de">AUX 3</label>
+          <label xml:lang="ca">AUX 3</label>
+        </output>
+        <output name="6" label="AUX|4" maxcurrent="NC - Logic Level">
+          <label xml:lang="de">AUX 4</label>
+          <label xml:lang="ca">AUX 4</label>
+        </output>
+        <output name="7" label="AUX|5" maxcurrent="0.5A">
+          <label xml:lang="de">AUX 5</label>
+          <label xml:lang="ca">AUX 5</label>
+        </output>
+        <output name="8" label="AUX|6" maxcurrent="0.5A">
+          <label xml:lang="de">AUX 6</label>
+          <label xml:lang="ca">AUX 6</label>
+        </output>
+        <output name="9" label="AUX|7" maxcurrent="0.5A">
+          <label xml:lang="de">AUX 7</label>
+          <label xml:lang="ca">AUX 7</label>
+        </output>
+        <output name="10" label="AUX|8" maxcurrent="0.5A">
+          <label xml:lang="de">AUX 8</label>
+          <label xml:lang="ca">AUX 8</label>
+        </output>
+        <output name="11" label="AUX 10|(or GPIO)" maxcurrent="NC - Logic Level">
+          <label xml:lang="de">AUX 10</label>
+          <label xml:lang="ca">AUX 10</label>
+        </output>
+        <output name="12" label="AUX 11|(or SUSI ZDAT)" maxcurrent="20mA">
+          <label xml:lang="de">AUX 11</label>
+          <label xml:lang="ca">AUX 11</label>
+        </output>
+        <output name="13" label="AUX 12|(or SUSI ZCLK)" maxcurrent="20mA">
+          <label xml:lang="de">AUX 12</label>
+          <label xml:lang="ca">AUX 12</label>
+        </output>
+        <output name="14" label="Dimmed|Lights">
+          <label xml:lang="de">Abblend-|licht</label>
+          <label xml:lang="ca">Intensitat Llums</label>
+        </output>
+        <output name="15" label="Shunting|Speed">
+          <label xml:lang="de">Rangiergang</label>
+          <label xml:lang="ca">Marxa de maniobres</label>
+        </output>
+        <size length="14.0" width="8.4" height="2.8" units="mm"/>
+        <protocols>
+          <protocol>dcc</protocol>
+          <protocol>selectrix</protocol>
+          <protocol>motorola</protocol>
+        </protocols>
+      </model>
+      <model model="DHSP10A (firmware 3.13.053+)" lowVersionID="53" highVersionID="53" numOuts="8" numFns="16" productID="110" comment="DHSP10A-0 / -1 / -2 / -3 / -4, with integrated buffer capacitor (16 V, 470 uF)" maxInputVolts="30V" maxMotorCurrent="0.7A" maxTotalCurrent="1.5A" connector="Wires/NEM651">
+        <output name="1" label="Front|Light" maxcurrent="150mA">
+          <label xml:lang="de">LV</label>
+          <label xml:lang="ca">Llum Frontal</label>
+        </output>
+        <output name="2" label="Rear|Light" maxcurrent="150mA">
+          <label xml:lang="de">LR</label>
+          <label xml:lang="ca">Llum Posterior</label>
+        </output>
+        <output name="3" label="AUX|1" maxcurrent="300mA">
+          <label xml:lang="de">AUX 1</label>
+          <label xml:lang="ca">AUX 1</label>
+        </output>
+        <output name="4" label="AUX|2" maxcurrent="300mA">
+          <label xml:lang="de">AUX 2</label>
+          <label xml:lang="ca">AUX 2</label>
+        </output>
+        <output name="5" label="AUX|3" maxcurrent="1.0A">
+          <label xml:lang="de">AUX 3</label>
+          <label xml:lang="ca">AUX 3</label>
+        </output>
+        <output name="6" label="AUX|4" maxcurrent="1.0A">
+          <label xml:lang="de">AUX 4</label>
+          <label xml:lang="ca">AUX 4</label>
+        </output>
+        <output name="7" label="AUX 5|(or SUSI ZCLK)" maxcurrent="20mA">
+          <label xml:lang="de">AUX 5</label>
+          <label xml:lang="ca">AUX 5</label>
+        </output>
+        <output name="8" label="AUX 6|(or SUSI ZDAT)" maxcurrent="20mA">
+          <label xml:lang="de">AUX 6</label>
+          <label xml:lang="ca">AUX 6</label>
+        </output>
+        <output name="9" label="Dimmed|Lights">
+          <label xml:lang="de">Abblend-|licht</label>
+          <label xml:lang="ca">Intensitat Llums</label>
+        </output>
+        <output name="10" label="Shunting|Speed">
+          <label xml:lang="de">Rangiergang</label>
+          <label xml:lang="ca">Marxa de maniobres</label>
+        </output>
+        <size length="12.7" width="8.9" height="3.6" units="mm"/>
         <protocols>
           <protocol>dcc</protocol>
           <protocol>selectrix</protocol>

--- a/xml/decoders/Doehler_Haass_fw3.13_DH05-22B_PD05-21A.xml
+++ b/xml/decoders/Doehler_Haass_fw3.13_DH05-22B_PD05-21A.xml
@@ -12,6 +12,12 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+  <version version="1.5" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20260725"/>
+  <!--  CV112 is not offered on the FH* series or the PD05A any more; the D&amp;H CV table marks
+        it as not relevant for those, but the shared definition in Vars_post2012_dc.xml had no
+        such restriction. Now provided by doehler_haass/cv112_fw3.12-3.14.xml, which also carries
+        D&amp;H's documented default of 15 rather than 0.
+        -->
   <version version="1.4" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20260725"/>
   <!--  Fixed the gating of CV144 bits 3 and 4, the two GPIO brake settings. They were
         restricted to product IDs that no model in this file carries, so neither bit was
@@ -1176,6 +1182,7 @@
       <!-- RK xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv137_energysaving_fw3.03.xml"/-->
       <!--              - Extra general options as of fw3.10 -->
       <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv144_bits1-4.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv112_fw3.12-3.14.xml"/>
       <!-- SECTION 7    - Extra SUSI options as of fw3.03 -->
       <!-- RK xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv137_susi_fw3.03.xml"/-->
       <!-- SECTION 8    - Motorola format as of fw3.06 -->

--- a/xml/decoders/Doehler_Haass_fw3.13_DH05-22B_PD05-21A.xml
+++ b/xml/decoders/Doehler_Haass_fw3.13_DH05-22B_PD05-21A.xml
@@ -12,34 +12,22 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
-  <version version="1.5" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20260725"/>
-  <!--  CV112 is not offered on the FH* series or the PD05A any more; the D&amp;H CV table marks
-        it as not relevant for those, but the shared definition in Vars_post2012_dc.xml had no
-        such restriction. Now provided by doehler_haass/cv112_fw3.12-3.14.xml, which also carries
-        D&amp;H's documented default of 15 rather than 0.
-        -->
-  <version version="1.4" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20260725"/>
-  <!--  Fixed the gating of CV144 bits 3 and 4, the two GPIO brake settings. They were
-        restricted to product IDs that no model in this file carries, so neither bit was
-        ever shown. Now provided by doehler_haass/cv144_bits1-4.xml, whose include list
-        covers every product ID form these decoders use.
-        -->
-  <version version="1.3" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20260725"/>
-  <!--  Corrected the product IDs of DH21B (200 -&gt; 201) and DH22B (202 -&gt; 203), which had the
-        values of their A variants and so could not be told apart from them by decoder
-        identification. Values per the D&amp;H CV261 list.
-        -->
-  <version version="1.2" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20260725"/>
-  <!--  Added the DH24A and DHSP10A models, which Doehler &amp; Haass document from firmware 3.15
-        but which run this firmware too. On 3.13 the DH24A AUX10-AUX12 outputs cannot be
-        mapped, as CV101-103 only exist from firmware 3.15.
-        -->
   <version version="1.1" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20260725"/>
-  <!--  Added CV401-412 function swapping (documented by D&amp;H since firmware 3.12 or earlier,
-        never implemented for the non-sound decoders) and CV137 bit 6, which applies those
-        swappings to SUSI F1-F12 and was introduced in firmware 3.13.053.
-        New fragments: doehler_haass/cv401-412.xml, doehler_haass/cv137_bit6_fw3.13.xml,
-        doehler_haass/Pane_function_swapping_nonsound.xml
+  <!--  Firmware 3.13 completed and corrected:
+        - Added CV401-412 function swapping, documented by D&amp;H since firmware 3.12 or earlier
+          but never implemented for the non-sound decoders, and CV137 bit 6, which applies
+          those swappings to SUSI F1-F12 and was introduced in firmware 3.13.053. Both appear
+          on a new "Function Swapping" tab.
+        - Added the DH24A and DHSP10A models, which D&amp;H document from firmware 3.15 but which
+          run this firmware too. On 3.13 the DH24A AUX10-AUX12 outputs cannot be mapped, as
+          CV101-103 only exist from firmware 3.15.
+        - Corrected the product IDs of DH21B (200 -&gt; 201) and DH22B (202 -&gt; 203), which held
+          the values of their A variants and so could not be told apart from them by decoder
+          identification. Values per the D&amp;H CV261 list.
+        - CV144 bits 3 and 4, the GPIO brake settings, were gated to product IDs that no model
+          in this file carries, so neither was ever shown. Now from cv144_bits1-4.xml.
+        - CV112 is no longer offered on the FH* series or the PD05A, which the D&amp;H CV table
+          marks it as not relevant for, and it carries the documented default of 15.
         -->
   <version version="1.0" author="Ronald Kuhn, ronald@wirkuhns.de" lastUpdated="20230720"/>
   <!--  Creation (new firmware 3.13.053).

--- a/xml/decoders/Doehler_Haass_fw3.13_FH05B-22A.xml
+++ b/xml/decoders/Doehler_Haass_fw3.13_FH05B-22A.xml
@@ -29,9 +29,8 @@
         the FH series but it had never been declared.
         -->
   <version version="1.2" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20260725"/>
-  <!--  Added the DH24A, DHSP10A and FH16A models, which Doehler &amp; Haass document from
-        firmware 3.15 but which run this firmware too. On 3.13 the DH24A AUX10-AUX12
-        outputs cannot be mapped, as CV101-103 only exist from firmware 3.15.
+  <!--  Added the FH16A model, which Doehler &amp; Haass document from firmware 3.15 but which
+        runs this firmware too.
         -->
   <version version="1.1" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20260725"/>
   <!--  Added CV401-412 function swapping (documented by D&amp;H since firmware 3.12 or earlier,

--- a/xml/decoders/Doehler_Haass_fw3.13_FH05B-22A.xml
+++ b/xml/decoders/Doehler_Haass_fw3.13_FH05B-22A.xml
@@ -12,32 +12,20 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
-  <version version="1.5" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20260725"/>
-  <!--  CV112 is not offered on the FH* series or the PD05A any more; the D&amp;H CV table marks
-        it as not relevant for those, but the shared definition in Vars_post2012_dc.xml had no
-        such restriction. Now provided by doehler_haass/cv112_fw3.12-3.14.xml, which also carries
-        D&amp;H's documented default of 15 rather than 0.
-        -->
-  <version version="1.4" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20260725"/>
-  <!--  Fixed the gating of CV144 bits 3 and 4, the two GPIO brake settings. They were
-        restricted to product IDs that no model in this file carries, so neither bit was
-        ever shown. Now provided by doehler_haass/cv144_bits1-4.xml, whose include list
-        covers every product ID form these decoders use.
-        -->
-  <version version="1.3" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20260725"/>
-  <!--  Added the Motorola protocol to all four FH models; D&amp;H document MM1/MM2 support for
-        the FH series but it had never been declared.
-        -->
-  <version version="1.2" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20260725"/>
-  <!--  Added the FH16A model, which Doehler &amp; Haass document from firmware 3.15 but which
-        runs this firmware too.
-        -->
   <version version="1.1" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20260725"/>
-  <!--  Added CV401-412 function swapping (documented by D&amp;H since firmware 3.12 or earlier,
-        never implemented for the non-sound decoders) and CV137 bit 6, which applies those
-        swappings to SUSI F1-F12 and was introduced in firmware 3.13.053.
-        New fragments: doehler_haass/cv401-412.xml, doehler_haass/cv137_bit6_fw3.13.xml,
-        doehler_haass/Pane_function_swapping_nonsound.xml
+  <!--  Firmware 3.13 completed and corrected:
+        - Added CV401-412 function swapping, documented by D&amp;H since firmware 3.12 or earlier
+          but never implemented for the non-sound decoders, and CV137 bit 6, which applies
+          those swappings to SUSI F1-F12 and was introduced in firmware 3.13.053. Both appear
+          on a new "Function Swapping" tab.
+        - Added the FH16A model, which D&amp;H document from firmware 3.15 but which runs this
+          firmware too.
+        - Declared the Motorola protocol on all four FH models; D&amp;H document MM1/MM2 support
+          for the FH series but it had never been listed.
+        - CV144 bits 3 and 4, the GPIO brake settings, were gated to product IDs that no model
+          in this file carries, so neither was ever shown. Now from cv144_bits1-4.xml.
+        - CV112 is no longer offered on the FH* series, which the D&amp;H CV table marks it as not
+          relevant for, and it carries the documented default of 15.
         -->
   <version version="1.0" author="Ronald Kuhn, ronald@wirkuhns.de" lastUpdated="20230720"/>
   <!--  Creation (new firmware 3.13.053).

--- a/xml/decoders/Doehler_Haass_fw3.13_FH05B-22A.xml
+++ b/xml/decoders/Doehler_Haass_fw3.13_FH05B-22A.xml
@@ -12,6 +12,12 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+  <version version="1.4" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20260725"/>
+  <!--  Fixed the gating of CV144 bits 3 and 4, the two GPIO brake settings. They were
+        restricted to product IDs that no model in this file carries, so neither bit was
+        ever shown. Now provided by doehler_haass/cv144_bits1-4.xml, whose include list
+        covers every product ID form these decoders use.
+        -->
   <version version="1.3" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20260725"/>
   <!--  Added the Motorola protocol to all four FH models; D&amp;H document MM1/MM2 support for
         the FH series but it had never been declared.
@@ -250,7 +256,7 @@
       <!-- RK xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv137_energysaving_fw3.03.xml"/-->
 <!-- relevant für FH ??? Start-->
       <!--              - Extra general options as of fw3.10 -->
-      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv144_fw3.10.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv144_bits1-4.xml"/>
 <!-- relevant für FH ??? Ende-->
       <!-- SECTION 7    - Extra SUSI options as of fw3.03 -->
       <!-- RK xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv137_susi_fw3.03.xml"/-->

--- a/xml/decoders/Doehler_Haass_fw3.13_FH05B-22A.xml
+++ b/xml/decoders/Doehler_Haass_fw3.13_FH05B-22A.xml
@@ -12,6 +12,13 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+  <version version="1.1" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20260725"/>
+  <!--  Added CV401-412 function swapping (documented by D&amp;H since firmware 3.12 or earlier,
+        never implemented for the non-sound decoders) and CV137 bit 6, which applies those
+        swappings to SUSI F1-F12 and was introduced in firmware 3.13.053.
+        New fragments: doehler_haass/cv401-412.xml, doehler_haass/cv137_bit6_fw3.13.xml,
+        doehler_haass/Pane_function_swapping_nonsound.xml
+        -->
   <version version="1.0" author="Ronald Kuhn, ronald@wirkuhns.de" lastUpdated="20230720"/>
   <!--  Creation (new firmware 3.13.053).
         Based on Doehler_Haass_fw3.12_FH05B-18-22A.xml
@@ -212,6 +219,8 @@
       <!-- SECTION 17    - advanced function options as of fw3.06 -->
       <!-- RK xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv137_adv_function_fw3.06.xml"/-->
       <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv137.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv137_bit6_fw3.13.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv401-412.xml"/>
     </variables>
     <resets>
      <factReset label="Reset All CVs" CV="8" default="8">
@@ -230,6 +239,7 @@
   <xi:include href="http://jmri.org/xml/decoders/doehler_haass/Pane_common_fw3.10.xml"/>
 <!-- relevant für FH ??? Ende-->
   <xi:include href="http://jmri.org/xml/decoders/doehler_haass/Pane_info.xml"/>
+  <xi:include href="http://jmri.org/xml/decoders/doehler_haass/Pane_function_swapping_nonsound.xml"/>
   <!-- Pane(s) valid for some decoders only  -->
   <xi:include href="http://jmri.org/xml/decoders/doehler_haass/Pane_railcom.xml"/>
   <xi:include href="http://jmri.org/xml/decoders/doehler_haass/Pane_motorola.xml"/>

--- a/xml/decoders/Doehler_Haass_fw3.13_FH05B-22A.xml
+++ b/xml/decoders/Doehler_Haass_fw3.13_FH05B-22A.xml
@@ -12,6 +12,15 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+  <version version="1.3" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20260725"/>
+  <!--  Added the Motorola protocol to all four FH models; D&amp;H document MM1/MM2 support for
+        the FH series but it had never been declared.
+        -->
+  <version version="1.2" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20260725"/>
+  <!--  Added the DH24A, DHSP10A and FH16A models, which Doehler &amp; Haass document from
+        firmware 3.15 but which run this firmware too. On 3.13 the DH24A AUX10-AUX12
+        outputs cannot be mapped, as CV101-103 only exist from firmware 3.15.
+        -->
   <version version="1.1" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20260725"/>
   <!--  Added CV401-412 function swapping (documented by D&amp;H since firmware 3.12 or earlier,
         never implemented for the non-sound decoders) and CV137 bit 6, which applies those
@@ -64,6 +73,55 @@
         <protocols>
           <protocol>dcc</protocol>
           <protocol>selectrix</protocol>
+          <protocol>motorola</protocol>
+        </protocols>
+      </model>
+      <model model="FH16A (firmware 3.13.053+)" lowVersionID="53" highVersionID="53" numOuts="8" numFns="16" productID="150" comment="FH16A-4, PluX16 direct plug" maxInputVolts="30V" maxTotalCurrent="1.5A" connector="PluX16">
+        <output name="1" label="Front|Light" maxcurrent="150mA">
+          <label xml:lang="de">LV</label>
+          <label xml:lang="ca">Llum Frontal</label>
+        </output>
+        <output name="2" label="Rear|Light" maxcurrent="150mA">
+          <label xml:lang="de">LR</label>
+          <label xml:lang="ca">Llum Posterior</label>
+        </output>
+        <output name="3" label="AUX|1" maxcurrent="300mA">
+          <label xml:lang="de">AUX 1</label>
+          <label xml:lang="ca">AUX 1</label>
+        </output>
+        <output name="4" label="AUX|2" maxcurrent="300mA">
+          <label xml:lang="de">AUX 2</label>
+          <label xml:lang="ca">AUX 2</label>
+        </output>
+        <output name="5" label="AUX|3" maxcurrent="1A">
+          <label xml:lang="de">AUX 3</label>
+          <label xml:lang="ca">AUX 3</label>
+        </output>
+        <output name="6" label="AUX|4" maxcurrent="1A">
+          <label xml:lang="de">AUX 4</label>
+          <label xml:lang="ca">AUX 4</label>
+        </output>
+        <output name="7" label="AUX 5|(or SUSI ZCLK)" maxcurrent="20mA">
+          <label xml:lang="de">AUX 5</label>
+          <label xml:lang="ca">AUX 5</label>
+        </output>
+        <output name="8" label="AUX 6|(or SUSI ZDAT)" maxcurrent="20mA">
+          <label xml:lang="de">AUX 6</label>
+          <label xml:lang="ca">AUX 6</label>
+        </output>
+        <output name="9" label="Dimmed|Lights">
+          <label xml:lang="de">Abblend-|licht</label>
+          <label xml:lang="ca">Intensitat Llums</label>
+        </output>
+        <output name="10" label="Shunting|Speed">
+          <label xml:lang="de">Rangiergang</label>
+          <label xml:lang="ca">Marxa de maniobres</label>
+        </output>
+        <size length="15.9" width="10.9" height="2.3" units="mm"/>
+        <protocols>
+          <protocol>dcc</protocol>
+          <protocol>selectrix</protocol>
+          <protocol>motorola</protocol>
         </protocols>
       </model>
       <model model="FH18A (firmware 3.13.053+)" lowVersionID="53" highVersionID="53" numOuts="8" numFns="18" productID="170" comment="FH18A with update from May 2020" maxInputVolts="30V" maxTotalCurrent="1.0A" connector="Next18">
@@ -111,6 +169,7 @@
         <protocols>
           <protocol>dcc</protocol>
           <protocol>selectrix</protocol>
+          <protocol>motorola</protocol>
         </protocols>
       </model>
       <model model="FH22A (firmware 3.13.053+)" lowVersionID="53" highVersionID="53" numOuts="8" numFns="18" productID="192" comment="FH22A with update from May 2020" maxInputVolts="30V" maxTotalCurrent="2.0A" connector="PluX22">
@@ -160,6 +219,7 @@
         <protocols>
           <protocol>dcc</protocol>
           <protocol>selectrix</protocol>
+          <protocol>motorola</protocol>
         </protocols>
       </model>
     </family>

--- a/xml/decoders/Doehler_Haass_fw3.13_FH05B-22A.xml
+++ b/xml/decoders/Doehler_Haass_fw3.13_FH05B-22A.xml
@@ -12,6 +12,12 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+  <version version="1.5" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20260725"/>
+  <!--  CV112 is not offered on the FH* series or the PD05A any more; the D&amp;H CV table marks
+        it as not relevant for those, but the shared definition in Vars_post2012_dc.xml had no
+        such restriction. Now provided by doehler_haass/cv112_fw3.12-3.14.xml, which also carries
+        D&amp;H's documented default of 15 rather than 0.
+        -->
   <version version="1.4" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20260725"/>
   <!--  Fixed the gating of CV144 bits 3 and 4, the two GPIO brake settings. They were
         restricted to product IDs that no model in this file carries, so neither bit was
@@ -257,6 +263,7 @@
 <!-- relevant für FH ??? Start-->
       <!--              - Extra general options as of fw3.10 -->
       <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv144_bits1-4.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv112_fw3.12-3.14.xml"/>
 <!-- relevant für FH ??? Ende-->
       <!-- SECTION 7    - Extra SUSI options as of fw3.03 -->
       <!-- RK xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv137_susi_fw3.03.xml"/-->

--- a/xml/decoders/Doehler_Haass_fw3.14_DH05-24A_PD05-21A.xml
+++ b/xml/decoders/Doehler_Haass_fw3.14_DH05-24A_PD05-21A.xml
@@ -1,0 +1,1205 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet type="text/xsl" href="../XSLT/decoder.xsl"?>
+<!-- Copyright (C) JMRI 2006, 2018, 2019, 2022 All rights reserved -->
+<!--                                                                        -->
+<!-- JMRI is free software; you can redistribute it and/or modify it under  -->
+<!-- the terms of version 2 of the GNU General Public License as published  -->
+<!-- by the Free Software Foundation. See the "COPYING" file for a copy     -->
+<!-- of this license.                                                       -->
+<!--                                                                        -->
+<!-- JMRI is distributed in the hope that it will be useful, but WITHOUT    -->
+<!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
+<!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
+<!-- for more details.                                                      -->
+<decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+  <version version="1" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20260725"/>
+  <!--  Creation (new firmware 3.14.095).
+        Based on Doehler_Haass_fw3.13_DH05-22B_PD05-21A.xml
+        Changes in firmware 3.14 relative to 3.13, per the D&amp;H ChangeLog:
+          - CV144 bit 5, disabling the restoration of the last driving state.
+          - CV144 bits 3 and 4 now also apply to DH21B, DH22B and DH24A.
+        The CV set is otherwise identical to firmware 3.13.
+        -->
+  <decoder>
+    <family name="Train Decoders (firmware 3.14+)" mfg="Doehler und Haass">
+      <model model="DH05C (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="6" numFns="16" productID="52" comment="DH05C-0 / DH05C-1 / DH05C-3 with update from May 2020" maxInputVolts="18V" maxMotorCurrent="0.5A" maxTotalCurrent="0.5A" connector="Wires/NEM651">
+        <output name="1" label="Front|Light" maxcurrent="150mA">
+          <label xml:lang="de">LV</label>
+          <label xml:lang="ca">Llum frontal</label>
+        </output>
+        <output name="2" label="Rear|Light" maxcurrent="150mA">
+          <label xml:lang="de">LR</label>
+          <label xml:lang="ca">Llum Posterior</label>
+        </output>
+        <output name="3" label="AUX|1" maxcurrent="300mA">
+          <label xml:lang="de">AUX 1</label>
+          <label xml:lang="ca">AUX 1</label>
+        </output>
+        <output name="4" label="AUX|2" maxcurrent="300mA">
+          <label xml:lang="de">AUX 2</label>
+          <label xml:lang="ca">AUX 2</label>
+        </output>
+        <output name="5" label="AUX 3|(or SUSI ZCLK)" maxcurrent="20mA">
+        <!-- New from fw3.03  -->
+          <label xml:lang="de">AUX 3|(o. SUSI ZCLK)</label>
+          <label xml:lang="ca">AUX 3| SUSI ZCLK </label>
+        </output>
+        <output name="6" label="AUX 4|(or SUSI ZDAT)" maxcurrent="20mA">
+        <!-- New from fw3.03  -->
+          <label xml:lang="de">AUX 4|(o. SUSI ZDAT)</label>
+          <label xml:lang="ca">AUX 4| SUSI ZDAT</label>
+        </output>
+        <output name="7" label="Dimmed|Lights">
+          <label xml:lang="de">Abblend-|licht</label>
+          <label xml:lang="ca">Intensitat de llums</label>
+        </output>
+        <output name="8" label="Shunting|Speed">
+          <label xml:lang="de">Rangiergang</label>
+          <label xml:lang="ca">Marxa de maniobres</label>
+        </output>
+        <size length="13.2" width="6.8" height="1.4" units="mm"/>
+        <protocols>
+          <protocol>dcc</protocol>
+          <protocol>selectrix</protocol>
+          <protocol>motorola</protocol>
+        </protocols>
+      </model>
+      <model model="DH05C Gen. 2 (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="8" numFns="16" productID="52" comment="DH05C-0 / DH05C-1 / DH05C-3 2nd Generation with update from May 2020" maxInputVolts="30V" maxMotorCurrent="0.5A" maxTotalCurrent="0.5A" connector="Wires/NEM651">
+        <output name="1" label="Front|Light" maxcurrent="150mA">
+          <label xml:lang="de">LV</label>
+          <label xml:lang="ca">Llum frontal</label>
+        </output>
+        <output name="2" label="Rear|Light" maxcurrent="150mA">
+          <label xml:lang="de">LR</label>
+          <label xml:lang="ca">Llum Posterior</label>
+        </output>
+        <output name="3" label="AUX|1" maxcurrent="300mA">
+          <label xml:lang="de">AUX 1</label>
+          <label xml:lang="ca">AUX 1</label>
+        </output>
+        <output name="4" label="AUX|2" maxcurrent="300mA">
+          <label xml:lang="de">AUX 2</label>
+          <label xml:lang="ca">AUX 2</label>
+        </output>
+        <output name="5" label="AUX|3" maxcurrent="20mA">
+          <!-- New in Gen 2 decoder  -->
+          <label xml:lang="de">AUX 3</label>
+          <label xml:lang="ca">AUX 3</label>
+        </output>
+        <output name="6" label="AUX|4" maxcurrent="20mA">
+          <!-- New in Gen 2 decoder  -->
+          <label xml:lang="de">AUX 4</label>
+          <label xml:lang="ca">AUX 4</label>
+        </output>
+        <output name="7" label="Dimming (with std mapping)|or AUX 5 or SUSI ZCLK" maxcurrent="20mA">
+          <label xml:lang="de">Abblendlicht (mit Std. Fn.-zuord.)|o. AUX 5 o. SUSI ZCLK</label>
+          <label xml:lang="ca">AUX 5 (SUSI ZCLK)|(Intensitat de llums con std. Mapping)</label>
+        </output>
+        <output name="8" label="Shunting (with std mapping)|or AUX 6 or SUSI ZDAT" maxcurrent="20mA">
+          <label xml:lang="de">Rangiergang (mit Std. Fn.-zuordnungen)|o. AUX 6 o. SUSI ZDAT</label>
+          <label xml:lang="ca">Marxa de maniobres (con std. Mapping)|o AUX 6 o SUSI ZDAT</label>
+        </output>
+        <size length="13.2" width="6.8" height="1.4" units="mm"/>
+        <protocols>
+          <protocol>dcc</protocol>
+          <protocol>selectrix</protocol>
+          <protocol>motorola</protocol>
+        </protocols>
+      </model>
+      <model model="DH06A (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="3" numFns="16" productID="60" comment="DH06A for Köf with no analog support, with update from May 2020" maxInputVolts="30V" maxMotorCurrent="0.3A" maxTotalCurrent="0.3A">
+        <output name="1" label="Front|Light" maxcurrent="20mA"/>
+        <output name="2" label="Rear|Light" maxcurrent="20mA"/>
+        <output name="3" label="Onboard|LED" maxcurrent="20mA"/>
+        <output name="4" label="|"/>    <!-- not available for this decoder -->
+        <output name="5" label="|"/>    <!-- not available for this decoder -->
+        <output name="6" label="|"/>    <!-- not available for this decoder -->
+        <output name="7" label="Dimmed|Lights"/>
+        <output name="8" label="Shunting|Speed"/>
+        <size length="16" width="9.3" height="3.4" units="mm"/>
+        <protocols>
+          <protocol>dcc</protocol>
+          <protocol>selectrix</protocol>
+        </protocols>
+      </model>
+      <model model="DH06A Gen. 2 (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="3" numFns="16" productID="60" comment="DH06A for Köf with no analog support, with update from May 2020" maxInputVolts="30V" maxMotorCurrent="0.3A" maxTotalCurrent="0.3A">
+        <output name="1" label="Front|Light" maxcurrent="20mA"/>
+        <output name="2" label="Rear|Light" maxcurrent="20mA"/>
+        <output name="3" label="Onboard|LED" maxcurrent="20mA"/>
+        <output name="4" label="|"/>    <!-- not available for this decoder -->
+        <output name="5" label="|"/>    <!-- not available for this decoder -->
+        <output name="6" label="|"/>    <!-- not available for this decoder -->
+        <output name="7" label="Dimmed|Lights"/>
+        <output name="8" label="Shunting|Speed"/>
+        <size length="16" width="9.3" height="3.4" units="mm"/>
+        <protocols>
+          <protocol>dcc</protocol>
+          <protocol>selectrix</protocol>
+        </protocols>
+      </model>
+      <model model="DH10C (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="6" numFns="16" productID="102" comment="DH10C-0 / DH10C-1 / DH10C-3 with update from May 2020" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="Wires/NEM651">
+        <output name="1" label="Front|Light" maxcurrent="150mA">
+          <label xml:lang="de">LV</label>
+          <label xml:lang="ca">Llum Frontal</label>
+        </output>
+        <output name="2" label="Rear|Light" maxcurrent="150mA">
+          <label xml:lang="de">LR</label>
+          <label xml:lang="ca">Llum posterior</label>
+        </output>
+        <output name="3" label="AUX|1" maxcurrent="300mA">
+          <label xml:lang="de">AUX 1</label>
+          <label xml:lang="ca">AUX 1</label>
+        </output>
+        <output name="4" label="AUX|2" maxcurrent="300mA">
+          <label xml:lang="de">AUX 2</label>
+          <label xml:lang="ca">AUX 2</label>
+        </output>
+        <output name="5" label="AUX 3|(or SUSI ZCLK)" maxcurrent="20mA">
+        <!-- New from fw3.03  -->
+          <label xml:lang="de">AUX 3|(o. SUSI ZCLK)</label>
+          <label xml:lang="ca">AUX 3| SUSI XCLK</label>
+        </output>
+        <output name="6" label="AUX 4|(or SUSI ZDAT)" maxcurrent="20mA">
+        <!-- New from fw3.03  -->
+          <label xml:lang="de">AUX 4|(o. SUSI ZDAT)</label>
+          <label xml:lang="ca">AUX 4| SUSI ZDAT</label>
+        </output>
+        <output name="7" label="Dimmed|Lights">
+          <label xml:lang="de">Abblend-|licht</label>
+          <label xml:lang="ca">Intensitat Llums</label>
+        </output>
+        <output name="8" label="Shunting|Speed">
+          <label xml:lang="de">Rangiergang</label>
+          <label xml:lang="ca">Marxa Maniobres</label>
+        </output>
+        <size length="14.2" width="9.3" height="1.5" units="mm"/>
+        <protocols>
+          <protocol>dcc</protocol>
+          <protocol>selectrix</protocol>
+          <protocol>motorola</protocol>
+        </protocols>
+      </model>
+      <model model="DH10C Gen. 2 (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="8" numFns="16" productID="102" comment="DH10C-0 / DH10C-1 / DH10C-3 2nd Generation with update from May 2020" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="Wires/NEM651">
+        <output name="1" label="Front|Light" maxcurrent="150mA">
+          <label xml:lang="de">LV</label>
+          <label xml:lang="ca">Llum Frontal</label>
+        </output>
+        <output name="2" label="Rear|Light" maxcurrent="150mA">
+          <label xml:lang="de">LR</label>
+          <label xml:lang="ca">Llum posterior</label>
+        </output>
+        <output name="3" label="AUX|1" maxcurrent="300mA">
+          <label xml:lang="de">AUX 1</label>
+          <label xml:lang="ca">AUX 1</label>
+        </output>
+        <output name="4" label="AUX|2" maxcurrent="300mA">
+          <label xml:lang="de">AUX 2</label>
+          <label xml:lang="ca">AUX 2</label>
+        </output>
+        <output name="5" label="AUX|3" maxcurrent="1A">
+          <!-- New in Gen 2 decoder  -->
+          <label xml:lang="de">AUX 3</label>
+          <label xml:lang="ca">AUX 3</label>
+        </output>
+        <output name="6" label="AUX|4" maxcurrent="1A">
+          <!-- New in Gen 2 decoder  -->
+          <label xml:lang="de">AUX 4</label>
+          <label xml:lang="ca">AUX 4</label>
+        </output>
+        <output name="7" label="Dimming (with std mapping)|or AUX 5 or SUSI ZCLK" maxcurrent="20mA">
+          <label xml:lang="de">Abblendlicht (mit Std. Fn.-zuord.)|o. AUX 5 o. SUSI ZCLK</label>
+          <label xml:lang="ca">AUX 5 (SUSI ZCLK)|(Intensitat de llums con std. Mapping)</label>
+        </output>
+        <output name="8" label="Shunting (with std mapping)|or AUX 6 or SUSI ZDAT" maxcurrent="20mA">
+          <label xml:lang="de">Rangiergang (mit Std. Fn.-zuordnungen)|o. AUX 6 o. SUSI ZDAT</label>
+          <label xml:lang="ca">Marxa de maniobres (con std. Mapping)|o AUX 6 o SUSI ZDAT</label>
+        </output>
+        <size length="12.7" width="8.9" height="1.4" units="mm"/>
+        <protocols>
+          <protocol>dcc</protocol>
+          <protocol>selectrix</protocol>
+          <protocol>motorola</protocol>
+        </protocols>
+      </model>
+      <model model="DH12A (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="6" numFns="16" productID="120" comment="DH12A with update from May 2020" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX12">
+        <output name="1" label="Front|Light" maxcurrent="150mA">
+          <label xml:lang="de">LV</label>
+          <label xml:lang="ca">Llum frontal</label>
+        </output>
+        <output name="2" label="Rear|Light" maxcurrent="150mA">
+          <label xml:lang="de">LR</label>
+          <label xml:lang="ca">Llum posterior</label>
+        </output>
+        <output name="3" label="AUX|1" maxcurrent="300mA">
+          <label xml:lang="de">AUX 1</label>
+          <label xml:lang="ca">AUX 1</label>
+        </output>
+        <output name="4" label="AUX|2" maxcurrent="300mA">
+          <label xml:lang="de">AUX 2</label>
+          <label xml:lang="ca">AUX 2</label>
+        </output>
+        <output name="5" label="AUX|3" maxcurrent="NC - Logic Level">
+          <label xml:lang="de">AUX 3</label>
+          <label xml:lang="ca">AUX 3</label>
+        </output>
+        <output name="6" label="AUX|4" maxcurrent="NC - Logic Level">
+          <label xml:lang="de">AUX 4</label>
+          <label xml:lang="ca">AUX 4</label>
+        </output>
+        <output name="7" label="Dimmed|Lights">
+          <label xml:lang="de">Abblend-|licht</label>
+          <label xml:lang="ca">Intensitat Llums</label>
+        </output>
+        <output name="8" label="Shunting|Speed">
+          <label xml:lang="de">Rangiergang</label>
+          <label xml:lang="ca">Marxa maniobres</label>
+        </output>
+        <size length="14.5" width="8" height="2.8" units="mm"/>
+        <protocols>
+          <protocol>dcc</protocol>
+          <protocol>selectrix</protocol>
+          <protocol>motorola</protocol>
+        </protocols>
+      </model>
+      <model model="DH14B (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="6" numFns="16" productID="141" comment="DH14B with update from May 2020" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="other">
+        <output name="1" label="Front|Light" maxcurrent="150mA">
+          <label xml:lang="de">LV</label>
+          <label xml:lang="ca">Llum frontal</label>
+        </output>
+        <output name="2" label="Rear|Light" maxcurrent="150mA">
+          <label xml:lang="de">LR</label>
+          <label xml:lang="ca">Llum posterior</label>
+        </output>
+        <output name="3" label="AUX|1" maxcurrent="300mA">
+          <label xml:lang="de">AUX 1</label>
+          <label xml:lang="ca">AUX 1</label>
+        </output>
+        <output name="4" label="AUX|2" maxcurrent="300mA">
+          <label xml:lang="de">AUX 2</label>
+          <label xml:lang="ca">AUX 2</label>
+        </output>
+        <output name="5" label="AUX|3" maxcurrent="NC - Logic Level">
+          <label xml:lang="de">AUX 3</label>
+          <label xml:lang="ca">AUX 3</label>
+        </output>
+        <output name="6" label="AUX|4" maxcurrent="NC - Logic Level">
+          <label xml:lang="de">AUX 4</label>
+          <label xml:lang="ca">AUX 4</label>
+        </output>
+        <output name="7" label="Dimmed|Lights">
+          <label xml:lang="de">Abblend-|licht</label>
+          <label xml:lang="ca">Intensitat Llums</label>
+        </output>
+        <output name="8" label="Shunting|Speed">
+          <label xml:lang="de">Rangiergang</label>
+          <label xml:lang="ca">Marxa maniobres</label>
+        </output>
+        <size length="18.5" width="9.2" height="1.7" units="mm"/>
+        <protocols>
+          <protocol>dcc</protocol>
+          <protocol>selectrix</protocol>
+          <protocol>motorola</protocol>
+        </protocols>
+      </model>
+      <model model="DH16A (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="6" numFns="16" productID="160" comment="DH16A-0 /DH16A-1 /DH16A-2 /DH16A-3 with update from May 2020" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX16">
+        <output name="1" label="Front|Light" maxcurrent="150mA">
+          <label xml:lang="de">LV</label>
+          <label xml:lang="ca">Llum Frontal</label>
+        </output>
+        <output name="2" label="Rear|Light" maxcurrent="150mA">
+          <label xml:lang="de">LR</label>
+          <label xml:lang="ca">Llum Posterior</label>
+        </output>
+        <output name="3" label="AUX|1" maxcurrent="300mA">
+          <label xml:lang="de">AUX 1</label>
+          <label xml:lang="ca">AUX 1</label>
+        </output>
+        <output name="4" label="AUX|2" maxcurrent="300mA">
+          <label xml:lang="de">AUX 2</label>
+          <label xml:lang="ca">AUX 2</label>
+        </output>
+        <output name="5" label="AUX|3" maxcurrent="1.0A">
+          <label xml:lang="de">AUX 3</label>
+          <label xml:lang="ca">AUX 3</label>
+        </output>
+        <output name="6" label="AUX|4" maxcurrent="1.0A">
+          <label xml:lang="de">AUX 4</label>
+          <label xml:lang="ca">AUX 4</label>
+        </output>
+        <output name="7" label="Dimmed|Lights">
+          <label xml:lang="de">Abblend-|licht</label>
+          <label xml:lang="ca">Intensitat Llums</label>
+        </output>
+        <output name="8" label="Shunting|Speed">
+          <label xml:lang="de">Rangiergang</label>
+          <label xml:lang="ca">Marxa Maniobres</label>
+        </output>
+        <size length="16.7" width="10.9" height="2.8" units="mm"/>
+        <protocols>
+          <protocol>dcc</protocol>
+          <protocol>selectrix</protocol>
+          <protocol>motorola</protocol>
+        </protocols>
+      </model>
+      <model model="DH16A Gen. 2 (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="6" numFns="16" productID="160" comment="DH16A-0 /DH16A-1 /DH16A-2 /DH16A-3 with update from May 2020" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX16">
+        <output name="1" label="Front|Light" maxcurrent="150mA">
+          <label xml:lang="de">LV</label>
+          <label xml:lang="ca">Llum Frontal</label>
+        </output>
+        <output name="2" label="Rear|Light" maxcurrent="150mA">
+          <label xml:lang="de">LR</label>
+          <label xml:lang="ca">Llum Posterior</label>
+        </output>
+        <output name="3" label="AUX|1" maxcurrent="300mA">
+          <label xml:lang="de">AUX 1</label>
+          <label xml:lang="ca">AUX 1</label>
+        </output>
+        <output name="4" label="AUX|2" maxcurrent="300mA">
+          <label xml:lang="de">AUX 2</label>
+          <label xml:lang="ca">AUX 2</label>
+        </output>
+        <output name="5" label="AUX|3" maxcurrent="1.0A">
+          <label xml:lang="de">AUX 3</label>
+          <label xml:lang="ca">AUX 3</label>
+        </output>
+        <output name="6" label="AUX|4" maxcurrent="1.0A">
+          <label xml:lang="de">AUX 4</label>
+          <label xml:lang="ca">AUX 4</label>
+        </output>
+        <output name="7" label="Dimmed|Lights">
+          <label xml:lang="de">Abblend-|licht</label>
+          <label xml:lang="ca">Intensitat Llums</label>
+        </output>
+        <output name="8" label="Shunting|Speed">
+          <label xml:lang="de">Rangiergang</label>
+          <label xml:lang="ca">Marxa Maniobres</label>
+        </output>
+        <size length="16.7" width="10.9" height="2.8" units="mm"/>
+        <protocols>
+          <protocol>dcc</protocol>
+          <protocol>selectrix</protocol>
+          <protocol>motorola</protocol>
+        </protocols>
+      </model>
+      <model model="DH18A (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="8" numFns="16" productID="180" comment="DH18A with update from May 2020" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="Next18">
+        <output name="1" label="Front|Light" maxcurrent="150mA">
+          <label xml:lang="de">LV</label>
+          <label xml:lang="ca">Llum Frontal</label>
+        </output>
+        <output name="2" label="Rear|Light" maxcurrent="150mA">
+          <label xml:lang="de">LR</label>
+          <label xml:lang="ca">Llum posterior</label>
+        </output>
+        <output name="3" label="AUX|1" maxcurrent="300mA">
+          <label xml:lang="de">AUX 1</label>
+          <label xml:lang="ca">AUX 1</label>
+        </output>
+        <output name="4" label="AUX|2" maxcurrent="300mA">
+          <label xml:lang="de">AUX 2</label>
+          <label xml:lang="ca">AUX 2</label>
+        </output>
+        <output name="5" label="AUX|3" maxcurrent="NC - Logic Level">
+          <label xml:lang="de">AUX 3</label>
+          <label xml:lang="ca">AUX 3</label>
+        </output>
+        <output name="6" label="AUX|4" maxcurrent="NC - Logic Level">
+          <label xml:lang="de">AUX 4</label>
+          <label xml:lang="ca">AUX 4</label>
+        </output>
+        <output name="7" label="AUX|5" maxcurrent="NC - Logic Level">
+          <label xml:lang="de">AUX 5</label>
+          <label xml:lang="ca">AUX 5</label>
+        </output>
+        <output name="8" label="AUX|6" maxcurrent="NC - Logic Level">
+          <label xml:lang="de">AUX 6</label>
+          <label xml:lang="ca">AUX 6</label>
+        </output>
+        <output name="9" label="Dimmed|Lights">
+          <label xml:lang="de">Abblend-|licht</label>
+          <label xml:lang="ca">Intensitat de llum</label>
+        </output>
+        <output name="10" label="Shunting|Speed">
+          <label xml:lang="de">Rangiergang</label>
+          <label xml:lang="ca">Marxa de maniobres</label>
+        </output>
+        <size length="13.5" width="9.0" height="2.8" units="mm"/>
+        <protocols>
+            <protocol>dcc</protocol>
+            <protocol>selectrix</protocol>
+            <protocol>motorola</protocol>
+        </protocols>
+      </model>
+      <model model="DH18A Gen. 2 (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="8" numFns="16" productID="180" comment="DH18A with update from May 2020" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="Next18">
+        <output name="1" label="Front|Light" maxcurrent="150mA">
+          <label xml:lang="de">LV</label>
+          <label xml:lang="ca">Llum Frontal</label>
+        </output>
+        <output name="2" label="Rear|Light" maxcurrent="150mA">
+          <label xml:lang="de">LR</label>
+          <label xml:lang="ca">Llum posterior</label>
+        </output>
+        <output name="3" label="AUX|1" maxcurrent="300mA">
+          <label xml:lang="de">AUX 1</label>
+          <label xml:lang="ca">AUX 1</label>
+        </output>
+        <output name="4" label="AUX|2" maxcurrent="300mA">
+          <label xml:lang="de">AUX 2</label>
+          <label xml:lang="ca">AUX 2</label>
+        </output>
+        <output name="5" label="AUX|3" maxcurrent="NC - Logic Level">
+          <label xml:lang="de">AUX 3</label>
+          <label xml:lang="ca">AUX 3</label>
+        </output>
+        <output name="6" label="AUX|4" maxcurrent="NC - Logic Level">
+          <label xml:lang="de">AUX 4</label>
+          <label xml:lang="ca">AUX 4</label>
+        </output>
+        <output name="7" label="AUX|5" maxcurrent="NC - Logic Level">
+          <label xml:lang="de">AUX 5</label>
+          <label xml:lang="ca">AUX 5</label>
+        </output>
+        <output name="8" label="AUX|6" maxcurrent="NC - Logic Level">
+          <label xml:lang="de">AUX 6</label>
+          <label xml:lang="ca">AUX 6</label>
+        </output>
+        <output name="9" label="Dimmed|Lights">
+          <label xml:lang="de">Abblend-|licht</label>
+          <label xml:lang="ca">Intensitat de llum</label>
+        </output>
+        <output name="10" label="Shunting|Speed">
+          <label xml:lang="de">Rangiergang</label>
+          <label xml:lang="ca">Marxa de maniobres</label>
+        </output>
+        <size length="9.7" width="8.9" height="2.8" units="mm"/>
+        <protocols>
+            <protocol>dcc</protocol>
+            <protocol>selectrix</protocol>
+            <protocol>motorola</protocol>
+        </protocols>
+      </model>
+      <model model="DH21A (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="8" numFns="16" productID="200" comment="DH21A with update from May 2020" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="21MTC">
+        <output name="1" label="Front|Light" maxcurrent="150mA">
+          <label xml:lang="de">LV</label>
+          <label xml:lang="ca">Llum frontal</label>
+        </output>
+        <output name="2" label="Rear|Light" maxcurrent="150mA">
+          <label xml:lang="de">LR</label>
+          <label xml:lang="ca">Llum posterior</label>
+        </output>
+        <output name="3" label="AUX|1" maxcurrent="300mA">
+          <label xml:lang="de">AUX 1</label>
+          <label xml:lang="ca">AUX 1</label>
+        </output>
+        <output name="4" label="AUX|2" maxcurrent="300mA">
+          <label xml:lang="de">AUX 2</label>
+          <label xml:lang="ca">AUX 2</label>
+        </output>
+        <output name="5" label="AUX|3" maxcurrent="1.0A">
+          <label xml:lang="de">AUX 3</label>
+          <label xml:lang="ca">AUX 3</label>
+        </output>
+        <output name="6" label="AUX|4" maxcurrent="1.0A">
+          <label xml:lang="de">AUX 4</label>
+          <label xml:lang="ca">AUX 4</label>
+        </output>
+        <output name="7" label="AUX|5" maxcurrent="NC - Logic Level">
+          <label xml:lang="de">AUX 5</label>
+          <label xml:lang="ca">AUX 5</label>
+        </output>
+        <output name="8" label="AUX|6" maxcurrent="NC - Logic Level">
+          <label xml:lang="de">AUX 6</label>
+          <label xml:lang="ca">AUX 6</label>
+        </output>
+        <output name="9" label="Dimmed|Lights">
+          <label xml:lang="de">Abblend-|licht</label>
+          <label xml:lang="ca">Intensitat de llums</label>
+        </output>
+        <output name="10" label="Shunting|Speed">
+          <label xml:lang="de">Rangiergang</label>
+          <label xml:lang="ca">Marxa de maniobres</label>
+        </output>
+        <size length="20.7" width="15.8" height="5.2" units="mm"/>
+        <protocols>
+          <protocol>dcc</protocol>
+          <protocol>selectrix</protocol>
+          <protocol>motorola</protocol>
+        </protocols>
+      </model>
+      <model model="DH21A Gen. 2 (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="8" numFns="16" productID="200" comment="DH21A with update from May 2020" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="21MTC">
+        <output name="1" label="Front|Light" maxcurrent="150mA">
+          <label xml:lang="de">LV</label>
+          <label xml:lang="ca">Llum frontal</label>
+        </output>
+        <output name="2" label="Rear|Light" maxcurrent="150mA">
+          <label xml:lang="de">LR</label>
+          <label xml:lang="ca">Llum posterior</label>
+        </output>
+        <output name="3" label="AUX|1" maxcurrent="300mA">
+          <label xml:lang="de">AUX 1</label>
+          <label xml:lang="ca">AUX 1</label>
+        </output>
+        <output name="4" label="AUX|2" maxcurrent="300mA">
+          <label xml:lang="de">AUX 2</label>
+          <label xml:lang="ca">AUX 2</label>
+        </output>
+        <output name="5" label="AUX|3" maxcurrent="1.0A">
+          <label xml:lang="de">AUX 3</label>
+          <label xml:lang="ca">AUX 3</label>
+        </output>
+        <output name="6" label="AUX|4" maxcurrent="1.0A">
+          <label xml:lang="de">AUX 4</label>
+          <label xml:lang="ca">AUX 4</label>
+        </output>
+        <output name="7" label="AUX|5" maxcurrent="NC - Logic Level">
+          <label xml:lang="de">AUX 5</label>
+          <label xml:lang="ca">AUX 5</label>
+        </output>
+        <output name="8" label="AUX|6" maxcurrent="NC - Logic Level">
+          <label xml:lang="de">AUX 6</label>
+          <label xml:lang="ca">AUX 6</label>
+        </output>
+        <output name="9" label="Dimmed|Lights">
+          <label xml:lang="de">Abblend-|licht</label>
+          <label xml:lang="ca">Intensitat de llums</label>
+        </output>
+        <output name="10" label="Shunting|Speed">
+          <label xml:lang="de">Rangiergang</label>
+          <label xml:lang="ca">Marxa de maniobres</label>
+        </output>
+        <size length="20.7" width="15.8" height="5.2" units="mm"/>
+        <protocols>
+          <protocol>dcc</protocol>
+          <protocol>selectrix</protocol>
+          <protocol>motorola</protocol>
+        </protocols>
+      </model>
+      <model model="DH21B (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="10" numFns="16" productID="201" comment="DH21B" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="21MTC">
+        <output name="1" label="Front|Light" maxcurrent="150mA">
+          <label xml:lang="de">LV</label>
+          <label xml:lang="ca">Llum frontal</label>
+        </output>
+        <output name="2" label="Rear|Light" maxcurrent="150mA">
+          <label xml:lang="de">LR</label>
+          <label xml:lang="ca">Llum posterior</label>
+        </output>
+        <output name="3" label="AUX|1" maxcurrent="300mA">
+          <label xml:lang="de">AUX 1</label>
+          <label xml:lang="ca">AUX 1</label>
+        </output>
+        <output name="4" label="AUX|2" maxcurrent="300mA">
+          <label xml:lang="de">AUX 2</label>
+          <label xml:lang="ca">AUX 2</label>
+        </output>
+        <output name="5" label="AUX|3" maxcurrent="1.0A">
+          <label xml:lang="de">AUX 3</label>
+          <label xml:lang="ca">AUX 3</label>
+        </output>
+        <output name="6" label="AUX|4" maxcurrent="1.0A">
+          <label xml:lang="de">AUX 4</label>
+          <label xml:lang="ca">AUX 4</label>
+        </output>
+        <output name="7" label="AUX|5" maxcurrent="NC - Logic Level">
+          <label xml:lang="de">AUX 5</label>
+          <label xml:lang="ca">AUX 5</label>
+        </output>
+        <output name="8" label="AUX|6" maxcurrent="NC - Logic Level">
+          <label xml:lang="de">AUX 6</label>
+          <label xml:lang="ca">AUX 6</label>
+        </output>
+        <output name="9" label="AUX|7" maxcurrent="NC - Logic Level">
+          <label xml:lang="de">AUX 7</label>
+          <label xml:lang="ca">AUX 7</label>
+        </output>
+        <output name="10" label="AUX|8" maxcurrent="NC - Logic Level">
+          <label xml:lang="de">AUX 8</label>
+          <label xml:lang="ca">AUX 8</label>
+        </output>
+        <output name="11" label="Dimmed|Lights">
+          <label xml:lang="de">Abblend-|licht</label>
+          <label xml:lang="ca">Intensitat de llums</label>
+        </output>
+        <output name="12" label="Shunting|Speed">
+          <label xml:lang="de">Rangiergang</label>
+          <label xml:lang="ca">Marxa de maniobres</label>
+        </output>
+        <size length="20.7" width="15.8" height="5.2" units="mm"/>
+        <protocols>
+          <protocol>dcc</protocol>
+          <protocol>selectrix</protocol>
+          <protocol>motorola</protocol>
+        </protocols>
+      </model>
+      <model model="DH22A (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="8" numFns="16" productID="202" comment="DH22A with update from May 2020" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="PluX22">
+        <output name="1" label="Front|Light" maxcurrent="150mA">
+          <label xml:lang="de">LV</label>
+          <label xml:lang="ca">Llum Frontal</label>
+        </output>
+        <output name="2" label="Rear|Light" maxcurrent="150mA">
+          <label xml:lang="de">LR</label>
+          <label xml:lang="ca">Llum Posterior</label>
+        </output>
+        <output name="3" label="AUX|1" maxcurrent="300mA">
+          <label xml:lang="de">AUX 1</label>
+          <label xml:lang="ca">AUX 1</label>
+        </output>
+        <output name="4" label="AUX|2" maxcurrent="300mA">
+          <label xml:lang="de">AUX 2</label>
+          <label xml:lang="ca">AUX 2</label>
+        </output>
+        <output name="5" label="AUX|3" maxcurrent="1.0A">
+          <label xml:lang="de">AUX 3</label>
+          <label xml:lang="ca">AUX 3</label>
+        </output>
+        <output name="6" label="AUX|4" maxcurrent="1.0A">
+          <label xml:lang="de">AUX 4</label>
+          <label xml:lang="ca">AUX 4</label>
+        </output>
+        <output name="7" label="AUX|5" maxcurrent="NC - Logic Level">
+          <label xml:lang="de">AUX 5</label>
+          <label xml:lang="ca">AUX 5</label>
+        </output>
+        <output name="8" label="AUX|6" maxcurrent="NC - Logic Level">
+          <label xml:lang="de">AUX 6</label>
+          <label xml:lang="ca">AUX 6</label>
+        </output>
+        <output name="9" label="Dimmed|Lights">
+          <label xml:lang="de">Abblend-|licht</label>
+          <label xml:lang="ca">Intensitat Llums</label>
+        </output>
+        <output name="10" label="Shunting|Speed">
+          <label xml:lang="de">Rangiergang</label>
+          <label xml:lang="ca">Marxa de maniobres</label>
+        </output>
+        <size length="20.7" width="15.8" height="5.2" units="mm"/>
+        <protocols>
+          <protocol>dcc</protocol>
+          <protocol>selectrix</protocol>
+          <protocol>motorola</protocol>
+        </protocols>
+      </model>
+      <model model="DH22A Gen. 2 (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="8" numFns="16" productID="202" comment="DH22A with update from May 2020" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="PluX22">
+        <output name="1" label="Front|Light" maxcurrent="150mA">
+          <label xml:lang="de">LV</label>
+          <label xml:lang="ca">Llum Frontal</label>
+        </output>
+        <output name="2" label="Rear|Light" maxcurrent="150mA">
+          <label xml:lang="de">LR</label>
+          <label xml:lang="ca">Llum Posterior</label>
+        </output>
+        <output name="3" label="AUX|1" maxcurrent="300mA">
+          <label xml:lang="de">AUX 1</label>
+          <label xml:lang="ca">AUX 1</label>
+        </output>
+        <output name="4" label="AUX|2" maxcurrent="300mA">
+          <label xml:lang="de">AUX 2</label>
+          <label xml:lang="ca">AUX 2</label>
+        </output>
+        <output name="5" label="AUX|3" maxcurrent="1.0A">
+          <label xml:lang="de">AUX 3</label>
+          <label xml:lang="ca">AUX 3</label>
+        </output>
+        <output name="6" label="AUX|4" maxcurrent="1.0A">
+          <label xml:lang="de">AUX 4</label>
+          <label xml:lang="ca">AUX 4</label>
+        </output>
+        <output name="7" label="AUX|5" maxcurrent="NC - Logic Level">
+          <label xml:lang="de">AUX 5</label>
+          <label xml:lang="ca">AUX 5</label>
+        </output>
+        <output name="8" label="AUX|6" maxcurrent="NC - Logic Level">
+          <label xml:lang="de">AUX 6</label>
+          <label xml:lang="ca">AUX 6</label>
+        </output>
+        <output name="9" label="Dimmed|Lights">
+          <label xml:lang="de">Abblend-|licht</label>
+          <label xml:lang="ca">Intensitat Llums</label>
+        </output>
+        <output name="10" label="Shunting|Speed">
+          <label xml:lang="de">Rangiergang</label>
+          <label xml:lang="ca">Marxa de maniobres</label>
+        </output>
+        <size length="20.7" width="15.8" height="5.2" units="mm"/>
+        <protocols>
+          <protocol>dcc</protocol>
+          <protocol>selectrix</protocol>
+          <protocol>motorola</protocol>
+        </protocols>
+      </model>
+      <model model="DH22B (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="10" numFns="16" productID="203" comment="DH22B" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="PluX22">
+        <output name="1" label="Front|Light" maxcurrent="150mA">
+          <label xml:lang="de">LV</label>
+          <label xml:lang="ca">Llum Frontal</label>
+        </output>
+        <output name="2" label="Rear|Light" maxcurrent="150mA">
+          <label xml:lang="de">LR</label>
+          <label xml:lang="ca">Llum Posterior</label>
+        </output>
+        <output name="3" label="AUX|1" maxcurrent="300mA">
+          <label xml:lang="de">AUX 1</label>
+          <label xml:lang="ca">AUX 1</label>
+        </output>
+        <output name="4" label="AUX|2" maxcurrent="300mA">
+          <label xml:lang="de">AUX 2</label>
+          <label xml:lang="ca">AUX 2</label>
+        </output>
+        <output name="5" label="AUX|3" maxcurrent="1.0A">
+          <label xml:lang="de">AUX 3</label>
+          <label xml:lang="ca">AUX 3</label>
+        </output>
+        <output name="6" label="AUX|4" maxcurrent="1.0A">
+          <label xml:lang="de">AUX 4</label>
+          <label xml:lang="ca">AUX 4</label>
+        </output>
+        <output name="7" label="AUX|5" maxcurrent="1.0A">
+          <label xml:lang="de">AUX 5</label>
+          <label xml:lang="ca">AUX 5</label>
+        </output>
+        <output name="8" label="AUX|6" maxcurrent="1.0A">
+          <label xml:lang="de">AUX 6</label>
+          <label xml:lang="ca">AUX 6</label>
+        </output>
+        <output name="9" label="AUX|7" maxcurrent="1.0A">
+          <label xml:lang="de">AUX 7</label>
+          <label xml:lang="ca">AUX 7</label>
+        </output>
+        <output name="10" label="AUX|8" maxcurrent="NC - Logic Level">
+          <label xml:lang="de">AUX 8</label>
+          <label xml:lang="ca">AUX 8</label>
+        </output>
+        <output name="11" label="Dimmed|Lights">
+          <label xml:lang="de">Abblend-|licht</label>
+          <label xml:lang="ca">Intensitat Llums</label>
+        </output>
+        <output name="12" label="Shunting|Speed">
+          <label xml:lang="de">Rangiergang</label>
+          <label xml:lang="ca">Marxa de maniobres</label>
+        </output>
+        <size length="20.7" width="15.8" height="5.2" units="mm"/>
+        <protocols>
+          <protocol>dcc</protocol>
+          <protocol>selectrix</protocol>
+          <protocol>motorola</protocol>
+        </protocols>
+      </model>
+      <model model="DH24A (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="13" numFns="16" productID="204" comment="DH24A, 24-pin E24 direct plug. AUX10-12 cannot be mapped on this firmware (CV101-103 exist from firmware 3.15)" maxInputVolts="30V" maxMotorCurrent="0.7A" maxTotalCurrent="1.5A" connector="other">
+        <output name="1" label="Front|Light" maxcurrent="150mA">
+          <label xml:lang="de">LV</label>
+          <label xml:lang="ca">Llum Frontal</label>
+        </output>
+        <output name="2" label="Rear|Light" maxcurrent="150mA">
+          <label xml:lang="de">LR</label>
+          <label xml:lang="ca">Llum Posterior</label>
+        </output>
+        <output name="3" label="AUX|1" maxcurrent="300mA">
+          <label xml:lang="de">AUX 1</label>
+          <label xml:lang="ca">AUX 1</label>
+        </output>
+        <output name="4" label="AUX|2" maxcurrent="300mA">
+          <label xml:lang="de">AUX 2</label>
+          <label xml:lang="ca">AUX 2</label>
+        </output>
+        <output name="5" label="AUX|3" maxcurrent="NC - Logic Level">
+          <label xml:lang="de">AUX 3</label>
+          <label xml:lang="ca">AUX 3</label>
+        </output>
+        <output name="6" label="AUX|4" maxcurrent="NC - Logic Level">
+          <label xml:lang="de">AUX 4</label>
+          <label xml:lang="ca">AUX 4</label>
+        </output>
+        <output name="7" label="AUX|5" maxcurrent="0.5A">
+          <label xml:lang="de">AUX 5</label>
+          <label xml:lang="ca">AUX 5</label>
+        </output>
+        <output name="8" label="AUX|6" maxcurrent="0.5A">
+          <label xml:lang="de">AUX 6</label>
+          <label xml:lang="ca">AUX 6</label>
+        </output>
+        <output name="9" label="AUX|7" maxcurrent="0.5A">
+          <label xml:lang="de">AUX 7</label>
+          <label xml:lang="ca">AUX 7</label>
+        </output>
+        <output name="10" label="AUX|8" maxcurrent="0.5A">
+          <label xml:lang="de">AUX 8</label>
+          <label xml:lang="ca">AUX 8</label>
+        </output>
+        <output name="11" label="AUX 10|(or GPIO)" maxcurrent="NC - Logic Level">
+          <label xml:lang="de">AUX 10</label>
+          <label xml:lang="ca">AUX 10</label>
+        </output>
+        <output name="12" label="AUX 11|(or SUSI ZDAT)" maxcurrent="20mA">
+          <label xml:lang="de">AUX 11</label>
+          <label xml:lang="ca">AUX 11</label>
+        </output>
+        <output name="13" label="AUX 12|(or SUSI ZCLK)" maxcurrent="20mA">
+          <label xml:lang="de">AUX 12</label>
+          <label xml:lang="ca">AUX 12</label>
+        </output>
+        <output name="14" label="Dimmed|Lights">
+          <label xml:lang="de">Abblend-|licht</label>
+          <label xml:lang="ca">Intensitat Llums</label>
+        </output>
+        <output name="15" label="Shunting|Speed">
+          <label xml:lang="de">Rangiergang</label>
+          <label xml:lang="ca">Marxa de maniobres</label>
+        </output>
+        <size length="14.0" width="8.4" height="2.8" units="mm"/>
+        <protocols>
+          <protocol>dcc</protocol>
+          <protocol>selectrix</protocol>
+          <protocol>motorola</protocol>
+        </protocols>
+      </model>
+      <model model="DHSP10A (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="8" numFns="16" productID="110" comment="DHSP10A-0 / -1 / -2 / -3 / -4, with integrated buffer capacitor (16 V, 470 uF)" maxInputVolts="30V" maxMotorCurrent="0.7A" maxTotalCurrent="1.5A" connector="Wires/NEM651">
+        <output name="1" label="Front|Light" maxcurrent="150mA">
+          <label xml:lang="de">LV</label>
+          <label xml:lang="ca">Llum Frontal</label>
+        </output>
+        <output name="2" label="Rear|Light" maxcurrent="150mA">
+          <label xml:lang="de">LR</label>
+          <label xml:lang="ca">Llum Posterior</label>
+        </output>
+        <output name="3" label="AUX|1" maxcurrent="300mA">
+          <label xml:lang="de">AUX 1</label>
+          <label xml:lang="ca">AUX 1</label>
+        </output>
+        <output name="4" label="AUX|2" maxcurrent="300mA">
+          <label xml:lang="de">AUX 2</label>
+          <label xml:lang="ca">AUX 2</label>
+        </output>
+        <output name="5" label="AUX|3" maxcurrent="1.0A">
+          <label xml:lang="de">AUX 3</label>
+          <label xml:lang="ca">AUX 3</label>
+        </output>
+        <output name="6" label="AUX|4" maxcurrent="1.0A">
+          <label xml:lang="de">AUX 4</label>
+          <label xml:lang="ca">AUX 4</label>
+        </output>
+        <output name="7" label="AUX 5|(or SUSI ZCLK)" maxcurrent="20mA">
+          <label xml:lang="de">AUX 5</label>
+          <label xml:lang="ca">AUX 5</label>
+        </output>
+        <output name="8" label="AUX 6|(or SUSI ZDAT)" maxcurrent="20mA">
+          <label xml:lang="de">AUX 6</label>
+          <label xml:lang="ca">AUX 6</label>
+        </output>
+        <output name="9" label="Dimmed|Lights">
+          <label xml:lang="de">Abblend-|licht</label>
+          <label xml:lang="ca">Intensitat Llums</label>
+        </output>
+        <output name="10" label="Shunting|Speed">
+          <label xml:lang="de">Rangiergang</label>
+          <label xml:lang="ca">Marxa de maniobres</label>
+        </output>
+        <size length="12.7" width="8.9" height="3.6" units="mm"/>
+        <protocols>
+          <protocol>dcc</protocol>
+          <protocol>selectrix</protocol>
+          <protocol>motorola</protocol>
+        </protocols>
+      </model>
+      <model model="PD05A (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="2" numFns="16" productID="131" comment="PD05A-0 / PD05A-2 / PD05A-3 with update from May 2020" maxInputVolts="30V" maxMotorCurrent="0.5A" maxTotalCurrent="0.5A" connector="Wires/NEM651">
+        <output name="1" label="Front|Light" maxcurrent="150mA">
+          <label xml:lang="de">LV</label>
+          <label xml:lang="ca">Llum Frontal</label>
+        </output>
+        <output name="2" label="Rear|Light" maxcurrent="150mA">
+          <label xml:lang="de">LR</label>
+          <label xml:lang="ca">Llum Poserior</label>
+        </output>
+        <output name="7" label="Dimmed|Lights">
+          <label xml:lang="de">Abblend-|licht</label>
+          <label xml:lang="ca">Intensitat Llums</label>
+        </output>
+        <output name="8" label="Shunting|Speed">
+          <label xml:lang="de">Rangier-|gang</label>
+          <label xml:lang="ca">Marxa de maniobres</label>
+        </output>
+        <size length="5.0" width="7.9" height="2.5" units="mm"/>
+        <protocols>
+          <protocol>dcc</protocol>
+          <protocol>selectrix</protocol>
+        </protocols>
+      </model>
+      <model model="PD05A Gen. 2 (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="2" numFns="16" productID="131" comment="PD05A-0 / PD05A-2 / PD05A-3 with update from May 2020" maxInputVolts="30V" maxMotorCurrent="0.5A" maxTotalCurrent="0.5A" connector="Wires/NEM651">
+        <output name="1" label="Front|Light" maxcurrent="150mA">
+          <label xml:lang="de">LV</label>
+          <label xml:lang="ca">Llum Frontal</label>
+        </output>
+        <output name="2" label="Rear|Light" maxcurrent="150mA">
+          <label xml:lang="de">LR</label>
+          <label xml:lang="ca">Llum Poserior</label>
+        </output>
+        <output name="7" label="Dimmed|Lights">
+          <label xml:lang="de">Abblend-|licht</label>
+          <label xml:lang="ca">Intensitat Llums</label>
+        </output>
+        <output name="8" label="Shunting|Speed">
+          <label xml:lang="de">Rangier-|gang</label>
+          <label xml:lang="ca">Marxa de maniobres</label>
+        </output>
+        <size length="5.2" width="8.0" height="2.5" units="mm"/>
+        <protocols>
+          <protocol>dcc</protocol>
+          <protocol>selectrix</protocol>
+        </protocols>
+      </model>
+      <model model="PD06A (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="4" numFns="16" productID="132" comment="PD06A-0 / PD06A-3" maxInputVolts="18V" maxMotorCurrent="0.2A/6V" maxTotalCurrent="0.5A" connector="Wires">
+        <output name="1" label="Front|Light" maxcurrent="150mA">
+          <label xml:lang="de">LV</label>
+          <label xml:lang="ca">Llum Frontal</label>
+        </output>
+        <output name="2" label="Rear|Light" maxcurrent="150mA">
+          <label xml:lang="de">LR</label>
+          <label xml:lang="ca">Llum Poserior</label>
+        </output>
+        <output name="7" label="Dimmed|Lights">
+          <label xml:lang="de">Abblend-|licht</label>
+          <label xml:lang="ca">Intensitat Llums</label>
+        </output>
+        <output name="8" label="Shunting|Speed">
+          <label xml:lang="de">Rangier-|gang</label>
+          <label xml:lang="ca">Marxa de maniobres</label>
+        </output>
+        <output name="3" label="AUX|1" maxcurrent="300mA">
+          <label xml:lang="de">AUX 1</label>
+          <label xml:lang="ca">AUX 1</label>
+        </output>
+        <output name="4" label="AUX|2" maxcurrent="300mA">
+          <label xml:lang="de">AUX 2</label>
+          <label xml:lang="ca">AUX 2</label>
+        </output>
+        <size length="6.8" width="11.4" height="2.8" units="mm"/>
+        <protocols>
+          <protocol>dcc</protocol>
+          <protocol>selectrix</protocol>
+        </protocols>
+      </model>
+      <model model="PD10MU (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="4" numFns="16" productID="130" comment="PD10MU-3 / PD10MU-4 commissioned by DM-Toys" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="Wires/NEM651">
+        <output name="1" label="Front|Light" maxcurrent="150mA">
+          <label xml:lang="de">LV</label>
+          <label xml:lang="ca">Llum Frontal</label>
+        </output>
+        <output name="2" label="Rear|Light" maxcurrent="150mA">
+          <label xml:lang="de">LR</label>
+          <label xml:lang="ca">Llum Poserior</label>
+        </output>
+        <output name="3" label="AUX|1" maxcurrent="300mA">
+          <label xml:lang="de">AUX 1</label>
+          <label xml:lang="ca">AUX 1</label>
+        </output>
+        <output name="4" label="AUX|2" maxcurrent="300mA">
+          <label xml:lang="de">AUX 2</label>
+          <label xml:lang="ca">AUX 2</label>
+        </output>
+        <output name="7" label="Dimmed|Lights">
+          <label xml:lang="de">Abblend-|licht</label>
+          <label xml:lang="ca">Intensitat Llums</label>
+        </output>
+        <output name="8" label="Shunting|Speed">
+          <label xml:lang="de">Rangier-|gang</label>
+          <label xml:lang="ca">Marxa de maniobres</label>
+        </output>
+        <size length="11.7" width="8.5" height="1.8" units="mm"/>
+        <protocols>
+          <protocol>dcc</protocol>
+        </protocols>
+      </model>
+      <model model="PD12A (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="4" numFns="16" productID="130" comment="PD12A-0 / PD12A-2 / PD12A-3 / PD12A-4 with update from May 2020" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="PluX12">
+        <output name="1" label="Front|Light" maxcurrent="150mA">
+          <label xml:lang="de">LV</label>
+          <label xml:lang="ca">Llum Frontal</label>
+        </output>
+        <output name="2" label="Rear|Light" maxcurrent="150mA">
+          <label xml:lang="de">LR</label>
+          <label xml:lang="ca">Llum Poserior</label>
+        </output>
+        <output name="3" label="AUX|1" maxcurrent="300mA">
+          <label xml:lang="de">AUX 1</label>
+          <label xml:lang="ca">AUX 1</label>
+        </output>
+        <output name="4" label="AUX|2" maxcurrent="300mA">
+          <label xml:lang="de">AUX 2</label>
+          <label xml:lang="ca">AUX 2</label>
+        </output>
+        <output name="7" label="Dimmed|Lights">
+          <label xml:lang="de">Abblend-|licht</label>
+          <label xml:lang="ca">Intensitat Llums</label>
+        </output>
+        <output name="8" label="Shunting|Speed">
+          <label xml:lang="de">Rangier-|gang</label>
+          <label xml:lang="ca">Marxa de maniobres</label>
+        </output>
+        <size length="24.2" width="11.0" height="2.4" units="mm"/>
+        <protocols>
+          <protocol>dcc</protocol>
+        </protocols>
+      </model>
+      <model model="PD18A (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="4" numFns="16" productID="134" comment="PD18A" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="Next18">
+        <output name="1" label="Front|Light" maxcurrent="150mA">
+          <label xml:lang="de">LV</label>
+          <label xml:lang="ca">Llum Frontal</label>
+        </output>
+        <output name="2" label="Rear|Light" maxcurrent="150mA">
+          <label xml:lang="de">LR</label>
+          <label xml:lang="ca">Llum Poserior</label>
+        </output>
+        <output name="3" label="AUX|1" maxcurrent="300mA">
+          <label xml:lang="de">AUX 1</label>
+          <label xml:lang="ca">AUX 1</label>
+        </output>
+        <output name="4" label="AUX|2" maxcurrent="300mA">
+          <label xml:lang="de">AUX 2</label>
+          <label xml:lang="ca">AUX 2</label>
+        </output>
+        <output name="7" label="Dimmed|Lights">
+          <label xml:lang="de">Abblend-|licht</label>
+          <label xml:lang="ca">Intensitat Llums</label>
+        </output>
+        <output name="8" label="Shunting|Speed">
+          <label xml:lang="de">Rangier-|gang</label>
+          <label xml:lang="ca">Marxa de maniobres</label>
+        </output>
+        <size length="23.8" width="10.8" height="2.0" units="mm"/>
+        <protocols>
+          <protocol>dcc</protocol>
+        </protocols>
+      </model>
+      <model model="PD18MU (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="4" numFns="16" productID="134" comment="PD18MU" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="Next18">
+        <output name="1" label="Front|Light" maxcurrent="150mA">
+          <label xml:lang="de">LV</label>
+          <label xml:lang="ca">Llum Frontal</label>
+        </output>
+        <output name="2" label="Rear|Light" maxcurrent="150mA">
+          <label xml:lang="de">LR</label>
+          <label xml:lang="ca">Llum Poserior</label>
+        </output>
+        <output name="3" label="AUX|1" maxcurrent="300mA">
+          <label xml:lang="de">AUX 1</label>
+          <label xml:lang="ca">AUX 1</label>
+        </output>
+        <output name="4" label="AUX|2" maxcurrent="300mA">
+          <label xml:lang="de">AUX 2</label>
+          <label xml:lang="ca">AUX 2</label>
+        </output>
+        <output name="7" label="Dimmed|Lights">
+          <label xml:lang="de">Abblend-|licht</label>
+          <label xml:lang="ca">Intensitat Llums</label>
+        </output>
+        <output name="8" label="Shunting|Speed">
+          <label xml:lang="de">Rangier-|gang</label>
+          <label xml:lang="ca">Marxa de maniobres</label>
+        </output>
+        <size length="9.0" width="9.7" height="2.9" units="mm"/>
+        <protocols>
+          <protocol>dcc</protocol>
+        </protocols>
+      </model>
+      <model model="PD21A (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="4" numFns="16" productID="133" comment="PD21A-4" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="21MTC">
+        <output name="1" label="Front|Light" maxcurrent="150mA">
+          <label xml:lang="de">LV</label>
+          <label xml:lang="ca">Llum Frontal</label>
+        </output>
+        <output name="2" label="Rear|Light" maxcurrent="150mA">
+          <label xml:lang="de">LR</label>
+          <label xml:lang="ca">Llum Poserior</label>
+        </output>
+        <output name="3" label="AUX|1" maxcurrent="300mA">
+          <label xml:lang="de">AUX 1</label>
+          <label xml:lang="ca">AUX 1</label>
+        </output>
+        <output name="4" label="AUX|2" maxcurrent="300mA">
+          <label xml:lang="de">AUX 2</label>
+          <label xml:lang="ca">AUX 2</label>
+        </output>
+        <output name="7" label="Dimmed|Lights">
+          <label xml:lang="de">Abblend-|licht</label>
+          <label xml:lang="ca">Intensitat Llums</label>
+        </output>
+        <output name="8" label="Shunting|Speed">
+          <label xml:lang="de">Rangier-|gang</label>
+          <label xml:lang="ca">Marxa de maniobres</label>
+        </output>
+        <size length="21.2" width="15.5" height="2.9" units="mm"/>
+        <protocols>
+          <protocol>dcc</protocol>
+        </protocols>
+      </model>
+    </family>
+    <programming direct="yes" paged="yes" register="yes" ops="yes"/>
+    <variables>
+      <!-- Common D&H variable files -->
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/Vars_common.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv9_fw3.06.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv9_fw3.11.xml"/>
+      <!-- NON common D&H variable files. Deactivate or Activate depending on decoder model and firmware version -->
+      <!-- SECTION 1 - Standard variables with defaults for most decoders  -->
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/Vars_common_pwr_normal.xml"/>
+      <!-- SECTION 2 - Standard variables for decoders released after around 2012  -->
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/Vars_post2012_base.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/Vars_post2012_dc.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv65_95.xml"/>
+
+      <!-- New CV for DH21B/DH22B -->
+       <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv98-99_158-159.xml"/>
+
+      <!-- New CV65 from Fw 3.08 and above -->
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv65_fw3.08.xml"/>
+      <!-- SECTION 3    - Analog functions  -->
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv29_analog.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv13_analogModeFunction.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv14_analogModeFunction.xml"/>
+      <!-- SECTION 4    - Basic Railcom feedback  -->
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv28-29_railcom_base.xml"/>
+      <!-- SECTION 5    - Extra Railcom feedback options as of fw3.03 -->
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv135-136_144_railcom_fw3.06.xml"/>
+      <!-- SECTION 6    - Extra general options as of fw3.03 -->
+      <!-- RK xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv137_energysaving_fw3.03.xml"/-->
+      <!--              - Extra general options as of fw3.10 -->
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv144_fw3.14.xml"/>
+      <!-- SECTION 7    - Extra SUSI options as of fw3.03 -->
+      <!-- RK xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv137_susi_fw3.03.xml"/-->
+      <!-- SECTION 8    - Motorola format as of fw3.06 -->
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv12_motorola_fw3.06.xml"/>
+      <!-- SECTION 9    - Extra SUSI options as of fw3.05 -->
+      <!-- RK xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv137_susi_fw3.05.xml"/-->
+      <!-- SECTION 10    - New Manufacturer ID and Version as of fw3.06 -->
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv260-265_fw3.06.xml"/>
+      <!-- SECTION 11    - New effects as of fw3.06 -->
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv145-152_fw3.06.xml"/>
+      <!--               - New effects as of fw3.10 -->
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv156-157_fw3.10.xml"/>
+      <!-- SECTION 12    - disable effects as of fw3.06 -->
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv125-133_fw3.06.xml"/>
+      <!-- SECTION 13    - shunt options as of fw3.06 -->
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv138-143.xml"/>
+      <!-- SECTION 14    - acceleration options as of fw3.06 -->
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv124_fw3.06.xml"/>
+      <!-- SECTION 15    - initialmapping options as of fw3.06 -->
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv153_fw3.06.xml"/>
+      <!-- SECTION 16    - deceleration options as of fw3.06 -->
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv154-155_fw3.06.xml"/>
+      <!-- SECTION 17    - advanced function options as of fw3.06 -->
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv137.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv137_bit6_fw3.13.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv401-412.xml"/>
+    </variables>
+    <resets>
+     <factReset label="Reset All CVs" CV="8" default="8">
+      <label xml:lang="fr">Reset - retour aux valeurs d'usine pour tous les CVs</label>
+      <label xml:lang="it">Reset delle CV ai valori di fabbrica</label>
+      <label xml:lang="de">Zurücksetzen aller CV auf die Werkseinstellungen</label>
+      <label xml:lang="ca">Reset a valors de fàbrica</label>
+     </factReset>
+    </resets>
+  </decoder>
+  <!-- Common pane(s) for all Doehler und Haass decoders  -->
+  <xi:include href="http://jmri.org/xml/decoders/doehler_haass/Pane_StartBrakeShunt.xml"/>
+  <xi:include href="http://jmri.org/xml/decoders/doehler_haass/Pane_function_fw3.06.xml"/>
+  <xi:include href="http://jmri.org/xml/decoders/doehler_haass/Pane_common_fw3.10.xml"/>
+  <xi:include href="http://jmri.org/xml/decoders/doehler_haass/Pane_info.xml"/>
+  <!-- Pane(s) valid for some decoders only  -->
+  <xi:include href="http://jmri.org/xml/decoders/doehler_haass/Pane_functionmap.xml"/>
+  <xi:include href="http://jmri.org/xml/decoders/doehler_haass/Pane_function_swapping_nonsound.xml"/>
+  <xi:include href="http://jmri.org/xml/decoders/doehler_haass/Pane_railcom.xml"/>
+  <xi:include href="http://jmri.org/xml/decoders/doehler_haass/Pane_motorola.xml"/>
+  <xi:include href="http://jmri.org/xml/decoders/doehler_haass/Pane_susi.xml"/>
+</decoder-config>

--- a/xml/decoders/Doehler_Haass_fw3.14_DH05-24A_PD05-21A.xml
+++ b/xml/decoders/Doehler_Haass_fw3.14_DH05-24A_PD05-21A.xml
@@ -1154,7 +1154,8 @@
       <!-- SECTION 6    - Extra general options as of fw3.03 -->
       <!-- RK xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv137_energysaving_fw3.03.xml"/-->
       <!--              - Extra general options as of fw3.10 -->
-      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv144_fw3.14.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv144_bits1-4.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv144_bit5_fw3.14.xml"/>
       <!-- SECTION 7    - Extra SUSI options as of fw3.03 -->
       <!-- RK xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv137_susi_fw3.03.xml"/-->
       <!-- SECTION 8    - Motorola format as of fw3.06 -->

--- a/xml/decoders/Doehler_Haass_fw3.14_DH05-24A_PD05-21A.xml
+++ b/xml/decoders/Doehler_Haass_fw3.14_DH05-24A_PD05-21A.xml
@@ -782,7 +782,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH24A (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="13" numFns="16" productID="204" comment="DH24A, 24-pin E24 direct plug. AUX10-12 cannot be mapped on this firmware (CV101-103 exist from firmware 3.15)" maxInputVolts="30V" maxMotorCurrent="0.7A" maxTotalCurrent="1.5A" connector="other">
+      <model model="DH24A (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="13" numFns="16" productID="204" comment="DH24A, 24-pin E24 direct plug. AUX10-12 cannot be mapped on this firmware (CV101-103 exist from firmware 3.15)" maxInputVolts="30V" maxMotorCurrent="0.7A" maxTotalCurrent="1.5A" connector="E24">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>

--- a/xml/decoders/Doehler_Haass_fw3.14_DH05-24A_PD05-21A.xml
+++ b/xml/decoders/Doehler_Haass_fw3.14_DH05-24A_PD05-21A.xml
@@ -12,12 +12,6 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
-  <version version="1.1" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20260725"/>
-  <!--  CV112 is not offered on the FH* series or the PD05A any more; the D&amp;H CV table marks
-        it as not relevant for those, but the shared definition in Vars_post2012_dc.xml had no
-        such restriction. Now provided by doehler_haass/cv112_fw3.12-3.14.xml, which also carries
-        D&amp;H's documented default of 15 rather than 0.
-        -->
   <version version="1" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20260725"/>
   <!--  Creation (new firmware 3.14.095).
         Based on Doehler_Haass_fw3.13_DH05-22B_PD05-21A.xml
@@ -25,6 +19,8 @@
           - CV144 bit 5, disabling the restoration of the last driving state.
           - CV144 bits 3 and 4 now also apply to DH21B, DH22B and DH24A.
         The CV set is otherwise identical to firmware 3.13.
+        CV112 is not offered on the FH* series or the PD05A, which the D&amp;H CV table
+        marks it as not relevant for, and carries the documented default of 15.
         -->
   <decoder>
     <family name="Train Decoders (firmware 3.14+)" mfg="Doehler und Haass">

--- a/xml/decoders/Doehler_Haass_fw3.14_FH05B-22A.xml
+++ b/xml/decoders/Doehler_Haass_fw3.14_FH05B-22A.xml
@@ -1,0 +1,294 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet type="text/xsl" href="../XSLT/decoder.xsl"?>
+<!-- Copyright (C) JMRI 2006 All rights reserved -->
+<!--                                                                        -->
+<!-- JMRI is free software; you can redistribute it and/or modify it under  -->
+<!-- the terms of version 2 of the GNU General Public License as published  -->
+<!-- by the Free Software Foundation. See the "COPYING" file for a copy     -->
+<!-- of this license.                                                       -->
+<!--                                                                        -->
+<!-- JMRI is distributed in the hope that it will be useful, but WITHOUT    -->
+<!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
+<!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
+<!-- for more details.                                                      -->
+<decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+  <version version="1" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20260725"/>
+  <!--  Creation (new firmware 3.14.095).
+        Based on Doehler_Haass_fw3.13_FH05B-22A.xml
+        Changes in firmware 3.14 relative to 3.13, per the D&amp;H ChangeLog:
+          - CV144 bit 5, disabling the restoration of the last driving state.
+        The CV set is otherwise identical to firmware 3.13.
+        -->
+  <decoder>
+    <family name="Function Decoders (firmware 3.14+)" mfg="Doehler und Haass">
+      <model model="FH05B (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="6" numFns="16" productID="41" comment="FH05B-0 / FH05B-1 / FH05B-3 with update from May 2020" maxInputVolts="30V" maxTotalCurrent="0.5A" connector="Wires/NEM651">
+        <output name="1" label="Front|Light" maxcurrent="150mA">
+          <label xml:lang="de">LV</label>
+          <label xml:lang="ca">Llum Frontal</label>
+        </output>
+        <output name="2" label="Rear|Light" maxcurrent="150mA">
+          <label xml:lang="de">LR</label>
+          <label xml:lang="ca">Llum Posterior</label>
+        </output>
+        <output name="3" label="AUX|1" maxcurrent="300mA">
+          <label xml:lang="de">AUX 1</label>
+          <label xml:lang="ca">AUX 1</label>
+        </output>
+        <output name="4" label="AUX|2" maxcurrent="300mA">
+          <label xml:lang="de">AUX 2</label>
+          <label xml:lang="ca">AUX 2</label>
+        </output>
+        <output name="5" label="AUX 3|(or SUSI ZCLK)" maxcurrent="20mA">
+        <!-- New from fw3.03  -->
+          <label xml:lang="de">AUX 3|SUSI ZCLK</label>
+          <label xml:lang="ca">AUX 3| SUSI ZCLK</label>
+        </output>
+        <output name="6" label="AUX 4|(or SUSI ZDAT)" maxcurrent="20mA">
+        <!-- New from fw3.03  -->
+          <label xml:lang="de">AUX 4|SUSI ZDAT</label>
+          <label xml:lang="ca">AUX 4\SUSI ZDAT</label>
+        </output>
+        <output name="7" label="Dimmed|Lights">
+          <label xml:lang="de">Abblend-|licht</label>
+          <label xml:lang="ca">Intensitat de llums</label>
+        </output>
+        <output name="8" label="Shunting|Speed">
+          <label xml:lang="de">Rangier-|gang</label>
+          <label xml:lang="ca">Marxa de maniobres</label>
+        </output>
+        <size length="13.7" width="7.8" height="1.5" units="mm"/>
+        <protocols>
+          <protocol>dcc</protocol>
+          <protocol>selectrix</protocol>
+          <protocol>motorola</protocol>
+        </protocols>
+      </model>
+      <model model="FH16A (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="8" numFns="16" productID="150" comment="FH16A-4, PluX16 direct plug" maxInputVolts="30V" maxTotalCurrent="1.5A" connector="PluX16">
+        <output name="1" label="Front|Light" maxcurrent="150mA">
+          <label xml:lang="de">LV</label>
+          <label xml:lang="ca">Llum Frontal</label>
+        </output>
+        <output name="2" label="Rear|Light" maxcurrent="150mA">
+          <label xml:lang="de">LR</label>
+          <label xml:lang="ca">Llum Posterior</label>
+        </output>
+        <output name="3" label="AUX|1" maxcurrent="300mA">
+          <label xml:lang="de">AUX 1</label>
+          <label xml:lang="ca">AUX 1</label>
+        </output>
+        <output name="4" label="AUX|2" maxcurrent="300mA">
+          <label xml:lang="de">AUX 2</label>
+          <label xml:lang="ca">AUX 2</label>
+        </output>
+        <output name="5" label="AUX|3" maxcurrent="1A">
+          <label xml:lang="de">AUX 3</label>
+          <label xml:lang="ca">AUX 3</label>
+        </output>
+        <output name="6" label="AUX|4" maxcurrent="1A">
+          <label xml:lang="de">AUX 4</label>
+          <label xml:lang="ca">AUX 4</label>
+        </output>
+        <output name="7" label="AUX 5|(or SUSI ZCLK)" maxcurrent="20mA">
+          <label xml:lang="de">AUX 5</label>
+          <label xml:lang="ca">AUX 5</label>
+        </output>
+        <output name="8" label="AUX 6|(or SUSI ZDAT)" maxcurrent="20mA">
+          <label xml:lang="de">AUX 6</label>
+          <label xml:lang="ca">AUX 6</label>
+        </output>
+        <output name="9" label="Dimmed|Lights">
+          <label xml:lang="de">Abblend-|licht</label>
+          <label xml:lang="ca">Intensitat Llums</label>
+        </output>
+        <output name="10" label="Shunting|Speed">
+          <label xml:lang="de">Rangiergang</label>
+          <label xml:lang="ca">Marxa de maniobres</label>
+        </output>
+        <size length="15.9" width="10.9" height="2.3" units="mm"/>
+        <protocols>
+          <protocol>dcc</protocol>
+          <protocol>selectrix</protocol>
+          <protocol>motorola</protocol>
+        </protocols>
+      </model>
+      <model model="FH18A (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="8" numFns="18" productID="170" comment="FH18A with update from May 2020" maxInputVolts="30V" maxTotalCurrent="1.0A" connector="Next18">
+        <output name="1" label="Front|Light" maxcurrent="150mA">
+          <label xml:lang="de">LV</label>
+          <label xml:lang="ca">Llum Frontal</label>
+        </output>
+        <output name="2" label="Rear|Light" maxcurrent="150mA">
+          <label xml:lang="de">LR</label>
+          <label xml:lang="ca">Llum Posterior</label>
+        </output>
+        <output name="3" label="AUX|1" maxcurrent="300mA">
+          <label xml:lang="de">AUX 1</label>
+          <label xml:lang="ca">AUX 1</label>
+        </output>
+        <output name="4" label="AUX|2" maxcurrent="300mA">
+          <label xml:lang="de">AUX 2</label>
+          <label xml:lang="ca">AUX 2</label>
+        </output>
+        <output name="5" label="AUX|3" maxcurrent="20mA">
+          <label xml:lang="de">AUX 3</label>
+          <label xml:lang="ca">AUX 3</label>
+        </output>
+        <output name="6" label="AUX|4" maxcurrent="20mA">
+          <label xml:lang="de">AUX 4</label>
+          <label xml:lang="ca">AUX 4</label>
+        </output>
+        <output name="7" label="AUX 5|(or SUSI ZCLK)" maxcurrent="20mA">
+          <label xml:lang="de">AUX 5|SUSI ZCLK</label>
+          <label xml:lang="ca">AUX 5| SUSI ZCLK</label>
+        </output>
+        <output name="8" label="AUX 6|(or SUSI ZDAT)" maxcurrent="20mA">
+          <label xml:lang="de">AUX 6|SUSI ZDAT</label>
+          <label xml:lang="ca">AUX 6| SUSI ZDAT</label>
+        </output>
+        <output name="9" label="Dimmed|Lights">
+          <label xml:lang="de">Abblend-|licht</label>
+          <label xml:lang="ca">Intensitat Llums</label>
+        </output>
+        <output name="10" label="Shunting|Speed">
+          <label xml:lang="de">Rangier-|gang</label>
+          <label xml:lang="ca">Marxa de Maniobres</label>
+        </output>
+        <size length="10.7" width="9.7" height="3.2" units="mm"/>
+        <protocols>
+          <protocol>dcc</protocol>
+          <protocol>selectrix</protocol>
+          <protocol>motorola</protocol>
+        </protocols>
+      </model>
+      <model model="FH22A (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="8" numFns="18" productID="192" comment="FH22A with update from May 2020" maxInputVolts="30V" maxTotalCurrent="2.0A" connector="PluX22">
+        <output name="1" label="Front|Light" maxcurrent="150mA">
+          <label xml:lang="de">LV</label>
+          <label xml:lang="ca">Llum Frontal</label>
+        </output>
+        <output name="2" label="Rear|Light" maxcurrent="150mA">
+          <label xml:lang="de">LR</label>
+          <label xml:lang="ca">Llum Posterior</label>
+        </output>
+        <output name="3" label="AUX|1" maxcurrent="300mA">
+          <label xml:lang="de">AUX 1</label>
+          <label xml:lang="ca">AUX 1</label>
+        </output>
+        <output name="4" label="AUX|2" maxcurrent="300mA">
+          <label xml:lang="de">AUX 2</label>
+          <label xml:lang="ca">AUX 2</label>
+        </output>
+        <output name="5" label="AUX|3" maxcurrent="1A">
+          <label xml:lang="de">AUX 3</label>
+          <label xml:lang="ca">AUX 3</label>
+        </output>
+        <output name="6" label="AUX|4" maxcurrent="1A">
+          <label xml:lang="de">AUX 4</label>
+          <label xml:lang="ca">AUX 4</label>
+        </output>
+        <output name="7" label="AUX 5|(or SUSI ZCLK)" maxcurrent="20mA">
+        <!-- New from fw3.03  -->
+          <label xml:lang="de">AUX 5|SUSI ZCLK</label>
+          <label xml:lang="ca">AUX 5| SUSI ZCLK</label>
+        </output>
+        <output name="8" label="AUX 6|(or SUSI ZDAT)" maxcurrent="20mA">
+        <!-- New from fw3.03  -->
+          <label xml:lang="de">AUX 6|SUSI ZDAT</label>
+          <label xml:lang="ca">AUX 6| SUSI ZDAT</label>
+        </output>
+        <output name="9" label="Dimmed|Lights">
+          <label xml:lang="de">Abblend-|licht</label>
+          <label xml:lang="ca">Intensitat Llums</label>
+        </output>
+        <output name="10" label="Shunting|Speed">
+          <label xml:lang="de">Rangier-|gang</label>
+          <label xml:lang="ca">Marxa Maniobres</label>
+        </output>
+        <size length="16.1" width="15.8" height="3.3" units="mm"/>
+        <protocols>
+          <protocol>dcc</protocol>
+          <protocol>selectrix</protocol>
+          <protocol>motorola</protocol>
+        </protocols>
+      </model>
+    </family>
+    <programming direct="yes" paged="yes" register="yes" ops="yes"/>
+    <variables>
+      <!-- Common D&H variable files -->
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/Vars_common.xml"/>
+      <!-- NON common D&H variable files. Deactivate or Activate depending on decoder model and firmware version -->
+      <!-- SECTION 1 - Standard variables with defaults for most decoders  -->
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/Vars_common_pwr_normal.xml"/>
+      <!-- SECTION 2 - Standard variables for decoders released after around 2012  -->
+      <!--  <xi:include href="http://jmri.org/xml/decoders/doehler_haass/Vars_post2012_base.xml"/> -->
+      <!--  <xi:include href="http://jmri.org/xml/decoders/doehler_haass/Vars_post2012_dc.xml"/> -->
+<!-- relevant für FH ??? Start-->
+     <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv65_95.xml"/>
+      <!-- New CV65 from Fw 3.08 and above -->
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv65_fw3.08.xml"/>
+<!-- relevant für FH ??? Ende-->
+       <!-- SECTION 3    - Analog functions  -->
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv29_analog.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/nmra/analogModeFunction.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv14_analogModeFunction.xml"/>
+      <!-- SECTION 4    - Basic Railcom feedback  -->
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv28-29_railcom_base.xml"/>
+      <!-- SECTION 5    - Extra Railcom feedback options as of fw3.03 -->
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv135-136_144_railcom_fw3.06.xml"/>
+      <!-- SECTION 6    - Extra general options as of fw3.03 -->
+      <!-- RK xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv137_energysaving_fw3.03.xml"/-->
+<!-- relevant für FH ??? Start-->
+      <!--              - Extra general options as of fw3.10 -->
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv144_fw3.14.xml"/>
+<!-- relevant für FH ??? Ende-->
+      <!-- SECTION 7    - Extra SUSI options as of fw3.03 -->
+      <!-- RK xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv137_susi_fw3.03.xml"/-->
+      <!-- SECTION 8    - Motorola format as of fw3.04 -->
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv12_motorola_fw3.06.xml"/>
+      <!-- SECTION 9    - Extra SUSI options as of fw3.05 -->
+      <!-- RK i:include href="http://jmri.org/xml/decoders/doehler_haass/cv137_susi_fw3.05.xml"/-->
+      <!-- SECTION 10    - New Manufacturer ID and Version as of fw3.06 -->
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv260-265_fw3.06.xml"/>
+      <!-- SECTION 11    - New effects as of fw3.06 -->
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv145-152_fw3.06.xml"/>
+<!-- relevant für FH ??? Start-->
+      <!--               - New effects as of fw3.10 -->
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv156-157_fw3.10.xml"/>
+<!-- relevant für FH ??? Ende-->
+      <!-- SECTION 12    - disable effects as of fw3.06 -->
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv125-133_fw3.06.xml"/>
+      <!-- SECTION 13    - shunt options as of fw3.06 -->
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv138-143.xml"/>
+      <!-- SECTION 14    - acceleration options as of fw3.06 -->
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv124_fw3.06.xml"/>
+      <!-- SECTION 15    - initialmapping options as of fw3.06 -->
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv153_fw3.06.xml"/>
+      <!-- SECTION 16    - deceleration options as of fw3.06 -->
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv154-155_fw3.06.xml"/>
+      <!-- SECTION 17    - advanced function options as of fw3.06 -->
+      <!-- RK xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv137_adv_function_fw3.06.xml"/-->
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv137.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv137_bit6_fw3.13.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv401-412.xml"/>
+    </variables>
+    <resets>
+     <factReset label="Reset All CVs" CV="8" default="8">
+      <label xml:lang="fr">Reset - retour aux valeurs d'usine pour tous les CVs</label>
+      <label xml:lang="it">Reset delle CV ai valori di fabbrica</label>
+      <label xml:lang="de">Zurücksetzen aller CV auf die Werkseinstellungen</label>
+      <label xml:lang="ca">Reset a valors de fàbrica</label>
+     </factReset>
+    </resets>
+  </decoder>
+  <!-- Common pane(s) for all Doehler und Haass decoders  -->
+  <xi:include href="http://jmri.org/xml/decoders/doehler_haass/Pane_StartBrakeShunt.xml"/>
+  <xi:include href="http://jmri.org/xml/decoders/doehler_haass/Pane_function_fw3.06.xml"/>
+  <!-- xi:include href="http://jmri.org/xml/decoders/doehler_haass/Pane_common.xml"/ -->
+<!-- relevant für FH ??? Start-->
+  <xi:include href="http://jmri.org/xml/decoders/doehler_haass/Pane_common_fw3.10.xml"/>
+<!-- relevant für FH ??? Ende-->
+  <xi:include href="http://jmri.org/xml/decoders/doehler_haass/Pane_info.xml"/>
+  <xi:include href="http://jmri.org/xml/decoders/doehler_haass/Pane_function_swapping_nonsound.xml"/>
+  <!-- Pane(s) valid for some decoders only  -->
+  <xi:include href="http://jmri.org/xml/decoders/doehler_haass/Pane_railcom.xml"/>
+  <xi:include href="http://jmri.org/xml/decoders/doehler_haass/Pane_motorola.xml"/>
+  <xi:include href="http://jmri.org/xml/decoders/doehler_haass/Pane_susi.xml"/>
+</decoder-config>

--- a/xml/decoders/Doehler_Haass_fw3.14_FH05B-22A.xml
+++ b/xml/decoders/Doehler_Haass_fw3.14_FH05B-22A.xml
@@ -12,18 +12,14 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
-  <version version="1.1" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20260725"/>
-  <!--  CV112 is not offered on the FH* series or the PD05A any more; the D&amp;H CV table marks
-        it as not relevant for those, but the shared definition in Vars_post2012_dc.xml had no
-        such restriction. Now provided by doehler_haass/cv112_fw3.12-3.14.xml, which also carries
-        D&amp;H's documented default of 15 rather than 0.
-        -->
   <version version="1" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20260725"/>
   <!--  Creation (new firmware 3.14.095).
         Based on Doehler_Haass_fw3.13_FH05B-22A.xml
         Changes in firmware 3.14 relative to 3.13, per the D&amp;H ChangeLog:
           - CV144 bit 5, disabling the restoration of the last driving state.
         The CV set is otherwise identical to firmware 3.13.
+        CV112 is not offered on the FH* series or the PD05A, which the D&amp;H CV table
+        marks it as not relevant for, and carries the documented default of 15.
         -->
   <decoder>
     <family name="Function Decoders (firmware 3.14+)" mfg="Doehler und Haass">

--- a/xml/decoders/Doehler_Haass_fw3.14_FH05B-22A.xml
+++ b/xml/decoders/Doehler_Haass_fw3.14_FH05B-22A.xml
@@ -237,7 +237,8 @@
       <!-- RK xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv137_energysaving_fw3.03.xml"/-->
 <!-- relevant für FH ??? Start-->
       <!--              - Extra general options as of fw3.10 -->
-      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv144_fw3.14.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv144_bits1-4.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv144_bit5_fw3.14.xml"/>
 <!-- relevant für FH ??? Ende-->
       <!-- SECTION 7    - Extra SUSI options as of fw3.03 -->
       <!-- RK xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv137_susi_fw3.03.xml"/-->

--- a/xml/decoders/Doehler_Haass_fw3.15_DH05-24A_PD05-21A.xml
+++ b/xml/decoders/Doehler_Haass_fw3.15_DH05-24A_PD05-21A.xml
@@ -784,7 +784,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH24A (firmware 3.15.016+)" lowVersionID="16" highVersionID="16" numOuts="13" numFns="16" productID="204" comment="DH24A, 24-pin E24 direct plug. AUX10-12 cannot be mapped on this firmware (CV101-103 exist from firmware 3.15)" maxInputVolts="30V" maxMotorCurrent="0.7A" maxTotalCurrent="1.5A" connector="other">
+      <model model="DH24A (firmware 3.15.016+)" lowVersionID="16" highVersionID="16" numOuts="13" numFns="16" productID="204" comment="DH24A, 24-pin E24 direct plug. AUX10-12 cannot be mapped on this firmware (CV101-103 exist from firmware 3.15)" maxInputVolts="30V" maxMotorCurrent="0.7A" maxTotalCurrent="1.5A" connector="E24">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>

--- a/xml/decoders/Doehler_Haass_fw3.15_DH05-24A_PD05-21A.xml
+++ b/xml/decoders/Doehler_Haass_fw3.15_DH05-24A_PD05-21A.xml
@@ -12,23 +12,21 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
-  <version version="1.1" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20260725"/>
-  <!--  CV112 is not offered on the FH* series or the PD05A any more; the D&amp;H CV table marks
-        it as not relevant for those, but the shared definition in Vars_post2012_dc.xml had no
-        such restriction. Now provided by doehler_haass/cv112_fw3.12-3.14.xml, which also carries
-        D&amp;H's documented default of 15 rather than 0.
-        -->
   <version version="1" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20260725"/>
-  <!--  Creation (new firmware 3.14.095).
-        Based on Doehler_Haass_fw3.13_DH05-22B_PD05-21A.xml
-        Changes in firmware 3.14 relative to 3.13, per the D&amp;H ChangeLog:
-          - CV144 bit 5, disabling the restoration of the last driving state.
-          - CV144 bits 3 and 4 now also apply to DH21B, DH22B and DH24A.
-        The CV set is otherwise identical to firmware 3.13.
+  <!--  Creation (new firmware 3.15.016).
+        Based on Doehler_Haass_fw3.14_DH05-24A_PD05-21A.xml
+        Changes in firmware 3.15 relative to 3.14:
+          - CV60 becomes a settings register: bit 1 enables a minimum speed step for the
+            brake ramp, bits 2 and 3 configure the shuttle mode (Pendelbetrieb).
+          - CV101-103 map AUX10-AUX12 on the DH21B, DH22B and DH24A.
+          - CV461, 463, 465 and 467 dim AUX3-AUX6 (odd addresses only).
+          - CV156 gains bits 4-7, dimming AUX3-AUX6; its range widens to 0-255.
+          - CV112 widens from 0-31 to 0-127.
+          - CV63 and CV65 change meaning depending on CV60.
         -->
   <decoder>
-    <family name="Train Decoders (firmware 3.14+)" mfg="Doehler und Haass">
-      <model model="DH05C (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="6" numFns="16" productID="52" comment="DH05C-0 / DH05C-1 / DH05C-3 with update from May 2020" maxInputVolts="18V" maxMotorCurrent="0.5A" maxTotalCurrent="0.5A" connector="Wires/NEM651">
+    <family name="Train Decoders (firmware 3.15+)" mfg="Doehler und Haass">
+      <model model="DH05C (firmware 3.15.016+)" lowVersionID="16" highVersionID="16" numOuts="6" numFns="16" productID="52" comment="DH05C-0 / DH05C-1 / DH05C-3 with update from May 2020" maxInputVolts="18V" maxMotorCurrent="0.5A" maxTotalCurrent="0.5A" connector="Wires/NEM651">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum frontal</label>
@@ -70,7 +68,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH05C Gen. 2 (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="8" numFns="16" productID="52" comment="DH05C-0 / DH05C-1 / DH05C-3 2nd Generation with update from May 2020" maxInputVolts="30V" maxMotorCurrent="0.5A" maxTotalCurrent="0.5A" connector="Wires/NEM651">
+      <model model="DH05C Gen. 2 (firmware 3.15.016+)" lowVersionID="16" highVersionID="16" numOuts="8" numFns="16" productID="52" comment="DH05C-0 / DH05C-1 / DH05C-3 2nd Generation with update from May 2020" maxInputVolts="30V" maxMotorCurrent="0.5A" maxTotalCurrent="0.5A" connector="Wires/NEM651">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum frontal</label>
@@ -112,7 +110,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH06A (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="3" numFns="16" productID="60" comment="DH06A for Köf with no analog support, with update from May 2020" maxInputVolts="30V" maxMotorCurrent="0.3A" maxTotalCurrent="0.3A">
+      <model model="DH06A (firmware 3.15.016+)" lowVersionID="16" highVersionID="16" numOuts="3" numFns="16" productID="60" comment="DH06A for Köf with no analog support, with update from May 2020" maxInputVolts="30V" maxMotorCurrent="0.3A" maxTotalCurrent="0.3A">
         <output name="1" label="Front|Light" maxcurrent="20mA"/>
         <output name="2" label="Rear|Light" maxcurrent="20mA"/>
         <output name="3" label="Onboard|LED" maxcurrent="20mA"/>
@@ -127,7 +125,7 @@
           <protocol>selectrix</protocol>
         </protocols>
       </model>
-      <model model="DH06A Gen. 2 (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="3" numFns="16" productID="60" comment="DH06A for Köf with no analog support, with update from May 2020" maxInputVolts="30V" maxMotorCurrent="0.3A" maxTotalCurrent="0.3A">
+      <model model="DH06A Gen. 2 (firmware 3.15.016+)" lowVersionID="16" highVersionID="16" numOuts="3" numFns="16" productID="60" comment="DH06A for Köf with no analog support, with update from May 2020" maxInputVolts="30V" maxMotorCurrent="0.3A" maxTotalCurrent="0.3A">
         <output name="1" label="Front|Light" maxcurrent="20mA"/>
         <output name="2" label="Rear|Light" maxcurrent="20mA"/>
         <output name="3" label="Onboard|LED" maxcurrent="20mA"/>
@@ -142,7 +140,7 @@
           <protocol>selectrix</protocol>
         </protocols>
       </model>
-      <model model="DH10C (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="6" numFns="16" productID="102" comment="DH10C-0 / DH10C-1 / DH10C-3 with update from May 2020" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="Wires/NEM651">
+      <model model="DH10C (firmware 3.15.016+)" lowVersionID="16" highVersionID="16" numOuts="6" numFns="16" productID="102" comment="DH10C-0 / DH10C-1 / DH10C-3 with update from May 2020" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="Wires/NEM651">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -184,7 +182,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH10C Gen. 2 (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="8" numFns="16" productID="102" comment="DH10C-0 / DH10C-1 / DH10C-3 2nd Generation with update from May 2020" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="Wires/NEM651">
+      <model model="DH10C Gen. 2 (firmware 3.15.016+)" lowVersionID="16" highVersionID="16" numOuts="8" numFns="16" productID="102" comment="DH10C-0 / DH10C-1 / DH10C-3 2nd Generation with update from May 2020" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="Wires/NEM651">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -226,7 +224,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH12A (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="6" numFns="16" productID="120" comment="DH12A with update from May 2020" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX12">
+      <model model="DH12A (firmware 3.15.016+)" lowVersionID="16" highVersionID="16" numOuts="6" numFns="16" productID="120" comment="DH12A with update from May 2020" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX12">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum frontal</label>
@@ -266,7 +264,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH14B (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="6" numFns="16" productID="141" comment="DH14B with update from May 2020" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="other">
+      <model model="DH14B (firmware 3.15.016+)" lowVersionID="16" highVersionID="16" numOuts="6" numFns="16" productID="141" comment="DH14B with update from May 2020" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="other">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum frontal</label>
@@ -306,7 +304,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH16A (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="6" numFns="16" productID="160" comment="DH16A-0 /DH16A-1 /DH16A-2 /DH16A-3 with update from May 2020" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX16">
+      <model model="DH16A (firmware 3.15.016+)" lowVersionID="16" highVersionID="16" numOuts="6" numFns="16" productID="160" comment="DH16A-0 /DH16A-1 /DH16A-2 /DH16A-3 with update from May 2020" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX16">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -346,7 +344,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH16A Gen. 2 (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="6" numFns="16" productID="160" comment="DH16A-0 /DH16A-1 /DH16A-2 /DH16A-3 with update from May 2020" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX16">
+      <model model="DH16A Gen. 2 (firmware 3.15.016+)" lowVersionID="16" highVersionID="16" numOuts="6" numFns="16" productID="160" comment="DH16A-0 /DH16A-1 /DH16A-2 /DH16A-3 with update from May 2020" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX16">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -386,7 +384,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH18A (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="8" numFns="16" productID="180" comment="DH18A with update from May 2020" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="Next18">
+      <model model="DH18A (firmware 3.15.016+)" lowVersionID="16" highVersionID="16" numOuts="8" numFns="16" productID="180" comment="DH18A with update from May 2020" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="Next18">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -434,7 +432,7 @@
             <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH18A Gen. 2 (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="8" numFns="16" productID="180" comment="DH18A with update from May 2020" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="Next18">
+      <model model="DH18A Gen. 2 (firmware 3.15.016+)" lowVersionID="16" highVersionID="16" numOuts="8" numFns="16" productID="180" comment="DH18A with update from May 2020" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="Next18">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -482,7 +480,7 @@
             <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH21A (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="8" numFns="16" productID="200" comment="DH21A with update from May 2020" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="21MTC">
+      <model model="DH21A (firmware 3.15.016+)" lowVersionID="16" highVersionID="16" numOuts="8" numFns="16" productID="200" comment="DH21A with update from May 2020" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="21MTC">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum frontal</label>
@@ -530,7 +528,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH21A Gen. 2 (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="8" numFns="16" productID="200" comment="DH21A with update from May 2020" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="21MTC">
+      <model model="DH21A Gen. 2 (firmware 3.15.016+)" lowVersionID="16" highVersionID="16" numOuts="8" numFns="16" productID="200" comment="DH21A with update from May 2020" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="21MTC">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum frontal</label>
@@ -578,7 +576,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH21B (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="10" numFns="16" productID="201" comment="DH21B" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="21MTC">
+      <model model="DH21B (firmware 3.15.016+)" lowVersionID="16" highVersionID="16" numOuts="10" numFns="16" productID="201" comment="DH21B" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="21MTC">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum frontal</label>
@@ -634,7 +632,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH22A (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="8" numFns="16" productID="202" comment="DH22A with update from May 2020" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="PluX22">
+      <model model="DH22A (firmware 3.15.016+)" lowVersionID="16" highVersionID="16" numOuts="8" numFns="16" productID="202" comment="DH22A with update from May 2020" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="PluX22">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -682,7 +680,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH22A Gen. 2 (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="8" numFns="16" productID="202" comment="DH22A with update from May 2020" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="PluX22">
+      <model model="DH22A Gen. 2 (firmware 3.15.016+)" lowVersionID="16" highVersionID="16" numOuts="8" numFns="16" productID="202" comment="DH22A with update from May 2020" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="PluX22">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -730,7 +728,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH22B (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="10" numFns="16" productID="203" comment="DH22B" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="PluX22">
+      <model model="DH22B (firmware 3.15.016+)" lowVersionID="16" highVersionID="16" numOuts="10" numFns="16" productID="203" comment="DH22B" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="PluX22">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -786,7 +784,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH24A (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="13" numFns="16" productID="204" comment="DH24A, 24-pin E24 direct plug. AUX10-12 cannot be mapped on this firmware (CV101-103 exist from firmware 3.15)" maxInputVolts="30V" maxMotorCurrent="0.7A" maxTotalCurrent="1.5A" connector="other">
+      <model model="DH24A (firmware 3.15.016+)" lowVersionID="16" highVersionID="16" numOuts="13" numFns="16" productID="204" comment="DH24A, 24-pin E24 direct plug. AUX10-12 cannot be mapped on this firmware (CV101-103 exist from firmware 3.15)" maxInputVolts="30V" maxMotorCurrent="0.7A" maxTotalCurrent="1.5A" connector="other">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -854,7 +852,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DHSP10A (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="8" numFns="16" productID="110" comment="DHSP10A-0 / -1 / -2 / -3 / -4, with integrated buffer capacitor (16 V, 470 uF)" maxInputVolts="30V" maxMotorCurrent="0.7A" maxTotalCurrent="1.5A" connector="Wires/NEM651">
+      <model model="DHSP10A (firmware 3.15.016+)" lowVersionID="16" highVersionID="16" numOuts="8" numFns="16" productID="110" comment="DHSP10A-0 / -1 / -2 / -3 / -4, with integrated buffer capacitor (16 V, 470 uF)" maxInputVolts="30V" maxMotorCurrent="0.7A" maxTotalCurrent="1.5A" connector="Wires/NEM651">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -902,7 +900,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="PD05A (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="2" numFns="16" productID="131" comment="PD05A-0 / PD05A-2 / PD05A-3 with update from May 2020" maxInputVolts="30V" maxMotorCurrent="0.5A" maxTotalCurrent="0.5A" connector="Wires/NEM651">
+      <model model="PD05A (firmware 3.15.016+)" lowVersionID="16" highVersionID="16" numOuts="2" numFns="16" productID="131" comment="PD05A-0 / PD05A-2 / PD05A-3 with update from May 2020" maxInputVolts="30V" maxMotorCurrent="0.5A" maxTotalCurrent="0.5A" connector="Wires/NEM651">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -925,7 +923,7 @@
           <protocol>selectrix</protocol>
         </protocols>
       </model>
-      <model model="PD05A Gen. 2 (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="2" numFns="16" productID="131" comment="PD05A-0 / PD05A-2 / PD05A-3 with update from May 2020" maxInputVolts="30V" maxMotorCurrent="0.5A" maxTotalCurrent="0.5A" connector="Wires/NEM651">
+      <model model="PD05A Gen. 2 (firmware 3.15.016+)" lowVersionID="16" highVersionID="16" numOuts="2" numFns="16" productID="131" comment="PD05A-0 / PD05A-2 / PD05A-3 with update from May 2020" maxInputVolts="30V" maxMotorCurrent="0.5A" maxTotalCurrent="0.5A" connector="Wires/NEM651">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -948,7 +946,7 @@
           <protocol>selectrix</protocol>
         </protocols>
       </model>
-      <model model="PD06A (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="4" numFns="16" productID="132" comment="PD06A-0 / PD06A-3" maxInputVolts="18V" maxMotorCurrent="0.2A/6V" maxTotalCurrent="0.5A" connector="Wires">
+      <model model="PD06A (firmware 3.15.016+)" lowVersionID="16" highVersionID="16" numOuts="4" numFns="16" productID="132" comment="PD06A-0 / PD06A-3" maxInputVolts="18V" maxMotorCurrent="0.2A/6V" maxTotalCurrent="0.5A" connector="Wires">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -979,7 +977,7 @@
           <protocol>selectrix</protocol>
         </protocols>
       </model>
-      <model model="PD10MU (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="4" numFns="16" productID="130" comment="PD10MU-3 / PD10MU-4 commissioned by DM-Toys" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="Wires/NEM651">
+      <model model="PD10MU (firmware 3.15.016+)" lowVersionID="16" highVersionID="16" numOuts="4" numFns="16" productID="130" comment="PD10MU-3 / PD10MU-4 commissioned by DM-Toys" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="Wires/NEM651">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -1009,7 +1007,7 @@
           <protocol>dcc</protocol>
         </protocols>
       </model>
-      <model model="PD12A (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="4" numFns="16" productID="130" comment="PD12A-0 / PD12A-2 / PD12A-3 / PD12A-4 with update from May 2020" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="PluX12">
+      <model model="PD12A (firmware 3.15.016+)" lowVersionID="16" highVersionID="16" numOuts="4" numFns="16" productID="130" comment="PD12A-0 / PD12A-2 / PD12A-3 / PD12A-4 with update from May 2020" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="PluX12">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -1039,7 +1037,7 @@
           <protocol>dcc</protocol>
         </protocols>
       </model>
-      <model model="PD18A (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="4" numFns="16" productID="134" comment="PD18A" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="Next18">
+      <model model="PD18A (firmware 3.15.016+)" lowVersionID="16" highVersionID="16" numOuts="4" numFns="16" productID="134" comment="PD18A" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="Next18">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -1069,7 +1067,7 @@
           <protocol>dcc</protocol>
         </protocols>
       </model>
-      <model model="PD18MU (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="4" numFns="16" productID="134" comment="PD18MU" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="Next18">
+      <model model="PD18MU (firmware 3.15.016+)" lowVersionID="16" highVersionID="16" numOuts="4" numFns="16" productID="134" comment="PD18MU" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="Next18">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -1099,7 +1097,7 @@
           <protocol>dcc</protocol>
         </protocols>
       </model>
-      <model model="PD21A (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="4" numFns="16" productID="133" comment="PD21A-4" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="21MTC">
+      <model model="PD21A (firmware 3.15.016+)" lowVersionID="16" highVersionID="16" numOuts="4" numFns="16" productID="133" comment="PD21A-4" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="21MTC">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -1161,8 +1159,14 @@
       <!-- RK xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv137_energysaving_fw3.03.xml"/-->
       <!--              - Extra general options as of fw3.10 -->
       <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv144_bits1-4.xml"/>
-      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv112_fw3.12-3.14.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv144_bit5_fw3.14.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv60_bits1-3_fw3.15.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv63_fw3.15.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv65_fw3.15.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv112_fw3.15.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv101-103_fw3.15.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv156_bits4-7_fw3.15.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv461-467_fw3.15.xml"/>
       <!-- SECTION 7    - Extra SUSI options as of fw3.03 -->
       <!-- RK xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv137_susi_fw3.03.xml"/-->
       <!-- SECTION 8    - Motorola format as of fw3.06 -->

--- a/xml/decoders/Doehler_Haass_fw3.15_FH05B-22A.xml
+++ b/xml/decoders/Doehler_Haass_fw3.15_FH05B-22A.xml
@@ -18,7 +18,6 @@
         Changes in firmware 3.15 relative to 3.14:
           - CV60 becomes a settings register: bit 1 enables a minimum speed step for the
             brake ramp, bits 2 and 3 configure the shuttle mode (Pendelbetrieb).
-          - CV101-103 map AUX10-AUX12 on the DH21B, DH22B and DH24A.
           - CV461, 463, 465 and 467 dim AUX3-AUX6 (odd addresses only).
           - CV156 gains bits 4-7, dimming AUX3-AUX6; its range widens to 0-255.
           - CV112 widens from 0-31 to 0-127.

--- a/xml/decoders/Doehler_Haass_fw3.15_FH05B-22A.xml
+++ b/xml/decoders/Doehler_Haass_fw3.15_FH05B-22A.xml
@@ -12,22 +12,21 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
-  <version version="1.1" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20260725"/>
-  <!--  CV112 is not offered on the FH* series or the PD05A any more; the D&amp;H CV table marks
-        it as not relevant for those, but the shared definition in Vars_post2012_dc.xml had no
-        such restriction. Now provided by doehler_haass/cv112_fw3.12-3.14.xml, which also carries
-        D&amp;H's documented default of 15 rather than 0.
-        -->
   <version version="1" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20260725"/>
-  <!--  Creation (new firmware 3.14.095).
-        Based on Doehler_Haass_fw3.13_FH05B-22A.xml
-        Changes in firmware 3.14 relative to 3.13, per the D&amp;H ChangeLog:
-          - CV144 bit 5, disabling the restoration of the last driving state.
-        The CV set is otherwise identical to firmware 3.13.
+  <!--  Creation (new firmware 3.15.016).
+        Based on Doehler_Haass_fw3.14_FH05B-22A.xml
+        Changes in firmware 3.15 relative to 3.14:
+          - CV60 becomes a settings register: bit 1 enables a minimum speed step for the
+            brake ramp, bits 2 and 3 configure the shuttle mode (Pendelbetrieb).
+          - CV101-103 map AUX10-AUX12 on the DH21B, DH22B and DH24A.
+          - CV461, 463, 465 and 467 dim AUX3-AUX6 (odd addresses only).
+          - CV156 gains bits 4-7, dimming AUX3-AUX6; its range widens to 0-255.
+          - CV112 widens from 0-31 to 0-127.
+          - CV63 and CV65 change meaning depending on CV60.
         -->
   <decoder>
-    <family name="Function Decoders (firmware 3.14+)" mfg="Doehler und Haass">
-      <model model="FH05B (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="6" numFns="16" productID="41" comment="FH05B-0 / FH05B-1 / FH05B-3 with update from May 2020" maxInputVolts="30V" maxTotalCurrent="0.5A" connector="Wires/NEM651">
+    <family name="Function Decoders (firmware 3.15+)" mfg="Doehler und Haass">
+      <model model="FH05B (firmware 3.15.016+)" lowVersionID="16" highVersionID="16" numOuts="6" numFns="16" productID="41" comment="FH05B-0 / FH05B-1 / FH05B-3 with update from May 2020" maxInputVolts="30V" maxTotalCurrent="0.5A" connector="Wires/NEM651">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -69,7 +68,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="FH16A (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="8" numFns="16" productID="150" comment="FH16A-4, PluX16 direct plug" maxInputVolts="30V" maxTotalCurrent="1.5A" connector="PluX16">
+      <model model="FH16A (firmware 3.15.016+)" lowVersionID="16" highVersionID="16" numOuts="8" numFns="16" productID="150" comment="FH16A-4, PluX16 direct plug" maxInputVolts="30V" maxTotalCurrent="1.5A" connector="PluX16">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -117,7 +116,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="FH18A (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="8" numFns="18" productID="170" comment="FH18A with update from May 2020" maxInputVolts="30V" maxTotalCurrent="1.0A" connector="Next18">
+      <model model="FH18A (firmware 3.15.016+)" lowVersionID="16" highVersionID="16" numOuts="8" numFns="18" productID="170" comment="FH18A with update from May 2020" maxInputVolts="30V" maxTotalCurrent="1.0A" connector="Next18">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -165,7 +164,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="FH22A (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="8" numFns="18" productID="192" comment="FH22A with update from May 2020" maxInputVolts="30V" maxTotalCurrent="2.0A" connector="PluX22">
+      <model model="FH22A (firmware 3.15.016+)" lowVersionID="16" highVersionID="16" numOuts="8" numFns="18" productID="192" comment="FH22A with update from May 2020" maxInputVolts="30V" maxTotalCurrent="2.0A" connector="PluX22">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -244,8 +243,13 @@
 <!-- relevant für FH ??? Start-->
       <!--              - Extra general options as of fw3.10 -->
       <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv144_bits1-4.xml"/>
-      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv112_fw3.12-3.14.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv144_bit5_fw3.14.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv60_bits1-3_fw3.15.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv63_fw3.15.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv65_fw3.15.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv112_fw3.15.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv156_bits4-7_fw3.15.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv461-467_fw3.15.xml"/>
 <!-- relevant für FH ??? Ende-->
       <!-- SECTION 7    - Extra SUSI options as of fw3.03 -->
       <!-- RK xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv137_susi_fw3.03.xml"/-->

--- a/xml/decoders/doehler_haass/Pane_StartBrakeShunt.xml
+++ b/xml/decoders/doehler_haass/Pane_StartBrakeShunt.xml
@@ -36,6 +36,26 @@
 				<display item="Nbr of braking sections"/>
 			</row>
 		</griditem>
+		<!-- CV60 became a settings register in firmware 3.15. Gated on the variable existing
+		     rather than on a family name, so any later firmware that includes
+		     doehler_haass/cv60_bits1-3_fw3.15.xml picks these up without editing this pane. -->
+		<group>
+			<qualifier>
+			  <variableref>Shuttle mode</variableref>
+			  <relation>exists</relation>
+			  <value>1</value>
+			</qualifier>
+			<griditem gridx="0" gridy="NEXT" gridwidth="3">
+				<row>
+					<display item="Minimum speed step for brake ramp" format="checkbox"/>
+				</row>
+			</griditem>
+			<griditem gridx="0" gridy="NEXT" gridwidth="3">
+				<row>
+					<display item="Shuttle mode"/>
+				</row>
+			</griditem>
+		</group>
 		<griditem gridx="0" gridy="1" gridwidth="3">
 			<label>
       			<text> </text>

--- a/xml/decoders/doehler_haass/Pane_StartBrakeShunt.xml
+++ b/xml/decoders/doehler_haass/Pane_StartBrakeShunt.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet type="text/xsl" href="../XSLT/decoder.xsl"?>
+<!-- version 4 - 2026-07-25 - PB - add CV60 brake ramp minimum and shuttle mode (fw 3.15) -->
 <!-- version 3 - 2020-04-30 - RK - Add CV160 to CV165, CV390, Cv391  -->
 <!-- version 2 - 2019-07-28 - ALM - Add CV144 bits 3 & 4, CV154 and CV155"  -->
 <!-- version 2 - 2018-02-04 - ALM - Add CV65 "Max Speed Braking Section 2"  -->

--- a/xml/decoders/doehler_haass/Pane_common.xml
+++ b/xml/decoders/doehler_haass/Pane_common.xml
@@ -431,6 +431,14 @@
 				  <display item="Function to deactivate start delay"/>
 				  <display item="Function for dimmed lights"/>
 				  <display item="Function for shunting speed"/>
+				  <display item="F1 starts delay" format="checkbox"/>
+				  <display item="F2 starts delay" format="checkbox"/>
+				  <display item="F3 starts delay" format="checkbox"/>
+				  <display item="F4 starts delay" format="checkbox"/>
+				  <display item="F5 starts delay" format="checkbox"/>
+				  <display item="F6 starts delay" format="checkbox"/>
+				  <display item="F7 starts delay" format="checkbox"/>
+				  <display item="F8 starts delay" format="checkbox"/>
 			  </column>
 		  </griditem>
 		</group>

--- a/xml/decoders/doehler_haass/Pane_common.xml
+++ b/xml/decoders/doehler_haass/Pane_common.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet type="text/xsl" href="../XSLT/decoder.xsl"?>
+<!-- version 6 - 2026-07-25 - PB - add CV124 as eight bits -->
 <!-- version 5 - 2020-05-03 - RK - correction of a very small spelling mistake -->
 <!-- version 4 - 2015-10-14 - PB - grids added and new SD fw functions -->
 <!-- version 3 - 2015-03-05 - PB - Spelling.  -->

--- a/xml/decoders/doehler_haass/Pane_common_fw3.10.xml
+++ b/xml/decoders/doehler_haass/Pane_common_fw3.10.xml
@@ -61,6 +61,52 @@
               <display item="AUX 2 dimming" label="" format="hslider"/>
             </row>
           </griditem>
+          <!-- AUX3-AUX6 dimming levels, CV461/463/465/467, new in firmware 3.15. Gated on the
+               variable existing rather than on a family name, so later firmware definitions that
+               include doehler_haass/cv461-467_fw3.15.xml pick these up without editing this pane. -->
+          <group>
+            <qualifier>
+              <variableref>AUX 3 dimming</variableref>
+              <relation>exists</relation>
+              <value>1</value>
+            </qualifier>
+            <griditem gridx="0" gridy="NEXT" gridwidth="1" anchor="LINE_END">
+              <row>
+                <display item="AUX 3 dimming"/>
+                <label>
+                  <text> </text>
+                </label>
+                <display item="AUX 3 dimming" label="" format="hslider"/>
+              </row>
+            </griditem>
+            <griditem gridx="0" gridy="NEXT" gridwidth="1" anchor="LINE_END">
+              <row>
+                <display item="AUX 4 dimming"/>
+                <label>
+                  <text> </text>
+                </label>
+                <display item="AUX 4 dimming" label="" format="hslider"/>
+              </row>
+            </griditem>
+            <griditem gridx="0" gridy="NEXT" gridwidth="1" anchor="LINE_END">
+              <row>
+                <display item="AUX 5 dimming"/>
+                <label>
+                  <text> </text>
+                </label>
+                <display item="AUX 5 dimming" label="" format="hslider"/>
+              </row>
+            </griditem>
+            <griditem gridx="0" gridy="NEXT" gridwidth="1" anchor="LINE_END">
+              <row>
+                <display item="AUX 6 dimming"/>
+                <label>
+                  <text> </text>
+                </label>
+                <display item="AUX 6 dimming" label="" format="hslider"/>
+              </row>
+            </griditem>
+          </group>
         </grid>
         <!-- END - Dimming grid -->
       </column>
@@ -113,6 +159,35 @@
               <display item="Dim AUX2" format="checkbox"/>
             </row>
           </griditem>
+          <!-- CV156 bits 4-7, dimming mask for AUX3-AUX6, new in firmware 3.15. Gated on the
+               variable existing, as above. -->
+          <group>
+            <qualifier>
+              <variableref>Dim AUX3</variableref>
+              <relation>exists</relation>
+              <value>1</value>
+            </qualifier>
+            <griditem gridx="0" gridy="NEXT" gridwidth="1" anchor="LINE_END">
+              <row>
+                <display item="Dim AUX3" format="checkbox"/>
+              </row>
+            </griditem>
+            <griditem gridx="0" gridy="NEXT" gridwidth="1" anchor="LINE_END">
+              <row>
+                <display item="Dim AUX4" format="checkbox"/>
+              </row>
+            </griditem>
+            <griditem gridx="0" gridy="NEXT" gridwidth="1" anchor="LINE_END">
+              <row>
+                <display item="Dim AUX5" format="checkbox"/>
+              </row>
+            </griditem>
+            <griditem gridx="0" gridy="NEXT" gridwidth="1" anchor="LINE_END">
+              <row>
+                <display item="Dim AUX6" format="checkbox"/>
+              </row>
+            </griditem>
+          </group>
         </grid>
         <!-- END - Dimming mask -->
       </column>

--- a/xml/decoders/doehler_haass/Pane_common_fw3.10.xml
+++ b/xml/decoders/doehler_haass/Pane_common_fw3.10.xml
@@ -559,6 +559,14 @@
 				  <display item="Function to deactivate start delay"/>
 				  <display item="Function for dimmed lights"/>
 				  <display item="Function for shunting speed"/>
+				  <display item="F1 starts delay" format="checkbox"/>
+				  <display item="F2 starts delay" format="checkbox"/>
+				  <display item="F3 starts delay" format="checkbox"/>
+				  <display item="F4 starts delay" format="checkbox"/>
+				  <display item="F5 starts delay" format="checkbox"/>
+				  <display item="F6 starts delay" format="checkbox"/>
+				  <display item="F7 starts delay" format="checkbox"/>
+				  <display item="F8 starts delay" format="checkbox"/>
 			  </column>
 		  </griditem>
 		</group>

--- a/xml/decoders/doehler_haass/Pane_common_fw3.10.xml
+++ b/xml/decoders/doehler_haass/Pane_common_fw3.10.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet type="text/xsl" href="../XSLT/decoder.xsl"?>
+<!-- version 7 - 2026-07-25 - PB - add AUX3-AUX6 dimming and dim mask (fw 3.15), and CV124 as eight bits -->
 <!-- version 6 - 2023-07-17 - RK - disable unimplemented options for PD10MU -->
 <!-- version 5 - 2020-05-02 - RK - added initialmapping functions -->
 <!-- version 4 - 2015-10-14 - PB - grids added and new SD fw functions -->

--- a/xml/decoders/doehler_haass/Pane_function_swapping_nonsound.xml
+++ b/xml/decoders/doehler_haass/Pane_function_swapping_nonsound.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet type="text/xsl" href="../XSLT/decoder.xsl"?>
+<!-- version 1 - 2026-07-25 - PB - new file - function swapping pane for the non-sound decoders -->
 <!-- Copyright (C) JMRI 2001, 2005, 2007, 2-009, 2010 All rights reserved -->
 <!--                                                                        -->
 <!-- JMRI is free software; you can redistribute it and/or modify it under  -->

--- a/xml/decoders/doehler_haass/Pane_function_swapping_nonsound.xml
+++ b/xml/decoders/doehler_haass/Pane_function_swapping_nonsound.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet type="text/xsl" href="../XSLT/decoder.xsl"?>
+<!-- Copyright (C) JMRI 2001, 2005, 2007, 2-009, 2010 All rights reserved -->
+<!--                                                                        -->
+<!-- JMRI is free software; you can redistribute it and/or modify it under  -->
+<!-- the terms of version 2 of the GNU General Public License as published  -->
+<!-- by the Free Software Foundation. See the "COPYING" file for a copy     -->
+<!-- of this license.                                                       -->
+<!--                                                                        -->
+<!-- JMRI is distributed in the hope that it will be useful, but WITHOUT    -->
+<!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
+<!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
+<!-- for more details.                                                      -->
+<pane xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd" exclude="130,131,132,133,134">
+  <!-- Function swapping pane for the NON-SOUND decoders (CV401-412, range 0-29).            -->
+  <!-- The sound decoders have their own Pane_function_swapping.xml, whose numeric legend     -->
+  <!-- also covers the sound-only values 30-46. Here the choices are shown by name in the     -->
+  <!-- drop-downs, so no numeric legend is needed.                                            -->
+  <!-- CV137 bit 6 is shown here too: it decides whether these swappings also apply to SUSI.  -->
+  <!-- The exclude on the pane element is required, not just on the variables: this is a      -->
+  <!-- CUSTOM pane name, and custom panes always show even when empty, regardless of the      -->
+  <!-- showEmptyPanes="no" on the decoder-config. Only a pane-level exclude suppresses it.    -->
+  <name>Function Swapping</name>
+  <name xml:lang="fr">Permutation de fonctions</name>
+  <name xml:lang="de">Funktionsvertauschung</name>
+  <column>
+    <row>
+      <column>
+        <display item="Function Swapping F1"/>
+        <display item="Function Swapping F2"/>
+        <display item="Function Swapping F3"/>
+        <display item="Function Swapping F4"/>
+        <display item="Function Swapping F5"/>
+        <display item="Function Swapping F6"/>
+      </column>
+      <column>
+        <label><text>     </text></label>
+      </column>
+      <column>
+        <display item="Function Swapping F7"/>
+        <display item="Function Swapping F8"/>
+        <display item="Function Swapping F9"/>
+        <display item="Function Swapping F10"/>
+        <display item="Function Swapping F11"/>
+        <display item="Function Swapping F12"/>
+      </column>
+    </row>
+    <separator/>
+    <row>
+      <column>
+        <display item="Adopt function swapping for SUSI" format="checkbox"/>
+      </column>
+    </row>
+  </column>
+</pane>

--- a/xml/decoders/doehler_haass/Pane_functionmap.xml
+++ b/xml/decoders/doehler_haass/Pane_functionmap.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- version 1 - 2026-07-25 - PB - gate the AUX 7+ note by product ID and include the DH24A -->
 <pane xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/programmer.xsd">
   <name>Function Map</name>
   <name xml:lang="ca">Mapejat de funcions</name>

--- a/xml/decoders/doehler_haass/Pane_functionmap.xml
+++ b/xml/decoders/doehler_haass/Pane_functionmap.xml
@@ -29,9 +29,9 @@
              across firmware versions, unlike the model names. -->
         <group include="201,203,204">
         <label>
-          <text>With types DH21B, DH22B and DH24A, the F-button for AUX 7 and AUX 8 is selected from a list!</text>
-          <text xml:lang="fr">Sur les DH21B, DH22B et DH24A, la touche F pour AUX 7 et AUX 8 se choisit dans une liste !</text>
-          <text xml:lang="de">Bei den Typen DH21B, DH22B und DH24A wird die F-Taste für AUX 7 und AUX 8 aus einer Liste gewählt!</text>
+          <text>With types DH21B, DH22B and DH24A, the F-button for AUX 7 and above is selected from a list!</text>
+          <text xml:lang="fr">Sur les DH21B, DH22B et DH24A, la touche F pour AUX 7 et au-delà se choisit dans une liste !</text>
+          <text xml:lang="de">Bei den Typen DH21B, DH22B und DH24A wird die F-Taste für AUX 7 und höher aus einer Liste gewählt!</text>
         </label>
         </group>
         <label>

--- a/xml/decoders/doehler_haass/Pane_functionmap.xml
+++ b/xml/decoders/doehler_haass/Pane_functionmap.xml
@@ -25,10 +25,13 @@
         <label>
           <text> </text>
         </label>
-        <group include="DH21B (firmware 3.13.053+),DH22B (firmware 3.13.053+)">
+        <!-- Gated by productID: 201 = DH21B, 203 = DH22B, 204 = DH24A. Product IDs are stable
+             across firmware versions, unlike the model names. -->
+        <group include="201,203,204">
         <label>
-          <text>With types DH21B and DH22B, the F-button for AUX 7 and AUX 8 is selected from a list!</text>
-          <text xml:lang="de">Bei den Typen DH21B und DH22B wird die F-Taste für AUX 7 und AUX 8 aus einer Liste gewählt!</text>
+          <text>With types DH21B, DH22B and DH24A, the F-button for AUX 7 and AUX 8 is selected from a list!</text>
+          <text xml:lang="fr">Sur les DH21B, DH22B et DH24A, la touche F pour AUX 7 et AUX 8 se choisit dans une liste !</text>
+          <text xml:lang="de">Bei den Typen DH21B, DH22B und DH24A wird die F-Taste für AUX 7 und AUX 8 aus einer Liste gewählt!</text>
         </label>
         </group>
         <label>

--- a/xml/decoders/doehler_haass/Vars_common.xml
+++ b/xml/decoders/doehler_haass/Vars_common.xml
@@ -44,6 +44,12 @@
   </authorgroup>
   <revhistory xmlns="http://docbook.org/ns/docbook">
     <revision>
+      <revnumber>12</revnumber>
+      <date>2026-07-25</date>
+      <authorinitials>PB</authorinitials>
+      <revremark>Exclude CV63 for the firmware 3.15 families</revremark>
+    </revision>
+    <revision>
       <revnumber>11</revnumber>
       <date>2023-07-22</date>
       <authorinitials>RK</authorinitials>

--- a/xml/decoders/doehler_haass/Vars_common.xml
+++ b/xml/decoders/doehler_haass/Vars_common.xml
@@ -1012,7 +1012,7 @@
     <label xml:lang="de">Kennlinie</label>
     <label xml:lang="ca">Tipus de corba de velocitat</label>
   </variable>
-  <variable CV="63" default="0" item="Start delay for speed step 1" tooltip="CV63 (0-250)" exclude="Combo sound decoders,Sound Decoders (2016),Sound Decoders (2018),Sound Decoders (2020),Sound Decoders (2022)">
+  <variable CV="63" default="0" item="Start delay for speed step 1" tooltip="CV63 (0-250)" exclude="Combo sound decoders,Sound Decoders (2016),Sound Decoders (2018),Sound Decoders (2020),Sound Decoders (2022),Train Decoders (firmware 3.15+),Function Decoders (firmware 3.15+)">
     <decVal min="0" max="250"/>
     <label>Start delay for speed step 1</label>
     <label xml:lang="it">Inizio ritardo velocità step 1</label>

--- a/xml/decoders/doehler_haass/Vars_post2012_dc.xml
+++ b/xml/decoders/doehler_haass/Vars_post2012_dc.xml
@@ -36,6 +36,12 @@
 		even with the latest firmware upgrades.
 	  </revremark>
     </revision>
+    <revision>
+      <revnumber>2</revnumber>
+      <date>2026-07-25</date>
+      <authorinitials>PB</authorinitials>
+      <revremark>Exclude CV112 for the firmware 3.12+ families; correct its default to 15</revremark>
+    </revision>
   </revhistory>
   <variable CV="112" default="15" item="DC Brake Momentum" tooltip="CV112 (0:none, 31:strong)" exclude="Train Decoders (2020),Function Decoders (2020),Train Decoders (2023),Function Decoders (2023),Train Decoders (firmware 3.14+),Function Decoders (firmware 3.14+),Train Decoders (firmware 3.15+),Function Decoders (firmware 3.15+)">
     <decVal min="0" max="31"/>

--- a/xml/decoders/doehler_haass/cv101-103_fw3.15.xml
+++ b/xml/decoders/doehler_haass/cv101-103_fw3.15.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet type="text/xsl" href="../XSLT/decoder.xsl"?>
+<!-- Copyright (C) JMRI 2001, 2005, 2007, 2-009, 2010 All rights reserved -->
+<!--                                                                        -->
+<!-- JMRI is free software; you can redistribute it and/or modify it under  -->
+<!-- the terms of version 2 of the GNU General Public License as published  -->
+<!-- by the Free Software Foundation. See the "COPYING" file for a copy     -->
+<!-- of this license.                                                       -->
+<!--                                                                        -->
+<!-- JMRI is distributed in the hope that it will be useful, but WITHOUT    -->
+<!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
+<!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
+<!-- for more details.                                                      -->
+<variables xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+  <copyright xmlns="http://docbook.org/ns/docbook">
+    <year>2026</year>
+    <holder>JMRI</holder>
+  </copyright>
+  <authorgroup xmlns="http://docbook.org/ns/docbook">
+    <author>
+      <personname>
+        <firstname>Pierre</firstname>
+        <surname>Billon</surname>
+      </personname>
+    </author>
+  </authorgroup>
+  <revhistory xmlns="http://docbook.org/ns/docbook">
+    <revision>
+      <revnumber>1</revnumber>
+      <date>2026-07-25</date>
+      <authorinitials>PB</authorinitials>
+      <revremark>Creation. CV101-103, AUX10-AUX12 function mapping, new in firmware 3.15.</revremark>
+    </revision>
+  </revhistory>
+  <!-- CV101-103 map AUX10, AUX11 and AUX12; new in firmware 3.15 and only on the DH21B,      -->
+  <!-- DH22B and DH24A (product IDs 201, 203, 204).                                            -->
+  <!-- The item names use the "F<n> controls output <m>" form so that the standard function     -->
+  <!-- map grid renders them as drop-downs, exactly as CV98/99 do for AUX7 and AUX8. Outputs    -->
+  <!-- 11, 12 and 13 are AUX10, AUX11 and AUX12 in the DH24A output list.                       -->
+  <variable item="F4 controls output 11" CV="101" default="12" include="201,203,204">
+    <xi:include href="http://jmri.org/xml/decoders/doehler_haass/Susi-SD_enum-map.xml"/>
+    <label>Function mapping AUX10</label>
+    <label xml:lang="fr">Affectation de fonction AUX10</label>
+    <label xml:lang="de">Funktionszuordnung AUX10</label>
+    <tooltip>CV101: 0 = off, 1-28 = F1-F28, 29 = F0 (light)</tooltip>
+    <tooltip xml:lang="fr">CV101 : 0 = désactivé, 1-28 = F1-F28, 29 = F0 (feux)</tooltip>
+    <tooltip xml:lang="de">CV101: 0 = deaktiviert, 1-28 = F1-F28, 29 = F0 (Licht)</tooltip>
+  </variable>
+  <variable item="F4 controls output 12" CV="102" default="13" include="201,203,204">
+    <xi:include href="http://jmri.org/xml/decoders/doehler_haass/Susi-SD_enum-map.xml"/>
+    <label>Function mapping AUX11</label>
+    <label xml:lang="fr">Affectation de fonction AUX11</label>
+    <label xml:lang="de">Funktionszuordnung AUX11</label>
+    <tooltip>CV102: 0 = off, 1-28 = F1-F28, 29 = F0 (light)</tooltip>
+    <tooltip xml:lang="fr">CV102 : 0 = désactivé, 1-28 = F1-F28, 29 = F0 (feux)</tooltip>
+    <tooltip xml:lang="de">CV102: 0 = deaktiviert, 1-28 = F1-F28, 29 = F0 (Licht)</tooltip>
+  </variable>
+  <variable item="F4 controls output 13" CV="103" default="14" include="201,203,204">
+    <xi:include href="http://jmri.org/xml/decoders/doehler_haass/Susi-SD_enum-map.xml"/>
+    <label>Function mapping AUX12</label>
+    <label xml:lang="fr">Affectation de fonction AUX12</label>
+    <label xml:lang="de">Funktionszuordnung AUX12</label>
+    <tooltip>CV103: 0 = off, 1-28 = F1-F28, 29 = F0 (light)</tooltip>
+    <tooltip xml:lang="fr">CV103 : 0 = désactivé, 1-28 = F1-F28, 29 = F0 (feux)</tooltip>
+    <tooltip xml:lang="de">CV103: 0 = deaktiviert, 1-28 = F1-F28, 29 = F0 (Licht)</tooltip>
+  </variable>
+</variables>

--- a/xml/decoders/doehler_haass/cv112_fw3.12-3.14.xml
+++ b/xml/decoders/doehler_haass/cv112_fw3.12-3.14.xml
@@ -13,7 +13,7 @@
 <!-- for more details.                                                      -->
 <variables xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
   <copyright xmlns="http://docbook.org/ns/docbook">
-    <year>2014</year>
+    <year>2026</year>
     <holder>JMRI</holder>
   </copyright>
   <authorgroup xmlns="http://docbook.org/ns/docbook">
@@ -27,22 +27,30 @@
   <revhistory xmlns="http://docbook.org/ns/docbook">
     <revision>
       <revnumber>1</revnumber>
-      <date>2014-02-20</date>
+      <date>2026-07-25</date>
       <authorinitials>PB</authorinitials>
-      <revremark>This file contains only variables that are common to D&amp;H decoders released
-		after around 2012 that support DC operation (as of 2014-02: all except the
-		DH06A).
-		Those CVs don't seem to be able applicable to older decoders,
-		even with the latest firmware upgrades.
-	  </revremark>
+      <revremark>Creation. CV112 for firmware 3.12 to 3.14, excluded for FH* and PD05A.</revremark>
     </revision>
   </revhistory>
-  <variable CV="112" default="15" item="DC Brake Momentum" tooltip="CV112 (0:none, 31:strong)" exclude="Train Decoders (2020),Function Decoders (2020),Train Decoders (2023),Function Decoders (2023),Train Decoders (firmware 3.14+),Function Decoders (firmware 3.14+),Train Decoders (firmware 3.15+),Function Decoders (firmware 3.15+)">
+  <!-- Not relevant for the FH* series (product IDs 41, 150, 170, 192) or the PD05A (131),     -->
+  <!-- per the D&H CV table. Gated by product ID so the fragment behaves the same whichever    -->
+  <!-- definition includes it.                                                                -->
+  <!-- CV112 for firmware 3.12 to 3.14, range 0-31. Identical to the definition in            -->
+  <!-- Vars_post2012_dc.xml except that it is not offered on the FH* series or the PD05A, which -->
+  <!-- the D&H CV table marks it as not relevant for, and it carries D&H's documented default   -->
+  <!-- of 15. Vars_post2012_dc.xml excludes these families instead.                            -->
+  <!--                                                                                          -->
+  <!-- The FH*/PD05A restriction is NOT retrospective: the D&H CV tables for 3.02, 3.03, 3.04    -->
+  <!-- and 3.05 carry no such note, so those definitions correctly still offer CV112 on the      -->
+  <!-- FH05A. The restriction first appears in the 3.12 table. No tables exist for 3.06-3.11,    -->
+  <!-- so those definitions are left alone.                                                     -->
+  <variable CV="112" default="15" item="DC Brake Momentum" exclude="41,150,170,192,131">
     <decVal min="0" max="31"/>
     <label>Speed reduction in DC mode</label>
-    <label xml:lang="it">Riduzione velocità in analogico</label>
     <label xml:lang="fr">Réduction vitesse en analogique</label>
     <label xml:lang="de">Geschw.-minderung in Analog</label>
-    <label xml:lang="ca">Reducció de velocitat en CC</label>
+    <tooltip>CV112: 0 = small reduction … 31 = strong reduction</tooltip>
+    <tooltip xml:lang="fr">CV112 : 0 = faible réduction … 31 = forte réduction</tooltip>
+    <tooltip xml:lang="de">CV112: 0 = geringe Minderung … 31 = starke Minderung</tooltip>
   </variable>
 </variables>

--- a/xml/decoders/doehler_haass/cv112_fw3.15.xml
+++ b/xml/decoders/doehler_haass/cv112_fw3.15.xml
@@ -13,7 +13,7 @@
 <!-- for more details.                                                      -->
 <variables xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
   <copyright xmlns="http://docbook.org/ns/docbook">
-    <year>2014</year>
+    <year>2026</year>
     <holder>JMRI</holder>
   </copyright>
   <authorgroup xmlns="http://docbook.org/ns/docbook">
@@ -27,22 +27,24 @@
   <revhistory xmlns="http://docbook.org/ns/docbook">
     <revision>
       <revnumber>1</revnumber>
-      <date>2014-02-20</date>
+      <date>2026-07-25</date>
       <authorinitials>PB</authorinitials>
-      <revremark>This file contains only variables that are common to D&amp;H decoders released
-		after around 2012 that support DC operation (as of 2014-02: all except the
-		DH06A).
-		Those CVs don't seem to be able applicable to older decoders,
-		even with the latest firmware upgrades.
-	  </revremark>
+      <revremark>Creation. CV112 with the firmware 3.15 range of 0-127.</revremark>
     </revision>
   </revhistory>
-  <variable CV="112" default="15" item="DC Brake Momentum" tooltip="CV112 (0:none, 31:strong)" exclude="Train Decoders (2020),Function Decoders (2020),Train Decoders (2023),Function Decoders (2023),Train Decoders (firmware 3.14+),Function Decoders (firmware 3.14+),Train Decoders (firmware 3.15+),Function Decoders (firmware 3.15+)">
-    <decVal min="0" max="31"/>
-    <label>Speed reduction in DC mode</label>
-    <label xml:lang="it">Riduzione velocità in analogico</label>
-    <label xml:lang="fr">Réduction vitesse en analogique</label>
-    <label xml:lang="de">Geschw.-minderung in Analog</label>
-    <label xml:lang="ca">Reducció de velocitat en CC</label>
+  <!-- Not relevant for the FH* series (product IDs 41, 150, 170, 192) or the PD05A (131),     -->
+  <!-- per the D&H CV table. Gated by product ID so the fragment behaves the same whichever    -->
+  <!-- definition includes it.                                                                -->
+  <!-- CV112 widened from 0-31 to 0-127 in firmware 3.15, and D&H renamed it from             -->
+  <!-- "Geschwindigkeitsminderung Analog" to "...Analogbetrieb". Replaces the definition in     -->
+  <!-- Vars_post2012_dc.xml, which is excluded for the firmware 3.15 families.                  -->
+  <variable CV="112" default="15" item="DC Brake Momentum" exclude="41,150,170,192,131">
+    <decVal min="0" max="127"/>
+    <label>Speed reduction in analog operation</label>
+    <label xml:lang="fr">Réduction de vitesse en mode analogique</label>
+    <label xml:lang="de">Geschwindigkeitsminderung Analogbetrieb</label>
+    <tooltip>CV112: 0 = small reduction … 127 = strong reduction</tooltip>
+    <tooltip xml:lang="fr">CV112 : 0 = faible réduction … 127 = forte réduction</tooltip>
+    <tooltip xml:lang="de">CV112: 0 = geringe Minderung … 127 = starke Minderung</tooltip>
   </variable>
 </variables>

--- a/xml/decoders/doehler_haass/cv124_fw3.06.xml
+++ b/xml/decoders/doehler_haass/cv124_fw3.06.xml
@@ -34,10 +34,81 @@
       <revremark>for fw 3.06 and 3.07</revremark>
     </revision>
    </revhistory>
-  <variable item="F-Key Accel Delay" CV="124" mask="VVVVVVVV">
-    <xi:include href="http://jmri.org/xml/decoders/doehler_haass/choice-F1F8.xml"/>
-    <label>Acceleration Delay</label>
-    <label xml:lang="de">Anfahrverzögerung F-Taste</label>
-    <label xml:lang="ca">Retard d'acceleració</label>
+  <!-- CV124 is a bit mask, not a selection: D&H document "Bit 0 = F1 ... Bit 7 = F8",       -->
+  <!-- range 0-255, so several keys can start the delay at once. It was previously a single  -->
+  <!-- 10-entry enumeration on the whole byte, which could only ever produce 10 of the 256   -->
+  <!-- possible values. Now eight one-bit variables, matching CV125-CV128 which share the    -->
+  <!-- same format. The delay itself is CV63.                                                -->
+  <variable item="F1 starts delay" CV="124" mask="XXXXXXXV">
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+    <label>F1 activates the starting delay</label>
+    <label xml:lang="fr">F1 active le retard au démarrage</label>
+    <label xml:lang="de">F1 aktiviert die Anfahrverzögerung</label>
+    <tooltip>CV124 bit 0 - the delay itself is set in CV63</tooltip>
+    <tooltip xml:lang="fr">CV124 bit 0 - le retard lui-même se règle au CV63</tooltip>
+    <tooltip xml:lang="de">CV124 Bit 0 - die Verzögerung selbst wird in CV63 eingestellt</tooltip>
+  </variable>
+  <variable item="F2 starts delay" CV="124" mask="XXXXXXVX">
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+    <label>F2 activates the starting delay</label>
+    <label xml:lang="fr">F2 active le retard au démarrage</label>
+    <label xml:lang="de">F2 aktiviert die Anfahrverzögerung</label>
+    <tooltip>CV124 bit 1 - the delay itself is set in CV63</tooltip>
+    <tooltip xml:lang="fr">CV124 bit 1 - le retard lui-même se règle au CV63</tooltip>
+    <tooltip xml:lang="de">CV124 Bit 1 - die Verzögerung selbst wird in CV63 eingestellt</tooltip>
+  </variable>
+  <variable item="F3 starts delay" CV="124" mask="XXXXXVXX">
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+    <label>F3 activates the starting delay</label>
+    <label xml:lang="fr">F3 active le retard au démarrage</label>
+    <label xml:lang="de">F3 aktiviert die Anfahrverzögerung</label>
+    <tooltip>CV124 bit 2 - the delay itself is set in CV63</tooltip>
+    <tooltip xml:lang="fr">CV124 bit 2 - le retard lui-même se règle au CV63</tooltip>
+    <tooltip xml:lang="de">CV124 Bit 2 - die Verzögerung selbst wird in CV63 eingestellt</tooltip>
+  </variable>
+  <variable item="F4 starts delay" CV="124" mask="XXXXVXXX">
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+    <label>F4 activates the starting delay</label>
+    <label xml:lang="fr">F4 active le retard au démarrage</label>
+    <label xml:lang="de">F4 aktiviert die Anfahrverzögerung</label>
+    <tooltip>CV124 bit 3 - the delay itself is set in CV63</tooltip>
+    <tooltip xml:lang="fr">CV124 bit 3 - le retard lui-même se règle au CV63</tooltip>
+    <tooltip xml:lang="de">CV124 Bit 3 - die Verzögerung selbst wird in CV63 eingestellt</tooltip>
+  </variable>
+  <variable item="F5 starts delay" CV="124" mask="XXXVXXXX">
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+    <label>F5 activates the starting delay</label>
+    <label xml:lang="fr">F5 active le retard au démarrage</label>
+    <label xml:lang="de">F5 aktiviert die Anfahrverzögerung</label>
+    <tooltip>CV124 bit 4 - the delay itself is set in CV63</tooltip>
+    <tooltip xml:lang="fr">CV124 bit 4 - le retard lui-même se règle au CV63</tooltip>
+    <tooltip xml:lang="de">CV124 Bit 4 - die Verzögerung selbst wird in CV63 eingestellt</tooltip>
+  </variable>
+  <variable item="F6 starts delay" CV="124" mask="XXVXXXXX">
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+    <label>F6 activates the starting delay</label>
+    <label xml:lang="fr">F6 active le retard au démarrage</label>
+    <label xml:lang="de">F6 aktiviert die Anfahrverzögerung</label>
+    <tooltip>CV124 bit 5 - the delay itself is set in CV63</tooltip>
+    <tooltip xml:lang="fr">CV124 bit 5 - le retard lui-même se règle au CV63</tooltip>
+    <tooltip xml:lang="de">CV124 Bit 5 - die Verzögerung selbst wird in CV63 eingestellt</tooltip>
+  </variable>
+  <variable item="F7 starts delay" CV="124" mask="XVXXXXXX">
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+    <label>F7 activates the starting delay</label>
+    <label xml:lang="fr">F7 active le retard au démarrage</label>
+    <label xml:lang="de">F7 aktiviert die Anfahrverzögerung</label>
+    <tooltip>CV124 bit 6 - the delay itself is set in CV63</tooltip>
+    <tooltip xml:lang="fr">CV124 bit 6 - le retard lui-même se règle au CV63</tooltip>
+    <tooltip xml:lang="de">CV124 Bit 6 - die Verzögerung selbst wird in CV63 eingestellt</tooltip>
+  </variable>
+  <variable item="F8 starts delay" CV="124" mask="VXXXXXXX">
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+    <label>F8 activates the starting delay</label>
+    <label xml:lang="fr">F8 active le retard au démarrage</label>
+    <label xml:lang="de">F8 aktiviert die Anfahrverzögerung</label>
+    <tooltip>CV124 bit 7 - the delay itself is set in CV63</tooltip>
+    <tooltip xml:lang="fr">CV124 bit 7 - le retard lui-même se règle au CV63</tooltip>
+    <tooltip xml:lang="de">CV124 Bit 7 - die Verzögerung selbst wird in CV63 eingestellt</tooltip>
   </variable>
 </variables>

--- a/xml/decoders/doehler_haass/cv124_fw3.06.xml
+++ b/xml/decoders/doehler_haass/cv124_fw3.06.xml
@@ -33,6 +33,12 @@
       <authorinitials>RK</authorinitials>
       <revremark>for fw 3.06 and 3.07</revremark>
     </revision>
+    <revision>
+      <revnumber>2</revnumber>
+      <date>2026-07-25</date>
+      <authorinitials>PB</authorinitials>
+      <revremark>CV124 is a bit mask over F1-F8, not a single choice; now eight bits</revremark>
+    </revision>
    </revhistory>
   <!-- CV124 is a bit mask, not a selection: D&H document "Bit 0 = F1 ... Bit 7 = F8",       -->
   <!-- range 0-255, so several keys can start the delay at once. It was previously a single  -->

--- a/xml/decoders/doehler_haass/cv125-133_fw3.06.xml
+++ b/xml/decoders/doehler_haass/cv125-133_fw3.06.xml
@@ -46,6 +46,12 @@
   </authorgroup>
   <revhistory xmlns="http://docbook.org/ns/docbook">
     <revision>
+      <revnumber>5</revnumber>
+      <date>2026-07-25</date>
+      <authorinitials>PB</authorinitials>
+      <revremark>Correct the CV131-133 defaults, English labels and tooltips</revremark>
+    </revision>
+    <revision>
       <revnumber>4</revnumber>
       <date>2023-07-15</date>
       <authorinitials>RK</authorinitials>

--- a/xml/decoders/doehler_haass/cv125-133_fw3.06.xml
+++ b/xml/decoders/doehler_haass/cv125-133_fw3.06.xml
@@ -348,28 +348,31 @@
     <tooltip xml:lang="de">Je 100 ms, 0 = ausgeschaltet</tooltip>
     <tooltip xml:lang="ca">Sí 100 ms, 0 = apagat</tooltip>
   </variable>
-  <variable item="Function for dimmed lights" CV="131" default="1" exclude="130,131,132,133,134,SD18A_1.00,SD18A_1.01,SD21A_1.01,SD18A_1.02,SD21A_1.02,SD18A_1.03,SD21A_1.03">
+  <variable item="Function for dimmed lights" CV="131" default="8" exclude="130,131,132,133,134,SD18A_1.00,SD18A_1.01,SD21A_1.01,SD18A_1.02,SD21A_1.02,SD18A_1.03,SD21A_1.03">
     <xi:include href="http://jmri.org/xml/decoders/doehler_haass/Susi-SD_enum-map.xml"/>
+    <label>Function mapping low beam light</label>
     <label xml:lang="fr">Fonction pour feux réduits</label>
     <label xml:lang="de">Funktionszuordnung Abblendlicht</label>
-    <label xml:lang="ca">Apagat programat de AUX 5</label>
-    <tooltip>CV131: 0=>Off, 1-28=>F1-F8, 29=>F0</tooltip>
+    <label xml:lang="ca">Funció per als llums atenuats</label>
+    <tooltip>CV131: 0=>Off, 1-28=>F1-F28, 29=>F0</tooltip>
     <tooltip xml:lang="de">&lt;html&gt;0 = deaktiviert, 1 … 28 = F1 … F28, 29 = F0 (Licht)&lt;br&gt;Nur bei CV137 Bit 4 = 1&lt;/html&gt;</tooltip>
   </variable>
-  <variable item="Function for shunting speed" CV="132" default="1" exclude="PD05A,130,D12A,SD18A_1.00,SD18A_1.01,SD21A_1.01,SD18A_1.02,SD21A_1.02,SD18A_1.03,SD21A_1.03">
+  <variable item="Function for shunting speed" CV="132" default="4" exclude="PD05A,130,D12A,SD18A_1.00,SD18A_1.01,SD21A_1.01,SD18A_1.02,SD21A_1.02,SD18A_1.03,SD21A_1.03">
     <xi:include href="http://jmri.org/xml/decoders/doehler_haass/Susi-SD_enum-map.xml"/>
+    <label>Function mapping shunting gear</label>
     <label xml:lang="fr">Fonction pour marche réduite</label>
     <label xml:lang="de">Funktionszuordnung Rangiergang</label>
-    <label xml:lang="ca">Apagat programat de AUX 5</label>
-    <tooltip>CV132: 0=>Off, 1-28=>F1-F8, 29=>F0</tooltip>
+    <label xml:lang="ca">Funció per a la marxa de maniobres</label>
+    <tooltip>CV132: 0=>Off, 1-28=>F1-F28, 29=>F0</tooltip>
     <tooltip xml:lang="de">&lt;html&gt;0 = deaktiviert, 1 … 28 = F1 … F28, 29 = F0 (Licht)&lt;br&gt;Nur bei CV137 Bit 4 = 1&lt;/html&gt;</tooltip>
   </variable>
-  <variable item="Function to deactivate start delay" CV="133" default="1" exclude="130,131,132,133,134,SD18A_1.00,SD18A_1.01,SD21A_1.01,SD18A_1.02,SD21A_1.02,SD18A_1.03,SD21A_1.03">
+  <variable item="Function to deactivate start delay" CV="133" default="9" exclude="130,131,132,133,134,SD18A_1.00,SD18A_1.01,SD21A_1.01,SD18A_1.02,SD21A_1.02,SD18A_1.03,SD21A_1.03">
     <xi:include href="http://jmri.org/xml/decoders/doehler_haass/Susi-SD_enum-map.xml"/>
-    <label xml:lang="fr">Fonction pour désactiver délai de départ</label>
-    <label xml:lang="de">Funktionszuordnung Verzögerung ausschalten</label>
-    <label xml:lang="ca">Apagat programat de AUX 5</label>
-    <tooltip>CV133: 0=>Off, 1-28=>F1-F8, 29=>F0</tooltip>
+    <label>Function mapping deceleration off</label>
+    <label xml:lang="fr">Fonction pour désactiver les temporisations</label>
+    <label xml:lang="de">Funktionszuordnung Verzögerungen ausschalten</label>
+    <label xml:lang="ca">Funció per desactivar les temporitzacions</label>
+    <tooltip>CV133: switches off the acceleration and deceleration rates (CV3/CV4). 0=>Off, 1-28=>F1-F28, 29=>F0</tooltip>
     <tooltip xml:lang="de">&lt;html&gt;0 = deaktiviert, 1 … 28 = F1 … F28, 29 = F0 (Licht)&lt;br&gt;Nur bei CV137 Bit 4 = 1&lt;/html&gt;</tooltip>
   </variable>
 </variables>

--- a/xml/decoders/doehler_haass/cv137.xml
+++ b/xml/decoders/doehler_haass/cv137.xml
@@ -122,7 +122,7 @@
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
     <label>Deactivate SUSI startup delay</label>
     <label xml:lang="fr">Désactiver délai de départ SUSI</label>
-    <label xml:lang="de">SUSI­Anfahrverzögerung ausschalten</label>
+    <label xml:lang="de">SUSI-Anfahrverzögerung ausschalten</label>
     <tooltip>bit 3</tooltip>
   </variable>
   <variable CV="137" item="Extended mapping" mask="XXXVXXXX" exclude="60,130,131,132,133,134">
@@ -149,7 +149,7 @@
       </enumChoice>
      </enumChoiceGroup>
     </enumVal>
-    <label>SUSI ouputs mapping</label>
+    <label>SUSI outputs mapping</label>
     <label xml:lang="de">AUX an SUSI</label>
     <label xml:lang="ca">AUX en SUSI</label>
     <tooltip>bit5 - Only valid if CV137/Bit 0=1 and Bit 4=1</tooltip>

--- a/xml/decoders/doehler_haass/cv137.xml
+++ b/xml/decoders/doehler_haass/cv137.xml
@@ -44,6 +44,12 @@
   </authorgroup>
   <revhistory xmlns="http://docbook.org/ns/docbook">
     <revision>
+      <revnumber>7</revnumber>
+      <date>2026-07-25</date>
+      <authorinitials>PB</authorinitials>
+      <revremark>Fix a misspelt label and a soft hyphen</revremark>
+    </revision>
+    <revision>
       <revnumber>6</revnumber>
       <date>2023-07-22</date>
       <authorinitials>RK</authorinitials>

--- a/xml/decoders/doehler_haass/cv137_bit6_fw3.13.xml
+++ b/xml/decoders/doehler_haass/cv137_bit6_fw3.13.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet type="text/xsl" href="../XSLT/decoder.xsl"?>
+<!-- Copyright (C) JMRI 2001, 2005, 2007, 2-009, 2010 All rights reserved -->
+<!--                                                                        -->
+<!-- JMRI is free software; you can redistribute it and/or modify it under  -->
+<!-- the terms of version 2 of the GNU General Public License as published  -->
+<!-- by the Free Software Foundation. See the "COPYING" file for a copy     -->
+<!-- of this license.                                                       -->
+<!--                                                                        -->
+<!-- JMRI is distributed in the hope that it will be useful, but WITHOUT    -->
+<!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
+<!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
+<!-- for more details.                                                      -->
+<variables xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+  <copyright xmlns="http://docbook.org/ns/docbook">
+    <year>2026</year>
+    <holder>JMRI</holder>
+  </copyright>
+  <authorgroup xmlns="http://docbook.org/ns/docbook">
+    <author>
+      <personname>
+        <firstname>Pierre</firstname>
+        <surname>Billon</surname>
+      </personname>
+    </author>
+  </authorgroup>
+  <revhistory xmlns="http://docbook.org/ns/docbook">
+    <revision>
+      <revnumber>1</revnumber>
+      <date>2026-07-25</date>
+      <authorinitials>PB</authorinitials>
+      <revremark>Creation. CV137 bit 6, introduced in firmware 3.13.053.</revremark>
+    </revision>
+  </revhistory>
+  <!-- CV137 bit 6 was introduced in firmware 3.13.053, so it is kept out of the shared      -->
+  <!-- cv137.xml (which is also used by firmware 3.05-3.12 and by the sound decoders).       -->
+  <!-- Include this fragment only from firmware 3.13 and later definitions.                  -->
+  <!-- Not relevant for the PD* series - excluded by productID (130-134).                    -->
+  <variable CV="137" item="Adopt function swapping for SUSI" mask="XVXXXXXX" exclude="130,131,132,133,134">
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+    <label>Adopt function interchanges (CV401ff.) for SUSI F1-F12</label>
+    <label xml:lang="fr">Appliquer les permutations de fonction (CV401ss.) aux SUSI F1-F12</label>
+    <label xml:lang="de">Funktionsvertauschungen (CV401ff.) für SUSI F1-F12 übernehmen</label>
+    <tooltip>bit 6 - since firmware 3.13.053</tooltip>
+    <tooltip xml:lang="fr">bit 6 - depuis le firmware 3.13.053</tooltip>
+    <tooltip xml:lang="de">bit 6 - ab Firmware 3.13.053</tooltip>
+  </variable>
+</variables>

--- a/xml/decoders/doehler_haass/cv137_susi_fw3.05.xml
+++ b/xml/decoders/doehler_haass/cv137_susi_fw3.05.xml
@@ -43,7 +43,7 @@
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
     <label>Deactivate SUSI startup delay</label>
     <label xml:lang="fr">Désactiver délai de départ SUSI</label>
-    <label xml:lang="de">SUSI­Anfahrverzögerung ausschalten</label>
+    <label xml:lang="de">SUSI-Anfahrverzögerung ausschalten</label>
     <label xml:lang="ca">Desactiva el retard d'arrencada SUSI</label>
   </variable>
 </variables>

--- a/xml/decoders/doehler_haass/cv137_susi_fw3.05.xml
+++ b/xml/decoders/doehler_haass/cv137_susi_fw3.05.xml
@@ -31,6 +31,12 @@
       <authorinitials>PB</authorinitials>
       <revremark>Creation. Valid for most decoders after Oct 2014.</revremark>
     </revision>
+    <revision>
+      <revnumber>2</revnumber>
+      <date>2026-07-25</date>
+      <authorinitials>PB</authorinitials>
+      <revremark>Fix a soft hyphen in the German label</revremark>
+    </revision>
   </revhistory>
   <variable item="Revert SUSI direction" CV="137" mask="XXXXXVXX" tooltip="CV137 bit 2">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>

--- a/xml/decoders/doehler_haass/cv144_bit5_fw3.14.xml
+++ b/xml/decoders/doehler_haass/cv144_bit5_fw3.14.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet type="text/xsl" href="../XSLT/decoder.xsl"?>
+<!-- Copyright (C) JMRI 2001, 2005, 2007, 2-009, 2010 All rights reserved -->
+<!--                                                                        -->
+<!-- JMRI is free software; you can redistribute it and/or modify it under  -->
+<!-- the terms of version 2 of the GNU General Public License as published  -->
+<!-- by the Free Software Foundation. See the "COPYING" file for a copy     -->
+<!-- of this license.                                                       -->
+<!--                                                                        -->
+<!-- JMRI is distributed in the hope that it will be useful, but WITHOUT    -->
+<!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
+<!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
+<!-- for more details.                                                      -->
+<variables xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+  <copyright xmlns="http://docbook.org/ns/docbook">
+    <year>2026</year>
+    <holder>JMRI</holder>
+  </copyright>
+  <authorgroup xmlns="http://docbook.org/ns/docbook">
+    <author>
+      <personname>
+        <firstname>Pierre</firstname>
+        <surname>Billon</surname>
+      </personname>
+    </author>
+  </authorgroup>
+  <revhistory xmlns="http://docbook.org/ns/docbook">
+    <revision>
+      <revnumber>1</revnumber>
+      <date>2026-07-25</date>
+      <authorinitials>PB</authorinitials>
+      <revremark>Creation. CV144 bits 1-5 for firmware 3.14 and later.</revremark>
+    </revision>
+  </revhistory>
+  <!-- CV144 bit 5, new in firmware 3.14.095. Include only from firmware 3.14 definitions      -->
+  <!-- onwards, alongside cv144_bits1-4.xml.                                                    -->
+  <!-- It uses the generic item name "Advanced Group 1 Option 2" so that the standard Advanced   -->
+  <!-- pane displays it, next to bit 1 which uses "Advanced Group 1 Option 1". A decoder-        -->
+  <!-- specific item name would not appear on any standard pane.                                -->
+  <variable item="Advanced Group 1 Option 2" CV="144" mask="XXVXXXXX" default="0">
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+    <label>Deactivate temporary data storage</label>
+    <label xml:lang="fr">Désactiver la mémorisation temporaire des données</label>
+    <label xml:lang="de">Kurzzeitige Datenspeicherung deaktivieren</label>
+    <tooltip>bit 5 - since firmware 3.14.095. Disables restoring the last driving state.</tooltip>
+    <tooltip xml:lang="fr">bit 5 - depuis le firmware 3.14.095. Désactive la restauration du dernier état de marche.</tooltip>
+    <tooltip xml:lang="de">bit 5 - ab Firmware 3.14.095. Schaltet die Wiederherstellung des letzten Fahrzustandes aus.</tooltip>
+  </variable>
+</variables>

--- a/xml/decoders/doehler_haass/cv144_bits1-4.xml
+++ b/xml/decoders/doehler_haass/cv144_bits1-4.xml
@@ -32,20 +32,17 @@
       <revremark>Creation. CV144 bits 1-5 for firmware 3.14 and later.</revremark>
     </revision>
   </revhistory>
-  <!-- CV144 bits 1-5 for firmware 3.14 and later. Replaces cv144_fw3.10.xml, which is kept    -->
-  <!-- unchanged for the firmware 3.10-3.13 and sound definitions that use it. Include this    -->
-  <!-- fragment INSTEAD of cv144_fw3.10.xml, not alongside it - the two overlap on bits 1-4.   -->
-  <!-- Bit 0 is unrelated and still comes from cv135-136_144_railcom_fw3.06.xml.               -->
-  <!--                                                                                        -->
-  <!-- Differences from cv144_fw3.10.xml:                                                      -->
-  <!--   - bit 5 added; new in firmware 3.14. It uses the generic item name                    -->
-  <!--     "Advanced Group 1 Option 2" so that the standard Advanced pane displays it, next    -->
-  <!--     to bit 1 which uses "Advanced Group 1 Option 1". A decoder-specific item name        -->
-  <!--     would not appear on any standard pane.                                              -->
-  <!--   - bits 3 and 4 are gated by productID (200 = DH21A, 201 = DH21B, 202 = DH22A,         -->
-  <!--     203 = DH22B, 204 = DH24A, 192 = FH22A), matching the applicability D&H document.    -->
-  <!--     The old fragment listed 2018-era identifiers that match no model from firmware      -->
-  <!--     3.13 onwards, so these two bits never appeared on those decoders.                   -->
+  <!-- CV144 bits 1-4 for the non-sound decoders, firmware 3.10 and later.                    -->
+  <!-- Bit 0 is unrelated and comes from cv135-136_144_railcom_fw3.06.xml; bit 5 exists only    -->
+  <!-- from firmware 3.14 and lives in cv144_bit5_fw3.14.xml.                                   -->
+  <!--                                                                                          -->
+  <!-- Bits 3 and 4 (the two GPIO brake settings) are gated to the models D&H document:          -->
+  <!-- DH21A, DH21B, DH22A, DH22B, DH24A and FH22A. The include list carries every product ID    -->
+  <!-- form these decoders use across firmware versions - the alphanumeric 2018-era ones and     -->
+  <!-- the numeric ones from firmware 3.12 on. The previous list in cv144_fw3.10.xml held only   -->
+  <!-- the 2018 DH values, and even those were wrong for FH22A ("FH22A_2018_09" against an       -->
+  <!-- actual "FH22A_2018.10"), so both bits were invisible on firmware 3.12, 3.13 and on every  -->
+  <!-- FH22A. The sound definitions keep cv144_fw3.10.xml, where family-name gating works.       -->
   <variable item="Advanced Group 1 Option 1" CV="144" mask="XXXXXXVX" default="0">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-disabledEnabled.xml"/>
     <label>Immediate starting after current interruption</label>
@@ -61,7 +58,7 @@
     <tooltip xml:lang="fr">Bit Spécial Lumières en mode Analogique</tooltip>
     <tooltip xml:lang="de">Spezielles Bit für Beleuchtung im Analogbetrieb</tooltip>
   </variable>
-  <variable item="Brake Section Output" CV="144" mask="XXXXVXXX" default="0" include="200,201,202,203,204,192">
+  <variable item="Brake Section Output" CV="144" mask="XXXXVXXX" default="0" include="DH21A_2018_04,DH21A_2018_09,DH22A_2018_04,DH22A_2018_09,FH22A_2018.04,FH22A_2018.10,200,201,202,203,204,192">
     <enumVal>
       <enumChoice choice="Braking">
         <choice>Braking</choice>
@@ -78,7 +75,7 @@
     <label xml:lang="fr">Sortie Section Freinage sur "GPIO"</label>
     <label xml:lang="de">Bremsstreckenausgabe an "GPIO"</label>
   </variable>
-  <variable item="Brake with GPIO" CV="144" mask="XXXVXXXX" default="0" include="200,201,202,203,204,192">
+  <variable item="Brake with GPIO" CV="144" mask="XXXVXXXX" default="0" include="DH21A_2018_04,DH21A_2018_09,DH22A_2018_04,DH22A_2018_09,FH22A_2018.04,FH22A_2018.10,200,201,202,203,204,192">
     <enumVal>
       <enumChoice choice="Braking">
         <choice>Braking</choice>
@@ -97,14 +94,5 @@
     <tooltip>1 = driving, 0 = braking</tooltip>
     <tooltip xml:lang="fr">1 = rouler, 0 = freiner</tooltip>
     <tooltip xml:lang="de">1 = Fahren, 0 = Bremsen</tooltip>
-  </variable>
-  <variable item="Advanced Group 1 Option 2" CV="144" mask="XXVXXXXX" default="0">
-    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
-    <label>Deactivate temporary data storage</label>
-    <label xml:lang="fr">Désactiver la mémorisation temporaire des données</label>
-    <label xml:lang="de">Kurzzeitige Datenspeicherung deaktivieren</label>
-    <tooltip>bit 5 - since firmware 3.14.095. Disables restoring the last driving state.</tooltip>
-    <tooltip xml:lang="fr">bit 5 - depuis le firmware 3.14.095. Désactive la restauration du dernier état de marche.</tooltip>
-    <tooltip xml:lang="de">bit 5 - ab Firmware 3.14.095. Schaltet die Wiederherstellung des letzten Fahrzustandes aus.</tooltip>
   </variable>
 </variables>

--- a/xml/decoders/doehler_haass/cv144_fw3.14.xml
+++ b/xml/decoders/doehler_haass/cv144_fw3.14.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet type="text/xsl" href="../XSLT/decoder.xsl"?>
+<!-- Copyright (C) JMRI 2001, 2005, 2007, 2-009, 2010 All rights reserved -->
+<!--                                                                        -->
+<!-- JMRI is free software; you can redistribute it and/or modify it under  -->
+<!-- the terms of version 2 of the GNU General Public License as published  -->
+<!-- by the Free Software Foundation. See the "COPYING" file for a copy     -->
+<!-- of this license.                                                       -->
+<!--                                                                        -->
+<!-- JMRI is distributed in the hope that it will be useful, but WITHOUT    -->
+<!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
+<!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
+<!-- for more details.                                                      -->
+<variables xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+  <copyright xmlns="http://docbook.org/ns/docbook">
+    <year>2026</year>
+    <holder>JMRI</holder>
+  </copyright>
+  <authorgroup xmlns="http://docbook.org/ns/docbook">
+    <author>
+      <personname>
+        <firstname>Pierre</firstname>
+        <surname>Billon</surname>
+      </personname>
+    </author>
+  </authorgroup>
+  <revhistory xmlns="http://docbook.org/ns/docbook">
+    <revision>
+      <revnumber>1</revnumber>
+      <date>2026-07-25</date>
+      <authorinitials>PB</authorinitials>
+      <revremark>Creation. CV144 bits 1-5 for firmware 3.14 and later.</revremark>
+    </revision>
+  </revhistory>
+  <!-- CV144 bits 1-5 for firmware 3.14 and later. Replaces cv144_fw3.10.xml, which is kept    -->
+  <!-- unchanged for the firmware 3.10-3.13 and sound definitions that use it. Include this    -->
+  <!-- fragment INSTEAD of cv144_fw3.10.xml, not alongside it - the two overlap on bits 1-4.   -->
+  <!-- Bit 0 is unrelated and still comes from cv135-136_144_railcom_fw3.06.xml.               -->
+  <!--                                                                                        -->
+  <!-- Differences from cv144_fw3.10.xml:                                                      -->
+  <!--   - bit 5 added; new in firmware 3.14. It uses the generic item name                    -->
+  <!--     "Advanced Group 1 Option 2" so that the standard Advanced pane displays it, next    -->
+  <!--     to bit 1 which uses "Advanced Group 1 Option 1". A decoder-specific item name        -->
+  <!--     would not appear on any standard pane.                                              -->
+  <!--   - bits 3 and 4 are gated by productID (200 = DH21A, 201 = DH21B, 202 = DH22A,         -->
+  <!--     203 = DH22B, 204 = DH24A, 192 = FH22A), matching the applicability D&H document.    -->
+  <!--     The old fragment listed 2018-era identifiers that match no model from firmware      -->
+  <!--     3.13 onwards, so these two bits never appeared on those decoders.                   -->
+  <variable item="Advanced Group 1 Option 1" CV="144" mask="XXXXXXVX" default="0">
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-disabledEnabled.xml"/>
+    <label>Immediate starting after current interruption</label>
+    <label xml:lang="fr">Démarrage immédiat après interruption courant</label>
+    <label xml:lang="de">Sofortiges Anfahren nach Stromunterbrechung</label>
+  </variable>
+  <variable item="Radio Power Conversion" CV="144" mask="XXXXXVXX" default="0" exclude="60,131">
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+    <label>Lighting in analog operation</label>
+    <label xml:lang="fr">Lumières en mode Analogique</label>
+    <label xml:lang="de">Beleuchtung im Analogbetrieb</label>
+    <tooltip>Special bit for lighting in analog operation</tooltip>
+    <tooltip xml:lang="fr">Bit Spécial Lumières en mode Analogique</tooltip>
+    <tooltip xml:lang="de">Spezielles Bit für Beleuchtung im Analogbetrieb</tooltip>
+  </variable>
+  <variable item="Brake Section Output" CV="144" mask="XXXXVXXX" default="0" include="200,201,202,203,204,192">
+    <enumVal>
+      <enumChoice choice="Braking">
+        <choice>Braking</choice>
+        <choice xml:lang="fr">Freiner</choice>
+        <choice xml:lang="de">Bremsen</choice>
+      </enumChoice>
+      <enumChoice choice="No Brake Section">
+        <choice>No Brake Section detected</choice>
+        <choice xml:lang="fr">Pas Section Freinage Détectée</choice>
+        <choice xml:lang="de">Keine Bremsstrecke erkannt</choice>
+      </enumChoice>
+    </enumVal>
+    <label>Brake section output to "GPIO"</label>
+    <label xml:lang="fr">Sortie Section Freinage sur "GPIO"</label>
+    <label xml:lang="de">Bremsstreckenausgabe an "GPIO"</label>
+  </variable>
+  <variable item="Brake with GPIO" CV="144" mask="XXXVXXXX" default="0" include="200,201,202,203,204,192">
+    <enumVal>
+      <enumChoice choice="Braking">
+        <choice>Braking</choice>
+        <choice xml:lang="fr">Freiner</choice>
+        <choice xml:lang="de">Bremsen</choice>
+      </enumChoice>
+      <enumChoice choice="Driving">
+        <choice>Driving</choice>
+        <choice xml:lang="fr">Rouler</choice>
+        <choice xml:lang="de">Fahren</choice>
+      </enumChoice>
+    </enumVal>
+    <label>Brake with "GPIO"</label>
+    <label xml:lang="fr">Freinage avec "GPIO"</label>
+    <label xml:lang="de">Bremsen mit "GPIO"</label>
+    <tooltip>1 = driving, 0 = braking</tooltip>
+    <tooltip xml:lang="fr">1 = rouler, 0 = freiner</tooltip>
+    <tooltip xml:lang="de">1 = Fahren, 0 = Bremsen</tooltip>
+  </variable>
+  <variable item="Advanced Group 1 Option 2" CV="144" mask="XXVXXXXX" default="0">
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+    <label>Deactivate temporary data storage</label>
+    <label xml:lang="fr">Désactiver la mémorisation temporaire des données</label>
+    <label xml:lang="de">Kurzzeitige Datenspeicherung deaktivieren</label>
+    <tooltip>bit 5 - since firmware 3.14.095. Disables restoring the last driving state.</tooltip>
+    <tooltip xml:lang="fr">bit 5 - depuis le firmware 3.14.095. Désactive la restauration du dernier état de marche.</tooltip>
+    <tooltip xml:lang="de">bit 5 - ab Firmware 3.14.095. Schaltet die Wiederherstellung des letzten Fahrzustandes aus.</tooltip>
+  </variable>
+</variables>

--- a/xml/decoders/doehler_haass/cv156_bits4-7_fw3.15.xml
+++ b/xml/decoders/doehler_haass/cv156_bits4-7_fw3.15.xml
@@ -13,7 +13,7 @@
 <!-- for more details.                                                      -->
 <variables xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
   <copyright xmlns="http://docbook.org/ns/docbook">
-    <year>2014</year>
+    <year>2026</year>
     <holder>JMRI</holder>
   </copyright>
   <authorgroup xmlns="http://docbook.org/ns/docbook">
@@ -27,22 +27,36 @@
   <revhistory xmlns="http://docbook.org/ns/docbook">
     <revision>
       <revnumber>1</revnumber>
-      <date>2014-02-20</date>
+      <date>2026-07-25</date>
       <authorinitials>PB</authorinitials>
-      <revremark>This file contains only variables that are common to D&amp;H decoders released
-		after around 2012 that support DC operation (as of 2014-02: all except the
-		DH06A).
-		Those CVs don't seem to be able applicable to older decoders,
-		even with the latest firmware upgrades.
-	  </revremark>
+      <revremark>Creation. CV156 bits 4-7, dimming mask for AUX3-AUX6, new in firmware 3.15.</revremark>
     </revision>
   </revhistory>
-  <variable CV="112" default="15" item="DC Brake Momentum" tooltip="CV112 (0:none, 31:strong)" exclude="Train Decoders (2020),Function Decoders (2020),Train Decoders (2023),Function Decoders (2023),Train Decoders (firmware 3.14+),Function Decoders (firmware 3.14+),Train Decoders (firmware 3.15+),Function Decoders (firmware 3.15+)">
-    <decVal min="0" max="31"/>
-    <label>Speed reduction in DC mode</label>
-    <label xml:lang="it">Riduzione velocità in analogico</label>
-    <label xml:lang="fr">Réduction vitesse en analogique</label>
-    <label xml:lang="de">Geschw.-minderung in Analog</label>
-    <label xml:lang="ca">Reducció de velocitat en CC</label>
+  <!-- CV156 bits 4-7, new in firmware 3.15: before 3.15 these four bits were unused           -->
+  <!-- ("Derzeit ohne Funktion") and the CV ran 0-15; from 3.15 they select AUX3-AUX6 and the   -->
+  <!-- range is 0-255. Bits 0-3 are unchanged and still come from cv156-157_fw3.10.xml.         -->
+  <variable item="Dim AUX3" CV="156" default="0" mask="XXXVXXXX" minOut="5">
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+    <label>Dim AUX3</label>
+    <label xml:lang="fr">Atténuer AUX3</label>
+    <label xml:lang="de">Abblendlicht AUX3</label>
+  </variable>
+  <variable item="Dim AUX4" CV="156" default="0" mask="XXVXXXXX" minOut="6">
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+    <label>Dim AUX4</label>
+    <label xml:lang="fr">Atténuer AUX4</label>
+    <label xml:lang="de">Abblendlicht AUX4</label>
+  </variable>
+  <variable item="Dim AUX5" CV="156" default="0" mask="XVXXXXXX" minOut="7">
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+    <label>Dim AUX5</label>
+    <label xml:lang="fr">Atténuer AUX5</label>
+    <label xml:lang="de">Abblendlicht AUX5</label>
+  </variable>
+  <variable item="Dim AUX6" CV="156" default="0" mask="VXXXXXXX" minOut="8">
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
+    <label>Dim AUX6</label>
+    <label xml:lang="fr">Atténuer AUX6</label>
+    <label xml:lang="de">Abblendlicht AUX6</label>
   </variable>
 </variables>

--- a/xml/decoders/doehler_haass/cv401-412.xml
+++ b/xml/decoders/doehler_haass/cv401-412.xml
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet type="text/xsl" href="../XSLT/decoder.xsl"?>
+<!-- Copyright (C) JMRI 2001, 2005, 2007, 2-009, 2010 All rights reserved -->
+<!--                                                                        -->
+<!-- JMRI is free software; you can redistribute it and/or modify it under  -->
+<!-- the terms of version 2 of the GNU General Public License as published  -->
+<!-- by the Free Software Foundation. See the "COPYING" file for a copy     -->
+<!-- of this license.                                                       -->
+<!--                                                                        -->
+<!-- JMRI is distributed in the hope that it will be useful, but WITHOUT    -->
+<!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
+<!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
+<!-- for more details.                                                      -->
+<variables xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+  <copyright xmlns="http://docbook.org/ns/docbook">
+    <year>2026</year>
+    <holder>JMRI</holder>
+  </copyright>
+  <authorgroup xmlns="http://docbook.org/ns/docbook">
+    <author>
+      <personname>
+        <firstname>Pierre</firstname>
+        <surname>Billon</surname>
+      </personname>
+    </author>
+  </authorgroup>
+  <revhistory xmlns="http://docbook.org/ns/docbook">
+    <revision>
+      <revnumber>1</revnumber>
+      <date>2026-07-25</date>
+      <authorinitials>PB</authorinitials>
+      <revremark>Creation. Function swapping CV401-412 for the non-sound decoders (range 0-29).</revremark>
+    </revision>
+  </revhistory>
+  <!-- Function swapping (Funktionsvertauschung) CV401-412, non-sound decoders.               -->
+  <!-- Range is 0-29 here: 0 = off, 1..28 = F1..F28, 29 = F0 (light).                          -->
+  <!-- The sound decoders use the same CVs with an extended range of 0-46 (values 30-46 select -->
+  <!-- sound triggers), so they keep their own fragment SD_cv401_412.xml. Do not merge these.  -->
+  <!-- Not relevant for the PD* series - excluded by productID (130-134), which is stable across  -->
+  <!-- firmware versions, unlike the model names which carry a "(firmware x.yy.zzz+)" suffix.     -->
+  <variable item="Function Swapping F1" CV="401" default="1" exclude="130,131,132,133,134">
+    <xi:include href="http://jmri.org/xml/decoders/doehler_haass/Susi-SD_enum-map.xml"/>
+    <label>Function interchange F1</label>
+    <label xml:lang="fr">Permutation de fonction F1</label>
+    <label xml:lang="de">Funktionsvertauschung F1</label>
+    <tooltip>CV401: 0 = off, 1-28 = F1-F28, 29 = F0 (light)</tooltip>
+    <tooltip xml:lang="fr">CV401 : 0 = désactivé, 1-28 = F1-F28, 29 = F0 (feux)</tooltip>
+    <tooltip xml:lang="de">CV401: 0 = deaktiviert, 1-28 = F1-F28, 29 = F0 (Licht)</tooltip>
+  </variable>
+  <variable item="Function Swapping F2" CV="402" default="2" exclude="130,131,132,133,134">
+    <xi:include href="http://jmri.org/xml/decoders/doehler_haass/Susi-SD_enum-map.xml"/>
+    <label>Function interchange F2</label>
+    <label xml:lang="fr">Permutation de fonction F2</label>
+    <label xml:lang="de">Funktionsvertauschung F2</label>
+    <tooltip>CV402: 0 = off, 1-28 = F1-F28, 29 = F0 (light)</tooltip>
+    <tooltip xml:lang="fr">CV402 : 0 = désactivé, 1-28 = F1-F28, 29 = F0 (feux)</tooltip>
+    <tooltip xml:lang="de">CV402: 0 = deaktiviert, 1-28 = F1-F28, 29 = F0 (Licht)</tooltip>
+  </variable>
+  <variable item="Function Swapping F3" CV="403" default="3" exclude="130,131,132,133,134">
+    <xi:include href="http://jmri.org/xml/decoders/doehler_haass/Susi-SD_enum-map.xml"/>
+    <label>Function interchange F3</label>
+    <label xml:lang="fr">Permutation de fonction F3</label>
+    <label xml:lang="de">Funktionsvertauschung F3</label>
+    <tooltip>CV403: 0 = off, 1-28 = F1-F28, 29 = F0 (light)</tooltip>
+    <tooltip xml:lang="fr">CV403 : 0 = désactivé, 1-28 = F1-F28, 29 = F0 (feux)</tooltip>
+    <tooltip xml:lang="de">CV403: 0 = deaktiviert, 1-28 = F1-F28, 29 = F0 (Licht)</tooltip>
+  </variable>
+  <variable item="Function Swapping F4" CV="404" default="4" exclude="130,131,132,133,134">
+    <xi:include href="http://jmri.org/xml/decoders/doehler_haass/Susi-SD_enum-map.xml"/>
+    <label>Function interchange F4</label>
+    <label xml:lang="fr">Permutation de fonction F4</label>
+    <label xml:lang="de">Funktionsvertauschung F4</label>
+    <tooltip>CV404: 0 = off, 1-28 = F1-F28, 29 = F0 (light)</tooltip>
+    <tooltip xml:lang="fr">CV404 : 0 = désactivé, 1-28 = F1-F28, 29 = F0 (feux)</tooltip>
+    <tooltip xml:lang="de">CV404: 0 = deaktiviert, 1-28 = F1-F28, 29 = F0 (Licht)</tooltip>
+  </variable>
+  <variable item="Function Swapping F5" CV="405" default="5" exclude="130,131,132,133,134">
+    <xi:include href="http://jmri.org/xml/decoders/doehler_haass/Susi-SD_enum-map.xml"/>
+    <label>Function interchange F5</label>
+    <label xml:lang="fr">Permutation de fonction F5</label>
+    <label xml:lang="de">Funktionsvertauschung F5</label>
+    <tooltip>CV405: 0 = off, 1-28 = F1-F28, 29 = F0 (light)</tooltip>
+    <tooltip xml:lang="fr">CV405 : 0 = désactivé, 1-28 = F1-F28, 29 = F0 (feux)</tooltip>
+    <tooltip xml:lang="de">CV405: 0 = deaktiviert, 1-28 = F1-F28, 29 = F0 (Licht)</tooltip>
+  </variable>
+  <variable item="Function Swapping F6" CV="406" default="6" exclude="130,131,132,133,134">
+    <xi:include href="http://jmri.org/xml/decoders/doehler_haass/Susi-SD_enum-map.xml"/>
+    <label>Function interchange F6</label>
+    <label xml:lang="fr">Permutation de fonction F6</label>
+    <label xml:lang="de">Funktionsvertauschung F6</label>
+    <tooltip>CV406: 0 = off, 1-28 = F1-F28, 29 = F0 (light)</tooltip>
+    <tooltip xml:lang="fr">CV406 : 0 = désactivé, 1-28 = F1-F28, 29 = F0 (feux)</tooltip>
+    <tooltip xml:lang="de">CV406: 0 = deaktiviert, 1-28 = F1-F28, 29 = F0 (Licht)</tooltip>
+  </variable>
+  <variable item="Function Swapping F7" CV="407" default="7" exclude="130,131,132,133,134">
+    <xi:include href="http://jmri.org/xml/decoders/doehler_haass/Susi-SD_enum-map.xml"/>
+    <label>Function interchange F7</label>
+    <label xml:lang="fr">Permutation de fonction F7</label>
+    <label xml:lang="de">Funktionsvertauschung F7</label>
+    <tooltip>CV407: 0 = off, 1-28 = F1-F28, 29 = F0 (light)</tooltip>
+    <tooltip xml:lang="fr">CV407 : 0 = désactivé, 1-28 = F1-F28, 29 = F0 (feux)</tooltip>
+    <tooltip xml:lang="de">CV407: 0 = deaktiviert, 1-28 = F1-F28, 29 = F0 (Licht)</tooltip>
+  </variable>
+  <variable item="Function Swapping F8" CV="408" default="8" exclude="130,131,132,133,134">
+    <xi:include href="http://jmri.org/xml/decoders/doehler_haass/Susi-SD_enum-map.xml"/>
+    <label>Function interchange F8</label>
+    <label xml:lang="fr">Permutation de fonction F8</label>
+    <label xml:lang="de">Funktionsvertauschung F8</label>
+    <tooltip>CV408: 0 = off, 1-28 = F1-F28, 29 = F0 (light)</tooltip>
+    <tooltip xml:lang="fr">CV408 : 0 = désactivé, 1-28 = F1-F28, 29 = F0 (feux)</tooltip>
+    <tooltip xml:lang="de">CV408: 0 = deaktiviert, 1-28 = F1-F28, 29 = F0 (Licht)</tooltip>
+  </variable>
+  <variable item="Function Swapping F9" CV="409" default="9" exclude="130,131,132,133,134">
+    <xi:include href="http://jmri.org/xml/decoders/doehler_haass/Susi-SD_enum-map.xml"/>
+    <label>Function interchange F9</label>
+    <label xml:lang="fr">Permutation de fonction F9</label>
+    <label xml:lang="de">Funktionsvertauschung F9</label>
+    <tooltip>CV409: 0 = off, 1-28 = F1-F28, 29 = F0 (light)</tooltip>
+    <tooltip xml:lang="fr">CV409 : 0 = désactivé, 1-28 = F1-F28, 29 = F0 (feux)</tooltip>
+    <tooltip xml:lang="de">CV409: 0 = deaktiviert, 1-28 = F1-F28, 29 = F0 (Licht)</tooltip>
+  </variable>
+  <variable item="Function Swapping F10" CV="410" default="10" exclude="130,131,132,133,134">
+    <xi:include href="http://jmri.org/xml/decoders/doehler_haass/Susi-SD_enum-map.xml"/>
+    <label>Function interchange F10</label>
+    <label xml:lang="fr">Permutation de fonction F10</label>
+    <label xml:lang="de">Funktionsvertauschung F10</label>
+    <tooltip>CV410: 0 = off, 1-28 = F1-F28, 29 = F0 (light)</tooltip>
+    <tooltip xml:lang="fr">CV410 : 0 = désactivé, 1-28 = F1-F28, 29 = F0 (feux)</tooltip>
+    <tooltip xml:lang="de">CV410: 0 = deaktiviert, 1-28 = F1-F28, 29 = F0 (Licht)</tooltip>
+  </variable>
+  <variable item="Function Swapping F11" CV="411" default="11" exclude="130,131,132,133,134">
+    <xi:include href="http://jmri.org/xml/decoders/doehler_haass/Susi-SD_enum-map.xml"/>
+    <label>Function interchange F11</label>
+    <label xml:lang="fr">Permutation de fonction F11</label>
+    <label xml:lang="de">Funktionsvertauschung F11</label>
+    <tooltip>CV411: 0 = off, 1-28 = F1-F28, 29 = F0 (light)</tooltip>
+    <tooltip xml:lang="fr">CV411 : 0 = désactivé, 1-28 = F1-F28, 29 = F0 (feux)</tooltip>
+    <tooltip xml:lang="de">CV411: 0 = deaktiviert, 1-28 = F1-F28, 29 = F0 (Licht)</tooltip>
+  </variable>
+  <variable item="Function Swapping F12" CV="412" default="12" exclude="130,131,132,133,134">
+    <xi:include href="http://jmri.org/xml/decoders/doehler_haass/Susi-SD_enum-map.xml"/>
+    <label>Function interchange F12</label>
+    <label xml:lang="fr">Permutation de fonction F12</label>
+    <label xml:lang="de">Funktionsvertauschung F12</label>
+    <tooltip>CV412: 0 = off, 1-28 = F1-F28, 29 = F0 (light)</tooltip>
+    <tooltip xml:lang="fr">CV412 : 0 = désactivé, 1-28 = F1-F28, 29 = F0 (feux)</tooltip>
+    <tooltip xml:lang="de">CV412: 0 = deaktiviert, 1-28 = F1-F28, 29 = F0 (Licht)</tooltip>
+  </variable>
+</variables>

--- a/xml/decoders/doehler_haass/cv461-467_fw3.15.xml
+++ b/xml/decoders/doehler_haass/cv461-467_fw3.15.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet type="text/xsl" href="../XSLT/decoder.xsl"?>
+<!-- Copyright (C) JMRI 2001, 2005, 2007, 2-009, 2010 All rights reserved -->
+<!--                                                                        -->
+<!-- JMRI is free software; you can redistribute it and/or modify it under  -->
+<!-- the terms of version 2 of the GNU General Public License as published  -->
+<!-- by the Free Software Foundation. See the "COPYING" file for a copy     -->
+<!-- of this license.                                                       -->
+<!--                                                                        -->
+<!-- JMRI is distributed in the hope that it will be useful, but WITHOUT    -->
+<!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
+<!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
+<!-- for more details.                                                      -->
+<variables xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+  <copyright xmlns="http://docbook.org/ns/docbook">
+    <year>2026</year>
+    <holder>JMRI</holder>
+  </copyright>
+  <authorgroup xmlns="http://docbook.org/ns/docbook">
+    <author>
+      <personname>
+        <firstname>Pierre</firstname>
+        <surname>Billon</surname>
+      </personname>
+    </author>
+  </authorgroup>
+  <revhistory xmlns="http://docbook.org/ns/docbook">
+    <revision>
+      <revnumber>1</revnumber>
+      <date>2026-07-25</date>
+      <authorinitials>PB</authorinitials>
+      <revremark>Creation. CV461/463/465/467, dimming AUX3-AUX6, new in firmware 3.15.</revremark>
+    </revision>
+  </revhistory>
+  <!-- Dimming levels for AUX3-AUX6, new in firmware 3.15. Odd addresses only: 461, 463, 465   -->
+  <!-- and 467. D&H's own ChangeLog states "CV461 bis CV466", which is wrong - the CV table is  -->
+  <!-- correct. Not every AUX is independently dimmable on every decoder.                       -->
+  <!-- Not relevant for the PD* series (product IDs 130-134).                                   -->
+  <variable item="AUX 3 dimming" CV="461" default="31" exclude="130,131,132,133,134" minOut="5">
+    <decVal min="0" max="31"/>
+    <label>AUX 3 dimming</label>
+    <label xml:lang="fr">AUX 3 intensité</label>
+    <label xml:lang="de">AUX 3 Dimmung</label>
+    <tooltip>CV461: 0 = dark … 31 = full brightness.</tooltip>
+    <tooltip xml:lang="fr">CV461 : 0 = éteint … 31 = pleine luminosité.</tooltip>
+    <tooltip xml:lang="de">CV461: 0 = dunkel … 31 = volle Helligkeit.</tooltip>
+  </variable>
+  <variable item="AUX 4 dimming" CV="463" default="31" exclude="130,131,132,133,134" minOut="6">
+    <decVal min="0" max="31"/>
+    <label>AUX 4 dimming</label>
+    <label xml:lang="fr">AUX 4 intensité</label>
+    <label xml:lang="de">AUX 4 Dimmung</label>
+    <tooltip>CV463: 0 = dark … 31 = full brightness.</tooltip>
+    <tooltip xml:lang="fr">CV463 : 0 = éteint … 31 = pleine luminosité.</tooltip>
+    <tooltip xml:lang="de">CV463: 0 = dunkel … 31 = volle Helligkeit.</tooltip>
+  </variable>
+  <variable item="AUX 5 dimming" CV="465" default="31" exclude="130,131,132,133,134" minOut="7">
+    <decVal min="0" max="31"/>
+    <label>AUX 5 dimming</label>
+    <label xml:lang="fr">AUX 5 intensité</label>
+    <label xml:lang="de">AUX 5 Dimmung</label>
+    <tooltip>CV465: 0 = dark … 31 = full brightness.</tooltip>
+    <tooltip xml:lang="fr">CV465 : 0 = éteint … 31 = pleine luminosité.</tooltip>
+    <tooltip xml:lang="de">CV465: 0 = dunkel … 31 = volle Helligkeit.</tooltip>
+  </variable>
+  <variable item="AUX 6 dimming" CV="467" default="31" exclude="130,131,132,133,134" minOut="8">
+    <decVal min="0" max="31"/>
+    <label>AUX 6 dimming</label>
+    <label xml:lang="fr">AUX 6 intensité</label>
+    <label xml:lang="de">AUX 6 Dimmung</label>
+    <tooltip>CV467: 0 = dark … 31 = full brightness. WARNING: after a firmware update this CV may read 255 instead of 31; perform a reset (CV8 = 8) or write 31 by hand.</tooltip>
+    <tooltip xml:lang="fr">CV467 : 0 = éteint … 31 = pleine luminosité. ATTENTION : après une mise à jour du firmware, ce CV peut se lire 255 au lieu de 31 ; faire un reset (CV8 = 8) ou écrire 31 manuellement.</tooltip>
+    <tooltip xml:lang="de">CV467: 0 = dunkel … 31 = volle Helligkeit. ACHTUNG: nach einem Firmware-Update kann dieses CV 255 statt 31 anzeigen; Reset (CV8 = 8) durchführen oder 31 von Hand schreiben.</tooltip>
+  </variable>
+</variables>

--- a/xml/decoders/doehler_haass/cv60_bits1-3_fw3.15.xml
+++ b/xml/decoders/doehler_haass/cv60_bits1-3_fw3.15.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet type="text/xsl" href="../XSLT/decoder.xsl"?>
+<!-- Copyright (C) JMRI 2001, 2005, 2007, 2-009, 2010 All rights reserved -->
+<!--                                                                        -->
+<!-- JMRI is free software; you can redistribute it and/or modify it under  -->
+<!-- the terms of version 2 of the GNU General Public License as published  -->
+<!-- by the Free Software Foundation. See the "COPYING" file for a copy     -->
+<!-- of this license.                                                       -->
+<!--                                                                        -->
+<!-- JMRI is distributed in the hope that it will be useful, but WITHOUT    -->
+<!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
+<!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
+<!-- for more details.                                                      -->
+<variables xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+  <copyright xmlns="http://docbook.org/ns/docbook">
+    <year>2026</year>
+    <holder>JMRI</holder>
+  </copyright>
+  <authorgroup xmlns="http://docbook.org/ns/docbook">
+    <author>
+      <personname>
+        <firstname>Pierre</firstname>
+        <surname>Billon</surname>
+      </personname>
+    </author>
+  </authorgroup>
+  <revhistory xmlns="http://docbook.org/ns/docbook">
+    <revision>
+      <revnumber>1</revnumber>
+      <date>2026-07-25</date>
+      <authorinitials>PB</authorinitials>
+      <revremark>Creation. CV60 bits 1-3, new in firmware 3.15.</revremark>
+    </revision>
+  </revhistory>
+  <!-- CV60 became a settings register in firmware 3.15. Bit 0, selecting one- or two-part SX  -->
+  <!-- brake sections, is unchanged and still comes from Vars_common.xml; this fragment adds   -->
+  <!-- the two settings that are new in 3.15. Include only from firmware 3.15 definitions.     -->
+  <variable item="Minimum speed step for brake ramp" CV="60" mask="XXXXXXVX" default="0">
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+    <label>Minimum speed step for brake ramp active</label>
+    <label xml:lang="fr">Cran de vitesse minimal actif pour la rampe de freinage</label>
+    <label xml:lang="de">Mindestfahrstufe für Bremsrampe aktiv</label>
+    <tooltip>CV60 bit 1 - the minimum speed step is then taken from CV65 (see CV154/CV155)</tooltip>
+    <tooltip xml:lang="fr">CV60 bit 1 - le cran minimal est alors donné par le CV65 (voir CV154/CV155)</tooltip>
+    <tooltip xml:lang="de">CV60 Bit 1 - die Mindestfahrstufe wird dann aus CV65 genommen (siehe CV154/CV155)</tooltip>
+  </variable>
+  <variable item="Shuttle mode" CV="60" mask="XXXXVVXX" default="0">
+    <enumVal>
+      <enumChoice choice="Deactivated" value="0">
+        <choice>Shuttle mode deactivated</choice>
+        <choice xml:lang="fr">Navette désactivée</choice>
+        <choice xml:lang="de">Pendelbetrieb deaktiviert</choice>
+      </enumChoice>
+      <enumChoice choice="No intermediate stop" value="1">
+        <choice>Without intermediate stop</choice>
+        <choice xml:lang="fr">Sans arrêt intermédiaire</choice>
+        <choice xml:lang="de">Ohne Zwischenhalt</choice>
+      </enumChoice>
+      <enumChoice choice="Manual intermediate stop" value="2">
+        <choice>With manual intermediate stop</choice>
+        <choice xml:lang="fr">Avec arrêt intermédiaire manuel</choice>
+        <choice xml:lang="de">Mit manuellem Zwischenhalt</choice>
+      </enumChoice>
+      <enumChoice choice="Automatic intermediate stop" value="3">
+        <choice>With automatic intermediate stop</choice>
+        <choice xml:lang="fr">Avec arrêt intermédiaire automatique</choice>
+        <choice xml:lang="de">Mit automatischem Zwischenhalt</choice>
+      </enumChoice>
+    </enumVal>
+    <label>Shuttle mode</label>
+    <label xml:lang="fr">Navette</label>
+    <label xml:lang="de">Pendelbetrieb</label>
+    <tooltip>CV60 bits 2-3 - only with suitable asymmetry braking modules (CV27 bits 0 and 1). Dwell times in CV63</tooltip>
+    <tooltip xml:lang="fr">CV60 bits 2-3 - uniquement avec des modules de freinage par asymétrie adaptés (CV27 bits 0 et 1). Durées d'arrêt dans le CV63</tooltip>
+    <tooltip xml:lang="de">CV60 Bits 2-3 - nur mit geeigneten Asymmetrie-Bremsmodulen (CV27 Bits 0 und 1). Aufenthaltsdauern in CV63</tooltip>
+  </variable>
+</variables>

--- a/xml/decoders/doehler_haass/cv63_fw3.15.xml
+++ b/xml/decoders/doehler_haass/cv63_fw3.15.xml
@@ -13,7 +13,7 @@
 <!-- for more details.                                                      -->
 <variables xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
   <copyright xmlns="http://docbook.org/ns/docbook">
-    <year>2014</year>
+    <year>2026</year>
     <holder>JMRI</holder>
   </copyright>
   <authorgroup xmlns="http://docbook.org/ns/docbook">
@@ -27,22 +27,21 @@
   <revhistory xmlns="http://docbook.org/ns/docbook">
     <revision>
       <revnumber>1</revnumber>
-      <date>2014-02-20</date>
+      <date>2026-07-25</date>
       <authorinitials>PB</authorinitials>
-      <revremark>This file contains only variables that are common to D&amp;H decoders released
-		after around 2012 that support DC operation (as of 2014-02: all except the
-		DH06A).
-		Those CVs don't seem to be able applicable to older decoders,
-		even with the latest firmware upgrades.
-	  </revremark>
+      <revremark>Creation. CV63 with the firmware 3.15 dual meaning.</revremark>
     </revision>
   </revhistory>
-  <variable CV="112" default="15" item="DC Brake Momentum" tooltip="CV112 (0:none, 31:strong)" exclude="Train Decoders (2020),Function Decoders (2020),Train Decoders (2023),Function Decoders (2023),Train Decoders (firmware 3.14+),Function Decoders (firmware 3.14+),Train Decoders (firmware 3.15+),Function Decoders (firmware 3.15+)">
-    <decVal min="0" max="31"/>
-    <label>Speed reduction in DC mode</label>
-    <label xml:lang="it">Riduzione velocità in analogico</label>
-    <label xml:lang="fr">Réduction vitesse en analogique</label>
-    <label xml:lang="de">Geschw.-minderung in Analog</label>
-    <label xml:lang="ca">Reducció de velocitat en CC</label>
+  <!-- CV63 gained a second meaning in firmware 3.15: with the shuttle mode active it sets     -->
+  <!-- the dwell times instead of the start delay. Replaces the definition in Vars_common.xml,  -->
+  <!-- which is excluded for the firmware 3.15 families.                                       -->
+  <variable CV="63" default="0" item="Start delay for speed step 1">
+    <decVal min="0" max="250"/>
+    <label>Start delay / dwell time</label>
+    <label xml:lang="fr">Retard au démarrage / durée d'arrêt</label>
+    <label xml:lang="de">Anfahrverzögerung / Aufenthaltsdauer</label>
+    <tooltip>CV63: with shuttle mode off, an extra wait before starting (100 ms steps). With shuttle mode on (CV60 bits 2-3), the dwell before reversing (1 s steps) and before restarting (0.5 s steps)</tooltip>
+    <tooltip xml:lang="fr">CV63 : navette inactive, attente supplémentaire avant le démarrage (pas de 100 ms). Navette active (CV60 bits 2-3), durée d'arrêt avant l'inversion (pas de 1 s) et avant la reprise (pas de 0,5 s)</tooltip>
+    <tooltip xml:lang="de">CV63: bei ausgeschaltetem Pendelbetrieb eine zusätzliche Wartezeit vor der Anfahrt (je 100 ms). Bei aktivem Pendelbetrieb (CV60 Bits 2-3) die Aufenthaltsdauer vor dem Fahrtrichtungswechsel (je 1 s) und vor der Wiederanfahrt (je 0,5 s)</tooltip>
   </variable>
 </variables>

--- a/xml/decoders/doehler_haass/cv65_fw3.08.xml
+++ b/xml/decoders/doehler_haass/cv65_fw3.08.xml
@@ -33,6 +33,12 @@
       <authorinitials>ALM</authorinitials>
       <revremark>for fw 3.08 and above</revremark>
     </revision>
+    <revision>
+      <revnumber>2</revnumber>
+      <date>2026-07-25</date>
+      <authorinitials>PB</authorinitials>
+      <revremark>Exclude CV65 for the firmware 3.15 families</revremark>
+    </revision>
    </revhistory>
   <variable item="Max Speed Braking Section 2" CV="65" default="12" exclude="Train Decoders (firmware 3.15+),Function Decoders (firmware 3.15+)">
     <decVal max="127"/>

--- a/xml/decoders/doehler_haass/cv65_fw3.08.xml
+++ b/xml/decoders/doehler_haass/cv65_fw3.08.xml
@@ -34,7 +34,7 @@
       <revremark>for fw 3.08 and above</revremark>
     </revision>
    </revhistory>
-  <variable item="Max Speed Braking Section 2" CV="65" default="12">
+  <variable item="Max Speed Braking Section 2" CV="65" default="12" exclude="Train Decoders (firmware 3.15+),Function Decoders (firmware 3.15+)">
     <decVal max="127"/>
     <label>Max. speed in two-part braking section</label>
     <label xml:lang="de">Max. Fahrstufe in zweiteiligen Bremsabschnitten</label>

--- a/xml/decoders/doehler_haass/cv65_fw3.15.xml
+++ b/xml/decoders/doehler_haass/cv65_fw3.15.xml
@@ -13,7 +13,7 @@
 <!-- for more details.                                                      -->
 <variables xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
   <copyright xmlns="http://docbook.org/ns/docbook">
-    <year>2014</year>
+    <year>2026</year>
     <holder>JMRI</holder>
   </copyright>
   <authorgroup xmlns="http://docbook.org/ns/docbook">
@@ -27,22 +27,20 @@
   <revhistory xmlns="http://docbook.org/ns/docbook">
     <revision>
       <revnumber>1</revnumber>
-      <date>2014-02-20</date>
+      <date>2026-07-25</date>
       <authorinitials>PB</authorinitials>
-      <revremark>This file contains only variables that are common to D&amp;H decoders released
-		after around 2012 that support DC operation (as of 2014-02: all except the
-		DH06A).
-		Those CVs don't seem to be able applicable to older decoders,
-		even with the latest firmware upgrades.
-	  </revremark>
+      <revremark>Creation. CV65 with the firmware 3.15 dual meaning.</revremark>
     </revision>
   </revhistory>
-  <variable CV="112" default="15" item="DC Brake Momentum" tooltip="CV112 (0:none, 31:strong)" exclude="Train Decoders (2020),Function Decoders (2020),Train Decoders (2023),Function Decoders (2023),Train Decoders (firmware 3.14+),Function Decoders (firmware 3.14+),Train Decoders (firmware 3.15+),Function Decoders (firmware 3.15+)">
-    <decVal min="0" max="31"/>
-    <label>Speed reduction in DC mode</label>
-    <label xml:lang="it">Riduzione velocità in analogico</label>
-    <label xml:lang="fr">Réduction vitesse en analogique</label>
-    <label xml:lang="de">Geschw.-minderung in Analog</label>
-    <label xml:lang="ca">Reducció de velocitat en CC</label>
+  <!-- CV65 gained a second meaning in firmware 3.15, selected by CV60 bit 1. Replaces the     -->
+  <!-- definition in cv65_fw3.08.xml, which is excluded for the firmware 3.15 families.         -->
+  <variable item="Max Speed Braking Section 2" CV="65" default="12">
+    <decVal min="0" max="127"/>
+    <label>Speed step in braking sections</label>
+    <label xml:lang="fr">Cran de vitesse dans les sections de freinage</label>
+    <label xml:lang="de">Fahrstufe in Bremsabschnitten</label>
+    <tooltip>CV65: the maximum speed step in two-part SX braking sections (CV27 bits 6-7, CV60 bit 0), or the minimum speed step at which the brake ramp engages (CV60 bit 1, see CV154/CV155)</tooltip>
+    <tooltip xml:lang="fr">CV65 : le cran de vitesse maximal dans les sections de freinage SX en deux parties (CV27 bits 6-7, CV60 bit 0), ou le cran minimal à partir duquel la rampe de freinage agit (CV60 bit 1, voir CV154/CV155)</tooltip>
+    <tooltip xml:lang="de">CV65: die maximale Fahrstufe in zweiteiligen SX-Bremsabschnitten (CV27 Bits 6-7, CV60 Bit 0), oder die minimale Fahrstufe ab der die Bremsrampe aktiv wird (CV60 Bit 1, siehe CV154/CV155)</tooltip>
   </variable>
 </variables>

--- a/xml/decoders/doehler_haass/cv98-99_158-159.xml
+++ b/xml/decoders/doehler_haass/cv98-99_158-159.xml
@@ -32,178 +32,182 @@
       <revremark>Creation for DH21B/DH22B</revremark>
     </revision>
   </revhistory>
+  <!-- Gated by productID rather than model name: 201 = DH21B, 203 = DH22B, 204 = DH24A.      -->
+  <!-- Product IDs are stable across firmware versions, whereas the model names carry a       -->
+  <!-- "(firmware x.yy.zzz+)" suffix that changes with every release, which would mean         -->
+  <!-- editing all of these lists again for each new firmware definition.                     -->
   <!-- Function tables for outputs 9-10  -->
-  <variable item="F4 controls output 9" CV="98" default="10" include="DH21B (firmware 3.13.053+),DH22B (firmware 3.13.053+)">
+  <variable item="F4 controls output 9" CV="98" default="10" include="201,203,204">
     <xi:include href="http://jmri.org/xml/decoders/doehler_haass/Susi-SD_enum-map.xml"/>
   </variable>
-  <!--variable item="FL(f) controls output 9" CV="98" mask="XXXXXXXV" minOut="1" minFn="1" include="DH21B (firmware 3.13.053+),DH22B (firmware 3.13.053+)">
+  <!--variable item="FL(f) controls output 9" CV="98" mask="XXXXXXXV" minOut="1" minFn="1" include="201,203,204">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
     <label>FL(f) controls output 9</label>
   </variable>
-  <variable item="FL(r) controls output 9" CV="98" mask="XXXXXXXV" minOut="2" minFn="1" include="DH21B (firmware 3.13.053+),DH22B (firmware 3.13.053+)">
+  <variable item="FL(r) controls output 9" CV="98" mask="XXXXXXXV" minOut="2" minFn="1" include="201,203,204">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
     <label>FL(r) controls output 9</label>
   </variable>
-  <variable item="F1 controls output 9" CV="98" mask="XXXXXXVX" minOut="3" minFn="1" include="DH21B (firmware 3.13.053+),DH22B (firmware 3.13.053+)">
+  <variable item="F1 controls output 9" CV="98" mask="XXXXXXVX" minOut="3" minFn="1" include="201,203,204">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
     <label>F1 controls output 9</label>
   </variable>
-  <variable item="F2 controls output 9" CV="98" mask="XXXXXVXX" minOut="4" minFn="1" include="DH21B (firmware 3.13.053+),DH22B (firmware 3.13.053+)">
+  <variable item="F2 controls output 9" CV="98" mask="XXXXXVXX" minOut="4" minFn="1" include="201,203,204">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
     <label>F2 controls output 9</label>
   </variable>
-  <variable item="F3 controls output 9" CV="98" mask="XXXXVXXX" minOut="5" minFn="1" include="DH21B (firmware 3.13.053+),DH22B (firmware 3.13.053+)">
+  <variable item="F3 controls output 9" CV="98" mask="XXXXVXXX" minOut="5" minFn="1" include="201,203,204">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
     <label>F3 controls output 9</label>
   </variable>
-  <variable item="F4 controls output 9" CV="98" mask="XXXVXXXX" minOut="6" minFn="1" include="DH21B (firmware 3.13.053+),DH22B (firmware 3.13.053+)">
+  <variable item="F4 controls output 9" CV="98" mask="XXXVXXXX" minOut="6" minFn="1" include="201,203,204">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
     <label>F4 controls output 9</label>
   </variable>
-  <variable item="F5 controls output 9" CV="98" mask="XXVXXXXX" minOut="7" minFn="1" include="DH21B (firmware 3.13.053+),DH22B (firmware 3.13.053+)">
+  <variable item="F5 controls output 9" CV="98" mask="XXVXXXXX" minOut="7" minFn="1" include="201,203,204">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
     <label>F5 controls output 9</label>
   </variable>
-  <variable item="F6 controls output 9" CV="98" mask="XVXXXXXX" minOut="8" minFn="1" include="DH21B (firmware 3.13.053+),DH22B (firmware 3.13.053+)">
+  <variable item="F6 controls output 9" CV="98" mask="XVXXXXXX" minOut="8" minFn="1" include="201,203,204">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
     <label>F6 controls output 9</label>
   </variable>
-  <variable item="F7 controls output 9" CV="98" mask="VXXXXXXX" minOut="9" minFn="1" include="DH21B (firmware 3.13.053+),DH22B (firmware 3.13.053+)">
+  <variable item="F7 controls output 9" CV="98" mask="VXXXXXXX" minOut="9" minFn="1" include="201,203,204">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
     <label>F7 controls output 9</label>
   </variable>
-  <variable item="F8 controls output 9" CV="98" mask="VXXXXXXX" minOut="10" minFn="1" include="DH21B (firmware 3.13.053+),DH22B (firmware 3.13.053+)">
+  <variable item="F8 controls output 9" CV="98" mask="VXXXXXXX" minOut="10" minFn="1" include="201,203,204">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
     <label>F8 controls output 9</label>
   </variable>
-  <variable item="F9 controls output 9" CV="98" mask="VXXXXXXX" minOut="11" minFn="1" include="DH21B (firmware 3.13.053+),DH22B (firmware 3.13.053+)">
+  <variable item="F9 controls output 9" CV="98" mask="VXXXXXXX" minOut="11" minFn="1" include="201,203,204">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
     <label>F9 controls output 9</label>
   </variable>
-  <variable item="F10 controls output 9" CV="98" mask="VXXXXXXX" minOut="12" minFn="1" include="DH21B (firmware 3.13.053+),DH22B (firmware 3.13.053+)">
+  <variable item="F10 controls output 9" CV="98" mask="VXXXXXXX" minOut="12" minFn="1" include="201,203,204">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
     <label>F10 controls output 9</label>
   </variable>
-  <variable item="F11 controls output 9" CV="98" mask="VXXXXXXX" minOut="13" minFn="1" include="DH21B (firmware 3.13.053+),DH22B (firmware 3.13.053+)">
+  <variable item="F11 controls output 9" CV="98" mask="VXXXXXXX" minOut="13" minFn="1" include="201,203,204">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
     <label>F11 controls output 9</label>
   </variable>
-  <variable item="F12 controls output 9" CV="98" mask="VXXXXXXX" minOut="14" minFn="1" include="DH21B (firmware 3.13.053+),DH22B (firmware 3.13.053+)">
+  <variable item="F12 controls output 9" CV="98" mask="VXXXXXXX" minOut="14" minFn="1" include="201,203,204">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
     <label>F12 controls output 9</label>
   </variable-->
 
-  <variable item="F4 controls output 10" CV="99" default="11" include="DH21B (firmware 3.13.053+),DH22B (firmware 3.13.053+)">
+  <variable item="F4 controls output 10" CV="99" default="11" include="201,203,204">
     <xi:include href="http://jmri.org/xml/decoders/doehler_haass/Susi-SD_enum-map.xml"/>
   </variable>
-  <!--variable item="FL(f) controls output 10" CV="99" mask="XXXXXXXV" minOut="1" minFn="2" include="DH21B (firmware 3.13.053+),DH22B (firmware 3.13.053+)">
+  <!--variable item="FL(f) controls output 10" CV="99" mask="XXXXXXXV" minOut="1" minFn="2" include="201,203,204">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
     <label>FL(f) controls output 10</label>
   </variable>
-  <variable item="FL(r) controls output 10" CV="99" mask="XXXXXXXV" minOut="1" minFn="2" include="DH21B (firmware 3.13.053+),DH22B (firmware 3.13.053+)">
+  <variable item="FL(r) controls output 10" CV="99" mask="XXXXXXXV" minOut="1" minFn="2" include="201,203,204">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
     <label>FL(r) controls output 10</label>
   </variable>
-  <variable item="F1 controls output 10" CV="99" mask="XXXXXXVX" minOut="3" minFn="2" include="DH21B (firmware 3.13.053+),DH22B (firmware 3.13.053+)">
+  <variable item="F1 controls output 10" CV="99" mask="XXXXXXVX" minOut="3" minFn="2" include="201,203,204">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
     <label>F1 controls output 10</label>
   </variable>
-  <variable item="F2 controls output 10" CV="99" mask="XXXXXVXX" minOut="4" minFn="2" include="DH21B (firmware 3.13.053+),DH22B (firmware 3.13.053+)">
+  <variable item="F2 controls output 10" CV="99" mask="XXXXXVXX" minOut="4" minFn="2" include="201,203,204">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
     <label>F2 controls output 10</label>
   </variable>
-  <variable item="F3 controls output 10" CV="99" mask="XXXXVXXX" minOut="5" minFn="2" include="DH21B (firmware 3.13.053+),DH22B (firmware 3.13.053+)">
+  <variable item="F3 controls output 10" CV="99" mask="XXXXVXXX" minOut="5" minFn="2" include="201,203,204">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
     <label>F3 controls output 10</label>
   </variable>
-  <variable item="F4 controls output 10" CV="99" mask="XXXVXXXX" minOut="6" minFn="2" include="DH21B (firmware 3.13.053+),DH22B (firmware 3.13.053+)">
+  <variable item="F4 controls output 10" CV="99" mask="XXXVXXXX" minOut="6" minFn="2" include="201,203,204">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
     <label>F4 controls output 10</label>
   </variable>
-  <variable item="F5 controls output 10" CV="99" mask="XXVXXXXX" minOut="7" minFn="2" include="DH21B (firmware 3.13.053+),DH22B (firmware 3.13.053+)">
+  <variable item="F5 controls output 10" CV="99" mask="XXVXXXXX" minOut="7" minFn="2" include="201,203,204">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
     <label>F5 controls output 10</label>
   </variable>
-  <variable item="F6 controls output 10" CV="99" mask="XVXXXXXX" minOut="8" minFn="2" include="DH21B (firmware 3.13.053+),DH22B (firmware 3.13.053+)">
+  <variable item="F6 controls output 10" CV="99" mask="XVXXXXXX" minOut="8" minFn="2" include="201,203,204">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
     <label>F6 controls output 10</label>
   </variable>
-  <variable item="F7 controls output 10" CV="99" mask="VXXXXXXX" minOut="9" minFn="2" include="DH21B (firmware 3.13.053+),DH22B (firmware 3.13.053+)">
+  <variable item="F7 controls output 10" CV="99" mask="VXXXXXXX" minOut="9" minFn="2" include="201,203,204">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
     <label>F7 controls output 10</label>
   </variable>
-  <variable item="F8 controls output 10" CV="99" mask="VXXXXXXX" minOut="10" minFn="2" include="DH21B (firmware 3.13.053+),DH22B (firmware 3.13.053+)">
+  <variable item="F8 controls output 10" CV="99" mask="VXXXXXXX" minOut="10" minFn="2" include="201,203,204">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
     <label>F8 controls output 10</label>
   </variable>
-  <variable item="F9 controls output 10" CV="99" mask="VXXXXXXX" minOut="11" minFn="2" include="DH21B (firmware 3.13.053+),DH22B (firmware 3.13.053+)">
+  <variable item="F9 controls output 10" CV="99" mask="VXXXXXXX" minOut="11" minFn="2" include="201,203,204">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
     <label>F9 controls output 10</label>
   </variable>
-  <variable item="F10 controls output 10" CV="99" mask="VXXXXXXX" minOut="12" minFn="2" include="DH21B (firmware 3.13.053+),DH22B (firmware 3.13.053+)">
+  <variable item="F10 controls output 10" CV="99" mask="VXXXXXXX" minOut="12" minFn="2" include="201,203,204">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
     <label>F10 controls output 10</label>
   </variable>
-  <variable item="F11 controls output 10" CV="99" mask="VXXXXXXX" minOut="13" minFn="2" include="DH21B (firmware 3.13.053+),DH22B (firmware 3.13.053+)">
+  <variable item="F11 controls output 10" CV="99" mask="VXXXXXXX" minOut="13" minFn="2" include="201,203,204">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
     <label>F11 controls output 10</label>
   </variable>
-  <variable item="F12 controls output 10" CV="99" mask="VXXXXXXX" minOut="14" minFn="2" include="DH21B (firmware 3.13.053+),DH22B (firmware 3.13.053+)">
+  <variable item="F12 controls output 10" CV="99" mask="VXXXXXXX" minOut="14" minFn="2" include="201,203,204">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
     <label>F12 controls output 10</label>
   </variable-->
 
-  <variable item="Condition AUX7" CV="158" default="0" minOut="8" include="DH21B (firmware 3.13.053+),DH22B (firmware 3.13.053+)">
+  <variable item="Condition AUX7" CV="158" default="0" minOut="8" include="201,203,204">
     <decVal max="161"/>
     <label>Condition AUX7</label>
     <label xml:lang="de">Bedingung AUX7</label>
     <label xml:lang="ca">Condició  AUX7</label>
   </variable>
   <!-- Older form deprecated -->
-  <variable item="Condition AUX7 enum" CV="158" default="0" minOut="8" include="DH21B (firmware 3.13.053+),DH22B (firmware 3.13.053+)">
+  <variable item="Condition AUX7 enum" CV="158" default="0" minOut="8" include="201,203,204">
     <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv145-152_fw3.06_enum.xml"/>
     <label>Condition AUX7</label>
     <label xml:lang="de">Bedingung AUX7</label>
     <label xml:lang="ca">Condició  AUX7</label>
   </variable>
   <!-- New form: split in 4 different sub-CVs / enums -->
-  <variable item="Condition AUX7 A" CV="158" mask="1" default="0" minOut="8" include="DH21B (firmware 3.13.053+),DH22B (firmware 3.13.053+)">
+  <variable item="Condition AUX7 A" CV="158" mask="1" default="0" minOut="8" include="201,203,204">
     <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv145-152_fw3.06_enum_A.xml"/>
   </variable>
-  <variable item="Condition AUX7 B" CV="158" mask="3" default="0" minOut="8" include="DH21B (firmware 3.13.053+),DH22B (firmware 3.13.053+)">
+  <variable item="Condition AUX7 B" CV="158" mask="3" default="0" minOut="8" include="201,203,204">
     <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv145-152_fw3.06_enum_B.xml"/>
   </variable>
-  <variable item="Condition AUX7 C" CV="158" mask="9" default="0" minOut="8" include="DH21B (firmware 3.13.053+),DH22B (firmware 3.13.053+)">
+  <variable item="Condition AUX7 C" CV="158" mask="9" default="0" minOut="8" include="201,203,204">
     <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv145-152_fw3.06_enum_C.xml"/>
   </variable>
-  <variable item="Condition AUX7 D" CV="158" mask="27" default="0" minOut="8" include="DH21B (firmware 3.13.053+),DH22B (firmware 3.13.053+)">
+  <variable item="Condition AUX7 D" CV="158" mask="27" default="0" minOut="8" include="201,203,204">
     <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv145-152_fw3.06_enum_D.xml"/>
   </variable>
 
-  <variable item="Condition AUX8" CV="159" default="0" minOut="8" include="DH21B (firmware 3.13.053+),DH22B (firmware 3.13.053+)">
+  <variable item="Condition AUX8" CV="159" default="0" minOut="8" include="201,203,204">
     <decVal max="161"/>
     <label>Condition AUX8</label>
     <label xml:lang="de">Bedingung AUX8</label>
     <label xml:lang="ca">Condició  AUX8</label>
   </variable>
   <!-- Older form deprecated -->
-  <variable item="Condition AUX8 enum" CV="159" default="0" minOut="8" include="DH21B (firmware 3.13.053+),DH22B (firmware 3.13.053+)">
+  <variable item="Condition AUX8 enum" CV="159" default="0" minOut="8" include="201,203,204">
     <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv145-152_fw3.06_enum.xml"/>
     <label>Condition AUX8</label>
     <label xml:lang="de">Bedingung AUX8</label>
     <label xml:lang="ca">Condició  AUX8</label>
   </variable>
   <!-- New form: split in 4 different sub-CVs / enums -->
-  <variable item="Condition AUX8 A" CV="159" mask="1" default="0" minOut="8" include="DH21B (firmware 3.13.053+),DH22B (firmware 3.13.053+)">
+  <variable item="Condition AUX8 A" CV="159" mask="1" default="0" minOut="8" include="201,203,204">
     <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv145-152_fw3.06_enum_A.xml"/>
   </variable>
-  <variable item="Condition AUX8 B" CV="159" mask="3" default="0" minOut="8" include="DH21B (firmware 3.13.053+),DH22B (firmware 3.13.053+)">
+  <variable item="Condition AUX8 B" CV="159" mask="3" default="0" minOut="8" include="201,203,204">
     <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv145-152_fw3.06_enum_B.xml"/>
   </variable>
-  <variable item="Condition AUX8 C" CV="159" mask="9" default="0" minOut="8" include="DH21B (firmware 3.13.053+),DH22B (firmware 3.13.053+)">
+  <variable item="Condition AUX8 C" CV="159" mask="9" default="0" minOut="8" include="201,203,204">
     <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv145-152_fw3.06_enum_C.xml"/>
   </variable>
-  <variable item="Condition AUX8 D" CV="159" mask="27" default="0" minOut="8" include="DH21B (firmware 3.13.053+),DH22B (firmware 3.13.053+)">
+  <variable item="Condition AUX8 D" CV="159" mask="27" default="0" minOut="8" include="201,203,204">
     <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv145-152_fw3.06_enum_D.xml"/>
   </variable>
 

--- a/xml/decoders/doehler_haass/cv98-99_158-159.xml
+++ b/xml/decoders/doehler_haass/cv98-99_158-159.xml
@@ -31,6 +31,12 @@
       <authorinitials>RK</authorinitials>
       <revremark>Creation for DH21B/DH22B</revremark>
     </revision>
+    <revision>
+      <revnumber>2</revnumber>
+      <date>2026-07-25</date>
+      <authorinitials>PB</authorinitials>
+      <revremark>Gate by product ID instead of model name; add the DH24A</revremark>
+    </revision>
   </revhistory>
   <!-- Gated by productID rather than model name: 201 = DH21B, 203 = DH22B, 204 = DH24A.      -->
   <!-- Product IDs are stable across firmware versions, whereas the model names carry a       -->

--- a/xml/schema/decoder-4-15-2.xsd
+++ b/xml/schema/decoder-4-15-2.xsd
@@ -558,6 +558,7 @@
                 <xs:enumeration value="Wires"/>
                 <xs:enumeration value="21MTC"/>
                 <xs:enumeration value="Next18"/>
+                <xs:enumeration value="E24"/>
                 <xs:enumeration value="PluX8"/>
                 <xs:enumeration value="PluX12"/>
                 <xs:enumeration value="PluX16"/>


### PR DESCRIPTION

Adds definitions for Doehler & Haass firmware 3.14.095 and 3.15.016, completes 3.13.053, and a few other fixes.

### New
- Families `Train/Function Decoders (firmware 3.14+)` and `(firmware 3.15+)`
- Models DH24A, DHSP10A and FH16A, from 3.13 onwards
- 3.15: CV60 shuttle mode and brake-ramp minimum, CV101-103 (AUX10-12 mapping),
  CV461/463/465/467 (AUX3-6 dimming), CV156 bits 4-7, CV112 widened to 0-127
- 3.13: CV401-412 function swapping and CV137 bit 6 — documented by D&H, never implemented
- Also adds `E24` to the `connector` enumeration in `xml/schema/decoder-4-15-2.xsd`
(NEM 664 / RCN-124, ESU's "Next28"), per #15294.

### Family naming
The new families use the older `(firmware x.yy+)` form rather than the year-based names used
since 2016. The firmware version is what actually distinguishes one of these definitions from
another; a year does not, e.g. 3.14 and 3.15 were both released in 2025. Existing
year-named families are left untouched.

### Fixes to existing definitions

- DH21B and DH22B carried their A variants' product IDs (200/202), so identification could
  not distinguish them. Now 201/203.
- CV144 bits 3/4 (GPIO brake settings) were gated to product IDs no model carries from 3.12
  on, and misspelt for the FH22A throughout — invisible on 3.12/3.13 and on every FH22A.
- CV112 is not offered on FH*/PD05A for 3.12-3.14, per the CV tables from 3.12 on. Its
  default is corrected from 0 to the documented 15.
- Motorola protocol declared on the FH models.
- CV124 was a single-choice list, but D&H document it as a bit mask over F1-F8, so it could
  only ever express one key. Now eight bits, matching CV125-128 which share the format. It
  was displayed on no pane at all.
- CV131, CV132 and CV133 defaulted to F1 rather than the documented F8, F4 and F9.
- CV131-133 had no English label, so JMRI fell back to item names that paraphrased — and for
  CV133 misdescribed — the setting. Now D&H's own wording. Their tooltips said F1-F8 where the
  range covers F1-F28, and their Catalan labels were copied from an unrelated variable.
- A misspelt label in CV137.